### PR TITLE
feat: mDNS network discovery for remi ls and attach

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,8 +13,12 @@
     "packages/daemon": {
       "name": "@remi/daemon",
       "version": "0.1.0",
+      "bin": {
+        "remi-daemon": "./src/cli.ts",
+      },
       "dependencies": {
         "@remi/shared": "workspace:*",
+        "bonjour-service": "^1.3.0",
         "grammy": "^1.39.2",
       },
     },
@@ -310,6 +314,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -540,6 +546,8 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "bonjour-service": ["bonjour-service@1.3.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "multicast-dns": "^7.2.5" } }, "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA=="],
+
     "bplist-parser": ["bplist-parser@0.3.2", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -589,6 +597,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
@@ -776,6 +786,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
+
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
     "native-run": ["native-run@2.0.3", "", { "dependencies": { "@ionic/utils-fs": "^3.1.7", "@ionic/utils-terminal": "^2.3.4", "bplist-parser": "^0.3.2", "debug": "^4.3.4", "elementtree": "^0.1.7", "ini": "^4.1.1", "plist": "^3.1.0", "split2": "^4.2.0", "through2": "^4.0.2", "tslib": "^2.6.2", "yauzl": "^2.10.0" }, "bin": { "native-run": "bin/native-run" } }, "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q=="],
@@ -895,6 +907,8 @@
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
+
+    "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@remi/shared": "workspace:*",
+    "bonjour-service": "^1.3.0",
     "grammy": "^1.39.2"
   }
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -327,6 +327,8 @@ let cliLabel: string | undefined;
 let cliPublicOnly = false;
 let cliBindHost: string | undefined;
 let cliRemoveFingerprint: string | undefined;
+let cliNoMdns = false;
+let cliNetwork = false;
 const claudeArgs: string[] = [];
 
 for (let i = 0; i < args.length; i++) {
@@ -385,6 +387,10 @@ for (let i = 0; i < args.length; i++) {
   } else if (arg === '--remove' && nextArg) {
     cliRemoveFingerprint = nextArg;
     i++;
+  } else if (arg === '--no-mdns') {
+    cliNoMdns = true;
+  } else if (arg === '--network') {
+    cliNetwork = true;
   } else if (arg === '--version' || arg === '-v') {
     console.log(`remi ${REMI_VERSION}`);
     process.exit(0);
@@ -395,7 +401,9 @@ Remi - Claude Code with remote monitoring
 Usage:
   remi [claude-args...]          Start Claude with WebSocket monitoring
   remi ls                        List live sessions from running daemon
+  remi ls --network              Discover and list sessions across the network
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
+  remi attach host:port/id       Attach to a remote session
   remi code                      Show remote access connection code
   remi code --refresh            Generate a new connection code
   remi keygen                    Generate Ed25519 identity keypair
@@ -420,6 +428,7 @@ Options:
   --auth                   Force enable authentication (default: auto based on --bind)
   --no-auth                Disable authentication (even when binding to all interfaces)
   --no-tofu                Reject unknown clients (disable Trust On First Use)
+  --no-mdns                Disable mDNS network advertising
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
   --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
@@ -647,12 +656,22 @@ if (cliSubcommand === 'code') {
 if (cliSubcommand === 'ls') {
   const resolvedPort =
     cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
-  const { runLsClient } = await import('./cli/ls-client.ts');
-  try {
-    await runLsClient({ host: 'localhost', port: resolvedPort });
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
+  if (cliNetwork) {
+    const { runNetworkLs } = await import('./cli/ls-client.ts');
+    try {
+      await runNetworkLs({ localPort: resolvedPort });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  } else {
+    const { runLsClient } = await import('./cli/ls-client.ts');
+    try {
+      await runLsClient({ host: 'localhost', port: resolvedPort });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
   }
   process.exit(0);
 }
@@ -663,8 +682,21 @@ if (cliSubcommand === 'attach') {
   let targetSessionId = cliSubcommandArg;
   let resolvedPort =
     cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+  let resolvedHost = 'localhost';
 
-  if (!targetSessionId) {
+  // Check for remote attach: host:port/session-id
+  if (targetSessionId?.includes('/')) {
+    const slashIdx = targetSessionId.indexOf('/');
+    const hostPort = targetSessionId.slice(0, slashIdx);
+    targetSessionId = targetSessionId.slice(slashIdx + 1);
+    const colonIdx = hostPort.lastIndexOf(':');
+    if (colonIdx > 0) {
+      resolvedHost = hostPort.slice(0, colonIdx);
+      resolvedPort = Number.parseInt(hostPort.slice(colonIdx + 1));
+    } else {
+      resolvedHost = hostPort;
+    }
+  } else if (!targetSessionId) {
     // Auto-attach to most recent active (non-exited) session
     const sessions = store.list();
     const active = sessions.filter((s) => s.exitedAt === null);
@@ -711,7 +743,7 @@ if (cliSubcommand === 'attach') {
   const { runAttachClient } = await import('./cli/attach-client.ts');
   try {
     const result = await runAttachClient({
-      host: 'localhost',
+      host: resolvedHost,
       port: resolvedPort,
       sessionId: targetSessionId,
     });
@@ -851,6 +883,9 @@ let primarySessionId: UUID | null = null;
 const HOOK_PORT = PORT + 1;
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
+
+// mDNS publisher (initialized when daemon is network-accessible)
+let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = null;
 
 // ---------------------------------------------------------------------------
 // Create session helper (shared between wrapper and daemon modes)
@@ -1484,6 +1519,7 @@ const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1' || 
 const authEnabled = cliAuth ?? !isLocalhostBind;
 
 let authenticator: Authenticator | undefined;
+let serverFingerprint: string | undefined;
 
 if (authEnabled) {
   const identityStore = new IdentityStore();
@@ -1543,9 +1579,8 @@ if (authEnabled) {
 
   const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);
   authenticator = new Authenticator({ identity: unlockedIdentity, identityStore, tofuMode });
-  console.log(
-    `Authentication enabled (fingerprint: ${storedIdentity.fingerprint}, TOFU: ${tofuMode})`,
-  );
+  serverFingerprint = storedIdentity.fingerprint;
+  console.log(`Authentication enabled (fingerprint: ${serverFingerprint}, TOFU: ${tofuMode})`);
 } else {
   if (!isLocalhostBind) {
     console.warn(
@@ -1651,6 +1686,11 @@ async function cleanup(): Promise<void> {
     hookConfigManager = null;
   }
 
+  if (mdnsPublisher) {
+    await mdnsPublisher.stop();
+    mdnsPublisher = null;
+  }
+
   for (const watcher of transcriptWatchers.values()) {
     watcher.stop();
   }
@@ -1668,13 +1708,33 @@ if (cliDaemonMode) {
   console.log('Starting Remi daemon...');
   await registry.startAll();
 
+  // Start mDNS advertising when network-accessible
+  if (!cliNoMdns && !isLocalhostBind) {
+    try {
+      const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
+      mdnsPublisher = new MdnsPublisher({
+        port: PORT,
+        version: REMI_VERSION,
+        authEnabled,
+        fingerprint: serverFingerprint,
+      });
+      await mdnsPublisher.start();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[mDNS] Failed to start: ${msg}. Network discovery disabled.`);
+    }
+  }
+
   console.log('');
   console.log('Remi daemon ready!');
-  console.log(`  WebSocket: ws://localhost:${PORT}/ws`);
+  console.log(`  WebSocket: ws://${bindHost}:${PORT}/ws`);
   console.log(`  Port: ${PORT} (use --port to change)`);
   console.log(
     `  Bullet truncation: ${MAX_BULLET_LENGTH > 0 ? `${MAX_BULLET_LENGTH} chars` : 'disabled'}`,
   );
+  if (mdnsPublisher?.isRunning) {
+    console.log('  mDNS: Advertising on local network');
+  }
   if (TELEGRAM_ENABLED) {
     console.log('  Telegram: Bot is running');
   }
@@ -1750,7 +1810,25 @@ if (cliDaemonMode) {
   // In wrapper mode, don't crash if port is busy - Claude still works locally
   try {
     await registry.startAll();
-    log(`WebSocket server listening on ws://localhost:${PORT}/ws`);
+    log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
+
+    // Start mDNS advertising when network-accessible
+    if (!cliNoMdns && !isLocalhostBind) {
+      try {
+        const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
+        mdnsPublisher = new MdnsPublisher({
+          port: PORT,
+          version: REMI_VERSION,
+          authEnabled,
+          fingerprint: serverFingerprint,
+        });
+        await mdnsPublisher.start();
+        log('[mDNS] Advertising on local network');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`[mDNS] Failed to start: ${msg}. Network discovery disabled.`);
+      }
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('EADDRINUSE') || msg.includes('in use')) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -686,15 +686,15 @@ if (cliSubcommand === 'attach') {
 
   // Check for remote attach: host:port/session-id
   if (targetSessionId?.includes('/')) {
-    const slashIdx = targetSessionId.indexOf('/');
-    const hostPort = targetSessionId.slice(0, slashIdx);
-    targetSessionId = targetSessionId.slice(slashIdx + 1);
-    const colonIdx = hostPort.lastIndexOf(':');
-    if (colonIdx > 0) {
-      resolvedHost = hostPort.slice(0, colonIdx);
-      resolvedPort = Number.parseInt(hostPort.slice(colonIdx + 1));
-    } else {
-      resolvedHost = hostPort;
+    try {
+      const { parseRemoteTarget } = await import('./cli/ls-client.ts');
+      const remote = parseRemoteTarget(targetSessionId, resolvedPort);
+      resolvedHost = remote.host;
+      resolvedPort = remote.port;
+      targetSessionId = remote.sessionId;
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
     }
   } else if (!targetSessionId) {
     // Auto-attach to most recent active (non-exited) session
@@ -886,6 +886,28 @@ let hookConfigManager: HookConfigManager | null = null;
 
 // mDNS publisher (initialized when daemon is network-accessible)
 let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = null;
+
+async function startMdnsIfNeeded(
+  logFn: (msg: string) => void,
+): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
+  if (cliNoMdns || isLocalhostBind) return null;
+  try {
+    const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
+    const publisher = new MdnsPublisher({
+      port: PORT,
+      version: REMI_VERSION,
+      authEnabled,
+      fingerprint: serverFingerprint,
+    });
+    await publisher.start();
+    logFn('[mDNS] Advertising on local network');
+    return publisher;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logFn(`[mDNS] Failed to start: ${msg}. Network discovery disabled.`);
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Create session helper (shared between wrapper and daemon modes)
@@ -1687,7 +1709,12 @@ async function cleanup(): Promise<void> {
   }
 
   if (mdnsPublisher) {
-    await mdnsPublisher.stop();
+    try {
+      await mdnsPublisher.stop();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError(`[mDNS] Error during cleanup: ${msg}`);
+    }
     mdnsPublisher = null;
   }
 
@@ -1708,22 +1735,7 @@ if (cliDaemonMode) {
   console.log('Starting Remi daemon...');
   await registry.startAll();
 
-  // Start mDNS advertising when network-accessible
-  if (!cliNoMdns && !isLocalhostBind) {
-    try {
-      const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
-      mdnsPublisher = new MdnsPublisher({
-        port: PORT,
-        version: REMI_VERSION,
-        authEnabled,
-        fingerprint: serverFingerprint,
-      });
-      await mdnsPublisher.start();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[mDNS] Failed to start: ${msg}. Network discovery disabled.`);
-    }
-  }
+  mdnsPublisher = await startMdnsIfNeeded(console.log);
 
   console.log('');
   console.log('Remi daemon ready!');
@@ -1812,23 +1824,7 @@ if (cliDaemonMode) {
     await registry.startAll();
     log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
 
-    // Start mDNS advertising when network-accessible
-    if (!cliNoMdns && !isLocalhostBind) {
-      try {
-        const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
-        mdnsPublisher = new MdnsPublisher({
-          port: PORT,
-          version: REMI_VERSION,
-          authEnabled,
-          fingerprint: serverFingerprint,
-        });
-        await mdnsPublisher.start();
-        log('[mDNS] Advertising on local network');
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        log(`[mDNS] Failed to start: ${msg}. Network discovery disabled.`);
-      }
-    }
+    mdnsPublisher = await startMdnsIfNeeded(log);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('EADDRINUSE') || msg.includes('in use')) {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -1,3 +1,4 @@
+import * as os from 'node:os';
 import path from 'node:path';
 import {
   createHello,
@@ -16,10 +17,18 @@ export interface LsClientOptions {
 }
 
 export async function runLsClient(opts: LsClientOptions): Promise<void> {
-  const { host, port, timeout = 5000 } = opts;
+  const sessions = await fetchSessions(opts.host, opts.port, opts.timeout);
+  renderSessionList(sessions);
+}
+
+export async function fetchSessions(
+  host: string,
+  port: number,
+  timeout = 5000,
+): Promise<DiscoverableSession[]> {
   const url = `ws://${host}:${port}/ws`;
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<DiscoverableSession[]>((resolve, reject) => {
     let settled = false;
     let authInProgress = false;
     let ws: WebSocket;
@@ -50,10 +59,8 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
         clearTimeout(timer);
         settled = true;
         ws.close();
-        renderSessionList(msg.sessions);
-        resolve();
+        resolve(msg.sessions as DiscoverableSession[]);
       } else if (msg.type === 'error') {
-        // AUTH_REQUIRED is expected when hello is sent before auth completes
         if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
         clearTimeout(timer);
         settled = true;
@@ -63,9 +70,6 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
     }
 
     ws.onopen = () => {
-      // Send hello immediately. If auth is needed, the daemon will send
-      // auth_challenge and reject this hello with AUTH_REQUIRED (benign).
-      // After auth succeeds, we re-send hello.
       sendHelloAndRequestList();
     };
 
@@ -74,9 +78,8 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
       const msg = deserialize(data);
       if (!msg) return;
 
-      // If daemon sends auth_challenge, perform handshake then re-send hello
       if (msg.type === 'auth_challenge') {
-        if (authInProgress) return; // duplicate challenge; ignore
+        if (authInProgress) return;
         authInProgress = true;
         performAuthHandshake(ws, msg)
           .then(() => {
@@ -93,10 +96,7 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
         return;
       }
 
-      // During auth, the auth-helper's addEventListener handles messages;
-      // only process in the caller after auth is done
       if (authInProgress) return;
-
       handleProtocolMessage(msg);
     };
 
@@ -118,6 +118,133 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Network discovery
+// ---------------------------------------------------------------------------
+
+export interface NetworkLsOptions {
+  localPort: number;
+  timeout?: number;
+  mdnsTimeout?: number;
+}
+
+interface DaemonSessions {
+  daemon: { name: string; host: string; port: number; hostname: string };
+  sessions: DiscoverableSession[];
+}
+
+export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
+  const { localPort, timeout = 5000, mdnsTimeout = 3000 } = opts;
+
+  // Try local daemon first
+  let localSessions: DiscoverableSession[] = [];
+  try {
+    localSessions = await fetchSessions('localhost', localPort, timeout);
+  } catch {
+    // Local daemon not running; that's OK when scanning network
+  }
+
+  console.error('Scanning network for Remi daemons...');
+  const { discoverDaemons } = await import('../mdns/mdns-browser.ts');
+  const daemons = await discoverDaemons({ timeout: mdnsTimeout });
+
+  const results: DaemonSessions[] = [];
+  const myHostname = os.hostname();
+
+  if (localSessions.length > 0) {
+    results.push({
+      daemon: { name: 'local', host: 'localhost', port: localPort, hostname: myHostname },
+      sessions: localSessions,
+    });
+  }
+
+  // Query remote daemons in parallel, filtering out self
+  const remotePromises = daemons
+    .filter((d) => !(d.port === localPort && isLocalAddress(d.host, myHostname)))
+    .map(async (daemon) => {
+      try {
+        const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
+        results.push({
+          daemon: {
+            name: daemon.name,
+            host: daemon.host,
+            port: daemon.port,
+            hostname: daemon.hostname,
+          },
+          sessions,
+        });
+      } catch {
+        // Could not reach this daemon; skip
+      }
+    });
+
+  await Promise.all(remotePromises);
+
+  renderNetworkSessionList(results);
+}
+
+function isLocalAddress(addr: string, hostname: string): boolean {
+  return addr === '127.0.0.1' || addr === '::1' || addr === 'localhost' || addr === hostname;
+}
+
+function renderNetworkSessionList(results: DaemonSessions[]): void {
+  if (results.length === 0) {
+    console.log('No daemons found on the network.');
+    console.log('Tip: run `remi ls` for local sessions, or start a daemon with `--bind 0.0.0.0`');
+    return;
+  }
+
+  for (const { daemon, sessions } of results) {
+    const label =
+      daemon.host === 'localhost'
+        ? `local (port ${daemon.port})`
+        : `${daemon.hostname} (${daemon.host}:${daemon.port})`;
+    console.log(`\n== ${label} ==`);
+
+    if (sessions.length === 0) {
+      console.log('  No active sessions');
+      continue;
+    }
+
+    const header = `  ${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
+    console.log(header);
+    console.log(`  ${'-'.repeat(header.length - 2)}`);
+
+    for (const s of sessions) {
+      const id = s.sessionId.slice(0, 8);
+      const project = path.basename(s.projectPath).slice(0, 28);
+      const age = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
+
+      console.log(
+        `  ${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+      );
+    }
+  }
+
+  const totalSessions = results.reduce((sum, r) => sum + r.sessions.length, 0);
+  console.log(`\n${totalSessions} session(s) across ${results.length} daemon(s)`);
+
+  const attachable = results.flatMap((r) =>
+    r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, daemon: r.daemon })),
+  );
+  if (attachable.length > 0) {
+    console.log('');
+    for (const a of attachable) {
+      const id = a.sessionId.slice(0, 8);
+      if (a.daemon.host === 'localhost') {
+        console.log(`  * ${id}: remi attach ${id}`);
+      } else {
+        console.log(`  * ${id}: remi attach ${a.daemon.host}:${a.daemon.port}/${id}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
 function renderSessionList(sessions: readonly DiscoverableSession[]): void {
   if (sessions.length === 0) {
     console.log('No active sessions. Start one with: remi [claude-args...]');
@@ -130,13 +257,12 @@ function renderSessionList(sessions: readonly DiscoverableSession[]): void {
 
   for (const s of sessions) {
     const id = s.sessionId.slice(0, 8);
-    const status = s.status;
     const project = path.basename(s.projectPath).slice(0, 28);
     const age = formatAge(s.lastActivity);
     const mark = s.canAttach ? ' *' : '';
 
     console.log(
-      `${id.padEnd(10)}${status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+      `${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
     );
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -10,6 +10,36 @@ import {
 import type { DiscoverableSession, ProtocolMessage, Timestamp } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 
+export interface RemoteTarget {
+  readonly host: string;
+  readonly port: number;
+  readonly sessionId: string;
+}
+
+export function parseRemoteTarget(input: string, defaultPort: number): RemoteTarget {
+  const slashIdx = input.indexOf('/');
+  if (slashIdx < 0) {
+    throw new Error(`Invalid remote address "${input}". Expected: host:port/session-id`);
+  }
+  const hostPort = input.slice(0, slashIdx);
+  const sessionId = input.slice(slashIdx + 1);
+  if (!sessionId) {
+    throw new Error(`Missing session ID in "${input}". Expected: host:port/session-id`);
+  }
+
+  const colonIdx = hostPort.lastIndexOf(':');
+  if (colonIdx > 0) {
+    const host = hostPort.slice(0, colonIdx);
+    const portStr = hostPort.slice(colonIdx + 1);
+    const port = Number.parseInt(portStr);
+    if (Number.isNaN(port) || port < 1 || port > 65535) {
+      throw new Error(`Invalid port "${portStr}" in remote address. Must be 1-65535.`);
+    }
+    return { host, port, sessionId };
+  }
+  return { host: hostPort, port: defaultPort, sessionId };
+}
+
 export interface LsClientOptions {
   host: string;
   port: number;
@@ -123,30 +153,41 @@ export async function fetchSessions(
 // ---------------------------------------------------------------------------
 
 export interface NetworkLsOptions {
-  localPort: number;
-  timeout?: number;
-  mdnsTimeout?: number;
+  readonly localPort: number;
+  /** Timeout for WebSocket session fetches, in ms. Default: 5000 */
+  readonly fetchTimeoutMs?: number | undefined;
+  /** Timeout for mDNS network browse, in ms. Default: 3000 */
+  readonly browseTimeoutMs?: number | undefined;
 }
 
 interface DaemonSessions {
-  daemon: { name: string; host: string; port: number; hostname: string };
-  sessions: DiscoverableSession[];
+  readonly daemon: {
+    readonly name: string;
+    readonly host: string;
+    readonly port: number;
+    readonly hostname: string;
+  };
+  readonly sessions: readonly DiscoverableSession[];
 }
 
 export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
-  const { localPort, timeout = 5000, mdnsTimeout = 3000 } = opts;
+  const { localPort, fetchTimeoutMs: timeout = 5000, browseTimeoutMs: mdnsTimeout = 3000 } = opts;
 
   // Try local daemon first
   let localSessions: DiscoverableSession[] = [];
   try {
     localSessions = await fetchSessions('localhost', localPort, timeout);
-  } catch {
-    // Local daemon not running; that's OK when scanning network
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Connection refused is expected when no local daemon is running
+    if (!msg.includes('Cannot connect') && !msg.includes('closed unexpectedly')) {
+      console.error(`Warning: local daemon error: ${msg}`);
+    }
   }
 
   console.error('Scanning network for Remi daemons...');
   const { discoverDaemons } = await import('../mdns/mdns-browser.ts');
-  const daemons = await discoverDaemons({ timeout: mdnsTimeout });
+  const daemons = await discoverDaemons({ timeoutMs: mdnsTimeout });
 
   const results: DaemonSessions[] = [];
   const myHostname = os.hostname();
@@ -159,32 +200,44 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   }
 
   // Query remote daemons in parallel, filtering out self
-  const remotePromises = daemons
-    .filter((d) => !(d.port === localPort && isLocalAddress(d.host, myHostname)))
-    .map(async (daemon) => {
-      try {
-        const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
-        results.push({
-          daemon: {
-            name: daemon.name,
-            host: daemon.host,
-            port: daemon.port,
-            hostname: daemon.hostname,
-          },
-          sessions,
-        });
-      } catch {
-        // Could not reach this daemon; skip
-      }
-    });
+  const localAddrs = getLocalAddresses(myHostname);
+  const remoteDaemons = daemons.filter((d) => !(d.port === localPort && localAddrs.has(d.host)));
 
-  await Promise.all(remotePromises);
+  const remoteResults = await Promise.allSettled(
+    remoteDaemons.map(async (daemon) => {
+      const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
+      return {
+        daemon: {
+          name: daemon.name,
+          host: daemon.host,
+          port: daemon.port,
+          hostname: daemon.hostname,
+        },
+        sessions,
+      } satisfies DaemonSessions;
+    }),
+  );
+
+  for (const r of remoteResults) {
+    if (r.status === 'fulfilled') {
+      results.push(r.value);
+    }
+  }
 
   renderNetworkSessionList(results);
 }
 
-function isLocalAddress(addr: string, hostname: string): boolean {
-  return addr === '127.0.0.1' || addr === '::1' || addr === 'localhost' || addr === hostname;
+export function getLocalAddresses(hostname: string): Set<string> {
+  const addrs = new Set(['127.0.0.1', '::1', 'localhost', hostname]);
+  const interfaces = os.networkInterfaces();
+  for (const ifaces of Object.values(interfaces)) {
+    if (ifaces) {
+      for (const iface of ifaces) {
+        addrs.add(iface.address);
+      }
+    }
+  }
+  return addrs;
 }
 
 function renderNetworkSessionList(results: DaemonSessions[]): void {

--- a/packages/daemon/src/mdns/index.ts
+++ b/packages/daemon/src/mdns/index.ts
@@ -1,0 +1,6 @@
+export { MdnsPublisher, type MdnsPublisherConfig } from './mdns-publisher.ts';
+export {
+  discoverDaemons,
+  type DiscoveredDaemon,
+  type BrowseOptions,
+} from './mdns-browser.ts';

--- a/packages/daemon/src/mdns/mdns-browser.ts
+++ b/packages/daemon/src/mdns/mdns-browser.ts
@@ -1,0 +1,53 @@
+import type { Service } from 'bonjour-service';
+
+export interface DiscoveredDaemon {
+  name: string;
+  host: string;
+  port: number;
+  version: string;
+  authEnabled: boolean;
+  fingerprint?: string | undefined;
+  hostname: string;
+}
+
+export interface BrowseOptions {
+  timeout?: number;
+}
+
+export async function discoverDaemons(opts?: BrowseOptions): Promise<DiscoveredDaemon[]> {
+  const timeout = opts?.timeout ?? 3000;
+  const daemons: DiscoveredDaemon[] = [];
+
+  const { Bonjour } = await import('bonjour-service');
+  const instance = new Bonjour(undefined, (err: Error) => {
+    console.error(`[mDNS] Browse error: ${err.message}`);
+  });
+
+  return new Promise<DiscoveredDaemon[]>((resolve) => {
+    const browser = instance.find({ type: 'remi' }, (service: Service) => {
+      const txt = (service.txt || {}) as Record<string, string>;
+
+      let host = service.host || 'localhost';
+      if (service.addresses && service.addresses.length > 0) {
+        const ipv4 = service.addresses.find((a: string) => !a.includes(':'));
+        host = ipv4 || service.addresses[0] || host;
+      }
+
+      daemons.push({
+        name: service.name,
+        host,
+        port: service.port,
+        version: txt['version'] || 'unknown',
+        authEnabled: txt['auth'] === 'true',
+        fingerprint: txt['fingerprint'],
+        hostname: txt['hostname'] || service.name,
+      });
+    });
+
+    setTimeout(() => {
+      browser.stop();
+      instance.destroy();
+      resolve(daemons);
+    }, timeout);
+  });
+}

--- a/packages/daemon/src/mdns/mdns-browser.ts
+++ b/packages/daemon/src/mdns/mdns-browser.ts
@@ -1,21 +1,25 @@
 import type { Service } from 'bonjour-service';
 
 export interface DiscoveredDaemon {
-  name: string;
-  host: string;
-  port: number;
-  version: string;
-  authEnabled: boolean;
-  fingerprint?: string | undefined;
-  hostname: string;
+  /** mDNS service name (e.g., "remi-macbook-pro") */
+  readonly name: string;
+  /** Resolved IP address to connect to (prefers IPv4) */
+  readonly host: string;
+  readonly port: number;
+  readonly version: string;
+  readonly authEnabled: boolean;
+  readonly fingerprint?: string | undefined;
+  /** OS hostname from TXT record */
+  readonly hostname: string;
 }
 
 export interface BrowseOptions {
-  timeout?: number;
+  /** Browse duration in milliseconds. Default: 3000 */
+  readonly timeoutMs?: number | undefined;
 }
 
 export async function discoverDaemons(opts?: BrowseOptions): Promise<DiscoveredDaemon[]> {
-  const timeout = opts?.timeout ?? 3000;
+  const timeout = opts?.timeoutMs ?? 3000;
   const daemons: DiscoveredDaemon[] = [];
 
   const { Bonjour } = await import('bonjour-service');

--- a/packages/daemon/src/mdns/mdns-publisher.ts
+++ b/packages/daemon/src/mdns/mdns-publisher.ts
@@ -1,0 +1,76 @@
+import * as os from 'node:os';
+import type { Bonjour, Service } from 'bonjour-service';
+
+export interface MdnsPublisherConfig {
+  readonly port: number;
+  readonly version: string;
+  readonly authEnabled: boolean;
+  readonly fingerprint?: string | undefined;
+  readonly name?: string | undefined;
+  readonly probe?: boolean | undefined;
+}
+
+export class MdnsPublisher {
+  private instance: Bonjour | null = null;
+  private service: Service | null = null;
+  private running = false;
+  private readonly config: MdnsPublisherConfig;
+
+  constructor(config: MdnsPublisherConfig) {
+    this.config = config;
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+
+    const { Bonjour: BonjourClass } = await import('bonjour-service');
+    this.instance = new BonjourClass(undefined, (err: Error) => {
+      console.error(`[mDNS] Error: ${err.message}`);
+    });
+
+    const hostname = os.hostname();
+    const txt: Record<string, string> = {
+      version: this.config.version,
+      auth: this.config.authEnabled ? 'true' : 'false',
+      hostname,
+    };
+    if (this.config.fingerprint) {
+      txt['fingerprint'] = this.config.fingerprint;
+    }
+
+    this.service = this.instance.publish({
+      name: this.config.name ?? `remi-${hostname}`,
+      type: 'remi',
+      port: this.config.port,
+      txt,
+      probe: this.config.probe ?? true,
+    });
+
+    this.running = true;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running || !this.instance) return;
+
+    return new Promise<void>((resolve) => {
+      try {
+        this.instance?.unpublishAll(() => {
+          this.instance?.destroy();
+          this.instance = null;
+          this.service = null;
+          this.running = false;
+          resolve();
+        });
+      } catch {
+        this.instance = null;
+        this.service = null;
+        this.running = false;
+        resolve();
+      }
+    });
+  }
+}

--- a/packages/daemon/src/mdns/mdns-publisher.ts
+++ b/packages/daemon/src/mdns/mdns-publisher.ts
@@ -57,20 +57,32 @@ export class MdnsPublisher {
     if (!this.running || !this.instance) return;
 
     return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        console.error('[mDNS] Shutdown timed out, forcing cleanup');
+        this.forceCleanup();
+        resolve();
+      }, 2000);
+
       try {
         this.instance?.unpublishAll(() => {
+          clearTimeout(timer);
           this.instance?.destroy();
-          this.instance = null;
-          this.service = null;
-          this.running = false;
+          this.forceCleanup();
           resolve();
         });
-      } catch {
-        this.instance = null;
-        this.service = null;
-        this.running = false;
+      } catch (err) {
+        clearTimeout(timer);
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[mDNS] Error during shutdown: ${msg}`);
+        this.forceCleanup();
         resolve();
       }
     });
+  }
+
+  private forceCleanup(): void {
+    this.instance = null;
+    this.service = null;
+    this.running = false;
   }
 }

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -8,7 +8,7 @@ import {
   now,
   serialize,
 } from '@remi/shared';
-import { runLsClient } from '../../src/cli/ls-client.ts';
+import { fetchSessions, runLsClient } from '../../src/cli/ls-client.ts';
 
 const TEST_PORT = 9871;
 
@@ -105,5 +105,57 @@ describe('runLsClient', () => {
     await expect(
       runLsClient({ host: 'localhost', port: timeoutPort, timeout: 500 }),
     ).rejects.toThrow(/Timed out|closed unexpectedly/);
+  });
+});
+
+describe('fetchSessions', () => {
+  let server: ReturnType<typeof Bun.serve> | null = null;
+  const FETCH_PORT = 9875;
+
+  afterEach(() => {
+    if (server) {
+      server.stop(true);
+      server = null;
+    }
+  });
+
+  test('returns session array without rendering', async () => {
+    const sessions = [
+      makeSession({ status: 'active', canAttach: true }),
+      makeSession({ status: 'idle', canAttach: false }),
+    ];
+
+    server = Bun.serve({
+      port: FETCH_PORT,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            const sessionId = generateId();
+            ws.send(serialize(createHelloAck('1.0.0', sessionId)));
+          } else if (msg.type === 'session_list_request') {
+            ws.send(serialize(createSessionListResponse(sessions, msg.id)));
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await fetchSessions('localhost', FETCH_PORT, 3000);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.status).toBe('active');
+    expect(result[1]?.status).toBe('idle');
+  });
+
+  test('rejects when server is unreachable', async () => {
+    await expect(fetchSessions('localhost', 9876, 1000)).rejects.toThrow();
   });
 });

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -8,7 +8,12 @@ import {
   now,
   serialize,
 } from '@remi/shared';
-import { fetchSessions, runLsClient } from '../../src/cli/ls-client.ts';
+import {
+  fetchSessions,
+  getLocalAddresses,
+  parseRemoteTarget,
+  runLsClient,
+} from '../../src/cli/ls-client.ts';
 
 const TEST_PORT = 9871;
 
@@ -156,6 +161,65 @@ describe('fetchSessions', () => {
   });
 
   test('rejects when server is unreachable', async () => {
-    await expect(fetchSessions('localhost', 9876, 1000)).rejects.toThrow();
+    await expect(fetchSessions('localhost', 9876, 1000)).rejects.toThrow(/Cannot connect/);
+  });
+});
+
+describe('parseRemoteTarget', () => {
+  test('parses host:port/session-id', () => {
+    const result = parseRemoteTarget('192.168.1.5:18765/abc123', 18765);
+    expect(result).toEqual({ host: '192.168.1.5', port: 18765, sessionId: 'abc123' });
+  });
+
+  test('parses host/session-id with default port', () => {
+    const result = parseRemoteTarget('myhost/abc123', 18765);
+    expect(result).toEqual({ host: 'myhost', port: 18765, sessionId: 'abc123' });
+  });
+
+  test('parses hostname with dots', () => {
+    const result = parseRemoteTarget('my.host.local:9000/sess-id', 18765);
+    expect(result).toEqual({ host: 'my.host.local', port: 9000, sessionId: 'sess-id' });
+  });
+
+  test('throws on invalid port', () => {
+    expect(() => parseRemoteTarget('host:abc/session', 18765)).toThrow(/Invalid port/);
+  });
+
+  test('throws on port out of range', () => {
+    expect(() => parseRemoteTarget('host:99999/session', 18765)).toThrow(/Invalid port/);
+  });
+
+  test('throws on port 0', () => {
+    expect(() => parseRemoteTarget('host:0/session', 18765)).toThrow(/Invalid port/);
+  });
+
+  test('throws on missing session ID', () => {
+    expect(() => parseRemoteTarget('host:1234/', 18765)).toThrow(/Missing session ID/);
+  });
+
+  test('throws on input without slash', () => {
+    expect(() => parseRemoteTarget('noseparator', 18765)).toThrow(/Invalid remote address/);
+  });
+});
+
+describe('getLocalAddresses', () => {
+  test('includes standard local addresses', () => {
+    const addrs = getLocalAddresses('my-host');
+    expect(addrs.has('127.0.0.1')).toBe(true);
+    expect(addrs.has('::1')).toBe(true);
+    expect(addrs.has('localhost')).toBe(true);
+    expect(addrs.has('my-host')).toBe(true);
+  });
+
+  test('includes at least one network interface address', () => {
+    const addrs = getLocalAddresses('test');
+    // Should have more than just the 4 hardcoded entries
+    expect(addrs.size).toBeGreaterThan(4);
+  });
+
+  test('does not include random addresses', () => {
+    const addrs = getLocalAddresses('test');
+    expect(addrs.has('8.8.8.8')).toBe(false);
+    expect(addrs.has('not-a-host')).toBe(false);
   });
 });

--- a/packages/daemon/tests/mdns/mdns-browser.test.ts
+++ b/packages/daemon/tests/mdns/mdns-browser.test.ts
@@ -22,7 +22,7 @@ describe('discoverDaemons', () => {
     });
     await publisher.start();
 
-    const daemons = await discoverDaemons({ timeout: 2000 });
+    const daemons = await discoverDaemons({ timeoutMs: 2000 });
     const found = daemons.find((d) => d.port === 19990);
     expect(found).toBeDefined();
     expect(found?.version).toBe('0.2.3');
@@ -30,7 +30,7 @@ describe('discoverDaemons', () => {
   });
 
   test('returns empty array gracefully on short timeout', async () => {
-    const daemons = await discoverDaemons({ timeout: 100 });
+    const daemons = await discoverDaemons({ timeoutMs: 100 });
     expect(Array.isArray(daemons)).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe('discoverDaemons', () => {
     });
     await publisher.start();
 
-    const daemons = await discoverDaemons({ timeout: 2000 });
+    const daemons = await discoverDaemons({ timeoutMs: 2000 });
     const found = daemons.find((d) => d.port === 19989);
     expect(found).toBeDefined();
     expect(found?.authEnabled).toBe(true);
@@ -63,7 +63,7 @@ describe('discoverDaemons', () => {
     });
     await publisher.start();
 
-    const daemons = await discoverDaemons({ timeout: 2000 });
+    const daemons = await discoverDaemons({ timeoutMs: 2000 });
     const found = daemons.find((d) => d.port === 19988);
     expect(found).toBeDefined();
     expect(found?.hostname).toBeTruthy();

--- a/packages/daemon/tests/mdns/mdns-browser.test.ts
+++ b/packages/daemon/tests/mdns/mdns-browser.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { discoverDaemons } from '../../src/mdns/mdns-browser.ts';
+import { MdnsPublisher } from '../../src/mdns/mdns-publisher.ts';
+
+describe('discoverDaemons', () => {
+  let publisher: MdnsPublisher | null = null;
+
+  afterEach(async () => {
+    if (publisher) {
+      await publisher.stop();
+      publisher = null;
+    }
+  });
+
+  test('discovers a published service', async () => {
+    publisher = new MdnsPublisher({
+      port: 19990,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-browser-test-1',
+      probe: false,
+    });
+    await publisher.start();
+
+    const daemons = await discoverDaemons({ timeout: 2000 });
+    const found = daemons.find((d) => d.port === 19990);
+    expect(found).toBeDefined();
+    expect(found?.version).toBe('0.2.3');
+    expect(found?.authEnabled).toBe(false);
+  });
+
+  test('returns empty array gracefully on short timeout', async () => {
+    const daemons = await discoverDaemons({ timeout: 100 });
+    expect(Array.isArray(daemons)).toBe(true);
+  });
+
+  test('includes auth and fingerprint in discovered data', async () => {
+    publisher = new MdnsPublisher({
+      port: 19989,
+      version: '0.2.4',
+      authEnabled: true,
+      fingerprint: 'SHA256:abc123',
+      name: 'remi-browser-test-2',
+      probe: false,
+    });
+    await publisher.start();
+
+    const daemons = await discoverDaemons({ timeout: 2000 });
+    const found = daemons.find((d) => d.port === 19989);
+    expect(found).toBeDefined();
+    expect(found?.authEnabled).toBe(true);
+    expect(found?.fingerprint).toBe('SHA256:abc123');
+    expect(found?.version).toBe('0.2.4');
+  });
+
+  test('discovered daemon has hostname', async () => {
+    publisher = new MdnsPublisher({
+      port: 19988,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-browser-test-3',
+      probe: false,
+    });
+    await publisher.start();
+
+    const daemons = await discoverDaemons({ timeout: 2000 });
+    const found = daemons.find((d) => d.port === 19988);
+    expect(found).toBeDefined();
+    expect(found?.hostname).toBeTruthy();
+    expect(found?.name).toContain('remi-');
+  });
+});

--- a/packages/daemon/tests/mdns/mdns-publisher.test.ts
+++ b/packages/daemon/tests/mdns/mdns-publisher.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { MdnsPublisher } from '../../src/mdns/mdns-publisher.ts';
+
+describe('MdnsPublisher', () => {
+  let publisher: MdnsPublisher | null = null;
+
+  afterEach(async () => {
+    if (publisher) {
+      await publisher.stop();
+      publisher = null;
+    }
+  });
+
+  test('starts and reports running', async () => {
+    publisher = new MdnsPublisher({
+      port: 19999,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-test-start',
+      probe: false,
+    });
+    await publisher.start();
+    expect(publisher.isRunning).toBe(true);
+  });
+
+  test('stops cleanly', async () => {
+    publisher = new MdnsPublisher({
+      port: 19998,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-test-stop',
+      probe: false,
+    });
+    await publisher.start();
+    await publisher.stop();
+    expect(publisher.isRunning).toBe(false);
+    publisher = null;
+  });
+
+  test('double start is idempotent', async () => {
+    publisher = new MdnsPublisher({
+      port: 19997,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-test-double',
+      probe: false,
+    });
+    await publisher.start();
+    await publisher.start();
+    expect(publisher.isRunning).toBe(true);
+  });
+
+  test('stop without start is safe', async () => {
+    publisher = new MdnsPublisher({
+      port: 19996,
+      version: '0.2.3',
+      authEnabled: false,
+      name: 'remi-test-nostop',
+      probe: false,
+    });
+    await publisher.stop();
+    expect(publisher.isRunning).toBe(false);
+    publisher = null;
+  });
+
+  test('starts with auth and fingerprint', async () => {
+    publisher = new MdnsPublisher({
+      port: 19995,
+      version: '0.2.3',
+      authEnabled: true,
+      fingerprint: 'SHA256:testfingerprint',
+      name: 'remi-test-auth',
+      probe: false,
+    });
+    await publisher.start();
+    expect(publisher.isRunning).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add mDNS/Bonjour service advertisement and browsing so Remi daemons on the same LAN, Tailscale, or VPN can discover each other
- Daemon advertises `_remi._tcp` with TXT records (version, auth, hostname, fingerprint) when bound to network (`--bind 0.0.0.0`)
- `remi ls --network` discovers remote daemons via mDNS, queries each for sessions, and renders a grouped listing
- `remi attach host:port/session-id` connects to sessions on remote daemons
- `--no-mdns` flag to disable mDNS advertising

## Test plan

- [x] 821 tests pass (14 new for mDNS publisher/browser and fetchSessions)
- [x] TypeScript typecheck clean
- [x] Biome lint clean
- [ ] Manual: start daemon with `--bind 0.0.0.0`, verify `dns-sd -B _remi._tcp` shows service
- [ ] Manual: run `remi ls --network` from another machine on the same network
- [ ] Manual: `remi attach <ip>:18765/<session-id>` to attach remotely

Closes #33