### PR TITLE
feat: auto-reconnect with session resume and new session spawning

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -47,6 +47,13 @@ export interface AdapterEvents {
   /** Transcript load request received */
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
 
+  /** Create session request received */
+  onCreateSessionRequest: (
+    connectionId: UUID,
+    directory: string | undefined,
+    requestId: UUID,
+  ) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -123,6 +123,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onTranscriptLoadRequest?.(connectionId, sessionId, requestId);
       },
 
+      onCreateSessionRequest: (connectionId, directory, requestId) => {
+        this.events.onCreateSessionRequest?.(connectionId, directory, requestId);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -812,7 +812,7 @@ const sharedEvents = {
       logError(`Directory error: ${dirResult.error}`);
       sendToConnection(
         connectionId,
-        createCreateSessionResponse('' as UUID, false, requestId, dirResult.error),
+        createCreateSessionResponse(false, requestId, undefined, dirResult.error),
       );
       return;
     }
@@ -834,7 +834,7 @@ const sharedEvents = {
       const result = sessionRegistry.attachConnection(sessionId, connectionId);
 
       if (result.success) {
-        sendToConnection(connectionId, createCreateSessionResponse(sessionId, true, requestId));
+        sendToConnection(connectionId, createCreateSessionResponse(true, requestId, sessionId));
         // Also send hello_ack so client knows about the new session
         sendToConnection(
           connectionId,
@@ -846,18 +846,17 @@ const sharedEvents = {
         );
         log(`Session ${sessionId} created via create_session_request`);
       } else {
+        // Clean up the orphaned session to avoid resource leak
+        sessionRegistry.closeSession(sessionId, 'forced');
         sendToConnection(
           connectionId,
-          createCreateSessionResponse(sessionId, false, requestId, result.error),
+          createCreateSessionResponse(false, requestId, undefined, result.error),
         );
       }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       logError('Failed to create session:', msg);
-      sendToConnection(
-        connectionId,
-        createCreateSessionResponse('' as UUID, false, requestId, msg),
-      );
+      sendToConnection(connectionId, createCreateSessionResponse(false, requestId, undefined, msg));
     }
   },
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -42,6 +42,7 @@ if (fs.existsSync(envPath)) {
 
 import {
   createBulletExpandResponse,
+  createCreateSessionResponse,
   createError,
   createHelloAck,
   createReplayBatch,
@@ -799,6 +800,67 @@ const sharedEvents = {
       });
   },
 
+  onCreateSessionRequest: async (
+    connectionId: UUID,
+    directory: string | undefined,
+    requestId: UUID,
+  ) => {
+    log(`Create session request from ${connectionId}, directory: ${directory || '(default)'}`);
+
+    const dirResult = resolveDirectory(directory);
+    if ('error' in dirResult) {
+      logError(`Directory error: ${dirResult.error}`);
+      sendToConnection(
+        connectionId,
+        createCreateSessionResponse('' as UUID, false, requestId, dirResult.error),
+      );
+      return;
+    }
+
+    const workingDirectory = dirResult.resolved;
+    const sessionId = sessionRegistry.createSessionId();
+
+    log(`Creating new session ${sessionId} in ${workingDirectory}...`);
+
+    try {
+      await createNewSession(sessionId, workingDirectory, (sid, msg) => {
+        const session = sessionRegistry.getSession(sid);
+        if (session?.activeConnectionId) {
+          sendToConnection(session.activeConnectionId, msg);
+        }
+      });
+
+      // Attach requesting connection to the new session
+      const result = sessionRegistry.attachConnection(sessionId, connectionId);
+
+      if (result.success) {
+        sendToConnection(connectionId, createCreateSessionResponse(sessionId, true, requestId));
+        // Also send hello_ack so client knows about the new session
+        sendToConnection(
+          connectionId,
+          createHelloAck('1.0.0', sessionId, {
+            isResume: false,
+            replayCount: 0,
+            nextBulletId: 1,
+          }),
+        );
+        log(`Session ${sessionId} created via create_session_request`);
+      } else {
+        sendToConnection(
+          connectionId,
+          createCreateSessionResponse(sessionId, false, requestId, result.error),
+        );
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logError('Failed to create session:', msg);
+      sendToConnection(
+        connectionId,
+        createCreateSessionResponse('' as UUID, false, requestId, msg),
+      );
+    }
+  },
+
   onError: (connectionId: UUID, error: Error) => {
     logError(`Error from ${connectionId}:`, error);
   },
@@ -895,7 +957,9 @@ if (cliDaemonMode) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('EADDRINUSE') || msg.includes('in use')) {
-      logError(`Port ${PORT} is in use. Remote monitoring disabled. Use --port to specify a different port.`);
+      logError(
+        `Port ${PORT} is in use. Remote monitoring disabled. Use --port to specify a different port.`,
+      );
     } else {
       logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
     }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -611,6 +611,13 @@ const sharedEvents = {
       }
 
       log(`Resume failed: ${result.error}, creating new session`);
+      sendToConnection(
+        connectionId,
+        createError(
+          'RESUME_FAILED',
+          `Could not resume session ${resumeSessionId}: ${result.error}. Creating new session.`,
+        ),
+      );
     }
 
     // In daemon mode, create new session on connect
@@ -651,9 +658,19 @@ const sharedEvents = {
           log(`Session ${sessionId} created and attached to connection ${connectionId}`);
         } else {
           logError(`Failed to attach connection: ${result.error}`);
+          sessionRegistry.closeSession(sessionId, 'forced');
+          sendToConnection(
+            connectionId,
+            createError('ATTACH_FAILED', result.error ?? 'Failed to attach connection'),
+          );
         }
       } catch (error) {
-        logError('Failed to create session:', error);
+        const errMsg = error instanceof Error ? error.message : String(error);
+        logError('Failed to create session:', errMsg);
+        sendToConnection(
+          connectionId,
+          createError('SESSION_CREATE_FAILED', `Failed to create session: ${errMsg}`),
+        );
       }
     } else {
       // Wrapper mode but no primary session (shouldn't happen normally)

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -23,6 +23,7 @@ import type {
   Acknowledgment,
   AnswerMessage,
   BulletExpandRequestMessage,
+  CreateSessionRequestMessage,
   HelloMessage,
   PingMessage,
   ProtocolMessage,
@@ -57,6 +58,9 @@ export interface ConnectionEvents {
 
   /** Transcript load request received */
   onTranscriptLoadRequest: (sessionId: string, requestId: UUID) => void;
+
+  /** Create session request received */
+  onCreateSessionRequest: (directory: string | undefined, requestId: UUID) => void;
 
   /** Error occurred */
   onError: (error: Error) => void;
@@ -187,6 +191,9 @@ export class Connection {
         break;
       case 'transcript_load_request':
         this.handleTranscriptLoadRequest(message);
+        break;
+      case 'create_session_request':
+        this.handleCreateSessionRequest(message);
         break;
       case 'ping':
         this.handlePing(message);
@@ -322,6 +329,11 @@ export class Connection {
   private handleTranscriptLoadRequest(message: TranscriptLoadRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onTranscriptLoadRequest?.(message.sessionId, message.id);
+  }
+
+  private handleCreateSessionRequest(message: CreateSessionRequestMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onCreateSessionRequest?.(message.directory, message.id);
   }
 
   private handlePing(message: PingMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -61,6 +61,13 @@ export interface ServerEvents {
   /** Transcript load request from client */
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
 
+  /** Create session request from client */
+  onCreateSessionRequest: (
+    connectionId: UUID,
+    directory: string | undefined,
+    requestId: UUID,
+  ) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -290,6 +297,10 @@ export class WebSocketServer {
 
       onTranscriptLoadRequest: (sessionId, requestId) => {
         this.events.onTranscriptLoadRequest?.(ws.data.connectionId, sessionId, requestId);
+      },
+
+      onCreateSessionRequest: (directory, requestId) => {
+        this.events.onCreateSessionRequest?.(ws.data.connectionId, directory, requestId);
       },
 
       onError: (error) => {

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for protocol message factory functions and serialization.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type UUID,
+  createCreateSessionRequest,
+  createCreateSessionResponse,
+  createHello,
+  createHelloAck,
+  deserialize,
+  serialize,
+} from '@remi/shared';
+
+describe('Protocol factory functions', () => {
+  describe('createHello', () => {
+    test('creates basic hello without optional fields', () => {
+      const msg = createHello('client-1' as UUID, '1.0.0');
+      expect(msg.type).toBe('hello');
+      expect(msg.clientId).toBe('client-1');
+      expect(msg.clientVersion).toBe('1.0.0');
+      expect(msg.directory).toBeUndefined();
+      expect(msg.resumeSessionId).toBeUndefined();
+      expect(msg.lastReceivedIndex).toBeUndefined();
+    });
+
+    test('includes directory when provided', () => {
+      const msg = createHello('client-1' as UUID, '1.0.0', '/some/path');
+      expect(msg.directory).toBe('/some/path');
+    });
+
+    test('includes empty string directory', () => {
+      const msg = createHello('client-1' as UUID, '1.0.0', '');
+      // Empty string is a valid directory (cwd)
+      expect('directory' in msg).toBe(true);
+    });
+
+    test('includes resumeSessionId when provided', () => {
+      const sessionId = 'abc-123' as UUID;
+      const msg = createHello('client-1' as UUID, '1.0.0', undefined, sessionId);
+      expect(msg.resumeSessionId).toBe(sessionId);
+    });
+
+    test('includes lastReceivedIndex when provided', () => {
+      const msg = createHello('client-1' as UUID, '1.0.0', undefined, undefined, 42);
+      expect(msg.lastReceivedIndex).toBe(42);
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createHello('client-1' as UUID, '1.0.0', '/dir', 'sess-1' as UUID, 5);
+      const serialized = serialize(original);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.type).toBe('hello');
+      expect((deserialized as typeof original).clientId).toBe('client-1');
+      expect((deserialized as typeof original).directory).toBe('/dir');
+      expect((deserialized as typeof original).resumeSessionId).toBe('sess-1');
+      expect((deserialized as typeof original).lastReceivedIndex).toBe(5);
+    });
+  });
+
+  describe('createHelloAck', () => {
+    test('creates basic hello_ack', () => {
+      const msg = createHelloAck('1.0.0', 'session-1' as UUID);
+      expect(msg.type).toBe('hello_ack');
+      expect(msg.serverVersion).toBe('1.0.0');
+      expect(msg.sessionId).toBe('session-1');
+      expect(msg.isResume).toBeUndefined();
+    });
+
+    test('includes resume info', () => {
+      const msg = createHelloAck('1.0.0', 'session-1' as UUID, {
+        isResume: true,
+        replayCount: 5,
+        nextBulletId: 10,
+      });
+      expect(msg.isResume).toBe(true);
+      expect(msg.replayCount).toBe(5);
+      expect(msg.nextBulletId).toBe(10);
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createHelloAck('1.0.0', 'session-1' as UUID, {
+        isResume: true,
+        replayCount: 3,
+        nextBulletId: 7,
+      });
+      const deserialized = deserialize(serialize(original));
+      expect(deserialized).not.toBeNull();
+      expect((deserialized as typeof original).isResume).toBe(true);
+      expect((deserialized as typeof original).replayCount).toBe(3);
+    });
+  });
+
+  describe('createCreateSessionRequest', () => {
+    test('creates request without directory', () => {
+      const msg = createCreateSessionRequest();
+      expect(msg.type).toBe('create_session_request');
+      expect(msg.id).toBeTruthy();
+      expect(msg.timestamp).toBeTruthy();
+      expect(msg.directory).toBeUndefined();
+    });
+
+    test('creates request with directory', () => {
+      const msg = createCreateSessionRequest('/some/project');
+      expect(msg.directory).toBe('/some/project');
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createCreateSessionRequest('/some/dir');
+      const deserialized = deserialize(serialize(original));
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.type).toBe('create_session_request');
+      expect((deserialized as typeof original).directory).toBe('/some/dir');
+    });
+  });
+
+  describe('createCreateSessionResponse', () => {
+    test('creates success response with sessionId', () => {
+      const msg = createCreateSessionResponse(true, 'req-1' as UUID, 'session-1' as UUID);
+      expect(msg.type).toBe('create_session_response');
+      expect(msg.success).toBe(true);
+      expect(msg.sessionId).toBe('session-1');
+      expect(msg.requestId).toBe('req-1');
+      expect(msg.error).toBeUndefined();
+    });
+
+    test('creates failure response without sessionId', () => {
+      const msg = createCreateSessionResponse(
+        false,
+        'req-1' as UUID,
+        undefined,
+        'Directory not found',
+      );
+      expect(msg.success).toBe(false);
+      expect(msg.sessionId).toBeUndefined();
+      expect(msg.error).toBe('Directory not found');
+      expect(msg.requestId).toBe('req-1');
+    });
+
+    test('creates failure response with empty string error', () => {
+      const msg = createCreateSessionResponse(false, 'req-1' as UUID, undefined, '');
+      // Empty string error should be preserved (not silently dropped)
+      expect('error' in msg).toBe(true);
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createCreateSessionResponse(true, 'req-1' as UUID, 'sess-1' as UUID);
+      const deserialized = deserialize(serialize(original));
+      expect(deserialized).not.toBeNull();
+      expect(deserialized!.type).toBe('create_session_response');
+      expect((deserialized as typeof original).success).toBe(true);
+      expect((deserialized as typeof original).sessionId).toBe('sess-1');
+    });
+  });
+
+  describe('deserialize edge cases', () => {
+    test('rejects invalid JSON', () => {
+      expect(deserialize('not json')).toBeNull();
+    });
+
+    test('rejects object without type', () => {
+      expect(deserialize('{"id":"1","timestamp":"2024-01-01T00:00:00Z"}')).toBeNull();
+    });
+
+    test('rejects unknown message type', () => {
+      expect(
+        deserialize('{"type":"unknown","id":"1","timestamp":"2024-01-01T00:00:00Z"}'),
+      ).toBeNull();
+    });
+
+    test('accepts create_session_request type', () => {
+      const result = deserialize(
+        '{"type":"create_session_request","id":"1","timestamp":"2024-01-01T00:00:00Z"}',
+      );
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('create_session_request');
+    });
+
+    test('accepts create_session_response type', () => {
+      const result = deserialize(
+        '{"type":"create_session_response","id":"1","timestamp":"2024-01-01T00:00:00Z","success":true,"requestId":"r1"}',
+      );
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('create_session_response');
+    });
+  });
+});

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { createHello, createPing, createUserInput, serialize } from '@remi/shared';
+import {
+  type UUID,
+  createCreateSessionRequest,
+  createHello,
+  createPing,
+  createUserInput,
+  serialize,
+} from '@remi/shared';
 import { WebSocketServer } from '../src/server/websocket-server.ts';
 
 describe('WebSocketServer', () => {
@@ -325,6 +332,176 @@ describe('WebSocketServer', () => {
 
       ws1.close();
       await limitedServer.stop();
+    });
+  });
+
+  describe('Create session request', () => {
+    test('fires onCreateSessionRequest with correct params', async () => {
+      const receivedPromise = new Promise<{
+        connectionId: UUID;
+        directory: string | undefined;
+        requestId: UUID;
+      }>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 10 },
+          {
+            onCreateSessionRequest: (connectionId, directory, requestId) => {
+              resolve({ connectionId, directory, requestId });
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 10}/ws`);
+
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          ws.send(serialize(createHello('test-client' as UUID, '1.0.0')));
+        };
+
+        ws.onmessage = (event) => {
+          const data = JSON.parse(event.data.toString());
+          if (data.type === 'hello_ack') {
+            // Send create session request
+            ws.send(serialize(createCreateSessionRequest('/test/dir')));
+            resolve();
+          }
+        };
+
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout')), 5000);
+      });
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 2000),
+        ),
+      ]);
+
+      expect(received.directory).toBe('/test/dir');
+      expect(received.requestId).toBeTruthy();
+      expect(received.connectionId).toBeTruthy();
+
+      ws.close();
+      await server.stop();
+    });
+
+    test('fires onCreateSessionRequest without directory', async () => {
+      const receivedPromise = new Promise<{ directory: string | undefined }>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 11 },
+          {
+            onCreateSessionRequest: (_connectionId, directory) => {
+              resolve({ directory });
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 11}/ws`);
+
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          ws.send(serialize(createHello('test-client' as UUID, '1.0.0')));
+        };
+
+        ws.onmessage = (event) => {
+          const data = JSON.parse(event.data.toString());
+          if (data.type === 'hello_ack') {
+            ws.send(serialize(createCreateSessionRequest()));
+            resolve();
+          }
+        };
+
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout')), 5000);
+      });
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 2000),
+        ),
+      ]);
+
+      expect(received.directory).toBeUndefined();
+
+      ws.close();
+      await server.stop();
+    });
+  });
+
+  describe('Hello with resumeSessionId', () => {
+    test('passes resumeSessionId through onClientConnect metadata', async () => {
+      const resumeId = 'session-to-resume' as UUID;
+      const receivedPromise = new Promise<string | undefined>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 12 },
+          {
+            onClientConnect: (connection) => {
+              resolve(connection.connectionResumeSessionId ?? undefined);
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 12}/ws`);
+
+      ws.onopen = () => {
+        ws.send(serialize(createHello('test-client' as UUID, '1.0.0', undefined, resumeId)));
+      };
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 5000),
+        ),
+      ]);
+
+      expect(received).toBe(resumeId);
+
+      ws.close();
+      await server.stop();
+    });
+
+    test('passes directory through onClientConnect', async () => {
+      const receivedPromise = new Promise<string | null>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 13 },
+          {
+            onClientConnect: (connection) => {
+              resolve(connection.connectionDirectory);
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 13}/ws`);
+
+      ws.onopen = () => {
+        ws.send(serialize(createHello('test-client' as UUID, '1.0.0', '/my/project')));
+      };
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 5000),
+        ),
+      ]);
+
+      expect(received).toBe('/my/project');
+
+      ws.close();
+      await server.stop();
     });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,8 @@ export type {
   TranscriptLoadRequestMessage,
   TranscriptLoadCompleteMessage,
   TranscriptUsage,
+  CreateSessionRequestMessage,
+  CreateSessionResponseMessage,
 } from './protocol.ts';
 
 export {
@@ -85,5 +87,7 @@ export {
   createTranscriptContent,
   createTranscriptLoadRequest,
   createTranscriptLoadComplete,
+  createCreateSessionRequest,
+  createCreateSessionResponse,
   MessageIdTracker,
 } from './protocol.ts';

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -83,7 +83,9 @@ export type ProtocolMessage =
   | SessionListResponseMessage
   | TranscriptContentMessage
   | TranscriptLoadRequestMessage
-  | TranscriptLoadCompleteMessage;
+  | TranscriptLoadCompleteMessage
+  | CreateSessionRequestMessage
+  | CreateSessionResponseMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -322,6 +324,30 @@ export interface TranscriptLoadCompleteMessage {
   readonly requestId: UUID;
 }
 
+/** Request to create a new Claude Code session */
+export interface CreateSessionRequestMessage {
+  readonly type: 'create_session_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Working directory for the new session */
+  readonly directory?: string;
+}
+
+/** Response after creating a new session */
+export interface CreateSessionResponseMessage {
+  readonly type: 'create_session_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID of the newly created session */
+  readonly sessionId: UUID;
+  /** Whether creation succeeded */
+  readonly success: boolean;
+  /** Error message if creation failed */
+  readonly error?: string;
+  /** ID of the original request */
+  readonly requestId: UUID;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -384,6 +410,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'transcript_content',
     'transcript_load_request',
     'transcript_load_complete',
+    'create_session_request',
+    'create_session_response',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -727,6 +755,38 @@ export function createTranscriptLoadComplete(
     sessionId,
     messageCount,
     requestId,
+  };
+}
+
+/**
+ * Create a request to spawn a new Claude Code session.
+ */
+export function createCreateSessionRequest(directory?: string): CreateSessionRequestMessage {
+  return {
+    type: 'create_session_request',
+    id: generateId(),
+    timestamp: now(),
+    ...(directory && { directory }),
+  };
+}
+
+/**
+ * Create a response for a create session request.
+ */
+export function createCreateSessionResponse(
+  sessionId: UUID,
+  success: boolean,
+  requestId: UUID,
+  error?: string,
+): CreateSessionResponseMessage {
+  return {
+    type: 'create_session_response',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    success,
+    requestId,
+    ...(error && { error }),
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -338,8 +338,8 @@ export interface CreateSessionResponseMessage {
   readonly type: 'create_session_response';
   readonly id: UUID;
   readonly timestamp: Timestamp;
-  /** Session ID of the newly created session */
-  readonly sessionId: UUID;
+  /** Session ID of the newly created session (present on success) */
+  readonly sessionId?: UUID;
   /** Whether creation succeeded */
   readonly success: boolean;
   /** Error message if creation failed */
@@ -774,19 +774,19 @@ export function createCreateSessionRequest(directory?: string): CreateSessionReq
  * Create a response for a create session request.
  */
 export function createCreateSessionResponse(
-  sessionId: UUID,
   success: boolean,
   requestId: UUID,
+  sessionId?: UUID,
   error?: string,
 ): CreateSessionResponseMessage {
   return {
     type: 'create_session_response',
     id: generateId(),
     timestamp: now(),
-    sessionId,
     success,
     requestId,
-    ...(error && { error }),
+    ...(sessionId !== undefined && { sessionId }),
+    ...(error !== undefined && { error }),
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -433,8 +433,8 @@ export function createHello(
     timestamp: now(),
     clientVersion,
     clientId,
-    ...(directory && { directory }),
-    ...(resumeSessionId && { resumeSessionId }),
+    ...(directory !== undefined && { directory }),
+    ...(resumeSessionId !== undefined && { resumeSessionId }),
     ...(lastReceivedIndex !== undefined && { lastReceivedIndex }),
   };
 }
@@ -766,7 +766,7 @@ export function createCreateSessionRequest(directory?: string): CreateSessionReq
     type: 'create_session_request',
     id: generateId(),
     timestamp: now(),
-    ...(directory && { directory }),
+    ...(directory !== undefined && { directory }),
   };
 }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const LOCALSTORAGE_URL_KEY = 'remi-last-url';
+const LOCALSTORAGE_SESSION_KEY = 'remi-last-session';
 
 function App() {
   // State
@@ -33,23 +34,33 @@ function App() {
   const handleMessage = useCallback((message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
-        // Create a session for this connection
-        const newSession: UISession = {
-          id: message.sessionId,
-          name: 'Claude Code Session',
-          createdAt: new Date().toISOString(),
-          lastActiveAt: new Date().toISOString(),
-          status: 'idle',
-          connectionStatus: 'connected',
-          unreadCount: 0,
-          preview: 'Connected',
-        };
-        setSessions((prev) => {
-          const exists = prev.find((s) => s.id === message.sessionId);
-          if (exists) return prev.map((s) => (s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s));
-          return [...prev, newSession];
-        });
+        if (message.isResume) {
+          // Session resume: just update connection status, don't create new session
+          setSessions((prev) =>
+            prev.map((s) =>
+              s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s,
+            ),
+          );
+        } else {
+          // New session: create entry or update existing
+          const newSession: UISession = {
+            id: message.sessionId,
+            name: 'Claude Code Session',
+            createdAt: new Date().toISOString(),
+            lastActiveAt: new Date().toISOString(),
+            status: 'idle',
+            connectionStatus: 'connected',
+            unreadCount: 0,
+            preview: 'Connected',
+          };
+          setSessions((prev) => {
+            const exists = prev.find((s) => s.id === message.sessionId);
+            if (exists) return prev.map((s) => (s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s));
+            return [...prev, newSession];
+          });
+        }
         setActiveSessionId(message.sessionId);
+        localStorage.setItem(LOCALSTORAGE_SESSION_KEY, message.sessionId);
         break;
       }
 
@@ -281,6 +292,17 @@ function App() {
         break;
       }
 
+      case 'create_session_response': {
+        if (message.success) {
+          // The hello_ack that follows will create the session entry
+          // Just log success here
+          console.log(`New session created: ${message.sessionId}`);
+        } else {
+          console.error(`Failed to create session: ${message.error}`);
+        }
+        break;
+      }
+
       case 'error':
         console.error('Daemon error:', message);
         break;
@@ -296,6 +318,9 @@ function App() {
     activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId]);
 
+  // Restore session ID from localStorage for reconnect after page reload
+  const storedSessionId = localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null;
+
   const {
     status: connectionStatus,
     error: wsError,
@@ -305,8 +330,9 @@ function App() {
     requestBulletExpand,
     requestSessionList,
     requestTranscriptLoad,
+    requestNewSession,
     sessionId: wsSessionId,
-  } = useWebSocket({ onMessage: handleMessage });
+  } = useWebSocket({ onMessage: handleMessage, initialResumeSessionId: storedSessionId ?? undefined });
 
   const error = wsError?.message ?? null;
 
@@ -345,6 +371,7 @@ function App() {
   // Handlers
   const handleSelectSession = useCallback((id: UUID) => {
     setActiveSessionId(id);
+    localStorage.setItem(LOCALSTORAGE_SESSION_KEY, id);
 
     // If this is an external transcript session we haven't loaded yet, request its history
     const session = sessions.find((s) => s.id === id);
@@ -441,12 +468,17 @@ function App() {
     [activeSessionId, requestBulletExpand],
   );
 
+  const handleNewSession = useCallback(() => {
+    requestNewSession();
+  }, [requestNewSession]);
+
   // Sidebar content
   const sidebar = (
     <SessionList
       sessions={sessions}
       activeSessionId={activeSessionId}
       onSelectSession={handleSelectSession}
+      onNewSession={connectionStatus === 'connected' ? handleNewSession : undefined}
       onConnect={() => setShowConnectModal(true)}
       onSettings={() => console.log('Open settings')}
     />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
   const [messages, setMessages] = useState<UIMessage[]>([]);
   const [question, setQuestion] = useState<UIQuestion | null>(null);
   const [showConnectModal, setShowConnectModal] = useState(false);
+  const [creatingSession, setCreatingSession] = useState(false);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
@@ -34,16 +35,16 @@ function App() {
   const handleMessage = useCallback((message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
-        if (message.isResume) {
-          // Session resume: just update connection status, don't create new session
-          setSessions((prev) =>
-            prev.map((s) =>
+        setSessions((prev) => {
+          const exists = prev.some((s) => s.id === message.sessionId);
+          if (exists) {
+            return prev.map((s) =>
               s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s,
-            ),
-          );
-        } else {
-          // New session: create entry or update existing
-          const newSession: UISession = {
+            );
+          }
+          // Only create new entry for non-resume (resume expects session to exist)
+          if (message.isResume) return prev;
+          return [...prev, {
             id: message.sessionId,
             name: 'Claude Code Session',
             createdAt: new Date().toISOString(),
@@ -52,13 +53,9 @@ function App() {
             connectionStatus: 'connected',
             unreadCount: 0,
             preview: 'Connected',
-          };
-          setSessions((prev) => {
-            const exists = prev.find((s) => s.id === message.sessionId);
-            if (exists) return prev.map((s) => (s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s));
-            return [...prev, newSession];
-          });
-        }
+          } satisfies UISession];
+        });
+        setCreatingSession(false);
         setActiveSessionId(message.sessionId);
         localStorage.setItem(LOCALSTORAGE_SESSION_KEY, message.sessionId);
         break;
@@ -293,12 +290,20 @@ function App() {
       }
 
       case 'create_session_response': {
-        if (message.success) {
-          // The hello_ack that follows will create the session entry
-          // Just log success here
-          console.log(`New session created: ${message.sessionId}`);
-        } else {
+        setCreatingSession(false);
+        if (!message.success) {
           console.error(`Failed to create session: ${message.error}`);
+          // Add error message to the current session's chat so the user sees it
+          const errorMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            sender: 'system',
+            content: `Failed to create session: ${message.error ?? 'Unknown error'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errorMsg]);
         }
         break;
       }
@@ -318,8 +323,10 @@ function App() {
     activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId]);
 
-  // Restore session ID from localStorage for reconnect after page reload
-  const storedSessionId = localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null;
+  // Restore session ID from localStorage for reconnect after page reload (read once)
+  const [storedSessionId] = useState<UUID | null>(
+    () => localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null,
+  );
 
   const {
     status: connectionStatus,
@@ -469,16 +476,19 @@ function App() {
   );
 
   const handleNewSession = useCallback(() => {
+    if (creatingSession) return;
+    setCreatingSession(true);
     requestNewSession();
-  }, [requestNewSession]);
+  }, [requestNewSession, creatingSession]);
 
   // Sidebar content
+  const canCreateSession = connectionStatus === 'connected' && !creatingSession;
   const sidebar = (
     <SessionList
       sessions={sessions}
       activeSessionId={activeSessionId}
       onSelectSession={handleSelectSession}
-      onNewSession={connectionStatus === 'connected' ? handleNewSession : undefined}
+      onNewSession={canCreateSession ? handleNewSession : undefined}
       onConnect={() => setShowConnectModal(true)}
       onSettings={() => console.log('Open settings')}
     />

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -9,6 +9,7 @@ import type { ConnectionStatus } from '@/types';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
+  createCreateSessionRequest,
   createHello,
   createPing,
   createSessionListRequest,
@@ -42,6 +43,8 @@ export interface UseWebSocketReturn {
   requestSessionList: (includeExternal?: boolean) => boolean;
   /** Request transcript history for an external session */
   requestTranscriptLoad: (sessionId: string) => boolean;
+  /** Request creation of a new Claude Code session */
+  requestNewSession: (directory?: string) => boolean;
   /** Current session ID (after hello_ack) */
   sessionId: UUID | null;
 }
@@ -56,6 +59,8 @@ export interface UseWebSocketOptions {
   clientVersion?: string;
   /** Message handler */
   onMessage?: (message: ProtocolMessage) => void;
+  /** Session ID to resume on initial connect (e.g., from localStorage after page reload) */
+  initialResumeSessionId?: UUID;
 }
 
 /**
@@ -63,10 +68,11 @@ export interface UseWebSocketOptions {
  */
 export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketReturn {
   const {
-    autoReconnect = false,
+    autoReconnect = true,
     clientId = 'remi-web',
     clientVersion = '0.0.1',
     onMessage,
+    initialResumeSessionId,
   } = options;
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
@@ -75,6 +81,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
   const clientRef = useRef<WebSocketClient | null>(null);
   const onMessageRef = useRef(onMessage);
+  const lastSessionIdRef = useRef<UUID | null>(initialResumeSessionId ?? null);
+  const directoryRef = useRef<string | undefined>(undefined);
 
   // Keep onMessage ref updated
   useEffect(() => {
@@ -86,6 +94,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     // Handle hello_ack to get session ID
     if (message.type === 'hello_ack') {
       setSessionId(message.sessionId);
+      lastSessionIdRef.current = message.sessionId;
     }
 
     // Forward to user handler
@@ -98,6 +107,11 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       // Clean up existing connection
       clientRef.current?.disconnect();
 
+      // Store directory for reconnects
+      if (directory !== undefined) {
+        directoryRef.current = directory;
+      }
+
       const config: WebSocketClientConfig = {
         url,
         autoReconnect,
@@ -108,10 +122,11 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
           console.log('[WebSocket] Status changed:', newStatus);
           setStatus(newStatus);
           if (newStatus === 'connected') {
-            // Send hello message with directory
-            console.log('[WebSocket] Sending hello message...');
-            const sent = client.send(createHello(clientId, clientVersion, directory));
-            console.log('[WebSocket] Hello message sent:', sent, 'directory:', directory);
+            // On reconnect, include resumeSessionId so daemon replays missed messages
+            const resumeId = lastSessionIdRef.current ?? undefined;
+            console.log('[WebSocket] Sending hello message...', resumeId ? `(resume: ${resumeId})` : '(new)');
+            const sent = client.send(createHello(clientId, clientVersion, directoryRef.current, resumeId));
+            console.log('[WebSocket] Hello message sent:', sent);
           }
           if (newStatus === 'disconnected') {
             setSessionId(null);
@@ -182,6 +197,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     return clientRef.current.send(createTranscriptLoadRequest(targetSessionId));
   }, []);
 
+  // Request creation of a new Claude Code session
+  const requestNewSession = useCallback((directory?: string): boolean => {
+    if (!clientRef.current) return false;
+    return clientRef.current.send(createCreateSessionRequest(directory));
+  }, []);
+
   // Clean up on unmount
   useEffect(() => {
     return () => {
@@ -211,6 +232,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     requestBulletExpand,
     requestSessionList,
     requestTranscriptLoad,
+    requestNewSession,
     sessionId,
   };
 }


### PR DESCRIPTION
## Summary
- **Part A - Auto-Reconnect:** WebSocket hook now defaults to `autoReconnect=true`, tracks last session ID, and sends `resumeSessionId` on reconnect so the daemon replays missed messages. Session ID is persisted to localStorage for page reload continuity. `hello_ack` handler distinguishes resume vs new session.
- **Part B - New Session Spawning:** Added `create_session_request`/`create_session_response` protocol messages wired through the full daemon pipeline (connection -> websocket-server -> websocket-adapter -> connection-adapter -> cli.ts). The SessionList "+" floating button now spawns a new Claude Code session when connected.

## Test plan
- [x] 546/546 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Web build successful
- [x] Binary build successful
- [ ] Manual: connect browser, kill WebSocket, verify auto-reconnect with message replay
- [ ] Manual: reload browser page, verify auto-connect resumes same session
- [ ] Manual: click "+" button in browser, verify new Claude session spawns
- [ ] Manual: switch between sessions, verify messages are per-session