### PR TITLE
fix: raw byte PTY pass-through to prevent terminal garbling

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -24,9 +24,9 @@ const LOG_FILE = path.join(REMI_DIR, 'remi.log');
 const STATUS_FILE = path.join(REMI_DIR, 'status.json');
 let logFd: number | null = null;
 
-// In wrapper mode, we save the real stdout.write before overriding it.
-// Only the PTY pass-through uses this; everything else is silenced.
-let ptyWrite: ((chunk: string) => boolean) | null = null;
+// In wrapper mode, we save the real stdout file descriptor before overriding.
+// Raw PTY bytes are written directly via fs.writeSync to avoid decode/encode.
+let ptyStdoutFd: number | null = null;
 
 function ensureRemiDir(): void {
   fs.mkdirSync(REMI_DIR, { recursive: true });
@@ -545,14 +545,17 @@ async function createNewSession(
       size: termSize,
     },
     {
-      onData: (output: string) => {
+      onRawData: (data: Uint8Array) => {
         if (passThrough) {
-          // Write to terminal FIRST to avoid ANSI escape sequence corruption.
-          // Processing (which does synchronous file I/O for status updates)
-          // must happen AFTER the terminal write to prevent display delays.
-          const write = ptyWrite ?? process.stdout.write.bind(process.stdout);
-          write(output);
+          // Write raw bytes directly to terminal - no decode/encode round-trip.
+          // This preserves multi-byte UTF-8 sequences split across chunks and
+          // avoids ANSI escape corruption from processing delays.
+          const fd = ptyStdoutFd ?? 1;
+          fs.writeSync(fd, data);
         }
+      },
+      onData: (output: string) => {
+        // Decoded text goes to processor only (status detection, questions)
         if (processor) {
           processor.process(output);
         }
@@ -1132,9 +1135,9 @@ if (cliDaemonMode) {
   // Wrapper mode: spawn Claude immediately, pass through terminal I/O
   // Block ALL output paths to the terminal. In Bun compiled binaries,
   // console.log uses a native path that bypasses process.stdout.write,
-  // so we must override both layers. Only the PTY pass-through (via
-  // saved ptyWrite) can reach the actual terminal.
-  ptyWrite = process.stdout.write.bind(process.stdout);
+  // so we must override both layers. Only the PTY raw byte pass-through
+  // (via fs.writeSync to stdout fd) can reach the actual terminal.
+  ptyStdoutFd = 1; // stdout file descriptor
 
   try {
     logFd = openLogFile();

--- a/packages/daemon/src/pty/pty-session.ts
+++ b/packages/daemon/src/pty/pty-session.ts
@@ -16,8 +16,11 @@ export interface TerminalSize {
 
 /** Events emitted by PTY session */
 export interface PTYSessionEvents {
-  /** Raw output data from terminal */
+  /** Raw output data from terminal (decoded to string) */
   onData: (data: string) => void;
+
+  /** Raw bytes from terminal, before text decoding. Use for direct pass-through. */
+  onRawData?: (data: Uint8Array) => void;
 
   /** Session status changed */
   onStatusChange: (status: AgentStatus) => void;
@@ -315,11 +318,18 @@ export class PTYSession {
     }
   }
 
+  /** Text decoder with streaming mode to handle multi-byte UTF-8 across chunks */
+  private textDecoder = new TextDecoder('utf-8', { fatal: false });
+
   /** Handle data from terminal */
   private handleData(data: Uint8Array): void {
-    // Convert to string
-    const text = new TextDecoder().decode(data);
-    this.events.onData?.(text);
+    // Emit raw bytes first for direct terminal pass-through (no decode/encode)
+    this.events.onRawData?.(data);
+    // Then decode for text processing (stream: true handles split UTF-8)
+    const text = this.textDecoder.decode(data, { stream: true });
+    if (text.length > 0) {
+      this.events.onData?.(text);
+    }
   }
 
   /** Handle process exit */


### PR DESCRIPTION
## Summary
- Use raw `Uint8Array` bytes for terminal output pass-through instead of decoded strings, fixing multi-byte UTF-8 corruption (??? characters) and ANSI escape garbling
- PTY session now emits `onRawData` (raw bytes before decoding) alongside `onData` (decoded text)
- `TextDecoder` uses `{ stream: true }` to correctly handle UTF-8 sequences split across chunks
- Terminal writes use `fs.writeSync(fd, data)` with raw bytes; decoded text only feeds the status/question processor

## Test plan
- [x] All 571 tests pass
- [x] Typecheck clean
- [x] Biome check clean
- [x] Binary compiles and runs (`remi --help`)
- [ ] Manual test: run `remi` and verify no ??? characters in separator lines
- [ ] Manual test: verify spinner animations render correctly without interleaving