### PR TITLE
SSH-style public key authentication

### DIFF
--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -60,6 +60,7 @@ export class WebSocketAdapter implements ConnectionAdapter {
       ...(config.host && { host: config.host }),
       ...(config.path && { path: config.path }),
       ...(config.maxConnections !== undefined && { maxConnections: config.maxConnections }),
+      ...(config.authenticator && { authenticator: config.authenticator }),
     } as WebSocketAdapterConfig;
     this.events = events;
   }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -7,6 +7,7 @@
 
 import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
 import { createAgentOutput, createQuestion, createSessionUpdate } from '@remi/shared';
+import type { Authenticator } from '../auth/authenticator.ts';
 import {
   type ServerConfig,
   type ServerEvents,
@@ -32,6 +33,9 @@ export interface WebSocketAdapterConfig extends AdapterConfig {
 
   /** Maximum concurrent connections */
   readonly maxConnections?: number;
+
+  /** Authenticator instance (enables SSH-style auth) */
+  readonly authenticator?: Authenticator | undefined;
 }
 
 const DEFAULT_PORT = 8765;
@@ -147,6 +151,7 @@ export class WebSocketAdapter implements ConnectionAdapter {
       // Let daemon handle HelloAck to include resume info
       connection: {
         skipHelloAck: true,
+        ...(this.config.authenticator && { authenticator: this.config.authenticator }),
       },
     };
 

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -1,10 +1,13 @@
 /**
  * Authenticator - Server-side authentication logic.
  *
- * Handles the challenge-response handshake:
- * 1. Generate challenge with server's public key
+ * Handles the Ed25519 challenge-response handshake:
+ * 1. Generate a random one-time challenge with server's public key
  * 2. Verify client's signature and check authorized keys
  * 3. Sign challenge for mutual authentication
+ *
+ * Each challenge is consumed on first verification attempt (one-time use)
+ * to prevent replay attacks.
  */
 
 import type {
@@ -25,8 +28,8 @@ import {
 import type { IdentityStore } from './identity-store.ts';
 
 export interface AuthenticatorConfig {
-  identity: UnlockedIdentity;
-  identityStore: IdentityStore;
+  readonly identity: UnlockedIdentity;
+  readonly identityStore: IdentityStore;
 }
 
 export class Authenticator {
@@ -67,10 +70,13 @@ export class Authenticator {
     this.pendingChallenges.delete(connectionId);
 
     // Check if client's key is authorized
-    const isAuthorized = this.store.isAuthorized(
-      response.clientPublicKey,
-      response.clientFingerprint,
-    );
+    let isAuthorized: boolean;
+    try {
+      isAuthorized = this.store.isAuthorized(response.clientPublicKey, response.clientFingerprint);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`);
+    }
     if (!isAuthorized) {
       return createAuthResult(false, undefined, 'UNKNOWN_KEY');
     }

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -2,9 +2,9 @@
  * Authenticator - Server-side authentication logic.
  *
  * Handles the Ed25519 challenge-response handshake:
- * 1. Generate a random one-time challenge with server's public key
- * 2. Verify client's signature and check authorized keys
- * 3. Sign challenge for mutual authentication
+ * 1. Generate a random one-time challenge, include server's fingerprint and public key
+ * 2. Verify client's Ed25519 signature and check authorized keys list
+ * 3. Sign the same challenge with the server's private key (mutual authentication)
  *
  * Each challenge is consumed on first verification attempt (one-time use)
  * to prevent replay attacks.
@@ -75,6 +75,7 @@ export class Authenticator {
       isAuthorized = this.store.isAuthorized(response.clientPublicKey, response.clientFingerprint);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Auth store error during verification: ${detail}`);
       return createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`);
     }
     if (!isAuthorized) {
@@ -95,14 +96,19 @@ export class Authenticator {
       return createAuthResult(false, undefined, code);
     }
 
-    // Update lastUsedAt
+    // Update lastUsedAt (non-critical; don't let failures break auth)
     this.store.touchAuthorizedKey(response.clientFingerprint);
 
-    // Sign the challenge ourselves for mutual authentication
-    const challengeData = fromBase64(challenge);
-    const serverSignature = await sign(this.identity.privateKey, challengeData);
-
-    return createAuthResult(true, serverSignature);
+    // Sign the same challenge with server's key for mutual authentication
+    try {
+      const challengeData = fromBase64(challenge);
+      const serverSignature = await sign(this.identity.privateKey, challengeData);
+      return createAuthResult(true, serverSignature);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Server failed to sign mutual auth challenge: ${detail}`);
+      return createAuthResult(false, undefined, 'SERVER_SIGN_ERROR');
+    }
   }
 
   /**

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -84,8 +84,9 @@ export class Authenticator {
       if (!valid) {
         return createAuthResult(false, undefined, 'INVALID_SIGNATURE');
       }
-    } catch {
-      return createAuthResult(false, undefined, 'INVALID_SIGNATURE');
+    } catch (err) {
+      const code = err instanceof DOMException ? 'INVALID_KEY_DATA' : 'VERIFICATION_ERROR';
+      return createAuthResult(false, undefined, code);
     }
 
     // Update lastUsedAt

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -1,0 +1,117 @@
+/**
+ * Authenticator - Server-side authentication logic.
+ *
+ * Handles the challenge-response handshake:
+ * 1. Generate challenge with server's public key
+ * 2. Verify client's signature and check authorized keys
+ * 3. Sign challenge for mutual authentication
+ */
+
+import type {
+  AuthChallengeMessage,
+  AuthResponseMessage,
+  AuthResultMessage,
+  UnlockedIdentity,
+} from '@remi/shared';
+import {
+  createAuthChallenge,
+  createAuthResult,
+  fromBase64,
+  generateChallenge,
+  importPublicKey,
+  sign,
+  verify,
+} from '@remi/shared';
+import type { IdentityStore } from './identity-store.ts';
+
+export interface AuthenticatorConfig {
+  identity: UnlockedIdentity;
+  identityStore: IdentityStore;
+}
+
+export class Authenticator {
+  private readonly identity: UnlockedIdentity;
+  private readonly store: IdentityStore;
+  /** Active challenges keyed by connection ID */
+  private readonly pendingChallenges = new Map<string, string>();
+
+  constructor(config: AuthenticatorConfig) {
+    this.identity = config.identity;
+    this.store = config.identityStore;
+  }
+
+  /**
+   * Create an auth challenge for a new connection.
+   * @param connectionId Unique connection identifier to track the challenge
+   */
+  createChallenge(connectionId: string): AuthChallengeMessage {
+    const challenge = generateChallenge();
+    this.pendingChallenges.set(connectionId, challenge);
+    return createAuthChallenge(challenge, this.identity.fingerprint, this.identity.publicKeyRaw);
+  }
+
+  /**
+   * Verify a client's auth response.
+   * Returns an AuthResultMessage with success/failure.
+   */
+  async verifyResponse(
+    connectionId: string,
+    response: AuthResponseMessage,
+  ): Promise<AuthResultMessage> {
+    const challenge = this.pendingChallenges.get(connectionId);
+    if (!challenge) {
+      return createAuthResult(false, undefined, 'NO_PENDING_CHALLENGE');
+    }
+
+    // Remove challenge (one-time use)
+    this.pendingChallenges.delete(connectionId);
+
+    // Check if client's key is authorized
+    const isAuthorized = this.store.isAuthorized(
+      response.clientPublicKey,
+      response.clientFingerprint,
+    );
+    if (!isAuthorized) {
+      return createAuthResult(false, undefined, 'UNKNOWN_KEY');
+    }
+
+    // Verify the signature
+    try {
+      const clientPublicKey = await importPublicKey(fromBase64(response.clientPublicKey));
+      const challengeData = fromBase64(challenge);
+      const valid = await verify(clientPublicKey, challengeData, response.signature);
+
+      if (!valid) {
+        return createAuthResult(false, undefined, 'INVALID_SIGNATURE');
+      }
+    } catch {
+      return createAuthResult(false, undefined, 'INVALID_SIGNATURE');
+    }
+
+    // Update lastUsedAt
+    this.store.touchAuthorizedKey(response.clientFingerprint);
+
+    // Sign the challenge ourselves for mutual authentication
+    const challengeData = fromBase64(challenge);
+    const serverSignature = await sign(this.identity.privateKey, challengeData);
+
+    return createAuthResult(true, serverSignature);
+  }
+
+  /**
+   * Clean up a pending challenge (e.g., on connection close).
+   */
+  removePendingChallenge(connectionId: string): void {
+    this.pendingChallenges.delete(connectionId);
+  }
+
+  /** Get the server's fingerprint for display. */
+  get serverFingerprint(): string {
+    return this.identity.fingerprint;
+  }
+
+  /** Get the server's public key (Base64) for display. */
+  get serverPublicKey(): string {
+    return this.identity.publicKeyRaw;
+  }
+}

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -53,14 +53,16 @@ export class IdentityStore {
     return fs.existsSync(this.identityPath);
   }
 
-  /** Load the stored identity. Returns null if not found or corrupt. */
+  /** Load the stored identity. Returns null if file does not exist. Throws on corrupt file. */
   load(): RemiIdentity | null {
+    if (!fs.existsSync(this.identityPath)) return null;
     try {
-      if (!fs.existsSync(this.identityPath)) return null;
       const raw = fs.readFileSync(this.identityPath, 'utf-8');
       return deserializeIdentity(raw);
-    } catch {
-      return null;
+    } catch (err) {
+      throw new Error(
+        `Identity file exists at ${this.identityPath} but is corrupt or unreadable: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -91,17 +93,24 @@ export class IdentityStore {
 
   // -- Authorized Keys --
 
-  /** Load authorized keys. Returns empty file if not found. */
+  /** Load authorized keys. Returns empty file if not found. Throws on corrupt file. */
   loadAuthorizedKeys(): AuthorizedKeysFile {
+    if (!fs.existsSync(this.authorizedKeysPath)) return createAuthorizedKeysFile();
+    const raw = fs.readFileSync(this.authorizedKeysPath, 'utf-8');
+    let parsed: Record<string, unknown>;
     try {
-      if (!fs.existsSync(this.authorizedKeysPath)) return createAuthorizedKeysFile();
-      const raw = fs.readFileSync(this.authorizedKeysPath, 'utf-8');
-      const parsed = JSON.parse(raw) as AuthorizedKeysFile;
-      if (parsed.version !== 1 || !Array.isArray(parsed.keys)) return createAuthorizedKeysFile();
-      return parsed;
-    } catch {
-      return createAuthorizedKeysFile();
+      parsed = JSON.parse(raw) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `Authorized keys file is corrupt (${this.authorizedKeysPath}): ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
+    if (parsed['version'] !== 1 || !Array.isArray(parsed['keys'])) {
+      throw new Error(
+        `Authorized keys file has unsupported format (version: ${parsed['version']})`,
+      );
+    }
+    return parsed as unknown as AuthorizedKeysFile;
   }
 
   /** Save authorized keys to disk. */

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -1,0 +1,164 @@
+/**
+ * IdentityStore - Persistent storage for daemon identity and authorized keys.
+ *
+ * Stores:
+ * - ~/.remi/identity.json - Daemon's Ed25519 keypair (private key encrypted)
+ * - ~/.remi/authorized_keys.json - Client public keys allowed to connect
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  AuthorizedKey,
+  AuthorizedKeysFile,
+  Fingerprint,
+  RemiIdentity,
+  UnlockedIdentity,
+} from '@remi/shared';
+import {
+  createAuthorizedKey,
+  createAuthorizedKeysFile,
+  createIdentity,
+  deserializeIdentity,
+  serializeIdentity,
+  unlockIdentity,
+} from '@remi/shared';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const IDENTITY_FILE = 'identity.json';
+const AUTHORIZED_KEYS_FILE = 'authorized_keys.json';
+
+export class IdentityStore {
+  private readonly dir: string;
+  private readonly identityPath: string;
+  private readonly authorizedKeysPath: string;
+
+  constructor(dir?: string) {
+    this.dir = dir ?? REMI_DIR;
+    this.identityPath = path.join(this.dir, IDENTITY_FILE);
+    this.authorizedKeysPath = path.join(this.dir, AUTHORIZED_KEYS_FILE);
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dir)) {
+      fs.mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  // -- Identity --
+
+  /** Check if an identity file exists. */
+  exists(): boolean {
+    return fs.existsSync(this.identityPath);
+  }
+
+  /** Load the stored identity. Returns null if not found or corrupt. */
+  load(): RemiIdentity | null {
+    try {
+      if (!fs.existsSync(this.identityPath)) return null;
+      const raw = fs.readFileSync(this.identityPath, 'utf-8');
+      return deserializeIdentity(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Save an identity to disk with restricted permissions. */
+  save(identity: RemiIdentity): void {
+    this.ensureDir();
+    fs.writeFileSync(this.identityPath, serializeIdentity(identity), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+  }
+
+  /** Generate a new identity and save it. Returns the identity. */
+  async generate(passphrase: string): Promise<RemiIdentity> {
+    const identity = await createIdentity(passphrase);
+    this.save(identity);
+    return identity;
+  }
+
+  /** Unlock the stored identity with a passphrase. */
+  async unlock(passphrase: string): Promise<UnlockedIdentity> {
+    const identity = this.load();
+    if (!identity) {
+      throw new Error('No identity found. Run `remi keygen` first.');
+    }
+    return unlockIdentity(identity, passphrase);
+  }
+
+  // -- Authorized Keys --
+
+  /** Load authorized keys. Returns empty file if not found. */
+  loadAuthorizedKeys(): AuthorizedKeysFile {
+    try {
+      if (!fs.existsSync(this.authorizedKeysPath)) return createAuthorizedKeysFile();
+      const raw = fs.readFileSync(this.authorizedKeysPath, 'utf-8');
+      const parsed = JSON.parse(raw) as AuthorizedKeysFile;
+      if (parsed.version !== 1 || !Array.isArray(parsed.keys)) return createAuthorizedKeysFile();
+      return parsed;
+    } catch {
+      return createAuthorizedKeysFile();
+    }
+  }
+
+  /** Save authorized keys to disk. */
+  saveAuthorizedKeys(file: AuthorizedKeysFile): void {
+    this.ensureDir();
+    fs.writeFileSync(this.authorizedKeysPath, JSON.stringify(file, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+  }
+
+  /** Add a client public key to authorized keys. */
+  async addAuthorizedKey(publicKeyBase64: string, label: string): Promise<AuthorizedKey> {
+    const file = this.loadAuthorizedKeys();
+    const key = await createAuthorizedKey(publicKeyBase64, label);
+
+    // Check for duplicate
+    const existing = file.keys.find((k) => k.fingerprint === key.fingerprint);
+    if (existing) {
+      throw new Error(`Key with fingerprint ${key.fingerprint} already authorized`);
+    }
+
+    file.keys.push(key);
+    this.saveAuthorizedKeys(file);
+    return key;
+  }
+
+  /** Remove an authorized key by fingerprint. */
+  removeAuthorizedKey(fp: Fingerprint): boolean {
+    const file = this.loadAuthorizedKeys();
+    const before = file.keys.length;
+    const filtered = file.keys.filter((k) => k.fingerprint !== fp);
+
+    if (filtered.length === before) return false;
+
+    this.saveAuthorizedKeys({ ...file, keys: filtered });
+    return true;
+  }
+
+  /** Check if a public key is authorized. */
+  isAuthorized(publicKeyBase64: string, fp: Fingerprint): boolean {
+    const file = this.loadAuthorizedKeys();
+    return file.keys.some((k) => k.fingerprint === fp && k.publicKey === publicKeyBase64);
+  }
+
+  /** Update lastUsedAt for an authorized key. */
+  touchAuthorizedKey(fp: Fingerprint): void {
+    const file = this.loadAuthorizedKeys();
+    const key = file.keys.find((k) => k.fingerprint === fp);
+    if (key) {
+      (key as { lastUsedAt: string | null }).lastUsedAt = new Date().toISOString();
+      this.saveAuthorizedKeys(file);
+    }
+  }
+
+  /** List all authorized keys. */
+  listAuthorizedKeys(): readonly AuthorizedKey[] {
+    return this.loadAuthorizedKeys().keys;
+  }
+}

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -31,7 +31,7 @@ const AUTHORIZED_KEYS_FILE = 'authorized_keys.json';
 
 export class IdentityStore {
   private readonly dir: string;
-  private readonly identityPath: string;
+  readonly identityPath: string;
   private readonly authorizedKeysPath: string;
 
   constructor(dir?: string) {

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -156,13 +156,21 @@ export class IdentityStore {
     return file.keys.some((k) => k.fingerprint === fp && k.publicKey === publicKeyBase64);
   }
 
-  /** Update lastUsedAt for an authorized key. */
+  /** Update lastUsedAt for an authorized key. Non-critical; errors are logged but not thrown. */
   touchAuthorizedKey(fp: Fingerprint): void {
-    const file = this.loadAuthorizedKeys();
-    const key = file.keys.find((k) => k.fingerprint === fp);
-    if (key) {
-      (key as { lastUsedAt: string | null }).lastUsedAt = new Date().toISOString();
-      this.saveAuthorizedKeys(file);
+    try {
+      const file = this.loadAuthorizedKeys();
+      const updated = {
+        ...file,
+        keys: file.keys.map((k) =>
+          k.fingerprint === fp ? { ...k, lastUsedAt: new Date().toISOString() } : k,
+        ),
+      };
+      this.saveAuthorizedKeys(updated);
+    } catch (err) {
+      console.warn(
+        `Failed to update lastUsedAt for key ${fp}: ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -322,7 +322,7 @@ let cliPermanentCode = false;
 let cliForce = false;
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
-let cliPassphrase: string | undefined;
+let cliBindHost: string | undefined;
 let cliRemoveFingerprint: string | undefined;
 const claudeArgs: string[] = [];
 
@@ -368,8 +368,8 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--public-only') {
     cliPublicOnly = true;
-  } else if (arg === '--passphrase' && nextArg) {
-    cliPassphrase = nextArg;
+  } else if (arg === '--bind' && nextArg) {
+    cliBindHost = nextArg;
     i++;
   } else if (arg === '--remove' && nextArg) {
     cliRemoveFingerprint = nextArg;
@@ -403,7 +403,7 @@ Options:
   --no-relay               Disable signaling relay (no remote access via connection code)
   --permanent-code         Use a persistent connection code (requires Ed25519 auth over relay)
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
-  --passphrase PASS        Passphrase for keygen (avoids interactive prompt)
+  --bind HOST              Bind WebSocket to HOST (default: localhost; use 0.0.0.0 for all interfaces)
   --force                  Overwrite existing identity (keygen/import-key)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
@@ -417,7 +417,7 @@ Environment:
   REMI_PORT                WebSocket port
   REMI_MAX_BULLET_LENGTH   Max bullet length before truncation (default: 500, 0=disabled)
   TELEGRAM_BOT_TOKEN       Telegram bot token (enables Telegram adapter)
-  REMI_PASSPHRASE              Passphrase to unlock identity (avoids interactive prompt)
+  REMI_PASSPHRASE              Passphrase for identity operations (avoids interactive prompt)
   TELEGRAM_ENABLED              Set to 'false' to disable Telegram
   TELEGRAM_AUTHORIZED_CHAT_IDS  Comma-separated authorized chat IDs
   TELEGRAM_AUTHORIZED_USER_IDS  Comma-separated authorized user IDs
@@ -568,7 +568,7 @@ WantedBy=default.target`;
 // Handle key management subcommands
 if (cliSubcommand === 'keygen') {
   const { runKeygen } = await import('./cli/keygen.ts');
-  await runKeygen({ passphrase: cliPassphrase, force: cliForce });
+  await runKeygen({ passphrase: process.env['REMI_PASSPHRASE'], force: cliForce });
   process.exit(0);
 }
 
@@ -1455,55 +1455,16 @@ if (!storedIdentity) {
   process.exit(1);
 }
 
-let passphrase = process.env['REMI_PASSPHRASE'];
-if (!passphrase) {
-  if (!process.stdin.isTTY) {
-    console.error('No TTY and REMI_PASSPHRASE not set. Cannot unlock identity.');
-    process.exit(1);
-  }
-  process.stdout.write('Passphrase to unlock identity: ');
-  passphrase = await new Promise<string>((resolve, reject) => {
-    let input = '';
-    process.stdin.setRawMode?.(true);
-    process.stdin.resume();
-    process.stdin.setEncoding('utf-8');
-    const onData = (chunk: string) => {
-      for (const ch of chunk) {
-        if (ch === '\r' || ch === '\n') {
-          process.stdin.setRawMode?.(false);
-          process.stdin.pause();
-          process.stdin.removeListener('data', onData);
-          process.stdout.write('\n');
-          resolve(input);
-          return;
-        }
-        if (ch === '\x7f' || ch === '\b') {
-          if (input.length > 0) {
-            input = input.slice(0, -1);
-            process.stdout.write('\b \b');
-          }
-        } else if (ch === '\x03') {
-          process.stdout.write('\n');
-          process.exit(130);
-        } else if (ch >= ' ') {
-          input += ch;
-          process.stdout.write('*');
-        }
-      }
-    };
-    process.stdin.on('data', onData);
-    process.stdin.on('error', (err: Error) => {
-      process.stdin.setRawMode?.(false);
-      reject(new Error(`Failed to read passphrase: ${err.message}`));
-    });
-  });
-}
+const { promptPassphrase } = await import('./cli/prompt-passphrase.ts');
+const passphrase = await promptPassphrase('Passphrase to unlock identity');
 
 let unlockedIdentity: UnlockedIdentity;
 try {
   unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
-} catch {
-  console.error('Failed to unlock identity. Wrong passphrase?');
+} catch (err) {
+  const detail = err instanceof Error ? err.message : String(err);
+  console.error(`Failed to unlock identity: ${detail}`);
+  console.error('Wrong passphrase?');
   process.exit(1);
 }
 
@@ -1516,7 +1477,7 @@ console.log(`Authentication enabled (fingerprint: ${storedIdentity.fingerprint})
 const wsAdapter = new WebSocketAdapter(
   {
     port: PORT,
-    host: '0.0.0.0',
+    host: cliBindHost ?? 'localhost',
     authenticator,
   },
   sharedEvents,
@@ -1545,36 +1506,34 @@ if (!cliNoRelay) {
   const { generateConnectionCode } = await import('./remote/signaling-client.ts');
   const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.dev-941.workers.dev/connect';
 
+  let relayCode: string;
+  let rotateCode: boolean;
+  let relayAuth: typeof authenticator | undefined;
+
   if (cliPermanentCode) {
     // Permanent code mode: persist code to disk, require Ed25519 auth over relay
     const { CodeStore } = await import('./remote/code-store.ts');
     const codeStore = new CodeStore();
-    const code = codeStore.load() ?? codeStore.refresh();
-    const relayAdapter = new RelayAdapter(
-      {
-        enabled: true,
-        signalingUrl,
-        code,
-        rotateCode: false,
-        authenticator,
-      },
-      sharedEvents,
-    );
-    registry.register(relayAdapter);
+    relayCode = codeStore.load() ?? codeStore.refresh();
+    rotateCode = false;
+    relayAuth = authenticator;
   } else {
     // Rotating code mode (default): ephemeral code, no Ed25519 auth
-    const code = generateConnectionCode();
-    const relayAdapter = new RelayAdapter(
-      {
-        enabled: true,
-        signalingUrl,
-        code,
-        rotateCode: true,
-      },
-      sharedEvents,
-    );
-    registry.register(relayAdapter);
+    relayCode = generateConnectionCode();
+    rotateCode = true;
   }
+
+  const relayAdapter = new RelayAdapter(
+    {
+      enabled: true,
+      signalingUrl,
+      code: relayCode,
+      rotateCode,
+      ...(relayAuth ? { authenticator: relayAuth } : {}),
+    },
+    sharedEvents,
+  );
+  registry.register(relayAdapter);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -316,8 +316,6 @@ let cliSubcommand:
   | 'keys'
   | undefined;
 let cliSubcommandArg: string | undefined;
-// TODO: wire --no-auth to connection handler to skip authentication
-let _cliNoAuth = false;
 let cliForce = false;
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
@@ -358,8 +356,6 @@ for (let i = 0; i < args.length; i++) {
     cliInstall = true;
   } else if (arg === '--uninstall') {
     cliUninstall = true;
-  } else if (arg === '--no-auth') {
-    _cliNoAuth = true;
   } else if (arg === '--force') {
     cliForce = true;
   } else if (arg === '--label' && nextArg) {
@@ -397,7 +393,6 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
-  --no-auth                Disable authentication (development only, not yet wired)
   --remote                 Enable remote access via signaling relay
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --passphrase PASS        Passphrase for keygen (avoids interactive prompt)
@@ -1408,83 +1403,75 @@ const sharedEvents = {
 };
 
 // ---------------------------------------------------------------------------
-// Auth setup: load identity and create authenticator if available
+// Auth setup: identity is required
 // ---------------------------------------------------------------------------
-let authenticator: Authenticator | undefined;
+const identityStore = new IdentityStore();
 
-if (!_cliNoAuth) {
-  const identityStore = new IdentityStore();
-  if (identityStore.exists()) {
-    let unlockedIdentity: UnlockedIdentity | undefined;
-    const storedIdentity = identityStore.load();
-    if (storedIdentity) {
-      // Get passphrase from env, CLI flag, or interactive prompt
-      const envPassphrase = process.env['REMI_PASSPHRASE'];
-      if (envPassphrase) {
-        try {
-          unlockedIdentity = await unlockIdentity(storedIdentity, envPassphrase);
-        } catch {
-          console.error('REMI_PASSPHRASE is incorrect.');
-          process.exit(1);
-        }
-      } else if (process.stdin.isTTY) {
-        process.stdout.write('Passphrase to unlock identity: ');
-        const passphrase = await new Promise<string>((resolve, reject) => {
-          let input = '';
-          process.stdin.setRawMode?.(true);
-          process.stdin.resume();
-          process.stdin.setEncoding('utf-8');
-          const onData = (chunk: string) => {
-            for (const ch of chunk) {
-              if (ch === '\r' || ch === '\n') {
-                process.stdin.setRawMode?.(false);
-                process.stdin.pause();
-                process.stdin.removeListener('data', onData);
-                process.stdout.write('\n');
-                resolve(input);
-                return;
-              }
-              if (ch === '\x7f' || ch === '\b') {
-                if (input.length > 0) {
-                  input = input.slice(0, -1);
-                  process.stdout.write('\b \b');
-                }
-              } else if (ch === '\x03') {
-                process.stdout.write('\n');
-                process.exit(130);
-              } else if (ch >= ' ') {
-                input += ch;
-                process.stdout.write('*');
-              }
-            }
-          };
-          process.stdin.on('data', onData);
-          process.stdin.on('error', (err: Error) => {
-            process.stdin.setRawMode?.(false);
-            reject(new Error(`Failed to read passphrase: ${err.message}`));
-          });
-        });
-        try {
-          unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
-        } catch {
-          console.error('Failed to unlock identity. Wrong passphrase?');
-          process.exit(1);
-        }
-      } else {
-        console.warn('No TTY available; running without authentication.');
-        console.warn('Use --no-auth to suppress this warning.');
-      }
-    }
-
-    if (unlockedIdentity) {
-      authenticator = new Authenticator({ identity: unlockedIdentity, identityStore });
-      console.log(`Authentication enabled (fingerprint: ${storedIdentity?.fingerprint})`);
-    }
-  } else {
-    console.log('No identity found. Running without authentication.');
-    console.log('Run "remi keygen" to generate an identity.');
-  }
+if (!identityStore.exists()) {
+  console.error('No identity found. Run "remi keygen" first.');
+  process.exit(1);
 }
+
+const storedIdentity = identityStore.load();
+if (!storedIdentity) {
+  console.error('Identity file is empty. Run "remi keygen --force" to regenerate.');
+  process.exit(1);
+}
+
+let passphrase = process.env['REMI_PASSPHRASE'];
+if (!passphrase) {
+  if (!process.stdin.isTTY) {
+    console.error('No TTY and REMI_PASSPHRASE not set. Cannot unlock identity.');
+    process.exit(1);
+  }
+  process.stdout.write('Passphrase to unlock identity: ');
+  passphrase = await new Promise<string>((resolve, reject) => {
+    let input = '';
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf-8');
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          process.stdin.setRawMode?.(false);
+          process.stdin.pause();
+          process.stdin.removeListener('data', onData);
+          process.stdout.write('\n');
+          resolve(input);
+          return;
+        }
+        if (ch === '\x7f' || ch === '\b') {
+          if (input.length > 0) {
+            input = input.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+        } else if (ch === '\x03') {
+          process.stdout.write('\n');
+          process.exit(130);
+        } else if (ch >= ' ') {
+          input += ch;
+          process.stdout.write('*');
+        }
+      }
+    };
+    process.stdin.on('data', onData);
+    process.stdin.on('error', (err: Error) => {
+      process.stdin.setRawMode?.(false);
+      reject(new Error(`Failed to read passphrase: ${err.message}`));
+    });
+  });
+}
+
+let unlockedIdentity: UnlockedIdentity;
+try {
+  unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
+} catch {
+  console.error('Failed to unlock identity. Wrong passphrase?');
+  process.exit(1);
+}
+
+const authenticator = new Authenticator({ identity: unlockedIdentity, identityStore });
+console.log(`Authentication enabled (fingerprint: ${storedIdentity.fingerprint})`);
 
 // ---------------------------------------------------------------------------
 // Create and register adapters
@@ -1493,7 +1480,7 @@ const wsAdapter = new WebSocketAdapter(
   {
     port: PORT,
     host: 'localhost',
-    ...(authenticator && { authenticator }),
+    authenticator,
   },
   sharedEvents,
 );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -313,6 +313,7 @@ let cliSubcommand:
   | 'keys'
   | undefined;
 let cliSubcommandArg: string | undefined;
+// TODO: wire --no-auth to connection handler to skip authentication
 let _cliNoAuth = false;
 let cliForce = false;
 let cliLabel: string | undefined;
@@ -389,7 +390,7 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
-  --no-auth                Disable authentication (development only)
+  --no-auth                Disable authentication (development only, not yet wired)
   --remote                 Enable remote access via signaling relay
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --force                  Overwrite existing identity (keygen/import-key)

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -223,7 +223,8 @@ import {
   generateId,
   now,
 } from '@remi/shared';
-import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
+import { unlockIdentity } from '@remi/shared';
 import {
   type AdapterMetadata,
   AdapterRegistry,
@@ -231,6 +232,8 @@ import {
   WebSocketAdapter,
 } from './adapters/index.ts';
 import { MessageAPI } from './api/index.ts';
+import { Authenticator } from './auth/authenticator.ts';
+import { IdentityStore } from './auth/identity-store.ts';
 import { OutputProcessor } from './parser/index.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
 import { SessionRegistry, SessionStore, type StoredSession } from './session/index.ts';
@@ -318,6 +321,7 @@ let _cliNoAuth = false;
 let cliForce = false;
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
+let cliPassphrase: string | undefined;
 let cliRemoveFingerprint: string | undefined;
 const claudeArgs: string[] = [];
 
@@ -363,6 +367,9 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--public-only') {
     cliPublicOnly = true;
+  } else if (arg === '--passphrase' && nextArg) {
+    cliPassphrase = nextArg;
+    i++;
   } else if (arg === '--remove' && nextArg) {
     cliRemoveFingerprint = nextArg;
     i++;
@@ -393,6 +400,7 @@ Options:
   --no-auth                Disable authentication (development only, not yet wired)
   --remote                 Enable remote access via signaling relay
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
+  --passphrase PASS        Passphrase for keygen (avoids interactive prompt)
   --force                  Overwrite existing identity (keygen/import-key)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
@@ -431,6 +439,17 @@ Any other arguments are passed through to Claude Code.
       cliSubcommandArg = nextArg;
       i++;
     }
+  } else if (
+    cliSubcommand &&
+    (cliSubcommand === 'import-key' ||
+      cliSubcommand === 'authorize' ||
+      cliSubcommand === 'attach') &&
+    !cliSubcommandArg &&
+    arg &&
+    !arg.startsWith('-')
+  ) {
+    // Positional arg for subcommand (supports flags before or after)
+    cliSubcommandArg = arg;
   } else {
     // Pass through to Claude
     if (arg) claudeArgs.push(arg);
@@ -540,7 +559,7 @@ WantedBy=default.target`;
 // Handle key management subcommands
 if (cliSubcommand === 'keygen') {
   const { runKeygen } = await import('./cli/keygen.ts');
-  await runKeygen({ force: cliForce });
+  await runKeygen({ passphrase: cliPassphrase, force: cliForce });
   process.exit(0);
 }
 
@@ -1388,12 +1407,84 @@ const sharedEvents = {
 };
 
 // ---------------------------------------------------------------------------
+// Auth setup: load identity and create authenticator if available
+// ---------------------------------------------------------------------------
+let authenticator: Authenticator | undefined;
+
+if (!_cliNoAuth) {
+  const identityStore = new IdentityStore();
+  if (identityStore.exists()) {
+    let unlockedIdentity: UnlockedIdentity | undefined;
+    const storedIdentity = identityStore.load();
+    if (storedIdentity) {
+      // Prompt for passphrase to unlock identity
+      if (process.stdin.isTTY) {
+        process.stdout.write('Passphrase to unlock identity: ');
+        const passphrase = await new Promise<string>((resolve, reject) => {
+          let input = '';
+          process.stdin.setRawMode?.(true);
+          process.stdin.resume();
+          process.stdin.setEncoding('utf-8');
+          const onData = (chunk: string) => {
+            for (const ch of chunk) {
+              if (ch === '\r' || ch === '\n') {
+                process.stdin.setRawMode?.(false);
+                process.stdin.pause();
+                process.stdin.removeListener('data', onData);
+                process.stdout.write('\n');
+                resolve(input);
+                return;
+              }
+              if (ch === '\x7f' || ch === '\b') {
+                if (input.length > 0) {
+                  input = input.slice(0, -1);
+                  process.stdout.write('\b \b');
+                }
+              } else if (ch === '\x03') {
+                process.stdout.write('\n');
+                process.exit(130);
+              } else if (ch >= ' ') {
+                input += ch;
+                process.stdout.write('*');
+              }
+            }
+          };
+          process.stdin.on('data', onData);
+          process.stdin.on('error', (err: Error) => {
+            process.stdin.setRawMode?.(false);
+            reject(new Error(`Failed to read passphrase: ${err.message}`));
+          });
+        });
+        try {
+          unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
+        } catch {
+          console.error('Failed to unlock identity. Wrong passphrase?');
+          process.exit(1);
+        }
+      } else {
+        console.warn('No TTY available; running without authentication.');
+        console.warn('Use --no-auth to suppress this warning.');
+      }
+    }
+
+    if (unlockedIdentity) {
+      authenticator = new Authenticator({ identity: unlockedIdentity, identityStore });
+      console.log(`Authentication enabled (fingerprint: ${storedIdentity?.fingerprint})`);
+    }
+  } else {
+    console.log('No identity found. Running without authentication.');
+    console.log('Run "remi keygen" to generate an identity.');
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Create and register adapters
 // ---------------------------------------------------------------------------
 const wsAdapter = new WebSocketAdapter(
   {
     port: PORT,
     host: 'localhost',
+    ...(authenticator && { authenticator }),
   },
   sharedEvents,
 );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -303,8 +303,21 @@ let cliResume: string | true | undefined; // true = resume most recent, string =
 let cliShowSessions = false;
 let cliInstall = false;
 let cliUninstall = false;
-let cliSubcommand: 'ls' | 'attach' | undefined;
+let cliSubcommand:
+  | 'ls'
+  | 'attach'
+  | 'keygen'
+  | 'export-key'
+  | 'import-key'
+  | 'authorize'
+  | 'keys'
+  | undefined;
 let cliSubcommandArg: string | undefined;
+let _cliNoAuth = false;
+let cliForce = false;
+let cliLabel: string | undefined;
+let cliPublicOnly = false;
+let cliRemoveFingerprint: string | undefined;
 const claudeArgs: string[] = [];
 
 for (let i = 0; i < args.length; i++) {
@@ -340,6 +353,18 @@ for (let i = 0; i < args.length; i++) {
     cliInstall = true;
   } else if (arg === '--uninstall') {
     cliUninstall = true;
+  } else if (arg === '--no-auth') {
+    _cliNoAuth = true;
+  } else if (arg === '--force') {
+    cliForce = true;
+  } else if (arg === '--label' && nextArg) {
+    cliLabel = nextArg;
+    i++;
+  } else if (arg === '--public-only') {
+    cliPublicOnly = true;
+  } else if (arg === '--remove' && nextArg) {
+    cliRemoveFingerprint = nextArg;
+    i++;
   } else if (arg === '--version' || arg === '-v') {
     console.log(`remi ${REMI_VERSION}`);
     process.exit(0);
@@ -351,6 +376,11 @@ Usage:
   remi [claude-args...]          Start Claude with WebSocket monitoring
   remi ls                        List live sessions from running daemon
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
+  remi keygen                    Generate Ed25519 identity keypair
+  remi export-key                Export identity JSON (for sharing across devices)
+  remi import-key [file]         Import identity from file or stdin
+  remi authorize <key-file>      Add a client's public key to authorized keys
+  remi keys                      List authorized keys
   remi --resume [session-id]     Resume a previous session
   remi --sessions                List stored sessions
   remi --daemon                  Legacy daemon mode (headless server)
@@ -359,8 +389,13 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
+  --no-auth                Disable authentication (development only)
   --remote                 Enable remote access via signaling relay
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
+  --force                  Overwrite existing identity (keygen/import-key)
+  --label NAME             Label for authorized key (authorize)
+  --public-only            Export only public key (export-key)
+  --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
   --install                Install as autostart service
   --uninstall              Remove autostart service
   --version, -v            Show version
@@ -377,9 +412,21 @@ Environment:
 Any other arguments are passed through to Claude Code.
 `);
     process.exit(0);
-  } else if (arg === 'ls' || arg === 'attach') {
+  } else if (
+    arg === 'ls' ||
+    arg === 'attach' ||
+    arg === 'keygen' ||
+    arg === 'export-key' ||
+    arg === 'import-key' ||
+    arg === 'authorize' ||
+    arg === 'keys'
+  ) {
     cliSubcommand = arg;
-    if (arg === 'attach' && nextArg && !nextArg.startsWith('-')) {
+    if (
+      (arg === 'attach' || arg === 'import-key' || arg === 'authorize') &&
+      nextArg &&
+      !nextArg.startsWith('-')
+    ) {
       cliSubcommandArg = nextArg;
       i++;
     }
@@ -486,6 +533,41 @@ WantedBy=default.target`;
     console.error(`Autostart not supported on ${platform}. Run remi --daemon manually.`);
     process.exit(1);
   }
+  process.exit(0);
+}
+
+// Handle key management subcommands
+if (cliSubcommand === 'keygen') {
+  const { runKeygen } = await import('./cli/keygen.ts');
+  await runKeygen({ force: cliForce });
+  process.exit(0);
+}
+
+if (cliSubcommand === 'export-key') {
+  const { runKeyExport } = await import('./cli/key-export.ts');
+  runKeyExport({ publicOnly: cliPublicOnly });
+  process.exit(0);
+}
+
+if (cliSubcommand === 'import-key') {
+  const { runKeyImport } = await import('./cli/key-import.ts');
+  await runKeyImport({ file: cliSubcommandArg, force: cliForce });
+  process.exit(0);
+}
+
+if (cliSubcommand === 'authorize') {
+  const { runAuthorize } = await import('./cli/authorize.ts');
+  await runAuthorize({
+    input: cliSubcommandArg,
+    label: cliLabel,
+    remove: cliRemoveFingerprint,
+  });
+  process.exit(0);
+}
+
+if (cliSubcommand === 'keys') {
+  const { runListKeys } = await import('./cli/authorize.ts');
+  runListKeys();
   process.exit(0);
 }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1506,33 +1506,26 @@ if (!cliNoRelay) {
   const { generateConnectionCode } = await import('./remote/signaling-client.ts');
   const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.dev-941.workers.dev/connect';
 
-  let relayCode: string;
-  let rotateCode: boolean;
-  let relayAuth: typeof authenticator | undefined;
+  let relayAdapter: InstanceType<typeof RelayAdapter>;
 
   if (cliPermanentCode) {
     // Permanent code mode: persist code to disk, require Ed25519 auth over relay
     const { CodeStore } = await import('./remote/code-store.ts');
     const codeStore = new CodeStore();
-    relayCode = codeStore.load() ?? codeStore.refresh();
-    rotateCode = false;
-    relayAuth = authenticator;
+    const code = codeStore.load() ?? codeStore.refresh();
+    relayAdapter = new RelayAdapter(
+      { enabled: true, signalingUrl, code, rotateCode: false as const, authenticator },
+      sharedEvents,
+    );
   } else {
     // Rotating code mode (default): ephemeral code, no Ed25519 auth
-    relayCode = generateConnectionCode();
-    rotateCode = true;
+    const code = generateConnectionCode();
+    relayAdapter = new RelayAdapter(
+      { enabled: true, signalingUrl, code, rotateCode: true as const },
+      sharedEvents,
+    );
   }
 
-  const relayAdapter = new RelayAdapter(
-    {
-      enabled: true,
-      signalingUrl,
-      code: relayCode,
-      rotateCode,
-      ...(relayAuth ? { authenticator: relayAuth } : {}),
-    },
-    sharedEvents,
-  );
   registry.register(relayAdapter);
 }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1479,7 +1479,7 @@ console.log(`Authentication enabled (fingerprint: ${storedIdentity.fingerprint})
 const wsAdapter = new WebSocketAdapter(
   {
     port: PORT,
-    host: 'localhost',
+    host: '0.0.0.0',
     authenticator,
   },
   sharedEvents,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -414,6 +414,7 @@ Environment:
   REMI_PORT                WebSocket port
   REMI_MAX_BULLET_LENGTH   Max bullet length before truncation (default: 500, 0=disabled)
   TELEGRAM_BOT_TOKEN       Telegram bot token (enables Telegram adapter)
+  REMI_PASSPHRASE              Passphrase to unlock identity (avoids interactive prompt)
   TELEGRAM_ENABLED              Set to 'false' to disable Telegram
   TELEGRAM_AUTHORIZED_CHAT_IDS  Comma-separated authorized chat IDs
   TELEGRAM_AUTHORIZED_USER_IDS  Comma-separated authorized user IDs
@@ -1417,8 +1418,16 @@ if (!_cliNoAuth) {
     let unlockedIdentity: UnlockedIdentity | undefined;
     const storedIdentity = identityStore.load();
     if (storedIdentity) {
-      // Prompt for passphrase to unlock identity
-      if (process.stdin.isTTY) {
+      // Get passphrase from env, CLI flag, or interactive prompt
+      const envPassphrase = process.env['REMI_PASSPHRASE'];
+      if (envPassphrase) {
+        try {
+          unlockedIdentity = await unlockIdentity(storedIdentity, envPassphrase);
+        } catch {
+          console.error('REMI_PASSPHRASE is incorrect.');
+          process.exit(1);
+        }
+      } else if (process.stdin.isTTY) {
         process.stdout.write('Passphrase to unlock identity: ');
         const passphrase = await new Promise<string>((resolve, reject) => {
           let input = '';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -318,6 +318,7 @@ let cliSubcommand:
   | undefined;
 let cliSubcommandArg: string | undefined;
 let cliCodeRefresh = false;
+let cliPermanentCode = false;
 let cliForce = false;
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
@@ -351,6 +352,8 @@ for (let i = 0; i < args.length; i++) {
     cliNoTelegram = true;
   } else if (arg === '--no-relay') {
     cliNoRelay = true;
+  } else if (arg === '--permanent-code') {
+    cliPermanentCode = true;
   } else if (arg === '--signaling-url' && nextArg) {
     cliSignalingUrl = nextArg;
     i++;
@@ -398,6 +401,7 @@ Options:
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
   --no-relay               Disable signaling relay (no remote access via connection code)
+  --permanent-code         Use a persistent connection code (requires Ed25519 auth over relay)
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --passphrase PASS        Passphrase for keygen (avoids interactive prompt)
   --force                  Overwrite existing identity (keygen/import-key)
@@ -596,23 +600,27 @@ if (cliSubcommand === 'keys') {
   process.exit(0);
 }
 
-// Handle 'code' subcommand: show or refresh the remote access code
+// Handle 'code' subcommand: show or refresh the persistent connection code
 if (cliSubcommand === 'code') {
   const { CodeStore } = await import('./remote/code-store.ts');
   const codeStore = new CodeStore();
   if (cliCodeRefresh) {
     const newCode = codeStore.refresh();
-    console.log(`New connection code: ${newCode}`);
+    console.log(`New permanent connection code: ${newCode}`);
     console.log('Restart the daemon for the new code to take effect.');
   } else {
     const code = codeStore.load();
     if (code) {
-      console.log(`Connection code: ${code}`);
+      console.log(`Permanent connection code: ${code}`);
+      console.log('Use --permanent-code flag when starting daemon to enable this code.');
     } else {
       const newCode = codeStore.refresh();
-      console.log(`Connection code: ${newCode} (newly generated)`);
+      console.log(`Permanent connection code: ${newCode} (newly generated)`);
+      console.log('Use --permanent-code flag when starting daemon to enable this code.');
     }
   }
+  console.log('\nNote: By default, codes rotate on each reconnect. Use --permanent-code to');
+  console.log('persist a fixed code (requires Ed25519 authentication for relay connections).');
   process.exit(0);
 }
 
@@ -1534,19 +1542,39 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
 
 if (!cliNoRelay) {
   const { RelayAdapter } = await import('./remote/relay-adapter.ts');
-  const { CodeStore } = await import('./remote/code-store.ts');
-  const codeStore = new CodeStore();
-  const code = codeStore.load() ?? codeStore.refresh();
+  const { generateConnectionCode } = await import('./remote/signaling-client.ts');
   const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.dev-941.workers.dev/connect';
-  const relayAdapter = new RelayAdapter(
-    {
-      enabled: true,
-      signalingUrl,
-      code,
-    },
-    sharedEvents,
-  );
-  registry.register(relayAdapter);
+
+  if (cliPermanentCode) {
+    // Permanent code mode: persist code to disk, require Ed25519 auth over relay
+    const { CodeStore } = await import('./remote/code-store.ts');
+    const codeStore = new CodeStore();
+    const code = codeStore.load() ?? codeStore.refresh();
+    const relayAdapter = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl,
+        code,
+        rotateCode: false,
+        authenticator,
+      },
+      sharedEvents,
+    );
+    registry.register(relayAdapter);
+  } else {
+    // Rotating code mode (default): ephemeral code, no Ed25519 auth
+    const code = generateConnectionCode();
+    const relayAdapter = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl,
+        code,
+        rotateCode: true,
+      },
+      sharedEvents,
+    );
+    registry.register(relayAdapter);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli/authorize.ts
+++ b/packages/daemon/src/cli/authorize.ts
@@ -1,0 +1,98 @@
+/**
+ * `remi authorize` - Manage authorized client keys.
+ *
+ * remi authorize <file-or-json>   Add a client's public key
+ * remi authorize --remove <fp>    Remove a key by fingerprint
+ * remi keys                       List authorized keys
+ */
+
+import * as fs from 'node:fs';
+import { IdentityStore } from '../auth/identity-store.ts';
+
+export interface AuthorizeOptions {
+  input?: string | undefined;
+  label?: string | undefined;
+  remove?: string | undefined;
+  dir?: string | undefined;
+}
+
+export async function runAuthorize(options: AuthorizeOptions): Promise<void> {
+  const store = new IdentityStore(options.dir);
+
+  // Remove mode
+  if (options.remove) {
+    const removed = store.removeAuthorizedKey(options.remove);
+    if (removed) {
+      console.log(`Removed key with fingerprint ${options.remove}`);
+    } else {
+      console.error(`No key found with fingerprint ${options.remove}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Add mode
+  if (!options.input) {
+    console.error('Usage: remi authorize <public-key-file-or-json> [--label name]');
+    console.error('       remi authorize --remove <fingerprint>');
+    process.exit(1);
+  }
+
+  let json: string;
+  if (fs.existsSync(options.input)) {
+    json = fs.readFileSync(options.input, 'utf-8');
+  } else {
+    // Treat as inline JSON
+    json = options.input;
+  }
+
+  let publicKey: string;
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    publicKey = parsed['publicKey'] as string;
+    if (typeof publicKey !== 'string') {
+      throw new Error('Missing publicKey field');
+    }
+  } catch (err) {
+    console.error(
+      `Failed to parse public key: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+    return; // unreachable, helps TS
+  }
+
+  const label = options.label ?? 'unnamed';
+
+  try {
+    const key = await store.addAuthorizedKey(publicKey, label);
+    console.log('Authorized key added:');
+    console.log(`  Fingerprint: ${key.fingerprint}`);
+    console.log(`  Label:       ${key.label}`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+export function runListKeys(dir?: string): void {
+  const store = new IdentityStore(dir);
+  const keys = store.listAuthorizedKeys();
+
+  if (keys.length === 0) {
+    console.log('No authorized keys.');
+    console.log('Add one with: remi authorize <public-key-file>');
+    return;
+  }
+
+  console.log(`${keys.length} authorized key(s):\n`);
+  console.log('FINGERPRINT       LABEL            ADDED         LAST USED');
+  console.log('----------------------------------------------------------------');
+
+  for (const key of keys) {
+    const added = new Date(key.addedAt).toLocaleDateString();
+    const lastUsed = key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleDateString() : 'never';
+    const fp = key.fingerprint.padEnd(18);
+    const label = key.label.slice(0, 16).padEnd(17);
+    console.log(`${fp}${label}${added.padEnd(14)}${lastUsed}`);
+  }
+}

--- a/packages/daemon/src/cli/key-export.ts
+++ b/packages/daemon/src/cli/key-export.ts
@@ -1,0 +1,34 @@
+/**
+ * `remi export-key` - Export identity for sharing across devices.
+ *
+ * --public-only: Output only the public key (for authorizing on daemon).
+ * Default: Output full identity JSON (encrypted private key included).
+ */
+
+import { serializeIdentity } from '@remi/shared';
+import { IdentityStore } from '../auth/identity-store.ts';
+
+export interface KeyExportOptions {
+  publicOnly?: boolean;
+  dir?: string;
+}
+
+export function runKeyExport(options: KeyExportOptions = {}): void {
+  const store = new IdentityStore(options.dir);
+  const identity = store.load();
+
+  if (!identity) {
+    console.error('No identity found. Run `remi keygen` first.');
+    process.exit(1);
+  }
+
+  if (options.publicOnly) {
+    const publicInfo = {
+      publicKey: identity.publicKey,
+      fingerprint: identity.fingerprint,
+    };
+    console.log(JSON.stringify(publicInfo, null, 2));
+  } else {
+    console.log(serializeIdentity(identity));
+  }
+}

--- a/packages/daemon/src/cli/key-import.ts
+++ b/packages/daemon/src/cli/key-import.ts
@@ -55,12 +55,15 @@ async function readStdin(): Promise<string> {
   process.stdin.setEncoding('utf-8');
   process.stdin.resume();
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     process.stdin.on('data', (chunk: string) => {
       chunks.push(chunk);
     });
     process.stdin.on('end', () => {
       resolve(chunks.join(''));
+    });
+    process.stdin.on('error', (err: Error) => {
+      reject(new Error(`Failed to read from stdin: ${err.message}`));
     });
   });
 }

--- a/packages/daemon/src/cli/key-import.ts
+++ b/packages/daemon/src/cli/key-import.ts
@@ -1,0 +1,66 @@
+/**
+ * `remi import-key [file]` - Import an identity from JSON.
+ *
+ * Reads from file argument or stdin.
+ * Writes to ~/.remi/identity.json.
+ */
+
+import * as fs from 'node:fs';
+import { deserializeIdentity } from '@remi/shared';
+import { IdentityStore } from '../auth/identity-store.ts';
+
+export interface KeyImportOptions {
+  file?: string | undefined;
+  force?: boolean | undefined;
+  dir?: string | undefined;
+}
+
+export async function runKeyImport(options: KeyImportOptions = {}): Promise<void> {
+  const store = new IdentityStore(options.dir);
+
+  if (store.exists() && !options.force) {
+    const existing = store.load();
+    console.error(`Identity already exists (fingerprint: ${existing?.fingerprint ?? 'unknown'}).`);
+    console.error('Use --force to overwrite.');
+    process.exit(1);
+  }
+
+  let json: string;
+
+  if (options.file) {
+    if (!fs.existsSync(options.file)) {
+      console.error(`File not found: ${options.file}`);
+      process.exit(1);
+    }
+    json = fs.readFileSync(options.file, 'utf-8');
+  } else {
+    // Read from stdin
+    console.error('Reading identity from stdin (paste JSON, then Ctrl+D):');
+    json = await readStdin();
+  }
+
+  try {
+    const identity = deserializeIdentity(json);
+    store.save(identity);
+    console.log('Identity imported successfully.');
+    console.log(`  Fingerprint: ${identity.fingerprint}`);
+  } catch (err) {
+    console.error(`Failed to import identity: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: string[] = [];
+  process.stdin.setEncoding('utf-8');
+  process.stdin.resume();
+
+  return new Promise((resolve) => {
+    process.stdin.on('data', (chunk: string) => {
+      chunks.push(chunk);
+    });
+    process.stdin.on('end', () => {
+      resolve(chunks.join(''));
+    });
+  });
+}

--- a/packages/daemon/src/cli/key-import.ts
+++ b/packages/daemon/src/cli/key-import.ts
@@ -19,8 +19,13 @@ export async function runKeyImport(options: KeyImportOptions = {}): Promise<void
   const store = new IdentityStore(options.dir);
 
   if (store.exists() && !options.force) {
-    const existing = store.load();
-    console.error(`Identity already exists (fingerprint: ${existing?.fingerprint ?? 'unknown'}).`);
+    let fp = 'unknown';
+    try {
+      fp = store.load()?.fingerprint ?? 'unknown';
+    } catch {
+      /* corrupt file; show unknown */
+    }
+    console.error(`Identity already exists (fingerprint: ${fp}).`);
     console.error('Use --force to overwrite.');
     process.exit(1);
   }

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -8,9 +8,9 @@
 import { IdentityStore } from '../auth/identity-store.ts';
 
 export interface KeygenOptions {
-  passphrase?: string;
-  force?: boolean;
-  dir?: string;
+  passphrase?: string | undefined;
+  force?: boolean | undefined;
+  dir?: string | undefined;
 }
 
 export async function runKeygen(options: KeygenOptions = {}): Promise<void> {

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -1,0 +1,85 @@
+/**
+ * `remi keygen` - Generate a new Ed25519 identity keypair.
+ *
+ * Prompts for a passphrase to encrypt the private key.
+ * Writes identity to ~/.remi/identity.json with 0600 permissions.
+ */
+
+import { IdentityStore } from '../auth/identity-store.ts';
+
+export interface KeygenOptions {
+  passphrase?: string;
+  force?: boolean;
+  dir?: string;
+}
+
+export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
+  const store = new IdentityStore(options.dir);
+
+  if (store.exists() && !options.force) {
+    const existing = store.load();
+    console.error(`Identity already exists (fingerprint: ${existing?.fingerprint ?? 'unknown'}).`);
+    console.error('Use --force to overwrite.');
+    process.exit(1);
+  }
+
+  let passphrase = options.passphrase;
+
+  if (!passphrase) {
+    passphrase = await promptPassphrase();
+  }
+
+  if (passphrase.length < 8) {
+    console.error('Passphrase must be at least 8 characters.');
+    process.exit(1);
+  }
+
+  console.log('Generating Ed25519 keypair...');
+  const identity = await store.generate(passphrase);
+
+  console.log('Identity generated successfully.');
+  console.log(`  Fingerprint: ${identity.fingerprint}`);
+  console.log('  Stored at:   ~/.remi/identity.json');
+  console.log('');
+  console.log('Share your public key with clients using: remi export-key --public-only');
+}
+
+async function promptPassphrase(): Promise<string> {
+  process.stdout.write('Passphrase (min 8 chars): ');
+
+  return new Promise((resolve) => {
+    let input = '';
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf-8');
+
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          process.stdin.setRawMode?.(false);
+          process.stdin.pause();
+          process.stdin.removeListener('data', onData);
+          process.stdout.write('\n');
+          resolve(input);
+          return;
+        }
+        if (ch === '\x7f' || ch === '\b') {
+          // Backspace
+          if (input.length > 0) {
+            input = input.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+        } else if (ch === '\x03') {
+          // Ctrl+C
+          process.stdout.write('\n');
+          process.exit(130);
+        } else if (ch >= ' ') {
+          input += ch;
+          process.stdout.write('*');
+        }
+      }
+    };
+
+    process.stdin.on('data', onData);
+  });
+}

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -18,8 +18,13 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
   const store = new IdentityStore(options.dir);
 
   if (store.exists() && !options.force) {
-    const existing = store.load();
-    console.error(`Identity already exists (fingerprint: ${existing?.fingerprint ?? 'unknown'}).`);
+    let fp = 'unknown';
+    try {
+      fp = store.load()?.fingerprint ?? 'unknown';
+    } catch {
+      /* corrupt file; show unknown */
+    }
+    console.error(`Identity already exists (fingerprint: ${fp}).`);
     console.error('Use --force to overwrite.');
     process.exit(1);
   }

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -6,6 +6,7 @@
  */
 
 import { IdentityStore } from '../auth/identity-store.ts';
+import { promptPassphrase } from './prompt-passphrase.ts';
 
 export interface KeygenOptions {
   passphrase?: string | undefined;
@@ -23,11 +24,7 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
     process.exit(1);
   }
 
-  let passphrase = options.passphrase;
-
-  if (!passphrase) {
-    passphrase = await promptPassphrase();
-  }
+  const passphrase = options.passphrase ?? (await promptPassphrase('Passphrase (min 8 chars)'));
 
   if (passphrase.length < 8) {
     console.error('Passphrase must be at least 8 characters.');
@@ -39,57 +36,7 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
 
   console.log('Identity generated successfully.');
   console.log(`  Fingerprint: ${identity.fingerprint}`);
-  console.log('  Stored at:   ~/.remi/identity.json');
+  console.log(`  Stored at:   ${store.identityPath}`);
   console.log('');
   console.log('Share your public key with clients using: remi export-key --public-only');
-}
-
-async function promptPassphrase(): Promise<string> {
-  if (!process.stdin.isTTY) {
-    console.error('Cannot prompt for passphrase: stdin is not a terminal.');
-    console.error('Use --passphrase option instead.');
-    process.exit(1);
-  }
-
-  process.stdout.write('Passphrase (min 8 chars): ');
-
-  return new Promise((resolve, reject) => {
-    let input = '';
-    process.stdin.setRawMode?.(true);
-    process.stdin.resume();
-    process.stdin.setEncoding('utf-8');
-
-    const onData = (chunk: string) => {
-      for (const ch of chunk) {
-        if (ch === '\r' || ch === '\n') {
-          process.stdin.setRawMode?.(false);
-          process.stdin.pause();
-          process.stdin.removeListener('data', onData);
-          process.stdout.write('\n');
-          resolve(input);
-          return;
-        }
-        if (ch === '\x7f' || ch === '\b') {
-          // Backspace
-          if (input.length > 0) {
-            input = input.slice(0, -1);
-            process.stdout.write('\b \b');
-          }
-        } else if (ch === '\x03') {
-          // Ctrl+C
-          process.stdout.write('\n');
-          process.exit(130);
-        } else if (ch >= ' ') {
-          input += ch;
-          process.stdout.write('*');
-        }
-      }
-    };
-
-    process.stdin.on('data', onData);
-    process.stdin.on('error', (err: Error) => {
-      process.stdin.setRawMode?.(false);
-      reject(new Error(`Failed to read passphrase: ${err.message}`));
-    });
-  });
 }

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -45,9 +45,15 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
 }
 
 async function promptPassphrase(): Promise<string> {
+  if (!process.stdin.isTTY) {
+    console.error('Cannot prompt for passphrase: stdin is not a terminal.');
+    console.error('Use --passphrase option instead.');
+    process.exit(1);
+  }
+
   process.stdout.write('Passphrase (min 8 chars): ');
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let input = '';
     process.stdin.setRawMode?.(true);
     process.stdin.resume();
@@ -81,5 +87,9 @@ async function promptPassphrase(): Promise<string> {
     };
 
     process.stdin.on('data', onData);
+    process.stdin.on('error', (err: Error) => {
+      process.stdin.setRawMode?.(false);
+      reject(new Error(`Failed to read passphrase: ${err.message}`));
+    });
   });
 }

--- a/packages/daemon/src/cli/prompt-passphrase.ts
+++ b/packages/daemon/src/cli/prompt-passphrase.ts
@@ -27,9 +27,8 @@ export async function promptPassphrase(label = 'Passphrase'): Promise<string> {
     const onData = (chunk: string) => {
       for (const ch of chunk) {
         if (ch === '\r' || ch === '\n') {
-          process.stdin.setRawMode?.(false);
+          cleanup();
           process.stdin.pause();
-          process.stdin.removeListener('data', onData);
           process.stdout.write('\n');
           resolve(input);
           return;
@@ -49,10 +48,24 @@ export async function promptPassphrase(label = 'Passphrase'): Promise<string> {
       }
     };
 
+    const cleanup = () => {
+      process.stdin.setRawMode?.(false);
+      process.stdin.removeListener('data', onData);
+    };
+
     process.stdin.on('data', onData);
     process.stdin.on('error', (err: Error) => {
-      process.stdin.setRawMode?.(false);
+      cleanup();
       reject(new Error(`Failed to read passphrase: ${err.message}`));
+    });
+    process.stdin.on('end', () => {
+      cleanup();
+      if (input.length > 0) {
+        process.stdout.write('\n');
+        resolve(input);
+      } else {
+        reject(new Error('Passphrase input ended without data'));
+      }
     });
   });
 }

--- a/packages/daemon/src/cli/prompt-passphrase.ts
+++ b/packages/daemon/src/cli/prompt-passphrase.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared passphrase prompt for CLI operations.
+ *
+ * Reads a passphrase from stdin with masked echo (*).
+ * Falls back to REMI_PASSPHRASE env var when stdin is not a TTY.
+ */
+
+export async function promptPassphrase(label = 'Passphrase'): Promise<string> {
+  // Check env var first
+  const envPassphrase = process.env['REMI_PASSPHRASE'];
+  if (envPassphrase) return envPassphrase;
+
+  if (!process.stdin.isTTY) {
+    console.error('Cannot prompt for passphrase: stdin is not a terminal.');
+    console.error('Set the REMI_PASSPHRASE environment variable instead.');
+    process.exit(1);
+  }
+
+  process.stdout.write(`${label}: `);
+
+  return new Promise((resolve, reject) => {
+    let input = '';
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf-8');
+
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          process.stdin.setRawMode?.(false);
+          process.stdin.pause();
+          process.stdin.removeListener('data', onData);
+          process.stdout.write('\n');
+          resolve(input);
+          return;
+        }
+        if (ch === '\x7f' || ch === '\b') {
+          if (input.length > 0) {
+            input = input.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+        } else if (ch === '\x03') {
+          process.stdout.write('\n');
+          process.exit(130);
+        } else if (ch >= ' ') {
+          input += ch;
+          process.stdout.write('*');
+        }
+      }
+    };
+
+    process.stdin.on('data', onData);
+    process.stdin.on('error', (err: Error) => {
+      process.stdin.setRawMode?.(false);
+      reject(new Error(`Failed to read passphrase: ${err.message}`));
+    });
+  });
+}

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -7,6 +7,11 @@
  * Supports two modes:
  * - Rotating codes (default): code changes on each reconnect; no Ed25519 auth
  * - Permanent code (--permanent-code): code persists; Ed25519 auth required
+ *
+ * Auth is determined by the presence of an `authenticator` in the config.
+ * When set, the adapter runs a challenge-response handshake before accepting
+ * any protocol messages from the relay peer:
+ *   peer-connected -> auth_challenge -> auth_response -> auth_result -> onConnect
  */
 
 import { createAgentOutput, createQuestion, generateId } from '@remi/shared';
@@ -128,17 +133,7 @@ export class RelayAdapter implements ConnectionAdapter {
     });
 
     this.client.on('peer-disconnected', () => {
-      if (this.clientConnectionId) {
-        // Clean up pending auth challenge if peer disconnects during auth
-        if (this.authState === 'challenging' && this.config.authenticator) {
-          this.config.authenticator.removePendingChallenge(this.clientConnectionId);
-        }
-        if (this.authState === 'authenticated') {
-          this.events.onDisconnect?.(this.clientConnectionId, 'Remote client disconnected');
-        }
-        this.clientConnectionId = null;
-        this.authState = 'none';
-      }
+      this.resetClient('Remote client disconnected');
     });
 
     this.client.on('relay', (payload: string) => {
@@ -156,7 +151,10 @@ export class RelayAdapter implements ConnectionAdapter {
 
         // Handle auth_response during challenging state
         if (message.type === 'auth_response') {
-          this.handleAuthResponse(message as AuthResponseMessage);
+          this.handleAuthResponse(message as AuthResponseMessage).catch((err) => {
+            console.error('Relay auth error:', err instanceof Error ? err.message : err);
+            this.resetClient();
+          });
           return;
         }
 
@@ -209,9 +207,21 @@ export class RelayAdapter implements ConnectionAdapter {
       this.events.onConnect?.(this.clientConnectionId, metadata);
     } else {
       console.warn(`Relay auth failed: ${result.error}`);
-      this.authState = 'none';
-      // Don't disconnect; the peer can retry or the signaling TTL will clean up
+      this.resetClient();
     }
+  }
+
+  /** Reset client state, cleaning up auth challenges and notifying disconnect if authenticated. */
+  private resetClient(reason?: string): void {
+    if (!this.clientConnectionId) return;
+    if (this.authState === 'challenging' && this.config.authenticator) {
+      this.config.authenticator.removePendingChallenge(this.clientConnectionId);
+    }
+    if (this.authState === 'authenticated') {
+      this.events.onDisconnect?.(this.clientConnectionId, reason ?? 'Connection reset');
+    }
+    this.clientConnectionId = null;
+    this.authState = 'none';
   }
 
   private routeMessage(msg: Record<string, unknown>): void {
@@ -233,32 +243,48 @@ export class RelayAdapter implements ConnectionAdapter {
         this.events.onAnswer?.(connectionId, msg['questionId'], msg['answer']);
         break;
       case 'session_list_request':
+        if (typeof msg['id'] !== 'string') {
+          console.warn('Invalid session_list_request payload: missing id');
+          return;
+        }
         this.events.onSessionListRequest?.(
           connectionId,
-          msg['id'] as string,
+          msg['id'],
           (msg['includeExternal'] as boolean) ?? false,
         );
         break;
       case 'transcript_load_request':
-        this.events.onTranscriptLoadRequest?.(
-          connectionId,
-          msg['sessionId'] as string,
-          msg['id'] as string,
-        );
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid transcript_load_request payload: missing sessionId or id');
+          return;
+        }
+        this.events.onTranscriptLoadRequest?.(connectionId, msg['sessionId'], msg['id']);
         break;
       case 'create_session_request':
+        if (typeof msg['id'] !== 'string') {
+          console.warn('Invalid create_session_request payload: missing id');
+          return;
+        }
         this.events.onCreateSessionRequest?.(
           connectionId,
           msg['directory'] as string | undefined,
-          msg['id'] as string,
+          msg['id'],
         );
         break;
       case 'bullet_expand_request':
+        if (
+          typeof msg['sessionId'] !== 'string' ||
+          typeof msg['bulletId'] !== 'number' ||
+          typeof msg['id'] !== 'string'
+        ) {
+          console.warn('Invalid bullet_expand_request payload: missing required fields');
+          return;
+        }
         this.events.onBulletExpandRequest?.(
           connectionId,
-          msg['sessionId'] as string,
-          msg['bulletId'] as number,
-          msg['id'] as string,
+          msg['sessionId'],
+          msg['bulletId'],
+          msg['id'],
         );
         break;
       case 'terminal_resize':
@@ -279,16 +305,7 @@ export class RelayAdapter implements ConnectionAdapter {
   async stop(): Promise<void> {
     if (!this.running || !this.client) return;
 
-    if (this.clientConnectionId) {
-      if (this.authState === 'challenging' && this.config.authenticator) {
-        this.config.authenticator.removePendingChallenge(this.clientConnectionId);
-      }
-      if (this.authState === 'authenticated') {
-        this.events.onDisconnect?.(this.clientConnectionId, 'Relay adapter stopped');
-      }
-      this.clientConnectionId = null;
-      this.authState = 'none';
-    }
+    this.resetClient('Relay adapter stopped');
 
     this.client.close();
     this.client = null;

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -14,7 +14,7 @@
  *   peer-connected -> auth_challenge -> auth_response -> auth_result -> onConnect
  */
 
-import { createAgentOutput, createQuestion, generateId } from '@remi/shared';
+import { createAgentOutput, createAuthResult, createQuestion, generateId } from '@remi/shared';
 import type {
   AgentStatus,
   AuthResponseMessage,
@@ -32,15 +32,26 @@ import type {
 import type { Authenticator } from '../auth/authenticator.ts';
 import { SignalingClient } from './signaling-client.ts';
 
-export interface RelayAdapterConfig extends AdapterConfig {
+/** Base relay config fields shared by both modes */
+interface RelayAdapterConfigBase extends AdapterConfig {
   readonly signalingUrl: string;
-  /** Pre-set connection code (persisted across restarts) */
+}
+
+/** Rotating codes (default): code changes on reconnect; no auth required */
+interface RelayRotatingConfig extends RelayAdapterConfigBase {
+  readonly rotateCode?: true;
   readonly code?: string;
-  /** Rotate to a new code on each reconnect (default: true) */
-  readonly rotateCode?: boolean;
-  /** Authenticator for Ed25519 auth (required when rotateCode is false) */
   readonly authenticator?: Authenticator;
 }
+
+/** Permanent code: code persists; Ed25519 auth is mandatory */
+interface RelayPermanentConfig extends RelayAdapterConfigBase {
+  readonly rotateCode: false;
+  readonly code: string;
+  readonly authenticator: Authenticator;
+}
+
+export type RelayAdapterConfig = RelayRotatingConfig | RelayPermanentConfig;
 
 type RelayAuthState = 'none' | 'challenging' | 'authenticated';
 
@@ -153,6 +164,8 @@ export class RelayAdapter implements ConnectionAdapter {
         if (message.type === 'auth_response') {
           this.handleAuthResponse(message as AuthResponseMessage).catch((err) => {
             console.error('Relay auth error:', err instanceof Error ? err.message : err);
+            const failResult = createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR');
+            this.client?.sendRelay(JSON.stringify(failResult));
             this.resetClient();
           });
           return;

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -3,23 +3,41 @@
  *
  * Uses the signaling server as a message relay for remote clients.
  * Remi protocol messages are serialized as relay payloads.
+ *
+ * Supports two modes:
+ * - Rotating codes (default): code changes on each reconnect; no Ed25519 auth
+ * - Permanent code (--permanent-code): code persists; Ed25519 auth required
  */
 
 import { createAgentOutput, createQuestion, generateId } from '@remi/shared';
-import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
+import type {
+  AgentStatus,
+  AuthResponseMessage,
+  Message,
+  ProtocolMessage,
+  Question,
+  UUID,
+} from '@remi/shared';
 import type {
   AdapterConfig,
   AdapterEvents,
   AdapterMetadata,
   ConnectionAdapter,
 } from '../adapters/connection-adapter.ts';
+import type { Authenticator } from '../auth/authenticator.ts';
 import { SignalingClient } from './signaling-client.ts';
 
 export interface RelayAdapterConfig extends AdapterConfig {
   readonly signalingUrl: string;
   /** Pre-set connection code (persisted across restarts) */
   readonly code?: string;
+  /** Rotate to a new code on each reconnect (default: true) */
+  readonly rotateCode?: boolean;
+  /** Authenticator for Ed25519 auth (required when rotateCode is false) */
+  readonly authenticator?: Authenticator;
 }
+
+type RelayAuthState = 'none' | 'challenging' | 'authenticated';
 
 export class RelayAdapter implements ConnectionAdapter {
   readonly type = 'relay';
@@ -32,6 +50,9 @@ export class RelayAdapter implements ConnectionAdapter {
 
   /** Single client connection ID (relay supports one remote client at a time) */
   private clientConnectionId: UUID | null = null;
+
+  /** Auth state for the current relay peer */
+  private authState: RelayAuthState = 'none';
 
   constructor(config: RelayAdapterConfig, events: Partial<AdapterEvents> = {}) {
     this.config = config;
@@ -50,6 +71,10 @@ export class RelayAdapter implements ConnectionAdapter {
     return this.connectionCode;
   }
 
+  private get requiresAuth(): boolean {
+    return this.config.authenticator != null;
+  }
+
   async start(): Promise<void> {
     if (this.running) {
       throw new Error('Relay adapter already running');
@@ -60,7 +85,9 @@ export class RelayAdapter implements ConnectionAdapter {
       return;
     }
 
-    this.client = new SignalingClient(this.config.signalingUrl);
+    const rotateOnReconnect = this.config.rotateCode !== false;
+
+    this.client = new SignalingClient(this.config.signalingUrl, { rotateOnReconnect });
 
     this.client.on('registered', (code: string) => {
       this.connectionCode = code;
@@ -68,30 +95,49 @@ export class RelayAdapter implements ConnectionAdapter {
     });
 
     this.client.on('open', () => {
-      // The code is generated locally by SignalingClient before connecting
       this.connectionCode = this.client?.connectionCode ?? null;
       if (this.connectionCode) {
         console.log(`Remote access code: ${this.connectionCode}`);
       }
     });
 
+    this.client.on('code-rotated', (newCode: string) => {
+      this.connectionCode = newCode;
+      console.log(`Code rotated: ${newCode}`);
+    });
+
     this.client.on('peer-connected', () => {
       const connectionId = generateId();
       this.clientConnectionId = connectionId;
 
-      const metadata: AdapterMetadata = {
-        adapterType: this.type,
-        displayName: 'Remote Client',
-        platformData: { code: this.connectionCode },
-      };
-
-      this.events.onConnect?.(connectionId, metadata);
+      if (this.requiresAuth && this.config.authenticator) {
+        // Send auth challenge before accepting messages
+        const challenge = this.config.authenticator.createChallenge(connectionId);
+        this.authState = 'challenging';
+        this.client?.sendRelay(JSON.stringify(challenge));
+      } else {
+        // No auth required; accept connection immediately
+        this.authState = 'authenticated';
+        const metadata: AdapterMetadata = {
+          adapterType: this.type,
+          displayName: 'Remote Client',
+          platformData: { code: this.connectionCode },
+        };
+        this.events.onConnect?.(connectionId, metadata);
+      }
     });
 
     this.client.on('peer-disconnected', () => {
       if (this.clientConnectionId) {
-        this.events.onDisconnect?.(this.clientConnectionId, 'Remote client disconnected');
+        // Clean up pending auth challenge if peer disconnects during auth
+        if (this.authState === 'challenging' && this.config.authenticator) {
+          this.config.authenticator.removePendingChallenge(this.clientConnectionId);
+        }
+        if (this.authState === 'authenticated') {
+          this.events.onDisconnect?.(this.clientConnectionId, 'Remote client disconnected');
+        }
         this.clientConnectionId = null;
+        this.authState = 'none';
       }
     });
 
@@ -108,64 +154,20 @@ export class RelayAdapter implements ConnectionAdapter {
           return;
         }
 
-        // Route incoming protocol messages from the remote client
-        switch (message.type) {
-          case 'user_input':
-            if (typeof message.content !== 'string' || typeof message.sessionId !== 'string') {
-              console.warn('Invalid user_input payload: missing content or sessionId');
-              return;
-            }
-            this.events.onUserInput?.(this.clientConnectionId, message.sessionId, message.content);
-            break;
-          case 'answer':
-            if (typeof message.questionId !== 'string' || typeof message.answer !== 'string') {
-              console.warn('Invalid answer payload: missing questionId or answer');
-              return;
-            }
-            this.events.onAnswer?.(this.clientConnectionId, message.questionId, message.answer);
-            break;
-          case 'session_list_request':
-            this.events.onSessionListRequest?.(
-              this.clientConnectionId,
-              message.id,
-              message.includeExternal ?? false,
-            );
-            break;
-          case 'transcript_load_request':
-            this.events.onTranscriptLoadRequest?.(
-              this.clientConnectionId,
-              message.sessionId,
-              message.id,
-            );
-            break;
-          case 'create_session_request':
-            this.events.onCreateSessionRequest?.(
-              this.clientConnectionId,
-              message.directory,
-              message.id,
-            );
-            break;
-          case 'bullet_expand_request':
-            this.events.onBulletExpandRequest?.(
-              this.clientConnectionId,
-              message.sessionId,
-              message.bulletId,
-              message.id,
-            );
-            break;
-          case 'terminal_resize':
-            if (typeof message.cols !== 'number' || typeof message.rows !== 'number') {
-              console.warn('Invalid terminal_resize payload: cols and rows must be numbers');
-              return;
-            }
-            this.events.onTerminalResize?.(this.clientConnectionId, message.cols, message.rows);
-            break;
-          case 'hello':
-            // Forward as connect event (already handled above)
-            break;
-          default:
-            console.warn(`Unknown relay message type: ${message.type}`);
+        // Handle auth_response during challenging state
+        if (message.type === 'auth_response') {
+          this.handleAuthResponse(message as AuthResponseMessage);
+          return;
         }
+
+        // Block all other messages until authenticated
+        if (this.authState !== 'authenticated') {
+          console.warn(`Relay message '${message.type}' dropped: not authenticated`);
+          return;
+        }
+
+        // Route incoming protocol messages from the remote client
+        this.routeMessage(message);
       } catch (e) {
         console.warn('Failed to parse relay payload:', e instanceof Error ? e.message : e);
       }
@@ -179,12 +181,113 @@ export class RelayAdapter implements ConnectionAdapter {
     this.running = true;
   }
 
+  private async handleAuthResponse(response: AuthResponseMessage): Promise<void> {
+    if (
+      this.authState !== 'challenging' ||
+      !this.clientConnectionId ||
+      !this.config.authenticator
+    ) {
+      console.warn('Unexpected auth_response: not in challenging state');
+      return;
+    }
+
+    const result = await this.config.authenticator.verifyResponse(
+      this.clientConnectionId,
+      response,
+    );
+
+    // Send auth_result to the client
+    this.client?.sendRelay(JSON.stringify(result));
+
+    if (result.success) {
+      this.authState = 'authenticated';
+      const metadata: AdapterMetadata = {
+        adapterType: this.type,
+        displayName: 'Remote Client (authenticated)',
+        platformData: { code: this.connectionCode },
+      };
+      this.events.onConnect?.(this.clientConnectionId, metadata);
+    } else {
+      console.warn(`Relay auth failed: ${result.error}`);
+      this.authState = 'none';
+      // Don't disconnect; the peer can retry or the signaling TTL will clean up
+    }
+  }
+
+  private routeMessage(msg: Record<string, unknown>): void {
+    if (!this.clientConnectionId) return;
+    const connectionId = this.clientConnectionId;
+    switch (msg['type']) {
+      case 'user_input':
+        if (typeof msg['content'] !== 'string' || typeof msg['sessionId'] !== 'string') {
+          console.warn('Invalid user_input payload: missing content or sessionId');
+          return;
+        }
+        this.events.onUserInput?.(connectionId, msg['sessionId'], msg['content']);
+        break;
+      case 'answer':
+        if (typeof msg['questionId'] !== 'string' || typeof msg['answer'] !== 'string') {
+          console.warn('Invalid answer payload: missing questionId or answer');
+          return;
+        }
+        this.events.onAnswer?.(connectionId, msg['questionId'], msg['answer']);
+        break;
+      case 'session_list_request':
+        this.events.onSessionListRequest?.(
+          connectionId,
+          msg['id'] as string,
+          (msg['includeExternal'] as boolean) ?? false,
+        );
+        break;
+      case 'transcript_load_request':
+        this.events.onTranscriptLoadRequest?.(
+          connectionId,
+          msg['sessionId'] as string,
+          msg['id'] as string,
+        );
+        break;
+      case 'create_session_request':
+        this.events.onCreateSessionRequest?.(
+          connectionId,
+          msg['directory'] as string | undefined,
+          msg['id'] as string,
+        );
+        break;
+      case 'bullet_expand_request':
+        this.events.onBulletExpandRequest?.(
+          connectionId,
+          msg['sessionId'] as string,
+          msg['bulletId'] as number,
+          msg['id'] as string,
+        );
+        break;
+      case 'terminal_resize':
+        if (typeof msg['cols'] !== 'number' || typeof msg['rows'] !== 'number') {
+          console.warn('Invalid terminal_resize payload: cols and rows must be numbers');
+          return;
+        }
+        this.events.onTerminalResize?.(connectionId, msg['cols'], msg['rows']);
+        break;
+      case 'hello':
+        // Hello is handled at connection level, not message level
+        break;
+      default:
+        console.warn(`Unknown relay message type: ${msg['type']}`);
+    }
+  }
+
   async stop(): Promise<void> {
     if (!this.running || !this.client) return;
 
     if (this.clientConnectionId) {
-      this.events.onDisconnect?.(this.clientConnectionId, 'Relay adapter stopped');
+      if (this.authState === 'challenging' && this.config.authenticator) {
+        this.config.authenticator.removePendingChallenge(this.clientConnectionId);
+      }
+      if (this.authState === 'authenticated') {
+        this.events.onDisconnect?.(this.clientConnectionId, 'Relay adapter stopped');
+      }
       this.clientConnectionId = null;
+      this.authState = 'none';
     }
 
     this.client.close();

--- a/packages/daemon/src/remote/signaling-client.ts
+++ b/packages/daemon/src/remote/signaling-client.ts
@@ -12,7 +12,7 @@ const ALPHA_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ';
 const NUMERIC_CHARS = '23456789';
 
 /** Generate a connection code locally (XXXX-YYYY format) */
-function generateConnectionCode(): string {
+export function generateConnectionCode(): string {
   const bytes = new Uint8Array(8);
   crypto.getRandomValues(bytes);
   let alpha = '';
@@ -28,6 +28,11 @@ function generateConnectionCode(): string {
   return `${alpha}-${numeric}`;
 }
 
+export interface SignalingClientOptions {
+  /** Rotate to a new code on each auto-reconnect (default: true) */
+  rotateOnReconnect?: boolean;
+}
+
 export interface SignalingClientEvents {
   registered: (code: string, expiresAt: string) => void;
   'peer-connected': () => void;
@@ -36,19 +41,23 @@ export interface SignalingClientEvents {
   error: (code: string, message: string) => void;
   close: () => void;
   open: () => void;
+  'code-rotated': (newCode: string) => void;
 }
 
 export class SignalingClient extends EventEmitter {
   private ws: WebSocket | null = null;
   private readonly baseUrl: string;
+  private readonly rotateOnReconnect: boolean;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
   private code: string | null = null;
+  private isReconnect = false;
 
-  constructor(baseUrl: string) {
+  constructor(baseUrl: string, options?: SignalingClientOptions) {
     super();
     // Strip trailing slash
     this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.rotateOnReconnect = options?.rotateOnReconnect ?? true;
   }
 
   connect(code?: string): void {
@@ -58,12 +67,18 @@ export class SignalingClient extends EventEmitter {
     }
     this.closed = false;
 
-    // Use provided code or generate one; reuse on reconnect
     if (code) {
+      // Explicit code provided (initial connect)
       this.code = code;
+    } else if (this.isReconnect && this.rotateOnReconnect) {
+      // Auto-reconnect with rotation: generate new code
+      this.code = generateConnectionCode();
+      this.emit('code-rotated', this.code);
     } else if (!this.code) {
+      // First connect with no code: generate one
       this.code = generateConnectionCode();
     }
+    // Otherwise: reuse existing code (permanent mode)
     const wsUrl = `${this.baseUrl}/${this.code}`;
     this.ws = new WebSocket(wsUrl);
 
@@ -149,6 +164,7 @@ export class SignalingClient extends EventEmitter {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       if (!this.closed) {
+        this.isReconnect = true;
         this.connect();
       }
     }, 5000);

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -23,6 +23,7 @@ import {
 import type {
   Acknowledgment,
   AnswerMessage,
+  AuthResponseMessage,
   BulletExpandRequestMessage,
   CreateSessionRequestMessage,
   HelloMessage,
@@ -34,9 +35,10 @@ import type {
   UUID,
   UserInputMessage,
 } from '@remi/shared';
+import type { Authenticator } from '../auth/authenticator.ts';
 
 /** Connection state */
-export type ConnectionState = 'connecting' | 'connected' | 'disconnected';
+export type ConnectionState = 'connecting' | 'authenticating' | 'connected' | 'disconnected';
 
 /** Events emitted by connection */
 export interface ConnectionEvents {
@@ -67,6 +69,12 @@ export interface ConnectionEvents {
   /** Terminal resize from attached CLI client */
   onTerminalResize: (cols: number, rows: number) => void;
 
+  /** Authentication succeeded */
+  onAuthSuccess: (clientFingerprint: string) => void;
+
+  /** Authentication failed */
+  onAuthFailed: (error: string, clientFingerprint?: string) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -84,6 +92,9 @@ export interface ConnectionConfig {
 
   /** Skip sending HelloAck from Connection (let daemon handle it) */
   readonly skipHelloAck?: boolean;
+
+  /** Authenticator instance (if set, authentication is required) */
+  readonly authenticator?: Authenticator | undefined;
 }
 
 const DEFAULT_PING_INTERVAL = 30000;
@@ -101,7 +112,10 @@ export class Connection {
   private resumeSessionId: UUID | null = null;
 
   private readonly ws: WebSocket;
-  private readonly config: Required<ConnectionConfig> & { skipHelloAck: boolean };
+  private readonly config: Required<ConnectionConfig> & {
+    skipHelloAck: boolean;
+    authenticator: Authenticator | undefined;
+  };
   private readonly events: Partial<ConnectionEvents>;
   private readonly messageTracker: MessageIdTracker;
 
@@ -124,14 +138,22 @@ export class Connection {
       pingInterval: config.pingInterval ?? DEFAULT_PING_INTERVAL,
       connectionTimeout: config.connectionTimeout ?? DEFAULT_CONNECTION_TIMEOUT,
       skipHelloAck: config.skipHelloAck ?? false,
+      authenticator: config.authenticator,
     };
 
-    // Set connection timeout
+    // Set connection timeout (applies to both auth and hello phases)
     this.connectionTimer = setTimeout(() => {
-      if (this.state === 'connecting') {
+      if (this.state === 'connecting' || this.state === 'authenticating') {
         this.close('Connection timeout');
       }
     }, this.config.connectionTimeout);
+
+    // If authenticator is configured, send challenge immediately
+    if (this.config.authenticator) {
+      this.state = 'authenticating';
+      const challenge = this.config.authenticator.createChallenge(this.id);
+      this.send(challenge);
+    }
   }
 
   /** Get current state */
@@ -174,6 +196,18 @@ export class Connection {
     if (this.messageTracker.checkAndMark(message.id)) {
       // Duplicate - still acknowledge but don't process
       this.sendAck(message.id, 'delivered');
+      return;
+    }
+
+    // In authenticating state, only accept auth_response
+    if (this.state === 'authenticating') {
+      if (message.type === 'auth_response') {
+        this.handleAuthResponse(message);
+      } else if (message.type === 'ping') {
+        this.handlePing(message);
+      } else {
+        this.sendError('AUTH_REQUIRED', 'Authentication required before other messages');
+      }
       return;
     }
 
@@ -247,6 +281,25 @@ export class Connection {
       this.sendError('CLOSING', reason);
       this.ws.close();
       this.cleanup(reason);
+    }
+  }
+
+  private async handleAuthResponse(message: AuthResponseMessage): Promise<void> {
+    if (this.state !== 'authenticating' || !this.config.authenticator) {
+      this.sendError('INVALID_STATE', 'Not in authenticating state');
+      return;
+    }
+
+    const result = await this.config.authenticator.verifyResponse(this.id, message);
+    this.send(result);
+
+    if (result.success) {
+      // Auth passed; transition to 'connecting' (waiting for hello)
+      this.state = 'connecting';
+      this.events.onAuthSuccess?.(message.clientFingerprint);
+    } else {
+      this.events.onAuthFailed?.(result.error ?? 'unknown', message.clientFingerprint);
+      this.close(`Authentication failed: ${result.error}`);
     }
   }
 
@@ -385,6 +438,9 @@ export class Connection {
       clearTimeout(this.connectionTimer);
       this.connectionTimer = null;
     }
+
+    // Clean up pending auth challenge if connection closes during auth
+    this.config.authenticator?.removePendingChallenge(this.id);
 
     this.state = 'disconnected';
     this.events.onDisconnect?.(reason);

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -9,13 +9,14 @@
  * - Ping/pong keep-alive
  *
  * State transitions:
- *   With auth:    connecting -> authenticating -> connecting -> connected
- *   Without auth: connecting -> connected
+ *   With auth:    authenticating -> connecting (post-auth) -> connected -> disconnected
+ *   Without auth: connecting -> connected -> disconnected
  */
 
 import {
   MessageIdTracker,
   createAck,
+  createAuthResult,
   createError,
   createHelloAck,
   createPing,
@@ -208,7 +209,7 @@ export class Connection {
     if (this.state === 'authenticating') {
       if (message.type === 'auth_response') {
         this.handleAuthResponse(message).catch((err) => {
-          this.sendError('AUTH_ERROR', 'Internal authentication error');
+          this.send(createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR'));
           this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
           this.close('Authentication error');
         });

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -2,10 +2,15 @@
  * WebSocket Connection - Wraps a WebSocket with protocol handling.
  *
  * Features:
+ * - Authentication state machine (challenge-response before hello)
  * - Message serialization/deserialization
  * - Message ID tracking for deduplication
  * - Acknowledgment handling
  * - Ping/pong keep-alive
+ *
+ * State transitions:
+ *   With auth:    connecting -> authenticating -> connecting -> connected
+ *   Without auth: connecting -> connected
  */
 
 import {
@@ -202,7 +207,11 @@ export class Connection {
     // In authenticating state, only accept auth_response
     if (this.state === 'authenticating') {
       if (message.type === 'auth_response') {
-        this.handleAuthResponse(message);
+        this.handleAuthResponse(message).catch((err) => {
+          this.sendError('AUTH_ERROR', 'Internal authentication error');
+          this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+          this.close('Authentication error');
+        });
       } else if (message.type === 'ping') {
         this.handlePing(message);
       } else {

--- a/packages/daemon/tests/authenticator.test.ts
+++ b/packages/daemon/tests/authenticator.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Authenticator - server-side challenge-response authentication.
+ * All tests use real cryptographic operations.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createAuthResponse, createIdentity, fromBase64, sign, unlockIdentity } from '@remi/shared';
+import type { UnlockedIdentity } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-auth-test-'));
+}
+
+describe('Authenticator', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+  let serverIdentity: UnlockedIdentity;
+  let authenticator: Authenticator;
+
+  // Client identity for testing
+  let clientIdentity: UnlockedIdentity;
+  let clientPublicKeyBase64: string;
+  let clientFingerprint: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+
+    // Generate server identity
+    await store.generate('serverpass');
+    serverIdentity = await store.unlock('serverpass');
+
+    // Generate client identity
+    const clientIdFile = await createIdentity('clientpass');
+    clientIdentity = await unlockIdentity(clientIdFile, 'clientpass');
+    clientPublicKeyBase64 = clientIdFile.publicKey;
+    clientFingerprint = clientIdFile.fingerprint;
+
+    // Authorize the client
+    await store.addAuthorizedKey(clientPublicKeyBase64, 'Test Client');
+
+    authenticator = new Authenticator({
+      identity: serverIdentity,
+      identityStore: store,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  describe('createChallenge', () => {
+    test('creates a valid auth challenge message', () => {
+      const challenge = authenticator.createChallenge('conn-1');
+      expect(challenge.type).toBe('auth_challenge');
+      expect(typeof challenge.challenge).toBe('string');
+      expect(challenge.serverFingerprint).toBe(serverIdentity.fingerprint);
+      expect(challenge.serverPublicKey).toBe(serverIdentity.publicKeyRaw);
+    });
+
+    test('creates unique challenges per connection', () => {
+      const c1 = authenticator.createChallenge('conn-1');
+      const c2 = authenticator.createChallenge('conn-2');
+      expect(c1.challenge).not.toBe(c2.challenge);
+    });
+  });
+
+  describe('verifyResponse', () => {
+    test('accepts valid response from authorized client', async () => {
+      const challenge = authenticator.createChallenge('conn-1');
+
+      // Client signs the challenge
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      const result = await authenticator.verifyResponse('conn-1', response);
+      expect(result.success).toBe(true);
+      expect(result.serverSignature).toBeDefined();
+      expect(result.error).toBeUndefined();
+    });
+
+    test('rejects unknown client key', async () => {
+      const challenge = authenticator.createChallenge('conn-1');
+
+      // Create a different client (not authorized)
+      const unknownId = await createIdentity('unknown');
+      const unknownUnlocked = await unlockIdentity(unknownId, 'unknown');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownUnlocked.privateKey, challengeData);
+
+      const response = createAuthResponse(unknownId.publicKey, signature, unknownId.fingerprint);
+
+      const result = await authenticator.verifyResponse('conn-1', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('UNKNOWN_KEY');
+    });
+
+    test('rejects invalid signature', async () => {
+      const _challenge = authenticator.createChallenge('conn-1');
+
+      // Sign wrong data
+      const wrongData = new TextEncoder().encode('wrong data');
+      const signature = await sign(clientIdentity.privateKey, wrongData.buffer);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      const result = await authenticator.verifyResponse('conn-1', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_SIGNATURE');
+    });
+
+    test('rejects reused challenge (one-time use)', async () => {
+      const challenge = authenticator.createChallenge('conn-1');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      // First use succeeds
+      const result1 = await authenticator.verifyResponse('conn-1', response);
+      expect(result1.success).toBe(true);
+
+      // Second use fails (challenge consumed)
+      const result2 = await authenticator.verifyResponse('conn-1', response);
+      expect(result2.success).toBe(false);
+      expect(result2.error).toBe('NO_PENDING_CHALLENGE');
+    });
+
+    test('rejects response for wrong connection', async () => {
+      authenticator.createChallenge('conn-1');
+
+      const challengeData = fromBase64(authenticator.createChallenge('conn-2').challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      // Try to use conn-2's response for conn-1 (conn-1's challenge was already consumed by conn-2's creation)
+      const result = await authenticator.verifyResponse('conn-999', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('NO_PENDING_CHALLENGE');
+    });
+
+    test('updates lastUsedAt on successful auth', async () => {
+      const challenge = authenticator.createChallenge('conn-1');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      await authenticator.verifyResponse('conn-1', response);
+
+      const keys = store.listAuthorizedKeys();
+      expect(keys[0]?.lastUsedAt).not.toBeNull();
+    });
+  });
+
+  describe('removePendingChallenge', () => {
+    test('cleans up pending challenge', async () => {
+      authenticator.createChallenge('conn-1');
+      authenticator.removePendingChallenge('conn-1');
+
+      const challengeData = new TextEncoder().encode('anything');
+      const signature = await sign(clientIdentity.privateKey, challengeData.buffer);
+
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      const result = await authenticator.verifyResponse('conn-1', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('NO_PENDING_CHALLENGE');
+    });
+  });
+
+  describe('properties', () => {
+    test('serverFingerprint returns identity fingerprint', () => {
+      expect(authenticator.serverFingerprint).toBe(serverIdentity.fingerprint);
+    });
+
+    test('serverPublicKey returns identity public key', () => {
+      expect(authenticator.serverPublicKey).toBe(serverIdentity.publicKeyRaw);
+    });
+  });
+});

--- a/packages/daemon/tests/connection-auth.test.ts
+++ b/packages/daemon/tests/connection-auth.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for Connection auth state machine.
+ * Uses real crypto operations (no mocks).
+ *
+ * Tests the state transitions:
+ *   With auth:    authenticating -> connecting -> connected -> disconnected
+ *   Without auth: connecting -> connected -> disconnected
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  createAuthResponse,
+  createHello,
+  createIdentity,
+  createPing,
+  createUserInput,
+  deserialize,
+  fromBase64,
+  serialize,
+  sign,
+  unlockIdentity,
+} from '@remi/shared';
+import type { ProtocolMessage, UnlockedIdentity } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+import { Connection } from '../src/server/connection.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-conn-auth-test-'));
+}
+
+/** Mock WebSocket that captures sent messages */
+class MockWebSocket {
+  readyState = WebSocket.OPEN;
+  sentMessages: ProtocolMessage[] = [];
+  closed = false;
+
+  send(data: string): void {
+    const msg = deserialize(data);
+    if (msg) this.sentMessages.push(msg);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Get last sent message of a given type */
+  lastOfType(type: string): ProtocolMessage | undefined {
+    return [...this.sentMessages].reverse().find((m) => m.type === type);
+  }
+}
+
+describe('Connection auth state machine', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+  let serverIdentity: UnlockedIdentity;
+  let authenticator: Authenticator;
+  let clientIdentity: UnlockedIdentity;
+  let clientPublicKeyBase64: string;
+  let clientFingerprint: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+
+    await store.generate('serverpass');
+    serverIdentity = await store.unlock('serverpass');
+
+    const clientIdFile = await createIdentity('clientpass');
+    clientIdentity = await unlockIdentity(clientIdFile, 'clientpass');
+    clientPublicKeyBase64 = clientIdFile.publicKey;
+    clientFingerprint = clientIdFile.fingerprint;
+
+    await store.addAuthorizedKey(clientPublicKeyBase64, 'Test Client');
+
+    authenticator = new Authenticator({
+      identity: serverIdentity,
+      identityStore: store,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch { /* ignore */ }
+  });
+
+  describe('with auth', () => {
+    test('starts in authenticating state and sends auth_challenge', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
+
+      expect(conn.connectionState).toBe('authenticating');
+      expect(ws.sentMessages.length).toBe(1);
+      expect(ws.sentMessages[0]!.type).toBe('auth_challenge');
+    });
+
+    test('transitions to connecting after valid auth_response', async () => {
+      const ws = new MockWebSocket();
+      let authSuccess = false;
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onAuthSuccess: () => { authSuccess = true; },
+      }, { authenticator });
+
+      // Get the challenge from the sent message
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+
+      // Client signs the challenge
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+
+      // Send auth_response to connection
+      conn.handleMessage(serialize(response));
+
+      // Wait for async auth processing
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(conn.connectionState).toBe('connecting');
+      expect(authSuccess).toBe(true);
+
+      // Should have sent auth_result(success)
+      const result = ws.lastOfType('auth_result') as ProtocolMessage & { success: boolean };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(true);
+    });
+
+    test('full handshake: auth -> hello -> connected', async () => {
+      const ws = new MockWebSocket();
+      let connectedSessionId: string | null = null;
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onConnect: (sessionId) => { connectedSessionId = sessionId; },
+      }, { authenticator, skipHelloAck: false });
+
+      // Auth phase
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+      conn.handleMessage(serialize(response));
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(conn.connectionState).toBe('connecting');
+
+      // Hello phase
+      const hello = createHello('test-client', '1.0.0');
+      conn.handleMessage(serialize(hello));
+
+      expect(conn.connectionState).toBe('connected');
+      expect(connectedSessionId).toBe(conn.id);
+
+      // Should have sent hello_ack
+      const helloAck = ws.lastOfType('hello_ack');
+      expect(helloAck).toBeDefined();
+    });
+
+    test('rejects non-auth messages during authenticating state', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
+
+      // Try sending user_input during authenticating state
+      const hello = createHello('test-client', '1.0.0');
+      conn.handleMessage(serialize(hello));
+
+      // Should get AUTH_REQUIRED error
+      const errorMsg = ws.lastOfType('error') as ProtocolMessage & { code: string };
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg.code).toBe('AUTH_REQUIRED');
+      expect(conn.connectionState).toBe('authenticating');
+    });
+
+    test('allows ping during authenticating state', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
+
+      const ping = createPing();
+      conn.handleMessage(serialize(ping));
+
+      // Should get pong back (not AUTH_REQUIRED)
+      const pong = ws.lastOfType('pong');
+      expect(pong).toBeDefined();
+    });
+
+    test('closes connection on failed auth', async () => {
+      const ws = new MockWebSocket();
+      let authFailed = false;
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onAuthFailed: () => { authFailed = true; },
+        onDisconnect: () => {},
+      }, { authenticator });
+
+      // Create unauthorized client
+      const unknownId = await createIdentity('unknown');
+      const unknownUnlocked = await unlockIdentity(unknownId, 'unknown');
+
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownUnlocked.privateKey, challengeData);
+      const response = createAuthResponse(unknownId.publicKey, signature, unknownId.fingerprint);
+
+      conn.handleMessage(serialize(response));
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(authFailed).toBe(true);
+      expect(conn.connectionState).toBe('disconnected');
+
+      // Should have sent auth_result(failure)
+      const result = ws.lastOfType('auth_result') as ProtocolMessage & { success: boolean; error?: string };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(false);
+    });
+
+    test('sends auth_result(false) on internal auth error', async () => {
+      const ws = new MockWebSocket();
+      let errorOccurred = false;
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onError: () => { errorOccurred = true; },
+        onDisconnect: () => {},
+      }, { authenticator });
+
+      // Send a malformed auth_response (valid structure but garbage signature)
+      const malformed = createAuthResponse(clientPublicKeyBase64, 'not-valid-base64!!!', clientFingerprint);
+      conn.handleMessage(serialize(malformed));
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Should have sent auth_result(false) with INTERNAL_AUTH_ERROR
+      const result = ws.lastOfType('auth_result') as ProtocolMessage & { success: boolean; error?: string };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(false);
+      expect(conn.connectionState).toBe('disconnected');
+    });
+  });
+
+  describe('without auth', () => {
+    test('starts in connecting state', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, {});
+
+      expect(conn.connectionState).toBe('connecting');
+      // No auth_challenge sent
+      expect(ws.sentMessages.length).toBe(0);
+    });
+
+    test('accepts hello and transitions to connected', () => {
+      const ws = new MockWebSocket();
+      let connectedSessionId: string | null = null;
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onConnect: (sessionId) => { connectedSessionId = sessionId; },
+      }, { skipHelloAck: false });
+
+      const hello = createHello('test-client', '1.0.0');
+      conn.handleMessage(serialize(hello));
+
+      expect(conn.connectionState).toBe('connected');
+      expect(connectedSessionId).toBe(conn.id);
+    });
+
+    test('rejects messages before hello', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, {});
+
+      const input = createUserInput('session-1', 'test');
+      conn.handleMessage(serialize(input));
+
+      // Should get NOT_CONNECTED error
+      const errorMsg = ws.lastOfType('error') as ProtocolMessage & { code: string };
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg.code).toBe('NOT_CONNECTED');
+    });
+  });
+
+  describe('connection timeout', () => {
+    test('times out during authenticating state', async () => {
+      const ws = new MockWebSocket();
+      let disconnected = false;
+      new Connection(ws as unknown as WebSocket, {
+        onDisconnect: () => { disconnected = true; },
+      }, { authenticator, connectionTimeout: 50 });
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(disconnected).toBe(true);
+    });
+
+    test('times out during connecting state (no hello received)', async () => {
+      const ws = new MockWebSocket();
+      let disconnected = false;
+      new Connection(ws as unknown as WebSocket, {
+        onDisconnect: () => { disconnected = true; },
+      }, { connectionTimeout: 50 });
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(disconnected).toBe(true);
+    });
+  });
+
+  describe('cleanup', () => {
+    test('removes pending auth challenge on close during auth', () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {
+        onDisconnect: () => {},
+      }, { authenticator });
+
+      // Close during authenticating state
+      conn.handleClose();
+
+      expect(conn.connectionState).toBe('disconnected');
+    });
+  });
+});

--- a/packages/daemon/tests/connection-auth.test.ts
+++ b/packages/daemon/tests/connection-auth.test.ts
@@ -164,7 +164,7 @@ describe('Connection auth state machine', () => {
       conn.handleMessage(serialize(hello));
 
       expect(conn.connectionState).toBe('connected');
-      expect(connectedSessionId).toBe(conn.id);
+      expect(String(connectedSessionId)).toBe(conn.id);
 
       // Should have sent hello_ack
       const helloAck = ws.lastOfType('hello_ack');
@@ -294,7 +294,7 @@ describe('Connection auth state machine', () => {
       conn.handleMessage(serialize(hello));
 
       expect(conn.connectionState).toBe('connected');
-      expect(connectedSessionId).toBe(conn.id);
+      expect(String(connectedSessionId)).toBe(conn.id);
     });
 
     test('rejects messages before hello', () => {

--- a/packages/daemon/tests/connection-auth.test.ts
+++ b/packages/daemon/tests/connection-auth.test.ts
@@ -85,7 +85,9 @@ describe('Connection auth state machine', () => {
   afterEach(() => {
     try {
       fs.rmSync(tmpDir, { recursive: true });
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   });
 
   describe('with auth', () => {
@@ -95,15 +97,21 @@ describe('Connection auth state machine', () => {
 
       expect(conn.connectionState).toBe('authenticating');
       expect(ws.sentMessages.length).toBe(1);
-      expect(ws.sentMessages[0]!.type).toBe('auth_challenge');
+      expect(ws.sentMessages[0]?.type).toBe('auth_challenge');
     });
 
     test('transitions to connecting after valid auth_response', async () => {
       const ws = new MockWebSocket();
       let authSuccess = false;
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onAuthSuccess: () => { authSuccess = true; },
-      }, { authenticator });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onAuthSuccess: () => {
+            authSuccess = true;
+          },
+        },
+        { authenticator },
+      );
 
       // Get the challenge from the sent message
       const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
@@ -131,9 +139,15 @@ describe('Connection auth state machine', () => {
     test('full handshake: auth -> hello -> connected', async () => {
       const ws = new MockWebSocket();
       let connectedSessionId: string | null = null;
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onConnect: (sessionId) => { connectedSessionId = sessionId; },
-      }, { authenticator, skipHelloAck: false });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onConnect: (sessionId) => {
+            connectedSessionId = sessionId;
+          },
+        },
+        { authenticator, skipHelloAck: false },
+      );
 
       // Auth phase
       const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
@@ -187,10 +201,16 @@ describe('Connection auth state machine', () => {
     test('closes connection on failed auth', async () => {
       const ws = new MockWebSocket();
       let authFailed = false;
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onAuthFailed: () => { authFailed = true; },
-        onDisconnect: () => {},
-      }, { authenticator });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onAuthFailed: () => {
+            authFailed = true;
+          },
+          onDisconnect: () => {},
+        },
+        { authenticator },
+      );
 
       // Create unauthorized client
       const unknownId = await createIdentity('unknown');
@@ -208,26 +228,39 @@ describe('Connection auth state machine', () => {
       expect(conn.connectionState).toBe('disconnected');
 
       // Should have sent auth_result(failure)
-      const result = ws.lastOfType('auth_result') as ProtocolMessage & { success: boolean; error?: string };
+      const result = ws.lastOfType('auth_result') as ProtocolMessage & {
+        success: boolean;
+        error?: string;
+      };
       expect(result).toBeDefined();
       expect(result.success).toBe(false);
     });
 
     test('sends auth_result(false) on internal auth error', async () => {
       const ws = new MockWebSocket();
-      let errorOccurred = false;
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onError: () => { errorOccurred = true; },
-        onDisconnect: () => {},
-      }, { authenticator });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onError: () => {},
+          onDisconnect: () => {},
+        },
+        { authenticator },
+      );
 
       // Send a malformed auth_response (valid structure but garbage signature)
-      const malformed = createAuthResponse(clientPublicKeyBase64, 'not-valid-base64!!!', clientFingerprint);
+      const malformed = createAuthResponse(
+        clientPublicKeyBase64,
+        'not-valid-base64!!!',
+        clientFingerprint,
+      );
       conn.handleMessage(serialize(malformed));
       await new Promise((r) => setTimeout(r, 100));
 
       // Should have sent auth_result(false) with INTERNAL_AUTH_ERROR
-      const result = ws.lastOfType('auth_result') as ProtocolMessage & { success: boolean; error?: string };
+      const result = ws.lastOfType('auth_result') as ProtocolMessage & {
+        success: boolean;
+        error?: string;
+      };
       expect(result).toBeDefined();
       expect(result.success).toBe(false);
       expect(conn.connectionState).toBe('disconnected');
@@ -247,9 +280,15 @@ describe('Connection auth state machine', () => {
     test('accepts hello and transitions to connected', () => {
       const ws = new MockWebSocket();
       let connectedSessionId: string | null = null;
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onConnect: (sessionId) => { connectedSessionId = sessionId; },
-      }, { skipHelloAck: false });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onConnect: (sessionId) => {
+            connectedSessionId = sessionId;
+          },
+        },
+        { skipHelloAck: false },
+      );
 
       const hello = createHello('test-client', '1.0.0');
       conn.handleMessage(serialize(hello));
@@ -276,9 +315,15 @@ describe('Connection auth state machine', () => {
     test('times out during authenticating state', async () => {
       const ws = new MockWebSocket();
       let disconnected = false;
-      new Connection(ws as unknown as WebSocket, {
-        onDisconnect: () => { disconnected = true; },
-      }, { authenticator, connectionTimeout: 50 });
+      new Connection(
+        ws as unknown as WebSocket,
+        {
+          onDisconnect: () => {
+            disconnected = true;
+          },
+        },
+        { authenticator, connectionTimeout: 50 },
+      );
 
       await new Promise((r) => setTimeout(r, 100));
       expect(disconnected).toBe(true);
@@ -287,9 +332,15 @@ describe('Connection auth state machine', () => {
     test('times out during connecting state (no hello received)', async () => {
       const ws = new MockWebSocket();
       let disconnected = false;
-      new Connection(ws as unknown as WebSocket, {
-        onDisconnect: () => { disconnected = true; },
-      }, { connectionTimeout: 50 });
+      new Connection(
+        ws as unknown as WebSocket,
+        {
+          onDisconnect: () => {
+            disconnected = true;
+          },
+        },
+        { connectionTimeout: 50 },
+      );
 
       await new Promise((r) => setTimeout(r, 100));
       expect(disconnected).toBe(true);
@@ -299,9 +350,13 @@ describe('Connection auth state machine', () => {
   describe('cleanup', () => {
     test('removes pending auth challenge on close during auth', () => {
       const ws = new MockWebSocket();
-      const conn = new Connection(ws as unknown as WebSocket, {
-        onDisconnect: () => {},
-      }, { authenticator });
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {
+          onDisconnect: () => {},
+        },
+        { authenticator },
+      );
 
       // Close during authenticating state
       conn.handleClose();

--- a/packages/daemon/tests/identity-store.test.ts
+++ b/packages/daemon/tests/identity-store.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for IdentityStore - persistent identity and authorized keys management.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createIdentity } from '@remi/shared';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-auth-test-'));
+}
+
+describe('IdentityStore', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  describe('identity', () => {
+    test('exists returns false when no identity', () => {
+      expect(store.exists()).toBe(false);
+    });
+
+    test('load returns null when no identity', () => {
+      expect(store.load()).toBeNull();
+    });
+
+    test('generate creates and saves identity', async () => {
+      const identity = await store.generate('testpass');
+      expect(identity.version).toBe(1);
+      expect(identity.fingerprint).toMatch(/^[0-9a-f]+$/);
+      expect(store.exists()).toBe(true);
+    });
+
+    test('save and load round-trips identity', async () => {
+      const identity = await createIdentity('pass');
+      store.save(identity);
+
+      const loaded = store.load();
+      expect(loaded).not.toBeNull();
+      expect(loaded?.publicKey).toBe(identity.publicKey);
+      expect(loaded?.fingerprint).toBe(identity.fingerprint);
+      expect(loaded?.encryptedPrivateKey).toBe(identity.encryptedPrivateKey);
+    });
+
+    test('unlock succeeds with correct passphrase', async () => {
+      await store.generate('mypass');
+      const unlocked = await store.unlock('mypass');
+      expect(unlocked.publicKey.type).toBe('public');
+      expect(unlocked.privateKey.type).toBe('private');
+    });
+
+    test('unlock fails with wrong passphrase', async () => {
+      await store.generate('correct');
+      await expect(store.unlock('wrong')).rejects.toThrow();
+    });
+
+    test('unlock throws when no identity exists', async () => {
+      await expect(store.unlock('any')).rejects.toThrow('No identity found');
+    });
+
+    test('identity file has restricted permissions', async () => {
+      await store.generate('pass');
+      const identityPath = path.join(tmpDir, 'identity.json');
+      const stats = fs.statSync(identityPath);
+      // Check owner-only read/write (0600 = 0o600 = 384)
+      const mode = stats.mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  describe('authorized keys', () => {
+    test('loadAuthorizedKeys returns empty file when none exists', () => {
+      const file = store.loadAuthorizedKeys();
+      expect(file.version).toBe(1);
+      expect(file.keys).toEqual([]);
+    });
+
+    test('addAuthorizedKey adds a key', async () => {
+      const identity = await createIdentity('pass');
+      const key = await store.addAuthorizedKey(identity.publicKey, 'Test Device');
+
+      expect(key.publicKey).toBe(identity.publicKey);
+      expect(key.label).toBe('Test Device');
+      expect(key.fingerprint).toBe(identity.fingerprint);
+
+      const keys = store.listAuthorizedKeys();
+      expect(keys).toHaveLength(1);
+      expect(keys[0]?.fingerprint).toBe(identity.fingerprint);
+    });
+
+    test('addAuthorizedKey rejects duplicate fingerprint', async () => {
+      const identity = await createIdentity('pass');
+      await store.addAuthorizedKey(identity.publicKey, 'First');
+      await expect(store.addAuthorizedKey(identity.publicKey, 'Duplicate')).rejects.toThrow(
+        'already authorized',
+      );
+    });
+
+    test('removeAuthorizedKey removes a key', async () => {
+      const identity = await createIdentity('pass');
+      await store.addAuthorizedKey(identity.publicKey, 'Device');
+      const removed = store.removeAuthorizedKey(identity.fingerprint);
+      expect(removed).toBe(true);
+      expect(store.listAuthorizedKeys()).toHaveLength(0);
+    });
+
+    test('removeAuthorizedKey returns false for unknown fingerprint', () => {
+      const removed = store.removeAuthorizedKey('nonexistent');
+      expect(removed).toBe(false);
+    });
+
+    test('isAuthorized returns true for known key', async () => {
+      const identity = await createIdentity('pass');
+      await store.addAuthorizedKey(identity.publicKey, 'Device');
+      expect(store.isAuthorized(identity.publicKey, identity.fingerprint)).toBe(true);
+    });
+
+    test('isAuthorized returns false for unknown key', async () => {
+      const identity = await createIdentity('pass');
+      expect(store.isAuthorized(identity.publicKey, identity.fingerprint)).toBe(false);
+    });
+
+    test('touchAuthorizedKey updates lastUsedAt', async () => {
+      const identity = await createIdentity('pass');
+      await store.addAuthorizedKey(identity.publicKey, 'Device');
+
+      const before = store.listAuthorizedKeys();
+      expect(before[0]?.lastUsedAt).toBeNull();
+
+      store.touchAuthorizedKey(identity.fingerprint);
+
+      const after = store.listAuthorizedKeys();
+      expect(after[0]?.lastUsedAt).not.toBeNull();
+    });
+
+    test('multiple keys can be added', async () => {
+      const id1 = await createIdentity('pass1');
+      const id2 = await createIdentity('pass2');
+      await store.addAuthorizedKey(id1.publicKey, 'Device 1');
+      await store.addAuthorizedKey(id2.publicKey, 'Device 2');
+      expect(store.listAuthorizedKeys()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/daemon/tests/relay-adapter-auth.test.ts
+++ b/packages/daemon/tests/relay-adapter-auth.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for RelayAdapter authentication and code rotation.
+ * Uses real crypto, no mocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createAuthResponse, createIdentity, fromBase64, sign, unlockIdentity } from '@remi/shared';
+import type { UnlockedIdentity } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+import { SignalingClient, generateConnectionCode } from '../src/remote/signaling-client.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-relay-auth-test-'));
+}
+
+describe('generateConnectionCode', () => {
+  test('generates valid XXXX-YYYY format', () => {
+    const code = generateConnectionCode();
+    expect(code).toMatch(/^[A-Z]{4}-[0-9]{4}$/);
+    // Should not contain ambiguous characters
+    expect(code).not.toMatch(/[0OIL1]/);
+  });
+
+  test('generates unique codes', () => {
+    const codes = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      codes.add(generateConnectionCode());
+    }
+    // With ~49 bits of entropy, 100 codes should be unique
+    expect(codes.size).toBe(100);
+  });
+});
+
+describe('SignalingClient code rotation', () => {
+  test('rotateOnReconnect defaults to true', () => {
+    const client = new SignalingClient('wss://example.com');
+    // Can't test internal state directly, but we can verify the constructor accepts it
+    expect(client).toBeDefined();
+    client.close();
+  });
+
+  test('rotateOnReconnect can be set to false', () => {
+    const client = new SignalingClient('wss://example.com', { rotateOnReconnect: false });
+    expect(client).toBeDefined();
+    client.close();
+  });
+});
+
+describe('RelayAdapter auth flow', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+  let serverIdentity: UnlockedIdentity;
+  let authenticator: Authenticator;
+  let clientIdentity: UnlockedIdentity;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+
+    // Generate server identity
+    await store.generate('serverpass');
+    serverIdentity = await store.unlock('serverpass');
+
+    // Generate client identity
+    const clientIdFile = await createIdentity('clientpass');
+    clientIdentity = await unlockIdentity(clientIdFile, 'clientpass');
+
+    // Authorize the client
+    await store.addAuthorizedKey(clientIdFile.publicKey, 'Test Client');
+
+    authenticator = new Authenticator({
+      identity: serverIdentity,
+      identityStore: store,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('authenticator creates challenge with server public key', () => {
+    const challenge = authenticator.createChallenge('conn-1');
+    expect(challenge.type).toBe('auth_challenge');
+    expect(challenge.challenge).toBeDefined();
+    expect(challenge.serverPublicKey).toBeDefined();
+    expect(challenge.serverFingerprint).toBeDefined();
+  });
+
+  test('authenticator verifies valid client response', async () => {
+    const challenge = authenticator.createChallenge('conn-1');
+
+    // Client signs the challenge
+    const challengeData = fromBase64(challenge.challenge);
+    const signature = await sign(clientIdentity.privateKey, challengeData);
+    const response = createAuthResponse(
+      clientIdentity.publicKeyRaw,
+      signature,
+      clientIdentity.fingerprint,
+    );
+
+    const result = await authenticator.verifyResponse('conn-1', response);
+    expect(result.success).toBe(true);
+    expect(result.serverSignature).toBeDefined();
+  });
+
+  test('authenticator rejects unauthorized client', async () => {
+    const challenge = authenticator.createChallenge('conn-1');
+
+    // Create an unauthorized client
+    const unauthorizedId = await createIdentity('otherpass');
+    const unauthorizedIdentity = await unlockIdentity(unauthorizedId, 'otherpass');
+
+    const challengeData = fromBase64(challenge.challenge);
+    const signature = await sign(unauthorizedIdentity.privateKey, challengeData);
+    const response = createAuthResponse(
+      unauthorizedIdentity.publicKeyRaw,
+      signature,
+      unauthorizedIdentity.fingerprint,
+    );
+
+    const result = await authenticator.verifyResponse('conn-1', response);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('UNKNOWN_KEY');
+  });
+
+  test('authenticator cleanup removes pending challenge', () => {
+    authenticator.createChallenge('conn-1');
+    authenticator.removePendingChallenge('conn-1');
+    // No error thrown; subsequent verify should fail gracefully
+  });
+});

--- a/packages/shared/src/crypto.ts
+++ b/packages/shared/src/crypto.ts
@@ -43,7 +43,12 @@ export function toBase64(buffer: ArrayBuffer): Base64 {
 }
 
 export function fromBase64(base64: Base64): ArrayBuffer {
-  const binary = atob(base64);
+  let binary: string;
+  try {
+    binary = atob(base64);
+  } catch {
+    throw new Error(`Invalid Base64 input (length=${base64.length})`);
+  }
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);
@@ -79,7 +84,9 @@ export async function generateKeyPair(): Promise<RawKeyPair> {
 }
 
 /**
- * Export a keypair to raw bytes.
+ * Export a keypair to transferable byte arrays.
+ * Public key is exported as raw bytes (32 bytes for Ed25519).
+ * Private key is exported in PKCS8 format (48 bytes for Ed25519).
  */
 export async function exportKeyPair(keyPair: RawKeyPair): Promise<ExportedKeyPair> {
   const [publicKeyRaw, privateKeyRaw] = await Promise.all([
@@ -162,9 +169,9 @@ export async function deriveKeyFromPassphrase(
 // -- Private key encryption at rest --
 
 export interface EncryptedData {
-  ciphertext: Base64;
-  iv: Base64;
-  salt: Base64;
+  readonly ciphertext: Base64;
+  readonly iv: Base64;
+  readonly salt: Base64;
 }
 
 /**

--- a/packages/shared/src/crypto.ts
+++ b/packages/shared/src/crypto.ts
@@ -34,7 +34,12 @@ export const FINGERPRINT_LENGTH = 16;
 // -- Encoding helpers --
 
 export function toBase64(buffer: ArrayBuffer): Base64 {
-  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(binary);
 }
 
 export function fromBase64(base64: Base64): ArrayBuffer {

--- a/packages/shared/src/crypto.ts
+++ b/packages/shared/src/crypto.ts
@@ -46,8 +46,9 @@ export function fromBase64(base64: Base64): ArrayBuffer {
   let binary: string;
   try {
     binary = atob(base64);
-  } catch {
-    throw new Error(`Invalid Base64 input (length=${base64.length})`);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'unknown';
+    throw new Error(`Invalid Base64 input (length=${base64.length}): ${detail}`);
   }
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {

--- a/packages/shared/src/crypto.ts
+++ b/packages/shared/src/crypto.ts
@@ -1,0 +1,228 @@
+/**
+ * Cross-platform cryptographic utilities for Remi authentication.
+ *
+ * Uses the Web Crypto API exclusively (available in both Bun and browsers).
+ * No external dependencies required.
+ *
+ * Primitives:
+ * - Ed25519: Digital signatures for identity and authentication
+ * - PBKDF2-SHA-256: Key derivation from passphrase (600K iterations)
+ * - AES-256-GCM: Authenticated encryption for private key at rest
+ */
+
+/** Base64-encoded string */
+export type Base64 = string;
+
+/** Hex-encoded fingerprint string */
+export type Fingerprint = string;
+
+/** Default PBKDF2 iteration count (OWASP 2023 recommendation for SHA-256) */
+export const PBKDF2_ITERATIONS = 600_000;
+
+/** Salt size in bytes */
+export const SALT_SIZE = 32;
+
+/** AES-GCM IV size in bytes */
+export const IV_SIZE = 12;
+
+/** Challenge nonce size in bytes */
+export const CHALLENGE_SIZE = 32;
+
+/** Fingerprint display length (hex characters) */
+export const FINGERPRINT_LENGTH = 16;
+
+// -- Encoding helpers --
+
+export function toBase64(buffer: ArrayBuffer): Base64 {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+}
+
+export function fromBase64(base64: Base64): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// -- Key generation --
+
+export interface RawKeyPair {
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+}
+
+export interface ExportedKeyPair {
+  publicKeyRaw: ArrayBuffer;
+  privateKeyRaw: ArrayBuffer;
+}
+
+/**
+ * Generate an Ed25519 keypair for signing.
+ */
+export async function generateKeyPair(): Promise<RawKeyPair> {
+  const keyPair = await crypto.subtle.generateKey('Ed25519', true, ['sign', 'verify']);
+  return {
+    publicKey: keyPair.publicKey,
+    privateKey: keyPair.privateKey,
+  };
+}
+
+/**
+ * Export a keypair to raw bytes.
+ */
+export async function exportKeyPair(keyPair: RawKeyPair): Promise<ExportedKeyPair> {
+  const [publicKeyRaw, privateKeyRaw] = await Promise.all([
+    crypto.subtle.exportKey('raw', keyPair.publicKey),
+    crypto.subtle.exportKey('pkcs8', keyPair.privateKey),
+  ]);
+  return { publicKeyRaw, privateKeyRaw };
+}
+
+/**
+ * Import a raw Ed25519 public key.
+ */
+export async function importPublicKey(raw: ArrayBuffer): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', raw, 'Ed25519', true, ['verify']);
+}
+
+/**
+ * Import a PKCS8-encoded Ed25519 private key.
+ */
+export async function importPrivateKey(pkcs8: ArrayBuffer): Promise<CryptoKey> {
+  return crypto.subtle.importKey('pkcs8', pkcs8, 'Ed25519', true, ['sign']);
+}
+
+// -- Signing --
+
+/**
+ * Sign data with an Ed25519 private key.
+ * @returns Base64-encoded signature
+ */
+export async function sign(privateKey: CryptoKey, data: ArrayBuffer): Promise<Base64> {
+  const signature = await crypto.subtle.sign('Ed25519', privateKey, data);
+  return toBase64(signature);
+}
+
+/**
+ * Verify an Ed25519 signature.
+ */
+export async function verify(
+  publicKey: CryptoKey,
+  data: ArrayBuffer,
+  signatureBase64: Base64,
+): Promise<boolean> {
+  const signature = fromBase64(signatureBase64);
+  return crypto.subtle.verify('Ed25519', publicKey, signature, data);
+}
+
+// -- Passphrase KDF --
+
+/**
+ * Derive an AES-256 key from a passphrase using PBKDF2-SHA-256.
+ */
+export async function deriveKeyFromPassphrase(
+  passphrase: string,
+  salt: ArrayBuffer,
+  iterations: number = PBKDF2_ITERATIONS,
+): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const passphraseKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations,
+      hash: 'SHA-256',
+    },
+    passphraseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+// -- Private key encryption at rest --
+
+export interface EncryptedData {
+  ciphertext: Base64;
+  iv: Base64;
+  salt: Base64;
+}
+
+/**
+ * Encrypt a private key with a passphrase-derived key.
+ * Generates fresh salt and IV.
+ */
+export async function encryptPrivateKey(
+  privateKeyPkcs8: ArrayBuffer,
+  passphrase: string,
+  iterations: number = PBKDF2_ITERATIONS,
+): Promise<EncryptedData> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_SIZE));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_SIZE));
+  const derivedKey = await deriveKeyFromPassphrase(passphrase, salt.buffer, iterations);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    derivedKey,
+    privateKeyPkcs8,
+  );
+
+  return {
+    ciphertext: toBase64(ciphertext),
+    iv: toBase64(iv.buffer),
+    salt: toBase64(salt.buffer),
+  };
+}
+
+/**
+ * Decrypt a private key with a passphrase.
+ * @throws if passphrase is wrong (AES-GCM auth tag verification fails)
+ */
+export async function decryptPrivateKey(
+  encrypted: EncryptedData,
+  passphrase: string,
+  iterations: number = PBKDF2_ITERATIONS,
+): Promise<ArrayBuffer> {
+  const salt = fromBase64(encrypted.salt);
+  const iv = fromBase64(encrypted.iv);
+  const ciphertext = fromBase64(encrypted.ciphertext);
+  const derivedKey = await deriveKeyFromPassphrase(passphrase, salt, iterations);
+
+  return crypto.subtle.decrypt({ name: 'AES-GCM', iv }, derivedKey, ciphertext);
+}
+
+// -- Fingerprint --
+
+/**
+ * Compute a fingerprint from a raw public key.
+ * Returns first 16 hex characters of SHA-256 hash.
+ */
+export async function fingerprint(publicKeyRaw: ArrayBuffer): Promise<Fingerprint> {
+  const hash = await crypto.subtle.digest('SHA-256', publicKeyRaw);
+  return toHex(hash).slice(0, FINGERPRINT_LENGTH);
+}
+
+// -- Challenge --
+
+/**
+ * Generate a random 32-byte challenge nonce.
+ * @returns Base64-encoded challenge
+ */
+export function generateChallenge(): Base64 {
+  const bytes = crypto.getRandomValues(new Uint8Array(CHALLENGE_SIZE));
+  return toBase64(bytes.buffer);
+}

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -1,0 +1,180 @@
+/**
+ * Identity management for Remi authentication.
+ *
+ * Handles creation, serialization, and unlocking of Ed25519 identities
+ * with passphrase-encrypted private keys.
+ */
+
+import type { Base64, Fingerprint } from './crypto.ts';
+import {
+  PBKDF2_ITERATIONS,
+  decryptPrivateKey,
+  encryptPrivateKey,
+  exportKeyPair,
+  fingerprint,
+  generateKeyPair,
+  importPrivateKey,
+  importPublicKey,
+  toBase64,
+} from './crypto.ts';
+
+/** Persisted identity with passphrase-encrypted private key */
+export interface RemiIdentity {
+  readonly version: 1;
+  readonly publicKey: Base64;
+  readonly encryptedPrivateKey: Base64;
+  readonly salt: Base64;
+  readonly iv: Base64;
+  readonly iterations: number;
+  readonly fingerprint: Fingerprint;
+  readonly createdAt: string;
+}
+
+/** An authorized client public key */
+export interface AuthorizedKey {
+  readonly publicKey: Base64;
+  readonly fingerprint: Fingerprint;
+  readonly label: string;
+  readonly addedAt: string;
+  readonly lastUsedAt: string | null;
+}
+
+/** Authorized keys file structure */
+export interface AuthorizedKeysFile {
+  readonly version: 1;
+  readonly keys: AuthorizedKey[];
+}
+
+/** Unlocked identity with usable CryptoKey objects */
+export interface UnlockedIdentity {
+  readonly publicKey: CryptoKey;
+  readonly privateKey: CryptoKey;
+  readonly publicKeyRaw: Base64;
+  readonly fingerprint: Fingerprint;
+}
+
+/** Known host entry (TOFU model) */
+export interface KnownHost {
+  readonly fingerprint: Fingerprint;
+  readonly publicKey: Base64;
+  readonly firstSeen: string;
+  readonly lastSeen: string;
+}
+
+/**
+ * Generate a new identity with a passphrase-encrypted private key.
+ */
+export async function createIdentity(passphrase: string): Promise<RemiIdentity> {
+  const keyPair = await generateKeyPair();
+  const exported = await exportKeyPair(keyPair);
+  const fp = await fingerprint(exported.publicKeyRaw);
+
+  const encrypted = await encryptPrivateKey(exported.privateKeyRaw, passphrase);
+
+  return {
+    version: 1,
+    publicKey: toBase64(exported.publicKeyRaw),
+    encryptedPrivateKey: encrypted.ciphertext,
+    salt: encrypted.salt,
+    iv: encrypted.iv,
+    iterations: PBKDF2_ITERATIONS,
+    fingerprint: fp,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Unlock an identity by decrypting the private key with a passphrase.
+ * @throws if passphrase is incorrect
+ */
+export async function unlockIdentity(
+  identity: RemiIdentity,
+  passphrase: string,
+): Promise<UnlockedIdentity> {
+  const privateKeyPkcs8 = await decryptPrivateKey(
+    {
+      ciphertext: identity.encryptedPrivateKey,
+      iv: identity.iv,
+      salt: identity.salt,
+    },
+    passphrase,
+    identity.iterations,
+  );
+
+  const privateKey = await importPrivateKey(privateKeyPkcs8);
+  const publicKey = await importPublicKey(
+    // Convert base64 public key back to ArrayBuffer
+    Uint8Array.from(atob(identity.publicKey), (c) => c.charCodeAt(0)).buffer,
+  );
+
+  return {
+    publicKey,
+    privateKey,
+    publicKeyRaw: identity.publicKey,
+    fingerprint: identity.fingerprint,
+  };
+}
+
+/**
+ * Serialize an identity to JSON string for export/storage.
+ */
+export function serializeIdentity(identity: RemiIdentity): string {
+  return JSON.stringify(identity, null, 2);
+}
+
+/**
+ * Deserialize an identity from JSON string.
+ * @throws if JSON is invalid or missing required fields
+ */
+export function deserializeIdentity(json: string): RemiIdentity {
+  const parsed: unknown = JSON.parse(json);
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Invalid identity: not an object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj['version'] !== 1) {
+    throw new Error(`Unsupported identity version: ${String(obj['version'])}`);
+  }
+
+  const required = ['publicKey', 'encryptedPrivateKey', 'salt', 'iv', 'fingerprint', 'createdAt'];
+  for (const field of required) {
+    if (typeof obj[field] !== 'string') {
+      throw new Error(`Invalid identity: missing or invalid field '${field}'`);
+    }
+  }
+
+  if (typeof obj['iterations'] !== 'number' || obj['iterations'] < 1) {
+    throw new Error('Invalid identity: invalid iterations count');
+  }
+
+  return parsed as RemiIdentity;
+}
+
+/**
+ * Create an AuthorizedKey entry from a public key.
+ */
+export async function createAuthorizedKey(
+  publicKeyBase64: Base64,
+  label: string,
+): Promise<AuthorizedKey> {
+  const publicKeyRaw = Uint8Array.from(atob(publicKeyBase64), (c) => c.charCodeAt(0)).buffer;
+  const fp = await fingerprint(publicKeyRaw);
+
+  return {
+    publicKey: publicKeyBase64,
+    fingerprint: fp,
+    label,
+    addedAt: new Date().toISOString(),
+    lastUsedAt: null,
+  };
+}
+
+/**
+ * Create an empty authorized keys file.
+ */
+export function createAuthorizedKeysFile(): AuthorizedKeysFile {
+  return { version: 1, keys: [] };
+}

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -12,6 +12,7 @@ import {
   encryptPrivateKey,
   exportKeyPair,
   fingerprint,
+  fromBase64,
   generateKeyPair,
   importPrivateKey,
   importPublicKey,
@@ -102,10 +103,7 @@ export async function unlockIdentity(
   );
 
   const privateKey = await importPrivateKey(privateKeyPkcs8);
-  const publicKey = await importPublicKey(
-    // Convert base64 public key back to ArrayBuffer
-    Uint8Array.from(atob(identity.publicKey), (c) => c.charCodeAt(0)).buffer,
-  );
+  const publicKey = await importPublicKey(fromBase64(identity.publicKey));
 
   return {
     publicKey,
@@ -160,7 +158,7 @@ export async function createAuthorizedKey(
   publicKeyBase64: Base64,
   label: string,
 ): Promise<AuthorizedKey> {
-  const publicKeyRaw = Uint8Array.from(atob(publicKeyBase64), (c) => c.charCodeAt(0)).buffer;
+  const publicKeyRaw = fromBase64(publicKeyBase64);
   const fp = await fingerprint(publicKeyRaw);
 
   return {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -61,6 +61,9 @@ export type {
   CreateSessionRequestMessage,
   CreateSessionResponseMessage,
   TerminalResizeMessage,
+  AuthChallengeMessage,
+  AuthResponseMessage,
+  AuthResultMessage,
 } from './protocol.ts';
 
 export {
@@ -91,5 +94,48 @@ export {
   createCreateSessionRequest,
   createCreateSessionResponse,
   createTerminalResize,
+  createAuthChallenge,
+  createAuthResponse,
+  createAuthResult,
   MessageIdTracker,
 } from './protocol.ts';
+
+// Crypto
+export type { Base64, Fingerprint, RawKeyPair, ExportedKeyPair, EncryptedData } from './crypto.ts';
+export {
+  PBKDF2_ITERATIONS,
+  SALT_SIZE,
+  IV_SIZE,
+  CHALLENGE_SIZE,
+  FINGERPRINT_LENGTH,
+  toBase64,
+  fromBase64,
+  generateKeyPair,
+  exportKeyPair,
+  importPublicKey,
+  importPrivateKey,
+  sign,
+  verify,
+  deriveKeyFromPassphrase,
+  encryptPrivateKey,
+  decryptPrivateKey,
+  fingerprint,
+  generateChallenge,
+} from './crypto.ts';
+
+// Identity
+export type {
+  RemiIdentity,
+  AuthorizedKey,
+  AuthorizedKeysFile,
+  UnlockedIdentity,
+  KnownHost,
+} from './identity.ts';
+export {
+  createIdentity,
+  unlockIdentity,
+  serializeIdentity,
+  deserializeIdentity,
+  createAuthorizedKey,
+  createAuthorizedKeysFile,
+} from './identity.ts';

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -396,7 +396,7 @@ export interface AuthResultMessage {
   readonly timestamp: Timestamp;
   /** Whether authentication succeeded */
   readonly success: boolean;
-  /** Error code if failed: UNKNOWN_KEY, INVALID_SIGNATURE, AUTH_DISABLED */
+  /** Error code if failed: UNKNOWN_KEY, INVALID_SIGNATURE, NO_PENDING_CHALLENGE, VERIFICATION_ERROR */
   readonly error?: string;
   /** Server's signature of the challenge (for mutual authentication) */
   readonly serverSignature?: string;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -86,7 +86,10 @@ export type ProtocolMessage =
   | TranscriptLoadCompleteMessage
   | CreateSessionRequestMessage
   | CreateSessionResponseMessage
-  | TerminalResizeMessage;
+  | TerminalResizeMessage
+  | AuthChallengeMessage
+  | AuthResponseMessage
+  | AuthResultMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -360,6 +363,45 @@ export interface CreateSessionResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Authentication challenge from server to client */
+export interface AuthChallengeMessage {
+  readonly type: 'auth_challenge';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Base64-encoded 32-byte random challenge nonce */
+  readonly challenge: string;
+  /** Server's public key fingerprint for display */
+  readonly serverFingerprint: string;
+  /** Base64-encoded server Ed25519 public key */
+  readonly serverPublicKey: string;
+}
+
+/** Authentication response from client to server */
+export interface AuthResponseMessage {
+  readonly type: 'auth_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Base64-encoded client Ed25519 public key */
+  readonly clientPublicKey: string;
+  /** Base64-encoded Ed25519 signature of the challenge */
+  readonly signature: string;
+  /** Client's fingerprint for display */
+  readonly clientFingerprint: string;
+}
+
+/** Authentication result from server to client */
+export interface AuthResultMessage {
+  readonly type: 'auth_result';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Whether authentication succeeded */
+  readonly success: boolean;
+  /** Error code if failed: UNKNOWN_KEY, INVALID_SIGNATURE, AUTH_DISABLED */
+  readonly error?: string;
+  /** Server's signature of the challenge (for mutual authentication) */
+  readonly serverSignature?: string;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -425,6 +467,9 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'create_session_request',
     'create_session_response',
     'terminal_resize',
+    'auth_challenge',
+    'auth_response',
+    'auth_result',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -813,6 +858,60 @@ export function createTerminalResize(cols: number, rows: number): TerminalResize
     timestamp: now(),
     cols,
     rows,
+  };
+}
+
+/**
+ * Create an auth challenge message.
+ */
+export function createAuthChallenge(
+  challenge: string,
+  serverFingerprint: string,
+  serverPublicKey: string,
+): AuthChallengeMessage {
+  return {
+    type: 'auth_challenge',
+    id: generateId(),
+    timestamp: now(),
+    challenge,
+    serverFingerprint,
+    serverPublicKey,
+  };
+}
+
+/**
+ * Create an auth response message.
+ */
+export function createAuthResponse(
+  clientPublicKey: string,
+  signature: string,
+  clientFingerprint: string,
+): AuthResponseMessage {
+  return {
+    type: 'auth_response',
+    id: generateId(),
+    timestamp: now(),
+    clientPublicKey,
+    signature,
+    clientFingerprint,
+  };
+}
+
+/**
+ * Create an auth result message.
+ */
+export function createAuthResult(
+  success: boolean,
+  serverSignature?: string,
+  error?: string,
+): AuthResultMessage {
+  return {
+    type: 'auth_result',
+    id: generateId(),
+    timestamp: now(),
+    success,
+    ...(serverSignature !== undefined && { serverSignature }),
+    ...(error !== undefined && { error }),
   };
 }
 

--- a/packages/shared/tests/crypto.test.ts
+++ b/packages/shared/tests/crypto.test.ts
@@ -35,6 +35,22 @@ describe('toBase64 / fromBase64', () => {
     const decoded = new Uint8Array(fromBase64(encoded));
     expect(decoded).toEqual(empty);
   });
+
+  test('fromBase64 throws on invalid input with error context', () => {
+    expect(() => fromBase64('not-valid-base64!!!')).toThrow(/Invalid Base64 input/);
+    expect(() => fromBase64('not-valid-base64!!!')).toThrow(/length=19/);
+  });
+
+  test('fromBase64 throws with original error detail', () => {
+    try {
+      fromBase64('###invalid###');
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      // Should include both length and the underlying error message
+      expect((err as Error).message).toContain('length=');
+    }
+  });
 });
 
 describe('generateKeyPair', () => {

--- a/packages/shared/tests/crypto.test.ts
+++ b/packages/shared/tests/crypto.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for cross-platform crypto utilities.
+ * All tests use real cryptographic operations (no mocks).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  CHALLENGE_SIZE,
+  FINGERPRINT_LENGTH,
+  decryptPrivateKey,
+  encryptPrivateKey,
+  exportKeyPair,
+  fingerprint,
+  fromBase64,
+  generateChallenge,
+  generateKeyPair,
+  importPrivateKey,
+  importPublicKey,
+  sign,
+  toBase64,
+  verify,
+} from '../src/crypto.ts';
+
+describe('toBase64 / fromBase64', () => {
+  test('round-trips arbitrary bytes', () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255]);
+    const encoded = toBase64(original.buffer);
+    const decoded = new Uint8Array(fromBase64(encoded));
+    expect(decoded).toEqual(original);
+  });
+
+  test('round-trips empty buffer', () => {
+    const empty = new Uint8Array(0);
+    const encoded = toBase64(empty.buffer);
+    const decoded = new Uint8Array(fromBase64(encoded));
+    expect(decoded).toEqual(empty);
+  });
+});
+
+describe('generateKeyPair', () => {
+  test('generates an Ed25519 keypair', async () => {
+    const keyPair = await generateKeyPair();
+    expect(keyPair.publicKey).toBeDefined();
+    expect(keyPair.privateKey).toBeDefined();
+    expect(keyPair.publicKey.type).toBe('public');
+    expect(keyPair.privateKey.type).toBe('private');
+  });
+
+  test('generates unique keypairs', async () => {
+    const kp1 = await generateKeyPair();
+    const kp2 = await generateKeyPair();
+    const exp1 = await exportKeyPair(kp1);
+    const exp2 = await exportKeyPair(kp2);
+    expect(toBase64(exp1.publicKeyRaw)).not.toBe(toBase64(exp2.publicKeyRaw));
+  });
+});
+
+describe('exportKeyPair / importPublicKey / importPrivateKey', () => {
+  test('exports and re-imports public key', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+    expect(exported.publicKeyRaw.byteLength).toBe(32); // Ed25519 public key is 32 bytes
+
+    const reimported = await importPublicKey(exported.publicKeyRaw);
+    expect(reimported.type).toBe('public');
+  });
+
+  test('exports and re-imports private key', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+
+    const reimported = await importPrivateKey(exported.privateKeyRaw);
+    expect(reimported.type).toBe('private');
+  });
+
+  test('re-imported key can sign and verify', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+    const reimportedPrivate = await importPrivateKey(exported.privateKeyRaw);
+    const reimportedPublic = await importPublicKey(exported.publicKeyRaw);
+
+    const data = new TextEncoder().encode('test message');
+    const sig = await sign(reimportedPrivate, data.buffer);
+    const valid = await verify(reimportedPublic, data.buffer, sig);
+    expect(valid).toBe(true);
+  });
+});
+
+describe('sign / verify', () => {
+  test('signs and verifies data', async () => {
+    const keyPair = await generateKeyPair();
+    const data = new TextEncoder().encode('hello world');
+    const sig = await sign(keyPair.privateKey, data.buffer);
+    expect(typeof sig).toBe('string');
+    expect(sig.length).toBeGreaterThan(0);
+
+    const valid = await verify(keyPair.publicKey, data.buffer, sig);
+    expect(valid).toBe(true);
+  });
+
+  test('rejects tampered data', async () => {
+    const keyPair = await generateKeyPair();
+    const data = new TextEncoder().encode('original');
+    const sig = await sign(keyPair.privateKey, data.buffer);
+
+    const tampered = new TextEncoder().encode('tampered');
+    const valid = await verify(keyPair.publicKey, tampered.buffer, sig);
+    expect(valid).toBe(false);
+  });
+
+  test('rejects signature from different key', async () => {
+    const kp1 = await generateKeyPair();
+    const kp2 = await generateKeyPair();
+    const data = new TextEncoder().encode('test');
+    const sig = await sign(kp1.privateKey, data.buffer);
+
+    const valid = await verify(kp2.publicKey, data.buffer, sig);
+    expect(valid).toBe(false);
+  });
+
+  test('signs empty data', async () => {
+    const keyPair = await generateKeyPair();
+    const empty = new Uint8Array(0);
+    const sig = await sign(keyPair.privateKey, empty.buffer);
+    const valid = await verify(keyPair.publicKey, empty.buffer, sig);
+    expect(valid).toBe(true);
+  });
+});
+
+describe('encryptPrivateKey / decryptPrivateKey', () => {
+  // Use fewer iterations for test speed
+  const testIterations = 1000;
+
+  test('encrypts and decrypts with correct passphrase', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+
+    const encrypted = await encryptPrivateKey(
+      exported.privateKeyRaw,
+      'mypassphrase',
+      testIterations,
+    );
+    expect(encrypted.ciphertext).toBeDefined();
+    expect(encrypted.iv).toBeDefined();
+    expect(encrypted.salt).toBeDefined();
+
+    const decrypted = await decryptPrivateKey(encrypted, 'mypassphrase', testIterations);
+    expect(new Uint8Array(decrypted)).toEqual(new Uint8Array(exported.privateKeyRaw));
+  });
+
+  test('rejects wrong passphrase', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+
+    const encrypted = await encryptPrivateKey(exported.privateKeyRaw, 'correct', testIterations);
+    await expect(decryptPrivateKey(encrypted, 'wrong', testIterations)).rejects.toThrow();
+  });
+
+  test('produces different ciphertext for same key (random salt/iv)', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+
+    const enc1 = await encryptPrivateKey(exported.privateKeyRaw, 'pass', testIterations);
+    const enc2 = await encryptPrivateKey(exported.privateKeyRaw, 'pass', testIterations);
+    expect(enc1.ciphertext).not.toBe(enc2.ciphertext);
+    expect(enc1.salt).not.toBe(enc2.salt);
+    expect(enc1.iv).not.toBe(enc2.iv);
+  });
+
+  test('decrypted key can sign and verify', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+
+    const encrypted = await encryptPrivateKey(exported.privateKeyRaw, 'test', testIterations);
+    const decrypted = await decryptPrivateKey(encrypted, 'test', testIterations);
+    const privateKey = await importPrivateKey(decrypted);
+    const publicKey = await importPublicKey(exported.publicKeyRaw);
+
+    const data = new TextEncoder().encode('verify round-trip');
+    const sig = await sign(privateKey, data.buffer);
+    const valid = await verify(publicKey, data.buffer, sig);
+    expect(valid).toBe(true);
+  });
+});
+
+describe('fingerprint', () => {
+  test('returns hex string of expected length', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+    const fp = await fingerprint(exported.publicKeyRaw);
+
+    expect(typeof fp).toBe('string');
+    expect(fp.length).toBe(FINGERPRINT_LENGTH);
+    expect(fp).toMatch(/^[0-9a-f]+$/);
+  });
+
+  test('same key produces same fingerprint', async () => {
+    const keyPair = await generateKeyPair();
+    const exported = await exportKeyPair(keyPair);
+    const fp1 = await fingerprint(exported.publicKeyRaw);
+    const fp2 = await fingerprint(exported.publicKeyRaw);
+    expect(fp1).toBe(fp2);
+  });
+
+  test('different keys produce different fingerprints', async () => {
+    const kp1 = await generateKeyPair();
+    const kp2 = await generateKeyPair();
+    const exp1 = await exportKeyPair(kp1);
+    const exp2 = await exportKeyPair(kp2);
+    const fp1 = await fingerprint(exp1.publicKeyRaw);
+    const fp2 = await fingerprint(exp2.publicKeyRaw);
+    expect(fp1).not.toBe(fp2);
+  });
+});
+
+describe('generateChallenge', () => {
+  test('returns base64-encoded challenge', () => {
+    const challenge = generateChallenge();
+    expect(typeof challenge).toBe('string');
+    const decoded = fromBase64(challenge);
+    expect(decoded.byteLength).toBe(CHALLENGE_SIZE);
+  });
+
+  test('generates unique challenges', () => {
+    const challenges = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      challenges.add(generateChallenge());
+    }
+    expect(challenges.size).toBe(100);
+  });
+});

--- a/packages/shared/tests/identity.test.ts
+++ b/packages/shared/tests/identity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for identity management.
+ * All tests use real crypto (no mocks).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { FINGERPRINT_LENGTH, fromBase64, sign, verify } from '../src/crypto.ts';
+import {
+  createAuthorizedKey,
+  createAuthorizedKeysFile,
+  createIdentity,
+  deserializeIdentity,
+  serializeIdentity,
+  unlockIdentity,
+} from '../src/identity.ts';
+import type { RemiIdentity } from '../src/identity.ts';
+
+// Use fewer PBKDF2 iterations for test speed by creating identity with low iterations
+// We test the identity module functions which internally use PBKDF2_ITERATIONS
+// For speed, we create identity objects directly with low iterations
+
+async function createTestIdentity(passphrase: string): Promise<RemiIdentity> {
+  // Use the real createIdentity (uses 600K iterations)
+  // For testing speed, we just accept the latency or test with smaller scope
+  return createIdentity(passphrase);
+}
+
+describe('createIdentity', () => {
+  test('creates a valid identity with all fields', async () => {
+    const identity = await createTestIdentity('testpass');
+
+    expect(identity.version).toBe(1);
+    expect(typeof identity.publicKey).toBe('string');
+    expect(typeof identity.encryptedPrivateKey).toBe('string');
+    expect(typeof identity.salt).toBe('string');
+    expect(typeof identity.iv).toBe('string');
+    expect(identity.iterations).toBe(600_000);
+    expect(identity.fingerprint.length).toBe(FINGERPRINT_LENGTH);
+    expect(identity.fingerprint).toMatch(/^[0-9a-f]+$/);
+    expect(typeof identity.createdAt).toBe('string');
+  });
+
+  test('public key is valid base64 of 32 bytes', async () => {
+    const identity = await createTestIdentity('pass');
+    const raw = fromBase64(identity.publicKey);
+    expect(raw.byteLength).toBe(32);
+  });
+});
+
+describe('unlockIdentity', () => {
+  test('unlocks with correct passphrase', async () => {
+    const identity = await createTestIdentity('correct');
+    const unlocked = await unlockIdentity(identity, 'correct');
+
+    expect(unlocked.publicKey.type).toBe('public');
+    expect(unlocked.privateKey.type).toBe('private');
+    expect(unlocked.publicKeyRaw).toBe(identity.publicKey);
+    expect(unlocked.fingerprint).toBe(identity.fingerprint);
+  });
+
+  test('rejects wrong passphrase', async () => {
+    const identity = await createTestIdentity('correct');
+    await expect(unlockIdentity(identity, 'wrong')).rejects.toThrow();
+  });
+
+  test('unlocked key can sign and verify', async () => {
+    const identity = await createTestIdentity('mypass');
+    const unlocked = await unlockIdentity(identity, 'mypass');
+
+    const data = new TextEncoder().encode('test data');
+    const sig = await sign(unlocked.privateKey, data.buffer);
+    const valid = await verify(unlocked.publicKey, data.buffer, sig);
+    expect(valid).toBe(true);
+  });
+});
+
+describe('serializeIdentity / deserializeIdentity', () => {
+  test('round-trips identity through JSON', async () => {
+    const original = await createTestIdentity('pass');
+    const json = serializeIdentity(original);
+    const deserialized = deserializeIdentity(json);
+
+    expect(deserialized.version).toBe(original.version);
+    expect(deserialized.publicKey).toBe(original.publicKey);
+    expect(deserialized.encryptedPrivateKey).toBe(original.encryptedPrivateKey);
+    expect(deserialized.salt).toBe(original.salt);
+    expect(deserialized.iv).toBe(original.iv);
+    expect(deserialized.iterations).toBe(original.iterations);
+    expect(deserialized.fingerprint).toBe(original.fingerprint);
+  });
+
+  test('rejects invalid JSON', () => {
+    expect(() => deserializeIdentity('not json')).toThrow();
+  });
+
+  test('rejects missing fields', () => {
+    expect(() => deserializeIdentity(JSON.stringify({ version: 1 }))).toThrow();
+  });
+
+  test('rejects wrong version', () => {
+    expect(() =>
+      deserializeIdentity(
+        JSON.stringify({
+          version: 2,
+          publicKey: 'x',
+          encryptedPrivateKey: 'x',
+          salt: 'x',
+          iv: 'x',
+          iterations: 1000,
+          fingerprint: 'x',
+          createdAt: 'x',
+        }),
+      ),
+    ).toThrow();
+  });
+
+  test('rejects non-object', () => {
+    expect(() => deserializeIdentity('"string"')).toThrow();
+    expect(() => deserializeIdentity('null')).toThrow();
+    expect(() => deserializeIdentity('42')).toThrow();
+  });
+});
+
+describe('createAuthorizedKey', () => {
+  test('creates authorized key from public key', async () => {
+    const identity = await createTestIdentity('pass');
+    const authKey = await createAuthorizedKey(identity.publicKey, 'Test Device');
+
+    expect(authKey.publicKey).toBe(identity.publicKey);
+    expect(authKey.fingerprint).toBe(identity.fingerprint);
+    expect(authKey.label).toBe('Test Device');
+    expect(authKey.lastUsedAt).toBeNull();
+    expect(typeof authKey.addedAt).toBe('string');
+  });
+});
+
+describe('createAuthorizedKeysFile', () => {
+  test('creates empty authorized keys file', () => {
+    const file = createAuthorizedKeysFile();
+    expect(file.version).toBe(1);
+    expect(file.keys).toEqual([]);
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -16,8 +16,11 @@ import type { UnlockedIdentity } from '@remi/shared';
 import {
   createAuthResponse,
   fromBase64,
+  importPublicKey,
   sign,
+  verify,
 } from '@remi/shared';
+import { checkKnownHost, trustHost } from '@/lib/identity-client';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
@@ -70,6 +73,7 @@ function App() {
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
   const activeSessionIdRef = useRef<UUID | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
+  const unlockedIdentityRef = useRef<UnlockedIdentity | null>(null);
 
   // Apply theme and font size on settings change
   useEffect(() => {
@@ -380,14 +384,29 @@ function App() {
     activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId]);
 
+  useEffect(() => {
+    unlockedIdentityRef.current = unlockedIdentity;
+  }, [unlockedIdentity]);
+
   // Restore session ID from localStorage for reconnect after page reload (read once)
   const [storedSessionId] = useState<UUID | null>(
     () => localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null,
   );
 
   const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
+  const pendingRelayChallengeRef = useRef<{
+    challenge: string;
+    serverPublicKey: string;
+    serverFingerprint: string;
+  } | null>(null);
   const [connectionMode, setConnectionMode] = useState<'direct' | 'relay'>('direct');
   const [relayStatus, setRelayStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
+  const [relayError, setRelayError] = useState<Error | null>(null);
+
+  /** Set error (works for both direct and relay modes) */
+  const setError = useCallback((err: Error) => {
+    setRelayError(err);
+  }, []);
 
   const {
     status: connectionStatus,
@@ -409,7 +428,7 @@ function App() {
     unlockedIdentity,
   });
 
-  const error = wsError?.message ?? null;
+  const error = (connectionMode === 'relay' ? relayError?.message : wsError?.message) ?? null;
 
   // Effective connection status: use relay status when in relay mode
   const effectiveStatus = connectionMode === 'relay' ? relayStatus : connectionStatus;
@@ -607,6 +626,8 @@ function App() {
 
       setConnectionMode('relay');
       setRelayStatus('connecting');
+      setRelayError(null);
+      pendingRelayChallengeRef.current = null;
 
       const signalingUrl = 'wss://remi-signaling.dev-941.workers.dev/connect';
       const client = new WebSignalingClient({
@@ -627,15 +648,37 @@ function App() {
           if (!message || typeof message !== 'object' || !('type' in message)) return;
           const msg = message as ProtocolMessage;
 
-          // Handle auth_challenge: sign with identity and respond
+          // Handle auth_challenge: TOFU check, sign, and respond
           if (msg.type === 'auth_challenge') {
-            const identity = unlockedIdentity;
+            const identity = unlockedIdentityRef.current;
             if (!identity) {
-              console.error('Relay auth_challenge received but no unlocked identity');
+              setError(new Error(
+                'This daemon requires authentication. Unlock your identity first (Settings > Identity).',
+              ));
               setRelayStatus('disconnected');
               client.close();
               return;
             }
+
+            // TOFU: check known hosts for relay server
+            const relayUrl = `relay:${msg.serverFingerprint}`;
+            const tofuResult = checkKnownHost(relayUrl, msg.serverFingerprint);
+            if (tofuResult === 'mismatch') {
+              setError(new Error(
+                'Server fingerprint changed. This could indicate a MITM attack. Connection rejected.',
+              ));
+              setRelayStatus('disconnected');
+              client.close();
+              return;
+            }
+
+            // Store challenge data for mutual auth verification in auth_result
+            pendingRelayChallengeRef.current = {
+              challenge: msg.challenge,
+              serverPublicKey: msg.serverPublicKey,
+              serverFingerprint: msg.serverFingerprint,
+            };
+
             (async () => {
               try {
                 const challengeData = fromBase64(msg.challenge);
@@ -646,22 +689,59 @@ function App() {
                   identity.fingerprint,
                 ));
               } catch (err) {
-                console.error('Relay auth failed:', err instanceof Error ? err.message : err);
+                const detail = err instanceof Error ? err.message : String(err);
+                setError(new Error(`Relay authentication failed: ${detail}`));
                 setRelayStatus('disconnected');
+                client.close();
               }
             })();
             return;
           }
 
-          // Handle auth_result: on success re-send hello, on failure disconnect
+          // Handle auth_result: verify mutual auth, TOFU trust, then send hello
           if (msg.type === 'auth_result') {
             if (!msg.success) {
-              console.error(`Relay auth rejected: ${msg.error ?? 'unknown'}`);
+              setError(new Error(`Relay auth rejected: ${msg.error ?? 'unknown'}`));
               setRelayStatus('disconnected');
-            } else {
-              // Auth succeeded; now send hello so the daemon creates our session
-              client.sendMessage(createHello('remi-web', '0.1.0'));
+              client.close();
+              return;
             }
+
+            const pending = pendingRelayChallengeRef.current;
+            if (!msg.serverSignature || !pending) {
+              setError(new Error('Server did not provide mutual authentication signature'));
+              setRelayStatus('disconnected');
+              client.close();
+              return;
+            }
+
+            // Verify server signature for mutual auth
+            (async () => {
+              try {
+                const serverPubKey = await importPublicKey(fromBase64(pending.serverPublicKey));
+                const challengeData = fromBase64(pending.challenge);
+                const valid = await verify(serverPubKey, challengeData, msg.serverSignature!);
+                if (!valid) {
+                  setError(new Error('Server signature verification failed'));
+                  setRelayStatus('disconnected');
+                  client.close();
+                  return;
+                }
+
+                // TOFU: trust server on first use
+                const relayUrl = `relay:${pending.serverFingerprint}`;
+                trustHost(relayUrl, pending.serverFingerprint, pending.serverPublicKey);
+                pendingRelayChallengeRef.current = null;
+
+                // Auth succeeded; now send hello so the daemon creates our session
+                client.sendMessage(createHello('remi-web', '0.1.0'));
+              } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                setError(new Error(`Server verification failed: ${detail}`));
+                setRelayStatus('disconnected');
+                client.close();
+              }
+            })();
             return;
           }
 
@@ -680,7 +760,7 @@ function App() {
       setRelayStatus('disconnected');
       setConnectionMode('direct');
     });
-  }, [unlockedIdentity]);
+  }, []);
 
   const handleBulletExpand = useCallback(
     (bulletId: number) => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,8 @@ import { SettingsPanel } from '@/components/settings';
 import { useWebSocket } from '@/hooks';
 import type { AppSettings, UIBullet, UIMessage, UIQuestion, UISession } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
+import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
+import type { UnlockedIdentity } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import { generateId } from '@remi/shared/protocol.ts';
 import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
@@ -48,6 +50,7 @@ function App() {
   const [creatingSession, setCreatingSession] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
+  const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
@@ -379,7 +382,14 @@ function App() {
     requestTranscriptLoad,
     requestNewSession,
     sessionId: wsSessionId,
-  } = useWebSocket({ onMessage: handleMessage, initialResumeSessionId: storedSessionId ?? undefined });
+    needsPassphrase,
+    serverFingerprint,
+    provideIdentity,
+  } = useWebSocket({
+    onMessage: handleMessage,
+    initialResumeSessionId: storedSessionId ?? undefined,
+    unlockedIdentity,
+  });
 
   const error = wsError?.message ?? null;
 
@@ -479,6 +489,17 @@ function App() {
     },
     [activeSessionId, sendInput, sendAnswer, sessionQuestion],
   );
+
+  const handlePassphraseSubmit = useCallback(async (passphrase: string) => {
+    try {
+      const identity = await unlockStoredIdentity(passphrase);
+      setUnlockedIdentity(identity);
+      provideIdentity(identity);
+    } catch (err) {
+      console.error('Failed to unlock identity:', err);
+      throw err;
+    }
+  }, [provideIdentity]);
 
   const handleConnectDirect = useCallback(
     (url: string, directory?: string) => {
@@ -637,12 +658,16 @@ function App() {
       />
 
       <ConnectModal
-        isOpen={showConnectModal}
+        isOpen={showConnectModal || needsPassphrase}
         onClose={() => setShowConnectModal(false)}
         onConnectDirect={handleConnectDirect}
         onConnectCode={handleConnectCode}
         connectionStatus={connectionStatus}
         error={null}
+        needsPassphrase={needsPassphrase}
+        hasIdentity={hasIdentity()}
+        serverFingerprint={serverFingerprint}
+        onPassphraseSubmit={handlePassphraseSubmit}
       />
     </>
   );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,10 +13,16 @@ import type { AppSettings, UIBullet, UIMessage, UIQuestion, UISession } from '@/
 import { DEFAULT_SETTINGS } from '@/types';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
 import type { UnlockedIdentity } from '@remi/shared';
+import {
+  createAuthResponse,
+  fromBase64,
+  sign,
+} from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
   createCreateSessionRequest,
+  createHello,
   createSessionListRequest,
   createTranscriptLoadRequest,
   createUserInput,
@@ -608,15 +614,9 @@ function App() {
           if (state === 'connected') {
             setRelayStatus('connected');
             setShowConnectModal(false);
-            // Send hello via relay
-            const hello: ProtocolMessage = {
-              type: 'hello',
-              id: generateId(),
-              timestamp: now(),
-              clientId: 'remi-web',
-              clientVersion: '0.1.0',
-            };
-            client.sendMessage(hello);
+            // Send hello via relay (harmless if auth is required; daemon drops it
+            // and sends auth_challenge first, then hello_ack after auth completes)
+            client.sendMessage(createHello('remi-web', '0.1.0'));
           } else if (state === 'connecting' || state === 'joined') {
             setRelayStatus('connecting');
           } else if (state === 'disconnected' || state === 'error') {
@@ -624,10 +624,46 @@ function App() {
           }
         },
         onMessage: (message) => {
-          // Forward relay messages to the existing message handler
-          if (handleMessageRef.current && message && typeof message === 'object' && 'type' in message) {
-            handleMessageRef.current(message as ProtocolMessage);
+          if (!message || typeof message !== 'object' || !('type' in message)) return;
+          const msg = message as ProtocolMessage;
+
+          // Handle auth_challenge: sign with identity and respond
+          if (msg.type === 'auth_challenge') {
+            const identity = unlockedIdentity;
+            if (!identity) {
+              console.error('Relay auth_challenge received but no unlocked identity');
+              // TODO: prompt for passphrase in relay mode
+              return;
+            }
+            (async () => {
+              try {
+                const challengeData = fromBase64(msg.challenge);
+                const signature = await sign(identity.privateKey, challengeData);
+                const response = createAuthResponse(
+                  identity.publicKeyRaw,
+                  signature,
+                  identity.fingerprint,
+                );
+                client.sendMessage(response);
+              } catch (err) {
+                console.error('Relay auth failed:', err instanceof Error ? err.message : err);
+              }
+            })();
+            return;
           }
+
+          // Handle auth_result: log success/failure
+          if (msg.type === 'auth_result') {
+            if (!msg.success) {
+              console.error(`Relay auth rejected: ${msg.error ?? 'unknown'}`);
+              setRelayStatus('disconnected');
+            }
+            // On success, daemon will send hello_ack next (handled by handleMessage)
+            return;
+          }
+
+          // Forward all other messages to the existing handler
+          handleMessageRef.current?.(msg);
         },
         onError: (errCode, errMsg) => {
           console.error(`Signaling error [${errCode}]: ${errMsg}`);
@@ -641,7 +677,7 @@ function App() {
       setRelayStatus('disconnected');
       setConnectionMode('direct');
     });
-  }, []);
+  }, [unlockedIdentity]);
 
   const handleBulletExpand = useCallback(
     (bulletId: number) => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -632,33 +632,36 @@ function App() {
             const identity = unlockedIdentity;
             if (!identity) {
               console.error('Relay auth_challenge received but no unlocked identity');
-              // TODO: prompt for passphrase in relay mode
+              setRelayStatus('disconnected');
+              client.close();
               return;
             }
             (async () => {
               try {
                 const challengeData = fromBase64(msg.challenge);
                 const signature = await sign(identity.privateKey, challengeData);
-                const response = createAuthResponse(
+                client.sendMessage(createAuthResponse(
                   identity.publicKeyRaw,
                   signature,
                   identity.fingerprint,
-                );
-                client.sendMessage(response);
+                ));
               } catch (err) {
                 console.error('Relay auth failed:', err instanceof Error ? err.message : err);
+                setRelayStatus('disconnected');
               }
             })();
             return;
           }
 
-          // Handle auth_result: log success/failure
+          // Handle auth_result: on success re-send hello, on failure disconnect
           if (msg.type === 'auth_result') {
             if (!msg.success) {
               console.error(`Relay auth rejected: ${msg.error ?? 'unknown'}`);
               setRelayStatus('disconnected');
+            } else {
+              // Auth succeeded; now send hello so the daemon creates our session
+              client.sendMessage(createHello('remi-web', '0.1.0'));
             }
-            // On success, daemon will send hello_ack next (handled by handleMessage)
             return;
           }
 
@@ -784,7 +787,7 @@ function App() {
         onConnectDirect={handleConnectDirect}
         onConnectCode={handleConnectCode}
         connectionStatus={effectiveStatus}
-        error={null}
+        error={error}
         needsPassphrase={needsPassphrase}
         hasIdentity={hasIdentity()}
         serverFingerprint={serverFingerprint}

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -2,12 +2,23 @@
  * ConnectModal component.
  *
  * Modal for connecting to a daemon via direct URL or connection code.
+ * Includes passphrase prompt when daemon requires authentication.
  */
 
 import type { ConnectionStatus } from '@/types';
 import { clsx } from 'clsx';
-import { AlertCircle, CheckCircle2, Globe, Link2, Loader2, Wifi, X } from 'lucide-react';
-import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Globe,
+  Key,
+  Link2,
+  Loader2,
+  Shield,
+  Wifi,
+  X,
+} from 'lucide-react';
+import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from 'react';
 
 interface ConnectModalProps {
   readonly isOpen: boolean;
@@ -16,6 +27,10 @@ interface ConnectModalProps {
   readonly onConnectCode: (code: string) => void;
   readonly connectionStatus: ConnectionStatus;
   readonly error?: string | null;
+  readonly needsPassphrase?: boolean;
+  readonly hasIdentity?: boolean;
+  readonly serverFingerprint?: string | null;
+  readonly onPassphraseSubmit?: (passphrase: string) => Promise<void>;
 }
 
 type ConnectionMode = 'direct' | 'code';
@@ -60,6 +75,121 @@ function CodeInput({
   );
 }
 
+/** Passphrase input view */
+function PassphraseView({
+  serverFingerprint,
+  hasIdentity,
+  onSubmit,
+}: {
+  readonly serverFingerprint?: string | null;
+  readonly hasIdentity?: boolean;
+  readonly onSubmit: (passphrase: string) => Promise<void>;
+}) {
+  const [passphrase, setPassphrase] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [passphraseError, setPassphraseError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!passphrase || isSubmitting) return;
+
+    setIsSubmitting(true);
+    setPassphraseError(null);
+    try {
+      await onSubmit(passphrase);
+    } catch (err) {
+      setPassphraseError(
+        err instanceof Error ? err.message : 'Failed to unlock identity',
+      );
+      setPassphrase('');
+      inputRef.current?.focus();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!hasIdentity) {
+    return (
+      <div className="space-y-3 text-center">
+        <Shield className="mx-auto size-10 text-[--color-warning]" />
+        <p className="text-sm text-[--color-text]">
+          This daemon requires authentication, but no identity is configured.
+        </p>
+        <p className="text-xs text-[--color-text-muted]">
+          Generate an identity in Settings, or import one from another device.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center gap-3 rounded-lg bg-[--color-surface-light] p-3">
+        <Shield className="size-5 shrink-0 text-[--color-primary]" />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-[--color-text]">Authentication Required</p>
+          {serverFingerprint && (
+            <p className="truncate text-xs font-mono text-[--color-text-muted]">
+              Server: {serverFingerprint}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <label className="block">
+        <span className="mb-1 block text-sm text-[--color-text-secondary]">
+          Passphrase
+        </span>
+        <input
+          ref={inputRef}
+          type="password"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+          disabled={isSubmitting}
+          placeholder="Enter your passphrase"
+          className={clsx(
+            'w-full rounded-xl bg-[--color-surface-light] px-4 py-3',
+            'text-sm text-[--color-text] placeholder:text-[--color-text-muted]',
+            'outline-none transition-colors',
+            'focus:ring-2 focus:ring-[--color-primary]/50',
+            isSubmitting && 'cursor-not-allowed opacity-50',
+          )}
+        />
+      </label>
+
+      {passphraseError && (
+        <div className="flex items-center gap-2 rounded-lg bg-[--color-error]/10 p-3 text-[--color-error]">
+          <AlertCircle className="size-4 shrink-0" />
+          <span className="text-sm">{passphraseError}</span>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={!passphrase || isSubmitting}
+        className={clsx(
+          'flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
+          passphrase && !isSubmitting
+            ? 'bg-[--color-primary] hover:bg-[--color-primary-dark]'
+            : 'cursor-not-allowed bg-[--color-primary]/50',
+        )}
+      >
+        {isSubmitting ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Key className="size-4" />
+        )}
+        {isSubmitting ? 'Unlocking...' : 'Unlock & Authenticate'}
+      </button>
+    </form>
+  );
+}
+
 export function ConnectModal({
   isOpen,
   onClose,
@@ -67,6 +197,10 @@ export function ConnectModal({
   onConnectCode,
   connectionStatus,
   error,
+  needsPassphrase,
+  hasIdentity: hasId,
+  serverFingerprint,
+  onPassphraseSubmit,
 }: ConnectModalProps) {
   const [mode, setMode] = useState<ConnectionMode>('direct');
   const [directUrl, setDirectUrl] = useState('ws://localhost:18765/ws');
@@ -85,7 +219,35 @@ export function ConnectModal({
   if (!isOpen) return null;
 
   const isConnecting = connectionStatus === 'connecting' || connectionStatus === 'reconnecting';
+  const isAuthenticating = connectionStatus === 'authenticating';
   const isConnected = connectionStatus === 'connected';
+
+  // Show passphrase view when auth is needed
+  if (needsPassphrase && onPassphraseSubmit) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+        <div className="w-full max-w-md rounded-2xl bg-[--color-surface] shadow-xl">
+          <div className="flex items-center justify-between border-b border-[--color-border] p-4">
+            <h2 className="text-lg font-semibold text-[--color-text]">Authenticate</h2>
+            <button
+              onClick={onClose}
+              className="rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
+              aria-label="Close"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+          <div className="p-4">
+            <PassphraseView
+              serverFingerprint={serverFingerprint}
+              hasIdentity={hasId}
+              onSubmit={onPassphraseSubmit}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const handleConnect = () => {
     if (mode === 'direct') {
@@ -205,19 +367,21 @@ export function ConnectModal({
           )}
 
           {/* Status/Error */}
-          {(isConnecting || isConnected || error) && (
+          {(isConnecting || isAuthenticating || isConnected || error) && (
             <div
               className={clsx(
                 'mt-4 flex items-center gap-2 rounded-lg p-3',
                 error && 'bg-[--color-error]/10 text-[--color-error]',
-                isConnecting && 'bg-[--color-warning]/10 text-[--color-warning]',
+                (isConnecting || isAuthenticating) && 'bg-[--color-warning]/10 text-[--color-warning]',
                 isConnected && 'bg-[--color-success]/10 text-[--color-success]',
               )}
             >
-              {isConnecting && (
+              {(isConnecting || isAuthenticating) && (
                 <>
                   <Loader2 className="size-4 animate-spin" />
-                  <span className="text-sm">Connecting...</span>
+                  <span className="text-sm">
+                    {isAuthenticating ? 'Authenticating...' : 'Connecting...'}
+                  </span>
                 </>
               )}
               {isConnected && (
@@ -246,20 +410,20 @@ export function ConnectModal({
           </button>
           <button
             onClick={handleConnect}
-            disabled={!canConnect || isConnecting || isConnected}
+            disabled={!canConnect || isConnecting || isAuthenticating || isConnected}
             className={clsx(
               'flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
-              canConnect && !isConnecting && !isConnected
+              canConnect && !isConnecting && !isAuthenticating && !isConnected
                 ? 'bg-[--color-primary] hover:bg-[--color-primary-dark]'
                 : 'cursor-not-allowed bg-[--color-primary]/50',
             )}
           >
-            {isConnecting ? (
+            {isConnecting || isAuthenticating ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Link2 className="size-4" />
             )}
-            {isConnecting ? 'Connecting...' : 'Connect'}
+            {isConnecting || isAuthenticating ? 'Connecting...' : 'Connect'}
           </button>
         </div>
       </div>

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -1,14 +1,21 @@
 /**
  * SettingsPanel component.
  *
- * Slide-in panel for app settings.
+ * Slide-in panel for app settings including identity management.
  */
 
+import {
+  exportIdentity,
+  generateIdentity,
+  getFingerprint,
+  importIdentity,
+  removeIdentity,
+} from '@/lib/identity-client';
 import type { AppSettings } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
 import { clsx } from 'clsx';
-import { Moon, Sun, Monitor, X } from 'lucide-react';
-import { useEffect } from 'react';
+import { Copy, Download, Key, Moon, Monitor, Shield, Sun, Upload, X } from 'lucide-react';
+import { type FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 interface SettingsPanelProps {
   readonly open: boolean;
@@ -76,6 +83,234 @@ function Toggle({
   );
 }
 
+/** Identity management sub-section */
+function IdentitySection() {
+  const [fingerprint, setFingerprint] = useState<string | null>(getFingerprint);
+  const [showGenerate, setShowGenerate] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+  const [confirmPassphrase, setConfirmPassphrase] = useState('');
+  const [importJson, setImportJson] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const passphraseRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(() => {
+    setFingerprint(getFingerprint());
+  }, []);
+
+  const handleGenerate = async (e: FormEvent) => {
+    e.preventDefault();
+    if (passphrase.length < 8) {
+      setFeedback('Passphrase must be at least 8 characters.');
+      return;
+    }
+    if (passphrase !== confirmPassphrase) {
+      setFeedback('Passphrases do not match.');
+      return;
+    }
+    setGenerating(true);
+    setFeedback(null);
+    try {
+      await generateIdentity(passphrase);
+      refresh();
+      setShowGenerate(false);
+      setPassphrase('');
+      setConfirmPassphrase('');
+      setFeedback('Identity generated successfully.');
+    } catch (err) {
+      setFeedback(err instanceof Error ? err.message : 'Failed to generate identity');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleImport = (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      importIdentity(importJson);
+      refresh();
+      setShowImport(false);
+      setImportJson('');
+      setFeedback('Identity imported successfully.');
+    } catch (err) {
+      setFeedback(err instanceof Error ? err.message : 'Failed to import identity');
+    }
+  };
+
+  const handleExport = () => {
+    const json = exportIdentity();
+    if (!json) return;
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'remi-identity.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleCopyFingerprint = () => {
+    if (fingerprint) {
+      navigator.clipboard.writeText(fingerprint);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleRemove = () => {
+    removeIdentity();
+    refresh();
+    setFeedback('Identity removed.');
+  };
+
+  return (
+    <section>
+      <h3 className="mb-3 text-sm font-medium text-[--color-text-secondary]">
+        Identity & Security
+      </h3>
+
+      {fingerprint ? (
+        <div className="space-y-3">
+          {/* Fingerprint display */}
+          <div className="flex items-center gap-2 rounded-lg bg-[--color-surface-light] p-3">
+            <Shield className="size-5 shrink-0 text-[--color-primary]" />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs text-[--color-text-muted]">Your fingerprint</p>
+              <p className="truncate font-mono text-sm text-[--color-text]">{fingerprint}</p>
+            </div>
+            <button
+              onClick={handleCopyFingerprint}
+              className="shrink-0 rounded p-1 text-[--color-text-muted] hover:text-[--color-text]"
+              title="Copy fingerprint"
+            >
+              <Copy className="size-4" />
+            </button>
+          </div>
+          {copied && (
+            <p className="text-xs text-[--color-success]">Copied to clipboard</p>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-2">
+            <button
+              onClick={handleExport}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[--color-surface-light] py-2 text-xs text-[--color-text-secondary] hover:bg-[--color-surface-elevated]"
+            >
+              <Download className="size-3.5" />
+              Export
+            </button>
+            <button
+              onClick={handleRemove}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[--color-error]/10 py-2 text-xs text-[--color-error] hover:bg-[--color-error]/20"
+            >
+              <X className="size-3.5" />
+              Remove
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm text-[--color-text-muted]">
+            No identity configured. Generate one or import from another device.
+          </p>
+
+          {!showGenerate && !showImport && (
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setShowGenerate(true); setShowImport(false); }}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[--color-primary] py-2 text-xs text-white hover:bg-[--color-primary-dark]"
+              >
+                <Key className="size-3.5" />
+                Generate
+              </button>
+              <button
+                onClick={() => { setShowImport(true); setShowGenerate(false); }}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[--color-surface-light] py-2 text-xs text-[--color-text-secondary] hover:bg-[--color-surface-elevated]"
+              >
+                <Upload className="size-3.5" />
+                Import
+              </button>
+            </div>
+          )}
+
+          {/* Generate form */}
+          {showGenerate && (
+            <form onSubmit={handleGenerate} className="space-y-2">
+              <input
+                ref={passphraseRef}
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                placeholder="Passphrase (min 8 chars)"
+                className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
+              />
+              <input
+                type="password"
+                value={confirmPassphrase}
+                onChange={(e) => setConfirmPassphrase(e.target.value)}
+                placeholder="Confirm passphrase"
+                className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
+              />
+              <div className="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={generating}
+                  className="flex-1 rounded-lg bg-[--color-primary] py-2 text-xs text-white hover:bg-[--color-primary-dark] disabled:opacity-50"
+                >
+                  {generating ? 'Generating...' : 'Create Identity'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowGenerate(false); setPassphrase(''); setConfirmPassphrase(''); }}
+                  className="rounded-lg bg-[--color-surface-light] px-3 py-2 text-xs text-[--color-text-secondary]"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+
+          {/* Import form */}
+          {showImport && (
+            <form onSubmit={handleImport} className="space-y-2">
+              <textarea
+                value={importJson}
+                onChange={(e) => setImportJson(e.target.value)}
+                placeholder="Paste identity JSON here"
+                rows={4}
+                className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm font-mono text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
+              />
+              <div className="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={!importJson.trim()}
+                  className="flex-1 rounded-lg bg-[--color-primary] py-2 text-xs text-white hover:bg-[--color-primary-dark] disabled:opacity-50"
+                >
+                  Import
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowImport(false); setImportJson(''); }}
+                  className="rounded-lg bg-[--color-surface-light] px-3 py-2 text-xs text-[--color-text-secondary]"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+
+      {feedback && (
+        <p className="mt-2 text-xs text-[--color-text-muted]">{feedback}</p>
+      )}
+    </section>
+  );
+}
+
 export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPanelProps) {
   // Close on Escape key
   useEffect(() => {
@@ -113,6 +348,9 @@ export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPan
         </header>
 
         <div className="overflow-y-auto p-4 space-y-6">
+          {/* Identity & Security */}
+          <IdentitySection />
+
           {/* Theme */}
           <section>
             <h3 className="mb-3 text-sm font-medium text-[--color-text-secondary]">Theme</h3>

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -160,9 +160,17 @@ function IdentitySection() {
     }
   };
 
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
   const handleRemove = () => {
+    if (!confirmRemove) {
+      setConfirmRemove(true);
+      setFeedback('Click Remove again to confirm. This is irreversible.');
+      return;
+    }
     removeIdentity();
     refresh();
+    setConfirmRemove(false);
     setFeedback('Identity removed.');
   };
 

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -203,38 +203,42 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       return;
     }
 
+    // Server signature is mandatory when auth was performed (prevents MITM bypass)
+    if (!srvSignature || !pendingChallengeRef.current) {
+      setError(new Error('Server did not provide mutual authentication signature'));
+      client.disconnect();
+      return;
+    }
+
     // Verify server signature for mutual auth
-    if (srvSignature && pendingChallengeRef.current) {
-      try {
-        const serverPubKey = await importPublicKey(
-          fromBase64(pendingChallengeRef.current.serverPublicKey),
-        );
-        const challengeData = fromBase64(pendingChallengeRef.current.challenge);
-        const valid = await verify(serverPubKey, challengeData, srvSignature);
-        if (!valid) {
-          setError(new Error('Server signature verification failed'));
-          client.disconnect();
-          return;
-        }
-      } catch (err) {
-        setError(new Error(
-          `Server verification error: ${err instanceof Error ? err.message : String(err)}`,
-        ));
+    try {
+      const serverPubKey = await importPublicKey(
+        fromBase64(pendingChallengeRef.current.serverPublicKey),
+      );
+      const challengeData = fromBase64(pendingChallengeRef.current.challenge);
+      const valid = await verify(serverPubKey, challengeData, srvSignature);
+      if (!valid) {
+        setError(new Error('Server signature verification failed'));
         client.disconnect();
         return;
       }
+    } catch (err) {
+      setError(new Error(
+        `Server verification error: ${err instanceof Error ? err.message : String(err)}`,
+      ));
+      client.disconnect();
+      return;
     }
 
     // TOFU: trust the server on first use (or update lastSeen)
     const pending = pendingChallengeRef.current;
-    if (pending) {
-      trustHost(urlRef.current, pending.serverFingerprint, pending.serverPublicKey);
-    }
+    trustHost(urlRef.current, pending.serverFingerprint, pending.serverPublicKey);
 
     pendingChallengeRef.current = null;
     setNeedsPassphrase(false);
 
-    // Auth passed; now send hello
+    // Auth passed; re-send hello (reset flag since the pre-auth hello was rejected)
+    helloSentRef.current = false;
     client.setConnected();
     sendHello(client);
   }, [sendHello]);
@@ -244,14 +248,17 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     const client = clientRef.current;
     if (!client) return;
 
-    // Intercept auth messages
+    // Intercept auth messages (both are async; attach .catch to surface errors)
     if (message.type === 'auth_challenge') {
       handleAuthChallenge(
         message.challenge,
         message.serverFingerprint,
         message.serverPublicKey,
         client,
-      );
+      ).catch((err) => {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        client.disconnect();
+      });
       return;
     }
 
@@ -261,14 +268,21 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         message.error,
         message.serverSignature,
         client,
-      );
+      ).catch((err) => {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        client.disconnect();
+      });
       return;
     }
 
-    // Handle hello_ack to get session ID
+    // Handle hello_ack to get session ID and ensure connected state
     if (message.type === 'hello_ack') {
       setSessionId(message.sessionId);
       lastSessionIdRef.current = message.sessionId;
+      // Ensure connected state (for non-auth path where setConnected wasn't called)
+      if (client && !client.isConnected) {
+        client.setConnected();
+      }
     }
 
     // Forward to user handler
@@ -321,6 +335,14 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         onStatusChange: (newStatus) => {
           setStatus(newStatus);
 
+          if (newStatus === 'authenticating') {
+            // Transport is open. Send hello immediately; if the daemon requires
+            // auth, it will send auth_challenge first and reject this hello with
+            // AUTH_REQUIRED (benign). After auth completes, hello is re-sent.
+            // For daemons without auth, this hello is accepted directly.
+            sendHello(client);
+          }
+
           if (newStatus === 'disconnected') {
             setSessionId(null);
             helloSentRef.current = false;
@@ -336,7 +358,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       clientRef.current = client;
       client.connect();
     },
-    [autoReconnect, handleMessage, sendHello],
+    [autoReconnect, handleMessage],
   );
 
   // Disconnect from daemon

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -2,10 +2,19 @@
  * React hook for WebSocket connection to daemon.
  *
  * Provides reactive connection state and message handling.
+ * Handles auth handshake when daemon requires authentication.
  */
 
 import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
 import type { ConnectionStatus } from '@/types';
+import type { UnlockedIdentity } from '@remi/shared';
+import {
+  createAuthResponse,
+  fromBase64,
+  importPublicKey,
+  sign,
+  verify,
+} from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
@@ -47,6 +56,14 @@ export interface UseWebSocketReturn {
   requestNewSession: (directory?: string) => boolean;
   /** Current session ID (after hello_ack) */
   sessionId: UUID | null;
+  /** Whether the daemon requires authentication */
+  authRequired: boolean;
+  /** Server fingerprint (from auth_challenge) */
+  serverFingerprint: string | null;
+  /** Whether auth is awaiting passphrase from user */
+  needsPassphrase: boolean;
+  /** Provide unlocked identity to complete auth */
+  provideIdentity: (identity: UnlockedIdentity) => void;
 }
 
 /** Hook options */
@@ -61,7 +78,12 @@ export interface UseWebSocketOptions {
   onMessage?: (message: ProtocolMessage) => void;
   /** Session ID to resume on initial connect (e.g., from localStorage after page reload) */
   initialResumeSessionId?: UUID;
+  /** Pre-unlocked identity (if user already provided passphrase) */
+  unlockedIdentity?: UnlockedIdentity | null;
 }
+
+/** Time to wait for auth_challenge before assuming no-auth mode (ms) */
+const AUTH_CHALLENGE_TIMEOUT = 500;
 
 /**
  * React hook for managing WebSocket connection.
@@ -73,24 +95,148 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     clientVersion = '0.0.1',
     onMessage,
     initialResumeSessionId,
+    unlockedIdentity,
   } = options;
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
   const [error, setError] = useState<Error | null>(null);
   const [sessionId, setSessionId] = useState<UUID | null>(null);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [serverFingerprint, setServerFingerprint] = useState<string | null>(null);
+  const [needsPassphrase, setNeedsPassphrase] = useState(false);
 
   const clientRef = useRef<WebSocketClient | null>(null);
   const onMessageRef = useRef(onMessage);
   const lastSessionIdRef = useRef<UUID | null>(initialResumeSessionId ?? null);
   const directoryRef = useRef<string | undefined>(undefined);
+  const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
+  const authChallengeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingChallengeRef = useRef<{ challenge: string; serverPublicKey: string } | null>(null);
+  const helloSentRef = useRef(false);
 
-  // Keep onMessage ref updated
+  // Keep refs updated
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
 
+  useEffect(() => {
+    if (unlockedIdentity) {
+      identityRef.current = unlockedIdentity;
+    }
+  }, [unlockedIdentity]);
+
+  /** Send hello message */
+  const sendHello = useCallback((client: WebSocketClient) => {
+    if (helloSentRef.current) return;
+    helloSentRef.current = true;
+    const resumeId = lastSessionIdRef.current ?? undefined;
+    client.send(createHello(clientId, clientVersion, directoryRef.current, resumeId));
+  }, [clientId, clientVersion]);
+
+  /** Handle auth_challenge: sign and respond */
+  const handleAuthChallenge = useCallback(async (
+    challenge: string,
+    srvFingerprint: string,
+    srvPublicKey: string,
+    client: WebSocketClient,
+  ) => {
+    // Clear no-auth timeout
+    if (authChallengeTimerRef.current) {
+      clearTimeout(authChallengeTimerRef.current);
+      authChallengeTimerRef.current = null;
+    }
+
+    setAuthRequired(true);
+    setServerFingerprint(srvFingerprint);
+
+    const identity = identityRef.current;
+    if (!identity) {
+      // Need passphrase from user; store pending challenge
+      pendingChallengeRef.current = { challenge, serverPublicKey: srvPublicKey };
+      setNeedsPassphrase(true);
+      return;
+    }
+
+    // Sign the challenge
+    try {
+      const challengeData = fromBase64(challenge);
+      const signature = await sign(identity.privateKey, challengeData);
+      const response = createAuthResponse(
+        identity.publicKeyRaw,
+        signature,
+        identity.fingerprint,
+      );
+      client.send(response);
+    } catch (err) {
+      setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
+    }
+  }, []);
+
+  /** Handle auth_result */
+  const handleAuthResult = useCallback(async (
+    success: boolean,
+    authError: string | undefined,
+    srvSignature: string | undefined,
+    client: WebSocketClient,
+  ) => {
+    if (!success) {
+      setError(new Error(`Authentication failed: ${authError ?? 'unknown error'}`));
+      client.disconnect();
+      return;
+    }
+
+    // Verify server signature for mutual auth
+    if (srvSignature && pendingChallengeRef.current) {
+      try {
+        const serverPubKey = await importPublicKey(
+          fromBase64(pendingChallengeRef.current.serverPublicKey),
+        );
+        const challengeData = fromBase64(pendingChallengeRef.current.challenge);
+        const valid = await verify(serverPubKey, challengeData, srvSignature);
+        if (!valid) {
+          setError(new Error('Server signature verification failed'));
+          client.disconnect();
+          return;
+        }
+      } catch {
+        // Non-fatal; server signature verification is optional
+      }
+    }
+
+    pendingChallengeRef.current = null;
+    setNeedsPassphrase(false);
+
+    // Auth passed; now send hello
+    client.setConnected();
+    sendHello(client);
+  }, [sendHello]);
+
   // Handle incoming messages
   const handleMessage = useCallback((message: ProtocolMessage) => {
+    const client = clientRef.current;
+    if (!client) return;
+
+    // Intercept auth messages
+    if (message.type === 'auth_challenge') {
+      handleAuthChallenge(
+        message.challenge,
+        message.serverFingerprint,
+        message.serverPublicKey,
+        client,
+      );
+      return;
+    }
+
+    if (message.type === 'auth_result') {
+      handleAuthResult(
+        message.success,
+        message.error,
+        message.serverSignature,
+        client,
+      );
+      return;
+    }
+
     // Handle hello_ack to get session ID
     if (message.type === 'hello_ack') {
       setSessionId(message.sessionId);
@@ -99,6 +245,32 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
     // Forward to user handler
     onMessageRef.current?.(message);
+  }, [handleAuthChallenge, handleAuthResult]);
+
+  /** Provide identity after passphrase unlock (called from UI) */
+  const provideIdentity = useCallback((identity: UnlockedIdentity) => {
+    identityRef.current = identity;
+    setNeedsPassphrase(false);
+
+    const client = clientRef.current;
+    const pending = pendingChallengeRef.current;
+    if (!client || !pending) return;
+
+    // Sign the pending challenge
+    (async () => {
+      try {
+        const challengeData = fromBase64(pending.challenge);
+        const signature = await sign(identity.privateKey, challengeData);
+        const response = createAuthResponse(
+          identity.publicKeyRaw,
+          signature,
+          identity.fingerprint,
+        );
+        client.send(response);
+      } catch (err) {
+        setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
+      }
+    })();
   }, []);
 
   // Connect to daemon
@@ -106,6 +278,17 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     (url: string, directory?: string) => {
       // Clean up existing connection
       clientRef.current?.disconnect();
+      if (authChallengeTimerRef.current) {
+        clearTimeout(authChallengeTimerRef.current);
+        authChallengeTimerRef.current = null;
+      }
+
+      // Reset state
+      helloSentRef.current = false;
+      pendingChallengeRef.current = null;
+      setAuthRequired(false);
+      setServerFingerprint(null);
+      setNeedsPassphrase(false);
 
       // Store directory for reconnects
       if (directory !== undefined) {
@@ -119,17 +302,21 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
       const client = new WebSocketClient(config, {
         onStatusChange: (newStatus) => {
-          console.log('[WebSocket] Status changed:', newStatus);
           setStatus(newStatus);
-          if (newStatus === 'connected') {
-            // On reconnect, include resumeSessionId so daemon replays missed messages
-            const resumeId = lastSessionIdRef.current ?? undefined;
-            console.log('[WebSocket] Sending hello message...', resumeId ? `(resume: ${resumeId})` : '(new)');
-            const sent = client.send(createHello(clientId, clientVersion, directoryRef.current, resumeId));
-            console.log('[WebSocket] Hello message sent:', sent);
+
+          if (newStatus === 'authenticating') {
+            // WebSocket is open; wait for auth_challenge or assume no-auth
+            authChallengeTimerRef.current = setTimeout(() => {
+              // No auth_challenge received; assume no-auth mode
+              authChallengeTimerRef.current = null;
+              client.setConnected();
+              sendHello(client);
+            }, AUTH_CHALLENGE_TIMEOUT);
           }
+
           if (newStatus === 'disconnected') {
             setSessionId(null);
+            helloSentRef.current = false;
           }
         },
         onMessage: handleMessage,
@@ -142,11 +329,15 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       clientRef.current = client;
       client.connect();
     },
-    [autoReconnect, clientId, clientVersion, handleMessage],
+    [autoReconnect, handleMessage, sendHello],
   );
 
   // Disconnect from daemon
   const disconnect = useCallback(() => {
+    if (authChallengeTimerRef.current) {
+      clearTimeout(authChallengeTimerRef.current);
+      authChallengeTimerRef.current = null;
+    }
     clientRef.current?.disconnect();
     setSessionId(null);
   }, []);
@@ -206,6 +397,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   // Clean up on unmount
   useEffect(() => {
     return () => {
+      if (authChallengeTimerRef.current) {
+        clearTimeout(authChallengeTimerRef.current);
+      }
       clientRef.current?.disconnect();
     };
   }, []);
@@ -234,5 +428,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     requestTranscriptLoad,
     requestNewSession,
     sessionId,
+    authRequired,
+    serverFingerprint,
+    needsPassphrase,
+    provideIdentity,
   };
 }

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -83,13 +83,6 @@ export interface UseWebSocketOptions {
 }
 
 /**
- * Time to wait for auth_challenge after WebSocket opens before assuming
- * no-auth mode. Set high enough for slow networks; auth-enabled servers
- * send the challenge immediately on connection.
- */
-const AUTH_CHALLENGE_TIMEOUT = 3000;
-
-/**
  * React hook for managing WebSocket connection.
  */
 export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketReturn {
@@ -114,7 +107,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   const lastSessionIdRef = useRef<UUID | null>(initialResumeSessionId ?? null);
   const directoryRef = useRef<string | undefined>(undefined);
   const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
-  const authChallengeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingChallengeRef = useRef<{ challenge: string; serverPublicKey: string } | null>(null);
   const helloSentRef = useRef(false);
 
@@ -144,12 +136,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     srvPublicKey: string,
     client: WebSocketClient,
   ) => {
-    // Clear no-auth timeout
-    if (authChallengeTimerRef.current) {
-      clearTimeout(authChallengeTimerRef.current);
-      authChallengeTimerRef.current = null;
-    }
-
     setAuthRequired(true);
     setServerFingerprint(srvFingerprint);
 
@@ -290,10 +276,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     (url: string, directory?: string) => {
       // Clean up existing connection
       clientRef.current?.disconnect();
-      if (authChallengeTimerRef.current) {
-        clearTimeout(authChallengeTimerRef.current);
-        authChallengeTimerRef.current = null;
-      }
 
       // Reset state
       helloSentRef.current = false;
@@ -316,16 +298,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         onStatusChange: (newStatus) => {
           setStatus(newStatus);
 
-          if (newStatus === 'authenticating') {
-            // WebSocket is open; wait for auth_challenge or assume no-auth
-            authChallengeTimerRef.current = setTimeout(() => {
-              authChallengeTimerRef.current = null;
-              console.warn('[remi] No auth_challenge received; assuming no-auth mode');
-              client.setConnected();
-              sendHello(client);
-            }, AUTH_CHALLENGE_TIMEOUT);
-          }
-
           if (newStatus === 'disconnected') {
             setSessionId(null);
             helloSentRef.current = false;
@@ -346,10 +318,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
   // Disconnect from daemon
   const disconnect = useCallback(() => {
-    if (authChallengeTimerRef.current) {
-      clearTimeout(authChallengeTimerRef.current);
-      authChallengeTimerRef.current = null;
-    }
     clientRef.current?.disconnect();
     setSessionId(null);
   }, []);
@@ -409,9 +377,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   // Clean up on unmount
   useEffect(() => {
     return () => {
-      if (authChallengeTimerRef.current) {
-        clearTimeout(authChallengeTimerRef.current);
-      }
       clientRef.current?.disconnect();
     };
   }, []);

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -5,6 +5,7 @@
  * Handles auth handshake when daemon requires authentication.
  */
 
+import { checkKnownHost, trustHost } from '@/lib/identity-client';
 import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
 import type { ConnectionStatus } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
@@ -82,6 +83,16 @@ export interface UseWebSocketOptions {
   unlockedIdentity?: UnlockedIdentity | null;
 }
 
+/** Sign an auth challenge with the given identity and return an auth_response message. */
+async function signChallenge(
+  identity: UnlockedIdentity,
+  challenge: string,
+): Promise<ProtocolMessage> {
+  const challengeData = fromBase64(challenge);
+  const signature = await sign(identity.privateKey, challengeData);
+  return createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);
+}
+
 /**
  * React hook for managing WebSocket connection.
  */
@@ -106,8 +117,13 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   const onMessageRef = useRef(onMessage);
   const lastSessionIdRef = useRef<UUID | null>(initialResumeSessionId ?? null);
   const directoryRef = useRef<string | undefined>(undefined);
+  const urlRef = useRef<string>('');
   const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
-  const pendingChallengeRef = useRef<{ challenge: string; serverPublicKey: string } | null>(null);
+  const pendingChallengeRef = useRef<{
+    challenge: string;
+    serverPublicKey: string;
+    serverFingerprint: string;
+  } | null>(null);
   const helloSentRef = useRef(false);
 
   // Keep refs updated
@@ -139,8 +155,23 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     setAuthRequired(true);
     setServerFingerprint(srvFingerprint);
 
+    // TOFU: check known hosts
+    const tofuResult = checkKnownHost(urlRef.current, srvFingerprint);
+    if (tofuResult === 'mismatch') {
+      setError(new Error(
+        `Server fingerprint changed for ${urlRef.current}. ` +
+        'This could indicate a MITM attack. Connection rejected.',
+      ));
+      client.disconnect();
+      return;
+    }
+
     // Always store for mutual auth verification in handleAuthResult
-    pendingChallengeRef.current = { challenge, serverPublicKey: srvPublicKey };
+    pendingChallengeRef.current = {
+      challenge,
+      serverPublicKey: srvPublicKey,
+      serverFingerprint: srvFingerprint,
+    };
 
     const identity = identityRef.current;
     if (!identity) {
@@ -151,13 +182,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
     // Sign the challenge
     try {
-      const challengeData = fromBase64(challenge);
-      const signature = await sign(identity.privateKey, challengeData);
-      const response = createAuthResponse(
-        identity.publicKeyRaw,
-        signature,
-        identity.fingerprint,
-      );
+      const response = await signChallenge(identity, challenge);
       client.send(response);
     } catch (err) {
       setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
@@ -198,6 +223,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         client.disconnect();
         return;
       }
+    }
+
+    // TOFU: trust the server on first use (or update lastSeen)
+    const pending = pendingChallengeRef.current;
+    if (pending) {
+      trustHost(urlRef.current, pending.serverFingerprint, pending.serverPublicKey);
     }
 
     pendingChallengeRef.current = null;
@@ -254,21 +285,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     if (!client || !pending) return;
 
     // Sign the pending challenge
-    (async () => {
-      try {
-        const challengeData = fromBase64(pending.challenge);
-        const signature = await sign(identity.privateKey, challengeData);
-        const response = createAuthResponse(
-          identity.publicKeyRaw,
-          signature,
-          identity.fingerprint,
-        );
-        client.send(response);
-      } catch (err) {
+    signChallenge(identity, pending.challenge)
+      .then((response) => client.send(response))
+      .catch((err) => {
         setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
         client.disconnect();
-      }
-    })();
+      });
   }, []);
 
   // Connect to daemon
@@ -284,7 +306,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       setServerFingerprint(null);
       setNeedsPassphrase(false);
 
-      // Store directory for reconnects
+      // Store URL and directory for reconnects/TOFU
+      urlRef.current = url;
       if (directory !== undefined) {
         directoryRef.current = directory;
       }

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -82,8 +82,12 @@ export interface UseWebSocketOptions {
   unlockedIdentity?: UnlockedIdentity | null;
 }
 
-/** Time to wait for auth_challenge before assuming no-auth mode (ms) */
-const AUTH_CHALLENGE_TIMEOUT = 500;
+/**
+ * Time to wait for auth_challenge after WebSocket opens before assuming
+ * no-auth mode. Set high enough for slow networks; auth-enabled servers
+ * send the challenge immediately on connection.
+ */
+const AUTH_CHALLENGE_TIMEOUT = 3000;
 
 /**
  * React hook for managing WebSocket connection.
@@ -149,10 +153,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     setAuthRequired(true);
     setServerFingerprint(srvFingerprint);
 
+    // Always store for mutual auth verification in handleAuthResult
+    pendingChallengeRef.current = { challenge, serverPublicKey: srvPublicKey };
+
     const identity = identityRef.current;
     if (!identity) {
-      // Need passphrase from user; store pending challenge
-      pendingChallengeRef.current = { challenge, serverPublicKey: srvPublicKey };
+      // Need passphrase from user
       setNeedsPassphrase(true);
       return;
     }
@@ -169,6 +175,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       client.send(response);
     } catch (err) {
       setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
+      client.disconnect();
     }
   }, []);
 
@@ -198,8 +205,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
           client.disconnect();
           return;
         }
-      } catch {
-        // Non-fatal; server signature verification is optional
+      } catch (err) {
+        setError(new Error(
+          `Server verification error: ${err instanceof Error ? err.message : String(err)}`,
+        ));
+        client.disconnect();
+        return;
       }
     }
 
@@ -269,6 +280,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         client.send(response);
       } catch (err) {
         setError(new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`));
+        client.disconnect();
       }
     })();
   }, []);
@@ -307,8 +319,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
           if (newStatus === 'authenticating') {
             // WebSocket is open; wait for auth_challenge or assume no-auth
             authChallengeTimerRef.current = setTimeout(() => {
-              // No auth_challenge received; assume no-auth mode
               authChallengeTimerRef.current = null;
+              console.warn('[remi] No auth_challenge received; assuming no-auth mode');
               client.setConnected();
               sendHello(client);
             }, AUTH_CHALLENGE_TIMEOUT);

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -1,0 +1,134 @@
+/**
+ * Client-side identity management.
+ *
+ * Stores identity in localStorage (private key stays passphrase-encrypted).
+ * Manages known hosts (TOFU model) for server fingerprint verification.
+ */
+
+import type { RemiIdentity, UnlockedIdentity } from '@remi/shared';
+import { createIdentity, deserializeIdentity, serializeIdentity, unlockIdentity } from '@remi/shared';
+
+const IDENTITY_KEY = 'remi-identity';
+const KNOWN_HOSTS_KEY = 'remi-known-hosts';
+
+/** Known host entry (TOFU) */
+export interface KnownHost {
+  readonly fingerprint: string;
+  readonly publicKey: string;
+  readonly firstSeen: string;
+  readonly lastSeen: string;
+}
+
+/** Load stored identity (still encrypted) */
+export function loadIdentity(): RemiIdentity | null {
+  try {
+    const stored = localStorage.getItem(IDENTITY_KEY);
+    if (!stored) return null;
+    return deserializeIdentity(stored);
+  } catch {
+    return null;
+  }
+}
+
+/** Save identity to localStorage */
+export function saveIdentity(identity: RemiIdentity): void {
+  localStorage.setItem(IDENTITY_KEY, serializeIdentity(identity));
+}
+
+/** Remove identity from localStorage */
+export function removeIdentity(): void {
+  localStorage.removeItem(IDENTITY_KEY);
+}
+
+/** Check if an identity exists */
+export function hasIdentity(): boolean {
+  return localStorage.getItem(IDENTITY_KEY) !== null;
+}
+
+/** Generate a new identity and store it */
+export async function generateIdentity(passphrase: string): Promise<RemiIdentity> {
+  const identity = await createIdentity(passphrase);
+  saveIdentity(identity);
+  return identity;
+}
+
+/** Unlock a stored identity with passphrase */
+export async function unlockStoredIdentity(passphrase: string): Promise<UnlockedIdentity> {
+  const identity = loadIdentity();
+  if (!identity) {
+    throw new Error('No identity found');
+  }
+  return unlockIdentity(identity, passphrase);
+}
+
+/** Import identity from JSON string */
+export function importIdentity(json: string): RemiIdentity {
+  const identity = deserializeIdentity(json);
+  saveIdentity(identity);
+  return identity;
+}
+
+/** Export identity as JSON string */
+export function exportIdentity(): string | null {
+  const identity = loadIdentity();
+  if (!identity) return null;
+  return serializeIdentity(identity);
+}
+
+/** Get the identity fingerprint without unlocking */
+export function getFingerprint(): string | null {
+  const identity = loadIdentity();
+  return identity?.fingerprint ?? null;
+}
+
+// -- Known Hosts (TOFU) --
+
+/** Load known hosts map */
+export function loadKnownHosts(): Record<string, KnownHost> {
+  try {
+    const stored = localStorage.getItem(KNOWN_HOSTS_KEY);
+    if (!stored) return {};
+    return JSON.parse(stored) as Record<string, KnownHost>;
+  } catch {
+    return {};
+  }
+}
+
+/** Save known hosts map */
+function saveKnownHosts(hosts: Record<string, KnownHost>): void {
+  localStorage.setItem(KNOWN_HOSTS_KEY, JSON.stringify(hosts));
+}
+
+/**
+ * Check a server's fingerprint against known hosts.
+ * Returns 'new' if never seen, 'match' if same, 'mismatch' if changed.
+ */
+export function checkKnownHost(
+  serverUrl: string,
+  fingerprint: string,
+): 'new' | 'match' | 'mismatch' {
+  const hosts = loadKnownHosts();
+  const existing = hosts[serverUrl];
+  if (!existing) return 'new';
+  return existing.fingerprint === fingerprint ? 'match' : 'mismatch';
+}
+
+/** Record a server fingerprint (TOFU - trust on first use) */
+export function trustHost(serverUrl: string, fingerprint: string, publicKey: string): void {
+  const hosts = loadKnownHosts();
+  const now = new Date().toISOString();
+  hosts[serverUrl] = {
+    fingerprint,
+    publicKey,
+    firstSeen: hosts[serverUrl]?.firstSeen ?? now,
+    lastSeen: now,
+  };
+  saveKnownHosts(hosts);
+}
+
+/** Remove a known host */
+export function removeKnownHost(serverUrl: string): void {
+  const hosts = loadKnownHosts();
+  delete hosts[serverUrl];
+  saveKnownHosts(hosts);
+}

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -5,19 +5,13 @@
  * Manages known hosts (TOFU model) for server fingerprint verification.
  */
 
-import type { RemiIdentity, UnlockedIdentity } from '@remi/shared';
+import type { KnownHost, RemiIdentity, UnlockedIdentity } from '@remi/shared';
 import { createIdentity, deserializeIdentity, serializeIdentity, unlockIdentity } from '@remi/shared';
+
+export type { KnownHost };
 
 const IDENTITY_KEY = 'remi-identity';
 const KNOWN_HOSTS_KEY = 'remi-known-hosts';
-
-/** Known host entry (TOFU) */
-export interface KnownHost {
-  readonly fingerprint: string;
-  readonly publicKey: string;
-  readonly firstSeen: string;
-  readonly lastSeen: string;
-}
 
 /** Load stored identity (still encrypted). Returns null if not found. Throws on corrupt data. */
 export function loadIdentity(): RemiIdentity | null {
@@ -86,14 +80,16 @@ export function getFingerprint(): string | null {
 
 // -- Known Hosts (TOFU) --
 
-/** Load known hosts map */
+/** Load known hosts map. Throws on corrupt data. */
 export function loadKnownHosts(): Record<string, KnownHost> {
+  const stored = localStorage.getItem(KNOWN_HOSTS_KEY);
+  if (!stored) return {};
   try {
-    const stored = localStorage.getItem(KNOWN_HOSTS_KEY);
-    if (!stored) return {};
     return JSON.parse(stored) as Record<string, KnownHost>;
   } catch {
-    return {};
+    throw new Error(
+      'Known hosts data is corrupt. Remove the entry from localStorage (key: remi-known-hosts) to reset.',
+    );
   }
 }
 

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -19,14 +19,17 @@ export interface KnownHost {
   readonly lastSeen: string;
 }
 
-/** Load stored identity (still encrypted) */
+/** Load stored identity (still encrypted). Returns null if not found. Throws on corrupt data. */
 export function loadIdentity(): RemiIdentity | null {
+  const stored = localStorage.getItem(IDENTITY_KEY);
+  if (!stored) return null;
   try {
-    const stored = localStorage.getItem(IDENTITY_KEY);
-    if (!stored) return null;
     return deserializeIdentity(stored);
-  } catch {
-    return null;
+  } catch (err) {
+    console.error('[remi] Stored identity is corrupt:', err);
+    throw new Error(
+      'Your stored identity is corrupt. You may need to remove and re-create it in Settings.',
+    );
   }
 }
 

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -72,10 +72,14 @@ export function exportIdentity(): string | null {
   return serializeIdentity(identity);
 }
 
-/** Get the identity fingerprint without unlocking */
+/** Get the identity fingerprint without unlocking. Returns null on missing or corrupt data. */
 export function getFingerprint(): string | null {
-  const identity = loadIdentity();
-  return identity?.fingerprint ?? null;
+  try {
+    const identity = loadIdentity();
+    return identity?.fingerprint ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // -- Known Hosts (TOFU) --
@@ -98,6 +102,11 @@ function saveKnownHosts(hosts: Record<string, KnownHost>): void {
   localStorage.setItem(KNOWN_HOSTS_KEY, JSON.stringify(hosts));
 }
 
+/** Normalize a URL for use as TOFU host key (strip trailing slashes, lowercase host). */
+function normalizeHostKey(url: string): string {
+  return url.replace(/\/+$/, '').toLowerCase();
+}
+
 /**
  * Check a server's fingerprint against known hosts.
  * Returns 'new' if never seen, 'match' if same, 'mismatch' if changed.
@@ -107,7 +116,7 @@ export function checkKnownHost(
   fingerprint: string,
 ): 'new' | 'match' | 'mismatch' {
   const hosts = loadKnownHosts();
-  const existing = hosts[serverUrl];
+  const existing = hosts[normalizeHostKey(serverUrl)];
   if (!existing) return 'new';
   return existing.fingerprint === fingerprint ? 'match' : 'mismatch';
 }
@@ -115,11 +124,12 @@ export function checkKnownHost(
 /** Record a server fingerprint (TOFU - trust on first use) */
 export function trustHost(serverUrl: string, fingerprint: string, publicKey: string): void {
   const hosts = loadKnownHosts();
+  const key = normalizeHostKey(serverUrl);
   const now = new Date().toISOString();
-  hosts[serverUrl] = {
+  hosts[key] = {
     fingerprint,
     publicKey,
-    firstSeen: hosts[serverUrl]?.firstSeen ?? now,
+    firstSeen: hosts[key]?.firstSeen ?? now,
     lastSeen: now,
   };
   saveKnownHosts(hosts);
@@ -128,6 +138,6 @@ export function trustHost(serverUrl: string, fingerprint: string, publicKey: str
 /** Remove a known host */
 export function removeKnownHost(serverUrl: string): void {
   const hosts = loadKnownHosts();
-  delete hosts[serverUrl];
+  delete hosts[normalizeHostKey(serverUrl)];
   saveKnownHosts(hosts);
 }

--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -82,7 +82,7 @@ export class WebSocketClient {
 
       // Set connection timeout
       this.connectionTimer = setTimeout(() => {
-        if (this.status === 'connecting') {
+        if (this.status === 'connecting' || this.status === 'authenticating') {
           this.handleError(new Error('Connection timeout'));
           this.ws?.close();
         }
@@ -112,7 +112,7 @@ export class WebSocketClient {
 
   /** Send a message to the daemon */
   send(message: ProtocolMessage): boolean {
-    if (!this.ws || this.status !== 'connected') {
+    if (!this.ws || (this.status !== 'connected' && this.status !== 'authenticating')) {
       return false;
     }
 
@@ -129,6 +129,13 @@ export class WebSocketClient {
   private handleOpen(): void {
     this.clearConnectionTimer();
     this.reconnectAttempts = 0;
+    // Don't set 'connected' yet; wait for auth handshake or hello_ack.
+    // Set 'authenticating' to signal that the transport is open but auth is pending.
+    this.setStatus('authenticating');
+  }
+
+  /** Transition to connected state (called after auth completes) */
+  setConnected(): void {
     this.setStatus('connected');
   }
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -13,6 +13,7 @@ export type PeerRole = 'host' | 'client';
 export type ConnectionStatus =
   | 'disconnected'
   | 'connecting'
+  | 'authenticating'
   | 'connected'
   | 'reconnecting'
   | 'error';


### PR DESCRIPTION
## Summary
- Ed25519 challenge-response authentication using Web Crypto API (cross-platform: Bun + browser)
- Passphrase-encrypted private keys at rest (PBKDF2-SHA-256 600K iterations, AES-256-GCM)
- Daemon: identity store (~/.remi/), authorized_keys management, connection state machine with auth phase
- CLI: `remi keygen`, `remi export-key`, `remi import-key`, `remi authorize`, `remi keys`
- Web client: auth handshake with 500ms no-auth fallback, passphrase prompt, identity management in Settings
- Mutual authentication (server signs challenge back to client)
- Backward compatible: daemons without auth configured work as before

## Test plan
- [x] 708 tests pass (60 new auth tests across crypto, identity, identity-store, authenticator)
- [x] TypeScript builds clean (`tsc -b`)
- [x] Biome lint passes
- [x] Web production build succeeds
- [ ] Manual: `remi keygen` + `remi authorize` + daemon with auth rejects unauthenticated clients
- [ ] Manual: web client generates identity, authenticates with passphrase
- [ ] Manual: multi-device test (mba, hallu, mcm)

Closes #20