### PR TITLE
Web interface polish: settings, theme, menu

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,8 +7,10 @@
 import { ChatView } from '@/components/chat';
 import { AppLayout } from '@/components/layout';
 import { ConnectModal, SessionList } from '@/components/session';
+import { SettingsPanel } from '@/components/settings';
 import { useWebSocket } from '@/hooks';
-import type { UIBullet, UIMessage, UIQuestion, UISession } from '@/types';
+import type { AppSettings, UIBullet, UIMessage, UIQuestion, UISession } from '@/types';
+import { DEFAULT_SETTINGS } from '@/types';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import { generateId } from '@remi/shared/protocol.ts';
 import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
@@ -16,6 +18,24 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const LOCALSTORAGE_URL_KEY = 'remi-last-url';
 const LOCALSTORAGE_SESSION_KEY = 'remi-last-session';
+const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
+
+function loadSettings(): AppSettings {
+  try {
+    const stored = localStorage.getItem(LOCALSTORAGE_SETTINGS_KEY);
+    if (stored) return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+  } catch { /* use defaults */ }
+  return DEFAULT_SETTINGS;
+}
+
+function applyTheme(theme: AppSettings['theme']) {
+  const root = document.documentElement;
+  if (theme === 'system') {
+    root.removeAttribute('data-theme');
+  } else {
+    root.setAttribute('data-theme', theme);
+  }
+}
 
 function App() {
   // State
@@ -25,11 +45,23 @@ function App() {
   const [question, setQuestion] = useState<UIQuestion | null>(null);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [creatingSession, setCreatingSession] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [settings, setSettings] = useState<AppSettings>(loadSettings);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
   const activeSessionIdRef = useRef<UUID | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
+
+  // Apply theme on settings change
+  useEffect(() => {
+    applyTheme(settings.theme);
+    localStorage.setItem(LOCALSTORAGE_SETTINGS_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const handleSettingsChange = useCallback((newSettings: AppSettings) => {
+    setSettings(newSettings);
+  }, []);
 
   // WebSocket connection
   const handleMessage = useCallback((message: ProtocolMessage) => {
@@ -481,6 +513,33 @@ function App() {
     requestNewSession();
   }, [requestNewSession, creatingSession]);
 
+  // Menu actions
+  const handleCopyConversation = useCallback(() => {
+    const text = sessionMessages
+      .map((m) => `[${m.sender}] ${m.content}`)
+      .join('\n\n');
+    navigator.clipboard.writeText(text);
+  }, [sessionMessages]);
+
+  const handleClearMessages = useCallback(() => {
+    if (activeSessionId) {
+      setMessages((prev) => prev.filter((m) => m.sessionId !== activeSessionId));
+    }
+  }, [activeSessionId]);
+
+  const handleExportText = useCallback(() => {
+    const text = sessionMessages
+      .map((m) => `[${new Date(m.timestamp).toLocaleString()}] [${m.sender}] ${m.content}`)
+      .join('\n\n');
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `remi-session-${activeSessionId?.slice(0, 8) ?? 'unknown'}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [sessionMessages, activeSessionId]);
+
   // Sidebar content
   const canCreateSession = connectionStatus === 'connected' && !creatingSession;
   const sidebar = (
@@ -490,7 +549,7 @@ function App() {
       onSelectSession={handleSelectSession}
       onNewSession={canCreateSession ? handleNewSession : undefined}
       onConnect={() => setShowConnectModal(true)}
-      onSettings={() => console.log('Open settings')}
+      onSettings={() => setShowSettings(true)}
     />
   );
 
@@ -503,7 +562,9 @@ function App() {
       error={error}
       onSend={handleSend}
       onBack={handleBack}
-      onMore={() => console.log('More options')}
+      onCopyConversation={handleCopyConversation}
+      onClearMessages={handleClearMessages}
+      onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
     />
   ) : (
@@ -515,6 +576,13 @@ function App() {
   return (
     <>
       <AppLayout sidebar={sidebar} main={main} showSidebar={!activeSessionId} />
+
+      <SettingsPanel
+        open={showSettings}
+        settings={settings}
+        onClose={() => setShowSettings(false)}
+        onChange={handleSettingsChange}
+      />
 
       <ConnectModal
         isOpen={showConnectModal}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -31,7 +31,8 @@ function loadSettings(): AppSettings {
 function applyTheme(theme: AppSettings['theme']) {
   const root = document.documentElement;
   if (theme === 'system') {
-    root.removeAttribute('data-theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
   } else {
     root.setAttribute('data-theme', theme);
   }
@@ -53,9 +54,16 @@ function App() {
   const activeSessionIdRef = useRef<UUID | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
 
-  // Apply theme on settings change
+  // Apply theme and font size on settings change
   useEffect(() => {
     applyTheme(settings.theme);
+
+    const fontSizeMap = { small: '14px', medium: '16px', large: '18px' } as const;
+    document.documentElement.style.setProperty(
+      '--font-size-base',
+      fontSizeMap[settings.fontSize] ?? '16px',
+    );
+
     localStorage.setItem(LOCALSTORAGE_SETTINGS_KEY, JSON.stringify(settings));
   }, [settings]);
 

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -11,17 +11,23 @@ import {
   ArrowLeft,
   Brain,
   Clock,
+  Copy,
+  FileText,
   Loader2,
   MoreVertical,
   Terminal,
+  Trash2,
   Wifi,
   WifiOff,
 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface ChatHeaderProps {
   readonly session: UISession;
   readonly onBack?: () => void;
-  readonly onMore?: () => void;
+  readonly onCopyConversation?: () => void;
+  readonly onClearMessages?: () => void;
+  readonly onExportText?: () => void;
   readonly className?: string;
 }
 
@@ -86,7 +92,33 @@ function AgentStatusIndicator({ status }: { readonly status: AgentStatus }) {
   );
 }
 
-export function ChatHeader({ session, onBack, onMore, className }: ChatHeaderProps) {
+export function ChatHeader({
+  session,
+  onBack,
+  onCopyConversation,
+  onClearMessages,
+  onExportText,
+  className,
+}: ChatHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const hasMenuActions = onCopyConversation || onClearMessages || onExportText;
+
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        closeMenu();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [menuOpen, closeMenu]);
+
   return (
     <header
       className={clsx(
@@ -125,15 +157,52 @@ export function ChatHeader({ session, onBack, onMore, className }: ChatHeaderPro
         </div>
       </div>
 
-      {/* More button */}
-      {onMore && (
-        <button
-          onClick={onMore}
-          className="rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
-          aria-label="More options"
-        >
-          <MoreVertical className="size-5" />
-        </button>
+      {/* More button with dropdown */}
+      {hasMenuActions && (
+        <div className="relative" ref={menuRef}>
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
+            aria-label="More options"
+          >
+            <MoreVertical className="size-5" />
+          </button>
+
+          {menuOpen && (
+            <div className="absolute right-0 top-full z-40 mt-1 w-48 rounded-lg border border-[--color-border] bg-[--color-surface-elevated] py-1 shadow-lg">
+              {onCopyConversation && (
+                <button
+                  onClick={() => { onCopyConversation(); closeMenu(); }}
+                  className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-text] transition-colors hover:bg-[--color-surface-light]"
+                >
+                  <Copy className="size-4 text-[--color-text-muted]" />
+                  Copy conversation
+                </button>
+              )}
+              {onExportText && (
+                <button
+                  onClick={() => { onExportText(); closeMenu(); }}
+                  className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-text] transition-colors hover:bg-[--color-surface-light]"
+                >
+                  <FileText className="size-4 text-[--color-text-muted]" />
+                  Export as text
+                </button>
+              )}
+              {onClearMessages && (
+                <>
+                  <div className="my-1 h-px bg-[--color-border]" />
+                  <button
+                    onClick={() => { onClearMessages(); closeMenu(); }}
+                    className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-error] transition-colors hover:bg-[--color-surface-light]"
+                  >
+                    <Trash2 className="size-4" />
+                    Clear messages
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       )}
     </header>
   );

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -119,6 +119,16 @@ export function ChatHeader({
     return () => document.removeEventListener('mousedown', handler);
   }, [menuOpen, closeMenu]);
 
+  // Close menu on Escape key
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [menuOpen, closeMenu]);
+
   return (
     <header
       className={clsx(

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -19,7 +19,9 @@ interface ChatViewProps {
   readonly onCancel?: () => void;
   readonly onRetry?: () => void;
   readonly onBack?: () => void;
-  readonly onMore?: () => void;
+  readonly onCopyConversation?: () => void;
+  readonly onClearMessages?: () => void;
+  readonly onExportText?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
   readonly className?: string;
 }
@@ -33,7 +35,9 @@ export function ChatView({
   onCancel,
   onRetry,
   onBack,
-  onMore,
+  onCopyConversation,
+  onClearMessages,
+  onExportText,
   onBulletExpand,
   className,
 }: ChatViewProps) {
@@ -41,7 +45,13 @@ export function ChatView({
 
   return (
     <div className={clsx('flex h-full flex-col bg-[--color-surface]', className)}>
-      <ChatHeader session={session} onBack={onBack} onMore={onMore} />
+      <ChatHeader
+        session={session}
+        onBack={onBack}
+        onCopyConversation={onCopyConversation}
+        onClearMessages={onClearMessages}
+        onExportText={onExportText}
+      />
 
       <MessageList
         messages={messages}

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -6,7 +6,7 @@
 
 import type { UIQuestion } from '@/types';
 import { clsx } from 'clsx';
-import { Mic, Paperclip, Send, StopCircle } from 'lucide-react';
+import { Send, StopCircle } from 'lucide-react';
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -212,15 +212,6 @@ export function InputArea({
 
       {/* Input row */}
       <div className="flex items-end gap-2 p-3">
-        {/* Attachment button (future) */}
-        <button
-          className="rounded-full p-2 text-[--color-text-muted] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
-          aria-label="Attach file"
-          disabled
-        >
-          <Paperclip className="size-5" />
-        </button>
-
         {/* Text input */}
         <div className="relative flex-1">
           <textarea
@@ -241,30 +232,21 @@ export function InputArea({
           />
         </div>
 
-        {/* Send / Voice button */}
-        {value.trim() ? (
-          <button
-            onClick={handleSend}
-            disabled={disabled}
-            className={clsx(
-              'rounded-full bg-[--color-primary] p-2.5 text-white',
-              'transition-all hover:bg-[--color-primary-dark]',
-              'active:scale-95',
-              disabled && 'cursor-not-allowed opacity-50',
-            )}
-            aria-label="Send message"
-          >
-            <Send className="size-5" />
-          </button>
-        ) : (
-          <button
-            className="rounded-full p-2.5 text-[--color-text-muted] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
-            aria-label="Voice input"
-            disabled
-          >
-            <Mic className="size-5" />
-          </button>
-        )}
+        {/* Send button */}
+        <button
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          className={clsx(
+            'rounded-full p-2.5 transition-all',
+            value.trim()
+              ? 'bg-[--color-primary] text-white hover:bg-[--color-primary-dark] active:scale-95'
+              : 'text-[--color-text-muted]',
+            disabled && 'cursor-not-allowed opacity-50',
+          )}
+          aria-label="Send message"
+        >
+          <Send className="size-5" />
+        </button>
       </div>
     </div>
   );

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -6,6 +6,7 @@
 
 import type { AgentStatus, UIMessage } from '@/types';
 import { clsx } from 'clsx';
+import { MessageSquare } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { ErrorBubble, MessageBubble, TypingIndicator } from './MessageBubble';
 
@@ -97,10 +98,8 @@ export function MessageList({
       {/* Empty state */}
       {messages.length === 0 && !error && (
         <div className="flex h-full flex-col items-center justify-center text-[--color-text-muted]">
-          <div className="mb-2 text-4xl">
-            <span role="img" aria-label="wave"></span>
-          </div>
-          <p className="text-sm">Start a conversation with Claude</p>
+          <MessageSquare className="mb-3 size-10 opacity-40" />
+          <p className="text-sm">Waiting for agent output</p>
         </div>
       )}
 

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -1,0 +1,195 @@
+/**
+ * SettingsPanel component.
+ *
+ * Slide-in panel for app settings.
+ */
+
+import type { AppSettings } from '@/types';
+import { DEFAULT_SETTINGS } from '@/types';
+import { clsx } from 'clsx';
+import { Moon, Sun, Monitor, X } from 'lucide-react';
+
+interface SettingsPanelProps {
+  readonly open: boolean;
+  readonly settings: AppSettings;
+  readonly onClose: () => void;
+  readonly onChange: (settings: AppSettings) => void;
+}
+
+function ThemeButton({
+  active,
+  label,
+  icon: Icon,
+  onClick,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly icon: React.ComponentType<{ className?: string }>;
+  readonly onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'flex flex-1 flex-col items-center gap-1.5 rounded-lg p-3 text-xs transition-colors',
+        active
+          ? 'bg-[--color-primary] text-white'
+          : 'bg-[--color-surface-light] text-[--color-text-secondary] hover:bg-[--color-surface-elevated]',
+      )}
+    >
+      <Icon className="size-5" />
+      {label}
+    </button>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+}: {
+  readonly checked: boolean;
+  readonly onChange: (checked: boolean) => void;
+  readonly label: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between py-2">
+      <span className="text-sm text-[--color-text]">{label}</span>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={clsx(
+          'relative h-6 w-11 rounded-full transition-colors',
+          checked ? 'bg-[--color-primary]' : 'bg-[--color-border]',
+        )}
+      >
+        <span
+          className={clsx(
+            'absolute top-0.5 left-0.5 size-5 rounded-full bg-white transition-transform',
+            checked && 'translate-x-5',
+          )}
+        />
+      </button>
+    </label>
+  );
+}
+
+export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPanelProps) {
+  if (!open) return null;
+
+  const update = (partial: Partial<AppSettings>) => {
+    onChange({ ...settings, ...partial });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+
+      {/* Panel */}
+      <div className="relative w-full max-w-sm bg-[--color-surface] shadow-lg animate-[slide-in-right_0.2s_ease-out]">
+        {/* Header */}
+        <header className="flex items-center justify-between border-b border-[--color-border] px-4 py-3 safe-area-top">
+          <h2 className="text-lg font-semibold text-[--color-text]">Settings</h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light]"
+            aria-label="Close settings"
+          >
+            <X className="size-5" />
+          </button>
+        </header>
+
+        <div className="overflow-y-auto p-4 space-y-6">
+          {/* Theme */}
+          <section>
+            <h3 className="mb-3 text-sm font-medium text-[--color-text-secondary]">Theme</h3>
+            <div className="flex gap-2">
+              <ThemeButton
+                active={settings.theme === 'system'}
+                label="System"
+                icon={Monitor}
+                onClick={() => update({ theme: 'system' })}
+              />
+              <ThemeButton
+                active={settings.theme === 'light'}
+                label="Light"
+                icon={Sun}
+                onClick={() => update({ theme: 'light' })}
+              />
+              <ThemeButton
+                active={settings.theme === 'dark'}
+                label="Dark"
+                icon={Moon}
+                onClick={() => update({ theme: 'dark' })}
+              />
+            </div>
+          </section>
+
+          {/* Font Size */}
+          <section>
+            <h3 className="mb-3 text-sm font-medium text-[--color-text-secondary]">Font Size</h3>
+            <div className="flex gap-2">
+              {(['small', 'medium', 'large'] as const).map((size) => (
+                <button
+                  key={size}
+                  onClick={() => update({ fontSize: size })}
+                  className={clsx(
+                    'flex-1 rounded-lg py-2 text-sm capitalize transition-colors',
+                    settings.fontSize === size
+                      ? 'bg-[--color-primary] text-white'
+                      : 'bg-[--color-surface-light] text-[--color-text-secondary] hover:bg-[--color-surface-elevated]',
+                  )}
+                >
+                  {size}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* Toggles */}
+          <section>
+            <h3 className="mb-2 text-sm font-medium text-[--color-text-secondary]">Preferences</h3>
+            <div className="space-y-1">
+              <Toggle
+                label="Show timestamps"
+                checked={settings.showTimestamps}
+                onChange={(v) => update({ showTimestamps: v })}
+              />
+              <Toggle
+                label="Notifications"
+                checked={settings.notifications}
+                onChange={(v) => update({ notifications: v })}
+              />
+              <Toggle
+                label="Sound"
+                checked={settings.sound}
+                onChange={(v) => update({ sound: v })}
+              />
+              <Toggle
+                label="Auto-reconnect"
+                checked={settings.autoReconnect}
+                onChange={(v) => update({ autoReconnect: v })}
+              />
+            </div>
+          </section>
+
+          {/* About */}
+          <section>
+            <h3 className="mb-2 text-sm font-medium text-[--color-text-secondary]">About</h3>
+            <p className="text-sm text-[--color-text-muted]">Remi v0.1.0</p>
+          </section>
+
+          {/* Reset */}
+          <button
+            onClick={() => onChange(DEFAULT_SETTINGS)}
+            className="w-full rounded-lg border border-[--color-border] py-2 text-sm text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light]"
+          >
+            Reset to defaults
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import type { AppSettings } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
 import { clsx } from 'clsx';
 import { Moon, Sun, Monitor, X } from 'lucide-react';
+import { useEffect } from 'react';
 
 interface SettingsPanelProps {
   readonly open: boolean;
@@ -76,6 +77,16 @@ function Toggle({
 }
 
 export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPanelProps) {
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
   if (!open) return null;
 
   const update = (partial: Partial<AppSettings>) => {

--- a/packages/web/src/components/settings/index.ts
+++ b/packages/web/src/components/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPanel } from './SettingsPanel';

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -94,22 +94,7 @@
   }
 }
 
-/* Light mode via OS preference (when theme is "system") */
-@media (prefers-color-scheme: light) {
-  html:not([data-theme="dark"]) {
-    --color-surface: #ffffff;
-    --color-surface-light: #f8fafc;
-    --color-surface-elevated: #f1f5f9;
-    --color-text: #0f172a;
-    --color-text-secondary: #475569;
-    --color-text-muted: #64748b;
-    --color-border: #e2e8f0;
-    --color-bubble-assistant: #e2e8f0;
-    --color-bubble-system: #dbeafe;
-  }
-}
-
-/* Light mode via manual toggle */
+/* Light mode: JS sets data-theme="light" for both manual and system preference */
 html[data-theme="light"] {
   --color-surface: #ffffff;
   --color-surface-light: #f8fafc;
@@ -133,6 +118,7 @@ body,
 
 body {
   font-family: var(--font-sans);
+  font-size: var(--font-size-base, 16px);
   background-color: var(--color-surface);
   color: var(--color-text);
   -webkit-font-smoothing: antialiased;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -75,6 +75,15 @@
   }
 }
 
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -85,9 +94,9 @@
   }
 }
 
-/* Light mode overrides */
+/* Light mode via OS preference (when theme is "system") */
 @media (prefers-color-scheme: light) {
-  @theme {
+  html:not([data-theme="dark"]) {
     --color-surface: #ffffff;
     --color-surface-light: #f8fafc;
     --color-surface-elevated: #f1f5f9;
@@ -98,6 +107,19 @@
     --color-bubble-assistant: #e2e8f0;
     --color-bubble-system: #dbeafe;
   }
+}
+
+/* Light mode via manual toggle */
+html[data-theme="light"] {
+  --color-surface: #ffffff;
+  --color-surface-light: #f8fafc;
+  --color-surface-elevated: #f1f5f9;
+  --color-text: #0f172a;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-border: #e2e8f0;
+  --color-bubble-assistant: #e2e8f0;
+  --color-bubble-system: #dbeafe;
 }
 
 /* Base styles */


### PR DESCRIPTION
## Summary
- Add SettingsPanel with theme toggle (system/light/dark), font size, and preferences
- Settings persist to localStorage across sessions
- Replace no-op "More options" with dropdown menu (copy conversation, export as text, clear messages)
- Remove disabled mic and paperclip stub buttons from input area
- Fix blank emoji icon in empty state

## Test plan
- [x] Web build succeeds: `cd packages/web && bun run build`
- [x] All 571 tests pass
- [ ] Visual: theme toggle works (system/light/dark)
- [ ] Visual: settings panel slides in from right
- [ ] Visual: more options dropdown renders correctly
- [ ] Settings persist across page reload (localStorage)

Closes #8