### PR TITLE
feat: Telegram adapter session discovery and transcript content

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "organizeImports": { "enabled": true },
   "linter": {
     "enabled": true,
     "rules": {
@@ -44,6 +42,14 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".git", "*.md", "packages/web", "packages/daemon/scripts"]
+    "include": ["**"],
+    "ignore": [
+      "**/node_modules",
+      "**/dist",
+      "**/.git",
+      "**/*.md",
+      "**/packages/web",
+      "**/packages/daemon/scripts"
+    ]
   }
 }

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -17,9 +17,12 @@ import type {
   Question,
   QuestionMessage,
   SessionUpdateMessage,
+  TranscriptContentMessage,
   UUID,
 } from '@remi/shared';
 import { Bot, type Context } from 'grammy';
+import type { SessionRegistry } from '../session/session-registry.ts';
+import type { TranscriptDiscovery } from '../transcript/transcript-discovery.ts';
 import type {
   AdapterConfig,
   AdapterEvents,
@@ -30,6 +33,8 @@ import {
   formatHelpMessage,
   formatMessageForTelegram,
   formatQuestionKeyboard,
+  formatSessionListForTelegram,
+  formatTranscriptContentForTelegram,
   isValidContent,
   stripTerminalCodes,
 } from './telegram-ui.ts';
@@ -72,6 +77,15 @@ export interface TelegramAdapterConfig extends AdapterConfig {
 
   /** Default working directory for new sessions */
   readonly defaultDirectory?: string;
+}
+
+/** Optional dependencies for session discovery features */
+export interface TelegramAdapterDependencies {
+  /** Session registry for listing daemon-managed sessions */
+  readonly sessionRegistry?: SessionRegistry;
+
+  /** Transcript discovery for listing external sessions */
+  readonly transcriptDiscovery?: TranscriptDiscovery;
 }
 
 /** Session binding - maps Telegram topic to Claude session */
@@ -124,6 +138,7 @@ export class TelegramAdapter implements ConnectionAdapter {
 
   private readonly config: TelegramAdapterConfig;
   private readonly events: Partial<AdapterEvents>;
+  private readonly deps: TelegramAdapterDependencies;
 
   private bot: Bot | null = null;
   private running = false;
@@ -137,13 +152,18 @@ export class TelegramAdapter implements ConnectionAdapter {
   /** Session counters per directory */
   private readonly sessionCounters: Map<string, number> = new Map();
 
-  constructor(config: TelegramAdapterConfig, events: Partial<AdapterEvents> = {}) {
+  constructor(
+    config: TelegramAdapterConfig,
+    events: Partial<AdapterEvents> = {},
+    deps: TelegramAdapterDependencies = {},
+  ) {
     this.config = {
       enabled: config.enabled ?? true,
       token: config.token,
       defaultDirectory: config.defaultDirectory ?? process.cwd(),
     };
     this.events = events;
+    this.deps = deps;
   }
 
   get connectionCount(): number {
@@ -284,7 +304,31 @@ export class TelegramAdapter implements ConnectionAdapter {
     if (message.type === 'session_update') {
       return this.sendStatus(connectionId, (message as SessionUpdateMessage).session.status);
     }
+    if (message.type === 'transcript_content') {
+      return this.sendTranscriptContent(connectionId, message as TranscriptContentMessage);
+    }
     return false;
+  }
+
+  /**
+   * Send transcript content to Telegram.
+   * Formats the structured content for Telegram display.
+   */
+  private sendTranscriptContent(connectionId: UUID, message: TranscriptContentMessage): boolean {
+    const sessionKey = this.connectionToSession.get(connectionId);
+    if (!sessionKey) return false;
+
+    const session = this.sessions.get(sessionKey);
+    if (!session || !this.bot || session.paused) return false;
+
+    const formatted = formatTranscriptContentForTelegram(message);
+    if (!formatted || !isValidContent(formatted)) return true;
+
+    this.streamMessage(session, formatted).catch((err) => {
+      console.error('Failed to send transcript content:', err);
+    });
+
+    return true;
   }
 
   broadcast(message: ProtocolMessage): void {
@@ -348,6 +392,21 @@ export class TelegramAdapter implements ConnectionAdapter {
     // Handle /help command
     this.bot.command('help', async (ctx) => {
       await this.handleHelp(ctx);
+    });
+
+    // Handle /sessions command - list discoverable sessions
+    this.bot.command('sessions', async (ctx) => {
+      await this.handleSessions(ctx);
+    });
+
+    // Handle /attach command - attach to existing session
+    this.bot.command('attach', async (ctx) => {
+      await this.handleAttach(ctx);
+    });
+
+    // Handle /detach command - detach without killing session
+    this.bot.command('detach', async (ctx) => {
+      await this.handleDetach(ctx);
     });
 
     // Handle callback queries (button presses)
@@ -547,6 +606,161 @@ export class TelegramAdapter implements ConnectionAdapter {
 
   private async handleHelp(ctx: Context): Promise<void> {
     await ctx.reply(formatHelpMessage());
+  }
+
+  /**
+   * Handle /sessions command - list all discoverable sessions.
+   * Works without requiring an active session in the current topic.
+   */
+  private async handleSessions(ctx: Context): Promise<void> {
+    const chatId = ctx.chat?.id;
+    if (!chatId) {
+      await ctx.reply('Unable to determine chat context.');
+      return;
+    }
+
+    if (!this.deps.sessionRegistry) {
+      await ctx.reply('Session discovery not available.');
+      return;
+    }
+
+    try {
+      // Get daemon-managed sessions
+      const daemonSessions = this.deps.sessionRegistry.listSessions();
+
+      // Get transcript sessions (exclude daemon-managed ones)
+      let allSessions = [...daemonSessions];
+      if (this.deps.transcriptDiscovery) {
+        const managedIds = new Set(this.deps.sessionRegistry.getActiveSessionIds());
+        const transcriptSessions = this.deps.transcriptDiscovery.discoverSessions(managedIds);
+        allSessions = [...daemonSessions, ...transcriptSessions];
+      }
+
+      // Format and send
+      const formatted = formatSessionListForTelegram(allSessions);
+      await ctx.reply(formatted);
+    } catch (error) {
+      console.error('Failed to list sessions:', error);
+      await ctx.reply('Failed to fetch sessions. Please try again.');
+    }
+  }
+
+  /**
+   * Handle /attach command - attach to an existing daemon session.
+   * Creates a new topic and binds it to the target session.
+   */
+  private async handleAttach(ctx: Context): Promise<void> {
+    const chatId = ctx.chat?.id;
+    if (!chatId) {
+      await ctx.reply('Unable to determine chat context.');
+      return;
+    }
+
+    const sessionIdArg = ctx.match?.toString().trim();
+    if (!sessionIdArg) {
+      await ctx.reply('Usage: /attach <session-id>\nUse /sessions to see available sessions.');
+      return;
+    }
+
+    // Validate UUID format (at least starts like one)
+    const uuidPattern = /^[0-9a-f]{8}-?/i;
+    if (!uuidPattern.test(sessionIdArg)) {
+      await ctx.reply('Invalid session ID format. Use /sessions to see available sessions.');
+      return;
+    }
+
+    if (!this.deps.sessionRegistry) {
+      await ctx.reply('Session attachment not available.');
+      return;
+    }
+
+    // Check if session can be resumed
+    if (!this.deps.sessionRegistry.canResume(sessionIdArg as UUID)) {
+      await ctx.reply(
+        'Session not found or cannot be attached.\n' +
+          'Only orphaned daemon sessions can be attached.\n' +
+          'Use /sessions to see available sessions.',
+      );
+      return;
+    }
+
+    try {
+      // Check forum mode
+      const chat = await ctx.api.getChat(chatId);
+      if (chat.type !== 'supergroup' || !('is_forum' in chat) || !chat.is_forum) {
+        await ctx.reply('Forum mode required. Enable Topics in group settings.');
+        return;
+      }
+
+      // Create new topic for attached session
+      const topicName = `attached-${sessionIdArg.slice(0, 8)}`;
+      const topic = await ctx.api.createForumTopic(chatId, topicName);
+      const topicId = topic.message_thread_id;
+
+      // Create session binding
+      const connectionId = generateId();
+      const sessionKey = `${chatId}:${topicId}`;
+
+      const session: SessionBinding = {
+        connectionId,
+        sessionId: sessionIdArg as UUID,
+        chatId,
+        topicId,
+        workingDirectory: '', // Will be filled from session info
+        machineName: os.hostname().replace(/\./g, '-').toLowerCase(),
+        topicName,
+        sessionNumber: 0,
+        startedAt: now(),
+        currentMessageId: undefined,
+        streamBuffer: '',
+        lastSentContent: '',
+        paused: false,
+      };
+
+      this.sessions.set(sessionKey, session);
+      this.connectionToSession.set(connectionId, sessionKey);
+
+      // Notify daemon - will attempt resume
+      const metadata: AdapterMetadata = {
+        adapterType: this.type,
+        displayName: topicName,
+        platformData: {
+          chatId,
+          topicId,
+          resumeSessionId: sessionIdArg,
+        },
+      };
+      this.events.onConnect?.(connectionId, metadata);
+
+      await ctx.reply(`Attaching to session in new topic "${topicName}"`);
+    } catch (error) {
+      console.error('Failed to attach to session:', error);
+      await ctx.reply('Failed to attach to session. Check bot permissions.');
+    }
+  }
+
+  /**
+   * Handle /detach command - detach from session without killing it.
+   * Session stays orphaned and can be reattached within 5 minutes.
+   */
+  private async handleDetach(ctx: Context): Promise<void> {
+    const session = this.getSessionFromContext(ctx);
+    if (!session) {
+      await ctx.reply('No active session in this topic.');
+      return;
+    }
+
+    // Remove from adapter maps
+    const sessionKey = `${session.chatId}:${session.topicId}`;
+    this.sessions.delete(sessionKey);
+    this.connectionToSession.delete(session.connectionId);
+
+    // Notify daemon (session stays orphaned for 5 minutes)
+    this.events.onDisconnect?.(session.connectionId, 'User detached from session');
+
+    await ctx.reply(
+      `Detached from session. Session remains active for 5 minutes.\nUse /attach ${session.sessionId} to reconnect.`,
+    );
   }
 
   private async handleAnswerCallback(ctx: Context): Promise<void> {

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -5,7 +5,6 @@
  * Each Claude Code session = one topic thread.
  */
 
-import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { generateId, now } from '@remi/shared';
@@ -23,6 +22,7 @@ import type {
 import { Bot, type Context } from 'grammy';
 import type { SessionRegistry } from '../session/session-registry.ts';
 import type { TranscriptDiscovery } from '../transcript/transcript-discovery.ts';
+import { resolveDirectory } from '../utils/path-resolver.ts';
 import type {
   AdapterConfig,
   AdapterEvents,
@@ -38,37 +38,6 @@ import {
   isValidContent,
   stripTerminalCodes,
 } from './telegram-ui.ts';
-
-/**
- * Resolve a directory path, expanding ~ and validating it exists.
- * Returns null with error message if invalid.
- */
-function resolveDirectory(inputPath: string): { resolved: string } | { error: string } {
-  let resolved = inputPath;
-
-  // Expand ~ to home directory
-  if (resolved.startsWith('~/')) {
-    resolved = path.join(os.homedir(), resolved.slice(2));
-  } else if (resolved === '~') {
-    resolved = os.homedir();
-  }
-
-  // Resolve to absolute path
-  resolved = path.resolve(resolved);
-
-  // Check if directory exists
-  if (!fs.existsSync(resolved)) {
-    return { error: `Directory not found: ${resolved}` };
-  }
-
-  // Check if it's actually a directory
-  const stat = fs.statSync(resolved);
-  if (!stat.isDirectory()) {
-    return { error: `Not a directory: ${resolved}` };
-  }
-
-  return { resolved };
-}
 
 /** Telegram adapter configuration */
 export interface TelegramAdapterConfig extends AdapterConfig {
@@ -641,12 +610,20 @@ export class TelegramAdapter implements ConnectionAdapter {
       await ctx.reply(formatted);
     } catch (error) {
       console.error('Failed to list sessions:', error);
-      await ctx.reply('Failed to fetch sessions. Please try again.');
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('ENOENT') || message.includes('no such file')) {
+        await ctx.reply('Session directory not found. No sessions available.');
+      } else if (message.includes('EACCES') || message.includes('permission')) {
+        await ctx.reply('Permission denied accessing session data.');
+      } else {
+        await ctx.reply('Failed to fetch sessions. Check daemon logs for details.');
+      }
     }
   }
 
   /**
-   * Handle /attach command - attach to an existing daemon session.
+   * Handle /attach command - attach to an orphaned daemon session.
+   * Only sessions without an active connection can be attached.
    * Creates a new topic and binds it to the target session.
    */
   private async handleAttach(ctx: Context): Promise<void> {
@@ -662,10 +639,12 @@ export class TelegramAdapter implements ConnectionAdapter {
       return;
     }
 
-    // Validate UUID format (at least starts like one)
-    const uuidPattern = /^[0-9a-f]{8}-?/i;
+    // Validate full UUID v4 format
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidPattern.test(sessionIdArg)) {
-      await ctx.reply('Invalid session ID format. Use /sessions to see available sessions.');
+      await ctx.reply(
+        'Invalid session ID format. Expected full UUID (e.g., 12345678-1234-1234-1234-123456789abc).\nUse /sessions to see available sessions.',
+      );
       return;
     }
 
@@ -684,14 +663,20 @@ export class TelegramAdapter implements ConnectionAdapter {
       return;
     }
 
+    // Check forum mode first (separate try-catch for clearer error handling)
     try {
-      // Check forum mode
       const chat = await ctx.api.getChat(chatId);
       if (chat.type !== 'supergroup' || !('is_forum' in chat) || !chat.is_forum) {
         await ctx.reply('Forum mode required. Enable Topics in group settings.');
         return;
       }
+    } catch (error) {
+      console.error('Failed to check chat settings:', error);
+      await ctx.reply('Failed to check chat settings. Please try again.');
+      return;
+    }
 
+    try {
       // Create new topic for attached session
       const topicName = `attached-${sessionIdArg.slice(0, 8)}`;
       const topic = await ctx.api.createForumTopic(chatId, topicName);
@@ -706,7 +691,7 @@ export class TelegramAdapter implements ConnectionAdapter {
         sessionId: sessionIdArg as UUID,
         chatId,
         topicId,
-        workingDirectory: '', // Will be filled from session info
+        workingDirectory: '', // Filled by daemon on resume via session registry
         machineName: os.hostname().replace(/\./g, '-').toLowerCase(),
         topicName,
         sessionNumber: 0,
@@ -730,18 +715,35 @@ export class TelegramAdapter implements ConnectionAdapter {
           resumeSessionId: sessionIdArg,
         },
       };
-      this.events.onConnect?.(connectionId, metadata);
+
+      try {
+        this.events.onConnect?.(connectionId, metadata);
+      } catch (callbackError) {
+        console.error('onConnect callback failed:', callbackError);
+        // Clean up on failure
+        this.sessions.delete(sessionKey);
+        this.connectionToSession.delete(connectionId);
+        await ctx.reply('Failed to attach: daemon rejected connection.');
+        return;
+      }
 
       await ctx.reply(`Attaching to session in new topic "${topicName}"`);
     } catch (error) {
       console.error('Failed to attach to session:', error);
-      await ctx.reply('Failed to attach to session. Check bot permissions.');
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('not enough rights') || message.includes('CHAT_ADMIN_REQUIRED')) {
+        await ctx.reply('Bot lacks permission to create topics. Grant admin rights.');
+      } else if (message.includes('TOPIC')) {
+        await ctx.reply(`Topic error: ${message.slice(0, 100)}`);
+      } else {
+        await ctx.reply('Failed to create topic for session. Check bot permissions.');
+      }
     }
   }
 
   /**
    * Handle /detach command - detach from session without killing it.
-   * Session stays orphaned and can be reattached within 5 minutes.
+   * Session stays orphaned and can be reattached within the configured timeout.
    */
   private async handleDetach(ctx: Context): Promise<void> {
     const session = this.getSessionFromContext(ctx);
@@ -755,11 +757,20 @@ export class TelegramAdapter implements ConnectionAdapter {
     this.sessions.delete(sessionKey);
     this.connectionToSession.delete(session.connectionId);
 
-    // Notify daemon (session stays orphaned for 5 minutes)
-    this.events.onDisconnect?.(session.connectionId, 'User detached from session');
+    // Notify daemon (session stays orphaned for configured timeout, default 5 minutes)
+    try {
+      this.events.onDisconnect?.(session.connectionId, 'User detached from session');
+    } catch (error) {
+      console.error('onDisconnect callback failed:', error);
+      // Session is already removed from adapter maps, warn user
+      await ctx.reply(
+        'Warning: Detach may not have registered with daemon. Session state may be inconsistent.',
+      );
+      return;
+    }
 
     await ctx.reply(
-      `Detached from session. Session remains active for 5 minutes.\nUse /attach ${session.sessionId} to reconnect.`,
+      `Detached from session. Session remains active for reconnection.\nUse /attach ${session.sessionId} to reconnect.`,
     );
   }
 

--- a/packages/daemon/src/adapters/telegram-ui.ts
+++ b/packages/daemon/src/adapters/telegram-ui.ts
@@ -5,7 +5,14 @@
  * Uses Telegram's MarkdownV2 formatting where appropriate.
  */
 
-import type { AgentStatus, Message, Question, QuestionOption } from '@remi/shared';
+import type {
+  AgentStatus,
+  DiscoverableSession,
+  Message,
+  Question,
+  QuestionOption,
+  TranscriptContentMessage,
+} from '@remi/shared';
 import { InlineKeyboard } from 'grammy';
 
 /**
@@ -219,8 +226,14 @@ export function formatHelpMessage(): string {
   return [
     '📖 Available Commands:',
     '',
+    '📂 Session Management:',
     '/start [directory] - Start new session',
     '/stop - End current session',
+    '/sessions - List all discoverable sessions',
+    '/attach <id> - Attach to existing session',
+    '/detach - Detach without ending session',
+    '',
+    '⚙️ Session Control:',
     '/interrupt - Send Esc to Claude (cancel current action)',
     '/pause - Pause the session',
     '/resume - Resume paused session',
@@ -233,6 +246,7 @@ export function formatHelpMessage(): string {
     '- Use /interrupt if Claude is stuck',
     '- Each topic = one Claude session',
     '- Paths can use ~ for home directory (e.g., ~/Projects/myapp)',
+    '- Use /detach to keep session alive when switching devices',
   ].join('\n');
 }
 
@@ -241,4 +255,127 @@ export function formatHelpMessage(): string {
  */
 export function formatErrorMessage(error: string): string {
   return `⚠️ Error: ${error}`;
+}
+
+/**
+ * Format a list of discoverable sessions for Telegram display.
+ */
+export function formatSessionListForTelegram(sessions: readonly DiscoverableSession[]): string {
+  if (sessions.length === 0) {
+    return ['📭 No sessions found.', '', 'Use /start [directory] to create a new session.'].join(
+      '\n',
+    );
+  }
+
+  const parts: string[] = ['📋 Available Sessions:', ''];
+
+  // Show up to 10 sessions for readability
+  const displayCount = Math.min(sessions.length, 10);
+  for (let i = 0; i < displayCount; i++) {
+    const session = sessions[i];
+    if (session) {
+      parts.push(formatDiscoverableSessionForTelegram(session, i + 1));
+      parts.push(''); // Empty line between sessions
+    }
+  }
+
+  if (sessions.length > 10) {
+    parts.push(`... and ${sessions.length - 10} more sessions`);
+    parts.push('');
+  }
+
+  parts.push('Use /attach <session-id> to connect to a session.');
+
+  return parts.join('\n');
+}
+
+/**
+ * Format a single discoverable session for Telegram display.
+ */
+export function formatDiscoverableSessionForTelegram(
+  session: DiscoverableSession,
+  index: number,
+): string {
+  const statusEmoji: Record<string, string> = {
+    active: '🟢',
+    idle: '🟡',
+    orphaned: '🟠',
+    completed: '⚫',
+  };
+
+  const emoji = statusEmoji[session.status] ?? '⚪';
+  const sourceLabel = session.source === 'daemon' ? 'daemon' : 'transcript';
+  const attachLabel = session.canAttach ? '' : ' [view-only]';
+
+  // Truncate path for display, keeping the end (most relevant part)
+  let pathDisplay = session.projectPath;
+  if (pathDisplay.length > 35) {
+    pathDisplay = `...${pathDisplay.slice(-32)}`;
+  }
+
+  const lines = [
+    `${index}. ${emoji} ${pathDisplay}`,
+    `   ID: ${session.sessionId.slice(0, 8)}... (${sourceLabel})${attachLabel}`,
+  ];
+
+  // Add last message preview if available
+  if (session.lastMessage) {
+    let preview = session.lastMessage.slice(0, 40);
+    if (session.lastMessage.length > 40) {
+      preview += '...';
+    }
+    lines.push(`   Last: ${preview}`);
+  }
+
+  // Add message count if available
+  if (session.messageCount !== undefined && session.messageCount > 0) {
+    lines.push(`   Messages: ${session.messageCount}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format TranscriptContentMessage for Telegram display.
+ * Handles structured content with proper truncation.
+ */
+export function formatTranscriptContentForTelegram(message: TranscriptContentMessage): string {
+  const parts: string[] = [];
+
+  // Header with metadata for assistant messages
+  if (message.role === 'assistant') {
+    const headerParts: string[] = [];
+    if (message.model) {
+      // Extract short model name (e.g., "opus-4-5" from "claude-opus-4-5-20251101")
+      const modelShort = message.model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
+      headerParts.push(`Model: ${modelShort}`);
+    }
+    if (message.tools && message.tools.length > 0) {
+      headerParts.push(`Tools: ${message.tools.join(', ')}`);
+    }
+    if (headerParts.length > 0) {
+      parts.push(`[${headerParts.join(' | ')}]`);
+    }
+  } else {
+    parts.push('[User]');
+  }
+
+  // Add content
+  let content = message.content;
+
+  // Strip any terminal codes that might have made it through
+  content = stripTerminalCodes(content);
+
+  // Calculate available space for content (4000 limit minus header and footer buffer)
+  const headerLength = parts.join('\n').length;
+  const footerBuffer = 50; // Space for truncation notice
+  const availableChars = 4000 - headerLength - footerBuffer;
+
+  if (content.length > availableChars) {
+    content = `${content.slice(0, availableChars - 25)}\n\n[... content truncated]`;
+  }
+
+  parts.push(content);
+
+  return parts.join('\n');
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -603,6 +603,10 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
       defaultDirectory: process.cwd(),
     },
     sharedEvents,
+    {
+      sessionRegistry,
+      transcriptDiscovery,
+    },
   );
   registry.register(telegramAdapter);
   console.log('Telegram adapter configured');

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -16,7 +16,6 @@
  */
 
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Load .env file if present
@@ -70,43 +69,7 @@ import {
   TranscriptWatcher,
 } from './transcript/index.ts';
 import type { AssistantEntry } from './transcript/index.ts';
-
-/**
- * Resolve a directory path, expanding ~ and validating it exists.
- * Returns resolved path or null with error message.
- */
-function resolveDirectory(
-  inputPath: string | null | undefined,
-): { resolved: string } | { error: string } {
-  if (!inputPath) {
-    return { resolved: process.cwd() };
-  }
-
-  let resolved = inputPath;
-
-  // Expand ~ to home directory
-  if (resolved.startsWith('~/')) {
-    resolved = path.join(os.homedir(), resolved.slice(2));
-  } else if (resolved === '~') {
-    resolved = os.homedir();
-  }
-
-  // Resolve to absolute path
-  resolved = path.resolve(resolved);
-
-  // Check if directory exists
-  if (!fs.existsSync(resolved)) {
-    return { error: `Directory not found: ${resolved}` };
-  }
-
-  // Check if it's actually a directory
-  const stat = fs.statSync(resolved);
-  if (!stat.isDirectory()) {
-    return { error: `Not a directory: ${resolved}` };
-  }
-
-  return { resolved };
-}
+import { resolveDirectory } from './utils/path-resolver.ts';
 
 // Parse CLI arguments
 const args = process.argv.slice(2);

--- a/packages/daemon/src/utils/path-resolver.ts
+++ b/packages/daemon/src/utils/path-resolver.ts
@@ -1,0 +1,46 @@
+/**
+ * Path resolution utilities.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Resolve a directory path, expanding ~ and validating it exists.
+ *
+ * @param inputPath - Path to resolve (optional, defaults to cwd)
+ * @returns Object with either `resolved` path or `error` message
+ */
+export function resolveDirectory(
+  inputPath?: string | null,
+): { resolved: string } | { error: string } {
+  if (!inputPath) {
+    return { resolved: process.cwd() };
+  }
+
+  let resolved = inputPath;
+
+  // Expand ~ to home directory
+  if (resolved.startsWith('~/')) {
+    resolved = path.join(os.homedir(), resolved.slice(2));
+  } else if (resolved === '~') {
+    resolved = os.homedir();
+  }
+
+  // Resolve to absolute path
+  resolved = path.resolve(resolved);
+
+  // Check if directory exists
+  if (!fs.existsSync(resolved)) {
+    return { error: `Directory not found: ${resolved}` };
+  }
+
+  // Check if it's actually a directory
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) {
+    return { error: `Not a directory: ${resolved}` };
+  }
+
+  return { resolved };
+}


### PR DESCRIPTION
## Summary

Adds session discovery and transcript content support to the Telegram adapter, achieving API feature parity with the WebSocket adapter (Track 2 from plan.md).

### New Features

- `/sessions` - List all discoverable sessions (daemon-managed + transcript-based)
- `/attach <id>` - Attach to an orphaned daemon session (creates new topic)
- `/detach` - Detach without killing session (keeps orphaned for 5 min reconnect window)
- Transcript content rendering with model/tools metadata
- Two-phase delivery integration

### Changes

- **telegram-adapter.ts**: Add dependency injection, 3 new command handlers, transcript_content in sendRaw
- **telegram-ui.ts**: Add formatting functions for session lists and transcript content, update help
- **cli.ts**: Pass sessionRegistry and transcriptDiscovery to TelegramAdapter
- **biome.json**: Fix migration issues from biome upgrade

## Test plan

- [x] All 531 existing tests pass
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual testing with Telegram bot:
  - [ ] Run `/sessions` in main chat and topic
  - [ ] Create session with `/start`, verify in `/sessions`
  - [ ] `/detach`, verify session shows as orphaned
  - [ ] `/attach` to orphaned session, verify messages flow
  - [ ] Verify transcript_content renders with model/tools metadata