### PR TITLE
fix: ls/attach auth handling, no-auth default on localhost

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1476,7 +1476,7 @@ const sharedEvents = {
 // Auth setup: auto based on bind host (localhost=off, 0.0.0.0=on), --auth/--no-auth override
 // ---------------------------------------------------------------------------
 const bindHost = cliBindHost ?? 'localhost';
-const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1';
+const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1' || bindHost === '::1';
 
 // Determine whether auth should be enabled
 // Default: auth off for localhost, auth on for 0.0.0.0/network binds
@@ -1547,7 +1547,14 @@ if (authEnabled) {
     `Authentication enabled (fingerprint: ${storedIdentity.fingerprint}, TOFU: ${tofuMode})`,
   );
 } else {
-  console.log('Authentication disabled (localhost binding)');
+  if (!isLocalhostBind) {
+    console.warn(
+      'WARNING: Authentication disabled on non-localhost bind. ' +
+        'The daemon is accessible without authentication on the network.',
+    );
+  } else {
+    console.log('Authentication disabled (localhost binding)');
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -322,6 +322,7 @@ let cliPermanentCode = false;
 let cliForce = false;
 let cliUsePassphrase = false;
 let cliNoTofu = false;
+let cliAuth: boolean | undefined; // undefined = auto (auth when bind != localhost)
 let cliLabel: string | undefined;
 let cliPublicOnly = false;
 let cliBindHost: string | undefined;
@@ -369,6 +370,10 @@ for (let i = 0; i < args.length; i++) {
     cliUsePassphrase = true;
   } else if (arg === '--no-tofu') {
     cliNoTofu = true;
+  } else if (arg === '--auth') {
+    cliAuth = true;
+  } else if (arg === '--no-auth') {
+    cliAuth = false;
   } else if (arg === '--label' && nextArg) {
     cliLabel = nextArg;
     i++;
@@ -412,6 +417,8 @@ Options:
   --bind HOST              Bind WebSocket to HOST (default: localhost; use 0.0.0.0 for all interfaces)
   --force                  Overwrite existing identity (keygen/import-key)
   --passphrase             Encrypt identity with a passphrase (keygen)
+  --auth                   Force enable authentication (default: auto based on --bind)
+  --no-auth                Disable authentication (even when binding to all interfaces)
   --no-tofu                Reject unknown clients (disable Trust On First Use)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
@@ -1466,68 +1473,82 @@ const sharedEvents = {
 };
 
 // ---------------------------------------------------------------------------
-// Auth setup: auto-generate identity if missing, auto-unlock if unencrypted
+// Auth setup: auto based on bind host (localhost=off, 0.0.0.0=on), --auth/--no-auth override
 // ---------------------------------------------------------------------------
-const identityStore = new IdentityStore();
+const bindHost = cliBindHost ?? 'localhost';
+const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1';
 
-if (!identityStore.exists()) {
-  console.log('No identity found. Generating new Ed25519 keypair...');
-  try {
-    const newIdentity = await identityStore.generate();
-    console.log(`Identity created (fingerprint: ${newIdentity.fingerprint})`);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error(`Failed to auto-generate identity: ${detail}`);
-    console.error('Check permissions on ~/.remi or generate manually with "remi keygen".');
+// Determine whether auth should be enabled
+// Default: auth off for localhost, auth on for 0.0.0.0/network binds
+// Explicit --auth/--no-auth overrides the default
+const authEnabled = cliAuth ?? !isLocalhostBind;
+
+let authenticator: Authenticator | undefined;
+
+if (authEnabled) {
+  const identityStore = new IdentityStore();
+
+  if (!identityStore.exists()) {
+    console.log('No identity found. Generating new Ed25519 keypair...');
+    try {
+      const newIdentity = await identityStore.generate();
+      console.log(`Identity created (fingerprint: ${newIdentity.fingerprint})`);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to auto-generate identity: ${detail}`);
+      console.error('Check permissions on ~/.remi or generate manually with "remi keygen".');
+      process.exit(1);
+    }
+  }
+
+  const storedIdentity = identityStore.load();
+  if (!storedIdentity) {
+    console.error('Identity file is empty. Run "remi keygen --force" to regenerate.');
     process.exit(1);
   }
-}
 
-const storedIdentity = identityStore.load();
-if (!storedIdentity) {
-  console.error('Identity file is empty. Run "remi keygen --force" to regenerate.');
-  process.exit(1);
-}
+  let unlockedIdentity: UnlockedIdentity;
 
-let unlockedIdentity: UnlockedIdentity;
+  if (isEncrypted(storedIdentity)) {
+    // Encrypted identity: use REMI_PASSPHRASE env var or prompt
+    const envPassphrase = process.env['REMI_PASSPHRASE'];
+    let passphrase: string;
 
-if (isEncrypted(storedIdentity)) {
-  // Encrypted identity: use REMI_PASSPHRASE env var or prompt
-  const envPassphrase = process.env['REMI_PASSPHRASE'];
-  let passphrase: string;
+    if (envPassphrase) {
+      passphrase = envPassphrase;
+    } else {
+      const { promptPassphrase } = await import('./cli/prompt-passphrase.ts');
+      passphrase = await promptPassphrase('Passphrase to unlock identity');
+    }
 
-  if (envPassphrase) {
-    passphrase = envPassphrase;
+    try {
+      unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to unlock identity: ${detail}`);
+      console.error('Wrong passphrase?');
+      process.exit(1);
+    }
   } else {
-    const { promptPassphrase } = await import('./cli/prompt-passphrase.ts');
-    passphrase = await promptPassphrase('Passphrase to unlock identity');
+    // Unencrypted identity: unlock instantly
+    try {
+      unlockedIdentity = await unlockIdentity(storedIdentity);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to unlock identity: ${detail}`);
+      console.error('Identity file may be corrupt. Run "remi keygen --force" to regenerate.');
+      process.exit(1);
+    }
   }
 
-  try {
-    unlockedIdentity = await unlockIdentity(storedIdentity, passphrase);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error(`Failed to unlock identity: ${detail}`);
-    console.error('Wrong passphrase?');
-    process.exit(1);
-  }
+  const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);
+  authenticator = new Authenticator({ identity: unlockedIdentity, identityStore, tofuMode });
+  console.log(
+    `Authentication enabled (fingerprint: ${storedIdentity.fingerprint}, TOFU: ${tofuMode})`,
+  );
 } else {
-  // Unencrypted identity: unlock instantly
-  try {
-    unlockedIdentity = await unlockIdentity(storedIdentity);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error(`Failed to unlock identity: ${detail}`);
-    console.error('Identity file may be corrupt. Run "remi keygen --force" to regenerate.');
-    process.exit(1);
-  }
+  console.log('Authentication disabled (localhost binding)');
 }
-
-const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);
-const authenticator = new Authenticator({ identity: unlockedIdentity, identityStore, tofuMode });
-console.log(
-  `Authentication enabled (fingerprint: ${storedIdentity.fingerprint}, TOFU: ${tofuMode})`,
-);
 
 // ---------------------------------------------------------------------------
 // Create and register adapters
@@ -1535,7 +1556,7 @@ console.log(
 const wsAdapter = new WebSocketAdapter(
   {
     port: PORT,
-    host: cliBindHost ?? 'localhost',
+    host: bindHost,
     authenticator,
   },
   sharedEvents,
@@ -1568,6 +1589,12 @@ if (!cliNoRelay) {
 
   if (cliPermanentCode) {
     // Permanent code mode: persist code to disk, require Ed25519 auth over relay
+    if (!authenticator) {
+      console.error(
+        'Permanent connection codes require authentication (--auth or non-localhost bind).',
+      );
+      process.exit(1);
+    }
     const { CodeStore } = await import('./remote/code-store.ts');
     const codeStore = new CodeStore();
     const code = codeStore.load() ?? codeStore.refresh();

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -9,6 +9,7 @@ import {
   serialize,
 } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
 
 export interface AttachClientOptions {
   host: string;
@@ -40,6 +41,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let resizeListener: (() => void) | null = null;
   let resolved = false;
   let outputBroken = false;
+  let authInProgress = false;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -114,11 +116,18 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         writeOutput(`\n[${msg.role}] ${msg.content}\n`);
         break;
       case 'error':
+        // Ignore AUTH_REQUIRED (benign; happens when hello sent before auth)
+        if (msg.code === 'AUTH_REQUIRED') return;
         writeOutput(`\n[error: ${msg.code} - ${msg.message}]\n`);
         break;
       default:
         break;
     }
+  }
+
+  function sendHello(): void {
+    const clientId = generateId();
+    ws.send(serialize(createHello(clientId, '1.0.0', undefined, sessionId as UUID)));
   }
 
   return new Promise<AttachClientResult>((resolve) => {
@@ -141,16 +150,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       finish({ exitCode: 1, reason: 'timeout' });
     }, timeout);
 
-    ws.onopen = () => {
-      const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0', undefined, sessionId as UUID)));
-    };
-
-    ws.onmessage = (event: MessageEvent) => {
-      const data = typeof event.data === 'string' ? event.data : String(event.data);
-      const msg = deserialize(data);
-      if (!msg) return;
-
+    function handleProtocolMessage(msg: ProtocolMessage): void {
       if (msg.type === 'hello_ack') {
         clearTimeout(connectionTimer);
         attachedSessionId = msg.sessionId;
@@ -240,6 +240,36 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       }
 
       renderMessage(msg);
+    }
+
+    ws.onopen = () => {
+      // Send hello immediately. If auth is needed, the daemon will send
+      // auth_challenge and reject this hello with AUTH_REQUIRED (benign).
+      // After auth succeeds, we re-send hello.
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      // If daemon sends auth_challenge, perform handshake then re-send hello
+      if (msg.type === 'auth_challenge' && !authInProgress) {
+        authInProgress = true;
+        performAuthHandshake(ws, msg, handleProtocolMessage)
+          .then(() => {
+            sendHello();
+          })
+          .catch((err) => {
+            clearTimeout(connectionTimer);
+            writeOutput(`\n[auth failed: ${err instanceof Error ? err.message : String(err)}]\n`);
+            finish({ exitCode: 1, reason: 'error' });
+          });
+        return;
+      }
+
+      handleProtocolMessage(msg);
     };
 
     ws.onclose = () => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -116,8 +116,6 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         writeOutput(`\n[${msg.role}] ${msg.content}\n`);
         break;
       case 'error':
-        // Ignore AUTH_REQUIRED (benign; happens when hello sent before auth)
-        if (msg.code === 'AUTH_REQUIRED') return;
         writeOutput(`\n[error: ${msg.code} - ${msg.message}]\n`);
         break;
       default:
@@ -255,10 +253,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       if (!msg) return;
 
       // If daemon sends auth_challenge, perform handshake then re-send hello
-      if (msg.type === 'auth_challenge' && !authInProgress) {
+      if (msg.type === 'auth_challenge') {
+        if (authInProgress) return; // duplicate challenge; ignore
         authInProgress = true;
-        performAuthHandshake(ws, msg, handleProtocolMessage)
+        performAuthHandshake(ws, msg)
           .then(() => {
+            authInProgress = false;
             sendHello();
           })
           .catch((err) => {
@@ -268,6 +268,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
           });
         return;
       }
+
+      // During auth, the auth-helper's addEventListener handles messages;
+      // only process in the caller after auth is done
+      if (authInProgress) return;
 
       handleProtocolMessage(msg);
     };

--- a/packages/daemon/src/cli/auth-helper.ts
+++ b/packages/daemon/src/cli/auth-helper.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared CLI auth helper for WebSocket clients (ls, attach, etc.).
+ *
+ * Handles the auth_challenge -> sign -> auth_response -> auth_result
+ * handshake so that subcommands can connect to an auth-enabled daemon.
+ */
+
+import {
+  createAuthResponse,
+  deserialize,
+  fromBase64,
+  isEncrypted,
+  serialize,
+  sign,
+  unlockIdentity,
+} from '@remi/shared';
+import type { ProtocolMessage, UnlockedIdentity } from '@remi/shared';
+import { IdentityStore } from '../auth/identity-store.ts';
+
+export interface AuthHandshakeResult {
+  /** The unlocked identity used for signing */
+  identity: UnlockedIdentity;
+}
+
+/**
+ * Perform auth handshake on a WebSocket that just received an auth_challenge.
+ *
+ * Resolves when auth_result with success=true is received.
+ * Rejects on auth failure, timeout, or connection error.
+ *
+ * @param ws Open WebSocket connection
+ * @param challengeMsg The auth_challenge message already received
+ * @param onMessage Callback invoked for non-auth messages received during handshake
+ * @returns Promise that resolves when auth succeeds
+ */
+export async function performAuthHandshake(
+  ws: WebSocket,
+  challengeMsg: ProtocolMessage & { type: 'auth_challenge' },
+  onMessage?: (msg: ProtocolMessage) => void,
+): Promise<AuthHandshakeResult> {
+  const store = new IdentityStore();
+
+  // Auto-generate identity if missing
+  if (!store.exists()) {
+    await store.generate();
+  }
+
+  const storedIdentity = store.load();
+  if (!storedIdentity) {
+    throw new Error('No identity found. Run "remi keygen" first.');
+  }
+
+  let identity: UnlockedIdentity;
+  if (isEncrypted(storedIdentity)) {
+    const envPassphrase = process.env['REMI_PASSPHRASE'];
+    if (!envPassphrase) {
+      throw new Error(
+        'Identity is encrypted and REMI_PASSPHRASE is not set. ' +
+          'Set REMI_PASSPHRASE or use an unencrypted identity.',
+      );
+    }
+    identity = await unlockIdentity(storedIdentity, envPassphrase);
+  } else {
+    identity = await unlockIdentity(storedIdentity);
+  }
+
+  // Sign the challenge
+  const challengeData = fromBase64(challengeMsg.challenge);
+  const signature = await sign(identity.privateKey, challengeData);
+  const response = createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);
+  ws.send(serialize(response));
+
+  // Wait for auth_result
+  return new Promise<AuthHandshakeResult>((resolve, reject) => {
+    const handler = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      if (msg.type === 'auth_result') {
+        ws.removeEventListener('message', handler);
+        if (msg.success) {
+          resolve({ identity });
+        } else {
+          reject(new Error(`Authentication failed: ${msg.error ?? 'unknown'}`));
+        }
+        return;
+      }
+
+      // Forward non-auth messages to caller
+      onMessage?.(msg);
+    };
+
+    ws.addEventListener('message', handler);
+  });
+}

--- a/packages/daemon/src/cli/auth-helper.ts
+++ b/packages/daemon/src/cli/auth-helper.ts
@@ -22,6 +22,8 @@ export interface AuthHandshakeResult {
   identity: UnlockedIdentity;
 }
 
+const AUTH_HANDSHAKE_TIMEOUT_MS = 10_000;
+
 /**
  * Perform auth handshake on a WebSocket that just received an auth_challenge.
  *
@@ -30,19 +32,26 @@ export interface AuthHandshakeResult {
  *
  * @param ws Open WebSocket connection
  * @param challengeMsg The auth_challenge message already received
- * @param onMessage Callback invoked for non-auth messages received during handshake
  * @returns Promise that resolves when auth succeeds
  */
 export async function performAuthHandshake(
   ws: WebSocket,
   challengeMsg: ProtocolMessage & { type: 'auth_challenge' },
-  onMessage?: (msg: ProtocolMessage) => void,
 ): Promise<AuthHandshakeResult> {
   const store = new IdentityStore();
 
   // Auto-generate identity if missing
   if (!store.exists()) {
-    await store.generate();
+    console.error('No client identity found. Generating new Ed25519 keypair...');
+    try {
+      const newIdentity = await store.generate();
+      console.error(`Client identity created (fingerprint: ${newIdentity.fingerprint})`);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to auto-generate client identity: ${detail}. Check permissions on ~/.remi or generate manually with "remi keygen".`,
+      );
+    }
   }
 
   const storedIdentity = store.load();
@@ -59,38 +68,75 @@ export async function performAuthHandshake(
           'Set REMI_PASSPHRASE or use an unencrypted identity.',
       );
     }
-    identity = await unlockIdentity(storedIdentity, envPassphrase);
+    try {
+      identity = await unlockIdentity(storedIdentity, envPassphrase);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to unlock identity: ${detail}. Wrong passphrase?`);
+    }
   } else {
-    identity = await unlockIdentity(storedIdentity);
+    try {
+      identity = await unlockIdentity(storedIdentity);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to unlock identity: ${detail}. Identity file may be corrupt. Run "remi keygen --force" to regenerate.`,
+      );
+    }
   }
 
   // Sign the challenge
-  const challengeData = fromBase64(challengeMsg.challenge);
-  const signature = await sign(identity.privateKey, challengeData);
-  const response = createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);
-  ws.send(serialize(response));
+  try {
+    const challengeData = fromBase64(challengeMsg.challenge);
+    const signature = await sign(identity.privateKey, challengeData);
+    const response = createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);
+    ws.send(serialize(response));
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to sign auth challenge: ${detail}`);
+  }
 
-  // Wait for auth_result
+  // Wait for auth_result (with timeout and close/error handling)
   return new Promise<AuthHandshakeResult>((resolve, reject) => {
-    const handler = (event: MessageEvent) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener('message', messageHandler);
+      ws.removeEventListener('close', closeHandler);
+      ws.removeEventListener('error', errorHandler);
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Auth handshake timed out waiting for auth_result'));
+    }, AUTH_HANDSHAKE_TIMEOUT_MS);
+
+    const closeHandler = () => {
+      cleanup();
+      reject(new Error('WebSocket closed during auth handshake'));
+    };
+
+    const errorHandler = () => {
+      cleanup();
+      reject(new Error('WebSocket error during auth handshake'));
+    };
+
+    const messageHandler = (event: MessageEvent) => {
       const data = typeof event.data === 'string' ? event.data : String(event.data);
       const msg = deserialize(data);
       if (!msg) return;
 
       if (msg.type === 'auth_result') {
-        ws.removeEventListener('message', handler);
+        cleanup();
         if (msg.success) {
           resolve({ identity });
         } else {
           reject(new Error(`Authentication failed: ${msg.error ?? 'unknown'}`));
         }
-        return;
       }
-
-      // Forward non-auth messages to caller
-      onMessage?.(msg);
     };
 
-    ws.addEventListener('message', handler);
+    ws.addEventListener('message', messageHandler);
+    ws.addEventListener('close', closeHandler);
+    ws.addEventListener('error', errorHandler);
   });
 }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -6,7 +6,8 @@ import {
   generateId,
   serialize,
 } from '@remi/shared';
-import type { DiscoverableSession, Timestamp } from '@remi/shared';
+import type { DiscoverableSession, ProtocolMessage, Timestamp } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
 
 export interface LsClientOptions {
   host: string;
@@ -20,6 +21,7 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;
+    let authInProgress = false;
     let ws: WebSocket;
     try {
       ws = new WebSocket(url);
@@ -36,16 +38,12 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
       }
     }, timeout);
 
-    ws.onopen = () => {
+    function sendHelloAndRequestList(): void {
       const clientId = generateId();
       ws.send(serialize(createHello(clientId, '1.0.0')));
-    };
+    }
 
-    ws.onmessage = (event: MessageEvent) => {
-      const data = typeof event.data === 'string' ? event.data : String(event.data);
-      const msg = deserialize(data);
-      if (!msg) return;
-
+    function handleProtocolMessage(msg: ProtocolMessage): void {
       if (msg.type === 'hello_ack') {
         ws.send(serialize(createSessionListRequest(false)));
       } else if (msg.type === 'session_list_response') {
@@ -55,11 +53,45 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
         renderSessionList(msg.sessions);
         resolve();
       } else if (msg.type === 'error') {
+        // Ignore AUTH_REQUIRED errors (benign; happens when hello is sent before auth)
+        if (msg.code === 'AUTH_REQUIRED') return;
         clearTimeout(timer);
         settled = true;
         ws.close();
         reject(new Error(`Daemon error: ${msg.message}`));
       }
+    }
+
+    ws.onopen = () => {
+      // Send hello immediately. If auth is needed, the daemon will send
+      // auth_challenge and reject this hello with AUTH_REQUIRED (benign).
+      // After auth succeeds, we re-send hello.
+      sendHelloAndRequestList();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      // If daemon sends auth_challenge, perform handshake then re-send hello
+      if (msg.type === 'auth_challenge' && !authInProgress) {
+        authInProgress = true;
+        performAuthHandshake(ws, msg, handleProtocolMessage)
+          .then(() => {
+            sendHelloAndRequestList();
+          })
+          .catch((err) => {
+            clearTimeout(timer);
+            if (!settled) {
+              settled = true;
+              reject(err);
+            }
+          });
+        return;
+      }
+
+      handleProtocolMessage(msg);
     };
 
     ws.onclose = () => {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -53,8 +53,8 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
         renderSessionList(msg.sessions);
         resolve();
       } else if (msg.type === 'error') {
-        // Ignore AUTH_REQUIRED errors (benign; happens when hello is sent before auth)
-        if (msg.code === 'AUTH_REQUIRED') return;
+        // AUTH_REQUIRED is expected when hello is sent before auth completes
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
         clearTimeout(timer);
         settled = true;
         ws.close();
@@ -75,10 +75,12 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
       if (!msg) return;
 
       // If daemon sends auth_challenge, perform handshake then re-send hello
-      if (msg.type === 'auth_challenge' && !authInProgress) {
+      if (msg.type === 'auth_challenge') {
+        if (authInProgress) return; // duplicate challenge; ignore
         authInProgress = true;
-        performAuthHandshake(ws, msg, handleProtocolMessage)
+        performAuthHandshake(ws, msg)
           .then(() => {
+            authInProgress = false;
             sendHelloAndRequestList();
           })
           .catch((err) => {
@@ -90,6 +92,10 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
           });
         return;
       }
+
+      // During auth, the auth-helper's addEventListener handles messages;
+      // only process in the caller after auth is done
+      if (authInProgress) return;
 
       handleProtocolMessage(msg);
     };


### PR DESCRIPTION
## Summary

- Default to no-auth when binding to localhost (zero friction for local dev)
- Auto-enable auth when binding to 0.0.0.0 or non-localhost interfaces
- Add `--auth`/`--no-auth` CLI flags for explicit override
- Add shared `auth-helper.ts` for ls/attach WebSocket clients
- `ls-client` and `attach-client` now handle `auth_challenge` handshake gracefully
- Ignore benign `AUTH_REQUIRED` errors during auth negotiation

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (810 tests)
- [x] `bunx biome check` passes
- [x] `remi ls` works against running daemon (no auth on localhost)
- [ ] `remi ls` works against auth-enabled daemon (`--auth` or `--bind 0.0.0.0`)
- [ ] `remi attach` works with both auth modes

Fixes #32
Related: #33