### PR TITLE
npm distribution with platform-specific packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -65,3 +66,57 @@ jobs:
             artifacts/remi-darwin-x64/remi-darwin-x64
             artifacts/remi-linux-x64/remi-linux-x64
             artifacts/remi-linux-arm64/remi-linux-arm64
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare npm packages
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            mkdir -p npm/remi-$PLAT/bin
+            cp "artifacts/remi-$PLAT/remi-$PLAT" "npm/remi-$PLAT/bin/remi"
+            chmod +x "npm/remi-$PLAT/bin/remi"
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('npm/remi-$PLAT/package.json', 'utf8'));
+              pkg.version = '$VERSION';
+              fs.writeFileSync('npm/remi-$PLAT/package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+          done
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('npm/remi/package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            for (const key of Object.keys(pkg.optionalDependencies || {})) {
+              pkg.optionalDependencies[key] = '$VERSION';
+            }
+            fs.writeFileSync('npm/remi/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish platform packages
+        run: |
+          for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            cd npm/remi-$PLAT
+            npm publish --provenance --access public
+            cd ../..
+          done
+
+      - name: Publish main package
+        run: |
+          cd npm/remi
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,34 +86,42 @@ jobs:
 
       - name: Prepare npm packages
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
+          if [[ -z "$VERSION" || ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
+            echo "ERROR: Invalid version from tag: '${GITHUB_REF_NAME}'" >&2
+            exit 1
+          fi
+          echo "Publishing version: $VERSION"
+          REPO_ROOT="$(pwd)"
           for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
             mkdir -p npm/remi-$PLAT/bin
             cp "artifacts/remi-$PLAT/remi-$PLAT" "npm/remi-$PLAT/bin/remi"
             chmod +x "npm/remi-$PLAT/bin/remi"
-            node -e "
+            PLAT_PKG="$REPO_ROOT/npm/remi-$PLAT/package.json" PKG_VERSION="$VERSION" node -e "
               const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('npm/remi-$PLAT/package.json', 'utf8'));
-              pkg.version = '$VERSION';
-              fs.writeFileSync('npm/remi-$PLAT/package.json', JSON.stringify(pkg, null, 2) + '\n');
+              const pkg = JSON.parse(fs.readFileSync(process.env.PLAT_PKG, 'utf8'));
+              pkg.version = process.env.PKG_VERSION;
+              fs.writeFileSync(process.env.PLAT_PKG, JSON.stringify(pkg, null, 2) + '\n');
             "
           done
-          node -e "
+          MAIN_PKG="$REPO_ROOT/npm/remi/package.json" PKG_VERSION="$VERSION" node -e "
             const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('npm/remi/package.json', 'utf8'));
-            pkg.version = '$VERSION';
+            const pkg = JSON.parse(fs.readFileSync(process.env.MAIN_PKG, 'utf8'));
+            pkg.version = process.env.PKG_VERSION;
             for (const key of Object.keys(pkg.optionalDependencies || {})) {
-              pkg.optionalDependencies[key] = '$VERSION';
+              pkg.optionalDependencies[key] = process.env.PKG_VERSION;
             }
-            fs.writeFileSync('npm/remi/package.json', JSON.stringify(pkg, null, 2) + '\n');
+            fs.writeFileSync(process.env.MAIN_PKG, JSON.stringify(pkg, null, 2) + '\n');
           "
 
       - name: Publish platform packages
         run: |
+          set -euo pipefail
+          REPO_ROOT="$(pwd)"
           for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
-            cd npm/remi-$PLAT
-            npm publish --provenance --access public
-            cd ../..
+            echo "Publishing @yooz-labs/remi-$PLAT..."
+            (cd "$REPO_ROOT/npm/remi-$PLAT" && npm publish --provenance --access public)
           done
 
       - name: Publish main package

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 .output/
 *.tsbuildinfo
 
+# npm platform binaries (copied at build/publish time)
+npm/remi-*/bin/
+
 # Bun
 bun.lockb
 *.bun-build

--- a/npm/remi-darwin-arm64/package.json
+++ b/npm/remi-darwin-arm64/package.json
@@ -7,11 +7,8 @@
     "type": "git",
     "url": "https://github.com/yooz-labs/remi"
   },
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "preferUnplugged": true
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "preferUnplugged": true,
+  "files": ["bin/remi"]
 }

--- a/npm/remi-darwin-arm64/package.json
+++ b/npm/remi-darwin-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@yooz-labs/remi-darwin-arm64",
+  "version": "0.1.0",
+  "description": "Remi binary for macOS ARM64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yooz-labs/remi"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "preferUnplugged": true
+}

--- a/npm/remi-darwin-x64/package.json
+++ b/npm/remi-darwin-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@yooz-labs/remi-darwin-x64",
+  "version": "0.1.0",
+  "description": "Remi binary for macOS x64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yooz-labs/remi"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "preferUnplugged": true
+}

--- a/npm/remi-darwin-x64/package.json
+++ b/npm/remi-darwin-x64/package.json
@@ -7,11 +7,8 @@
     "type": "git",
     "url": "https://github.com/yooz-labs/remi"
   },
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "preferUnplugged": true
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "preferUnplugged": true,
+  "files": ["bin/remi"]
 }

--- a/npm/remi-linux-arm64/package.json
+++ b/npm/remi-linux-arm64/package.json
@@ -7,11 +7,8 @@
     "type": "git",
     "url": "https://github.com/yooz-labs/remi"
   },
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "preferUnplugged": true
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "preferUnplugged": true,
+  "files": ["bin/remi"]
 }

--- a/npm/remi-linux-arm64/package.json
+++ b/npm/remi-linux-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@yooz-labs/remi-linux-arm64",
+  "version": "0.1.0",
+  "description": "Remi binary for Linux ARM64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yooz-labs/remi"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "preferUnplugged": true
+}

--- a/npm/remi-linux-x64/package.json
+++ b/npm/remi-linux-x64/package.json
@@ -7,11 +7,8 @@
     "type": "git",
     "url": "https://github.com/yooz-labs/remi"
   },
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "preferUnplugged": true
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "preferUnplugged": true,
+  "files": ["bin/remi"]
 }

--- a/npm/remi-linux-x64/package.json
+++ b/npm/remi-linux-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@yooz-labs/remi-linux-x64",
+  "version": "0.1.0",
+  "description": "Remi binary for Linux x64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yooz-labs/remi"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "preferUnplugged": true
+}

--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process");
+const path = require("path");
+const os = require("os");
+
+const PLATFORMS = {
+  "darwin-arm64": "@yooz-labs/remi-darwin-arm64",
+  "darwin-x64": "@yooz-labs/remi-darwin-x64",
+  "linux-arm64": "@yooz-labs/remi-linux-arm64",
+  "linux-x64": "@yooz-labs/remi-linux-x64",
+};
+
+const platform = os.platform();
+const arch = os.arch();
+const key = `${platform}-${arch}`;
+const pkg = PLATFORMS[key];
+
+if (!pkg) {
+  console.error(`Unsupported platform: ${key}`);
+  console.error("Remi supports: darwin-arm64, darwin-x64, linux-arm64, linux-x64");
+  process.exit(1);
+}
+
+let binPath;
+try {
+  const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+  binPath = path.join(pkgDir, "bin", "remi");
+} catch {
+  console.error(`Platform package ${pkg} is not installed.`);
+  console.error("Try reinstalling: npm install -g @yooz-labs/remi");
+  process.exit(1);
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+});
+
+process.exit(result.status ?? 1);

--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
@@ -26,8 +27,18 @@ let binPath;
 try {
   const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
   binPath = path.join(pkgDir, "bin", "remi");
-} catch {
-  console.error(`Platform package ${pkg} is not installed.`);
+} catch (err) {
+  if (err.code === "MODULE_NOT_FOUND") {
+    console.error(`Platform package ${pkg} is not installed.`);
+  } else {
+    console.error(`Failed to resolve ${pkg}: ${err.message}`);
+  }
+  console.error("Try reinstalling: npm install -g @yooz-labs/remi");
+  process.exit(1);
+}
+
+if (!fs.existsSync(binPath)) {
+  console.error(`Remi binary not found at: ${binPath}`);
   console.error("Try reinstalling: npm install -g @yooz-labs/remi");
   process.exit(1);
 }
@@ -36,5 +47,13 @@ const result = spawnSync(binPath, process.argv.slice(2), {
   stdio: "inherit",
   env: process.env,
 });
+
+if (result.error) {
+  console.error(`Failed to execute remi: ${result.error.message}`);
+  if (result.error.code === "EACCES") {
+    console.error(`Try: chmod +x "${binPath}"`);
+  }
+  process.exit(1);
+}
 
 process.exit(result.status ?? 1);

--- a/npm/remi/package.json
+++ b/npm/remi/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@yooz-labs/remi",
+  "version": "0.1.0",
+  "description": "Remote monitor for Claude Code CLI sessions",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yooz-labs/remi"
+  },
+  "homepage": "https://github.com/yooz-labs/remi",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "cli",
+    "monitor",
+    "remote",
+    "terminal"
+  ],
+  "bin": {
+    "remi": "bin/remi"
+  },
+  "optionalDependencies": {
+    "@yooz-labs/remi-darwin-arm64": "0.1.0",
+    "@yooz-labs/remi-darwin-x64": "0.1.0",
+    "@yooz-labs/remi-linux-arm64": "0.1.0",
+    "@yooz-labs/remi-linux-x64": "0.1.0"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/npm/remi/package.json
+++ b/npm/remi/package.json
@@ -8,14 +8,7 @@
     "url": "https://github.com/yooz-labs/remi"
   },
   "homepage": "https://github.com/yooz-labs/remi",
-  "keywords": [
-    "claude",
-    "claude-code",
-    "cli",
-    "monitor",
-    "remote",
-    "terminal"
-  ],
+  "keywords": ["claude", "claude-code", "cli", "monitor", "remote", "terminal"],
   "bin": {
     "remi": "bin/remi"
   },

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION="${1:?Usage: publish-npm.sh <version> [--dry-run]}"
+DRY_RUN=""
+if [[ "${2:-}" == "--dry-run" ]]; then
+  DRY_RUN="--dry-run"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+NPM_DIR="$ROOT_DIR/npm"
+
+PLATFORMS=("darwin-arm64" "darwin-x64" "linux-arm64" "linux-x64")
+
+echo "==> Building all platform binaries..."
+cd "$ROOT_DIR"
+bun run build:all
+
+echo "==> Updating versions to $VERSION..."
+
+# Update main package version and optionalDependencies versions
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('$NPM_DIR/remi/package.json', 'utf8'));
+pkg.version = '$VERSION';
+for (const key of Object.keys(pkg.optionalDependencies || {})) {
+  pkg.optionalDependencies[key] = '$VERSION';
+}
+fs.writeFileSync('$NPM_DIR/remi/package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+for PLAT in "${PLATFORMS[@]}"; do
+  PLAT_DIR="$NPM_DIR/remi-$PLAT"
+
+  # Update version
+  node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('$PLAT_DIR/package.json', 'utf8'));
+  pkg.version = '$VERSION';
+  fs.writeFileSync('$PLAT_DIR/package.json', JSON.stringify(pkg, null, 2) + '\n');
+  "
+
+  # Copy binary
+  mkdir -p "$PLAT_DIR/bin"
+  cp "$ROOT_DIR/dist/remi-$PLAT" "$PLAT_DIR/bin/remi"
+  chmod +x "$PLAT_DIR/bin/remi"
+
+  echo "==> Publishing @yooz-labs/remi-$PLAT@$VERSION..."
+  cd "$PLAT_DIR"
+  npm publish --access public $DRY_RUN
+done
+
+echo "==> Publishing @yooz-labs/remi@$VERSION..."
+cd "$NPM_DIR/remi"
+npm publish --access public $DRY_RUN
+
+echo "==> Done. Published @yooz-labs/remi@$VERSION"

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -7,6 +7,12 @@ if [[ "${2:-}" == "--dry-run" ]]; then
   DRY_RUN="--dry-run"
 fi
 
+# Validate semver format
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+  echo "Error: VERSION must be semver (e.g. 1.2.3), got: $VERSION" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 NPM_DIR="$ROOT_DIR/npm"
@@ -17,28 +23,39 @@ echo "==> Building all platform binaries..."
 cd "$ROOT_DIR"
 bun run build:all
 
+echo "==> Validating built binaries..."
+for PLAT in "${PLATFORMS[@]}"; do
+  BINARY="$ROOT_DIR/dist/remi-$PLAT"
+  if [[ ! -f "$BINARY" || ! -s "$BINARY" ]]; then
+    echo "Error: Missing or empty binary for $PLAT at $BINARY" >&2
+    exit 1
+  fi
+  echo "  OK: remi-$PLAT ($(wc -c < "$BINARY" | tr -d ' ') bytes)"
+done
+
 echo "==> Updating versions to $VERSION..."
 
-# Update main package version and optionalDependencies versions
-node -e "
+# Use env vars to avoid shell interpolation into JS
+# npm publish is used here because bun publish does not support provenance or scoped packages
+MAIN_PKG="$NPM_DIR/remi/package.json" PKG_VERSION="$VERSION" node -e "
 const fs = require('fs');
-const pkg = JSON.parse(fs.readFileSync('$NPM_DIR/remi/package.json', 'utf8'));
-pkg.version = '$VERSION';
+const pkg = JSON.parse(fs.readFileSync(process.env.MAIN_PKG, 'utf8'));
+pkg.version = process.env.PKG_VERSION;
 for (const key of Object.keys(pkg.optionalDependencies || {})) {
-  pkg.optionalDependencies[key] = '$VERSION';
+  pkg.optionalDependencies[key] = process.env.PKG_VERSION;
 }
-fs.writeFileSync('$NPM_DIR/remi/package.json', JSON.stringify(pkg, null, 2) + '\n');
+fs.writeFileSync(process.env.MAIN_PKG, JSON.stringify(pkg, null, 2) + '\n');
 "
 
 for PLAT in "${PLATFORMS[@]}"; do
   PLAT_DIR="$NPM_DIR/remi-$PLAT"
 
-  # Update version
-  node -e "
+  # Update version via env var
+  PLAT_PKG="$PLAT_DIR/package.json" PKG_VERSION="$VERSION" node -e "
   const fs = require('fs');
-  const pkg = JSON.parse(fs.readFileSync('$PLAT_DIR/package.json', 'utf8'));
-  pkg.version = '$VERSION';
-  fs.writeFileSync('$PLAT_DIR/package.json', JSON.stringify(pkg, null, 2) + '\n');
+  const pkg = JSON.parse(fs.readFileSync(process.env.PLAT_PKG, 'utf8'));
+  pkg.version = process.env.PKG_VERSION;
+  fs.writeFileSync(process.env.PLAT_PKG, JSON.stringify(pkg, null, 2) + '\n');
   "
 
   # Copy binary
@@ -47,12 +64,10 @@ for PLAT in "${PLATFORMS[@]}"; do
   chmod +x "$PLAT_DIR/bin/remi"
 
   echo "==> Publishing @yooz-labs/remi-$PLAT@$VERSION..."
-  cd "$PLAT_DIR"
-  npm publish --access public $DRY_RUN
+  (cd "$PLAT_DIR" && npm publish --access public $DRY_RUN)
 done
 
 echo "==> Publishing @yooz-labs/remi@$VERSION..."
-cd "$NPM_DIR/remi"
-npm publish --access public $DRY_RUN
+(cd "$NPM_DIR/remi" && npm publish --access public $DRY_RUN)
 
 echo "==> Done. Published @yooz-labs/remi@$VERSION"


### PR DESCRIPTION
## Summary
- Add `@yooz-labs/remi` npm package using the esbuild/turbo platform-specific binary pattern
- Main package (854 bytes) with `optionalDependencies` for 4 platform binary packages
- Thin Node.js launcher script detects OS/arch and executes the correct binary
- CI workflow (`release.yml`) extended with `publish-npm` job using OIDC trusted publishing
- Local `scripts/publish-npm.sh` for manual publishes

## Packages published (v0.1.0 already live)
- `@yooz-labs/remi` - main package with launcher
- `@yooz-labs/remi-darwin-arm64` - macOS ARM64 binary
- `@yooz-labs/remi-darwin-x64` - macOS x64 binary
- `@yooz-labs/remi-linux-arm64` - Linux ARM64 binary
- `@yooz-labs/remi-linux-x64` - Linux x64 binary

## Install experience
```
npm install -g @yooz-labs/remi
remi --version  # 0.1.0
```
Only 2 packages installed per user (main + matching platform), not all 5.

## Test plan
- [x] `scripts/publish-npm.sh 0.1.0 --dry-run` succeeds
- [x] All 5 packages published to npm
- [x] `npm install -g @yooz-labs/remi` installs successfully
- [x] `remi --version` outputs 0.1.0
- [x] `remi --help` shows full CLI help
- [ ] Configure OIDC trusted publishers on npmjs.com (post-merge, one-time)