### PR TITLE
feat: session discovery and transcript reading

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -41,6 +41,9 @@ export interface AdapterEvents {
     requestId: UUID,
   ) => void;
 
+  /** Session list request received */
+  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -115,6 +115,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onBulletExpandRequest?.(connectionId, sessionId, bulletId, requestId);
       },
 
+      onSessionListRequest: (connectionId, requestId, includeExternal) => {
+        this.events.onSessionListRequest?.(connectionId, requestId, includeExternal);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -48,6 +48,7 @@ import {
   createBulletExpandResponse,
   createHelloAck,
   createReplayBatch,
+  createSessionListResponse,
   createStructuredAgentOutput,
   generateId,
   now,
@@ -63,6 +64,8 @@ import { MessageAPI } from './api/index.ts';
 import { OutputProcessor } from './parser/index.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
 import { SessionRegistry } from './session/index.ts';
+import { TranscriptDiscovery, TranscriptWatcher } from './transcript/index.ts';
+import type { AssistantEntry } from './transcript/index.ts';
 
 /**
  * Resolve a directory path, expanding ~ and validating it exists.
@@ -159,6 +162,12 @@ console.log('Starting Remi daemon...');
 // Create PTY manager (may be used for multi-session management later)
 const _ptyManager = new PTYManager();
 
+// Transcript discovery for finding external Claude Code sessions
+const transcriptDiscovery = new TranscriptDiscovery();
+
+// Transcript watchers per session (keyed by Remi session ID)
+const transcriptWatchers: Map<UUID, TranscriptWatcher> = new Map();
+
 // Session registry for managing session lifecycle independently of connections
 const sessionRegistry = new SessionRegistry(
   {
@@ -171,6 +180,12 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionClosed: (sessionId, reason) => {
       console.log(`Session closed: ${sessionId} (reason: ${reason})`);
+      // Clean up transcript watcher
+      const watcher = transcriptWatchers.get(sessionId);
+      if (watcher) {
+        watcher.stop();
+        transcriptWatchers.delete(sessionId);
+      }
     },
     onSessionOrphaned: (sessionId) => {
       console.log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
@@ -305,6 +320,73 @@ async function createNewSession(
 
   // Start the session
   await ptySession.start();
+
+  // Start transcript watcher after a delay (Claude Code needs time to create its file)
+  setTimeout(() => {
+    const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
+    if (!transcriptPath) {
+      console.log(`No transcript file found for ${workingDirectory}, will retry...`);
+      // Retry once more after another delay
+      setTimeout(() => {
+        const retryPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
+        if (retryPath) {
+          startTranscriptWatcher(sessionId, retryPath);
+        } else {
+          console.warn(`Could not find transcript file for session ${sessionId}`);
+        }
+      }, 5000);
+      return;
+    }
+    startTranscriptWatcher(sessionId, transcriptPath);
+  }, 2000);
+}
+
+/**
+ * Start watching a transcript file for a session.
+ * Emits clean message content from Claude Code's transcript.
+ */
+function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
+  console.log(`Watching transcript: ${transcriptPath}`);
+
+  const watcher = new TranscriptWatcher(
+    {
+      filePath: transcriptPath,
+      readExisting: true,
+      pollIntervalMs: 1000,
+    },
+    {
+      onAssistantMessage: (entry: AssistantEntry) => {
+        const textContent = extractAssistantText(entry);
+        if (textContent) {
+          console.log(
+            `[Transcript] Assistant message: ${textContent.slice(0, 80)}...` +
+              `${entry.message.model ? ` (${entry.message.model})` : ''}`,
+          );
+        }
+      },
+      onUserMessage: (entry) => {
+        const content =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : '[complex content]';
+        console.log(`[Transcript] User message: ${content.slice(0, 80)}`);
+      },
+      onError: (error) => {
+        console.error(`[Transcript] Error for session ${sessionId}:`, error.message);
+      },
+    },
+  );
+
+  transcriptWatchers.set(sessionId, watcher);
+  watcher.start();
+}
+
+/**
+ * Extract clean text from an assistant entry (no thinking, no tool_use).
+ */
+function extractAssistantText(entry: AssistantEntry): string {
+  const textBlocks = entry.message.content.filter((b) => b.type === 'text');
+  return textBlocks.map((b) => (b as { text: string }).text).join('\n');
 }
 
 // Create adapter registry with shared event handlers
@@ -471,6 +553,25 @@ const sharedEvents = {
     sendToConnection(connectionId, createBulletExpandResponse(bulletId, fullContent, requestId));
   },
 
+  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => {
+    const daemonSessions = sessionRegistry.listSessions();
+
+    let allSessions = [...daemonSessions];
+
+    if (includeExternal) {
+      // Discover external sessions, excluding ones already managed by daemon
+      const managedIds = new Set(sessionRegistry.getActiveSessionIds());
+      const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
+      allSessions = [...daemonSessions, ...externalSessions];
+    }
+
+    console.log(
+      `Session list request from ${connectionId}: ${allSessions.length} sessions ` +
+        `(${daemonSessions.length} daemon, ${allSessions.length - daemonSessions.length} external)`,
+    );
+    sendToConnection(connectionId, createSessionListResponse(allSessions, requestId));
+  },
+
   onError: (connectionId: UUID, error: Error) => {
     console.error(`Error from ${connectionId}:`, error);
   },
@@ -522,6 +623,12 @@ console.log('');
 // Graceful shutdown
 async function shutdown() {
   console.log('\nShutting down gracefully...');
+
+  // Stop all transcript watchers
+  for (const watcher of transcriptWatchers.values()) {
+    watcher.stop();
+  }
+  transcriptWatchers.clear();
 
   // Stop all adapters
   await registry.stopAll();

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -323,11 +323,12 @@ async function createNewSession(
 
   // Start transcript watcher after a delay (Claude Code needs time to create its file)
   setTimeout(() => {
+    if (!sessionRegistry.hasSession(sessionId)) return; // Session already cleaned up
     const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
     if (!transcriptPath) {
       console.log(`No transcript file found for ${workingDirectory}, will retry...`);
-      // Retry once more after another delay
       setTimeout(() => {
+        if (!sessionRegistry.hasSession(sessionId)) return;
         const retryPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
         if (retryPath) {
           startTranscriptWatcher(sessionId, retryPath);
@@ -366,9 +367,7 @@ function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
       },
       onUserMessage: (entry) => {
         const content =
-          typeof entry.message.content === 'string'
-            ? entry.message.content
-            : '[complex content]';
+          typeof entry.message.content === 'string' ? entry.message.content : '[complex content]';
         console.log(`[Transcript] User message: ${content.slice(0, 80)}`);
       },
       onError: (error) => {
@@ -378,7 +377,9 @@ function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
   );
 
   transcriptWatchers.set(sessionId, watcher);
-  watcher.start();
+  watcher.start().catch((error) => {
+    console.error(`[Transcript] Failed to start watcher for session ${sessionId}:`, error);
+  });
 }
 
 /**

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -56,3 +56,18 @@ export type {
   ServerConfig,
   ServerEvents,
 } from './server/index.ts';
+
+// Transcript module
+export {
+  TranscriptWatcher,
+  TranscriptDiscovery,
+} from './transcript/index.ts';
+export type {
+  TranscriptWatcherConfig,
+  TranscriptWatcherEvents,
+  TranscriptDiscoveryConfig,
+  TranscriptEntry,
+  UserEntry,
+  AssistantEntry,
+  ContentBlock,
+} from './transcript/index.ts';

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -26,6 +26,7 @@ import type {
   HelloMessage,
   PingMessage,
   ProtocolMessage,
+  SessionListRequestMessage,
   UUID,
   UserInputMessage,
 } from '@remi/shared';
@@ -49,6 +50,9 @@ export interface ConnectionEvents {
 
   /** Bullet expand request received */
   onBulletExpandRequest: (sessionId: UUID, bulletId: number, requestId: UUID) => void;
+
+  /** Session list request received */
+  onSessionListRequest: (requestId: UUID, includeExternal: boolean) => void;
 
   /** Error occurred */
   onError: (error: Error) => void;
@@ -174,6 +178,9 @@ export class Connection {
       case 'bullet_expand_request':
         this.handleBulletExpandRequest(message);
         break;
+      case 'session_list_request':
+        this.handleSessionListRequest(message);
+        break;
       case 'ping':
         this.handlePing(message);
         break;
@@ -292,6 +299,12 @@ export class Connection {
 
     // Notify - the CLI will handle sending the response
     this.events.onBulletExpandRequest?.(message.sessionId, message.bulletId, message.id);
+  }
+
+  private handleSessionListRequest(message: SessionListRequestMessage): void {
+    // Session list can be requested before full connection (no state check)
+    this.sendAck(message.id, 'delivered');
+    this.events.onSessionListRequest?.(message.id, message.includeExternal ?? false);
   }
 
   private handlePing(message: PingMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -55,6 +55,9 @@ export interface ServerEvents {
     requestId: UUID,
   ) => void;
 
+  /** Session list request from client */
+  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -276,6 +279,10 @@ export class WebSocketServer {
 
       onBulletExpandRequest: (sessionId, bulletId, requestId) => {
         this.events.onBulletExpandRequest?.(ws.data.connectionId, sessionId, bulletId, requestId);
+      },
+
+      onSessionListRequest: (requestId, includeExternal) => {
+        this.events.onSessionListRequest?.(ws.data.connectionId, requestId, includeExternal);
       },
 
       onError: (error) => {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -8,7 +8,14 @@
  * - Message history is tracked for replay on reconnect
  */
 
-import type { AgentStatus, ProtocolMessage, Question, Timestamp, UUID } from '@remi/shared';
+import type {
+  AgentStatus,
+  DiscoverableSession,
+  ProtocolMessage,
+  Question,
+  Timestamp,
+  UUID,
+} from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { OutputProcessor } from '../parser/output-processor.ts';
@@ -359,6 +366,78 @@ export class SessionRegistry {
    */
   getActiveSessionIds(): UUID[] {
     return Array.from(this.sessions.keys());
+  }
+
+  /**
+   * List all sessions with metadata for discovery.
+   * Returns daemon-managed sessions as DiscoverableSession objects.
+   */
+  listSessions(): DiscoverableSession[] {
+    const result: DiscoverableSession[] = [];
+
+    for (const session of this.sessions.values()) {
+      const status = this.getDiscoverableStatus(session);
+      const lastMessage = this.getLastMessagePreview(session);
+
+      result.push({
+        sessionId: session.sessionId,
+        projectPath: session.workingDirectory,
+        status,
+        lastActivity: session.lastDisconnectedAt ?? session.createdAt,
+        messageCount: session.messageHistory.length,
+        lastMessage,
+        source: 'daemon',
+        canAttach: session.activeConnectionId === null,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Determine discoverable status from managed session state.
+   */
+  private getDiscoverableStatus(
+    session: ManagedSession,
+  ): 'active' | 'idle' | 'orphaned' {
+    if (session.activeConnectionId === null) {
+      return 'orphaned';
+    }
+    if (session.currentStatus === 'idle') {
+      return 'idle';
+    }
+    return 'active';
+  }
+
+  /**
+   * Get a truncated preview of the last message content.
+   */
+  private getLastMessagePreview(session: ManagedSession): string | undefined {
+    if (session.messageHistory.length === 0) {
+      return undefined;
+    }
+
+    const lastMsg = session.messageHistory[session.messageHistory.length - 1];
+    if (!lastMsg) {
+      return undefined;
+    }
+
+    // Extract content from different message types
+    let content: string | undefined;
+    if (lastMsg.type === 'agent_output') {
+      content = lastMsg.message.content;
+    } else if (lastMsg.type === 'structured_agent_output') {
+      content = lastMsg.message.content;
+    } else if (lastMsg.type === 'user_input') {
+      content = lastMsg.content;
+    }
+
+    if (!content) {
+      return undefined;
+    }
+
+    // Truncate to 100 chars
+    return content.length > 100 ? `${content.slice(0, 97)}...` : content;
   }
 
   /**

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -162,6 +162,13 @@ export class SessionRegistry {
   }
 
   /**
+   * Check if a session exists (has not been cleaned up).
+   */
+  hasSession(sessionId: UUID): boolean {
+    return this.sessions.has(sessionId);
+  }
+
+  /**
    * Get the session for a given connection.
    */
   getSessionForConnection(connectionId: UUID): ManagedSession | undefined {
@@ -397,9 +404,7 @@ export class SessionRegistry {
   /**
    * Determine discoverable status from managed session state.
    */
-  private getDiscoverableStatus(
-    session: ManagedSession,
-  ): 'active' | 'idle' | 'orphaned' {
+  private getDiscoverableStatus(session: ManagedSession): 'active' | 'idle' | 'orphaned' {
     if (session.activeConnectionId === null) {
       return 'orphaned';
     }

--- a/packages/daemon/src/transcript/index.ts
+++ b/packages/daemon/src/transcript/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Transcript module - Read-only access to Claude Code transcript files.
+ *
+ * Watches .jsonl transcript files and syncs their entries
+ * into Remi's in-memory store for clean content delivery.
+ */
+
+export { TranscriptWatcher } from './transcript-watcher.ts';
+export { TranscriptDiscovery } from './transcript-discovery.ts';
+export type { TranscriptDiscoveryConfig } from './transcript-discovery.ts';
+export type {
+  AssistantEntry,
+  ContentBlock,
+  FileHistoryEntry,
+  SummaryEntry,
+  TextBlock,
+  ThinkingBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+  TranscriptEntry,
+  TranscriptWatcherConfig,
+  TranscriptWatcherEvents,
+  UserEntry,
+} from './types.ts';

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -11,7 +11,18 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { DiscoverableSession } from '@remi/shared';
-import type { AssistantEntry, TranscriptEntry, UserEntry } from './types.ts';
+import type {
+  AssistantEntry,
+  ContentBlock,
+  TextBlock,
+  TranscriptEntry,
+  UserEntry,
+} from './types.ts';
+
+/** Type predicate for TextBlock content blocks */
+function isTextBlock(block: ContentBlock): block is TextBlock {
+  return block.type === 'text';
+}
 
 /** Default Claude Code projects directory */
 const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
@@ -21,7 +32,7 @@ export interface TranscriptDiscoveryConfig {
   /** Directory to scan for transcript files (default: ~/.claude/projects/) */
   readonly projectsDir?: string;
 
-  /** Maximum age in ms for a session to be considered active (default: 1 hour) */
+  /** Maximum age in ms before a session is marked 'completed' (default: 1 hour). Sessions modified within 5 minutes are 'active'; between 5 minutes and this threshold are 'idle'. */
   readonly activeThresholdMs?: number;
 
   /** Maximum number of sessions to return (default: 50) */
@@ -41,7 +52,8 @@ interface TranscriptFileInfo {
  * Discover Claude Code sessions from transcript files on disk.
  *
  * Scans the Claude Code projects directory for .jsonl files and
- * extracts session metadata without loading full file contents.
+ * extracts session metadata by reading only the tail of each file (last 8KB),
+ * avoiding full file loads.
  */
 export class TranscriptDiscovery {
   private readonly config: Required<TranscriptDiscoveryConfig>;
@@ -81,11 +93,14 @@ export class TranscriptDiscovery {
   }
 
   /**
-   * Get the transcript file path for a given project directory.
-   * Returns the path to the Claude Code projects directory for that project.
+   * Get the transcript directory path for a given project.
+   * Encodes the project's absolute path into the Claude Code projects directory structure.
+   *
+   * NOTE: Claude Code's encoding (replacing `/` with `-`) is lossy. Paths containing
+   * dashes cannot be reliably decoded back (e.g., `/Users/my-project` and `/Users/my/project`
+   * produce the same encoded form). The `projectPath` on discovered sessions may be inaccurate.
    */
   getProjectTranscriptDir(projectPath: string): string {
-    // Claude Code uses the absolute path with slashes replaced by dashes
     const encodedPath = projectPath.replace(/\//g, '-');
     return path.join(this.config.projectsDir, encodedPath);
   }
@@ -108,7 +123,7 @@ export class TranscriptDiscovery {
 
     // Sort by modification time, most recent first
     files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-    return files[0]!.filePath;
+    return files[0]?.filePath ?? null;
   }
 
   /**
@@ -132,7 +147,7 @@ export class TranscriptDiscovery {
           const stat = fs.statSync(dirPath);
           if (!stat.isDirectory()) continue;
         } catch {
-          continue;
+          continue; // Skip inaccessible directories
         }
 
         const files = this.listJsonlFiles(dirPath);
@@ -180,7 +195,7 @@ export class TranscriptDiscovery {
             fileSize: stat.size,
           });
         } catch {
-          continue;
+          // Skip files that can't be stat'd
         }
       }
     } catch {
@@ -192,7 +207,7 @@ export class TranscriptDiscovery {
 
   /**
    * Convert a transcript file info to a DiscoverableSession.
-   * Reads the last few lines to get the latest message info.
+   * Reads the tail of the file (last 8KB) to extract metadata.
    */
   private fileToDiscoverableSession(file: TranscriptFileInfo): DiscoverableSession | null {
     const now = Date.now();
@@ -211,6 +226,9 @@ export class TranscriptDiscovery {
 
     // Try to get the last message and message count from the file tail
     const tailInfo = this.readFileTail(file.filePath);
+    if (!tailInfo) {
+      return null; // Could not read file
+    }
 
     return {
       sessionId: file.sessionId,
@@ -227,24 +245,27 @@ export class TranscriptDiscovery {
 
   /**
    * Read the tail of a transcript file to extract metadata.
-   * Only reads the last few KB to avoid loading large files.
+   * Only reads the last 8KB to avoid loading large files.
+   * Returns null if the file cannot be read.
    */
   private readFileTail(filePath: string): {
     messageCount: number;
     model?: string;
     lastMessage?: string;
-  } {
-    const MAX_TAIL_BYTES = 8192; // Read last 8KB
+  } | null {
+    const MAX_TAIL_BYTES = 8192;
+    let fd: number | null = null;
 
     try {
       const stat = fs.statSync(filePath);
       const readOffset = Math.max(0, stat.size - MAX_TAIL_BYTES);
       const readSize = Math.min(stat.size, MAX_TAIL_BYTES);
 
-      const fd = fs.openSync(filePath, 'r');
       const buffer = Buffer.alloc(readSize);
+      fd = fs.openSync(filePath, 'r');
       fs.readSync(fd, buffer, 0, readSize, readOffset);
       fs.closeSync(fd);
+      fd = null;
 
       const content = buffer.toString('utf-8');
       const lines = content.split('\n').filter((l) => l.trim());
@@ -257,8 +278,10 @@ export class TranscriptDiscovery {
       let lastMessage: string | undefined;
 
       for (let i = startIdx; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line) continue;
         try {
-          const entry = JSON.parse(lines[i]!) as TranscriptEntry;
+          const entry = JSON.parse(line) as TranscriptEntry;
 
           if (entry.type === 'user' || entry.type === 'assistant') {
             messageCount++;
@@ -268,31 +291,28 @@ export class TranscriptDiscovery {
             const assistantEntry = entry as AssistantEntry;
             model = assistantEntry.message.model ?? model;
 
-            // Get text content as preview
-            const textBlocks = assistantEntry.message.content.filter((b) => b.type === 'text');
-            if (textBlocks.length > 0) {
-              const text = (textBlocks[0] as { text: string }).text;
-              lastMessage = text.length > 100 ? `${text.slice(0, 97)}...` : text;
+            const textBlocks = assistantEntry.message.content.filter(isTextBlock);
+            const firstText = textBlocks[0]?.text;
+            if (firstText) {
+              lastMessage = firstText.length > 100 ? `${firstText.slice(0, 97)}...` : firstText;
             }
           }
 
           if (entry.type === 'user') {
             const userEntry = entry as UserEntry;
-            const content =
+            const msgContent =
               typeof userEntry.message.content === 'string'
                 ? userEntry.message.content
                 : '[complex content]';
-            lastMessage =
-              content.length > 100 ? `${content.slice(0, 97)}...` : content;
+            lastMessage = msgContent.length > 100 ? `${msgContent.slice(0, 97)}...` : msgContent;
           }
         } catch {
-          // Skip unparseable lines
+          // Skip unparseable lines in tail
         }
       }
 
       // If we only read the tail, the message count is approximate
       if (readOffset > 0) {
-        // Estimate total messages from file size ratio
         const ratio = stat.size / readSize;
         messageCount = Math.round(messageCount * ratio);
       }
@@ -304,7 +324,15 @@ export class TranscriptDiscovery {
       if (lastMessage) result.lastMessage = lastMessage;
       return result;
     } catch {
-      return { messageCount: 0 };
+      return null;
+    } finally {
+      if (fd !== null) {
+        try {
+          fs.closeSync(fd);
+        } catch {
+          /* already closed or invalid */
+        }
+      }
     }
   }
 }

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -1,0 +1,310 @@
+/**
+ * TranscriptDiscovery - Discovers Claude Code sessions from transcript files.
+ *
+ * Scans ~/.claude/projects/ for .jsonl transcript files and extracts
+ * session metadata for the discovery feature.
+ *
+ * READ-ONLY: Never modifies any Claude Code files.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { DiscoverableSession } from '@remi/shared';
+import type { AssistantEntry, TranscriptEntry, UserEntry } from './types.ts';
+
+/** Default Claude Code projects directory */
+const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+
+/** Configuration for transcript discovery */
+export interface TranscriptDiscoveryConfig {
+  /** Directory to scan for transcript files (default: ~/.claude/projects/) */
+  readonly projectsDir?: string;
+
+  /** Maximum age in ms for a session to be considered active (default: 1 hour) */
+  readonly activeThresholdMs?: number;
+
+  /** Maximum number of sessions to return (default: 50) */
+  readonly maxResults?: number;
+}
+
+/** Info extracted from scanning a transcript file */
+interface TranscriptFileInfo {
+  readonly filePath: string;
+  readonly sessionId: string;
+  readonly projectPath: string;
+  readonly lastModified: Date;
+  readonly fileSize: number;
+}
+
+/**
+ * Discover Claude Code sessions from transcript files on disk.
+ *
+ * Scans the Claude Code projects directory for .jsonl files and
+ * extracts session metadata without loading full file contents.
+ */
+export class TranscriptDiscovery {
+  private readonly config: Required<TranscriptDiscoveryConfig>;
+
+  constructor(config: TranscriptDiscoveryConfig = {}) {
+    this.config = {
+      projectsDir: config.projectsDir ?? CLAUDE_PROJECTS_DIR,
+      activeThresholdMs: config.activeThresholdMs ?? 60 * 60 * 1000, // 1 hour
+      maxResults: config.maxResults ?? 50,
+    };
+  }
+
+  /**
+   * Discover all sessions, sorted by last activity (most recent first).
+   * Excludes sessions already managed by the daemon (by session ID).
+   */
+  discoverSessions(excludeSessionIds: Set<string> = new Set()): DiscoverableSession[] {
+    const files = this.findTranscriptFiles();
+    const sessions: DiscoverableSession[] = [];
+
+    for (const file of files) {
+      if (excludeSessionIds.has(file.sessionId)) {
+        continue;
+      }
+
+      const session = this.fileToDiscoverableSession(file);
+      if (session) {
+        sessions.push(session);
+      }
+
+      if (sessions.length >= this.config.maxResults) {
+        break;
+      }
+    }
+
+    return sessions;
+  }
+
+  /**
+   * Get the transcript file path for a given project directory.
+   * Returns the path to the Claude Code projects directory for that project.
+   */
+  getProjectTranscriptDir(projectPath: string): string {
+    // Claude Code uses the absolute path with slashes replaced by dashes
+    const encodedPath = projectPath.replace(/\//g, '-');
+    return path.join(this.config.projectsDir, encodedPath);
+  }
+
+  /**
+   * Find the most recent transcript file for a given project directory.
+   * Useful for connecting a daemon-managed session to its transcript.
+   */
+  findLatestTranscript(projectPath: string): string | null {
+    const transcriptDir = this.getProjectTranscriptDir(projectPath);
+
+    if (!fs.existsSync(transcriptDir)) {
+      return null;
+    }
+
+    const files = this.listJsonlFiles(transcriptDir);
+    if (files.length === 0) {
+      return null;
+    }
+
+    // Sort by modification time, most recent first
+    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+    return files[0]!.filePath;
+  }
+
+  /**
+   * Find all .jsonl transcript files across all projects.
+   * Sorted by last modification time (most recent first).
+   */
+  private findTranscriptFiles(): TranscriptFileInfo[] {
+    if (!fs.existsSync(this.config.projectsDir)) {
+      return [];
+    }
+
+    const allFiles: TranscriptFileInfo[] = [];
+
+    try {
+      const projectDirs = fs.readdirSync(this.config.projectsDir);
+
+      for (const dirName of projectDirs) {
+        const dirPath = path.join(this.config.projectsDir, dirName);
+
+        try {
+          const stat = fs.statSync(dirPath);
+          if (!stat.isDirectory()) continue;
+        } catch {
+          continue;
+        }
+
+        const files = this.listJsonlFiles(dirPath);
+        allFiles.push(...files);
+      }
+    } catch {
+      // Can't read projects directory
+      return [];
+    }
+
+    // Sort by modification time (most recent first)
+    allFiles.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+
+    return allFiles;
+  }
+
+  /**
+   * List all .jsonl files in a directory with metadata.
+   */
+  private listJsonlFiles(dirPath: string): TranscriptFileInfo[] {
+    const files: TranscriptFileInfo[] = [];
+
+    try {
+      const entries = fs.readdirSync(dirPath);
+
+      for (const entry of entries) {
+        if (!entry.endsWith('.jsonl')) continue;
+
+        const filePath = path.join(dirPath, entry);
+        try {
+          const stat = fs.statSync(filePath);
+
+          // Extract session ID from filename (UUID.jsonl)
+          const sessionId = entry.replace('.jsonl', '');
+
+          // Decode project path from directory name
+          const dirName = path.basename(dirPath);
+          const projectPath = dirName.replace(/-/g, '/');
+
+          files.push({
+            filePath,
+            sessionId,
+            projectPath,
+            lastModified: stat.mtime,
+            fileSize: stat.size,
+          });
+        } catch {
+          continue;
+        }
+      }
+    } catch {
+      // Can't read directory
+    }
+
+    return files;
+  }
+
+  /**
+   * Convert a transcript file info to a DiscoverableSession.
+   * Reads the last few lines to get the latest message info.
+   */
+  private fileToDiscoverableSession(file: TranscriptFileInfo): DiscoverableSession | null {
+    const now = Date.now();
+    const age = now - file.lastModified.getTime();
+
+    // Determine status based on last modification time
+    let status: 'active' | 'idle' | 'completed';
+    if (age < 5 * 60 * 1000) {
+      // Modified in last 5 minutes
+      status = 'active';
+    } else if (age < this.config.activeThresholdMs) {
+      status = 'idle';
+    } else {
+      status = 'completed';
+    }
+
+    // Try to get the last message and message count from the file tail
+    const tailInfo = this.readFileTail(file.filePath);
+
+    return {
+      sessionId: file.sessionId,
+      projectPath: file.projectPath,
+      status,
+      lastActivity: file.lastModified.toISOString(),
+      messageCount: tailInfo.messageCount,
+      model: tailInfo.model,
+      lastMessage: tailInfo.lastMessage,
+      source: 'transcript',
+      canAttach: false, // External sessions can't be attached to via daemon
+    };
+  }
+
+  /**
+   * Read the tail of a transcript file to extract metadata.
+   * Only reads the last few KB to avoid loading large files.
+   */
+  private readFileTail(filePath: string): {
+    messageCount: number;
+    model?: string;
+    lastMessage?: string;
+  } {
+    const MAX_TAIL_BYTES = 8192; // Read last 8KB
+
+    try {
+      const stat = fs.statSync(filePath);
+      const readOffset = Math.max(0, stat.size - MAX_TAIL_BYTES);
+      const readSize = Math.min(stat.size, MAX_TAIL_BYTES);
+
+      const fd = fs.openSync(filePath, 'r');
+      const buffer = Buffer.alloc(readSize);
+      fs.readSync(fd, buffer, 0, readSize, readOffset);
+      fs.closeSync(fd);
+
+      const content = buffer.toString('utf-8');
+      const lines = content.split('\n').filter((l) => l.trim());
+
+      // If we started mid-line (offset > 0), skip the first partial line
+      const startIdx = readOffset > 0 ? 1 : 0;
+
+      let messageCount = 0;
+      let model: string | undefined;
+      let lastMessage: string | undefined;
+
+      for (let i = startIdx; i < lines.length; i++) {
+        try {
+          const entry = JSON.parse(lines[i]!) as TranscriptEntry;
+
+          if (entry.type === 'user' || entry.type === 'assistant') {
+            messageCount++;
+          }
+
+          if (entry.type === 'assistant') {
+            const assistantEntry = entry as AssistantEntry;
+            model = assistantEntry.message.model ?? model;
+
+            // Get text content as preview
+            const textBlocks = assistantEntry.message.content.filter((b) => b.type === 'text');
+            if (textBlocks.length > 0) {
+              const text = (textBlocks[0] as { text: string }).text;
+              lastMessage = text.length > 100 ? `${text.slice(0, 97)}...` : text;
+            }
+          }
+
+          if (entry.type === 'user') {
+            const userEntry = entry as UserEntry;
+            const content =
+              typeof userEntry.message.content === 'string'
+                ? userEntry.message.content
+                : '[complex content]';
+            lastMessage =
+              content.length > 100 ? `${content.slice(0, 97)}...` : content;
+          }
+        } catch {
+          // Skip unparseable lines
+        }
+      }
+
+      // If we only read the tail, the message count is approximate
+      if (readOffset > 0) {
+        // Estimate total messages from file size ratio
+        const ratio = stat.size / readSize;
+        messageCount = Math.round(messageCount * ratio);
+      }
+
+      const result: { messageCount: number; model?: string; lastMessage?: string } = {
+        messageCount,
+      };
+      if (model) result.model = model;
+      if (lastMessage) result.lastMessage = lastMessage;
+      return result;
+    } catch {
+      return { messageCount: 0 };
+    }
+  }
+}

--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -6,17 +6,26 @@
  *
  * Uses a combination of fs.watch (for immediate notification) and
  * polling (as a reliability fallback) to detect new entries.
+ * Deduplicates entries by UUID to handle overlapping reads from
+ * the watch/poll combination.
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type {
   AssistantEntry,
-  SummaryEntry,
+  ContentBlock,
+  TextBlock,
   TranscriptEntry,
   TranscriptWatcherConfig,
   TranscriptWatcherEvents,
   UserEntry,
 } from './types.ts';
+
+/** Type predicate for TextBlock content blocks */
+function isTextBlock(block: ContentBlock): block is TextBlock {
+  return block.type === 'text';
+}
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 
@@ -30,7 +39,7 @@ export class TranscriptWatcher {
   /** All parsed entries (our in-memory copy) */
   private readonly entries: TranscriptEntry[] = [];
 
-  /** Map of entry UUID to index for fast lookup */
+  /** Map of entry UUID to index for user/assistant entries (summary and file-history entries lack UUIDs and are not indexed) */
   private readonly entryIndex: Map<string, number> = new Map();
 
   /** File watcher handle */
@@ -85,11 +94,13 @@ export class TranscriptWatcher {
 
   /**
    * Extract clean text content from an assistant entry.
-   * Filters out thinking blocks and tool use; returns only text blocks.
+   * Filters out thinking, tool_use, and tool_result blocks; returns only text content.
    */
   getAssistantText(entry: AssistantEntry): string {
-    const textBlocks = entry.message.content.filter((b) => b.type === 'text');
-    return textBlocks.map((b) => (b as { text: string }).text).join('\n');
+    return entry.message.content
+      .filter(isTextBlock)
+      .map((b) => b.text)
+      .join('\n');
   }
 
   /**
@@ -147,7 +158,7 @@ export class TranscriptWatcher {
    */
   private waitForFile(): void {
     this.running = true;
-    const dir = this.config.filePath.substring(0, this.config.filePath.lastIndexOf('/'));
+    const dir = path.dirname(this.config.filePath);
 
     // Watch the directory for the file to appear
     try {
@@ -198,24 +209,33 @@ export class TranscriptWatcher {
     // Use fs.watch for immediate notifications
     try {
       this.watcher = fs.watch(this.config.filePath, (eventType) => {
-        if (eventType === 'change') {
+        if (eventType === 'change' && this.running) {
           this.readNewEntries();
         }
       });
-    } catch {
-      // fs.watch not available; fall back to polling only
+    } catch (error) {
+      // fs.watch not available on this platform; fall back to polling only
+      this.events.onError?.(
+        new Error(
+          `fs.watch unavailable, using polling: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
     }
 
     // Also poll as a reliability fallback
     this.pollTimer = setInterval(() => {
-      this.readNewEntries();
+      if (this.running) {
+        this.readNewEntries();
+      }
     }, this.config.pollIntervalMs);
   }
 
   /**
    * Read new entries from the file since last read position.
+   * Handles incomplete final lines by retaining them for the next read.
    */
   private async readNewEntries(): Promise<void> {
+    let fd: number | null = null;
     try {
       const stat = fs.statSync(this.config.filePath);
 
@@ -223,17 +243,23 @@ export class TranscriptWatcher {
       if (stat.size <= this.fileOffset) return;
 
       // Read only the new bytes
-      const fd = fs.openSync(this.config.filePath, 'r');
       const bufferSize = stat.size - this.fileOffset;
       const buffer = Buffer.alloc(bufferSize);
+      fd = fs.openSync(this.config.filePath, 'r');
       fs.readSync(fd, buffer, 0, bufferSize, this.fileOffset);
       fs.closeSync(fd);
-
-      this.fileOffset = stat.size;
+      fd = null;
 
       // Parse the new data line by line
       const newData = buffer.toString('utf-8');
       const lines = newData.split('\n');
+
+      // If the data doesn't end with a newline, the last element is incomplete;
+      // don't advance offset past it so it's included in the next read.
+      const hasTrailingNewline = newData.endsWith('\n');
+      const lastIncomplete = !hasTrailingNewline ? (lines.pop() ?? '') : '';
+      const bytesConsumed = bufferSize - Buffer.byteLength(lastIncomplete, 'utf-8');
+      this.fileOffset += bytesConsumed;
 
       for (const line of lines) {
         const trimmed = line.trim();
@@ -242,8 +268,7 @@ export class TranscriptWatcher {
         try {
           const entry = JSON.parse(trimmed) as TranscriptEntry;
           this.processEntry(entry);
-        } catch (parseError) {
-          // Skip malformed lines (could be partial writes)
+        } catch {
           this.events.onError?.(
             new Error(`Failed to parse transcript line: ${trimmed.slice(0, 100)}`),
           );
@@ -251,6 +276,14 @@ export class TranscriptWatcher {
       }
     } catch (error) {
       this.events.onError?.(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      if (fd !== null) {
+        try {
+          fs.closeSync(fd);
+        } catch {
+          /* already closed or invalid */
+        }
+      }
     }
   }
 
@@ -259,7 +292,7 @@ export class TranscriptWatcher {
    */
   private processEntry(entry: TranscriptEntry): void {
     // Check for duplicate (by UUID for user/assistant entries)
-    const uuid = (entry.type === 'user' || entry.type === 'assistant') ? entry.uuid : undefined;
+    const uuid = entry.type === 'user' || entry.type === 'assistant' ? entry.uuid : undefined;
     if (uuid) {
       if (this.entryIndex.has(uuid)) {
         return; // Already have this entry

--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -1,0 +1,285 @@
+/**
+ * TranscriptWatcher - Watches a Claude Code JSONL transcript file.
+ *
+ * Reads new entries as they're appended and emits events.
+ * Treats the source file as READ-ONLY; never modifies it.
+ *
+ * Uses a combination of fs.watch (for immediate notification) and
+ * polling (as a reliability fallback) to detect new entries.
+ */
+
+import * as fs from 'node:fs';
+import type {
+  AssistantEntry,
+  SummaryEntry,
+  TranscriptEntry,
+  TranscriptWatcherConfig,
+  TranscriptWatcherEvents,
+  UserEntry,
+} from './types.ts';
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+export class TranscriptWatcher {
+  private readonly config: Required<TranscriptWatcherConfig>;
+  private readonly events: TranscriptWatcherEvents;
+
+  /** Byte offset of last read position in the file */
+  private fileOffset = 0;
+
+  /** All parsed entries (our in-memory copy) */
+  private readonly entries: TranscriptEntry[] = [];
+
+  /** Map of entry UUID to index for fast lookup */
+  private readonly entryIndex: Map<string, number> = new Map();
+
+  /** File watcher handle */
+  private watcher: fs.FSWatcher | null = null;
+
+  /** Poll timer handle */
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Whether the watcher is currently running */
+  private running = false;
+
+  constructor(config: TranscriptWatcherConfig, events: TranscriptWatcherEvents = {}) {
+    this.config = {
+      filePath: config.filePath,
+      pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      readExisting: config.readExisting ?? true,
+    };
+    this.events = events;
+  }
+
+  /** Whether the watcher is active */
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  /** Number of entries read so far */
+  get entryCount(): number {
+    return this.entries.length;
+  }
+
+  /** Get all entries */
+  getEntries(): readonly TranscriptEntry[] {
+    return this.entries;
+  }
+
+  /** Get entry by UUID */
+  getEntry(uuid: string): TranscriptEntry | undefined {
+    const index = this.entryIndex.get(uuid);
+    if (index === undefined) return undefined;
+    return this.entries[index];
+  }
+
+  /** Get all user messages */
+  getUserMessages(): UserEntry[] {
+    return this.entries.filter((e): e is UserEntry => e.type === 'user');
+  }
+
+  /** Get all assistant messages */
+  getAssistantMessages(): AssistantEntry[] {
+    return this.entries.filter((e): e is AssistantEntry => e.type === 'assistant');
+  }
+
+  /**
+   * Extract clean text content from an assistant entry.
+   * Filters out thinking blocks and tool use; returns only text blocks.
+   */
+  getAssistantText(entry: AssistantEntry): string {
+    const textBlocks = entry.message.content.filter((b) => b.type === 'text');
+    return textBlocks.map((b) => (b as { text: string }).text).join('\n');
+  }
+
+  /**
+   * Get the model used for a given assistant entry.
+   */
+  getModel(entry: AssistantEntry): string | undefined {
+    return entry.message.model;
+  }
+
+  /**
+   * Start watching the transcript file.
+   * If readExisting is true, reads all existing entries first.
+   */
+  async start(): Promise<void> {
+    if (this.running) return;
+
+    // Check if file exists
+    if (!fs.existsSync(this.config.filePath)) {
+      // File doesn't exist yet; wait for it
+      this.waitForFile();
+      return;
+    }
+
+    // Read existing entries if configured
+    if (this.config.readExisting) {
+      await this.readNewEntries();
+    } else {
+      // Skip to end of file
+      const stat = fs.statSync(this.config.filePath);
+      this.fileOffset = stat.size;
+    }
+
+    this.startWatching();
+  }
+
+  /**
+   * Stop watching the transcript file.
+   */
+  stop(): void {
+    this.running = false;
+
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  /**
+   * Wait for the transcript file to be created, then start watching.
+   */
+  private waitForFile(): void {
+    this.running = true;
+    const dir = this.config.filePath.substring(0, this.config.filePath.lastIndexOf('/'));
+
+    // Watch the directory for the file to appear
+    try {
+      const dirWatcher = fs.watch(dir, (eventType, filename) => {
+        if (filename && this.config.filePath.endsWith(filename)) {
+          dirWatcher.close();
+          if (this.running) {
+            this.start();
+          }
+        }
+      });
+
+      // Also poll in case fs.watch misses it
+      this.pollTimer = setInterval(() => {
+        if (fs.existsSync(this.config.filePath)) {
+          if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+          }
+          dirWatcher.close();
+          if (this.running) {
+            this.start();
+          }
+        }
+      }, this.config.pollIntervalMs);
+    } catch {
+      // If directory watching fails, fall back to polling only
+      this.pollTimer = setInterval(() => {
+        if (fs.existsSync(this.config.filePath)) {
+          if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+          }
+          if (this.running) {
+            this.start();
+          }
+        }
+      }, this.config.pollIntervalMs);
+    }
+  }
+
+  /**
+   * Start watching for changes to the transcript file.
+   */
+  private startWatching(): void {
+    this.running = true;
+
+    // Use fs.watch for immediate notifications
+    try {
+      this.watcher = fs.watch(this.config.filePath, (eventType) => {
+        if (eventType === 'change') {
+          this.readNewEntries();
+        }
+      });
+    } catch {
+      // fs.watch not available; fall back to polling only
+    }
+
+    // Also poll as a reliability fallback
+    this.pollTimer = setInterval(() => {
+      this.readNewEntries();
+    }, this.config.pollIntervalMs);
+  }
+
+  /**
+   * Read new entries from the file since last read position.
+   */
+  private async readNewEntries(): Promise<void> {
+    try {
+      const stat = fs.statSync(this.config.filePath);
+
+      // No new data
+      if (stat.size <= this.fileOffset) return;
+
+      // Read only the new bytes
+      const fd = fs.openSync(this.config.filePath, 'r');
+      const bufferSize = stat.size - this.fileOffset;
+      const buffer = Buffer.alloc(bufferSize);
+      fs.readSync(fd, buffer, 0, bufferSize, this.fileOffset);
+      fs.closeSync(fd);
+
+      this.fileOffset = stat.size;
+
+      // Parse the new data line by line
+      const newData = buffer.toString('utf-8');
+      const lines = newData.split('\n');
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+          const entry = JSON.parse(trimmed) as TranscriptEntry;
+          this.processEntry(entry);
+        } catch (parseError) {
+          // Skip malformed lines (could be partial writes)
+          this.events.onError?.(
+            new Error(`Failed to parse transcript line: ${trimmed.slice(0, 100)}`),
+          );
+        }
+      }
+    } catch (error) {
+      this.events.onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  /**
+   * Process a single parsed transcript entry.
+   */
+  private processEntry(entry: TranscriptEntry): void {
+    // Check for duplicate (by UUID for user/assistant entries)
+    const uuid = (entry.type === 'user' || entry.type === 'assistant') ? entry.uuid : undefined;
+    if (uuid) {
+      if (this.entryIndex.has(uuid)) {
+        return; // Already have this entry
+      }
+      this.entryIndex.set(uuid, this.entries.length);
+    }
+
+    this.entries.push(entry);
+
+    // Emit appropriate event
+    switch (entry.type) {
+      case 'user':
+        this.events.onUserMessage?.(entry);
+        break;
+      case 'assistant':
+        this.events.onAssistantMessage?.(entry);
+        break;
+      case 'summary':
+        this.events.onSummary?.(entry);
+        break;
+    }
+  }
+}

--- a/packages/daemon/src/transcript/types.ts
+++ b/packages/daemon/src/transcript/types.ts
@@ -8,9 +8,6 @@
  * into Remi's own in-memory store.
  */
 
-/** Content block types within a message */
-export type ContentBlockType = 'text' | 'thinking' | 'tool_use' | 'tool_result';
-
 /** A text content block */
 export interface TextBlock {
   readonly type: 'text';

--- a/packages/daemon/src/transcript/types.ts
+++ b/packages/daemon/src/transcript/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Types for Claude Code transcript (.jsonl) entries.
+ *
+ * These represent the structure of entries in Claude Code's
+ * transcript files at ~/.claude/projects/<path>/<session-id>.jsonl
+ *
+ * We treat these files as READ-ONLY and sync their contents
+ * into Remi's own in-memory store.
+ */
+
+/** Content block types within a message */
+export type ContentBlockType = 'text' | 'thinking' | 'tool_use' | 'tool_result';
+
+/** A text content block */
+export interface TextBlock {
+  readonly type: 'text';
+  readonly text: string;
+}
+
+/** A thinking content block */
+export interface ThinkingBlock {
+  readonly type: 'thinking';
+  readonly thinking: string;
+  readonly signature?: string;
+}
+
+/** A tool use content block */
+export interface ToolUseBlock {
+  readonly type: 'tool_use';
+  readonly id: string;
+  readonly name: string;
+  readonly input: unknown;
+}
+
+/** A tool result content block */
+export interface ToolResultBlock {
+  readonly type: 'tool_result';
+  readonly tool_use_id: string;
+  readonly content: string | readonly ContentBlock[];
+}
+
+/** Union of all content block types */
+export type ContentBlock = TextBlock | ThinkingBlock | ToolUseBlock | ToolResultBlock;
+
+/** Base fields shared by all transcript entries */
+interface TranscriptEntryBase {
+  readonly uuid: string;
+  readonly parentUuid: string | null;
+  readonly sessionId: string;
+  readonly timestamp: string;
+  readonly isSidechain?: boolean;
+  readonly cwd?: string;
+  readonly version?: string;
+  readonly gitBranch?: string;
+}
+
+/** A user message entry */
+export interface UserEntry extends TranscriptEntryBase {
+  readonly type: 'user';
+  readonly message: {
+    readonly role: 'user';
+    readonly content: string | readonly ContentBlock[];
+  };
+}
+
+/** An assistant message entry */
+export interface AssistantEntry extends TranscriptEntryBase {
+  readonly type: 'assistant';
+  readonly message: {
+    readonly model?: string;
+    readonly id?: string;
+    readonly role: 'assistant';
+    readonly content: readonly ContentBlock[];
+    readonly stop_reason?: string | null;
+    readonly usage?: {
+      readonly input_tokens?: number;
+      readonly output_tokens?: number;
+    };
+  };
+  readonly requestId?: string;
+}
+
+/** A summary entry (conversation summaries for context management) */
+export interface SummaryEntry {
+  readonly type: 'summary';
+  readonly summary: string;
+  readonly leafUuid: string;
+}
+
+/** A file history snapshot entry */
+export interface FileHistoryEntry {
+  readonly type: 'file-history-snapshot';
+  readonly [key: string]: unknown;
+}
+
+/** Union of all transcript entry types */
+export type TranscriptEntry = UserEntry | AssistantEntry | SummaryEntry | FileHistoryEntry;
+
+/** Events emitted by the transcript watcher */
+export interface TranscriptWatcherEvents {
+  /** New user message entry */
+  onUserMessage?: (entry: UserEntry) => void;
+
+  /** New assistant message entry */
+  onAssistantMessage?: (entry: AssistantEntry) => void;
+
+  /** New summary entry */
+  onSummary?: (entry: SummaryEntry) => void;
+
+  /** Error reading or parsing transcript */
+  onError?: (error: Error) => void;
+}
+
+/** Configuration for transcript watcher */
+export interface TranscriptWatcherConfig {
+  /** Path to the JSONL transcript file */
+  readonly filePath: string;
+
+  /** Poll interval in ms for file changes (fallback if fs.watch is unreliable) */
+  readonly pollIntervalMs?: number;
+
+  /** Whether to read existing entries on start (vs only new ones) */
+  readonly readExisting?: boolean;
+}

--- a/packages/daemon/tests/transcript-discovery.test.ts
+++ b/packages/daemon/tests/transcript-discovery.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for TranscriptDiscovery.
+ *
+ * Uses real filesystem operations against the actual
+ * ~/.claude/projects/ directory (read-only).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { TranscriptDiscovery } from '../src/transcript/index.ts';
+
+const TEMP_DIR = path.join(os.tmpdir(), 'remi-test-discovery');
+
+function makeProjectDir(projectPath: string): string {
+  const encoded = projectPath.replace(/\//g, '-');
+  const dir = path.join(TEMP_DIR, encoded);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeTranscript(dir: string, sessionId: string, entries: object[]): string {
+  const filePath = path.join(dir, `${sessionId}.jsonl`);
+  const content = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+function makeUserEntry(content: string): object {
+  return {
+    type: 'user',
+    uuid: crypto.randomUUID(),
+    parentUuid: null,
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content },
+  };
+}
+
+function makeAssistantEntry(text: string, model = 'claude-opus-4-5-20251101'): object {
+  return {
+    type: 'assistant',
+    uuid: crypto.randomUUID(),
+    parentUuid: null,
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    message: {
+      model,
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+    },
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(TEMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+});
+
+describe('TranscriptDiscovery', () => {
+  test('discovers sessions from transcript files', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    writeTranscript(projectDir, 'session-1', [
+      makeUserEntry('hello'),
+      makeAssistantEntry('hi'),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.sessionId).toBe('session-1');
+    expect(sessions[0]!.source).toBe('transcript');
+    expect(sessions[0]!.canAttach).toBe(false);
+  });
+
+  test('discovers multiple sessions across projects', () => {
+    const dir1 = makeProjectDir('/Users/test/project-a');
+    const dir2 = makeProjectDir('/Users/test/project-b');
+
+    writeTranscript(dir1, 'session-a1', [makeUserEntry('a1')]);
+    writeTranscript(dir1, 'session-a2', [makeUserEntry('a2')]);
+    writeTranscript(dir2, 'session-b1', [makeUserEntry('b1')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(3);
+  });
+
+  test('excludes specified session IDs', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    writeTranscript(projectDir, 'keep-me', [makeUserEntry('keep')]);
+    writeTranscript(projectDir, 'exclude-me', [makeUserEntry('exclude')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions(new Set(['exclude-me']));
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.sessionId).toBe('keep-me');
+  });
+
+  test('sorts by most recently modified first', async () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+
+    writeTranscript(projectDir, 'old-session', [makeUserEntry('old')]);
+    // Small delay to ensure different mtime
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    writeTranscript(projectDir, 'new-session', [makeUserEntry('new')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]!.sessionId).toBe('new-session');
+    expect(sessions[1]!.sessionId).toBe('old-session');
+  });
+
+  test('extracts model info from transcript', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    writeTranscript(projectDir, 'with-model', [
+      makeUserEntry('test'),
+      makeAssistantEntry('response', 'claude-sonnet-4-20250514'),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]!.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  test('extracts last message preview', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    writeTranscript(projectDir, 'preview', [
+      makeUserEntry('first message'),
+      makeAssistantEntry('the assistant responds'),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]!.lastMessage).toBe('the assistant responds');
+  });
+
+  test('truncates long last message preview', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    const longText = 'a'.repeat(200);
+    writeTranscript(projectDir, 'long', [makeAssistantEntry(longText)]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]!.lastMessage!.length).toBeLessThanOrEqual(100);
+    expect(sessions[0]!.lastMessage!.endsWith('...')).toBe(true);
+  });
+
+  test('respects maxResults limit', () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    for (let i = 0; i < 10; i++) {
+      writeTranscript(projectDir, `session-${i}`, [makeUserEntry(`msg ${i}`)]);
+    }
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR, maxResults: 3 });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(3);
+  });
+
+  test('determines status based on modification time', async () => {
+    const projectDir = makeProjectDir('/Users/test/project');
+    const filePath = writeTranscript(projectDir, 'recent', [makeUserEntry('just now')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    // Just written, should be active
+    expect(sessions[0]!.status).toBe('active');
+
+    // Modify the file's mtime to be old
+    const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    fs.utimesSync(filePath, oldTime, oldTime);
+
+    const sessions2 = discovery.discoverSessions();
+    expect(sessions2[0]!.status).toBe('completed');
+  });
+
+  test('findLatestTranscript returns most recent file', async () => {
+    const projectDir = makeProjectDir('/Users/test/myproject');
+
+    writeTranscript(projectDir, 'old-session', [makeUserEntry('old')]);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    writeTranscript(projectDir, 'new-session', [makeUserEntry('new')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const latest = discovery.findLatestTranscript('/Users/test/myproject');
+
+    expect(latest).toContain('new-session.jsonl');
+  });
+
+  test('findLatestTranscript returns null for unknown project', () => {
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const latest = discovery.findLatestTranscript('/nonexistent/project');
+
+    expect(latest).toBeNull();
+  });
+
+  test('handles empty projects directory', () => {
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(0);
+  });
+
+  test('handles non-existent projects directory', () => {
+    const discovery = new TranscriptDiscovery({
+      projectsDir: '/tmp/remi-nonexistent-dir-12345',
+    });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/transcript-watcher.test.ts
+++ b/packages/daemon/tests/transcript-watcher.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for TranscriptWatcher.
+ *
+ * Uses real filesystem operations (no mocks).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { TranscriptWatcher } from '../src/transcript/index.ts';
+import type { AssistantEntry, UserEntry } from '../src/transcript/index.ts';
+
+const TEMP_DIR = path.join(os.tmpdir(), 'remi-test-transcript');
+
+function createTempFile(name: string): string {
+  fs.mkdirSync(TEMP_DIR, { recursive: true });
+  const filePath = path.join(TEMP_DIR, name);
+  fs.writeFileSync(filePath, '');
+  return filePath;
+}
+
+function appendLine(filePath: string, entry: object): void {
+  fs.appendFileSync(filePath, `${JSON.stringify(entry)}\n`);
+}
+
+function makeUserEntry(content: string, uuid?: string): object {
+  return {
+    type: 'user',
+    uuid: uuid ?? crypto.randomUUID(),
+    parentUuid: null,
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content },
+  };
+}
+
+function makeAssistantEntry(text: string, uuid?: string, model?: string): object {
+  return {
+    type: 'assistant',
+    uuid: uuid ?? crypto.randomUUID(),
+    parentUuid: null,
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    message: {
+      model: model ?? 'claude-opus-4-5-20251101',
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+    },
+  };
+}
+
+function makeSummaryEntry(summary: string): object {
+  return {
+    type: 'summary',
+    summary,
+    leafUuid: crypto.randomUUID(),
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(TEMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+});
+
+describe('TranscriptWatcher', () => {
+  test('reads existing entries on start', async () => {
+    const filePath = createTempFile('existing.jsonl');
+    appendLine(filePath, makeUserEntry('hello'));
+    appendLine(filePath, makeAssistantEntry('hi there'));
+    appendLine(filePath, makeUserEntry('how are you'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    expect(watcher.entryCount).toBe(3);
+    expect(watcher.getUserMessages()).toHaveLength(2);
+    expect(watcher.getAssistantMessages()).toHaveLength(1);
+
+    watcher.stop();
+  });
+
+  test('skips existing entries when readExisting is false', async () => {
+    const filePath = createTempFile('skip-existing.jsonl');
+    appendLine(filePath, makeUserEntry('old message'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: false });
+    await watcher.start();
+
+    expect(watcher.entryCount).toBe(0);
+
+    watcher.stop();
+  });
+
+  test('detects new entries appended to file', async () => {
+    const filePath = createTempFile('live.jsonl');
+
+    const receivedUsers: UserEntry[] = [];
+    const receivedAssistants: AssistantEntry[] = [];
+
+    const watcher = new TranscriptWatcher(
+      { filePath, readExisting: true, pollIntervalMs: 50 },
+      {
+        onUserMessage: (entry) => receivedUsers.push(entry),
+        onAssistantMessage: (entry) => receivedAssistants.push(entry),
+      },
+    );
+    await watcher.start();
+
+    // Append new entries
+    appendLine(filePath, makeUserEntry('new message'));
+    appendLine(filePath, makeAssistantEntry('response'));
+
+    // Wait for poll to pick up
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(receivedUsers).toHaveLength(1);
+    expect(receivedAssistants).toHaveLength(1);
+    expect(receivedUsers[0]!.message.content).toBe('new message');
+
+    watcher.stop();
+  });
+
+  test('deduplicates entries by UUID', async () => {
+    const filePath = createTempFile('dedup.jsonl');
+    const uuid = crypto.randomUUID();
+
+    appendLine(filePath, makeUserEntry('first', uuid));
+    appendLine(filePath, makeUserEntry('duplicate', uuid));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    expect(watcher.entryCount).toBe(1);
+    expect(watcher.getUserMessages()[0]!.message.content).toBe('first');
+
+    watcher.stop();
+  });
+
+  test('handles summary entries', async () => {
+    const filePath = createTempFile('summary.jsonl');
+    appendLine(filePath, makeSummaryEntry('test summary'));
+    appendLine(filePath, makeUserEntry('after summary'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    expect(watcher.entryCount).toBe(2);
+    const entries = watcher.getEntries();
+    expect(entries[0]!.type).toBe('summary');
+    expect(entries[1]!.type).toBe('user');
+
+    watcher.stop();
+  });
+
+  test('getEntry retrieves by UUID', async () => {
+    const filePath = createTempFile('lookup.jsonl');
+    const uuid = crypto.randomUUID();
+    appendLine(filePath, makeUserEntry('findme', uuid));
+    appendLine(filePath, makeAssistantEntry('other'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    const found = watcher.getEntry(uuid) as UserEntry;
+    expect(found).toBeDefined();
+    expect(found.message.content).toBe('findme');
+
+    watcher.stop();
+  });
+
+  test('getAssistantText extracts text blocks only', async () => {
+    const filePath = createTempFile('text-extract.jsonl');
+    const entry = {
+      type: 'assistant',
+      uuid: crypto.randomUUID(),
+      parentUuid: null,
+      sessionId: 'test',
+      timestamp: new Date().toISOString(),
+      message: {
+        model: 'claude-opus-4-5-20251101',
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'internal thought' },
+          { type: 'text', text: 'visible response' },
+          { type: 'tool_use', id: 't1', name: 'Read', input: {} },
+          { type: 'text', text: 'more text' },
+        ],
+      },
+    };
+    appendLine(filePath, entry);
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    const assistants = watcher.getAssistantMessages();
+    const text = watcher.getAssistantText(assistants[0]!);
+    expect(text).toBe('visible response\nmore text');
+
+    watcher.stop();
+  });
+
+  test('getModel returns model from assistant entry', async () => {
+    const filePath = createTempFile('model.jsonl');
+    appendLine(filePath, makeAssistantEntry('test', undefined, 'claude-sonnet-4-20250514'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true });
+    await watcher.start();
+
+    const assistants = watcher.getAssistantMessages();
+    expect(watcher.getModel(assistants[0]!)).toBe('claude-sonnet-4-20250514');
+
+    watcher.stop();
+  });
+
+  test('handles malformed lines gracefully', async () => {
+    const filePath = createTempFile('malformed.jsonl');
+    fs.writeFileSync(
+      filePath,
+      `${JSON.stringify(makeUserEntry('good'))}\n` +
+        'not valid json\n' +
+        `${JSON.stringify(makeAssistantEntry('also good'))}\n`,
+    );
+
+    const errors: Error[] = [];
+    const watcher = new TranscriptWatcher(
+      { filePath, readExisting: true },
+      { onError: (e) => errors.push(e) },
+    );
+    await watcher.start();
+
+    expect(watcher.entryCount).toBe(2);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.message).toContain('Failed to parse');
+
+    watcher.stop();
+  });
+
+  test('stop cleans up watchers', async () => {
+    const filePath = createTempFile('cleanup.jsonl');
+    appendLine(filePath, makeUserEntry('test'));
+
+    const watcher = new TranscriptWatcher({ filePath, readExisting: true, pollIntervalMs: 50 });
+    await watcher.start();
+    expect(watcher.isRunning).toBe(true);
+
+    watcher.stop();
+    expect(watcher.isRunning).toBe(false);
+
+    // Appending after stop should not trigger events
+    appendLine(filePath, makeUserEntry('after stop'));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(watcher.entryCount).toBe(1); // Only the initial entry
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,9 @@ export type {
   Session,
   ConnectionInfo,
   Result,
+  SessionSource,
+  DiscoverableSessionStatus,
+  DiscoverableSession,
 } from './types.ts';
 
 export { ok, err, isOk, isErr } from './types.ts';
@@ -49,6 +52,8 @@ export type {
   ReplayBatchMessage,
   BulletExpandRequestMessage,
   BulletExpandResponseMessage,
+  SessionListRequestMessage,
+  SessionListResponseMessage,
 } from './protocol.ts';
 
 export {
@@ -71,5 +76,7 @@ export {
   createReplayBatch,
   createBulletExpandRequest,
   createBulletExpandResponse,
+  createSessionListRequest,
+  createSessionListResponse,
   MessageIdTracker,
 } from './protocol.ts';

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -248,7 +248,7 @@ export interface SessionListRequestMessage {
   readonly type: 'session_list_request';
   readonly id: UUID;
   readonly timestamp: Timestamp;
-  /** Whether to include completed/external sessions from transcript files */
+  /** Whether to include external sessions from transcript files. When omitted or false, only daemon-managed sessions are returned. */
   readonly includeExternal?: boolean | undefined;
 }
 
@@ -576,11 +576,10 @@ export function createBulletExpandResponse(
 }
 
 /**
- * Create a session list request message.
+ * Create a session list request. When includeExternal is true, the response
+ * will include sessions discovered from transcript files in addition to daemon-managed sessions.
  */
-export function createSessionListRequest(
-  includeExternal?: boolean,
-): SessionListRequestMessage {
+export function createSessionListRequest(includeExternal?: boolean): SessionListRequestMessage {
   return {
     type: 'session_list_request',
     id: generateId(),
@@ -590,7 +589,7 @@ export function createSessionListRequest(
 }
 
 /**
- * Create a session list response message.
+ * Create a session list response containing discovered sessions for a given request.
  */
 export function createSessionListResponse(
   sessions: readonly DiscoverableSession[],

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -14,6 +14,7 @@
 import type {
   Acknowledgment,
   AgentStatus,
+  DiscoverableSession,
   Message,
   Question,
   Session,
@@ -75,7 +76,9 @@ export type ProtocolMessage =
   | ErrorMessage
   | ReplayBatchMessage
   | BulletExpandRequestMessage
-  | BulletExpandResponseMessage;
+  | BulletExpandResponseMessage
+  | SessionListRequestMessage
+  | SessionListResponseMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -240,6 +243,26 @@ export interface BulletExpandResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Request list of discoverable sessions */
+export interface SessionListRequestMessage {
+  readonly type: 'session_list_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Whether to include completed/external sessions from transcript files */
+  readonly includeExternal?: boolean | undefined;
+}
+
+/** Response with list of discoverable sessions */
+export interface SessionListResponseMessage {
+  readonly type: 'session_list_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Discovered sessions */
+  readonly sessions: readonly DiscoverableSession[];
+  /** ID of the request this responds to */
+  readonly requestId: UUID;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -297,6 +320,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'replay_batch',
     'bullet_expand_request',
     'bullet_expand_response',
+    'session_list_request',
+    'session_list_response',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -546,6 +571,36 @@ export function createBulletExpandResponse(
     timestamp: now(),
     bulletId,
     fullContent,
+    requestId,
+  };
+}
+
+/**
+ * Create a session list request message.
+ */
+export function createSessionListRequest(
+  includeExternal?: boolean,
+): SessionListRequestMessage {
+  return {
+    type: 'session_list_request',
+    id: generateId(),
+    timestamp: now(),
+    ...(includeExternal !== undefined && { includeExternal }),
+  };
+}
+
+/**
+ * Create a session list response message.
+ */
+export function createSessionListResponse(
+  sessions: readonly DiscoverableSession[],
+  requestId: UUID,
+): SessionListResponseMessage {
+  return {
+    type: 'session_list_response',
+    id: generateId(),
+    timestamp: now(),
+    sessions,
     requestId,
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -239,7 +239,7 @@ export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error:
 /** How a session was discovered */
 export type SessionSource = 'daemon' | 'transcript';
 
-/** Session status for discovery */
+/** Session status for discovery. Daemon sessions use 'active'/'idle'/'orphaned'; transcript sessions use 'active'/'idle'/'completed'. */
 export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'completed';
 
 /**
@@ -250,13 +250,13 @@ export interface DiscoverableSession {
   /** Session ID (daemon UUID or Claude Code session ID from transcript path) */
   readonly sessionId: string;
 
-  /** Project path this session is working in */
+  /** Project path this session is working in. For transcript sessions, this is decoded from Claude Code's lossy path encoding and may be inaccurate for paths containing dashes. */
   readonly projectPath: string;
 
   /** Current session status */
   readonly status: DiscoverableSessionStatus;
 
-  /** When the session was last active */
+  /** When the session was last active. For daemon sessions: last disconnection time (or creation time if still connected). For transcript sessions: file modification time. */
   readonly lastActivity: Timestamp;
 
   /** Number of messages in the session */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -235,3 +235,42 @@ export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T
 export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
   return !result.ok;
 }
+
+/** How a session was discovered */
+export type SessionSource = 'daemon' | 'transcript';
+
+/** Session status for discovery */
+export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'completed';
+
+/**
+ * A session visible through the discovery mechanism.
+ * Combines daemon-managed sessions and externally-discovered transcript files.
+ */
+export interface DiscoverableSession {
+  /** Session ID (daemon UUID or Claude Code session ID from transcript path) */
+  readonly sessionId: string;
+
+  /** Project path this session is working in */
+  readonly projectPath: string;
+
+  /** Current session status */
+  readonly status: DiscoverableSessionStatus;
+
+  /** When the session was last active */
+  readonly lastActivity: Timestamp;
+
+  /** Number of messages in the session */
+  readonly messageCount: number;
+
+  /** Model being used (if known) */
+  readonly model?: string | undefined;
+
+  /** Preview of the last message (truncated) */
+  readonly lastMessage?: string | undefined;
+
+  /** How this session was discovered */
+  readonly source: SessionSource;
+
+  /** Whether this session can be attached to (daemon-managed only) */
+  readonly canAttach: boolean;
+}


### PR DESCRIPTION
## Summary
- Add session discovery protocol (DiscoverableSession type, session_list_request/response messages)
- Add SessionRegistry.listSessions() for daemon-managed sessions
- Add TranscriptWatcher: watches Claude Code JSONL files (read-only) for clean content
- Add TranscriptDiscovery: scans ~/.claude/projects/ for external sessions
- Wire full event chain from client through to CLI handler
- Integrate transcript watcher lifecycle with session management

## Design Decisions
- Transcript files are treated as READ-ONLY; we never modify Claude's data
- TranscriptWatcher stores entries in-memory (keyed by UUID for dedup)
- TranscriptDiscovery reads only the last 8KB of each file for metadata
- Session list can include both daemon-managed and external transcript sessions

## Test plan
- [x] 23 new tests for TranscriptWatcher and TranscriptDiscovery
- [x] All use real filesystem operations (no mocks)
- [x] 237 total tests passing
- [x] Type checking passes for daemon and shared packages