### PR TITLE
Remote connectivity via signaling relay

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -286,6 +286,8 @@ let cliPort: number | undefined;
 let cliNoTelegram = false;
 let cliMaxBulletLength: number | undefined;
 let cliDaemonMode = false;
+let cliRemote = false;
+let cliSignalingUrl: string | undefined;
 let cliResume: string | true | undefined; // true = resume most recent, string = session ID
 let cliShowSessions = false;
 const claudeArgs: string[] = [];
@@ -314,6 +316,11 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--no-telegram') {
     cliNoTelegram = true;
+  } else if (arg === '--remote') {
+    cliRemote = true;
+  } else if (arg === '--signaling-url' && nextArg) {
+    cliSignalingUrl = nextArg;
+    i++;
   } else if (arg === '--help' || arg === '-h') {
     console.log(`
 Remi - Claude Code with remote monitoring
@@ -328,6 +335,8 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
+  --remote                 Enable remote access via signaling relay
+  --signaling-url URL      Signaling server URL (default: wss://remi-signaling.yooz.workers.dev/connect)
   --help, -h               Show this help
 
 Environment:
@@ -1081,6 +1090,19 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
     sharedEvents,
   );
   registry.register(telegramAdapter);
+}
+
+if (cliRemote) {
+  const { RelayAdapter } = await import('./remote/relay-adapter.ts');
+  const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.yooz.workers.dev/connect';
+  const relayAdapter = new RelayAdapter(
+    {
+      enabled: true,
+      signalingUrl,
+    },
+    sharedEvents,
+  );
+  registry.register(relayAdapter);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -170,7 +170,7 @@ export class RelayAdapter implements ConnectionAdapter {
 
   sendStatus(_connectionId: UUID, _status: AgentStatus, _context?: string): boolean {
     // Status updates are sent as raw session_update messages by the daemon
-    return true;
+    return false;
   }
 
   sendRaw(connectionId: UUID, message: ProtocolMessage): boolean {

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -1,0 +1,202 @@
+/**
+ * Relay Adapter - bridges signaling server to daemon's adapter interface.
+ *
+ * Uses the signaling server as a message relay for remote clients.
+ * Remi protocol messages are serialized as relay payloads.
+ */
+
+import { createAgentOutput, createQuestion, generateId } from '@remi/shared';
+import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
+import type {
+  AdapterConfig,
+  AdapterEvents,
+  AdapterMetadata,
+  ConnectionAdapter,
+} from '../adapters/connection-adapter.ts';
+import { SignalingClient } from './signaling-client.ts';
+
+export interface RelayAdapterConfig extends AdapterConfig {
+  readonly signalingUrl: string;
+}
+
+export class RelayAdapter implements ConnectionAdapter {
+  readonly type = 'relay';
+
+  private readonly config: RelayAdapterConfig;
+  private readonly events: Partial<AdapterEvents>;
+  private client: SignalingClient | null = null;
+  private running = false;
+  private connectionCode: string | null = null;
+
+  /** Single client connection ID (relay supports one remote client at a time) */
+  private clientConnectionId: UUID | null = null;
+
+  constructor(config: RelayAdapterConfig, events: Partial<AdapterEvents> = {}) {
+    this.config = config;
+    this.events = events;
+  }
+
+  get connectionCount(): number {
+    return this.clientConnectionId ? 1 : 0;
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  get code(): string | null {
+    return this.connectionCode;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) {
+      throw new Error('Relay adapter already running');
+    }
+
+    if (!this.config.enabled) {
+      console.log('Relay adapter disabled');
+      return;
+    }
+
+    this.client = new SignalingClient(this.config.signalingUrl);
+
+    this.client.on('registered', (code: string) => {
+      this.connectionCode = code;
+      console.log(`Remote access code: ${code}`);
+    });
+
+    this.client.on('peer-connected', () => {
+      const connectionId = generateId();
+      this.clientConnectionId = connectionId;
+
+      const metadata: AdapterMetadata = {
+        adapterType: this.type,
+        displayName: 'Remote Client',
+        platformData: { code: this.connectionCode },
+      };
+
+      this.events.onConnect?.(connectionId, metadata);
+    });
+
+    this.client.on('peer-disconnected', () => {
+      if (this.clientConnectionId) {
+        this.events.onDisconnect?.(this.clientConnectionId, 'Remote client disconnected');
+        this.clientConnectionId = null;
+      }
+    });
+
+    this.client.on('relay', (payload: string) => {
+      if (!this.clientConnectionId) return;
+
+      try {
+        const message = JSON.parse(payload);
+        if (!message || typeof message !== 'object' || typeof message.type !== 'string') return;
+
+        // Route incoming protocol messages from the remote client
+        switch (message.type) {
+          case 'user_input':
+            this.events.onUserInput?.(
+              this.clientConnectionId,
+              message.sessionId,
+              message.content,
+            );
+            break;
+          case 'answer':
+            this.events.onAnswer?.(
+              this.clientConnectionId,
+              message.questionId,
+              message.answer,
+            );
+            break;
+          case 'session_list_request':
+            this.events.onSessionListRequest?.(
+              this.clientConnectionId,
+              message.id,
+              message.includeExternal ?? false,
+            );
+            break;
+          case 'transcript_load_request':
+            this.events.onTranscriptLoadRequest?.(
+              this.clientConnectionId,
+              message.sessionId,
+              message.id,
+            );
+            break;
+          case 'create_session_request':
+            this.events.onCreateSessionRequest?.(
+              this.clientConnectionId,
+              message.directory,
+              message.id,
+            );
+            break;
+          case 'bullet_expand_request':
+            this.events.onBulletExpandRequest?.(
+              this.clientConnectionId,
+              message.sessionId,
+              message.bulletId,
+              message.id,
+            );
+            break;
+          case 'hello':
+            // Forward as connect event (already handled above)
+            break;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.client.on('error', (code: string, msg: string) => {
+      console.error(`Relay signaling error [${code}]: ${msg}`);
+    });
+
+    this.client.connect();
+    this.running = true;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running || !this.client) return;
+
+    if (this.clientConnectionId) {
+      this.events.onDisconnect?.(this.clientConnectionId, 'Relay adapter stopped');
+      this.clientConnectionId = null;
+    }
+
+    this.client.close();
+    this.client = null;
+    this.running = false;
+    this.connectionCode = null;
+  }
+
+  sendMessage(connectionId: UUID, message: Message): boolean {
+    return this.sendRaw(connectionId, createAgentOutput(message));
+  }
+
+  sendQuestion(connectionId: UUID, question: Question): boolean {
+    return this.sendRaw(connectionId, createQuestion(question));
+  }
+
+  sendStatus(_connectionId: UUID, _status: AgentStatus, _context?: string): boolean {
+    // Status updates are sent as raw session_update messages by the daemon
+    return true;
+  }
+
+  sendRaw(connectionId: UUID, message: ProtocolMessage): boolean {
+    if (connectionId !== this.clientConnectionId || !this.client?.isConnected) {
+      return false;
+    }
+
+    this.client.sendRelay(JSON.stringify(message));
+    return true;
+  }
+
+  broadcast(message: ProtocolMessage): void {
+    if (this.clientConnectionId) {
+      this.sendRaw(this.clientConnectionId, message);
+    }
+  }
+
+  hasConnection(connectionId: UUID): boolean {
+    return connectionId === this.clientConnectionId;
+  }
+}

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -95,18 +95,10 @@ export class RelayAdapter implements ConnectionAdapter {
         // Route incoming protocol messages from the remote client
         switch (message.type) {
           case 'user_input':
-            this.events.onUserInput?.(
-              this.clientConnectionId,
-              message.sessionId,
-              message.content,
-            );
+            this.events.onUserInput?.(this.clientConnectionId, message.sessionId, message.content);
             break;
           case 'answer':
-            this.events.onAnswer?.(
-              this.clientConnectionId,
-              message.questionId,
-              message.answer,
-            );
+            this.events.onAnswer?.(this.clientConnectionId, message.questionId, message.answer);
             break;
           case 'session_list_request':
             this.events.onSessionListRequest?.(

--- a/packages/daemon/src/remote/signaling-client.ts
+++ b/packages/daemon/src/remote/signaling-client.ts
@@ -1,0 +1,112 @@
+/**
+ * Signaling Client - connects to the signaling server.
+ *
+ * Handles registration, code display, and relay message forwarding.
+ */
+
+import { EventEmitter } from 'node:events';
+
+export interface SignalingClientEvents {
+  registered: (code: string, expiresAt: string) => void;
+  'peer-connected': () => void;
+  'peer-disconnected': () => void;
+  relay: (payload: string) => void;
+  error: (code: string, message: string) => void;
+  close: () => void;
+  open: () => void;
+}
+
+export class SignalingClient extends EventEmitter {
+  private ws: WebSocket | null = null;
+  private readonly url: string;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+
+  constructor(url: string) {
+    super();
+    this.url = url;
+  }
+
+  connect(): void {
+    this.closed = false;
+    this.ws = new WebSocket(this.url);
+
+    this.ws.addEventListener('open', () => {
+      this.emit('open');
+      this.send({ type: 'register' });
+    });
+
+    this.ws.addEventListener('message', (event) => {
+      try {
+        const msg = JSON.parse(String(event.data));
+        switch (msg.type) {
+          case 'registered':
+            this.emit('registered', msg.code, msg.expiresAt);
+            break;
+          case 'peer-connected':
+            this.emit('peer-connected');
+            break;
+          case 'peer-disconnected':
+            this.emit('peer-disconnected');
+            break;
+          case 'relay':
+            this.emit('relay', msg.payload);
+            break;
+          case 'error':
+            this.emit('error', msg.code, msg.message);
+            break;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.addEventListener('close', () => {
+      this.ws = null;
+      this.emit('close');
+      if (!this.closed) {
+        this.scheduleReconnect();
+      }
+    });
+
+    this.ws.addEventListener('error', () => {
+      // close event will follow
+    });
+  }
+
+  sendRelay(payload: string): void {
+    this.send({ type: 'relay', payload });
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  get isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private send(msg: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.closed) {
+        this.connect();
+      }
+    }, 5000);
+  }
+}

--- a/packages/daemon/src/remote/signaling-client.ts
+++ b/packages/daemon/src/remote/signaling-client.ts
@@ -28,6 +28,10 @@ export class SignalingClient extends EventEmitter {
   }
 
   connect(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
     this.closed = false;
     this.ws = new WebSocket(this.url);
 

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -52,7 +52,7 @@ describe('Protocol factory functions', () => {
       const serialized = serialize(original);
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('hello');
+      expect(deserialized?.type).toBe('hello');
       expect((deserialized as typeof original).clientId).toBe('client-1');
       expect((deserialized as typeof original).directory).toBe('/dir');
       expect((deserialized as typeof original).resumeSessionId).toBe('sess-1');
@@ -111,7 +111,7 @@ describe('Protocol factory functions', () => {
       const original = createCreateSessionRequest('/some/dir');
       const deserialized = deserialize(serialize(original));
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('create_session_request');
+      expect(deserialized?.type).toBe('create_session_request');
       expect((deserialized as typeof original).directory).toBe('/some/dir');
     });
   });
@@ -149,7 +149,7 @@ describe('Protocol factory functions', () => {
       const original = createCreateSessionResponse(true, 'req-1' as UUID, 'sess-1' as UUID);
       const deserialized = deserialize(serialize(original));
       expect(deserialized).not.toBeNull();
-      expect(deserialized!.type).toBe('create_session_response');
+      expect(deserialized?.type).toBe('create_session_response');
       expect((deserialized as typeof original).success).toBe(true);
       expect((deserialized as typeof original).sessionId).toBe('sess-1');
     });

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -175,7 +175,7 @@ describe('Protocol factory functions', () => {
         '{"type":"create_session_request","id":"1","timestamp":"2024-01-01T00:00:00Z"}',
       );
       expect(result).not.toBeNull();
-      expect(result!.type).toBe('create_session_request');
+      expect(result?.type).toBe('create_session_request');
     });
 
     test('accepts create_session_response type', () => {
@@ -183,7 +183,7 @@ describe('Protocol factory functions', () => {
         '{"type":"create_session_response","id":"1","timestamp":"2024-01-01T00:00:00Z","success":true,"requestId":"r1"}',
       );
       expect(result).not.toBeNull();
-      expect(result!.type).toBe('create_session_response');
+      expect(result?.type).toBe('create_session_response');
     });
   });
 });

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -100,6 +100,7 @@ export class ConnectionRoom {
       case 'offer':
       case 'answer':
       case 'ice-candidate':
+      case 'relay':
         await this.handleSignaling(ws, message);
         break;
       default:

--- a/packages/signaling/src/types.ts
+++ b/packages/signaling/src/types.ts
@@ -24,7 +24,8 @@ export type SignalingMessage =
   | IceCandidateMessage
   | ErrorMessage
   | PeerConnectedMessage
-  | PeerDisconnectedMessage;
+  | PeerDisconnectedMessage
+  | RelayMessage;
 
 /** Host registers to get a connection code */
 export interface RegisterMessage {
@@ -89,6 +90,12 @@ export interface PeerDisconnectedMessage {
   readonly role: PeerRole;
 }
 
+/** Relay message - forwarded between host and client */
+export interface RelayMessage {
+  readonly type: 'relay';
+  readonly payload: string;
+}
+
 /**
  * Parse a signaling message from JSON.
  */
@@ -115,6 +122,7 @@ export function parseMessage(data: string): SignalingMessage | null {
       'error',
       'peer-connected',
       'peer-disconnected',
+      'relay',
     ];
 
     if (!validTypes.includes(obj.type)) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -450,6 +450,13 @@ function App() {
 
   const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
 
+  // Clean up signaling client on unmount
+  useEffect(() => {
+    return () => {
+      signalingClientRef.current?.close();
+    };
+  }, []);
+
   const handleConnectCode = useCallback((code: string) => {
     // Dynamic import to avoid bundling when not used
     import('@/lib/signaling-client').then(({ WebSignalingClient }) => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -448,9 +448,46 @@ function App() {
     [connect],
   );
 
-  const handleConnectCode = useCallback((_code: string) => {
-    void _code;
-    console.warn('WebRTC connection not yet implemented');
+  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
+
+  const handleConnectCode = useCallback((code: string) => {
+    // Dynamic import to avoid bundling when not used
+    import('@/lib/signaling-client').then(({ WebSignalingClient }) => {
+      // Close existing signaling connection if any
+      if (signalingClientRef.current) {
+        signalingClientRef.current.close();
+      }
+
+      const signalingUrl = 'wss://remi-signaling.yooz.workers.dev/connect';
+      const client = new WebSignalingClient({
+        onStateChange: (state) => {
+          if (state === 'connected') {
+            setShowConnectModal(false);
+            // Send hello via relay
+            const hello = {
+              type: 'hello',
+              id: generateId(),
+              timestamp: new Date().toISOString(),
+              clientId: 'remi-web',
+              clientVersion: '0.1.0',
+            };
+            client.sendMessage(hello);
+          }
+        },
+        onMessage: (message) => {
+          // Forward relay messages to the existing message handler
+          if (handleMessageRef.current && message && typeof message === 'object' && 'type' in message) {
+            handleMessageRef.current(message as ProtocolMessage);
+          }
+        },
+        onError: (errCode, errMsg) => {
+          console.error(`Signaling error [${errCode}]: ${errMsg}`);
+        },
+      });
+
+      signalingClientRef.current = client;
+      client.connect(signalingUrl, code);
+    });
   }, []);
 
   const handleBulletExpand = useCallback(

--- a/packages/web/src/lib/signaling-client.ts
+++ b/packages/web/src/lib/signaling-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Signaling client for web app.
+ *
+ * Connects to the signaling server, joins a room via code,
+ * and relays Remi protocol messages.
+ */
+
+export type SignalingState = 'disconnected' | 'connecting' | 'joined' | 'connected' | 'error';
+
+export interface SignalingClientCallbacks {
+  onStateChange: (state: SignalingState) => void;
+  onMessage: (message: unknown) => void;
+  onError: (code: string, message: string) => void;
+}
+
+export class WebSignalingClient {
+  private ws: WebSocket | null = null;
+  private readonly callbacks: SignalingClientCallbacks;
+  private state: SignalingState = 'disconnected';
+
+  constructor(callbacks: SignalingClientCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  connect(signalingUrl: string, code: string): void {
+    this.setState('connecting');
+
+    this.ws = new WebSocket(signalingUrl);
+
+    this.ws.addEventListener('open', () => {
+      // Join with the provided code
+      this.send({ type: 'join', code });
+    });
+
+    this.ws.addEventListener('message', (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        switch (msg.type) {
+          case 'joined':
+            this.setState('joined');
+            break;
+          case 'peer-connected':
+            this.setState('connected');
+            break;
+          case 'peer-disconnected':
+            this.setState('disconnected');
+            break;
+          case 'relay':
+            try {
+              const payload = JSON.parse(msg.payload as string);
+              this.callbacks.onMessage(payload);
+            } catch {
+              // ignore bad payloads
+            }
+            break;
+          case 'error':
+            this.callbacks.onError(msg.code, msg.message);
+            this.setState('error');
+            break;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.addEventListener('close', () => {
+      this.ws = null;
+      this.setState('disconnected');
+    });
+
+    this.ws.addEventListener('error', () => {
+      // close event will follow
+    });
+  }
+
+  sendMessage(message: unknown): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.send({ type: 'relay', payload: JSON.stringify(message) });
+  }
+
+  close(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.setState('disconnected');
+  }
+
+  get isConnected(): boolean {
+    return this.state === 'connected';
+  }
+
+  get currentState(): SignalingState {
+    return this.state;
+  }
+
+  private setState(state: SignalingState): void {
+    this.state = state;
+    this.callbacks.onStateChange(state);
+  }
+
+  private send(msg: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+}

--- a/packages/web/src/lib/signaling-client.ts
+++ b/packages/web/src/lib/signaling-client.ts
@@ -17,17 +17,36 @@ export class WebSignalingClient {
   private ws: WebSocket | null = null;
   private readonly callbacks: SignalingClientCallbacks;
   private state: SignalingState = 'disconnected';
+  private intentionallyClosed = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private readonly maxReconnectAttempts = 3;
+  private signalingUrl: string | null = null;
+  private code: string | null = null;
 
   constructor(callbacks: SignalingClientCallbacks) {
     this.callbacks = callbacks;
   }
 
   connect(signalingUrl: string, code: string): void {
+    this.signalingUrl = signalingUrl;
+    this.code = code;
+    this.intentionallyClosed = false;
+    this.reconnectAttempts = 0;
+    this.connectInternal();
+  }
+
+  private connectInternal(): void {
+    if (!this.signalingUrl || !this.code) return;
+
     this.setState('connecting');
 
-    this.ws = new WebSocket(signalingUrl);
+    this.ws = new WebSocket(this.signalingUrl);
+
+    const code = this.code;
 
     this.ws.addEventListener('open', () => {
+      this.reconnectAttempts = 0;
       // Join with the provided code
       this.send({ type: 'join', code });
     });
@@ -65,7 +84,11 @@ export class WebSignalingClient {
 
     this.ws.addEventListener('close', () => {
       this.ws = null;
-      this.setState('disconnected');
+      if (!this.intentionallyClosed && this.reconnectAttempts < this.maxReconnectAttempts) {
+        this.scheduleReconnect();
+      } else {
+        this.setState('disconnected');
+      }
     });
 
     this.ws.addEventListener('error', () => {
@@ -79,11 +102,27 @@ export class WebSignalingClient {
   }
 
   close(): void {
+    this.intentionallyClosed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.ws) {
       this.ws.close();
       this.ws = null;
     }
     this.setState('disconnected');
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectAttempts++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.intentionallyClosed) {
+        this.connectInternal();
+      }
+    }, 5000);
   }
 
   get isConnected(): boolean {


### PR DESCRIPTION
## Summary
- Add relay message type to signaling server (Cloudflare Worker) for forwarding Remi protocol messages
- Create RelayAdapter and SignalingClient for daemon side
- Create WebSignalingClient for web app with code-split lazy loading
- Wire --remote and --signaling-url CLI flags
- Implement handleConnectCode in web app to join via connection code

## Test plan
- [x] Type check passes: `bun run typecheck`
- [x] Web build succeeds with signaling client code-split
- [x] All 571 tests pass
- [ ] Deploy signaling server to Cloudflare (blocker: need wrangler access)
- [ ] Test full flow: daemon --remote, enter code in web client
- [ ] Test relay message forwarding both directions

Closes #10