### PR TITLE
Replace PTY output parsing with Claude Code hooks

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -899,6 +899,10 @@ async function createNewSession(
 
   // Hook-based event bridge for status/question detection
   if (hookServer) {
+    // Track the Claude session ID so we can filter hook events by session.
+    // Before SessionStart fires, we let events through (claudeSessionId is null).
+    let claudeSessionId: string | null = null;
+
     const hookBridge = new HookEventBridge(sessionId, {
       onStatusChange: (status: AgentStatus, context?: string) => {
         messageApi.handleStatusChange(status, context);
@@ -906,9 +910,10 @@ async function createNewSession(
       onQuestion: (question) => {
         messageApi.handleQuestion(question);
       },
-      onSessionInfo: (claudeSessionId: string, transcriptPath: string) => {
-        log(`[Hooks] SessionStart: claude=${claudeSessionId}, transcript=${transcriptPath}`);
-        sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+      onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
+        claudeSessionId = hookClaudeSessionId;
+        log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
+        sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
 
         // Start transcript watcher immediately using the path from the hook
         if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
@@ -918,11 +923,23 @@ async function createNewSession(
     });
 
     const handlers = hookBridge.hookHandlers();
-    hookServer.on('PreToolUse', (input) => handlers.onPreToolUse?.(input));
-    hookServer.on('PostToolUse', (input) => handlers.onPostToolUse?.(input));
-    hookServer.on('Notification', (input) => handlers.onNotification?.(input));
-    hookServer.on('Stop', (input) => handlers.onStop?.(input));
     hookServer.on('SessionStart', (input) => handlers.onSessionStart?.(input));
+    hookServer.on('PreToolUse', (input) => {
+      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      handlers.onPreToolUse?.(input);
+    });
+    hookServer.on('PostToolUse', (input) => {
+      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      handlers.onPostToolUse?.(input);
+    });
+    hookServer.on('Notification', (input) => {
+      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      handlers.onNotification?.(input);
+    });
+    hookServer.on('Stop', (input) => {
+      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      handlers.onStop?.(input);
+    });
 
     log(`[Hooks] Event bridge active for session ${sessionId}`);
   }
@@ -995,11 +1012,15 @@ async function createNewSession(
   setTimeout(() => {
     if (transcriptWatchers.has(sessionId)) return;
     if (!sessionRegistry.hasSession(sessionId)) return;
-    log('[Hooks] SessionStart hook not received, falling back to transcript discovery');
+    logError('[Hooks] SessionStart hook not received, falling back to transcript discovery');
     const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
     if (transcriptPath) {
       startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
       extractClaudeSessionId(transcriptPath, sessionId);
+    } else {
+      logError(
+        `[Hooks] Transcript discovery failed for session ${sessionId}. No transcript content available.`,
+      );
     }
   }, 5000);
 
@@ -1544,8 +1565,10 @@ async function cleanup(): Promise<void> {
   if (hookConfigManager) {
     try {
       hookConfigManager.uninstall();
-    } catch {
-      // Best-effort cleanup
+    } catch (err) {
+      logError(
+        `[Hooks] Failed to uninstall hook config: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     hookConfigManager = null;
   }
@@ -1678,7 +1701,9 @@ if (cliDaemonMode) {
     log('[Hooks] Claude Code hooks configured');
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logError(`Hook server failed to start: ${msg}.`);
+    logError(
+      `Hook server failed to start on port ${HOOK_PORT}: ${msg}. Status detection and question forwarding disabled.`,
+    );
     hookServer = null;
     hookConfigManager = null;
   }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -234,7 +234,7 @@ import {
 import { MessageAPI } from './api/index.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
-import { OutputProcessor } from './parser/index.ts';
+import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
 import { SessionRegistry, SessionStore, type StoredSession } from './session/index.ts';
 import {
@@ -828,6 +828,11 @@ const sessionRegistry = new SessionRegistry(
 // The primary session ID (in wrapper mode, this is the one running in the terminal)
 let primarySessionId: UUID | null = null;
 
+// Hook infrastructure (initialized in wrapper mode when hooks are enabled)
+const HOOK_PORT = PORT + 1;
+let hookServer: HookServer | null = null;
+let hookConfigManager: HookConfigManager | null = null;
+
 // ---------------------------------------------------------------------------
 // Create session helper (shared between wrapper and daemon modes)
 // ---------------------------------------------------------------------------
@@ -892,6 +897,36 @@ async function createNewSession(
     },
   );
 
+  // Hook-based event bridge for status/question detection
+  if (hookServer) {
+    const hookBridge = new HookEventBridge(sessionId, {
+      onStatusChange: (status: AgentStatus, context?: string) => {
+        messageApi.handleStatusChange(status, context);
+      },
+      onQuestion: (question) => {
+        messageApi.handleQuestion(question);
+      },
+      onSessionInfo: (claudeSessionId: string, transcriptPath: string) => {
+        log(`[Hooks] SessionStart: claude=${claudeSessionId}, transcript=${transcriptPath}`);
+        sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+
+        // Start transcript watcher immediately using the path from the hook
+        if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
+          startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
+        }
+      },
+    });
+
+    const handlers = hookBridge.hookHandlers();
+    hookServer.on('PreToolUse', (input) => handlers.onPreToolUse?.(input));
+    hookServer.on('PostToolUse', (input) => handlers.onPostToolUse?.(input));
+    hookServer.on('Notification', (input) => handlers.onNotification?.(input));
+    hookServer.on('Stop', (input) => handlers.onStop?.(input));
+    hookServer.on('SessionStart', (input) => handlers.onSessionStart?.(input));
+
+    log(`[Hooks] Event bridge active for session ${sessionId}`);
+  }
+
   // Determine terminal size
   const termSize = passThrough
     ? {
@@ -911,9 +946,6 @@ async function createNewSession(
     {
       onRawData: (data: Uint8Array) => {
         if (passThrough && ptyStdoutFd !== null) {
-          // Write raw bytes directly to terminal - no decode/encode round-trip.
-          // This preserves multi-byte UTF-8 sequences split across chunks and
-          // avoids ANSI escape corruption from processing delays.
           try {
             fs.writeSync(ptyStdoutFd, data);
           } catch (err) {
@@ -925,22 +957,15 @@ async function createNewSession(
           }
         }
       },
-      onData: (output: string) => {
-        // Decoded text goes to processor only (status detection, questions)
-        if (processor) {
-          processor.process(output);
-        }
+      onData: (_output: string) => {
+        // No PTY output parsing; hooks handle status/questions, transcript handles content
       },
       onExit: (code: number | null) => {
         log(`PTY ${ptySession.id} exited with code ${code}`);
-        if (processor) {
-          processor.flush();
-        }
         sessionRegistry.handlePTYExit(sessionId);
         sessionStore.markExited(sessionId, code);
 
         if (passThrough) {
-          // In wrapper mode, exit with the same code as Claude
           cleanup().then(() => {
             process.exit(code ?? 0);
           });
@@ -952,32 +977,9 @@ async function createNewSession(
     },
   );
 
-  const processor = new OutputProcessor(
-    {
-      sessionId: sessionId,
-      updateThrottleMs: 100,
-      streamStatusOnly: true,
-    },
-    {
-      onMessage: (message) => {
-        messageApi.handleMessage(message);
-      },
-      onMessageUpdate: (messageId, content, tool) => {
-        messageApi.handleMessageUpdate(messageId, content, tool);
-      },
-      onQuestion: (question) => {
-        messageApi.handleQuestion(question);
-      },
-      onStatusChange: (status: AgentStatus, context?: string) => {
-        messageApi.handleStatusChange(status, context);
-      },
-    },
-  );
-
-  sessionRegistry.registerSession(sessionId, workingDirectory, ptySession, processor, messageApi);
+  sessionRegistry.registerSession(sessionId, workingDirectory, ptySession, messageApi);
   await ptySession.start();
 
-  // Save session to persistent store
   sessionStore.save({
     remiSessionId: sessionId,
     claudeSessionId: null,
@@ -988,27 +990,18 @@ async function createNewSession(
     exitCode: null,
   });
 
-  // Start transcript watcher after delay
+  // Transcript watcher: started by SessionStart hook (provides path directly).
+  // Safety net: if hook doesn't fire within 5s, fall back to filesystem discovery.
   setTimeout(() => {
+    if (transcriptWatchers.has(sessionId)) return;
     if (!sessionRegistry.hasSession(sessionId)) return;
+    log('[Hooks] SessionStart hook not received, falling back to transcript discovery');
     const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
-    if (!transcriptPath) {
-      log(`No transcript file found for ${workingDirectory}, will retry...`);
-      setTimeout(() => {
-        if (!sessionRegistry.hasSession(sessionId)) return;
-        const retryPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
-        if (retryPath) {
-          startTranscriptWatcher(sessionId, retryPath, messageApi, sendAndRecord);
-          extractClaudeSessionId(retryPath, sessionId);
-        } else {
-          log(`Could not find transcript file for session ${sessionId}`);
-        }
-      }, 5000);
-      return;
+    if (transcriptPath) {
+      startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
+      extractClaudeSessionId(transcriptPath, sessionId);
     }
-    startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
-    extractClaudeSessionId(transcriptPath, sessionId);
-  }, 2000);
+  }, 5000);
 
   return ptySession;
 }
@@ -1543,6 +1536,20 @@ async function cleanup(): Promise<void> {
   }
   process.stdin.pause();
 
+  // Clean up hook infrastructure
+  if (hookServer) {
+    hookServer.stop();
+    hookServer = null;
+  }
+  if (hookConfigManager) {
+    try {
+      hookConfigManager.uninstall();
+    } catch {
+      // Best-effort cleanup
+    }
+    hookConfigManager = null;
+  }
+
   for (const watcher of transcriptWatchers.values()) {
     watcher.stop();
   }
@@ -1652,6 +1659,28 @@ if (cliDaemonMode) {
     } else {
       logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
     }
+  }
+
+  // Start hook server for Claude Code event detection
+  try {
+    hookServer = new HookServer(
+      { port: HOOK_PORT },
+      {
+        onError: (err) => logError(`[HookServer] ${err.message}`),
+      },
+    );
+    hookServer.start();
+    log(`Hook server listening on ${hookServer.url}`);
+
+    // Configure Claude Code hooks to POST to our server
+    hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
+    hookConfigManager.install();
+    log('[Hooks] Claude Code hooks configured');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logError(`Hook server failed to start: ${msg}.`);
+    hookServer = null;
+    hookConfigManager = null;
   }
 
   // Create and start the primary PTY session

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -1,0 +1,176 @@
+/**
+ * Manages Claude Code hook configuration for Remi.
+ *
+ * Before spawning Claude Code, writes HTTP hook entries to
+ * .claude/settings.local.json (project-scoped, gitignored).
+ * On cleanup, removes only Remi's hook entries.
+ *
+ * Important: Claude Code snapshots hooks at startup, so config
+ * must be written BEFORE spawning the process.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { HOOK_EVENT_NAMES } from './hook-types.ts';
+
+interface HookEntry {
+  type: 'http';
+  url: string;
+  timeout: number;
+}
+
+interface HookMatcher {
+  matcher?: string;
+  hooks: HookEntry[];
+}
+
+interface ClaudeSettings {
+  hooks?: Record<string, HookMatcher[]>;
+  [key: string]: unknown;
+}
+
+/** Marker in the URL that identifies Remi-managed hooks */
+const REMI_HOOK_URL_MARKER = '/hooks';
+
+export class HookConfigManager {
+  private readonly settingsPath: string;
+  private readonly hookUrl: string;
+  private hasWritten = false;
+
+  constructor(projectDir: string, hookServerUrl: string) {
+    this.settingsPath = path.join(projectDir, '.claude', 'settings.local.json');
+    this.hookUrl = hookServerUrl;
+  }
+
+  /**
+   * Write Remi hook configuration into Claude settings.
+   * Merges with existing user hooks; does not overwrite them.
+   */
+  install(): void {
+    const dir = path.dirname(this.settingsPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const settings = this.readSettings();
+    if (!settings.hooks) {
+      settings.hooks = {};
+    }
+
+    const remiHookEntry: HookEntry = {
+      type: 'http',
+      url: this.hookUrl,
+      timeout: 5,
+    };
+
+    for (const event of HOOK_EVENT_NAMES) {
+      if (!settings.hooks[event]) {
+        settings.hooks[event] = [];
+      }
+
+      const matchers = settings.hooks[event];
+      const alreadyInstalled = matchers.some((m) =>
+        m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
+      );
+
+      if (!alreadyInstalled) {
+        matchers.push({ hooks: [{ ...remiHookEntry }] });
+      }
+    }
+
+    this.writeSettings(settings);
+    this.hasWritten = true;
+  }
+
+  /**
+   * Remove Remi hook entries from Claude settings.
+   * Preserves all user-configured hooks.
+   */
+  uninstall(): void {
+    if (!this.hasWritten || !fs.existsSync(this.settingsPath)) return;
+
+    const settings = this.readSettings();
+    if (!settings.hooks) return;
+
+    let modified = false;
+    const hooks = settings.hooks;
+    for (const event of Object.keys(hooks)) {
+      const matchers = hooks[event];
+      if (!matchers) continue;
+      const filtered = matchers.filter(
+        (m) =>
+          !m.hooks.some(
+            (h) =>
+              h.type === 'http' && h.url === this.hookUrl && h.url.includes(REMI_HOOK_URL_MARKER),
+          ),
+      );
+      if (filtered.length !== matchers.length) {
+        hooks[event] = filtered;
+        modified = true;
+      }
+    }
+
+    // Clean up empty event arrays
+    for (const event of Object.keys(hooks)) {
+      if (hooks[event]?.length === 0) {
+        delete hooks[event];
+      }
+    }
+
+    // Remove hooks key if empty
+    let hooksEmpty = false;
+    if (settings.hooks && Object.keys(settings.hooks).length === 0) {
+      hooksEmpty = true;
+    }
+
+    if (modified) {
+      // Build clean settings without empty hooks
+      const cleanSettings: ClaudeSettings = {};
+      for (const [key, value] of Object.entries(settings)) {
+        if (key === 'hooks' && hooksEmpty) continue;
+        cleanSettings[key] = value;
+      }
+
+      if (Object.keys(cleanSettings).length === 0) {
+        // Settings file is empty; remove it
+        try {
+          fs.unlinkSync(this.settingsPath);
+        } catch {
+          // ignore
+        }
+      } else {
+        this.writeSettings(cleanSettings);
+      }
+    }
+  }
+
+  /** Check if Remi hooks are currently installed */
+  isInstalled(): boolean {
+    if (!fs.existsSync(this.settingsPath)) return false;
+
+    const settings = this.readSettings();
+    if (!settings.hooks) return false;
+
+    return HOOK_EVENT_NAMES.every((event) => {
+      const matchers = settings.hooks?.[event];
+      return matchers?.some((m) =>
+        m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
+      );
+    });
+  }
+
+  private readSettings(): ClaudeSettings {
+    if (!fs.existsSync(this.settingsPath)) return {};
+
+    try {
+      const content = fs.readFileSync(this.settingsPath, 'utf-8');
+      return JSON.parse(content) as ClaudeSettings;
+    } catch {
+      return {};
+    }
+  }
+
+  private writeSettings(settings: ClaudeSettings): void {
+    fs.writeFileSync(this.settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+  }
+}

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -29,9 +29,6 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
-/** Marker in the URL that identifies Remi-managed hooks */
-const REMI_HOOK_URL_MARKER = '/hooks';
-
 export class HookConfigManager {
   private readonly settingsPath: string;
   private readonly hookUrl: string;
@@ -98,11 +95,7 @@ export class HookConfigManager {
       const matchers = hooks[event];
       if (!matchers) continue;
       const filtered = matchers.filter(
-        (m) =>
-          !m.hooks.some(
-            (h) =>
-              h.type === 'http' && h.url === this.hookUrl && h.url.includes(REMI_HOOK_URL_MARKER),
-          ),
+        (m) => !m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
       );
       if (filtered.length !== matchers.length) {
         hooks[event] = filtered;
@@ -135,8 +128,10 @@ export class HookConfigManager {
         // Settings file is empty; remove it
         try {
           fs.unlinkSync(this.settingsPath);
-        } catch {
-          // ignore
+        } catch (err) {
+          console.error(
+            `Warning: failed to remove ${this.settingsPath}; stale hooks may remain: ${err}`,
+          );
         }
       } else {
         this.writeSettings(cleanSettings);
@@ -160,13 +155,26 @@ export class HookConfigManager {
   }
 
   private readSettings(): ClaudeSettings {
-    if (!fs.existsSync(this.settingsPath)) return {};
+    let content: string;
+    try {
+      content = fs.readFileSync(this.settingsPath, 'utf-8');
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        return {};
+      }
+      throw err;
+    }
 
     try {
-      const content = fs.readFileSync(this.settingsPath, 'utf-8');
       return JSON.parse(content) as ClaudeSettings;
-    } catch {
-      return {};
+    } catch (err) {
+      throw new Error(
+        `Corrupted settings file at ${this.settingsPath}: ${err}. Fix or remove the file before running Remi.`,
+      );
     }
   }
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -58,14 +58,25 @@ export class HookEventBridge {
       this.events.onStatusChange('waiting');
     } else if (input.notification_type === 'idle_prompt') {
       this.events.onStatusChange('idle');
+    } else {
+      // Intentionally unhandled notification types:
+      // - 'auth_success': informational only, no status change needed
+      // - 'elicitation_dialog': not yet supported by Remi
     }
   }
 
-  handleStop(_input: StopHookInput): void {
-    this.events.onStatusChange('idle');
+  handleStop(input: StopHookInput): void {
+    // When stop_hook_active is true, the stop hook is intercepting and the
+    // session is NOT actually stopping; it remains active.
+    if (!input.stop_hook_active) {
+      this.events.onStatusChange('idle');
+    }
   }
 
   handleSessionStart(input: SessionStartHookInput): void {
+    if (!input.session_id || !input.transcript_path) {
+      return;
+    }
     this.events.onSessionInfo(input.session_id, input.transcript_path);
   }
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -1,0 +1,97 @@
+/**
+ * Bridges Claude Code hook events to Remi's status/question system.
+ *
+ * Maps hook events to the same AgentStatus and Question types that
+ * the OutputProcessor previously produced from terminal parsing.
+ * This is the hook-based replacement for terminal output parsing.
+ */
+
+import { generateId } from '@remi/shared';
+import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
+import type { HookServerEvents } from './hook-server.ts';
+import type {
+  NotificationHookInput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SessionStartHookInput,
+  StopHookInput,
+} from './hook-types.ts';
+
+export interface HookBridgeEvents {
+  onStatusChange: (status: AgentStatus, context?: string) => void;
+  onQuestion: (question: Question) => void;
+  onSessionInfo: (claudeSessionId: string, transcriptPath: string) => void;
+}
+
+export class HookEventBridge {
+  private readonly sessionId: UUID;
+  private readonly events: HookBridgeEvents;
+
+  constructor(sessionId: UUID, events: HookBridgeEvents) {
+    this.sessionId = sessionId;
+    this.events = events;
+  }
+
+  /** Returns HookServerEvents handlers wired to this bridge */
+  hookHandlers(): Partial<HookServerEvents> {
+    return {
+      onPreToolUse: (input) => this.handlePreToolUse(input),
+      onPostToolUse: (input) => this.handlePostToolUse(input),
+      onNotification: (input) => this.handleNotification(input),
+      onStop: (input) => this.handleStop(input),
+      onSessionStart: (input) => this.handleSessionStart(input),
+    };
+  }
+
+  handlePreToolUse(input: PreToolUseHookInput): void {
+    this.events.onStatusChange('executing', input.tool_name);
+  }
+
+  handlePostToolUse(_input: PostToolUseHookInput): void {
+    this.events.onStatusChange('thinking');
+  }
+
+  handleNotification(input: NotificationHookInput): void {
+    if (input.notification_type === 'permission_prompt') {
+      const question = this.buildPermissionQuestion(input.message);
+      this.events.onQuestion(question);
+      this.events.onStatusChange('waiting');
+    } else if (input.notification_type === 'idle_prompt') {
+      this.events.onStatusChange('idle');
+    }
+  }
+
+  handleStop(_input: StopHookInput): void {
+    this.events.onStatusChange('idle');
+  }
+
+  handleSessionStart(input: SessionStartHookInput): void {
+    this.events.onSessionInfo(input.session_id, input.transcript_path);
+  }
+
+  private buildPermissionQuestion(message: string): Question {
+    const yesOption: QuestionOption = {
+      label: 'Yes',
+      value: 'y',
+      isRecommended: true,
+      isYes: true,
+      isNo: false,
+    };
+
+    const noOption: QuestionOption = {
+      label: 'No',
+      value: 'n',
+      isRecommended: false,
+      isYes: false,
+      isNo: true,
+    };
+
+    return {
+      id: generateId(),
+      text: message || 'Allow this action?',
+      options: [yesOption, noOption],
+      allowsFreeText: false,
+      isAnswered: false,
+    };
+  }
+}

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -25,14 +25,10 @@ export interface HookServerEvents {
   onError: (error: Error) => void;
 }
 
-/** Maps hook event names to their input types */
-interface HookEventMap {
-  PreToolUse: PreToolUseHookInput;
-  PostToolUse: PostToolUseHookInput;
-  Notification: NotificationHookInput;
-  Stop: StopHookInput;
-  SessionStart: SessionStartHookInput;
-}
+/** Maps hook event names to their input types, derived from the HookInput union */
+type HookEventMap = {
+  [E in HookInput['hook_event_name']]: Extract<HookInput, { hook_event_name: E }>;
+};
 
 export interface HookServerConfig {
   port: number;
@@ -67,11 +63,19 @@ export class HookServer {
     return this.server !== null;
   }
 
-  /** Register a listener for a specific hook event */
-  on<K extends keyof HookEventMap>(event: K, listener: Listener<HookEventMap[K]>): void {
+  /** Register a listener for a specific hook event. Returns a dispose function to remove it. */
+  on<K extends keyof HookEventMap>(event: K, listener: Listener<HookEventMap[K]>): () => void {
     const arr = this.listeners.get(event) ?? [];
-    arr.push(listener as Listener<HookInput>);
+    const wrapped = listener as Listener<HookInput>;
+    arr.push(wrapped);
     this.listeners.set(event, arr);
+    return () => {
+      const current = this.listeners.get(event);
+      if (current) {
+        const idx = current.indexOf(wrapped);
+        if (idx !== -1) current.splice(idx, 1);
+      }
+    };
   }
 
   /** Remove all listeners for a specific event or all events */
@@ -98,7 +102,6 @@ export class HookServer {
       this.server.stop(true);
       this.server = null;
     }
-    this.listeners.clear();
   }
 
   private async handleRequest(req: Request): Promise<Response> {
@@ -108,23 +111,9 @@ export class HookServer {
       return new Response('Not Found', { status: 404 });
     }
 
+    let body: Record<string, unknown>;
     try {
-      const body = (await req.json()) as Record<string, unknown>;
-      const eventName = body['hook_event_name'] as string;
-
-      if (!eventName || !isValidHookEvent(eventName)) {
-        return new Response(JSON.stringify({ error: 'unknown event' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-
-      this.dispatch(body as unknown as HookInput);
-
-      return new Response('{}', {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      body = (await req.json()) as Record<string, unknown>;
     } catch (err) {
       this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
       return new Response(JSON.stringify({ error: 'parse error' }), {
@@ -132,35 +121,63 @@ export class HookServer {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+
+    const eventName = body['hook_event_name'] as string;
+
+    if (!eventName || !isValidHookEvent(eventName)) {
+      return new Response(JSON.stringify({ error: 'unknown event' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    try {
+      this.dispatch(body as unknown as HookInput);
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
+
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   private dispatch(input: HookInput): void {
     const eventName = input.hook_event_name;
 
     // Fire constructor-provided events
-    switch (eventName) {
-      case 'PreToolUse':
-        this.events.onPreToolUse?.(input);
-        break;
-      case 'PostToolUse':
-        this.events.onPostToolUse?.(input);
-        break;
-      case 'Notification':
-        this.events.onNotification?.(input);
-        break;
-      case 'Stop':
-        this.events.onStop?.(input);
-        break;
-      case 'SessionStart':
-        this.events.onSessionStart?.(input);
-        break;
+    try {
+      switch (eventName) {
+        case 'PreToolUse':
+          this.events.onPreToolUse?.(input);
+          break;
+        case 'PostToolUse':
+          this.events.onPostToolUse?.(input);
+          break;
+        case 'Notification':
+          this.events.onNotification?.(input);
+          break;
+        case 'Stop':
+          this.events.onStop?.(input);
+          break;
+        case 'SessionStart':
+          this.events.onSessionStart?.(input);
+          break;
+      }
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
     }
 
     // Fire dynamic listeners
     const listeners = this.listeners.get(eventName);
     if (listeners) {
       for (const listener of listeners) {
-        listener(input);
+        try {
+          listener(input);
+        } catch (err) {
+          this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+        }
       }
     }
   }

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -1,0 +1,167 @@
+/**
+ * HTTP server receiving Claude Code hook events.
+ *
+ * Claude Code posts JSON to this endpoint when configured hooks fire.
+ * The server parses the payload and emits typed events for the daemon
+ * to consume (status changes, question detection, session info).
+ */
+
+import type {
+  HookInput,
+  NotificationHookInput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SessionStartHookInput,
+  StopHookInput,
+} from './hook-types.ts';
+import { isValidHookEvent } from './hook-types.ts';
+
+export interface HookServerEvents {
+  onPreToolUse: (input: PreToolUseHookInput) => void;
+  onPostToolUse: (input: PostToolUseHookInput) => void;
+  onNotification: (input: NotificationHookInput) => void;
+  onStop: (input: StopHookInput) => void;
+  onSessionStart: (input: SessionStartHookInput) => void;
+  onError: (error: Error) => void;
+}
+
+/** Maps hook event names to their input types */
+interface HookEventMap {
+  PreToolUse: PreToolUseHookInput;
+  PostToolUse: PostToolUseHookInput;
+  Notification: NotificationHookInput;
+  Stop: StopHookInput;
+  SessionStart: SessionStartHookInput;
+}
+
+export interface HookServerConfig {
+  port: number;
+  hostname?: string;
+}
+
+type Listener<T> = (input: T) => void;
+
+export class HookServer {
+  private server: ReturnType<typeof Bun.serve> | null = null;
+  private readonly config: Required<HookServerConfig>;
+  private readonly events: Partial<HookServerEvents>;
+  private readonly listeners: Map<string, Listener<HookInput>[]> = new Map();
+
+  constructor(config: HookServerConfig, events: Partial<HookServerEvents> = {}) {
+    this.config = {
+      port: config.port,
+      hostname: config.hostname ?? '127.0.0.1',
+    };
+    this.events = events;
+  }
+
+  get port(): number {
+    return this.config.port;
+  }
+
+  get url(): string {
+    return `http://${this.config.hostname}:${this.config.port}/hooks`;
+  }
+
+  get isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  /** Register a listener for a specific hook event */
+  on<K extends keyof HookEventMap>(event: K, listener: Listener<HookEventMap[K]>): void {
+    const arr = this.listeners.get(event) ?? [];
+    arr.push(listener as Listener<HookInput>);
+    this.listeners.set(event, arr);
+  }
+
+  /** Remove all listeners for a specific event or all events */
+  removeListeners(event?: keyof HookEventMap): void {
+    if (event) {
+      this.listeners.delete(event);
+    } else {
+      this.listeners.clear();
+    }
+  }
+
+  start(): void {
+    if (this.server) return;
+
+    this.server = Bun.serve({
+      port: this.config.port,
+      hostname: this.config.hostname,
+      fetch: (req) => this.handleRequest(req),
+    });
+  }
+
+  stop(): void {
+    if (this.server) {
+      this.server.stop(true);
+      this.server = null;
+    }
+    this.listeners.clear();
+  }
+
+  private async handleRequest(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (req.method !== 'POST' || url.pathname !== '/hooks') {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    try {
+      const body = (await req.json()) as Record<string, unknown>;
+      const eventName = body['hook_event_name'] as string;
+
+      if (!eventName || !isValidHookEvent(eventName)) {
+        return new Response(JSON.stringify({ error: 'unknown event' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      this.dispatch(body as unknown as HookInput);
+
+      return new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+      return new Response(JSON.stringify({ error: 'parse error' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  private dispatch(input: HookInput): void {
+    const eventName = input.hook_event_name;
+
+    // Fire constructor-provided events
+    switch (eventName) {
+      case 'PreToolUse':
+        this.events.onPreToolUse?.(input);
+        break;
+      case 'PostToolUse':
+        this.events.onPostToolUse?.(input);
+        break;
+      case 'Notification':
+        this.events.onNotification?.(input);
+        break;
+      case 'Stop':
+        this.events.onStop?.(input);
+        break;
+      case 'SessionStart':
+        this.events.onSessionStart?.(input);
+        break;
+    }
+
+    // Fire dynamic listeners
+    const listeners = this.listeners.get(eventName);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(input);
+      }
+    }
+  }
+}

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -3,7 +3,7 @@
  *
  * Claude Code HTTP hooks POST JSON to a configured URL when events fire.
  * These types match the documented hook input schemas.
- * Reference: https://code.claude.com/docs/en/hooks
+ * Reference: Claude Code hooks documentation (claude --help or docs.anthropic.com)
  */
 
 /** Fields present in all hook event payloads */
@@ -12,7 +12,7 @@ export interface HookCommonInput {
   transcript_path: string;
   cwd: string;
   permission_mode: string;
-  hook_event_name: string;
+  hook_event_name: HookEventName;
 }
 
 export interface PreToolUseHookInput extends HookCommonInput {

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -1,0 +1,71 @@
+/**
+ * TypeScript types for Claude Code hook event payloads.
+ *
+ * Claude Code HTTP hooks POST JSON to a configured URL when events fire.
+ * These types match the documented hook input schemas.
+ * Reference: https://code.claude.com/docs/en/hooks
+ */
+
+/** Fields present in all hook event payloads */
+export interface HookCommonInput {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  permission_mode: string;
+  hook_event_name: string;
+}
+
+export interface PreToolUseHookInput extends HookCommonInput {
+  hook_event_name: 'PreToolUse';
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+}
+
+export interface PostToolUseHookInput extends HookCommonInput {
+  hook_event_name: 'PostToolUse';
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_response: unknown;
+}
+
+export interface NotificationHookInput extends HookCommonInput {
+  hook_event_name: 'Notification';
+  message: string;
+  title?: string;
+  notification_type: 'permission_prompt' | 'idle_prompt' | 'auth_success' | 'elicitation_dialog';
+}
+
+export interface StopHookInput extends HookCommonInput {
+  hook_event_name: 'Stop';
+  stop_hook_active: boolean;
+}
+
+export interface SessionStartHookInput extends HookCommonInput {
+  hook_event_name: 'SessionStart';
+  source: 'startup' | 'resume' | 'clear' | 'compact';
+  model: string;
+}
+
+/** Discriminated union of all hook event inputs */
+export type HookInput =
+  | PreToolUseHookInput
+  | PostToolUseHookInput
+  | NotificationHookInput
+  | StopHookInput
+  | SessionStartHookInput;
+
+/** Valid hook event names */
+export const HOOK_EVENT_NAMES = [
+  'PreToolUse',
+  'PostToolUse',
+  'Notification',
+  'Stop',
+  'SessionStart',
+] as const;
+
+export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
+
+/** Type guard for valid hook event names */
+export function isValidHookEvent(name: string): name is HookEventName {
+  return (HOOK_EVENT_NAMES as readonly string[]).includes(name);
+}

--- a/packages/daemon/src/hooks/index.ts
+++ b/packages/daemon/src/hooks/index.ts
@@ -1,0 +1,16 @@
+export { HookServer } from './hook-server.ts';
+export type { HookServerConfig, HookServerEvents } from './hook-server.ts';
+export { HookConfigManager } from './hook-config-manager.ts';
+export { HookEventBridge } from './hook-event-bridge.ts';
+export type { HookBridgeEvents } from './hook-event-bridge.ts';
+export type {
+  HookInput,
+  HookEventName,
+  HookCommonInput,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  NotificationHookInput,
+  StopHookInput,
+  SessionStartHookInput,
+} from './hook-types.ts';
+export { HOOK_EVENT_NAMES, isValidHookEvent } from './hook-types.ts';

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -18,7 +18,6 @@ import type {
 } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
-import type { OutputProcessor } from '../parser/output-processor.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
 
 /** Configuration for SessionRegistry */
@@ -70,8 +69,6 @@ export interface ManagedSession {
 
   /** PTY session running Claude Code */
   pty: PTYSession;
-  /** Output processor for parsing PTY output */
-  processor: OutputProcessor;
   /** Message API for structured messages */
   messageApi: MessageAPI;
 
@@ -122,7 +119,6 @@ export class SessionRegistry {
     sessionId: UUID,
     workingDirectory: string,
     pty: PTYSession,
-    processor: OutputProcessor,
     messageApi: MessageAPI,
   ): void {
     const session: ManagedSession = {
@@ -130,7 +126,6 @@ export class SessionRegistry {
       createdAt: now(),
       workingDirectory,
       pty,
-      processor,
       messageApi,
       activeConnectionId: null,
       lastDisconnectedAt: null,
@@ -309,7 +304,7 @@ export class SessionRegistry {
   }
 
   /**
-   * Update session status (from OutputProcessor events).
+   * Update session status (from hook events).
    */
   updateStatus(sessionId: UUID, status: AgentStatus): void {
     const session = this.sessions.get(sessionId);
@@ -319,7 +314,7 @@ export class SessionRegistry {
   }
 
   /**
-   * Update current question (from OutputProcessor events).
+   * Update current question (from hook events).
    */
   updateQuestion(sessionId: UUID, question: Question | null): void {
     const session = this.sessions.get(sessionId);

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { HookConfigManager } from '../../src/hooks/hook-config-manager.ts';
+
+describe('HookConfigManager', () => {
+  let tmpDir: string;
+  let manager: HookConfigManager;
+  const hookUrl = 'http://127.0.0.1:28766/hooks';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-hook-config-'));
+    manager = new HookConfigManager(tmpDir, hookUrl);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readSettings(): Record<string, unknown> {
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+    if (!fs.existsSync(settingsPath)) return {};
+    return JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+  }
+
+  function writeSettings(settings: Record<string, unknown>): void {
+    const dir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'settings.local.json'), JSON.stringify(settings, null, 2));
+  }
+
+  it('creates .claude directory if it does not exist', () => {
+    manager.install();
+    expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
+  });
+
+  it('writes hook config with all required events', () => {
+    manager.install();
+    const settings = readSettings() as { hooks: Record<string, unknown[]> };
+
+    expect(settings.hooks).toBeDefined();
+    const events = Object.keys(settings.hooks);
+    expect(events).toContain('PreToolUse');
+    expect(events).toContain('PostToolUse');
+    expect(events).toContain('Notification');
+    expect(events).toContain('Stop');
+    expect(events).toContain('SessionStart');
+  });
+
+  it('each event has an HTTP hook entry with the correct URL', () => {
+    manager.install();
+    const settings = readSettings() as {
+      hooks: Record<
+        string,
+        Array<{ hooks: Array<{ type: string; url: string; timeout: number }> }>
+      >;
+    };
+
+    for (const event of ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'SessionStart']) {
+      const matchers = settings.hooks[event] as Array<{
+        hooks: Array<{ type: string; url: string; timeout: number }>;
+      }>;
+      expect(matchers.length).toBeGreaterThanOrEqual(1);
+      const lastMatcher = matchers[matchers.length - 1];
+      expect(lastMatcher).toBeDefined();
+      const hooks = lastMatcher?.hooks;
+      expect(hooks?.length).toBe(1);
+      expect(hooks?.[0]?.type).toBe('http');
+      expect(hooks?.[0]?.url).toBe(hookUrl);
+      expect(hooks?.[0]?.timeout).toBe(5);
+    }
+  });
+
+  it('does not duplicate hooks on repeated install', () => {
+    manager.install();
+    manager.install();
+    const settings = readSettings() as { hooks: Record<string, unknown[]> };
+
+    for (const event of ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'SessionStart']) {
+      expect(settings.hooks[event]?.length).toBe(1);
+    }
+  });
+
+  it('preserves existing user hooks', () => {
+    writeSettings({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: 'echo blocked' }],
+          },
+        ],
+      },
+      someOtherSetting: 'value',
+    });
+
+    manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, unknown[]>;
+      someOtherSetting: string;
+    };
+
+    // User's hook preserved
+    expect(settings.hooks['PreToolUse']?.length).toBe(2);
+    expect(settings.someOtherSetting).toBe('value');
+  });
+
+  it('uninstall removes only Remi hooks', () => {
+    writeSettings({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: 'echo user-hook' }],
+          },
+        ],
+      },
+    });
+
+    manager.install();
+    manager.uninstall();
+
+    const settings = readSettings() as { hooks: Record<string, unknown[]> };
+    // User's hook remains
+    expect(settings.hooks['PreToolUse']?.length).toBe(1);
+    // Remi's events that had no user hooks are removed
+    expect(settings.hooks['PostToolUse']).toBeUndefined();
+  });
+
+  it('uninstall removes settings file if empty', () => {
+    manager.install();
+    manager.uninstall();
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+    expect(fs.existsSync(settingsPath)).toBe(false);
+  });
+
+  it('uninstall is safe when file does not exist', () => {
+    // No install happened, but hasWritten is false so it should be a no-op
+    expect(() => manager.uninstall()).not.toThrow();
+  });
+
+  it('isInstalled returns true after install', () => {
+    expect(manager.isInstalled()).toBe(false);
+    manager.install();
+    expect(manager.isInstalled()).toBe(true);
+  });
+
+  it('isInstalled returns false after uninstall', () => {
+    manager.install();
+    manager.uninstall();
+    expect(manager.isInstalled()).toBe(false);
+  });
+});

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test';
+import type { AgentStatus, Question } from '@remi/shared';
+import { HookEventBridge } from '../../src/hooks/hook-event-bridge.ts';
+import type {
+  NotificationHookInput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SessionStartHookInput,
+  StopHookInput,
+} from '../../src/hooks/hook-types.ts';
+
+function makeCommon() {
+  return {
+    session_id: 'test-session',
+    transcript_path: '/tmp/test.jsonl',
+    cwd: '/tmp/project',
+    permission_mode: 'default',
+  };
+}
+
+describe('HookEventBridge', () => {
+  function createBridge() {
+    const statuses: Array<{ status: AgentStatus; context?: string }> = [];
+    const questions: Question[] = [];
+    const sessionInfos: Array<{ claudeSessionId: string; transcriptPath: string }> = [];
+
+    const bridge = new HookEventBridge('session-1', {
+      onStatusChange: (status, context) => {
+        if (context !== undefined) {
+          statuses.push({ status, context });
+        } else {
+          statuses.push({ status });
+        }
+      },
+      onQuestion: (q) => questions.push(q),
+      onSessionInfo: (id, path) => sessionInfos.push({ claudeSessionId: id, transcriptPath: path }),
+    });
+
+    return { bridge, statuses, questions, sessionInfos };
+  }
+
+  it('maps PreToolUse to executing status with tool name', () => {
+    const { bridge, statuses } = createBridge();
+
+    bridge.handlePreToolUse({
+      ...makeCommon(),
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    } as PreToolUseHookInput);
+
+    expect(statuses).toEqual([{ status: 'executing', context: 'Bash' }]);
+  });
+
+  it('maps PostToolUse to thinking status', () => {
+    const { bridge, statuses } = createBridge();
+
+    bridge.handlePostToolUse({
+      ...makeCommon(),
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: {},
+      tool_response: 'ok',
+    } as PostToolUseHookInput);
+
+    expect(statuses).toEqual([{ status: 'thinking' }]);
+  });
+
+  it('maps Notification(permission_prompt) to question + waiting status', () => {
+    const { bridge, statuses, questions } = createBridge();
+
+    bridge.handleNotification({
+      ...makeCommon(),
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Allow Bash: npm test?',
+    } as NotificationHookInput);
+
+    expect(statuses).toEqual([{ status: 'waiting' }]);
+    expect(questions.length).toBe(1);
+    expect(questions[0]?.text).toBe('Allow Bash: npm test?');
+    expect(questions[0]?.options.length).toBe(2);
+    expect(questions[0]?.options[0]?.isYes).toBe(true);
+    expect(questions[0]?.options[1]?.isNo).toBe(true);
+    expect(questions[0]?.allowsFreeText).toBe(false);
+    expect(questions[0]?.isAnswered).toBe(false);
+  });
+
+  it('maps Notification(idle_prompt) to idle status', () => {
+    const { bridge, statuses, questions } = createBridge();
+
+    bridge.handleNotification({
+      ...makeCommon(),
+      hook_event_name: 'Notification',
+      notification_type: 'idle_prompt',
+      message: '',
+    } as NotificationHookInput);
+
+    expect(statuses).toEqual([{ status: 'idle' }]);
+    expect(questions.length).toBe(0);
+  });
+
+  it('maps Stop to idle status', () => {
+    const { bridge, statuses } = createBridge();
+
+    bridge.handleStop({
+      ...makeCommon(),
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+    } as StopHookInput);
+
+    expect(statuses).toEqual([{ status: 'idle' }]);
+  });
+
+  it('maps SessionStart to session info', () => {
+    const { bridge, sessionInfos } = createBridge();
+
+    bridge.handleSessionStart({
+      ...makeCommon(),
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      model: 'claude-opus-4-6',
+    } as SessionStartHookInput);
+
+    expect(sessionInfos.length).toBe(1);
+    expect(sessionInfos[0]?.claudeSessionId).toBe('test-session');
+    expect(sessionInfos[0]?.transcriptPath).toBe('/tmp/test.jsonl');
+  });
+
+  it('provides default text for empty permission prompt', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handleNotification({
+      ...makeCommon(),
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: '',
+    } as NotificationHookInput);
+
+    expect(questions[0]?.text).toBe('Allow this action?');
+  });
+
+  it('hookHandlers returns handlers that delegate to bridge methods', () => {
+    const { bridge, statuses } = createBridge();
+    const handlers = bridge.hookHandlers();
+
+    handlers.onPreToolUse?.({
+      ...makeCommon(),
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: {},
+    } as PreToolUseHookInput);
+
+    expect(statuses).toEqual([{ status: 'executing', context: 'Edit' }]);
+  });
+});

--- a/packages/daemon/tests/hooks/hook-server.test.ts
+++ b/packages/daemon/tests/hooks/hook-server.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { HookServer } from '../../src/hooks/hook-server.ts';
+import type {
+  NotificationHookInput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SessionStartHookInput,
+  StopHookInput,
+} from '../../src/hooks/hook-types.ts';
+
+const TEST_PORT = 19876;
+
+function makeUrl(port: number): string {
+  return `http://127.0.0.1:${port}/hooks`;
+}
+
+function makePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: 'test-session',
+    transcript_path: '/tmp/test.jsonl',
+    cwd: '/tmp/project',
+    permission_mode: 'default',
+    ...overrides,
+  };
+}
+
+describe('HookServer', () => {
+  let server: HookServer;
+  let port: number;
+
+  beforeEach(() => {
+    port = TEST_PORT + Math.floor(Math.random() * 1000);
+  });
+
+  afterEach(() => {
+    server?.stop();
+  });
+
+  it('starts and stops', () => {
+    server = new HookServer({ port });
+    expect(server.isRunning).toBe(false);
+
+    server.start();
+    expect(server.isRunning).toBe(true);
+
+    server.stop();
+    expect(server.isRunning).toBe(false);
+  });
+
+  it('returns 404 for non-hook paths', async () => {
+    server = new HookServer({ port });
+    server.start();
+
+    const res = await fetch(`http://127.0.0.1:${port}/other`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for GET requests', async () => {
+    server = new HookServer({ port });
+    server.start();
+
+    const res = await fetch(makeUrl(port));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for unknown event names', async () => {
+    server = new HookServer({ port });
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(makePayload({ hook_event_name: 'UnknownEvent' })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const errors: Error[] = [];
+    server = new HookServer({ port }, { onError: (e) => errors.push(e) });
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    expect(res.status).toBe(400);
+    expect(errors.length).toBe(1);
+  });
+
+  it('dispatches PreToolUse events via constructor callback', async () => {
+    const received: PreToolUseHookInput[] = [];
+    server = new HookServer(
+      { port },
+      {
+        onPreToolUse: (input) => received.push(input),
+      },
+    );
+    server.start();
+
+    const payload = makePayload({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    expect(res.status).toBe(200);
+    expect(received.length).toBe(1);
+    expect(received[0]?.tool_name).toBe('Bash');
+  });
+
+  it('dispatches PostToolUse events', async () => {
+    const received: PostToolUseHookInput[] = [];
+    server = new HookServer(
+      { port },
+      {
+        onPostToolUse: (input) => received.push(input),
+      },
+    );
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+          tool_response: 'file1.txt\nfile2.txt',
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+    expect(received.length).toBe(1);
+  });
+
+  it('dispatches Notification events', async () => {
+    const received: NotificationHookInput[] = [];
+    server = new HookServer(
+      { port },
+      {
+        onNotification: (input) => received.push(input),
+      },
+    );
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'Notification',
+          notification_type: 'permission_prompt',
+          message: 'Allow Bash tool?',
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+    expect(received.length).toBe(1);
+    expect(received[0]?.notification_type).toBe('permission_prompt');
+    expect(received[0]?.message).toBe('Allow Bash tool?');
+  });
+
+  it('dispatches Stop events', async () => {
+    const received: StopHookInput[] = [];
+    server = new HookServer(
+      { port },
+      {
+        onStop: (input) => received.push(input),
+      },
+    );
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'Stop',
+          stop_hook_active: false,
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+    expect(received.length).toBe(1);
+  });
+
+  it('dispatches SessionStart events', async () => {
+    const received: SessionStartHookInput[] = [];
+    server = new HookServer(
+      { port },
+      {
+        onSessionStart: (input) => received.push(input),
+      },
+    );
+    server.start();
+
+    const res = await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'SessionStart',
+          source: 'startup',
+          model: 'claude-opus-4-6',
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+    expect(received.length).toBe(1);
+    expect(received[0]?.model).toBe('claude-opus-4-6');
+  });
+
+  it('supports dynamic listeners via on()', async () => {
+    server = new HookServer({ port });
+    server.start();
+
+    const received: PreToolUseHookInput[] = [];
+    server.on('PreToolUse', (input) => received.push(input));
+
+    await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Edit',
+          tool_input: {},
+        }),
+      ),
+    });
+
+    expect(received.length).toBe(1);
+    expect(received[0]?.tool_name).toBe('Edit');
+  });
+
+  it('fires both constructor and dynamic listeners', async () => {
+    const constructorReceived: PreToolUseHookInput[] = [];
+    const dynamicReceived: PreToolUseHookInput[] = [];
+
+    server = new HookServer(
+      { port },
+      {
+        onPreToolUse: (input) => constructorReceived.push(input),
+      },
+    );
+    server.start();
+    server.on('PreToolUse', (input) => dynamicReceived.push(input));
+
+    await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: {},
+        }),
+      ),
+    });
+
+    expect(constructorReceived.length).toBe(1);
+    expect(dynamicReceived.length).toBe(1);
+  });
+
+  it('removeListeners clears specific event', async () => {
+    server = new HookServer({ port });
+    server.start();
+
+    const received: PreToolUseHookInput[] = [];
+    server.on('PreToolUse', (input) => received.push(input));
+    server.removeListeners('PreToolUse');
+
+    await fetch(makeUrl(port), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        makePayload({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: {},
+        }),
+      ),
+    });
+
+    expect(received.length).toBe(0);
+  });
+
+  it('exposes url property', () => {
+    server = new HookServer({ port });
+    expect(server.url).toBe(`http://127.0.0.1:${port}/hooks`);
+  });
+});

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { ProtocolMessage } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../src/api/message-api.ts';
-import type { OutputProcessor } from '../src/parser/output-processor.ts';
 import type { PTYSession } from '../src/pty/pty-session.ts';
 import { SessionRegistry } from '../src/session/session-registry.ts';
 
@@ -15,13 +14,6 @@ function createMockPTY(): PTYSession {
     id: generateId(),
     close: mock(() => Promise.resolve()),
   } as unknown as PTYSession;
-}
-
-function createMockProcessor(): OutputProcessor {
-  return {
-    process: mock(() => {}),
-    flush: mock(() => {}),
-  } as unknown as OutputProcessor;
 }
 
 function createMockMessageAPI(bulletCount = 0): MessageAPI {
@@ -64,10 +56,9 @@ describe('SessionRegistry', () => {
     test('registers a new session', () => {
       const sessionId = generateId();
       const pty = createMockPTY();
-      const processor = createMockProcessor();
       const messageApi = createMockMessageAPI();
 
-      registry.registerSession(sessionId, '/test/dir', pty, processor, messageApi);
+      registry.registerSession(sessionId, '/test/dir', pty, messageApi);
 
       expect(registry.sessionCount).toBe(1);
       expect(registry.getSession(sessionId)).toBeDefined();
@@ -76,13 +67,7 @@ describe('SessionRegistry', () => {
 
     test('session starts with no connection', () => {
       const sessionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
       const session = registry.getSession(sessionId);
       expect(session?.activeConnectionId).toBeNull();
@@ -94,13 +79,7 @@ describe('SessionRegistry', () => {
     test('attaches connection to session', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
       const result = registry.attachConnection(sessionId, connectionId);
 
@@ -121,13 +100,7 @@ describe('SessionRegistry', () => {
 
     test('returns error if session already has connection', () => {
       const sessionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, generateId());
 
       const result = registry.attachConnection(sessionId, generateId());
@@ -139,13 +112,7 @@ describe('SessionRegistry', () => {
     test('getSessionForConnection works after attach', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
 
       const session = registry.getSessionForConnection(connectionId);
@@ -157,13 +124,7 @@ describe('SessionRegistry', () => {
     test('detaches connection and marks session orphaned', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
 
       registry.detachConnection(connectionId);
@@ -177,13 +138,7 @@ describe('SessionRegistry', () => {
     test('getSessionForConnection returns undefined after detach', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
       registry.detachConnection(connectionId);
 
@@ -194,13 +149,7 @@ describe('SessionRegistry', () => {
       const sessionId = generateId();
       const connectionId = generateId();
       const pty = createMockPTY();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        pty,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
       registry.detachConnection(connectionId);
 
@@ -220,13 +169,7 @@ describe('SessionRegistry', () => {
 
     test('returns false for connected session', () => {
       const sessionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, generateId());
 
       expect(registry.canResume(sessionId)).toBe(false);
@@ -235,13 +178,7 @@ describe('SessionRegistry', () => {
     test('returns true for orphaned session', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
       registry.detachConnection(connectionId);
 
@@ -256,13 +193,7 @@ describe('SessionRegistry', () => {
       const connectionId2 = generateId();
       const pty = createMockPTY();
 
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        pty,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId1);
       registry.detachConnection(connectionId1);
 
@@ -286,13 +217,7 @@ describe('SessionRegistry', () => {
       const connectionId1 = generateId();
       const connectionId2 = generateId();
 
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(5),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI(5));
       registry.attachConnection(sessionId, connectionId1);
 
       // Record some messages
@@ -320,13 +245,7 @@ describe('SessionRegistry', () => {
   describe('recordOutgoingMessage()', () => {
     test('stores messages in history', () => {
       const sessionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, generateId());
 
       const msg: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
@@ -344,7 +263,6 @@ describe('SessionRegistry', () => {
         sessionId,
         '/test/dir',
         createMockPTY(),
-        createMockProcessor(),
         createMockMessageAPI(),
       );
       registryWithSmallHistory.attachConnection(sessionId, generateId());
@@ -366,13 +284,7 @@ describe('SessionRegistry', () => {
   describe('updateStatus()', () => {
     test('updates session status', () => {
       const sessionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
       registry.updateStatus(sessionId, 'thinking');
 
@@ -385,13 +297,7 @@ describe('SessionRegistry', () => {
     test('closes session and emits event', () => {
       const sessionId = generateId();
       const pty = createMockPTY();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        pty,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
 
       registry.closeSession(sessionId, 'forced');
 
@@ -403,13 +309,7 @@ describe('SessionRegistry', () => {
     test('handlePTYExit closes session with pty_exit reason', () => {
       const sessionId = generateId();
       const pty = createMockPTY();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        pty,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
 
       registry.handlePTYExit(sessionId);
 
@@ -423,20 +323,8 @@ describe('SessionRegistry', () => {
       const sessionId2 = generateId();
       const connectionId1 = generateId();
 
-      registry.registerSession(
-        sessionId1,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
-      registry.registerSession(
-        sessionId2,
-        '/test/dir',
-        createMockPTY(),
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(sessionId1, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.registerSession(sessionId2, '/test/dir', createMockPTY(), createMockMessageAPI());
 
       registry.attachConnection(sessionId1, connectionId1);
       registry.attachConnection(sessionId2, generateId());
@@ -450,20 +338,8 @@ describe('SessionRegistry', () => {
     test('closes all sessions', async () => {
       const pty1 = createMockPTY();
       const pty2 = createMockPTY();
-      registry.registerSession(
-        generateId(),
-        '/test',
-        pty1,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
-      registry.registerSession(
-        generateId(),
-        '/test',
-        pty2,
-        createMockProcessor(),
-        createMockMessageAPI(),
-      );
+      registry.registerSession(generateId(), '/test', pty1, createMockMessageAPI());
+      registry.registerSession(generateId(), '/test', pty2, createMockMessageAPI());
 
       await registry.shutdown();
 


### PR DESCRIPTION
## Summary

- Replace fragile terminal output parsing (ANSI codes, status animations like "Vibing...", "Cooking...", cursor movements) with Claude Code's stable HTTP hooks API
- Daemon now receives structured JSON events via a local HTTP server instead of parsing raw PTY output
- New hook components: HookServer, HookConfigManager, HookEventBridge, hook-types
- PTY retained only for spawning Claude, stdin input, and raw stdout passthrough
- Removed OutputProcessor dependency from session creation; downstream protocol/client unchanged

## Architecture Change

```
BEFORE:                                    AFTER:
PTY output -> ANSI parse -> status         Claude Code hooks (HTTP) -> status
PTY output -> ANSI parse -> questions      Claude Code hooks (HTTP) -> questions
Transcript JSONL -> content                Transcript JSONL -> content (unchanged)
PTY stdin <- user input                    PTY stdin <- user input (unchanged)
```

## New Files

| File | Purpose |
|------|---------|
| `packages/daemon/src/hooks/hook-types.ts` | TypeScript types for hook payloads |
| `packages/daemon/src/hooks/hook-server.ts` | Bun HTTP server receiving hook events |
| `packages/daemon/src/hooks/hook-config-manager.ts` | Auto-configure hooks in Claude settings |
| `packages/daemon/src/hooks/hook-event-bridge.ts` | Map hooks to status/question events |
| `packages/daemon/src/hooks/index.ts` | Module exports |
| `packages/daemon/tests/hooks/*.test.ts` | Tests for all hook components (32 tests) |

## Modified Files

| File | Change |
|------|--------|
| `packages/daemon/src/cli.ts` | Wire hooks into startup flow, simplify PTY callbacks |
| `packages/daemon/src/session/session-registry.ts` | Remove OutputProcessor dependency |
| `packages/daemon/tests/session-registry.test.ts` | Remove mock processor from tests |

## Test plan

- [x] `bun run typecheck` passes (only pre-existing telegram errors)
- [x] `bunx biome check` passes clean
- [x] `bun test` passes (723 pass, 2 pre-existing grammy failures)
- [x] 32 new hook tests all pass
- [ ] Manual: run `remi` wrapper, verify Claude starts normally
- [ ] Manual: check `.claude/settings.local.json` has Remi hooks
- [ ] Manual: use Claude to trigger a tool, verify status updates via hooks