### PR TITLE
feat: two-phase message delivery via transcript bridge

### DIFF
--- a/packages/daemon/src/api/bullet-content-registry.ts
+++ b/packages/daemon/src/api/bullet-content-registry.ts
@@ -31,6 +31,8 @@ export class BulletContentRegistry {
   private readonly content: Map<number, ContentEntry> = new Map();
   private readonly maxBullets: number;
   private readonly maxAgeMs: number;
+  private getCallCount = 0;
+  private static readonly PRUNE_EVERY_N_GETS = 100;
 
   constructor(config?: BulletContentRegistryConfig) {
     this.maxBullets = config?.maxBullets ?? DEFAULT_MAX_BULLETS;
@@ -45,7 +47,7 @@ export class BulletContentRegistry {
     // Prune old entries before storing
     this.prune();
 
-    // If at capacity, remove oldest entries
+    // If at capacity, remove oldest entries to make room
     if (this.content.size >= this.maxBullets) {
       this.removeOldest(Math.ceil(this.maxBullets * 0.1)); // Remove 10%
     }
@@ -61,6 +63,13 @@ export class BulletContentRegistry {
    * Returns null if not found or expired.
    */
   get(bulletId: number): string | null {
+    // Periodically prune expired entries on reads
+    this.getCallCount++;
+    if (this.getCallCount >= BulletContentRegistry.PRUNE_EVERY_N_GETS) {
+      this.getCallCount = 0;
+      this.prune();
+    }
+
     const entry = this.content.get(bulletId);
     if (!entry) {
       return null;

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -257,7 +257,9 @@ async function createNewSession(
         // Trigger transcript read on status transitions (new content likely available)
         const watcher = transcriptWatchers.get(sessionId);
         if (watcher) {
-          watcher.forceRead();
+          watcher.forceRead().catch((err) => {
+            console.error(`[Transcript] forceRead failed for session ${sessionId}:`, err);
+          });
         }
       },
     },
@@ -459,7 +461,7 @@ const sharedEvents = {
 
     if ('error' in dirResult) {
       console.error(`Directory error: ${dirResult.error}`);
-      // TODO: Send error message to client
+      sendToConnection(connectionId, createError('INVALID_DIRECTORY', dirResult.error));
       return;
     }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -46,6 +46,7 @@ if (fs.existsSync(envPath)) {
 }
 import {
   createBulletExpandResponse,
+  createError,
   createHelloAck,
   createReplayBatch,
   createSessionListResponse,
@@ -543,12 +544,17 @@ const sharedEvents = {
     const session = sessionRegistry.getSession(sessionId);
     if (!session) {
       console.warn(`Bullet expand: session ${sessionId} not found`);
+      sendToConnection(connectionId, createError('NOT_FOUND', `Session ${sessionId} not found`));
       return;
     }
 
     const fullContent = session.messageApi.getFullBulletContent(bulletId);
     if (fullContent === null) {
       console.warn(`Bullet expand: content for bullet ${bulletId} not found or expired`);
+      sendToConnection(
+        connectionId,
+        createError('CONTENT_EXPIRED', `Content for bullet ${bulletId} not found or expired`),
+      );
       return;
     }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -49,7 +49,6 @@ import {
   createHelloAck,
   createReplayBatch,
   createSessionListResponse,
-  createStructuredAgentOutput,
   generateId,
   now,
 } from '@remi/shared';
@@ -64,7 +63,11 @@ import { MessageAPI } from './api/index.ts';
 import { OutputProcessor } from './parser/index.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
 import { SessionRegistry } from './session/index.ts';
-import { TranscriptDiscovery, TranscriptWatcher } from './transcript/index.ts';
+import {
+  TranscriptDiscovery,
+  TranscriptMessageBridge,
+  TranscriptWatcher,
+} from './transcript/index.ts';
 import type { AssistantEntry } from './transcript/index.ts';
 
 /**
@@ -211,7 +214,7 @@ async function createNewSession(
     sessionRegistry.recordOutgoingMessage(sessionId, message);
   };
 
-  // Create MessageAPI with event handlers for adapters
+  // Create MessageAPI for bullet structuring (content delivery via transcript bridge)
   const messageApi = new MessageAPI(
     {
       sessionId: sessionId,
@@ -219,17 +222,6 @@ async function createNewSession(
       maxBulletLength: MAX_BULLET_LENGTH,
     },
     {
-      onStructuredMessage: (message) => {
-        const bulletCount = message.bullets.length;
-        console.log(
-          `New message with ${bulletCount} bullets (IDs: ${message.firstBulletId}-${message.lastBulletId})`,
-        );
-        sendAndRecord(createStructuredAgentOutput(message, false));
-      },
-      onStructuredMessageUpdate: (msgId, message, changedBulletIds) => {
-        console.log(`Update message ${msgId}: ${changedBulletIds.length} bullets changed`);
-        sendAndRecord(createStructuredAgentOutput(message, true, changedBulletIds));
-      },
       onMessageFinalized: (msgId) => {
         console.log(`Message ${msgId} finalized`);
       },
@@ -260,6 +252,12 @@ async function createNewSession(
         };
         sendAndRecord(msg);
         sessionRegistry.updateStatus(sessionId, status);
+
+        // Trigger transcript read on status transitions (new content likely available)
+        const watcher = transcriptWatchers.get(sessionId);
+        if (watcher) {
+          watcher.forceRead();
+        }
       },
     },
   );
@@ -293,11 +291,12 @@ async function createNewSession(
     },
   );
 
-  // Create output processor that feeds into MessageAPI
+  // Create output processor (streamStatusOnly: transcript bridge handles content)
   const processor = new OutputProcessor(
     {
       sessionId: sessionId,
       updateThrottleMs: 100,
+      streamStatusOnly: true,
     },
     {
       onMessage: (message) => {
@@ -331,23 +330,42 @@ async function createNewSession(
         if (!sessionRegistry.hasSession(sessionId)) return;
         const retryPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
         if (retryPath) {
-          startTranscriptWatcher(sessionId, retryPath);
+          startTranscriptWatcher(sessionId, retryPath, messageApi, sendAndRecord);
         } else {
           console.warn(`Could not find transcript file for session ${sessionId}`);
         }
       }, 5000);
       return;
     }
-    startTranscriptWatcher(sessionId, transcriptPath);
+    startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
   }, 2000);
 }
 
 /**
  * Start watching a transcript file for a session.
- * Emits clean message content from Claude Code's transcript.
+ * Uses TranscriptMessageBridge for clean content delivery via protocol messages.
  */
-function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
+function startTranscriptWatcher(
+  sessionId: UUID,
+  transcriptPath: string,
+  messageApi: MessageAPI,
+  sendAndRecord: (message: ProtocolMessage) => void,
+): void {
   console.log(`Watching transcript: ${transcriptPath}`);
+
+  const bridge = new TranscriptMessageBridge(
+    { sessionId },
+    messageApi,
+    {
+      onTranscriptContent: (message) => {
+        console.log(
+          `[Transcript] ${message.role} content (${message.content.length} chars)` +
+            `${message.model ? ` [${message.model}]` : ''}`,
+        );
+        sendAndRecord(message);
+      },
+    },
+  );
 
   const watcher = new TranscriptWatcher(
     {
@@ -357,18 +375,10 @@ function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
     },
     {
       onAssistantMessage: (entry: AssistantEntry) => {
-        const textContent = extractAssistantText(entry);
-        if (textContent) {
-          console.log(
-            `[Transcript] Assistant message: ${textContent.slice(0, 80)}...` +
-              `${entry.message.model ? ` (${entry.message.model})` : ''}`,
-          );
-        }
+        bridge.handleAssistantEntry(entry);
       },
       onUserMessage: (entry) => {
-        const content =
-          typeof entry.message.content === 'string' ? entry.message.content : '[complex content]';
-        console.log(`[Transcript] User message: ${content.slice(0, 80)}`);
+        bridge.handleUserEntry(entry);
       },
       onError: (error) => {
         console.error(`[Transcript] Error for session ${sessionId}:`, error.message);
@@ -380,14 +390,6 @@ function startTranscriptWatcher(sessionId: UUID, transcriptPath: string): void {
   watcher.start().catch((error) => {
     console.error(`[Transcript] Failed to start watcher for session ${sessionId}:`, error);
   });
-}
-
-/**
- * Extract clean text from an assistant entry (no thinking, no tool_use).
- */
-function extractAssistantText(entry: AssistantEntry): string {
-  const textBlocks = entry.message.content.filter((b) => b.type === 'text');
-  return textBlocks.map((b) => (b as { text: string }).text).join('\n');
 }
 
 // Create adapter registry with shared event handlers

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -42,6 +42,10 @@ export interface ProcessorConfig {
 
   /** Buffer size before forcing message creation */
   readonly bufferSize?: number;
+
+  /** If true, only emit status and question events (no message content).
+   * Used in two-phase delivery mode where transcript provides clean content. */
+  readonly streamStatusOnly?: boolean;
 }
 
 const DEFAULT_UPDATE_THROTTLE_MS = 50;
@@ -74,6 +78,7 @@ export class OutputProcessor {
       sessionId: config.sessionId,
       updateThrottleMs: config.updateThrottleMs ?? DEFAULT_UPDATE_THROTTLE_MS,
       bufferSize: config.bufferSize ?? DEFAULT_BUFFER_SIZE,
+      streamStatusOnly: config.streamStatusOnly ?? false,
     };
     this.events = events;
   }
@@ -217,7 +222,9 @@ export class OutputProcessor {
               isEditing: true,
               tool,
             };
-            this.events.onMessage?.(message);
+            if (!this.config.streamStatusOnly) {
+              this.events.onMessage?.(message);
+            }
             this.hasEmittedCurrentMessage = true;
           }
         }
@@ -274,18 +281,24 @@ export class OutputProcessor {
         tool,
       };
 
-      this.events.onMessage?.(message);
+      if (!this.config.streamStatusOnly) {
+        this.events.onMessage?.(message);
+      }
       this.hasEmittedCurrentMessage = true;
     } else {
       // Update existing message
-      this.events.onMessageUpdate?.(this.currentMessageId!, this.currentMessageContent, tool);
+      if (!this.config.streamStatusOnly) {
+        this.events.onMessageUpdate?.(this.currentMessageId!, this.currentMessageContent, tool);
+      }
     }
   }
 
   private finalizeMessage(): void {
     if (this.currentMessageId !== null) {
       // Final update with isEditing = false
-      this.events.onMessageUpdate?.(this.currentMessageId, this.currentMessageContent, undefined);
+      if (!this.config.streamStatusOnly) {
+        this.events.onMessageUpdate?.(this.currentMessageId, this.currentMessageContent, undefined);
+      }
     }
 
     this.currentMessageId = null;

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -294,11 +294,16 @@ export class Connection {
       return;
     }
 
+    if (!this.events.onBulletExpandRequest) {
+      this.sendError('UNSUPPORTED', 'Bullet expansion not available');
+      return;
+    }
+
     // Acknowledge receipt
     this.sendAck(message.id, 'delivered');
 
     // Notify - the CLI will handle sending the response
-    this.events.onBulletExpandRequest?.(message.sessionId, message.bulletId, message.id);
+    this.events.onBulletExpandRequest(message.sessionId, message.bulletId, message.id);
   }
 
   private handleSessionListRequest(message: SessionListRequestMessage): void {

--- a/packages/daemon/src/transcript/index.ts
+++ b/packages/daemon/src/transcript/index.ts
@@ -7,7 +7,12 @@
 
 export { TranscriptWatcher } from './transcript-watcher.ts';
 export { TranscriptDiscovery } from './transcript-discovery.ts';
+export { TranscriptMessageBridge } from './transcript-message-bridge.ts';
 export type { TranscriptDiscoveryConfig } from './transcript-discovery.ts';
+export type {
+  TranscriptMessageBridgeConfig,
+  TranscriptMessageBridgeEvents,
+} from './transcript-message-bridge.ts';
 export type {
   AssistantEntry,
   ContentBlock,

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -65,11 +65,16 @@ export class TranscriptMessageBridge {
     if (this.processedEntryUuids.has(entry.uuid)) {
       return; // Already processed
     }
-    this.processedEntryUuids.add(entry.uuid);
 
     const textContent = this.extractTextContent(entry.message.content);
     const tools = this.extractToolNames(entry.message.content);
     const hadThinking = this.hasThinkingBlocks(entry.message.content);
+
+    // Skip entries with no meaningful content (pure tool invocations with no text)
+    if (!textContent && tools.length === 0) {
+      this.processedEntryUuids.add(entry.uuid);
+      return;
+    }
 
     // Create a Message for the MessageAPI to structure with bullets
     const message: Message = {
@@ -87,6 +92,9 @@ export class TranscriptMessageBridge {
     this.messageApi.handleMessage(message);
     const structured = this.messageApi.getMessage(message.id);
     if (!structured) return;
+
+    // Only mark as processed after successful structuring
+    this.processedEntryUuids.add(entry.uuid);
 
     // Emit the transcript content message
     const transcriptMessage = createTranscriptContent(
@@ -115,7 +123,6 @@ export class TranscriptMessageBridge {
     if (this.processedEntryUuids.has(entry.uuid)) {
       return; // Already processed
     }
-    this.processedEntryUuids.add(entry.uuid);
 
     const content =
       typeof entry.message.content === 'string'
@@ -137,6 +144,9 @@ export class TranscriptMessageBridge {
     this.messageApi.handleMessage(message);
     const structured = this.messageApi.getMessage(message.id);
     if (!structured) return;
+
+    // Only mark as processed after successful structuring
+    this.processedEntryUuids.add(entry.uuid);
 
     const transcriptMessage = createTranscriptContent(
       this.sessionId,

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -1,0 +1,186 @@
+/**
+ * TranscriptMessageBridge - Maps transcript entries to protocol messages.
+ *
+ * Sits between TranscriptWatcher and MessageAPI, converting clean
+ * transcript entries into structured messages for client delivery.
+ *
+ * Part of the two-phase message delivery system:
+ * - Phase 1 (PTY): Real-time status and question detection
+ * - Phase 2 (Transcript): Clean content delivery via this bridge
+ */
+
+import type {
+  Message,
+  StructuredMessage,
+  TranscriptContentMessage,
+  UUID,
+} from '@remi/shared';
+import { createTranscriptContent, generateId, now } from '@remi/shared';
+import type { MessageAPI } from '../api/message-api.ts';
+import type { AssistantEntry, ContentBlock, UserEntry } from './types.ts';
+
+/** Configuration for TranscriptMessageBridge */
+export interface TranscriptMessageBridgeConfig {
+  readonly sessionId: UUID;
+}
+
+/** Events emitted by TranscriptMessageBridge */
+export interface TranscriptMessageBridgeEvents {
+  /** New transcript content ready to send to client */
+  onTranscriptContent: (message: TranscriptContentMessage) => void;
+}
+
+/**
+ * Maps TranscriptWatcher events to TranscriptContentMessage protocol messages.
+ *
+ * Deduplicates entries by UUID to prevent re-processing on overlapping reads.
+ * Extracts clean text content, tool names, and metadata from entries.
+ */
+export class TranscriptMessageBridge {
+  private readonly sessionId: UUID;
+  private readonly messageApi: MessageAPI;
+  private readonly events: Partial<TranscriptMessageBridgeEvents>;
+  private readonly processedEntryUuids: Set<string> = new Set();
+
+  constructor(
+    config: TranscriptMessageBridgeConfig,
+    messageApi: MessageAPI,
+    events: Partial<TranscriptMessageBridgeEvents> = {},
+  ) {
+    this.sessionId = config.sessionId;
+    this.messageApi = messageApi;
+    this.events = events;
+  }
+
+  /** Number of entries processed so far */
+  get processedCount(): number {
+    return this.processedEntryUuids.size;
+  }
+
+  /**
+   * Handle an assistant entry from TranscriptWatcher.
+   * Extracts text content, tool names, and emits a TranscriptContentMessage.
+   */
+  handleAssistantEntry(entry: AssistantEntry): void {
+    if (this.processedEntryUuids.has(entry.uuid)) {
+      return; // Already processed
+    }
+    this.processedEntryUuids.add(entry.uuid);
+
+    const textContent = this.extractTextContent(entry.message.content);
+    const tools = this.extractToolNames(entry.message.content);
+    const hadThinking = this.hasThinkingBlocks(entry.message.content);
+
+    // Create a Message for the MessageAPI to structure with bullets
+    const message: Message = {
+      id: generateId(),
+      sessionId: this.sessionId,
+      sender: 'agent',
+      content: textContent,
+      createdAt: entry.timestamp ?? now(),
+      state: 'delivered',
+      stateChangedAt: now(),
+      isEditing: false,
+    };
+
+    // Structure the message (assigns bullet IDs)
+    this.messageApi.handleMessage(message);
+    const structured = this.messageApi.getMessage(message.id);
+    if (!structured) return;
+
+    // Emit the transcript content message
+    const transcriptMessage = createTranscriptContent(
+      this.sessionId,
+      entry.uuid,
+      'assistant',
+      textContent,
+      structured,
+      false, // not an update
+      {
+        ...(tools.length > 0 && { tools }),
+        ...(entry.message.model != null && { model: entry.message.model }),
+        ...(hadThinking && { hadThinking }),
+        ...(entry.message.usage != null && { usage: entry.message.usage }),
+      },
+    );
+
+    this.events.onTranscriptContent?.(transcriptMessage);
+  }
+
+  /**
+   * Handle a user entry from TranscriptWatcher.
+   * Emits a TranscriptContentMessage for user messages.
+   */
+  handleUserEntry(entry: UserEntry): void {
+    if (this.processedEntryUuids.has(entry.uuid)) {
+      return; // Already processed
+    }
+    this.processedEntryUuids.add(entry.uuid);
+
+    const content =
+      typeof entry.message.content === 'string'
+        ? entry.message.content
+        : this.extractTextContent(entry.message.content as readonly ContentBlock[]);
+
+    // Create a Message for the MessageAPI
+    const message: Message = {
+      id: generateId(),
+      sessionId: this.sessionId,
+      sender: 'user',
+      content,
+      createdAt: entry.timestamp ?? now(),
+      state: 'delivered',
+      stateChangedAt: now(),
+      isEditing: false,
+    };
+
+    this.messageApi.handleMessage(message);
+    const structured = this.messageApi.getMessage(message.id);
+    if (!structured) return;
+
+    const transcriptMessage = createTranscriptContent(
+      this.sessionId,
+      entry.uuid,
+      'user',
+      content,
+      structured,
+      false,
+    );
+
+    this.events.onTranscriptContent?.(transcriptMessage);
+  }
+
+  /**
+   * Extract text content from content blocks.
+   * Filters out thinking, tool_use, and tool_result blocks.
+   */
+  private extractTextContent(blocks: readonly ContentBlock[]): string {
+    return blocks
+      .filter((block): block is ContentBlock & { type: 'text' } => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n');
+  }
+
+  /**
+   * Extract tool names from content blocks.
+   */
+  private extractToolNames(blocks: readonly ContentBlock[]): string[] {
+    return blocks
+      .filter((block): block is ContentBlock & { type: 'tool_use' } => block.type === 'tool_use')
+      .map((block) => block.name);
+  }
+
+  /**
+   * Check if any content blocks are thinking blocks.
+   */
+  private hasThinkingBlocks(blocks: readonly ContentBlock[]): boolean {
+    return blocks.some((block) => block.type === 'thinking');
+  }
+
+  /**
+   * Reset state (for session cleanup).
+   */
+  reset(): void {
+    this.processedEntryUuids.clear();
+  }
+}

--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -111,6 +111,17 @@ export class TranscriptWatcher {
   }
 
   /**
+   * Force an immediate read of new entries.
+   * Useful when an external signal (e.g., PTY idle) indicates
+   * new transcript data is available without waiting for the poll cycle.
+   */
+  async forceRead(): Promise<void> {
+    if (this.running) {
+      await this.readNewEntries();
+    }
+  }
+
+  /**
    * Start watching the transcript file.
    * If readExisting is true, reads all existing entries first.
    */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,6 +54,8 @@ export type {
   BulletExpandResponseMessage,
   SessionListRequestMessage,
   SessionListResponseMessage,
+  TranscriptContentMessage,
+  TranscriptUsage,
 } from './protocol.ts';
 
 export {
@@ -78,5 +80,6 @@ export {
   createBulletExpandResponse,
   createSessionListRequest,
   createSessionListResponse,
+  createTranscriptContent,
   MessageIdTracker,
 } from './protocol.ts';

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -665,10 +665,10 @@ export function createTranscriptContent(
     content,
     message,
     isUpdate,
-    ...(options?.tools && { tools: options.tools }),
-    ...(options?.model && { model: options.model }),
-    ...(options?.hadThinking && { hadThinking: options.hadThinking }),
-    ...(options?.usage && { usage: options.usage }),
+    ...(options?.tools != null && options.tools.length > 0 && { tools: options.tools }),
+    ...(options?.model != null && options.model !== '' && { model: options.model }),
+    ...(options?.hadThinking != null && { hadThinking: options.hadThinking }),
+    ...(options?.usage != null && { usage: options.usage }),
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -78,7 +78,8 @@ export type ProtocolMessage =
   | BulletExpandRequestMessage
   | BulletExpandResponseMessage
   | SessionListRequestMessage
-  | SessionListResponseMessage;
+  | SessionListResponseMessage
+  | TranscriptContentMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -263,6 +264,38 @@ export interface SessionListResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Token usage information from a transcript entry */
+export interface TranscriptUsage {
+  readonly input_tokens?: number | undefined;
+  readonly output_tokens?: number | undefined;
+}
+
+/** Transcript-sourced content message (Phase 2 of two-phase delivery) */
+export interface TranscriptContentMessage {
+  readonly type: 'transcript_content';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  readonly sessionId: UUID;
+  /** Unique transcript entry UUID from Claude Code */
+  readonly entryUuid: string;
+  /** Message role */
+  readonly role: 'user' | 'assistant';
+  /** Clean text content (text blocks only, no thinking/tool_use) */
+  readonly content: string;
+  /** Tool names invoked in this turn */
+  readonly tools?: readonly string[] | undefined;
+  /** Model used (assistant entries only) */
+  readonly model?: string | undefined;
+  /** Whether thinking blocks were present */
+  readonly hadThinking?: boolean | undefined;
+  /** Token usage (if available) */
+  readonly usage?: TranscriptUsage | undefined;
+  /** Structured message with bullets */
+  readonly message: StructuredMessage;
+  /** Whether this updates a previously sent entry */
+  readonly isUpdate: boolean;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -322,6 +355,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'bullet_expand_response',
     'session_list_request',
     'session_list_response',
+    'transcript_content',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -601,6 +635,40 @@ export function createSessionListResponse(
     timestamp: now(),
     sessions,
     requestId,
+  };
+}
+
+/**
+ * Create a transcript content message (Phase 2 content delivery).
+ */
+export function createTranscriptContent(
+  sessionId: UUID,
+  entryUuid: string,
+  role: 'user' | 'assistant',
+  content: string,
+  message: StructuredMessage,
+  isUpdate: boolean,
+  options?: {
+    tools?: readonly string[];
+    model?: string;
+    hadThinking?: boolean;
+    usage?: TranscriptUsage;
+  },
+): TranscriptContentMessage {
+  return {
+    type: 'transcript_content',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    entryUuid,
+    role,
+    content,
+    message,
+    isUpdate,
+    ...(options?.tools && { tools: options.tools }),
+    ...(options?.model && { model: options.model }),
+    ...(options?.hadThinking && { hadThinking: options.hadThinking }),
+    ...(options?.usage && { usage: options.usage }),
   };
 }
 


### PR DESCRIPTION
## Summary

- Implements two-phase message delivery: Phase 1 (PTY) streams real-time status and question detection, Phase 2 (Transcript) delivers clean structured content via TranscriptMessageBridge
- Adds `TranscriptContentMessage` protocol type with metadata (tools, model, usage, thinking)
- Adds `streamStatusOnly` mode to OutputProcessor (suppresses message content from PTY)
- Adds `forceRead()` to TranscriptWatcher for immediate transcript reads on status transitions
- Creates TranscriptMessageBridge component for entry-to-protocol mapping with deduplication
- Fixes bullet-truncation review issues: error responses for missing content, periodic registry pruning, connection handler validation

## Test plan

- [x] All 378 tests pass, 0 failures
- [x] Zero type errors in daemon/shared packages
- [x] Bullet-truncation review issues addressed (silent failures, memory leak, handler validation)
- [ ] Manual test: start daemon, connect client, verify status/question events from PTY
- [ ] Manual test: verify transcript content messages arrive after agent completes
- [ ] Manual test: verify bullet expand still works with error responses on missing content