### PR TITLE
Telegram adapter: protocol coverage and security

### DIFF
--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -356,10 +356,16 @@ export class TelegramAdapter implements ConnectionAdapter {
         const editSession = this.getSession(connectionId);
         if (editSession && this.bot && edit.newContent) {
           const cleanContent = stripTerminalCodes(edit.newContent).trim();
-          if (cleanContent && isValidContent(cleanContent) && editSession.currentMessageId !== undefined) {
+          if (
+            cleanContent &&
+            isValidContent(cleanContent) &&
+            editSession.currentMessageId !== undefined
+          ) {
             this.bot.api
               .editMessageText(editSession.chatId, editSession.currentMessageId, cleanContent)
-              .catch(() => { /* message may not be editable */ });
+              .catch(() => {
+                /* message may not be editable */
+              });
           }
         }
         return true;
@@ -373,7 +379,9 @@ export class TelegramAdapter implements ConnectionAdapter {
             .sendMessage(errSession.chatId, `Error: ${err.message}`, {
               message_thread_id: errSession.topicId,
             })
-            .catch(() => { /* ignore send errors */ });
+            .catch(() => {
+              /* ignore send errors */
+            });
         }
         return true;
       }

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -12,11 +12,17 @@ import { generateId, now } from '@remi/shared';
 import type {
   AgentOutputMessage,
   AgentStatus,
+  EditMessage,
+  ErrorMessage,
+  HelloAckMessage,
   Message,
   ProtocolMessage,
   Question,
   QuestionMessage,
+  ReplayBatchMessage,
   SessionUpdateMessage,
+  StructuredAgentOutputMessage,
+  TranscriptContentMessage,
   UUID,
 } from '@remi/shared';
 import { Bot, type Context } from 'grammy';
@@ -72,6 +78,12 @@ export interface TelegramAdapterConfig extends AdapterConfig {
 
   /** Default working directory for new sessions */
   readonly defaultDirectory?: string;
+
+  /** Authorized chat IDs (empty = allow all) */
+  readonly authorizedChatIds?: readonly number[] | undefined;
+
+  /** Authorized user IDs (empty = allow all) */
+  readonly authorizedUserIds?: readonly number[] | undefined;
 }
 
 /** Session binding - maps Telegram topic to Claude session */
@@ -142,8 +154,30 @@ export class TelegramAdapter implements ConnectionAdapter {
       enabled: config.enabled ?? true,
       token: config.token,
       defaultDirectory: config.defaultDirectory ?? process.cwd(),
+      authorizedChatIds: config.authorizedChatIds,
+      authorizedUserIds: config.authorizedUserIds,
     };
     this.events = events;
+  }
+
+  /** Check if a chat/user is authorized */
+  private isAuthorized(ctx: Context): boolean {
+    const chatId = ctx.chat?.id;
+    const userId = ctx.from?.id;
+
+    if (this.config.authorizedChatIds?.length) {
+      if (!chatId || !this.config.authorizedChatIds.includes(chatId)) {
+        return false;
+      }
+    }
+
+    if (this.config.authorizedUserIds?.length) {
+      if (!userId || !this.config.authorizedUserIds.includes(userId)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   get connectionCount(): number {
@@ -273,18 +307,98 @@ export class TelegramAdapter implements ConnectionAdapter {
   }
 
   sendRaw(connectionId: UUID, message: ProtocolMessage): boolean {
-    // Telegram doesn't use raw protocol messages
-    // Convert to appropriate Telegram message type
-    if (message.type === 'agent_output') {
-      return this.sendMessage(connectionId, (message as AgentOutputMessage).message);
+    switch (message.type) {
+      case 'agent_output':
+        return this.sendMessage(connectionId, (message as AgentOutputMessage).message);
+
+      case 'structured_agent_output': {
+        const structured = message as StructuredAgentOutputMessage;
+        return this.sendMessage(connectionId, structured.message);
+      }
+
+      case 'question':
+        return this.sendQuestion(connectionId, (message as QuestionMessage).question);
+
+      case 'session_update':
+        return this.sendStatus(connectionId, (message as SessionUpdateMessage).session.status);
+
+      case 'hello_ack': {
+        const ack = message as HelloAckMessage;
+        const sessionKey = this.connectionToSession.get(connectionId);
+        if (sessionKey) {
+          const session = this.sessions.get(sessionKey);
+          if (session) {
+            session.sessionId = ack.sessionId;
+          }
+        }
+        return true;
+      }
+
+      case 'transcript_content': {
+        const tc = message as TranscriptContentMessage;
+        if (tc.role === 'assistant' && tc.content) {
+          return this.sendMessage(connectionId, {
+            id: tc.id,
+            sessionId: tc.sessionId,
+            sender: 'agent',
+            content: tc.content,
+            createdAt: tc.timestamp,
+            state: 'delivered',
+            stateChangedAt: tc.timestamp,
+            isEditing: false,
+          });
+        }
+        return true;
+      }
+
+      case 'edit': {
+        const edit = message as EditMessage;
+        const editSession = this.getSession(connectionId);
+        if (editSession && this.bot && edit.newContent) {
+          const cleanContent = stripTerminalCodes(edit.newContent).trim();
+          if (cleanContent && isValidContent(cleanContent) && editSession.currentMessageId !== undefined) {
+            this.bot.api
+              .editMessageText(editSession.chatId, editSession.currentMessageId, cleanContent)
+              .catch(() => { /* message may not be editable */ });
+          }
+        }
+        return true;
+      }
+
+      case 'error': {
+        const err = message as ErrorMessage;
+        const errSession = this.getSession(connectionId);
+        if (errSession && this.bot) {
+          this.bot.api
+            .sendMessage(errSession.chatId, `Error: ${err.message}`, {
+              message_thread_id: errSession.topicId,
+            })
+            .catch(() => { /* ignore send errors */ });
+        }
+        return true;
+      }
+
+      case 'replay_batch': {
+        const batch = message as ReplayBatchMessage;
+        for (const inner of batch.messages) {
+          this.sendRaw(connectionId, inner);
+        }
+        return true;
+      }
+
+      // Messages that don't need Telegram rendering
+      case 'session_list_response':
+      case 'transcript_load_complete':
+      case 'create_session_response':
+      case 'ping':
+      case 'pong':
+      case 'ack':
+      case 'bullet_expand_response':
+        return true;
+
+      default:
+        return false;
     }
-    if (message.type === 'question') {
-      return this.sendQuestion(connectionId, (message as QuestionMessage).question);
-    }
-    if (message.type === 'session_update') {
-      return this.sendStatus(connectionId, (message as SessionUpdateMessage).session.status);
-    }
-    return false;
   }
 
   broadcast(message: ProtocolMessage): void {
@@ -309,6 +423,14 @@ export class TelegramAdapter implements ConnectionAdapter {
 
   private setupHandlers(): void {
     if (!this.bot) return;
+
+    // Authorization middleware
+    this.bot.use(async (ctx, next) => {
+      if (!this.isAuthorized(ctx)) {
+        return; // silently ignore unauthorized messages
+      }
+      await next();
+    });
 
     // Handle /start command
     this.bot.command('start', async (ctx) => {

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -20,9 +20,11 @@ import type {
   Question,
   QuestionMessage,
   ReplayBatchMessage,
+  SessionListResponseMessage,
   SessionUpdateMessage,
   StructuredAgentOutputMessage,
   TranscriptContentMessage,
+  TranscriptLoadCompleteMessage,
   UUID,
 } from '@remi/shared';
 import { Bot, type Context } from 'grammy';
@@ -36,6 +38,7 @@ import {
   formatHelpMessage,
   formatMessageForTelegram,
   formatQuestionKeyboard,
+  formatSessionList,
   isValidContent,
   stripTerminalCodes,
 } from './telegram-ui.ts';
@@ -148,6 +151,12 @@ export class TelegramAdapter implements ConnectionAdapter {
 
   /** Session counters per directory */
   private readonly sessionCounters: Map<string, number> = new Map();
+
+  /** Rate limiter: last input timestamp per session key */
+  private readonly lastInputTimestamp: Map<string, number> = new Map();
+
+  /** Minimum interval between inputs in milliseconds */
+  private static readonly RATE_LIMIT_MS = 1000;
 
   constructor(config: TelegramAdapterConfig, events: Partial<AdapterEvents> = {}) {
     this.config = {
@@ -394,9 +403,40 @@ export class TelegramAdapter implements ConnectionAdapter {
         return true;
       }
 
+      case 'session_list_response': {
+        const slr = message as SessionListResponseMessage;
+        const slrSession = this.getSession(connectionId);
+        if (slrSession && this.bot) {
+          const text = formatSessionList(slr.sessions);
+          this.bot.api
+            .sendMessage(slrSession.chatId, text, {
+              message_thread_id: slrSession.topicId,
+            })
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'transcript_load_complete': {
+        const tlc = message as TranscriptLoadCompleteMessage;
+        const tlcSession = this.getSession(connectionId);
+        if (tlcSession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              tlcSession.chatId,
+              `Transcript loaded for session ${tlc.sessionId} (${tlc.messageCount} messages).`,
+              { message_thread_id: tlcSession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
       // Messages that don't need Telegram rendering
-      case 'session_list_response':
-      case 'transcript_load_complete':
       case 'create_session_response':
       case 'ping':
       case 'pong':
@@ -478,6 +518,16 @@ export class TelegramAdapter implements ConnectionAdapter {
     // Handle /help command
     this.bot.command('help', async (ctx) => {
       await this.handleHelp(ctx);
+    });
+
+    // Handle /sessions command - list all discoverable sessions
+    this.bot.command('sessions', async (ctx) => {
+      await this.handleSessions(ctx);
+    });
+
+    // Handle /load command - load transcript for an external session
+    this.bot.command('load', async (ctx) => {
+      await this.handleLoad(ctx);
     });
 
     // Handle callback queries (button presses)
@@ -679,6 +729,35 @@ export class TelegramAdapter implements ConnectionAdapter {
     await ctx.reply(formatHelpMessage());
   }
 
+  private async handleSessions(ctx: Context): Promise<void> {
+    const session = this.getSessionFromContext(ctx);
+    if (!session) {
+      await ctx.reply('No active session in this topic. Use /start to create one.');
+      return;
+    }
+
+    const requestId = generateId();
+    this.events.onSessionListRequest?.(session.connectionId, requestId, true);
+  }
+
+  private async handleLoad(ctx: Context): Promise<void> {
+    const session = this.getSessionFromContext(ctx);
+    if (!session) {
+      await ctx.reply('No active session in this topic. Use /start to create one.');
+      return;
+    }
+
+    const sessionId = ctx.match?.toString().trim();
+    if (!sessionId) {
+      await ctx.reply('Usage: /load <sessionId>');
+      return;
+    }
+
+    const requestId = generateId();
+    this.events.onTranscriptLoadRequest?.(session.connectionId, sessionId, requestId);
+    await ctx.reply(`Loading transcript for session ${sessionId}...`);
+  }
+
   private async handleAnswerCallback(ctx: Context): Promise<void> {
     const match = ctx.match as RegExpMatchArray;
     const questionId = match[1] as UUID;
@@ -714,6 +793,16 @@ export class TelegramAdapter implements ConnectionAdapter {
 
     const text = ctx.message?.text;
     if (!text) return;
+
+    // Rate limiting: reject inputs faster than 1 per second
+    const sessionKey = `${session.chatId}:${session.topicId}`;
+    const lastTime = this.lastInputTimestamp.get(sessionKey) ?? 0;
+    const currentTime = Date.now();
+    if (currentTime - lastTime < TelegramAdapter.RATE_LIMIT_MS) {
+      await ctx.reply('Please wait a moment before sending another message.');
+      return;
+    }
+    this.lastInputTimestamp.set(sessionKey, currentTime);
 
     // Notify daemon of user input
     this.events.onUserInput?.(session.connectionId, session.sessionId, text);

--- a/packages/daemon/src/adapters/telegram-ui.ts
+++ b/packages/daemon/src/adapters/telegram-ui.ts
@@ -5,7 +5,14 @@
  * Uses Telegram's MarkdownV2 formatting where appropriate.
  */
 
-import type { AgentStatus, Message, Question, QuestionOption } from '@remi/shared';
+import * as path from 'node:path';
+import type {
+  AgentStatus,
+  DiscoverableSession,
+  Message,
+  Question,
+  QuestionOption,
+} from '@remi/shared';
 import { InlineKeyboard } from 'grammy';
 
 /**
@@ -225,6 +232,8 @@ export function formatHelpMessage(): string {
     '/pause - Pause the session',
     '/resume - Resume paused session',
     '/status - Show session info',
+    '/sessions - List all discoverable sessions',
+    '/load <sessionId> - Load transcript for a session',
     '/clear - Clear and start fresh session',
     '/help - Show this help message',
     '',
@@ -234,6 +243,37 @@ export function formatHelpMessage(): string {
     '- Each topic = one Claude session',
     '- Paths can use ~ for home directory (e.g., ~/Projects/myapp)',
   ].join('\n');
+}
+
+/**
+ * Format a list of discoverable sessions for Telegram display.
+ */
+export function formatSessionList(sessions: readonly DiscoverableSession[]): string {
+  if (sessions.length === 0) {
+    return 'No sessions found.';
+  }
+
+  const lines: string[] = [`Sessions (${sessions.length}):\n`];
+
+  for (const session of sessions) {
+    const statusIcon =
+      session.status === 'active'
+        ? '🟢'
+        : session.status === 'idle'
+          ? '💤'
+          : session.status === 'orphaned'
+            ? '🔴'
+            : '✅';
+    const project = path.basename(session.projectPath);
+    lines.push(
+      `${statusIcon} ${project} [${session.status}]`,
+      `   ID: ${session.sessionId}`,
+      `   Messages: ${session.messageCount}`,
+      '',
+    );
+  }
+
+  return lines.join('\n').trim();
 }
 
 /**

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -334,7 +334,9 @@ Environment:
   REMI_PORT                WebSocket port
   REMI_MAX_BULLET_LENGTH   Max bullet length before truncation (default: 500, 0=disabled)
   TELEGRAM_BOT_TOKEN       Telegram bot token (enables Telegram adapter)
-  TELEGRAM_ENABLED         Set to 'false' to disable Telegram
+  TELEGRAM_ENABLED              Set to 'false' to disable Telegram
+  TELEGRAM_AUTHORIZED_CHAT_IDS  Comma-separated authorized chat IDs
+  TELEGRAM_AUTHORIZED_USER_IDS  Comma-separated authorized user IDs
 
 Any other arguments are passed through to Claude Code.
 `);
@@ -426,6 +428,12 @@ const MAX_BULLET_LENGTH =
 const TELEGRAM_TOKEN = process.env['TELEGRAM_BOT_TOKEN'];
 const TELEGRAM_ENABLED =
   !cliNoTelegram && process.env['TELEGRAM_ENABLED'] !== 'false' && !!TELEGRAM_TOKEN;
+const TELEGRAM_AUTHORIZED_CHAT_IDS = process.env['TELEGRAM_AUTHORIZED_CHAT_IDS']
+  ? process.env['TELEGRAM_AUTHORIZED_CHAT_IDS'].split(',').map(Number).filter(Boolean)
+  : [];
+const TELEGRAM_AUTHORIZED_USER_IDS = process.env['TELEGRAM_AUTHORIZED_USER_IDS']
+  ? process.env['TELEGRAM_AUTHORIZED_USER_IDS'].split(',').map(Number).filter(Boolean)
+  : [];
 
 // ---------------------------------------------------------------------------
 // Core components
@@ -1077,6 +1085,8 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
     {
       token: TELEGRAM_TOKEN,
       defaultDirectory: process.cwd(),
+      authorizedChatIds: TELEGRAM_AUTHORIZED_CHAT_IDS.length ? TELEGRAM_AUTHORIZED_CHAT_IDS : undefined,
+      authorizedUserIds: TELEGRAM_AUTHORIZED_USER_IDS.length ? TELEGRAM_AUTHORIZED_USER_IDS : undefined,
     },
     sharedEvents,
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1085,8 +1085,12 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
     {
       token: TELEGRAM_TOKEN,
       defaultDirectory: process.cwd(),
-      authorizedChatIds: TELEGRAM_AUTHORIZED_CHAT_IDS.length ? TELEGRAM_AUTHORIZED_CHAT_IDS : undefined,
-      authorizedUserIds: TELEGRAM_AUTHORIZED_USER_IDS.length ? TELEGRAM_AUTHORIZED_USER_IDS : undefined,
+      authorizedChatIds: TELEGRAM_AUTHORIZED_CHAT_IDS.length
+        ? TELEGRAM_AUTHORIZED_CHAT_IDS
+        : undefined,
+      authorizedUserIds: TELEGRAM_AUTHORIZED_USER_IDS.length
+        ? TELEGRAM_AUTHORIZED_USER_IDS
+        : undefined,
     },
     sharedEvents,
   );

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -52,7 +52,7 @@ describe('Protocol factory functions', () => {
       const serialized = serialize(original);
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('hello');
+      expect(deserialized?.type).toBe('hello');
       expect((deserialized as typeof original).clientId).toBe('client-1');
       expect((deserialized as typeof original).directory).toBe('/dir');
       expect((deserialized as typeof original).resumeSessionId).toBe('sess-1');
@@ -111,7 +111,7 @@ describe('Protocol factory functions', () => {
       const original = createCreateSessionRequest('/some/dir');
       const deserialized = deserialize(serialize(original));
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('create_session_request');
+      expect(deserialized?.type).toBe('create_session_request');
       expect((deserialized as typeof original).directory).toBe('/some/dir');
     });
   });
@@ -149,7 +149,7 @@ describe('Protocol factory functions', () => {
       const original = createCreateSessionResponse(true, 'req-1' as UUID, 'sess-1' as UUID);
       const deserialized = deserialize(serialize(original));
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('create_session_response');
+      expect(deserialized?.type).toBe('create_session_response');
       expect((deserialized as typeof original).success).toBe(true);
       expect((deserialized as typeof original).sessionId).toBe('sess-1');
     });

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -175,7 +175,7 @@ describe('Protocol factory functions', () => {
         '{"type":"create_session_request","id":"1","timestamp":"2024-01-01T00:00:00Z"}',
       );
       expect(result).not.toBeNull();
-      expect(result!.type).toBe('create_session_request');
+      expect(result?.type).toBe('create_session_request');
     });
 
     test('accepts create_session_response type', () => {
@@ -183,7 +183,7 @@ describe('Protocol factory functions', () => {
         '{"type":"create_session_response","id":"1","timestamp":"2024-01-01T00:00:00Z","success":true,"requestId":"r1"}',
       );
       expect(result).not.toBeNull();
-      expect(result!.type).toBe('create_session_response');
+      expect(result?.type).toBe('create_session_response');
     });
   });
 });

--- a/packages/daemon/tests/telegram-adapter.test.ts
+++ b/packages/daemon/tests/telegram-adapter.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for TelegramAdapter class.
+ *
+ * These tests create adapter instances without starting the bot
+ * (no TELEGRAM_BOT_TOKEN needed). They test method behavior on
+ * the adapter object directly.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type {
+  AgentOutputMessage,
+  ErrorMessage,
+  HelloAckMessage,
+  ProtocolMessage,
+  QuestionMessage,
+  ReplayBatchMessage,
+  SessionListResponseMessage,
+  SessionUpdateMessage,
+  StructuredAgentOutputMessage,
+  TranscriptContentMessage,
+  TranscriptLoadCompleteMessage,
+} from '@remi/shared';
+import { generateId, now } from '@remi/shared';
+import type { AdapterEvents } from '../src/adapters/connection-adapter.ts';
+import { TelegramAdapter } from '../src/adapters/telegram-adapter.ts';
+
+function createAdapter(events: Partial<AdapterEvents> = {}): TelegramAdapter {
+  return new TelegramAdapter(
+    {
+      token: 'fake-token-not-used',
+      enabled: true,
+      defaultDirectory: '/tmp',
+    },
+    events,
+  );
+}
+
+const unknownConnectionId = generateId();
+
+describe('TelegramAdapter constructor defaults', () => {
+  test('connectionCount is 0 before any sessions', () => {
+    const adapter = createAdapter();
+    expect(adapter.connectionCount).toBe(0);
+  });
+
+  test('isRunning is false before start', () => {
+    const adapter = createAdapter();
+    expect(adapter.isRunning).toBe(false);
+  });
+
+  test('type is telegram', () => {
+    const adapter = createAdapter();
+    expect(adapter.type).toBe('telegram');
+  });
+});
+
+describe('sendMessage with unknown connection', () => {
+  test('returns false for unknown connectionId', () => {
+    const adapter = createAdapter();
+    const result = adapter.sendMessage(unknownConnectionId, {
+      id: generateId(),
+      sessionId: generateId(),
+      sender: 'agent',
+      content: 'hello',
+      createdAt: now(),
+      state: 'delivered',
+      stateChangedAt: now(),
+      isEditing: false,
+    });
+    expect(result).toBe(false);
+  });
+});
+
+describe('sendQuestion with unknown connection', () => {
+  test('returns false for unknown connectionId', () => {
+    const adapter = createAdapter();
+    const result = adapter.sendQuestion(unknownConnectionId, {
+      id: generateId(),
+      text: 'Allow?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(result).toBe(false);
+  });
+});
+
+describe('sendStatus with unknown connection', () => {
+  test('returns false for unknown connectionId', () => {
+    const adapter = createAdapter();
+    const result = adapter.sendStatus(unknownConnectionId, 'thinking');
+    expect(result).toBe(false);
+  });
+});
+
+describe('sendRaw routing', () => {
+  test('agent_output returns false for unknown connection', () => {
+    const adapter = createAdapter();
+    const msg: AgentOutputMessage = {
+      type: 'agent_output',
+      id: generateId(),
+      timestamp: now(),
+      message: {
+        id: generateId(),
+        sessionId: generateId(),
+        sender: 'agent',
+        content: 'output',
+        createdAt: now(),
+        state: 'delivered',
+        stateChangedAt: now(),
+        isEditing: false,
+      },
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+
+  test('structured_agent_output returns false for unknown connection', () => {
+    const adapter = createAdapter();
+    const msg: StructuredAgentOutputMessage = {
+      type: 'structured_agent_output',
+      id: generateId(),
+      timestamp: now(),
+      message: {
+        id: generateId(),
+        sessionId: generateId(),
+        sender: 'agent',
+        content: 'structured output',
+        createdAt: now(),
+        state: 'delivered',
+        stateChangedAt: now(),
+        isEditing: false,
+        bullets: [],
+      },
+      isUpdate: false,
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+
+  test('question returns false for unknown connection', () => {
+    const adapter = createAdapter();
+    const msg: QuestionMessage = {
+      type: 'question',
+      id: generateId(),
+      timestamp: now(),
+      question: {
+        id: generateId(),
+        text: 'Allow?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      },
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+
+  test('session_update returns false for unknown connection', () => {
+    const adapter = createAdapter();
+    const msg: SessionUpdateMessage = {
+      type: 'session_update',
+      id: generateId(),
+      timestamp: now(),
+      session: {
+        id: generateId(),
+        name: 'test-session',
+        startedAt: now(),
+        status: 'thinking',
+        isActive: true,
+      },
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+
+  test('hello_ack returns true (no-op for unknown session)', () => {
+    const adapter = createAdapter();
+    const msg: HelloAckMessage = {
+      type: 'hello_ack',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      serverVersion: '1.0',
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('transcript_content returns true for user role (skipped)', () => {
+    const adapter = createAdapter();
+    const msg: TranscriptContentMessage = {
+      type: 'transcript_content',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      entryUuid: 'entry-1',
+      role: 'user',
+      content: 'user said something',
+      message: {
+        id: generateId(),
+        sessionId: generateId(),
+        sender: 'agent',
+        content: 'user said something',
+        createdAt: now(),
+        state: 'delivered',
+        stateChangedAt: now(),
+        isEditing: false,
+        bullets: [],
+      },
+      isUpdate: false,
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('transcript_content for assistant returns false for unknown connection', () => {
+    const adapter = createAdapter();
+    const msg: TranscriptContentMessage = {
+      type: 'transcript_content',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      entryUuid: 'entry-1',
+      role: 'assistant',
+      content: 'assistant response',
+      message: {
+        id: generateId(),
+        sessionId: generateId(),
+        sender: 'agent',
+        content: 'assistant response',
+        createdAt: now(),
+        state: 'delivered',
+        stateChangedAt: now(),
+        isEditing: false,
+        bullets: [],
+      },
+      isUpdate: false,
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+
+  test('error returns true (attempts to send but no session)', () => {
+    const adapter = createAdapter();
+    const msg: ErrorMessage = {
+      type: 'error',
+      id: generateId(),
+      timestamp: now(),
+      message: 'something went wrong',
+      code: 'UNKNOWN',
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('replay_batch processes inner messages', () => {
+    const adapter = createAdapter();
+    const inner: ErrorMessage = {
+      type: 'error',
+      id: generateId(),
+      timestamp: now(),
+      message: 'inner error',
+      code: 'UNKNOWN',
+    };
+    const msg: ReplayBatchMessage = {
+      type: 'replay_batch',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      messages: [inner],
+      isComplete: true,
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('session_list_response returns true', () => {
+    const adapter = createAdapter();
+    const msg: SessionListResponseMessage = {
+      type: 'session_list_response',
+      id: generateId(),
+      timestamp: now(),
+      sessions: [],
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('transcript_load_complete returns true', () => {
+    const adapter = createAdapter();
+    const msg: TranscriptLoadCompleteMessage = {
+      type: 'transcript_load_complete',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: 'sess-123',
+      messageCount: 10,
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('ping returns true', () => {
+    const adapter = createAdapter();
+    const msg = { type: 'ping', id: generateId(), timestamp: now() } as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('pong returns true', () => {
+    const adapter = createAdapter();
+    const msg = { type: 'pong', id: generateId(), timestamp: now() } as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('unknown type returns false', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'totally_unknown_type',
+      id: generateId(),
+      timestamp: now(),
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+  });
+});
+
+describe('broadcast', () => {
+  test('does not throw with no sessions', () => {
+    const adapter = createAdapter();
+    const msg: ErrorMessage = {
+      type: 'error',
+      id: generateId(),
+      timestamp: now(),
+      message: 'test',
+      code: 'UNKNOWN',
+    };
+    expect(() => adapter.broadcast(msg)).not.toThrow();
+  });
+});
+
+describe('hasConnection', () => {
+  test('returns false for unknown connectionId', () => {
+    const adapter = createAdapter();
+    expect(adapter.hasConnection(unknownConnectionId)).toBe(false);
+  });
+});

--- a/packages/daemon/tests/telegram-ui.test.ts
+++ b/packages/daemon/tests/telegram-ui.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for telegram-ui.ts pure utility functions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AgentStatus, DiscoverableSession, Message, Question, UUID } from '@remi/shared';
+import {
+  formatHelpMessage,
+  formatMessageForTelegram,
+  formatQuestionKeyboard,
+  formatSessionList,
+  formatStatusText,
+  isValidContent,
+  stripTerminalCodes,
+} from '../src/adapters/telegram-ui.ts';
+
+describe('stripTerminalCodes', () => {
+  test('removes ANSI color codes', () => {
+    expect(stripTerminalCodes('\x1b[31mred text\x1b[0m')).toBe('red text');
+  });
+
+  test('removes cursor movement sequences', () => {
+    expect(stripTerminalCodes('\x1b[2Ahello\x1b[3B')).toBe('hello');
+  });
+
+  test('removes OSC sequences', () => {
+    expect(stripTerminalCodes('\x1b]0;title\x07content')).toBe('content');
+  });
+
+  test('removes private mode sequences', () => {
+    expect(stripTerminalCodes('\x1b[?25hvisible\x1b[?25l')).toBe('visible');
+  });
+
+  test('removes control characters except newline and tab', () => {
+    expect(stripTerminalCodes('hello\x00\x01\x02world')).toBe('helloworld');
+    expect(stripTerminalCodes('line1\nline2\ttab')).toBe('line1\nline2\ttab');
+  });
+
+  test('passes through clean text unchanged', () => {
+    expect(stripTerminalCodes('hello world')).toBe('hello world');
+  });
+
+  test('handles empty string', () => {
+    expect(stripTerminalCodes('')).toBe('');
+  });
+
+  test('removes multiple mixed sequences', () => {
+    const input = '\x1b[1m\x1b[32mbold green\x1b[0m normal \x1b[?25h';
+    const result = stripTerminalCodes(input);
+    expect(result).toBe('bold green normal ');
+  });
+});
+
+describe('isValidContent', () => {
+  test('returns true for text with alphanumeric content', () => {
+    expect(isValidContent('hello world')).toBe(true);
+  });
+
+  test('returns true for text with numbers', () => {
+    expect(isValidContent('123')).toBe(true);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isValidContent('')).toBe(false);
+  });
+
+  test('returns false for whitespace only', () => {
+    expect(isValidContent('   ')).toBe(false);
+  });
+
+  test('returns false for only special characters', () => {
+    expect(isValidContent('---')).toBe(false);
+  });
+
+  test('returns true for text with ANSI codes that has content underneath', () => {
+    expect(isValidContent('\x1b[31mhello\x1b[0m')).toBe(true);
+  });
+
+  test('returns false for only ANSI codes with no real content', () => {
+    expect(isValidContent('\x1b[31m\x1b[0m')).toBe(false);
+  });
+});
+
+describe('formatMessageForTelegram', () => {
+  function makeMessage(overrides: Partial<Message> = {}): Message {
+    return {
+      id: 'msg-1' as UUID,
+      sessionId: 'sess-1' as UUID,
+      sender: 'agent',
+      content: 'Hello world',
+      createdAt: '2026-01-01T00:00:00Z',
+      state: 'delivered',
+      stateChangedAt: '2026-01-01T00:00:00Z',
+      isEditing: false,
+      ...overrides,
+    };
+  }
+
+  test('formats basic message', () => {
+    const result = formatMessageForTelegram(makeMessage());
+    expect(result).toBe('Hello world');
+  });
+
+  test('strips ANSI codes from content', () => {
+    const result = formatMessageForTelegram(makeMessage({ content: '\x1b[32mgreen\x1b[0m' }));
+    expect(result).toBe('green');
+  });
+
+  test('returns empty string for invalid content', () => {
+    const result = formatMessageForTelegram(makeMessage({ content: '\x1b[0m' }));
+    expect(result).toBe('');
+  });
+
+  test('truncates messages over 4000 characters', () => {
+    const longContent = 'a'.repeat(5000);
+    const result = formatMessageForTelegram(makeMessage({ content: longContent }));
+    expect(result.length).toBeLessThanOrEqual(4000);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  test('adds tool indicator for editing messages', () => {
+    const result = formatMessageForTelegram(
+      makeMessage({ tool: 'read_file', isEditing: true, content: 'Reading file...' }),
+    );
+    expect(result).toContain('read_file');
+    expect(result).toContain('Reading file...');
+  });
+
+  test('does not add tool indicator when not editing', () => {
+    const result = formatMessageForTelegram(
+      makeMessage({ tool: 'read_file', isEditing: false, content: 'Done' }),
+    );
+    expect(result).toBe('Done');
+  });
+});
+
+describe('formatQuestionKeyboard', () => {
+  function makeQuestion(overrides: Partial<Question> = {}): Question {
+    return {
+      id: 'q-1' as UUID,
+      text: 'Allow this?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      ...overrides,
+    };
+  }
+
+  test('returns an InlineKeyboard object', () => {
+    const keyboard = formatQuestionKeyboard(makeQuestion());
+    expect(keyboard).toBeDefined();
+  });
+
+  test('creates buttons for options', () => {
+    const question = makeQuestion({
+      options: [
+        { label: 'Yes', value: 'y', isYes: true, isNo: false, isRecommended: false },
+        { label: 'No', value: 'n', isYes: false, isNo: true, isRecommended: false },
+      ],
+    });
+    const keyboard = formatQuestionKeyboard(question);
+    // InlineKeyboard from grammY; the inline_keyboard property holds the rows
+    const raw = (keyboard as unknown as { inline_keyboard: unknown[][] }).inline_keyboard;
+    expect(raw).toBeDefined();
+  });
+
+  test('handles question with no options and free text', () => {
+    const question = makeQuestion({ options: [], allowsFreeText: true });
+    // Should not throw
+    const keyboard = formatQuestionKeyboard(question);
+    expect(keyboard).toBeDefined();
+  });
+});
+
+describe('formatStatusText', () => {
+  test('formats idle status', () => {
+    expect(formatStatusText('idle')).toContain('Idle');
+  });
+
+  test('formats thinking status', () => {
+    expect(formatStatusText('thinking')).toContain('Thinking');
+  });
+
+  test('formats executing status', () => {
+    expect(formatStatusText('executing')).toContain('Executing');
+  });
+
+  test('formats waiting status', () => {
+    expect(formatStatusText('waiting')).toContain('Waiting');
+  });
+
+  test('returns raw string for unknown status', () => {
+    expect(formatStatusText('custom' as AgentStatus)).toBe('custom');
+  });
+});
+
+describe('formatHelpMessage', () => {
+  test('returns a non-empty string', () => {
+    const help = formatHelpMessage();
+    expect(help.length).toBeGreaterThan(0);
+  });
+
+  test('includes key commands', () => {
+    const help = formatHelpMessage();
+    expect(help).toContain('/start');
+    expect(help).toContain('/stop');
+    expect(help).toContain('/help');
+    expect(help).toContain('/sessions');
+    expect(help).toContain('/load');
+  });
+});
+
+describe('formatSessionList', () => {
+  function makeSession(overrides: Partial<DiscoverableSession> = {}): DiscoverableSession {
+    return {
+      sessionId: 'sess-abc-123',
+      projectPath: '/home/user/projects/my-app',
+      status: 'active',
+      lastActivity: '2026-01-01T00:00:00Z',
+      messageCount: 42,
+      source: 'daemon',
+      canAttach: true,
+      ...overrides,
+    };
+  }
+
+  test('returns "No sessions found." for empty list', () => {
+    expect(formatSessionList([])).toBe('No sessions found.');
+  });
+
+  test('shows session count', () => {
+    const result = formatSessionList([makeSession()]);
+    expect(result).toContain('Sessions (1)');
+  });
+
+  test('shows project name from path', () => {
+    const result = formatSessionList([makeSession({ projectPath: '/home/user/projects/my-app' })]);
+    expect(result).toContain('my-app');
+  });
+
+  test('shows session ID', () => {
+    const result = formatSessionList([makeSession({ sessionId: 'abc-123' })]);
+    expect(result).toContain('abc-123');
+  });
+
+  test('shows message count', () => {
+    const result = formatSessionList([makeSession({ messageCount: 99 })]);
+    expect(result).toContain('99');
+  });
+
+  test('shows correct status icon for active', () => {
+    const result = formatSessionList([makeSession({ status: 'active' })]);
+    expect(result).toContain('🟢');
+  });
+
+  test('shows correct status icon for idle', () => {
+    const result = formatSessionList([makeSession({ status: 'idle' })]);
+    expect(result).toContain('💤');
+  });
+
+  test('shows correct status icon for orphaned', () => {
+    const result = formatSessionList([makeSession({ status: 'orphaned' })]);
+    expect(result).toContain('🔴');
+  });
+
+  test('shows correct status icon for completed', () => {
+    const result = formatSessionList([makeSession({ status: 'completed' })]);
+    expect(result).toContain('✅');
+  });
+
+  test('formats multiple sessions', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess-1', projectPath: '/a/proj1' }),
+      makeSession({ sessionId: 'sess-2', projectPath: '/b/proj2' }),
+    ];
+    const result = formatSessionList(sessions);
+    expect(result).toContain('Sessions (2)');
+    expect(result).toContain('sess-1');
+    expect(result).toContain('sess-2');
+    expect(result).toContain('proj1');
+    expect(result).toContain('proj2');
+  });
+});


### PR DESCRIPTION
## Summary
- Handle all protocol message types in sendRaw: structured_agent_output, transcript_content, edit, error, replay_batch, hello_ack (session ID sync)
- Add authorization middleware with TELEGRAM_AUTHORIZED_CHAT_IDS and TELEGRAM_AUTHORIZED_USER_IDS env vars
- Document new env vars in --help output

## Test plan
- [x] Type check passes: `bun run typecheck`
- [x] All 571 tests pass
- [ ] Manual: test sendRaw routing with each message type
- [ ] Manual: test authorization filtering with restricted chat IDs

Closes #9