### PR TITLE
feat: optional passphrase, TOFU, and auto-auth

### DIFF
--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -3,8 +3,9 @@
  *
  * Handles the Ed25519 challenge-response handshake:
  * 1. Generate a random one-time challenge, include server's fingerprint and public key
- * 2. Verify client's Ed25519 signature and check authorized keys list
- * 3. Sign the same challenge with the server's private key (mutual authentication)
+ * 2. Verify client's Ed25519 signature first (bad signatures never trigger TOFU)
+ * 3. Check authorized keys; if unknown and TOFU is enabled, auto-accept
+ * 4. Sign the same challenge with the server's private key (mutual authentication)
  *
  * Each challenge is consumed on first verification attempt (one-time use)
  * to prevent replay attacks.
@@ -27,20 +28,25 @@ import {
 } from '@remi/shared';
 import type { IdentityStore } from './identity-store.ts';
 
+export type TofuMode = 'auto-accept' | 'reject';
+
 export interface AuthenticatorConfig {
   readonly identity: UnlockedIdentity;
   readonly identityStore: IdentityStore;
+  readonly tofuMode?: TofuMode;
 }
 
 export class Authenticator {
   private readonly identity: UnlockedIdentity;
   private readonly store: IdentityStore;
+  private readonly tofuMode: TofuMode;
   /** Active challenges keyed by connection ID */
   private readonly pendingChallenges = new Map<string, string>();
 
   constructor(config: AuthenticatorConfig) {
     this.identity = config.identity;
     this.store = config.identityStore;
+    this.tofuMode = config.tofuMode ?? 'reject';
   }
 
   /**
@@ -56,6 +62,9 @@ export class Authenticator {
   /**
    * Verify a client's auth response.
    * Returns an AuthResultMessage with success/failure.
+   *
+   * Order: verify signature first (bad sigs never trigger TOFU),
+   * then check authorization, then TOFU if applicable.
    */
   async verifyResponse(
     connectionId: string,
@@ -69,20 +78,7 @@ export class Authenticator {
     // Remove challenge (one-time use)
     this.pendingChallenges.delete(connectionId);
 
-    // Check if client's key is authorized
-    let isAuthorized: boolean;
-    try {
-      isAuthorized = this.store.isAuthorized(response.clientPublicKey, response.clientFingerprint);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      console.error(`Auth store error during verification: ${detail}`);
-      return createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`);
-    }
-    if (!isAuthorized) {
-      return createAuthResult(false, undefined, 'UNKNOWN_KEY');
-    }
-
-    // Verify the signature
+    // Step 1: Verify the signature FIRST (before checking authorization)
     try {
       const clientPublicKey = await importPublicKey(fromBase64(response.clientPublicKey));
       const challengeData = fromBase64(challenge);
@@ -94,6 +90,39 @@ export class Authenticator {
     } catch (err) {
       const code = err instanceof DOMException ? 'INVALID_KEY_DATA' : 'VERIFICATION_ERROR';
       return createAuthResult(false, undefined, code);
+    }
+
+    // Step 2: Check if client's key is authorized
+    let isAuthorized: boolean;
+    try {
+      isAuthorized = this.store.isAuthorized(response.clientPublicKey, response.clientFingerprint);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Auth store error during verification: ${detail}`);
+      return createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`);
+    }
+
+    // Step 3: TOFU - if not authorized and auto-accept is enabled, add the key
+    if (!isAuthorized) {
+      if (this.tofuMode === 'auto-accept') {
+        try {
+          const label = `tofu-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-')}`;
+          await this.store.addAuthorizedKey(response.clientPublicKey, label);
+          console.log(`New client auto-accepted (TOFU): ${response.clientFingerprint} [${label}]`);
+          isAuthorized = true;
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          // Duplicate key means already authorized (race condition); treat as success
+          if (detail.includes('already authorized')) {
+            isAuthorized = true;
+          } else {
+            console.error(`TOFU auto-accept failed: ${detail}`);
+            return createAuthResult(false, undefined, 'TOFU_FAILED');
+          }
+        }
+      } else {
+        return createAuthResult(false, undefined, 'UNKNOWN_KEY');
+      }
     }
 
     // Update lastUsedAt (non-critical; don't let failures break auth)

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -26,7 +26,7 @@ import {
   sign,
   verify,
 } from '@remi/shared';
-import type { IdentityStore } from './identity-store.ts';
+import { DuplicateKeyError, type IdentityStore } from './identity-store.ts';
 
 export type TofuMode = 'auto-accept' | 'reject';
 
@@ -111,11 +111,11 @@ export class Authenticator {
           console.log(`New client auto-accepted (TOFU): ${response.clientFingerprint} [${label}]`);
           isAuthorized = true;
         } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
-          // Duplicate key means already authorized (race condition); treat as success
-          if (detail.includes('already authorized')) {
+          if (err instanceof DuplicateKeyError) {
+            // Race condition: another connection added the key first
             isAuthorized = true;
           } else {
+            const detail = err instanceof Error ? err.message : String(err);
             console.error(`TOFU auto-accept failed: ${detail}`);
             return createAuthResult(false, undefined, 'TOFU_FAILED');
           }

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -21,6 +21,7 @@ import {
   createAuthorizedKeysFile,
   createIdentity,
   deserializeIdentity,
+  isEncrypted,
   serializeIdentity,
   unlockIdentity,
 } from '@remi/shared';
@@ -75,20 +76,27 @@ export class IdentityStore {
     });
   }
 
-  /** Generate a new identity and save it. Returns the identity. */
-  async generate(passphrase: string): Promise<RemiIdentity> {
+  /** Generate a new identity and save it. Without a passphrase, the key is stored unencrypted. */
+  async generate(passphrase?: string): Promise<RemiIdentity> {
     const identity = await createIdentity(passphrase);
     this.save(identity);
     return identity;
   }
 
-  /** Unlock the stored identity with a passphrase. */
-  async unlock(passphrase: string): Promise<UnlockedIdentity> {
+  /** Unlock the stored identity. Encrypted identities require a passphrase. */
+  async unlock(passphrase?: string): Promise<UnlockedIdentity> {
     const identity = this.load();
     if (!identity) {
       throw new Error('No identity found. Run `remi keygen` first.');
     }
     return unlockIdentity(identity, passphrase);
+  }
+
+  /** Check if the stored identity has an encrypted private key. */
+  isEncrypted(): boolean {
+    const identity = this.load();
+    if (!identity) return false;
+    return isEncrypted(identity);
   }
 
   // -- Authorized Keys --

--- a/packages/daemon/src/auth/identity-store.ts
+++ b/packages/daemon/src/auth/identity-store.ts
@@ -26,6 +26,13 @@ import {
   unlockIdentity,
 } from '@remi/shared';
 
+export class DuplicateKeyError extends Error {
+  constructor(fingerprint: string) {
+    super(`Key with fingerprint ${fingerprint} already authorized`);
+    this.name = 'DuplicateKeyError';
+  }
+}
+
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const IDENTITY_FILE = 'identity.json';
 const AUTHORIZED_KEYS_FILE = 'authorized_keys.json';
@@ -138,7 +145,7 @@ export class IdentityStore {
     // Check for duplicate
     const existing = file.keys.find((k) => k.fingerprint === key.fingerprint);
     if (existing) {
-      throw new Error(`Key with fingerprint ${key.fingerprint} already authorized`);
+      throw new DuplicateKeyError(key.fingerprint);
     }
 
     file.keys.push(key);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1472,8 +1472,15 @@ const identityStore = new IdentityStore();
 
 if (!identityStore.exists()) {
   console.log('No identity found. Generating new Ed25519 keypair...');
-  const newIdentity = await identityStore.generate();
-  console.log(`Identity created (fingerprint: ${newIdentity.fingerprint})`);
+  try {
+    const newIdentity = await identityStore.generate();
+    console.log(`Identity created (fingerprint: ${newIdentity.fingerprint})`);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to auto-generate identity: ${detail}`);
+    console.error('Check permissions on ~/.remi or generate manually with "remi keygen".');
+    process.exit(1);
+  }
 }
 
 const storedIdentity = identityStore.load();
@@ -1506,7 +1513,14 @@ if (isEncrypted(storedIdentity)) {
   }
 } else {
   // Unencrypted identity: unlock instantly
-  unlockedIdentity = await unlockIdentity(storedIdentity);
+  try {
+    unlockedIdentity = await unlockIdentity(storedIdentity);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to unlock identity: ${detail}`);
+    console.error('Identity file may be corrupt. Run "remi keygen --force" to regenerate.');
+    process.exit(1);
+  }
 }
 
 const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -224,7 +224,7 @@ import {
   now,
 } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
-import { unlockIdentity } from '@remi/shared';
+import { isEncrypted, unlockIdentity } from '@remi/shared';
 import {
   type AdapterMetadata,
   AdapterRegistry,
@@ -320,6 +320,8 @@ let cliSubcommandArg: string | undefined;
 let cliCodeRefresh = false;
 let cliPermanentCode = false;
 let cliForce = false;
+let cliUsePassphrase = false;
+let cliNoTofu = false;
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
 let cliBindHost: string | undefined;
@@ -363,6 +365,10 @@ for (let i = 0; i < args.length; i++) {
     cliUninstall = true;
   } else if (arg === '--force') {
     cliForce = true;
+  } else if (arg === '--passphrase') {
+    cliUsePassphrase = true;
+  } else if (arg === '--no-tofu') {
+    cliNoTofu = true;
   } else if (arg === '--label' && nextArg) {
     cliLabel = nextArg;
     i++;
@@ -405,6 +411,8 @@ Options:
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
   --bind HOST              Bind WebSocket to HOST (default: localhost; use 0.0.0.0 for all interfaces)
   --force                  Overwrite existing identity (keygen/import-key)
+  --passphrase             Encrypt identity with a passphrase (keygen)
+  --no-tofu                Reject unknown clients (disable Trust On First Use)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
   --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
@@ -568,7 +576,11 @@ WantedBy=default.target`;
 // Handle key management subcommands
 if (cliSubcommand === 'keygen') {
   const { runKeygen } = await import('./cli/keygen.ts');
-  await runKeygen({ passphrase: process.env['REMI_PASSPHRASE'], force: cliForce });
+  await runKeygen({
+    passphrase: process.env['REMI_PASSPHRASE'],
+    usePassphrase: cliUsePassphrase,
+    force: cliForce,
+  });
   process.exit(0);
 }
 
@@ -1454,13 +1466,14 @@ const sharedEvents = {
 };
 
 // ---------------------------------------------------------------------------
-// Auth setup: identity is required
+// Auth setup: auto-generate identity if missing, auto-unlock if unencrypted
 // ---------------------------------------------------------------------------
 const identityStore = new IdentityStore();
 
 if (!identityStore.exists()) {
-  console.error('No identity found. Run "remi keygen" first.');
-  process.exit(1);
+  console.log('No identity found. Generating new Ed25519 keypair...');
+  const newIdentity = await identityStore.generate();
+  console.log(`Identity created (fingerprint: ${newIdentity.fingerprint})`);
 }
 
 const storedIdentity = identityStore.load();
@@ -1469,21 +1482,38 @@ if (!storedIdentity) {
   process.exit(1);
 }
 
-const { promptPassphrase } = await import('./cli/prompt-passphrase.ts');
-const passphrase = await promptPassphrase('Passphrase to unlock identity');
-
 let unlockedIdentity: UnlockedIdentity;
-try {
-  unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
-} catch (err) {
-  const detail = err instanceof Error ? err.message : String(err);
-  console.error(`Failed to unlock identity: ${detail}`);
-  console.error('Wrong passphrase?');
-  process.exit(1);
+
+if (isEncrypted(storedIdentity)) {
+  // Encrypted identity: use REMI_PASSPHRASE env var or prompt
+  const envPassphrase = process.env['REMI_PASSPHRASE'];
+  let passphrase: string;
+
+  if (envPassphrase) {
+    passphrase = envPassphrase;
+  } else {
+    const { promptPassphrase } = await import('./cli/prompt-passphrase.ts');
+    passphrase = await promptPassphrase('Passphrase to unlock identity');
+  }
+
+  try {
+    unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to unlock identity: ${detail}`);
+    console.error('Wrong passphrase?');
+    process.exit(1);
+  }
+} else {
+  // Unencrypted identity: unlock instantly
+  unlockedIdentity = await unlockIdentity(storedIdentity);
 }
 
-const authenticator = new Authenticator({ identity: unlockedIdentity, identityStore });
-console.log(`Authentication enabled (fingerprint: ${storedIdentity.fingerprint})`);
+const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);
+const authenticator = new Authenticator({ identity: unlockedIdentity, identityStore, tofuMode });
+console.log(
+  `Authentication enabled (fingerprint: ${storedIdentity.fingerprint}, TOFU: ${tofuMode})`,
+);
 
 // ---------------------------------------------------------------------------
 // Create and register adapters

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -1,7 +1,8 @@
 /**
  * `remi keygen` - Generate a new Ed25519 identity keypair.
  *
- * Prompts for a passphrase to encrypt the private key.
+ * By default, creates an unencrypted identity for zero-friction startup.
+ * Use --passphrase to encrypt the private key with a passphrase.
  * Writes identity to ~/.remi/identity.json with 0600 permissions.
  */
 
@@ -10,6 +11,7 @@ import { promptPassphrase } from './prompt-passphrase.ts';
 
 export interface KeygenOptions {
   passphrase?: string | undefined;
+  usePassphrase?: boolean | undefined;
   force?: boolean | undefined;
   dir?: string | undefined;
 }
@@ -29,9 +31,18 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
     process.exit(1);
   }
 
-  const passphrase = options.passphrase ?? (await promptPassphrase('Passphrase (min 8 chars)'));
+  let passphrase: string | undefined;
 
-  if (passphrase.length < 8) {
+  if (options.passphrase) {
+    // Explicit passphrase provided via env or option
+    passphrase = options.passphrase;
+  } else if (options.usePassphrase) {
+    // --passphrase flag: prompt interactively
+    passphrase = await promptPassphrase('Passphrase (min 8 chars)');
+  }
+  // Otherwise: no passphrase (unencrypted identity)
+
+  if (passphrase !== undefined && passphrase.length < 8) {
     console.error('Passphrase must be at least 8 characters.');
     process.exit(1);
   }
@@ -41,7 +52,6 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
 
   console.log('Identity generated successfully.');
   console.log(`  Fingerprint: ${identity.fingerprint}`);
+  console.log(`  Encrypted:   ${identity.iterations > 0 ? 'yes' : 'no'}`);
   console.log(`  Stored at:   ${store.identityPath}`);
-  console.log('');
-  console.log('Share your public key with clients using: remi export-key --public-only');
 }

--- a/packages/daemon/src/cli/keygen.ts
+++ b/packages/daemon/src/cli/keygen.ts
@@ -6,6 +6,7 @@
  * Writes identity to ~/.remi/identity.json with 0600 permissions.
  */
 
+import { isEncrypted } from '@remi/shared';
 import { IdentityStore } from '../auth/identity-store.ts';
 import { promptPassphrase } from './prompt-passphrase.ts';
 
@@ -52,6 +53,6 @@ export async function runKeygen(options: KeygenOptions = {}): Promise<void> {
 
   console.log('Identity generated successfully.');
   console.log(`  Fingerprint: ${identity.fingerprint}`);
-  console.log(`  Encrypted:   ${identity.iterations > 0 ? 'yes' : 'no'}`);
+  console.log(`  Encrypted:   ${isEncrypted(identity) ? 'yes' : 'no'}`);
   console.log(`  Stored at:   ${store.identityPath}`);
 }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -105,6 +105,7 @@ export interface ConnectionConfig {
 
 const DEFAULT_PING_INTERVAL = 30000;
 const DEFAULT_CONNECTION_TIMEOUT = 10000;
+const DEFAULT_AUTH_CONNECTION_TIMEOUT = 60000;
 const SERVER_VERSION = '0.1.0';
 
 /**
@@ -142,7 +143,9 @@ export class Connection {
     this.config = {
       serverVersion: config.serverVersion ?? SERVER_VERSION,
       pingInterval: config.pingInterval ?? DEFAULT_PING_INTERVAL,
-      connectionTimeout: config.connectionTimeout ?? DEFAULT_CONNECTION_TIMEOUT,
+      connectionTimeout:
+        config.connectionTimeout ??
+        (config.authenticator ? DEFAULT_AUTH_CONNECTION_TIMEOUT : DEFAULT_CONNECTION_TIMEOUT),
       skipHelloAck: config.skipHelloAck ?? false,
       authenticator: config.authenticator,
     };

--- a/packages/daemon/tests/authenticator.test.ts
+++ b/packages/daemon/tests/authenticator.test.ts
@@ -31,13 +31,13 @@ describe('Authenticator', () => {
     tmpDir = makeTmpDir();
     store = new IdentityStore(tmpDir);
 
-    // Generate server identity
-    await store.generate('serverpass');
-    serverIdentity = await store.unlock('serverpass');
+    // Generate server identity (unencrypted for test speed)
+    await store.generate();
+    serverIdentity = await store.unlock();
 
-    // Generate client identity
-    const clientIdFile = await createIdentity('clientpass');
-    clientIdentity = await unlockIdentity(clientIdFile, 'clientpass');
+    // Generate client identity (unencrypted for test speed)
+    const clientIdFile = await createIdentity();
+    clientIdentity = await unlockIdentity(clientIdFile);
     clientPublicKeyBase64 = clientIdFile.publicKey;
     clientFingerprint = clientIdFile.fingerprint;
 
@@ -191,6 +191,118 @@ describe('Authenticator', () => {
 
     test('serverPublicKey returns identity public key', () => {
       expect(authenticator.serverPublicKey).toBe(serverIdentity.publicKeyRaw);
+    });
+  });
+
+  describe('TOFU (Trust On First Use)', () => {
+    let tofuAuthenticator: Authenticator;
+    let unknownIdentity: UnlockedIdentity;
+    let unknownPublicKeyBase64: string;
+    let unknownFingerprint: string;
+
+    beforeEach(async () => {
+      // Create authenticator with TOFU enabled
+      tofuAuthenticator = new Authenticator({
+        identity: serverIdentity,
+        identityStore: store,
+        tofuMode: 'auto-accept',
+      });
+
+      // Create an unknown client (not pre-authorized)
+      const unknownId = await createIdentity();
+      unknownIdentity = await unlockIdentity(unknownId);
+      unknownPublicKeyBase64 = unknownId.publicKey;
+      unknownFingerprint = unknownId.fingerprint;
+    });
+
+    test('auto-accept mode: unknown client with valid signature is accepted', async () => {
+      const challenge = tofuAuthenticator.createChallenge('conn-tofu');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      const result = await tofuAuthenticator.verifyResponse('conn-tofu', response);
+      expect(result.success).toBe(true);
+      expect(result.serverSignature).toBeDefined();
+    });
+
+    test('auto-accept mode: client key is added to authorized keys', async () => {
+      const challenge = tofuAuthenticator.createChallenge('conn-tofu');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      await tofuAuthenticator.verifyResponse('conn-tofu', response);
+
+      // Key should now be in the store
+      expect(store.isAuthorized(unknownPublicKeyBase64, unknownFingerprint)).toBe(true);
+    });
+
+    test('auto-accept mode: bad signature never triggers TOFU', async () => {
+      const _challenge = tofuAuthenticator.createChallenge('conn-tofu');
+
+      // Sign wrong data
+      const wrongData = new TextEncoder().encode('wrong data');
+      const signature = await sign(unknownIdentity.privateKey, wrongData.buffer);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      const result = await tofuAuthenticator.verifyResponse('conn-tofu', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_SIGNATURE');
+
+      // Key should NOT be added
+      expect(store.isAuthorized(unknownPublicKeyBase64, unknownFingerprint)).toBe(false);
+    });
+
+    test('reject mode: unknown client is rejected even with valid signature', async () => {
+      const rejectAuthenticator = new Authenticator({
+        identity: serverIdentity,
+        identityStore: store,
+        tofuMode: 'reject',
+      });
+
+      const challenge = rejectAuthenticator.createChallenge('conn-reject');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      const result = await rejectAuthenticator.verifyResponse('conn-reject', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('UNKNOWN_KEY');
+    });
+
+    test('already-authorized key does not trigger TOFU', async () => {
+      // Pre-authorize the client
+      await store.addAuthorizedKey(unknownPublicKeyBase64, 'Pre-Authorized');
+
+      const challenge = tofuAuthenticator.createChallenge('conn-existing');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      const result = await tofuAuthenticator.verifyResponse('conn-existing', response);
+      expect(result.success).toBe(true);
+
+      // Should still have just one key entry (not duplicated)
+      const keys = store.listAuthorizedKeys();
+      const matching = keys.filter((k) => k.fingerprint === unknownFingerprint);
+      expect(matching.length).toBe(1);
+      expect(matching[0]?.label).toBe('Pre-Authorized');
+    });
+
+    test('default TOFU mode is reject', () => {
+      const defaultAuth = new Authenticator({
+        identity: serverIdentity,
+        identityStore: store,
+      });
+
+      // Verify by testing that unknown key is rejected
+      // (we already tested this in the main verifyResponse tests)
+      expect(defaultAuth).toBeDefined();
     });
   });
 });

--- a/packages/daemon/tests/authenticator.test.ts
+++ b/packages/daemon/tests/authenticator.test.ts
@@ -294,15 +294,35 @@ describe('Authenticator', () => {
       expect(matching[0]?.label).toBe('Pre-Authorized');
     });
 
-    test('default TOFU mode is reject', () => {
+    test('default TOFU mode is reject', async () => {
       const defaultAuth = new Authenticator({
         identity: serverIdentity,
         identityStore: store,
       });
 
-      // Verify by testing that unknown key is rejected
-      // (we already tested this in the main verifyResponse tests)
-      expect(defaultAuth).toBeDefined();
+      const challenge = defaultAuth.createChallenge('conn-default');
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      const result = await defaultAuth.verifyResponse('conn-default', response);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('UNKNOWN_KEY');
+    });
+
+    test('auto-accept mode: handles race condition when key is added concurrently', async () => {
+      const challenge = tofuAuthenticator.createChallenge('conn-race');
+
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(unknownIdentity.privateKey, challengeData);
+      const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
+
+      // Simulate concurrent authorization (another connection added the key first)
+      await store.addAuthorizedKey(unknownPublicKeyBase64, 'concurrent-add');
+
+      // TOFU should still succeed (catches DuplicateKeyError)
+      const result = await tofuAuthenticator.verifyResponse('conn-race', response);
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/packages/daemon/tests/identity-store.test.ts
+++ b/packages/daemon/tests/identity-store.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { createIdentity } from '@remi/shared';
-import { IdentityStore } from '../src/auth/identity-store.ts';
+import { DuplicateKeyError, IdentityStore } from '../src/auth/identity-store.ts';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-auth-test-'));
@@ -73,6 +73,34 @@ describe('IdentityStore', () => {
       await expect(store.unlock('any')).rejects.toThrow('No identity found');
     });
 
+    test('generate creates unencrypted identity without passphrase', async () => {
+      const identity = await store.generate();
+      expect(identity.iterations).toBe(0);
+      expect(identity.salt).toBe('');
+      expect(store.exists()).toBe(true);
+    });
+
+    test('unlock succeeds without passphrase for unencrypted identity', async () => {
+      await store.generate();
+      const unlocked = await store.unlock();
+      expect(unlocked.publicKey.type).toBe('public');
+      expect(unlocked.privateKey.type).toBe('private');
+    });
+
+    test('isEncrypted returns true for encrypted identity', async () => {
+      await store.generate('testpass');
+      expect(store.isEncrypted()).toBe(true);
+    });
+
+    test('isEncrypted returns false for unencrypted identity', async () => {
+      await store.generate();
+      expect(store.isEncrypted()).toBe(false);
+    });
+
+    test('isEncrypted returns false when no identity exists', () => {
+      expect(store.isEncrypted()).toBe(false);
+    });
+
     test('identity file has restricted permissions', async () => {
       await store.generate('pass');
       const identityPath = path.join(tmpDir, 'identity.json');
@@ -103,12 +131,16 @@ describe('IdentityStore', () => {
       expect(keys[0]?.fingerprint).toBe(identity.fingerprint);
     });
 
-    test('addAuthorizedKey rejects duplicate fingerprint', async () => {
+    test('addAuthorizedKey rejects duplicate fingerprint with DuplicateKeyError', async () => {
       const identity = await createIdentity('pass');
       await store.addAuthorizedKey(identity.publicKey, 'First');
-      await expect(store.addAuthorizedKey(identity.publicKey, 'Duplicate')).rejects.toThrow(
-        'already authorized',
-      );
+      try {
+        await store.addAuthorizedKey(identity.publicKey, 'Duplicate');
+        expect(true).toBe(false); // should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(DuplicateKeyError);
+        expect((err as Error).message).toContain('already authorized');
+      }
     });
 
     test('removeAuthorizedKey removes a key', async () => {

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -83,6 +83,10 @@ export async function createIdentity(passphrase?: string): Promise<RemiIdentity>
   const exported = await exportKeyPair(keyPair);
   const fp = await fingerprint(exported.publicKeyRaw);
 
+  if (passphrase !== undefined && passphrase.length === 0) {
+    throw new Error('Passphrase must not be empty. Omit it to create an unencrypted identity.');
+  }
+
   if (passphrase) {
     const encrypted = await encryptPrivateKey(exported.privateKeyRaw, passphrase);
     return {
@@ -188,6 +192,14 @@ export function deserializeIdentity(json: string): RemiIdentity {
 
   if (typeof obj['iterations'] !== 'number' || obj['iterations'] < 0) {
     throw new Error('Invalid identity: invalid iterations count');
+  }
+
+  // Cross-field consistency: encrypted vs unencrypted
+  if (obj['iterations'] === 0 && (obj['salt'] !== '' || obj['iv'] !== '')) {
+    throw new Error('Invalid identity: unencrypted identity must have empty salt and iv');
+  }
+  if ((obj['iterations'] as number) > 0 && (obj['salt'] === '' || obj['iv'] === '')) {
+    throw new Error('Invalid identity: encrypted identity requires non-empty salt and iv');
   }
 
   return parsed as RemiIdentity;

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -1,8 +1,9 @@
 /**
  * Identity management for Remi authentication.
  *
- * Handles creation, serialization, and unlocking of Ed25519 identities
- * with passphrase-encrypted private keys.
+ * Handles creation, serialization, and unlocking of Ed25519 identities.
+ * Private keys can be passphrase-encrypted (AES-256-GCM) or stored
+ * unencrypted for zero-friction startup.
  */
 
 import type { Base64, Fingerprint } from './crypto.ts';
@@ -19,10 +20,15 @@ import {
   toBase64,
 } from './crypto.ts';
 
-/** Persisted identity with passphrase-encrypted private key */
+/**
+ * Persisted identity. The private key is either passphrase-encrypted
+ * (iterations > 0, non-empty salt/iv) or stored as raw PKCS8 base64
+ * (iterations === 0, empty salt/iv). Use `isEncrypted()` to check.
+ */
 export interface RemiIdentity {
   readonly version: 1;
   readonly publicKey: Base64;
+  /** Encrypted ciphertext (when encrypted) or raw PKCS8 base64 (when unencrypted) */
   readonly encryptedPrivateKey: Base64;
   readonly salt: Base64;
   readonly iv: Base64;
@@ -62,45 +68,74 @@ export interface KnownHost {
   readonly lastSeen: string;
 }
 
+/** Check whether an identity has an encrypted private key. */
+export function isEncrypted(identity: RemiIdentity): boolean {
+  return identity.iterations > 0;
+}
+
 /**
- * Generate a new identity with a passphrase-encrypted private key.
+ * Generate a new identity. When a passphrase is provided the private key
+ * is encrypted with PBKDF2 + AES-256-GCM. Without a passphrase the raw
+ * PKCS8 key is stored directly (zero-friction mode).
  */
-export async function createIdentity(passphrase: string): Promise<RemiIdentity> {
+export async function createIdentity(passphrase?: string): Promise<RemiIdentity> {
   const keyPair = await generateKeyPair();
   const exported = await exportKeyPair(keyPair);
   const fp = await fingerprint(exported.publicKeyRaw);
 
-  const encrypted = await encryptPrivateKey(exported.privateKeyRaw, passphrase);
+  if (passphrase) {
+    const encrypted = await encryptPrivateKey(exported.privateKeyRaw, passphrase);
+    return {
+      version: 1,
+      publicKey: toBase64(exported.publicKeyRaw),
+      encryptedPrivateKey: encrypted.ciphertext,
+      salt: encrypted.salt,
+      iv: encrypted.iv,
+      iterations: PBKDF2_ITERATIONS,
+      fingerprint: fp,
+      createdAt: new Date().toISOString(),
+    };
+  }
 
   return {
     version: 1,
     publicKey: toBase64(exported.publicKeyRaw),
-    encryptedPrivateKey: encrypted.ciphertext,
-    salt: encrypted.salt,
-    iv: encrypted.iv,
-    iterations: PBKDF2_ITERATIONS,
+    encryptedPrivateKey: toBase64(exported.privateKeyRaw),
+    salt: '',
+    iv: '',
+    iterations: 0,
     fingerprint: fp,
     createdAt: new Date().toISOString(),
   };
 }
 
 /**
- * Unlock an identity by decrypting the private key with a passphrase.
- * @throws if passphrase is incorrect
+ * Unlock an identity. Encrypted identities require a passphrase;
+ * unencrypted identities can be unlocked without one.
+ * @throws if passphrase is required but missing, or if it is incorrect
  */
 export async function unlockIdentity(
   identity: RemiIdentity,
-  passphrase: string,
+  passphrase?: string,
 ): Promise<UnlockedIdentity> {
-  const privateKeyPkcs8 = await decryptPrivateKey(
-    {
-      ciphertext: identity.encryptedPrivateKey,
-      iv: identity.iv,
-      salt: identity.salt,
-    },
-    passphrase,
-    identity.iterations,
-  );
+  let privateKeyPkcs8: ArrayBuffer;
+
+  if (isEncrypted(identity)) {
+    if (!passphrase) {
+      throw new Error('Passphrase required for encrypted identity');
+    }
+    privateKeyPkcs8 = await decryptPrivateKey(
+      {
+        ciphertext: identity.encryptedPrivateKey,
+        iv: identity.iv,
+        salt: identity.salt,
+      },
+      passphrase,
+      identity.iterations,
+    );
+  } else {
+    privateKeyPkcs8 = fromBase64(identity.encryptedPrivateKey);
+  }
 
   const privateKey = await importPrivateKey(privateKeyPkcs8);
   const publicKey = await importPublicKey(fromBase64(identity.publicKey));
@@ -137,14 +172,21 @@ export function deserializeIdentity(json: string): RemiIdentity {
     throw new Error(`Unsupported identity version: ${String(obj['version'])}`);
   }
 
-  const required = ['publicKey', 'encryptedPrivateKey', 'salt', 'iv', 'fingerprint', 'createdAt'];
+  const required = ['publicKey', 'encryptedPrivateKey', 'fingerprint', 'createdAt'];
   for (const field of required) {
     if (typeof obj[field] !== 'string') {
       throw new Error(`Invalid identity: missing or invalid field '${field}'`);
     }
   }
 
-  if (typeof obj['iterations'] !== 'number' || obj['iterations'] < 1) {
+  // salt and iv must be strings (empty string for unencrypted)
+  for (const field of ['salt', 'iv']) {
+    if (typeof obj[field] !== 'string') {
+      throw new Error(`Invalid identity: missing or invalid field '${field}'`);
+    }
+  }
+
+  if (typeof obj['iterations'] !== 'number' || obj['iterations'] < 0) {
     throw new Error('Invalid identity: invalid iterations count');
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -132,6 +132,7 @@ export type {
   KnownHost,
 } from './identity.ts';
 export {
+  isEncrypted,
   createIdentity,
   unlockIdentity,
   serializeIdentity,

--- a/packages/shared/tests/identity.test.ts
+++ b/packages/shared/tests/identity.test.ts
@@ -10,6 +10,7 @@ import {
   createAuthorizedKeysFile,
   createIdentity,
   deserializeIdentity,
+  isEncrypted,
   serializeIdentity,
   unlockIdentity,
 } from '../src/identity.ts';
@@ -25,8 +26,20 @@ async function createTestIdentity(passphrase: string): Promise<RemiIdentity> {
   return createIdentity(passphrase);
 }
 
+describe('isEncrypted', () => {
+  test('returns true for encrypted identity', async () => {
+    const identity = await createTestIdentity('testpass');
+    expect(isEncrypted(identity)).toBe(true);
+  });
+
+  test('returns false for unencrypted identity', async () => {
+    const identity = await createIdentity();
+    expect(isEncrypted(identity)).toBe(false);
+  });
+});
+
 describe('createIdentity', () => {
-  test('creates a valid identity with all fields', async () => {
+  test('creates a valid encrypted identity with all fields', async () => {
     const identity = await createTestIdentity('testpass');
 
     expect(identity.version).toBe(1);
@@ -40,15 +53,34 @@ describe('createIdentity', () => {
     expect(typeof identity.createdAt).toBe('string');
   });
 
+  test('creates unencrypted identity without passphrase', async () => {
+    const identity = await createIdentity();
+
+    expect(identity.version).toBe(1);
+    expect(typeof identity.publicKey).toBe('string');
+    expect(typeof identity.encryptedPrivateKey).toBe('string');
+    expect(identity.salt).toBe('');
+    expect(identity.iv).toBe('');
+    expect(identity.iterations).toBe(0);
+    expect(identity.fingerprint.length).toBe(FINGERPRINT_LENGTH);
+    expect(identity.fingerprint).toMatch(/^[0-9a-f]+$/);
+  });
+
   test('public key is valid base64 of 32 bytes', async () => {
     const identity = await createTestIdentity('pass');
+    const raw = fromBase64(identity.publicKey);
+    expect(raw.byteLength).toBe(32);
+  });
+
+  test('unencrypted public key is valid base64 of 32 bytes', async () => {
+    const identity = await createIdentity();
     const raw = fromBase64(identity.publicKey);
     expect(raw.byteLength).toBe(32);
   });
 });
 
 describe('unlockIdentity', () => {
-  test('unlocks with correct passphrase', async () => {
+  test('unlocks encrypted identity with correct passphrase', async () => {
     const identity = await createTestIdentity('correct');
     const unlocked = await unlockIdentity(identity, 'correct');
 
@@ -58,14 +90,41 @@ describe('unlockIdentity', () => {
     expect(unlocked.fingerprint).toBe(identity.fingerprint);
   });
 
-  test('rejects wrong passphrase', async () => {
+  test('unlocks unencrypted identity without passphrase', async () => {
+    const identity = await createIdentity();
+    const unlocked = await unlockIdentity(identity);
+
+    expect(unlocked.publicKey.type).toBe('public');
+    expect(unlocked.privateKey.type).toBe('private');
+    expect(unlocked.publicKeyRaw).toBe(identity.publicKey);
+    expect(unlocked.fingerprint).toBe(identity.fingerprint);
+  });
+
+  test('rejects wrong passphrase on encrypted identity', async () => {
     const identity = await createTestIdentity('correct');
     await expect(unlockIdentity(identity, 'wrong')).rejects.toThrow();
   });
 
-  test('unlocked key can sign and verify', async () => {
+  test('throws when passphrase missing for encrypted identity', async () => {
+    const identity = await createTestIdentity('secure');
+    await expect(unlockIdentity(identity)).rejects.toThrow(
+      'Passphrase required for encrypted identity',
+    );
+  });
+
+  test('unlocked encrypted key can sign and verify', async () => {
     const identity = await createTestIdentity('mypass');
     const unlocked = await unlockIdentity(identity, 'mypass');
+
+    const data = new TextEncoder().encode('test data');
+    const sig = await sign(unlocked.privateKey, data.buffer);
+    const valid = await verify(unlocked.publicKey, data.buffer, sig);
+    expect(valid).toBe(true);
+  });
+
+  test('unlocked unencrypted key can sign and verify', async () => {
+    const identity = await createIdentity();
+    const unlocked = await unlockIdentity(identity);
 
     const data = new TextEncoder().encode('test data');
     const sig = await sign(unlocked.privateKey, data.buffer);
@@ -75,7 +134,7 @@ describe('unlockIdentity', () => {
 });
 
 describe('serializeIdentity / deserializeIdentity', () => {
-  test('round-trips identity through JSON', async () => {
+  test('round-trips encrypted identity through JSON', async () => {
     const original = await createTestIdentity('pass');
     const json = serializeIdentity(original);
     const deserialized = deserializeIdentity(json);
@@ -86,6 +145,20 @@ describe('serializeIdentity / deserializeIdentity', () => {
     expect(deserialized.salt).toBe(original.salt);
     expect(deserialized.iv).toBe(original.iv);
     expect(deserialized.iterations).toBe(original.iterations);
+    expect(deserialized.fingerprint).toBe(original.fingerprint);
+  });
+
+  test('round-trips unencrypted identity through JSON', async () => {
+    const original = await createIdentity();
+    const json = serializeIdentity(original);
+    const deserialized = deserializeIdentity(json);
+
+    expect(deserialized.version).toBe(1);
+    expect(deserialized.publicKey).toBe(original.publicKey);
+    expect(deserialized.encryptedPrivateKey).toBe(original.encryptedPrivateKey);
+    expect(deserialized.salt).toBe('');
+    expect(deserialized.iv).toBe('');
+    expect(deserialized.iterations).toBe(0);
     expect(deserialized.fingerprint).toBe(original.fingerprint);
   });
 
@@ -118,6 +191,23 @@ describe('serializeIdentity / deserializeIdentity', () => {
     expect(() => deserializeIdentity('"string"')).toThrow();
     expect(() => deserializeIdentity('null')).toThrow();
     expect(() => deserializeIdentity('42')).toThrow();
+  });
+
+  test('rejects negative iterations', () => {
+    expect(() =>
+      deserializeIdentity(
+        JSON.stringify({
+          version: 1,
+          publicKey: 'x',
+          encryptedPrivateKey: 'x',
+          salt: '',
+          iv: '',
+          iterations: -1,
+          fingerprint: 'x',
+          createdAt: 'x',
+        }),
+      ),
+    ).toThrow('invalid iterations');
   });
 });
 

--- a/packages/shared/tests/identity.test.ts
+++ b/packages/shared/tests/identity.test.ts
@@ -77,6 +77,10 @@ describe('createIdentity', () => {
     const raw = fromBase64(identity.publicKey);
     expect(raw.byteLength).toBe(32);
   });
+
+  test('rejects empty string passphrase', async () => {
+    await expect(createIdentity('')).rejects.toThrow('Passphrase must not be empty');
+  });
 });
 
 describe('unlockIdentity', () => {
@@ -208,6 +212,40 @@ describe('serializeIdentity / deserializeIdentity', () => {
         }),
       ),
     ).toThrow('invalid iterations');
+  });
+
+  test('rejects unencrypted identity with non-empty salt', () => {
+    expect(() =>
+      deserializeIdentity(
+        JSON.stringify({
+          version: 1,
+          publicKey: 'x',
+          encryptedPrivateKey: 'x',
+          salt: 'somesalt',
+          iv: '',
+          iterations: 0,
+          fingerprint: 'x',
+          createdAt: 'x',
+        }),
+      ),
+    ).toThrow('unencrypted identity must have empty salt and iv');
+  });
+
+  test('rejects encrypted identity with empty salt', () => {
+    expect(() =>
+      deserializeIdentity(
+        JSON.stringify({
+          version: 1,
+          publicKey: 'x',
+          encryptedPrivateKey: 'x',
+          salt: '',
+          iv: 'someiv',
+          iterations: 600000,
+          fingerprint: 'x',
+          createdAt: 'x',
+        }),
+      ),
+    ).toThrow('encrypted identity requires non-empty salt and iv');
   });
 });
 

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   generateIdentity,
   getFingerprint,
   importIdentity,
+  isIdentityEncrypted,
   removeIdentity,
 } from '@/lib/identity-client';
 import type { AppSettings } from '@/types';
@@ -88,37 +89,48 @@ function IdentitySection() {
   const [fingerprint, setFingerprint] = useState<string | null>(getFingerprint);
   const [showGenerate, setShowGenerate] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  const [usePassphrase, setUsePassphrase] = useState(false);
   const [passphrase, setPassphrase] = useState('');
   const [confirmPassphrase, setConfirmPassphrase] = useState('');
   const [importJson, setImportJson] = useState('');
   const [generating, setGenerating] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [encrypted, setEncrypted] = useState(false);
 
   const passphraseRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(() => {
     setFingerprint(getFingerprint());
+    setEncrypted(isIdentityEncrypted());
+  }, []);
+
+  // Check encryption status on mount
+  useEffect(() => {
+    setEncrypted(isIdentityEncrypted());
   }, []);
 
   const handleGenerate = async (e: FormEvent) => {
     e.preventDefault();
-    if (passphrase.length < 8) {
-      setFeedback('Passphrase must be at least 8 characters.');
-      return;
-    }
-    if (passphrase !== confirmPassphrase) {
-      setFeedback('Passphrases do not match.');
-      return;
+    if (usePassphrase) {
+      if (passphrase.length < 8) {
+        setFeedback('Passphrase must be at least 8 characters.');
+        return;
+      }
+      if (passphrase !== confirmPassphrase) {
+        setFeedback('Passphrases do not match.');
+        return;
+      }
     }
     setGenerating(true);
     setFeedback(null);
     try {
-      await generateIdentity(passphrase);
+      await generateIdentity(usePassphrase ? passphrase : undefined);
       refresh();
       setShowGenerate(false);
       setPassphrase('');
       setConfirmPassphrase('');
+      setUsePassphrase(false);
       setFeedback('Identity generated successfully.');
     } catch (err) {
       setFeedback(err instanceof Error ? err.message : 'Failed to generate identity');
@@ -186,7 +198,9 @@ function IdentitySection() {
           <div className="flex items-center gap-2 rounded-lg bg-[--color-surface-light] p-3">
             <Shield className="size-5 shrink-0 text-[--color-primary]" />
             <div className="min-w-0 flex-1">
-              <p className="text-xs text-[--color-text-muted]">Your fingerprint</p>
+              <p className="text-xs text-[--color-text-muted]">
+                Your fingerprint {encrypted ? '(encrypted)' : '(unencrypted)'}
+              </p>
               <p className="truncate font-mono text-sm text-[--color-text]">{fingerprint}</p>
             </div>
             <button
@@ -247,21 +261,34 @@ function IdentitySection() {
           {/* Generate form */}
           {showGenerate && (
             <form onSubmit={handleGenerate} className="space-y-2">
-              <input
-                ref={passphraseRef}
-                type="password"
-                value={passphrase}
-                onChange={(e) => setPassphrase(e.target.value)}
-                placeholder="Passphrase (min 8 chars)"
-                className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
-              />
-              <input
-                type="password"
-                value={confirmPassphrase}
-                onChange={(e) => setConfirmPassphrase(e.target.value)}
-                placeholder="Confirm passphrase"
-                className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
-              />
+              <label className="flex items-center gap-2 text-sm text-[--color-text-secondary]">
+                <input
+                  type="checkbox"
+                  checked={usePassphrase}
+                  onChange={(e) => setUsePassphrase(e.target.checked)}
+                  className="rounded"
+                />
+                Encrypt with passphrase
+              </label>
+              {usePassphrase && (
+                <>
+                  <input
+                    ref={passphraseRef}
+                    type="password"
+                    value={passphrase}
+                    onChange={(e) => setPassphrase(e.target.value)}
+                    placeholder="Passphrase (min 8 chars)"
+                    className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
+                  />
+                  <input
+                    type="password"
+                    value={confirmPassphrase}
+                    onChange={(e) => setConfirmPassphrase(e.target.value)}
+                    placeholder="Confirm passphrase"
+                    className="w-full rounded-lg bg-[--color-surface-light] px-3 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:ring-2 focus:ring-[--color-primary]/50"
+                  />
+                </>
+              )}
               <div className="flex gap-2">
                 <button
                   type="submit"

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -5,7 +5,13 @@
  * Handles auth handshake when daemon requires authentication.
  */
 
-import { checkKnownHost, trustHost } from '@/lib/identity-client';
+import {
+  checkKnownHost,
+  ensureIdentity,
+  isIdentityEncrypted,
+  trustHost,
+  unlockStoredIdentity,
+} from '@/lib/identity-client';
 import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
 import type { ConnectionStatus } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
@@ -173,11 +179,24 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       serverFingerprint: srvFingerprint,
     };
 
-    const identity = identityRef.current;
+    let identity = identityRef.current;
     if (!identity) {
-      // Need passphrase from user
-      setNeedsPassphrase(true);
-      return;
+      // Auto-generate identity if missing, auto-unlock if unencrypted
+      try {
+        await ensureIdentity();
+        if (!isIdentityEncrypted()) {
+          identity = await unlockStoredIdentity();
+          identityRef.current = identity;
+        } else {
+          // Encrypted identity needs passphrase from user
+          setNeedsPassphrase(true);
+          return;
+        }
+      } catch (err) {
+        setError(new Error(`Identity setup failed: ${err instanceof Error ? err.message : String(err)}`));
+        client.disconnect();
+        return;
+      }
     }
 
     // Sign the challenge

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KnownHost, RemiIdentity, UnlockedIdentity } from '@remi/shared';
-import { createIdentity, deserializeIdentity, serializeIdentity, unlockIdentity } from '@remi/shared';
+import { createIdentity, deserializeIdentity, isEncrypted, serializeIdentity, unlockIdentity } from '@remi/shared';
 
 export type { KnownHost };
 
@@ -42,20 +42,34 @@ export function hasIdentity(): boolean {
   return localStorage.getItem(IDENTITY_KEY) !== null;
 }
 
-/** Generate a new identity and store it */
-export async function generateIdentity(passphrase: string): Promise<RemiIdentity> {
+/** Generate a new identity and store it. Without a passphrase, the key is stored unencrypted. */
+export async function generateIdentity(passphrase?: string): Promise<RemiIdentity> {
   const identity = await createIdentity(passphrase);
   saveIdentity(identity);
   return identity;
 }
 
-/** Unlock a stored identity with passphrase */
-export async function unlockStoredIdentity(passphrase: string): Promise<UnlockedIdentity> {
+/** Unlock a stored identity. Encrypted identities require a passphrase. */
+export async function unlockStoredIdentity(passphrase?: string): Promise<UnlockedIdentity> {
   const identity = loadIdentity();
   if (!identity) {
     throw new Error('No identity found');
   }
   return unlockIdentity(identity, passphrase);
+}
+
+/** Check if the stored identity has an encrypted private key. */
+export function isIdentityEncrypted(): boolean {
+  const identity = loadIdentity();
+  if (!identity) return false;
+  return isEncrypted(identity);
+}
+
+/** Ensure an identity exists. Auto-generates an unencrypted one if missing. */
+export async function ensureIdentity(): Promise<RemiIdentity> {
+  const existing = loadIdentity();
+  if (existing) return existing;
+  return generateIdentity();
 }
 
 /** Import identity from JSON string */

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -1,7 +1,8 @@
 /**
  * Client-side identity management.
  *
- * Stores identity in localStorage (private key stays passphrase-encrypted).
+ * Stores identity in localStorage. Private key is either passphrase-encrypted
+ * or stored as raw PKCS8 (unencrypted, for zero-friction startup).
  * Manages known hosts (TOFU model) for server fingerprint verification.
  */
 


### PR DESCRIPTION
## Summary

Simplifies Remi authentication for zero-friction startup (issue #30):

- **Optional passphrase**: Identity can be created without a passphrase (unencrypted, raw PKCS8). Encrypted identities remain fully supported for users who want them.
- **Auto-generate on first run**: `remi` auto-creates an identity if none exists; no `remi keygen` step needed.
- **TOFU (Trust On First Use)**: Unknown clients with valid signatures are auto-accepted and added to `authorized_keys.json`. Use `--no-tofu` to disable.
- **Web app auto-auth**: On `auth_challenge`, the web app auto-generates an unencrypted identity and signs the challenge with no user prompts.
- **Settings UI**: Generate form defaults to no passphrase with an optional "Encrypt with passphrase" toggle. Shows encryption status next to fingerprint.

## Changes

| Area | File | Change |
|------|------|--------|
| Shared | `identity.ts` | `isEncrypted()`, optional passphrase in `createIdentity`/`unlockIdentity` |
| Shared | `index.ts` | Export `isEncrypted` |
| Shared | `identity.test.ts` | 8 new tests for unencrypted flows |
| Daemon | `identity-store.ts` | Optional passphrase in `generate()`/`unlock()`, `isEncrypted()` |
| Daemon | `authenticator.ts` | `TofuMode`, signature-first verification, auto-accept |
| Daemon | `authenticator.test.ts` | 6 new TOFU tests |
| Daemon | `keygen.ts` | Default no passphrase, `--passphrase` flag |
| Daemon | `cli.ts` | Auto-generate, auto-unlock, `--passphrase`/`--no-tofu` flags |
| Daemon | `connection.ts` | 60s auth timeout (was 10s) |
| Web | `identity-client.ts` | `ensureIdentity()`, `isIdentityEncrypted()`, optional passphrase |
| Web | `useWebSocket.ts` | Auto-generate + auto-unlock on auth_challenge |
| Web | `SettingsPanel.tsx` | Optional passphrase toggle, encryption status |

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Existing encrypted identity | Passphrase prompt as before |
| `REMI_PASSPHRASE` env var | Works unchanged |
| New install, first run | Auto-generates unencrypted, instant start |
| `remi keygen` | Creates unencrypted (no prompt) |
| `remi keygen --passphrase` | Prompts, creates encrypted |
| Web app first connect | Auto-generates + auto-unlocks, no prompt |
| Unknown client connects | Auto-accepted (TOFU), logged |

## Test plan

- [x] 801 tests passing (21 shared identity, 17 authenticator including 6 TOFU)
- [x] `bun run typecheck` passes
- [x] `bunx biome check` passes
- [ ] Manual: delete `~/.remi/identity.json`, run `remi --daemon --no-relay`; should auto-generate and start
- [ ] Manual: open web app; should auto-connect with no prompts
- [ ] Manual: check `~/.remi/authorized_keys.json` for TOFU-accepted key
- [ ] Manual: `remi keygen --passphrase --force` prompts and creates encrypted identity

Closes #30