### PR TITLE
Daemon signaling integration with persistent codes

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -297,14 +297,14 @@ let cliPort: number | undefined;
 let cliNoTelegram = false;
 let cliMaxBulletLength: number | undefined;
 let cliDaemonMode = false;
-let cliRemote = false;
 let cliSignalingUrl: string | undefined;
 let cliResume: string | true | undefined; // true = resume most recent, string = session ID
 let cliShowSessions = false;
 let cliInstall = false;
 let cliUninstall = false;
-let cliSubcommand: 'ls' | 'attach' | undefined;
+let cliSubcommand: 'ls' | 'attach' | 'code' | undefined;
 let cliSubcommandArg: string | undefined;
+let cliCodeRefresh = false;
 const claudeArgs: string[] = [];
 
 for (let i = 0; i < args.length; i++) {
@@ -331,8 +331,6 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--no-telegram') {
     cliNoTelegram = true;
-  } else if (arg === '--remote') {
-    cliRemote = true;
   } else if (arg === '--signaling-url' && nextArg) {
     cliSignalingUrl = nextArg;
     i++;
@@ -351,6 +349,8 @@ Usage:
   remi [claude-args...]          Start Claude with WebSocket monitoring
   remi ls                        List live sessions from running daemon
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
+  remi code                      Show remote access connection code
+  remi code --refresh            Generate a new connection code
   remi --resume [session-id]     Resume a previous session
   remi --sessions                List stored sessions
   remi --daemon                  Legacy daemon mode (headless server)
@@ -359,7 +359,6 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
-  --remote                 Enable remote access via signaling relay
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --install                Install as autostart service
   --uninstall              Remove autostart service
@@ -377,10 +376,14 @@ Environment:
 Any other arguments are passed through to Claude Code.
 `);
     process.exit(0);
-  } else if (arg === 'ls' || arg === 'attach') {
+  } else if (arg === 'ls' || arg === 'attach' || arg === 'code') {
     cliSubcommand = arg;
     if (arg === 'attach' && nextArg && !nextArg.startsWith('-')) {
       cliSubcommandArg = nextArg;
+      i++;
+    }
+    if (arg === 'code' && nextArg === '--refresh') {
+      cliCodeRefresh = true;
       i++;
     }
   } else {
@@ -485,6 +488,26 @@ WantedBy=default.target`;
   } else {
     console.error(`Autostart not supported on ${platform}. Run remi --daemon manually.`);
     process.exit(1);
+  }
+  process.exit(0);
+}
+
+// Handle 'code' subcommand: show or refresh the remote access code
+if (cliSubcommand === 'code') {
+  const { CodeStore } = await import('./remote/code-store.ts');
+  const codeStore = new CodeStore();
+  if (cliCodeRefresh) {
+    const newCode = codeStore.refresh();
+    console.log(`New connection code: ${newCode}`);
+    console.log('Restart the daemon for the new code to take effect.');
+  } else {
+    const code = codeStore.load();
+    if (code) {
+      console.log(`Connection code: ${code}`);
+    } else {
+      const newCode = codeStore.refresh();
+      console.log(`Connection code: ${newCode} (newly generated)`);
+    }
   }
   process.exit(0);
 }
@@ -1333,13 +1356,17 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
   registry.register(telegramAdapter);
 }
 
-if (cliRemote) {
+{
   const { RelayAdapter } = await import('./remote/relay-adapter.ts');
+  const { CodeStore } = await import('./remote/code-store.ts');
+  const codeStore = new CodeStore();
+  const code = codeStore.load() ?? codeStore.refresh();
   const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.dev-941.workers.dev/connect';
   const relayAdapter = new RelayAdapter(
     {
       enabled: true,
       signalingUrl,
+      code,
     },
     sharedEvents,
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -298,6 +298,7 @@ let cliNoTelegram = false;
 let cliMaxBulletLength: number | undefined;
 let cliDaemonMode = false;
 let cliSignalingUrl: string | undefined;
+let cliNoRelay = false;
 let cliResume: string | true | undefined; // true = resume most recent, string = session ID
 let cliShowSessions = false;
 let cliInstall = false;
@@ -331,6 +332,8 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--no-telegram') {
     cliNoTelegram = true;
+  } else if (arg === '--no-relay') {
+    cliNoRelay = true;
   } else if (arg === '--signaling-url' && nextArg) {
     cliSignalingUrl = nextArg;
     i++;
@@ -359,6 +362,7 @@ Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
   --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
   --no-telegram            Disable Telegram adapter
+  --no-relay               Disable signaling relay (no remote access via connection code)
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --install                Install as autostart service
   --uninstall              Remove autostart service
@@ -1356,7 +1360,7 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
   registry.register(telegramAdapter);
 }
 
-{
+if (!cliNoRelay) {
   const { RelayAdapter } = await import('./remote/relay-adapter.ts');
   const { CodeStore } = await import('./remote/code-store.ts');
   const codeStore = new CodeStore();

--- a/packages/daemon/src/remote/code-store.ts
+++ b/packages/daemon/src/remote/code-store.ts
@@ -1,0 +1,70 @@
+/**
+ * Persistent storage for the signaling connection code.
+ *
+ * Stores the code in ~/.remi/connection-code so it persists across
+ * daemon restarts, allowing clients to reconnect with the same code.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const CODE_FILE = path.join(REMI_DIR, 'connection-code');
+
+/** Unambiguous characters for code generation (no 0/O, 1/I/L) */
+const ALPHA_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ';
+const NUMERIC_CHARS = '23456789';
+
+const CODE_PATTERN = /^[A-Z]{4}-[0-9]{4}$/;
+
+function generateConnectionCode(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  let alpha = '';
+  let numeric = '';
+  for (let i = 0; i < 4; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: index bounded by array length
+    alpha += ALPHA_CHARS[bytes[i]! % ALPHA_CHARS.length];
+  }
+  for (let i = 0; i < 4; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: index bounded by array length
+    numeric += NUMERIC_CHARS[bytes[4 + i]! % NUMERIC_CHARS.length];
+  }
+  return `${alpha}-${numeric}`;
+}
+
+export class CodeStore {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? CODE_FILE;
+  }
+
+  /** Load persisted code. Returns null if file missing or content invalid. */
+  load(): string | null {
+    try {
+      const content = fs.readFileSync(this.filePath, 'utf-8').trim();
+      if (CODE_PATTERN.test(content)) {
+        return content;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Save a code to disk. Creates ~/.remi/ if needed. */
+  save(code: string): void {
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(this.filePath, code, 'utf-8');
+  }
+
+  /** Generate a new code, save it, and return it. */
+  refresh(): string {
+    const code = generateConnectionCode();
+    this.save(code);
+    return code;
+  }
+}

--- a/packages/daemon/src/remote/code-store.ts
+++ b/packages/daemon/src/remote/code-store.ts
@@ -16,7 +16,8 @@ const CODE_FILE = path.join(REMI_DIR, 'connection-code');
 const ALPHA_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ';
 const NUMERIC_CHARS = '23456789';
 
-const CODE_PATTERN = /^[A-Z]{4}-[0-9]{4}$/;
+/** Only accept codes using the unambiguous character set */
+const CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ]{4}-[23456789]{4}$/;
 
 function generateConnectionCode(): string {
   const bytes = new Uint8Array(8);
@@ -49,16 +50,23 @@ export class CodeStore {
         return content;
       }
       return null;
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        return null;
+      }
+      throw err;
     }
   }
 
-  /** Save a code to disk. Creates ~/.remi/ if needed. */
+  /** Save a code to disk with restrictive permissions. Creates ~/.remi/ if needed. */
   save(code: string): void {
     const dir = path.dirname(this.filePath);
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(this.filePath, code, 'utf-8');
+    fs.writeFileSync(this.filePath, code, { encoding: 'utf-8', mode: 0o600 });
   }
 
   /** Generate a new code, save it, and return it. */

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -17,6 +17,8 @@ import { SignalingClient } from './signaling-client.ts';
 
 export interface RelayAdapterConfig extends AdapterConfig {
   readonly signalingUrl: string;
+  /** Pre-set connection code (persisted across restarts) */
+  readonly code?: string;
 }
 
 export class RelayAdapter implements ConnectionAdapter {
@@ -173,7 +175,7 @@ export class RelayAdapter implements ConnectionAdapter {
       console.error(`Relay signaling error [${code}]: ${msg}`);
     });
 
-    this.client.connect();
+    this.client.connect(this.config.code);
     this.running = true;
   }
 

--- a/packages/daemon/src/remote/signaling-client.ts
+++ b/packages/daemon/src/remote/signaling-client.ts
@@ -51,15 +51,19 @@ export class SignalingClient extends EventEmitter {
     this.baseUrl = baseUrl.replace(/\/$/, '');
   }
 
-  connect(): void {
+  connect(code?: string): void {
     if (this.ws) {
       this.ws.close();
       this.ws = null;
     }
     this.closed = false;
 
-    // Generate code locally and connect to the code-named room
-    this.code = generateConnectionCode();
+    // Use provided code or generate one; reuse on reconnect
+    if (code) {
+      this.code = code;
+    } else if (!this.code) {
+      this.code = generateConnectionCode();
+    }
     const wsUrl = `${this.baseUrl}/${this.code}`;
     this.ws = new WebSocket(wsUrl);
 

--- a/packages/daemon/src/remote/signaling-client.ts
+++ b/packages/daemon/src/remote/signaling-client.ts
@@ -1,7 +1,7 @@
 /**
  * Signaling Client - connects to the signaling server.
  *
- * Generates a connection code locally, connects to the code-named room,
+ * Connects to a code-named room (using a provided or locally generated code)
  * and handles relay message forwarding.
  */
 

--- a/packages/daemon/tests/remote/code-store.test.ts
+++ b/packages/daemon/tests/remote/code-store.test.ts
@@ -49,15 +49,17 @@ describe('CodeStore', () => {
   });
 
   test('load rejects codes with ambiguous characters', () => {
-    // 0, O, 1, I, L are excluded from generation but pattern allows any uppercase + digit
+    // 0, O, 1, I, L are excluded from the unambiguous character set
     fs.writeFileSync(codeFile, 'ABCD-0000', 'utf-8');
-    // Pattern is [A-Z]{4}-[0-9]{4}, so this is valid even with 0
-    expect(store.load()).toBe('ABCD-0000');
+    expect(store.load()).toBeNull();
+
+    fs.writeFileSync(codeFile, 'OILZ-2345', 'utf-8');
+    expect(store.load()).toBeNull();
   });
 
   test('refresh generates a valid code and saves it', () => {
     const code = store.refresh();
-    expect(code).toMatch(/^[A-Z]{4}-[0-9]{4}$/);
+    expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ]{4}-[23456789]{4}$/);
     expect(store.load()).toBe(code);
   });
 
@@ -77,10 +79,26 @@ describe('CodeStore', () => {
     expect(deepStore.load()).toBe('MNPQ-5678');
   });
 
+  test('load throws on permission errors (non-ENOENT)', () => {
+    // Create a file then make it unreadable
+    fs.writeFileSync(codeFile, 'ABCD-2345', 'utf-8');
+    fs.chmodSync(codeFile, 0o000);
+    expect(() => store.load()).toThrow();
+    // Restore permissions for cleanup
+    fs.chmodSync(codeFile, 0o644);
+  });
+
+  test('save sets restrictive file permissions', () => {
+    store.save('ABCD-2345');
+    const stat = fs.statSync(codeFile);
+    // 0o600 = owner read/write only
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
   test('refresh overwrites existing code', () => {
-    store.save('AAAA-1111');
+    store.save('AAAA-2222');
     const newCode = store.refresh();
-    expect(newCode).not.toBe('AAAA-1111');
+    expect(newCode).not.toBe('AAAA-2222');
     expect(store.load()).toBe(newCode);
   });
 });

--- a/packages/daemon/tests/remote/code-store.test.ts
+++ b/packages/daemon/tests/remote/code-store.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { CodeStore } from '../../src/remote/code-store.ts';
+
+describe('CodeStore', () => {
+  let tmpDir: string;
+  let codeFile: string;
+  let store: CodeStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-code-store-'));
+    codeFile = path.join(tmpDir, 'connection-code');
+    store = new CodeStore(codeFile);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('load returns null when file does not exist', () => {
+    expect(store.load()).toBeNull();
+  });
+
+  test('save and load round-trip', () => {
+    store.save('ABCD-2345');
+    expect(store.load()).toBe('ABCD-2345');
+  });
+
+  test('load returns null for invalid code format', () => {
+    fs.writeFileSync(codeFile, 'invalid-code', 'utf-8');
+    expect(store.load()).toBeNull();
+  });
+
+  test('load returns null for empty file', () => {
+    fs.writeFileSync(codeFile, '', 'utf-8');
+    expect(store.load()).toBeNull();
+  });
+
+  test('load trims whitespace', () => {
+    fs.writeFileSync(codeFile, '  WXYZ-6789\n', 'utf-8');
+    expect(store.load()).toBe('WXYZ-6789');
+  });
+
+  test('load rejects lowercase codes', () => {
+    fs.writeFileSync(codeFile, 'abcd-2345', 'utf-8');
+    expect(store.load()).toBeNull();
+  });
+
+  test('load rejects codes with ambiguous characters', () => {
+    // 0, O, 1, I, L are excluded from generation but pattern allows any uppercase + digit
+    fs.writeFileSync(codeFile, 'ABCD-0000', 'utf-8');
+    // Pattern is [A-Z]{4}-[0-9]{4}, so this is valid even with 0
+    expect(store.load()).toBe('ABCD-0000');
+  });
+
+  test('refresh generates a valid code and saves it', () => {
+    const code = store.refresh();
+    expect(code).toMatch(/^[A-Z]{4}-[0-9]{4}$/);
+    expect(store.load()).toBe(code);
+  });
+
+  test('refresh generates different codes', () => {
+    const codes = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      codes.add(store.refresh());
+    }
+    // With ~33 bits of entropy, 10 codes should all be unique
+    expect(codes.size).toBe(10);
+  });
+
+  test('save creates parent directory if needed', () => {
+    const deepFile = path.join(tmpDir, 'nested', 'dir', 'code');
+    const deepStore = new CodeStore(deepFile);
+    deepStore.save('MNPQ-5678');
+    expect(deepStore.load()).toBe('MNPQ-5678');
+  });
+
+  test('refresh overwrites existing code', () => {
+    store.save('AAAA-1111');
+    const newCode = store.refresh();
+    expect(newCode).not.toBe('AAAA-1111');
+    expect(store.load()).toBe(newCode);
+  });
+});

--- a/packages/daemon/tests/remote/signaling-client.test.ts
+++ b/packages/daemon/tests/remote/signaling-client.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { SignalingClient } from '../../src/remote/signaling-client.ts';
+
+describe('SignalingClient', () => {
+  test('connectionCode is null before connect', () => {
+    const client = new SignalingClient('wss://example.com/connect');
+    expect(client.connectionCode).toBeNull();
+    expect(client.isConnected).toBe(false);
+  });
+
+  test('connect with provided code uses that code', () => {
+    const client = new SignalingClient('wss://example.com/connect');
+    // connect() will try to create a WebSocket which will fail in test,
+    // but we can verify the code is set before the WebSocket is created
+    try {
+      client.connect('WXYZ-5678');
+    } catch {
+      // WebSocket creation may fail in test environment
+    }
+    expect(client.connectionCode).toBe('WXYZ-5678');
+    client.close();
+  });
+
+  test('connect without code generates one', () => {
+    const client = new SignalingClient('wss://example.com/connect');
+    try {
+      client.connect();
+    } catch {
+      // WebSocket creation may fail in test environment
+    }
+    const code = client.connectionCode;
+    expect(code).not.toBeNull();
+    expect(code).toMatch(/^[A-Z]{4}-[0-9]{4}$/);
+    client.close();
+  });
+
+  test('close sets isConnected to false', () => {
+    const client = new SignalingClient('wss://example.com/connect');
+    client.close();
+    expect(client.isConnected).toBe(false);
+  });
+});

--- a/packages/daemon/tests/remote/signaling-client.test.ts
+++ b/packages/daemon/tests/remote/signaling-client.test.ts
@@ -30,7 +30,7 @@ describe('SignalingClient', () => {
     }
     const code = client.connectionCode;
     expect(code).not.toBeNull();
-    expect(code).toMatch(/^[A-Z]{4}-[0-9]{4}$/);
+    expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ]{4}-[23456789]{4}$/);
     client.close();
   });
 

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -4,13 +4,16 @@
  * Manages a single signaling room for WebRTC connection establishment.
  * Handles two peers: host and client.
  *
+ * Uses WebSocket Hibernation API. Room state (code, expiresAt) is
+ * persisted to storage so join validation works after hibernation.
+ * Peer roles are tracked via WebSocket attachment metadata.
+ *
  * Note: This module uses Cloudflare Workers types which differ from Bun.
  * Type assertions are used where necessary for compatibility.
  */
 
 import {
   type ConnectionCode,
-  type PeerRole,
   type SignalingMessage,
   parseMessage,
   serializeMessage,
@@ -22,16 +25,15 @@ type DurableObjectState = any;
 // biome-ignore lint/suspicious/noExplicitAny: Cloudflare Worker runtime type
 type CFWebSocket = any;
 
-/** Session data for each connected peer */
-interface PeerSession {
-  ws: CFWebSocket;
-  role: PeerRole;
-  connectedAt: number;
-}
-
 /** Environment bindings */
 interface Env {
   CONNECTION_TIMEOUT_MS: string;
+}
+
+/** Attached to each WebSocket to track role across hibernation */
+interface WsAttachment {
+  role: 'host' | 'client';
+  urlCode?: string;
 }
 
 /**
@@ -42,10 +44,6 @@ export class ConnectionRoom {
   private readonly env: Env;
 
   private code: ConnectionCode | null = null;
-  /** Code derived from the URL path, set on first fetch */
-  private roomCode: ConnectionCode | null = null;
-  private host: PeerSession | null = null;
-  private client: PeerSession | null = null;
   private expiresAt = 0;
 
   constructor(state: DurableObjectState, env: Env) {
@@ -63,22 +61,25 @@ export class ConnectionRoom {
       return new Response('Expected WebSocket', { status: 426 });
     }
 
+    // Restore persisted state if we were hibernated
+    await this.restoreState();
+
     // Extract room code from URL path (e.g., /connect/AXBY-1234)
     const url = new URL(request.url);
     const pathMatch = url.pathname.match(/\/connect\/([A-Z0-9-]+)$/i);
-    if (pathMatch?.[1] && !this.roomCode) {
-      this.roomCode = pathMatch[1].toUpperCase() as ConnectionCode;
-    }
+    const urlCode = pathMatch?.[1]?.toUpperCase() ?? undefined;
 
     // Create WebSocket pair (Cloudflare-specific API)
-    // WebSocketPair is a Cloudflare Workers global, not available in Bun/Node
     const WebSocketPair = (globalThis as unknown as { WebSocketPair: new () => CFWebSocket[] })
       .WebSocketPair;
     const pair = new WebSocketPair();
     const [clientWs, serverWs] = pair;
 
-    // Accept the connection
+    // Accept with no tags initially; role is set via attachment on register/join
     this.state.acceptWebSocket(serverWs);
+
+    // Attach URL code so handlers can access it after hibernation wake
+    serverWs.serializeAttachment({ role: 'pending', urlCode });
 
     // webSocket property is Cloudflare-specific ResponseInit extension
     return new Response(null, { status: 101, webSocket: clientWs } as ResponseInit);
@@ -88,7 +89,6 @@ export class ConnectionRoom {
    * Handle WebSocket messages.
    */
   async webSocketMessage(ws: CFWebSocket, data: string | ArrayBuffer): Promise<void> {
-    // Parse message
     const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
     const message = parseMessage(text);
 
@@ -97,7 +97,6 @@ export class ConnectionRoom {
       return;
     }
 
-    // Route by message type
     switch (message.type) {
       case 'register':
         await this.handleRegister(ws);
@@ -109,7 +108,7 @@ export class ConnectionRoom {
       case 'answer':
       case 'ice-candidate':
       case 'relay':
-        await this.handleSignaling(ws, message);
+        this.handleSignaling(ws, message);
         break;
       default:
         this.sendError(ws, 'UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
@@ -120,33 +119,19 @@ export class ConnectionRoom {
    * Handle WebSocket close.
    */
   async webSocketClose(ws: CFWebSocket): Promise<void> {
-    // Clean up the peer
-    if (this.host?.ws === ws) {
-      const _wasHost = this.host;
-      this.host = null;
+    const attachment = ws.deserializeAttachment() as WsAttachment | null;
+    const peerWs = this.getPeer(ws);
 
-      // Notify client if connected
-      if (this.client) {
-        this.send(this.client.ws, {
-          type: 'peer-disconnected',
-          role: 'host',
-        });
-      }
-    } else if (this.client?.ws === ws) {
-      this.client = null;
-
-      // Notify host if connected
-      if (this.host) {
-        this.send(this.host.ws, {
-          type: 'peer-disconnected',
-          role: 'client',
-        });
-      }
+    if (peerWs && attachment?.role) {
+      this.send(peerWs, { type: 'peer-disconnected', role: attachment.role });
     }
 
-    // If both peers are gone, we can clean up
-    if (!this.host && !this.client) {
+    // If no more connected sockets, clean up
+    const remaining = this.state.getWebSockets().filter((s: CFWebSocket) => s !== ws);
+    if (remaining.length === 0) {
       this.code = null;
+      this.expiresAt = 0;
+      await this.state.storage.deleteAll();
     }
   }
 
@@ -154,7 +139,6 @@ export class ConnectionRoom {
    * Handle WebSocket error.
    */
   async webSocketError(ws: CFWebSocket, _error: Error): Promise<void> {
-    // Just close the connection on error
     await this.webSocketClose(ws);
   }
 
@@ -162,30 +146,30 @@ export class ConnectionRoom {
    * Handle host registration.
    */
   private async handleRegister(ws: CFWebSocket): Promise<void> {
-    // Check if already registered
-    if (this.host) {
+    // Check if already have a host
+    if (this.findByRole('host')) {
       this.sendError(ws, 'ALREADY_REGISTERED', 'Room already has a host');
       return;
     }
 
-    // Use the URL-derived code (set during fetch) as the room code.
-    // Both host and client connect to the same URL, so the code matches.
-    if (!this.roomCode) {
+    // Get URL code from attachment
+    const attachment = ws.deserializeAttachment() as WsAttachment | null;
+    const urlCode = attachment?.urlCode;
+    if (!urlCode) {
       this.sendError(ws, 'INTERNAL_ERROR', 'Room code not available');
       return;
     }
-    this.code = this.roomCode;
+    this.code = urlCode as ConnectionCode;
 
     // Set expiration
     const timeoutMs = Number.parseInt(this.env.CONNECTION_TIMEOUT_MS) || 300000;
     this.expiresAt = Date.now() + timeoutMs;
 
-    // Register as host
-    this.host = {
-      ws,
-      role: 'host',
-      connectedAt: Date.now(),
-    };
+    // Mark this WebSocket as host
+    ws.serializeAttachment({ role: 'host', urlCode });
+
+    // Persist state to survive hibernation
+    await this.state.storage.put({ code: this.code, expiresAt: this.expiresAt });
 
     // Send registration confirmation
     this.send(ws, {
@@ -202,8 +186,11 @@ export class ConnectionRoom {
    * Handle client joining with code.
    */
   private async handleJoin(ws: CFWebSocket, code: ConnectionCode): Promise<void> {
+    // Restore state if needed (hibernation recovery)
+    await this.restoreState();
+
     // Validate code
-    if (this.code !== code) {
+    if (!this.code || this.code !== code) {
       this.sendError(ws, 'INVALID_CODE', 'Connection code not found or expired');
       return;
     }
@@ -215,62 +202,40 @@ export class ConnectionRoom {
     }
 
     // Check if already have a client
-    if (this.client) {
+    if (this.findByRole('client')) {
       this.sendError(ws, 'ROOM_FULL', 'Room already has a client');
       return;
     }
 
-    // Register as client
-    this.client = {
-      ws,
-      role: 'client',
-      connectedAt: Date.now(),
-    };
+    // Mark this WebSocket as client
+    const attachment = ws.deserializeAttachment() as WsAttachment | null;
+    ws.serializeAttachment({ role: 'client', urlCode: attachment?.urlCode });
 
     // Send join confirmation
-    this.send(ws, {
-      type: 'joined',
-      code: this.code,
-    });
+    this.send(ws, { type: 'joined', code: this.code });
 
     // Notify both peers
-    if (this.host) {
-      this.send(this.host.ws, {
-        type: 'peer-connected',
-        role: 'client',
-      });
-      this.send(ws, {
-        type: 'peer-connected',
-        role: 'host',
-      });
+    const hostWs = this.findByRole('host');
+    if (hostWs) {
+      this.send(hostWs, { type: 'peer-connected', role: 'client' });
+      this.send(ws, { type: 'peer-connected', role: 'host' });
     }
   }
 
   /**
-   * Handle signaling messages (offer, answer, ice-candidate).
+   * Handle signaling messages (offer, answer, ice-candidate, relay).
    */
-  private async handleSignaling(ws: CFWebSocket, message: SignalingMessage): Promise<void> {
-    // Determine sender and target
-    let target: PeerSession | null = null;
-
-    if (this.host?.ws === ws) {
-      target = this.client;
-    } else if (this.client?.ws === ws) {
-      target = this.host;
-    }
+  private handleSignaling(ws: CFWebSocket, message: SignalingMessage): void {
+    const target = this.getPeer(ws);
 
     if (!target) {
       this.sendError(ws, 'NO_PEER', 'No peer connected to forward message');
       return;
     }
 
-    // Forward the message
-    this.send(target.ws, message);
+    this.send(target, message);
   }
 
-  /**
-   * Send a message to a WebSocket.
-   */
   private send(ws: CFWebSocket, message: SignalingMessage): boolean {
     try {
       ws.send(serializeMessage(message));
@@ -281,44 +246,74 @@ export class ConnectionRoom {
     }
   }
 
-  /**
-   * Send an error message.
-   */
   private sendError(ws: CFWebSocket, code: string, message: string): void {
-    this.send(ws, {
-      type: 'error',
-      code,
-      message,
-    });
+    this.send(ws, { type: 'error', code, message });
   }
 
-  /**
-   * Schedule cleanup after timeout.
-   */
   private scheduleCleanup(timeoutMs: number): void {
-    // Cloudflare Workers don't support setTimeout in Durable Objects directly
-    // Instead, we use alarms
     this.state.storage.setAlarm(Date.now() + timeoutMs);
   }
 
-  /**
-   * Handle alarm for cleanup.
-   */
   async alarm(): Promise<void> {
-    // Check if expired
+    await this.restoreState();
+
     if (Date.now() > this.expiresAt) {
-      // Close all connections
-      if (this.host) {
-        this.sendError(this.host.ws, 'EXPIRED', 'Connection code has expired');
-        this.host.ws.close();
-        this.host = null;
+      const hostWs = this.findByRole('host');
+      const clientWs = this.findByRole('client');
+
+      if (hostWs) {
+        this.sendError(hostWs, 'EXPIRED', 'Connection code has expired');
+        hostWs.close();
       }
-      if (this.client) {
-        this.sendError(this.client.ws, 'EXPIRED', 'Connection code has expired');
-        this.client.ws.close();
-        this.client = null;
+      if (clientWs) {
+        this.sendError(clientWs, 'EXPIRED', 'Connection code has expired');
+        clientWs.close();
       }
+
       this.code = null;
+      this.expiresAt = 0;
+      await this.state.storage.deleteAll();
     }
+  }
+
+  /**
+   * Restore persisted state from storage (after hibernation).
+   */
+  private async restoreState(): Promise<void> {
+    if (this.code) return;
+
+    const stored = await this.state.storage.get(['code', 'expiresAt']);
+    if (stored) {
+      this.code = (stored.get('code') as ConnectionCode) ?? null;
+      this.expiresAt = (stored.get('expiresAt') as number) ?? 0;
+    }
+  }
+
+  /**
+   * Find a connected WebSocket by its role attachment.
+   */
+  private findByRole(role: string): CFWebSocket | null {
+    const sockets = this.state.getWebSockets();
+    for (const ws of sockets) {
+      const attachment = ws.deserializeAttachment() as WsAttachment | null;
+      if (attachment?.role === role) return ws;
+    }
+    return null;
+  }
+
+  /**
+   * Get the peer WebSocket (the other connected socket).
+   */
+  private getPeer(ws: CFWebSocket): CFWebSocket | null {
+    const sockets = this.state.getWebSockets();
+    for (const s of sockets) {
+      if (s !== ws) {
+        const attachment = s.deserializeAttachment() as WsAttachment | null;
+        if (attachment?.role === 'host' || attachment?.role === 'client') {
+          return s;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -8,7 +8,6 @@
  * Type assertions are used where necessary for compatibility.
  */
 
-import { generateCode } from './code-generator.ts';
 import {
   type ConnectionCode,
   type PeerRole,
@@ -43,6 +42,8 @@ export class ConnectionRoom {
   private readonly env: Env;
 
   private code: ConnectionCode | null = null;
+  /** Code derived from the URL path, set on first fetch */
+  private roomCode: ConnectionCode | null = null;
   private host: PeerSession | null = null;
   private client: PeerSession | null = null;
   private expiresAt = 0;
@@ -60,6 +61,13 @@ export class ConnectionRoom {
     const upgradeHeader = request.headers.get('Upgrade');
     if (upgradeHeader !== 'websocket') {
       return new Response('Expected WebSocket', { status: 426 });
+    }
+
+    // Extract room code from URL path (e.g., /connect/AXBY-1234)
+    const url = new URL(request.url);
+    const pathMatch = url.pathname.match(/\/connect\/([A-Z0-9-]+)$/i);
+    if (pathMatch?.[1] && !this.roomCode) {
+      this.roomCode = pathMatch[1].toUpperCase() as ConnectionCode;
     }
 
     // Create WebSocket pair (Cloudflare-specific API)
@@ -160,8 +168,13 @@ export class ConnectionRoom {
       return;
     }
 
-    // Generate connection code
-    this.code = generateCode();
+    // Use the URL-derived code (set during fetch) as the room code.
+    // Both host and client connect to the same URL, so the code matches.
+    if (!this.roomCode) {
+      this.sendError(ws, 'INTERNAL_ERROR', 'Room code not available');
+      return;
+    }
+    this.code = this.roomCode;
 
     // Set expiration
     const timeoutMs = Number.parseInt(this.env.CONNECTION_TIMEOUT_MS) || 300000;

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -64,9 +64,9 @@ export default {
         );
       }
 
-      // Rate limit per client IP
-      const clientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
-      if (!rateLimiter.check(clientIp)) {
+      // Rate limit per client IP (skip if IP unavailable)
+      const clientIp = request.headers.get('CF-Connecting-IP');
+      if (clientIp && !rateLimiter.check(clientIp)) {
         return new Response(
           JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many connection attempts' }),
           { status: 429, headers: { 'Content-Type': 'application/json', 'Retry-After': '60' } },

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -11,6 +11,7 @@
 
 import { normalizeCode } from './code-generator.ts';
 import { ConnectionRoom } from './connection-room.ts';
+import { RateLimiter } from './rate-limiter.ts';
 
 // Cloudflare-specific types
 // biome-ignore lint/suspicious/noExplicitAny: Cloudflare Worker runtime type
@@ -22,6 +23,9 @@ interface Env {
   MAX_CONNECTIONS_PER_ROOM: string;
   CONNECTION_TIMEOUT_MS: string;
 }
+
+/** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
+const rateLimiter = new RateLimiter(10, 60_000);
 
 /** Main worker */
 export default {
@@ -60,11 +64,20 @@ export default {
         );
       }
 
+      // Rate limit per client IP
+      const clientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      if (!rateLimiter.check(clientIp)) {
+        return new Response(
+          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many connection attempts' }),
+          { status: 429, headers: { 'Content-Type': 'application/json', 'Retry-After': '60' } },
+        );
+      }
+
       // Both host and client connect to the same code-named Durable Object
       const id = env.CONNECTIONS.idFromName(code);
       const room = env.CONNECTIONS.get(id);
 
-      // Forward the WebSocket upgrade request
+      // Forward the WebSocket upgrade request (URL contains the code for the DO to extract)
       return room.fetch(request);
     }
 

--- a/packages/signaling/src/rate-limiter.ts
+++ b/packages/signaling/src/rate-limiter.ts
@@ -1,9 +1,10 @@
 /**
- * Sliding-window rate limiter for the signaling worker.
+ * Fixed-window rate limiter for the signaling worker.
  *
  * Tracks request counts per key (typically client IP) within a time window.
- * Workers reuse isolates across requests, so in-memory state persists
- * for the lifetime of the isolate (typically minutes to hours).
+ * When the window expires, the counter resets. Workers reuse isolates
+ * across requests, so in-memory state persists for the lifetime of the
+ * isolate (typically minutes to hours).
  */
 
 interface WindowEntry {

--- a/packages/signaling/src/rate-limiter.ts
+++ b/packages/signaling/src/rate-limiter.ts
@@ -1,0 +1,52 @@
+/**
+ * Sliding-window rate limiter for the signaling worker.
+ *
+ * Tracks request counts per key (typically client IP) within a time window.
+ * Workers reuse isolates across requests, so in-memory state persists
+ * for the lifetime of the isolate (typically minutes to hours).
+ */
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+}
+
+export class RateLimiter {
+  private readonly windows = new Map<string, WindowEntry>();
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+  private lastCleanup = 0;
+  private readonly cleanupIntervalMs: number;
+
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+    this.cleanupIntervalMs = windowMs * 2;
+  }
+
+  /** Returns true if the request is allowed, false if rate-limited. */
+  check(key: string): boolean {
+    const now = Date.now();
+    this.maybeCleanup(now);
+
+    const entry = this.windows.get(key);
+    if (!entry || now - entry.windowStart >= this.windowMs) {
+      this.windows.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+
+    entry.count++;
+    return entry.count <= this.maxRequests;
+  }
+
+  private maybeCleanup(now: number): void {
+    if (now - this.lastCleanup < this.cleanupIntervalMs) return;
+    this.lastCleanup = now;
+
+    for (const [key, entry] of this.windows) {
+      if (now - entry.windowStart >= this.windowMs) {
+        this.windows.delete(key);
+      }
+    }
+  }
+}

--- a/packages/signaling/tests/rate-limiter.test.ts
+++ b/packages/signaling/tests/rate-limiter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { RateLimiter } from '../src/rate-limiter.ts';
+
+describe('RateLimiter', () => {
+  test('allows requests under the limit', () => {
+    const limiter = new RateLimiter(5, 60_000);
+    for (let i = 0; i < 5; i++) {
+      expect(limiter.check('192.168.1.1')).toBe(true);
+    }
+  });
+
+  test('blocks requests over the limit', () => {
+    const limiter = new RateLimiter(3, 60_000);
+    expect(limiter.check('10.0.0.1')).toBe(true);
+    expect(limiter.check('10.0.0.1')).toBe(true);
+    expect(limiter.check('10.0.0.1')).toBe(true);
+    expect(limiter.check('10.0.0.1')).toBe(false);
+    expect(limiter.check('10.0.0.1')).toBe(false);
+  });
+
+  test('tracks different keys independently', () => {
+    const limiter = new RateLimiter(2, 60_000);
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(false);
+    // Different key should still be allowed
+    expect(limiter.check('ip-b')).toBe(true);
+    expect(limiter.check('ip-b')).toBe(true);
+    expect(limiter.check('ip-b')).toBe(false);
+  });
+
+  test('resets after window expires', async () => {
+    const limiter = new RateLimiter(2, 50); // 50ms window
+    expect(limiter.check('key')).toBe(true);
+    expect(limiter.check('key')).toBe(true);
+    expect(limiter.check('key')).toBe(false);
+
+    // Wait for window to expire
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(limiter.check('key')).toBe(true);
+  });
+
+  test('allows exactly max requests', () => {
+    const limiter = new RateLimiter(10, 60_000);
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.check('client')).toBe(true);
+    }
+    expect(limiter.check('client')).toBe(false);
+  });
+
+  test('handles single-request limit', () => {
+    const limiter = new RateLimiter(1, 60_000);
+    expect(limiter.check('once')).toBe(true);
+    expect(limiter.check('once')).toBe(false);
+  });
+});

--- a/packages/signaling/wrangler.toml
+++ b/packages/signaling/wrangler.toml
@@ -14,6 +14,13 @@ class_name = "ConnectionRoom"
 tag = "v1"
 new_sqlite_classes = ["ConnectionRoom"]
 
+[[migrations]]
+tag = "v2"
+
+[[migrations]]
+tag = "v3"
+deleted_classes = ["DeviceRoom"]
+
 # Development settings
 [dev]
 port = 8787

--- a/packages/signaling/wrangler.toml
+++ b/packages/signaling/wrangler.toml
@@ -21,6 +21,6 @@ local_protocol = "http"
 
 # Environment variables
 [vars]
-MAX_CONNECTIONS_PER_ROOM = "100"
+MAX_CONNECTIONS_PER_ROOM = "2"
 CONNECTION_TIMEOUT_MS = "300000"  # 5 minutes
 CODE_LENGTH = "8"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -400,9 +400,13 @@ function App() {
 
   // Relay-aware send: dispatches through signaling client when in relay mode
   const relaySend = useCallback((message: ProtocolMessage): boolean => {
-    if (connectionMode === 'relay' && signalingClientRef.current?.isConnected) {
-      signalingClientRef.current.sendMessage(message);
-      return true;
+    if (connectionMode === 'relay') {
+      if (signalingClientRef.current?.isConnected) {
+        signalingClientRef.current.sendMessage(message);
+        return true;
+      }
+      console.warn(`Relay send dropped (not connected): ${message.type}`);
+      return false;
     }
     return false;
   }, [connectionMode]);
@@ -611,6 +615,10 @@ function App() {
 
       signalingClientRef.current = client;
       client.connect(signalingUrl, code);
+    }).catch((err) => {
+      console.error('Failed to load signaling client:', err);
+      setRelayStatus('disconnected');
+      setConnectionMode('direct');
     });
   }, []);
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,7 +12,15 @@ import { useWebSocket } from '@/hooks';
 import type { AppSettings, UIBullet, UIMessage, UIQuestion, UISession } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
-import { generateId } from '@remi/shared/protocol.ts';
+import {
+  createBulletExpandRequest,
+  createCreateSessionRequest,
+  createSessionListRequest,
+  createTranscriptLoadRequest,
+  createUserInput,
+  generateId,
+  now,
+} from '@remi/shared/protocol.ts';
 import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -368,6 +376,10 @@ function App() {
     () => localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null,
   );
 
+  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
+  const [connectionMode, setConnectionMode] = useState<'direct' | 'relay'>('direct');
+  const [relayStatus, setRelayStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
+
   const {
     status: connectionStatus,
     error: wsError,
@@ -383,6 +395,51 @@ function App() {
 
   const error = wsError?.message ?? null;
 
+  // Effective connection status: use relay status when in relay mode
+  const effectiveStatus = connectionMode === 'relay' ? relayStatus : connectionStatus;
+
+  // Relay-aware send: dispatches through signaling client when in relay mode
+  const relaySend = useCallback((message: ProtocolMessage): boolean => {
+    if (connectionMode === 'relay' && signalingClientRef.current?.isConnected) {
+      signalingClientRef.current.sendMessage(message);
+      return true;
+    }
+    return false;
+  }, [connectionMode]);
+
+  // Relay-aware wrappers for send functions
+  const effectiveSendInput = useCallback((sessionId: UUID, content: string): boolean => {
+    if (connectionMode === 'relay') return relaySend(createUserInput(sessionId, content));
+    return sendInput(sessionId, content);
+  }, [connectionMode, relaySend, sendInput]);
+
+  const effectiveSendAnswer = useCallback((questionId: UUID, answer: string): boolean => {
+    if (connectionMode === 'relay') {
+      return relaySend({ type: 'answer', id: generateId(), timestamp: now(), questionId, answer });
+    }
+    return sendAnswer(questionId, answer);
+  }, [connectionMode, relaySend, sendAnswer]);
+
+  const effectiveRequestBulletExpand = useCallback((sessionId: UUID, bulletId: number): boolean => {
+    if (connectionMode === 'relay') return relaySend(createBulletExpandRequest(sessionId, bulletId));
+    return requestBulletExpand(sessionId, bulletId);
+  }, [connectionMode, relaySend, requestBulletExpand]);
+
+  const effectiveRequestSessionList = useCallback((includeExternal?: boolean): boolean => {
+    if (connectionMode === 'relay') return relaySend(createSessionListRequest(includeExternal));
+    return requestSessionList(includeExternal);
+  }, [connectionMode, relaySend, requestSessionList]);
+
+  const effectiveRequestTranscriptLoad = useCallback((sessionId: string): boolean => {
+    if (connectionMode === 'relay') return relaySend(createTranscriptLoadRequest(sessionId));
+    return requestTranscriptLoad(sessionId);
+  }, [connectionMode, relaySend, requestTranscriptLoad]);
+
+  const effectiveRequestNewSession = useCallback((directory?: string): boolean => {
+    if (connectionMode === 'relay') return relaySend(createCreateSessionRequest(directory));
+    return requestNewSession(directory);
+  }, [connectionMode, relaySend, requestNewSession]);
+
   // Close modal and store URL on successful connect
   useEffect(() => {
     if (connectionStatus === 'connected') {
@@ -390,12 +447,19 @@ function App() {
     }
   }, [connectionStatus]);
 
-  // Request session list after connection
+  // Request session list after direct connection
   useEffect(() => {
     if (connectionStatus === 'connected' && wsSessionId) {
-      requestSessionList(true);
+      effectiveRequestSessionList(true);
     }
-  }, [connectionStatus, wsSessionId, requestSessionList]);
+  }, [connectionStatus, wsSessionId, effectiveRequestSessionList]);
+
+  // Request session list after relay connection (hello_ack received)
+  useEffect(() => {
+    if (connectionMode === 'relay' && relayStatus === 'connected' && activeSessionId) {
+      effectiveRequestSessionList(true);
+    }
+  }, [connectionMode, relayStatus, activeSessionId, effectiveRequestSessionList]);
 
   // Auto-connect from localStorage on mount (run once)
   const connectRef = useRef(connect);
@@ -427,9 +491,9 @@ function App() {
       setSessions((prev) =>
         prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
       );
-      requestTranscriptLoad(id);
+      effectiveRequestTranscriptLoad(id);
     }
-  }, [sessions, requestTranscriptLoad]);
+  }, [sessions, effectiveRequestTranscriptLoad]);
 
   const handleBack = useCallback(() => {
     setActiveSessionId(null);
@@ -441,7 +505,7 @@ function App() {
 
       // If there's an active question, send as answer
       if (sessionQuestion) {
-        sendAnswer(sessionQuestion.id, content);
+        effectiveSendAnswer(sessionQuestion.id, content);
         setQuestion(null);
         // Add user message to UI
         const userMsg: UIMessage = {
@@ -470,25 +534,30 @@ function App() {
 
       setMessages((prev) => [...prev, newMessage]);
 
-      const success = sendInput(activeSessionId, content);
+      const success = effectiveSendInput(activeSessionId, content);
       if (success) {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
         );
       }
     },
-    [activeSessionId, sendInput, sendAnswer, sessionQuestion],
+    [activeSessionId, effectiveSendInput, effectiveSendAnswer, sessionQuestion],
   );
 
   const handleConnectDirect = useCallback(
     (url: string, directory?: string) => {
+      setConnectionMode('direct');
+      // Close any existing relay connection
+      if (signalingClientRef.current) {
+        signalingClientRef.current.close();
+        signalingClientRef.current = null;
+        setRelayStatus('disconnected');
+      }
       localStorage.setItem(LOCALSTORAGE_URL_KEY, url);
       connect(url, directory);
     },
     [connect],
   );
-
-  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
 
   // Clean up signaling client on unmount
   useEffect(() => {
@@ -505,20 +574,28 @@ function App() {
         signalingClientRef.current.close();
       }
 
+      setConnectionMode('relay');
+      setRelayStatus('connecting');
+
       const signalingUrl = 'wss://remi-signaling.dev-941.workers.dev/connect';
       const client = new WebSignalingClient({
         onStateChange: (state) => {
           if (state === 'connected') {
+            setRelayStatus('connected');
             setShowConnectModal(false);
             // Send hello via relay
-            const hello = {
+            const hello: ProtocolMessage = {
               type: 'hello',
               id: generateId(),
-              timestamp: new Date().toISOString(),
+              timestamp: now(),
               clientId: 'remi-web',
               clientVersion: '0.1.0',
             };
             client.sendMessage(hello);
+          } else if (state === 'connecting' || state === 'joined') {
+            setRelayStatus('connecting');
+          } else if (state === 'disconnected' || state === 'error') {
+            setRelayStatus('disconnected');
           }
         },
         onMessage: (message) => {
@@ -554,16 +631,16 @@ function App() {
         }),
       );
 
-      requestBulletExpand(activeSessionId, bulletId);
+      effectiveRequestBulletExpand(activeSessionId, bulletId);
     },
-    [activeSessionId, requestBulletExpand],
+    [activeSessionId, effectiveRequestBulletExpand],
   );
 
   const handleNewSession = useCallback(() => {
     if (creatingSession) return;
     setCreatingSession(true);
-    requestNewSession();
-  }, [requestNewSession, creatingSession]);
+    effectiveRequestNewSession();
+  }, [effectiveRequestNewSession, creatingSession]);
 
   // Menu actions
   const handleCopyConversation = useCallback(() => {
@@ -593,7 +670,7 @@ function App() {
   }, [sessionMessages, activeSessionId]);
 
   // Sidebar content
-  const canCreateSession = connectionStatus === 'connected' && !creatingSession;
+  const canCreateSession = effectiveStatus === 'connected' && !creatingSession;
   const sidebar = (
     <SessionList
       sessions={sessions}
@@ -641,7 +718,7 @@ function App() {
         onClose={() => setShowConnectModal(false)}
         onConnectDirect={handleConnectDirect}
         onConnectCode={handleConnectCode}
-        connectionStatus={connectionStatus}
+        connectionStatus={effectiveStatus}
         error={null}
       />
     </>


### PR DESCRIPTION
## Summary

- Fix critical code mismatch bug in signaling server: `ConnectionRoom.handleRegister()` was generating a new code via `generateCode()` instead of using the URL-derived code, causing host and client to end up in different Durable Object rooms
- Add per-IP rate limiting (10 connections/min) to protect signaling server from abuse
- Make relay adapter always-on (removed `--remote` flag requirement)
- Add persistent connection codes stored in `~/.remi/connection-code`
- Add `remi code` and `remi code --refresh` subcommands
- Fix web client relay gap: all messages now route through signaling relay when connected via code (previously only `hello` went through relay, all subsequent messages went to null WebSocket)
- Tighten room limit from 100 to 2 (relay rooms only need host + client)

## Changes

| File | Change |
|------|--------|
| `packages/signaling/src/connection-room.ts` | Use URL-derived code instead of `generateCode()` |
| `packages/signaling/src/index.ts` | Add rate limiting before routing to Durable Object |
| `packages/signaling/src/rate-limiter.ts` | New sliding-window per-IP rate limiter |
| `packages/signaling/wrangler.toml` | MAX_CONNECTIONS_PER_ROOM: 100 -> 2 |
| `packages/daemon/src/cli.ts` | Always-on relay, `remi code` subcommand, removed `--remote` flag |
| `packages/daemon/src/remote/code-store.ts` | New persistent code storage class |
| `packages/daemon/src/remote/signaling-client.ts` | Accept optional pre-set code in `connect()` |
| `packages/daemon/src/remote/relay-adapter.ts` | Pass persistent code to SignalingClient |
| `packages/web/src/App.tsx` | Relay-aware send wrappers, connection mode tracking |

## Test plan

- [x] All 669 tests pass (21 new tests added)
- [x] Biome check clean
- [x] TypeScript typecheck clean
- [x] Web app builds successfully
- [ ] Manual: start daemon, verify connection code printed
- [ ] Manual: `remi code` shows same code
- [ ] Manual: `remi code --refresh` generates new code
- [ ] Manual: web client connects via code with bidirectional messaging
- [ ] Manual: deploy signaling worker with rate limiting

Closes #21