### PR TITLE
Auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,41 @@ jobs:
         run: |
           cd npm/remi
           npm publish --provenance --access public
+
+  update-homebrew:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for npm registry propagation
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Waiting for @yooz-labs/remi@$VERSION on npm..."
+          for i in $(seq 1 30); do
+            if curl -sf "https://registry.npmjs.org/@yooz-labs/remi-darwin-arm64/$VERSION" > /dev/null 2>&1; then
+              echo "Available after ${i}0 seconds"
+              break
+            fi
+            if [[ $i -eq 30 ]]; then
+              echo "ERROR: Timed out waiting for npm" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash scripts/update-homebrew.sh "$VERSION" > /tmp/remi.rb
+          gh api repos/yooz-labs/homebrew-tap/contents/Formula/remi.rb \
+            --method PUT \
+            --field message="remi ${VERSION}" \
+            --field content="$(base64 -w 0 /tmp/remi.rb)" \
+            --field sha="$(gh api repos/yooz-labs/homebrew-tap/contents/Formula/remi.rb --jq .sha)"
+          echo "Updated homebrew formula to ${VERSION}"

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION="${1:?Usage: update-homebrew.sh <version>}"
+
+# Validate semver
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+  echo "Error: VERSION must be semver (e.g. 1.2.3), got: $VERSION" >&2
+  exit 1
+fi
+
+PLATFORMS=("darwin-arm64" "darwin-x64" "linux-arm64" "linux-x64")
+declare -A SHAS
+
+echo "==> Fetching SHA-256 hashes from npm registry..."
+for PLAT in "${PLATFORMS[@]}"; do
+  URL="https://registry.npmjs.org/@yooz-labs/remi-${PLAT}/-/remi-${PLAT}-${VERSION}.tgz"
+  SHA=$(curl -sfL "$URL" | shasum -a 256 | cut -d' ' -f1)
+  if [[ -z "$SHA" ]]; then
+    echo "Error: Failed to fetch $URL" >&2
+    exit 1
+  fi
+  SHAS[$PLAT]="$SHA"
+  echo "  $PLAT: $SHA"
+done
+
+FORMULA="class Remi < Formula
+  desc \"Remote monitor for Claude Code CLI sessions\"
+  homepage \"https://github.com/yooz-labs/remi\"
+  version \"${VERSION}\"
+  license :cannot_represent
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url \"https://registry.npmjs.org/@yooz-labs/remi-darwin-arm64/-/remi-darwin-arm64-${VERSION}.tgz\"
+      sha256 \"${SHAS[darwin-arm64]}\"
+    else
+      url \"https://registry.npmjs.org/@yooz-labs/remi-darwin-x64/-/remi-darwin-x64-${VERSION}.tgz\"
+      sha256 \"${SHAS[darwin-x64]}\"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url \"https://registry.npmjs.org/@yooz-labs/remi-linux-arm64/-/remi-linux-arm64-${VERSION}.tgz\"
+      sha256 \"${SHAS[linux-arm64]}\"
+    else
+      url \"https://registry.npmjs.org/@yooz-labs/remi-linux-x64/-/remi-linux-x64-${VERSION}.tgz\"
+      sha256 \"${SHAS[linux-x64]}\"
+    end
+  end
+
+  def install
+    bin.install \"bin/remi\"
+  end
+
+  test do
+    assert_match \"remi #{version}\", shell_output(\"#{bin}/remi --version\")
+  end
+end
+"
+
+echo "==> Generated formula for remi ${VERSION}"
+echo "$FORMULA"


### PR DESCRIPTION
## Summary
- Add `scripts/update-homebrew.sh` to generate Homebrew formula from npm tarball SHA-256 hashes
- Add `update-homebrew` job to release CI that pushes updated formula to `yooz-labs/homebrew-tap`
- Uses `gh api` to update file via GitHub API (no git clone needed)
- Waits for npm registry propagation before computing hashes

## Setup required
- Create a fine-grained PAT with `contents: write` on `yooz-labs/homebrew-tap`
- Add as `HOMEBREW_TAP_TOKEN` secret on the remi repo

## Install experience
```
brew tap yooz-labs/tap
brew install remi
```

## Test plan
- [x] Homebrew formula tested locally: `brew install yooz-labs/tap/remi` works
- [x] `remi --version` outputs 0.1.0 after brew install
- [ ] CI auto-update will be tested on next release tag