### PR TITLE
Session UX and Chat Mode (Phase 2-3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -57,6 +57,9 @@ export interface AdapterEvents {
   /** Terminal resize from attached CLI client */
   onTerminalResize: (connectionId: UUID, cols: number, rows: number) => void;
 
+  /** Kill session request received */
+  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -136,6 +136,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onTerminalResize?.(connectionId, cols, rows);
       },
 
+      onKillSessionRequest: (connectionId, sessionId, requestId) => {
+        this.events.onKillSessionRequest?.(connectionId, sessionId, requestId);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -217,6 +217,7 @@ import {
   createCreateSessionResponse,
   createError,
   createHelloAck,
+  createKillSessionResponse,
   createReplayBatch,
   createSessionListResponse,
   createTranscriptLoadComplete,
@@ -317,6 +318,9 @@ let cliSubcommand:
   | 'import-key'
   | 'authorize'
   | 'keys'
+  | 'new'
+  | 'kill'
+  | 'detach'
   | undefined;
 let cliSubcommandArg: string | undefined;
 let cliCodeRefresh = false;
@@ -406,6 +410,9 @@ Remi - Claude Code with remote monitoring
 
 Usage:
   remi [claude-args...]          Start Claude with WebSocket monitoring
+  remi new [-- claude-args...]   Explicit session creation (alias for remi [args])
+  remi kill <name>               Kill a session by name or ID
+  remi detach [name]             Detach from current or named session
   remi ls                        List live sessions from running daemon
   remi ls --network              Discover and list sessions across the network
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
@@ -464,11 +471,18 @@ Any other arguments are passed through to Claude Code.
     arg === 'export-key' ||
     arg === 'import-key' ||
     arg === 'authorize' ||
-    arg === 'keys'
+    arg === 'keys' ||
+    arg === 'new' ||
+    arg === 'kill' ||
+    arg === 'detach'
   ) {
     cliSubcommand = arg;
     if (
-      (arg === 'attach' || arg === 'import-key' || arg === 'authorize') &&
+      (arg === 'attach' ||
+        arg === 'import-key' ||
+        arg === 'authorize' ||
+        arg === 'kill' ||
+        arg === 'detach') &&
       nextArg &&
       !nextArg.startsWith('-')
     ) {
@@ -479,11 +493,22 @@ Any other arguments are passed through to Claude Code.
       cliCodeRefresh = true;
       i++;
     }
+    // For 'new', collect remaining args after '--' as claude args
+    if (arg === 'new') {
+      for (let j = i + 1; j < args.length; j++) {
+        const nextA = args[j];
+        if (nextA === '--') continue; // skip bare '--'
+        if (nextA) claudeArgs.push(nextA);
+      }
+      break; // stop processing args
+    }
   } else if (
     cliSubcommand &&
     (cliSubcommand === 'import-key' ||
       cliSubcommand === 'authorize' ||
-      cliSubcommand === 'attach') &&
+      cliSubcommand === 'attach' ||
+      cliSubcommand === 'kill' ||
+      cliSubcommand === 'detach') &&
     !cliSubcommandArg &&
     arg &&
     !arg.startsWith('-')
@@ -679,6 +704,46 @@ if (cliSubcommand === 'ls') {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
+  }
+  process.exit(0);
+}
+
+// Handle 'kill' subcommand: kill a session by name or ID
+if (cliSubcommand === 'kill') {
+  if (!cliSubcommandArg) {
+    console.error('Usage: remi kill <session-name-or-id>');
+    console.error('Run `remi ls` to see live sessions.');
+    process.exit(1);
+  }
+  const resolvedPort =
+    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+  const resolvedHost = cliHost ?? 'localhost';
+
+  const { runKillClient } = await import('./cli/kill-client.ts');
+  try {
+    await runKillClient({
+      host: resolvedHost,
+      port: resolvedPort,
+      target: cliSubcommandArg,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// Handle 'detach' subcommand: detach from a session
+if (cliSubcommand === 'detach') {
+  // Without args: not meaningful from CLI (Ctrl+B d handles interactive detach)
+  // With name: informational only; there's no remote detach protocol yet
+  if (!cliSubcommandArg) {
+    console.log('To detach from a session interactively, press Ctrl+B d.');
+    console.log('To detach a specific session by name: remi detach <session-name>');
+    console.log('(Remote detach is not yet implemented; use Ctrl+B d in the attached terminal.)');
+  } else {
+    console.log('Remote detach of named sessions is not yet implemented.');
+    console.log('To detach, press Ctrl+B d in the attached terminal.');
   }
   process.exit(0);
 }
@@ -1549,6 +1614,25 @@ const sharedEvents = {
     }
   },
 
+  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
+    log(`Kill session request from ${connectionId} for session ${sessionId}`);
+
+    const session = sessionRegistry.getSession(sessionId);
+    if (!session) {
+      sendToConnection(
+        connectionId,
+        createKillSessionResponse(false, requestId, `Session ${sessionId} not found`),
+      );
+      return;
+    }
+
+    const sessionName = session.name;
+    log(`Killing session: ${sessionName} (${sessionId})`);
+    sessionRegistry.closeSession(sessionId, 'forced');
+    sendToConnection(connectionId, createKillSessionResponse(true, requestId));
+    log(`Session killed: ${sessionName}`);
+  },
+
   onTerminalResize: (connectionId: UUID, cols: number, rows: number) => {
     const session = sessionRegistry.getSessionForConnection(connectionId);
     if (session) {
@@ -1916,6 +2000,18 @@ if (cliDaemonMode) {
     claudeArgs,
     true, // pass-through mode
   );
+
+  // Print session name to terminal (useful for 'remi new' and general awareness)
+  if (ptyStdoutFd !== null) {
+    const managedSession = sessionRegistry.getSession(sessionId);
+    if (managedSession) {
+      try {
+        fs.writeSync(ptyStdoutFd, `Session: ${managedSession.name}\r\n`);
+      } catch {
+        // Terminal write may fail if output is piped
+      }
+    }
+  }
 
   // Set up raw stdin pass-through to PTY with Ctrl+B d detach detection.
   // Uses the extracted DetachScanner module for byte-level scanning.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -809,8 +809,11 @@ if (cliSubcommand === 'attach') {
         console.error('Provide a longer name to disambiguate.');
         process.exit(1);
       }
-    } catch {
-      // Daemon not reachable; fall through to local store lookup
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('connect') && !msg.includes('timeout') && !msg.includes('ECONNREFUSED')) {
+        log(`[Attach] Failed to query daemon for name resolution: ${msg}`);
+      }
     }
 
     if (!resolvedByName) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -692,7 +692,11 @@ if (cliSubcommand === 'attach') {
   let resolvedHost = cliHost ?? 'localhost';
 
   // Check for remote attach: host:port/session-id
-  if (targetSessionId?.includes('/')) {
+  // Remote targets have a colon before the first slash (port separator).
+  // Session names (hostname/dir/branch) do not have a colon before the first slash.
+  const firstSlash = targetSessionId?.indexOf('/') ?? -1;
+  const hasRemoteFormat = firstSlash > 0 && targetSessionId?.slice(0, firstSlash).includes(':');
+  if (targetSessionId && hasRemoteFormat) {
     try {
       const { parseRemoteTarget } = await import('./cli/ls-client.ts');
       const remote = parseRemoteTarget(targetSessionId, resolvedPort);
@@ -718,32 +722,60 @@ if (cliSubcommand === 'attach') {
     targetSessionId = latest.remiSessionId;
     resolvedPort = cliPort ?? latest.port;
   } else {
-    // Prefix-match session ID, look up port
-    const all = store.list();
-    const matches = all.filter(
-      (s) =>
-        s.remiSessionId === targetSessionId ||
-        s.remiSessionId.startsWith(targetSessionId as string),
-    );
-    if (matches.length === 1) {
-      // biome-ignore lint/style/noNonNullAssertion: length checked above
-      const match = matches[0]!;
-      resolvedPort = cliPort ?? match.port;
-      targetSessionId = match.remiSessionId;
-    } else if (matches.length > 1) {
-      console.error(
-        `Ambiguous session ID "${targetSessionId}" matches ${matches.length} sessions:`,
+    // Try name-based resolution first by querying the daemon
+    let resolvedByName = false;
+    try {
+      const { fetchSessions } = await import('./cli/ls-client.ts');
+      const sessions = await fetchSessions(resolvedHost, resolvedPort, 3000);
+      const nameMatches = sessions.filter(
+        (s) => s.name === targetSessionId || s.name?.startsWith(targetSessionId as string),
       );
-      for (const m of matches) {
-        console.error(`  ${m.remiSessionId.slice(0, 8)}  port=${m.port}`);
+      if (nameMatches.length === 1) {
+        // biome-ignore lint/style/noNonNullAssertion: length checked above
+        targetSessionId = nameMatches[0]!.sessionId;
+        resolvedByName = true;
+      } else if (nameMatches.length > 1) {
+        console.error(
+          `Ambiguous session name "${targetSessionId}" matches ${nameMatches.length} sessions:`,
+        );
+        for (const m of nameMatches) {
+          console.error(`  ${m.name ?? m.sessionId.slice(0, 8)}`);
+        }
+        console.error('Provide a longer name to disambiguate.');
+        process.exit(1);
       }
-      console.error('Provide a longer prefix to disambiguate.');
-      process.exit(1);
-    } else {
-      console.error(
-        `No session found matching "${targetSessionId}". Run \`remi ls\` to see live sessions.`,
+    } catch {
+      // Daemon not reachable; fall through to local store lookup
+    }
+
+    if (!resolvedByName) {
+      // Prefix-match session ID, look up port
+      const all = store.list();
+      const matches = all.filter(
+        (s) =>
+          s.remiSessionId === targetSessionId ||
+          s.remiSessionId.startsWith(targetSessionId as string),
       );
-      process.exit(1);
+      if (matches.length === 1) {
+        // biome-ignore lint/style/noNonNullAssertion: length checked above
+        const match = matches[0]!;
+        resolvedPort = cliPort ?? match.port;
+        targetSessionId = match.remiSessionId;
+      } else if (matches.length > 1) {
+        console.error(
+          `Ambiguous session ID "${targetSessionId}" matches ${matches.length} sessions:`,
+        );
+        for (const m of matches) {
+          console.error(`  ${m.remiSessionId.slice(0, 8)}  port=${m.port}`);
+        }
+        console.error('Provide a longer prefix to disambiguate.');
+        process.exit(1);
+      } else {
+        console.error(
+          `No session found matching "${targetSessionId}". Run \`remi ls\` to see live sessions.`,
+        );
+        process.exit(1);
+      }
     }
   }
 

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -146,7 +146,10 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
     ws.onmessage = (event: MessageEvent) => {
       const data = typeof event.data === 'string' ? event.data : String(event.data);
       const msg = deserialize(data);
-      if (!msg) return;
+      if (!msg) {
+        console.error('Warning: received unparseable message from daemon');
+        return;
+      }
 
       // Handle auth challenge if needed
       if (msg.type === 'auth_challenge') {

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -147,7 +147,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
       const data = typeof event.data === 'string' ? event.data : String(event.data);
       const msg = deserialize(data);
       if (!msg) {
-        console.error('Warning: received unparseable message from daemon');
+        console.error('Warning: received unparsable message from daemon');
         return;
       }
 

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -1,0 +1,178 @@
+/**
+ * Kill Client - Sends a kill request to a running daemon to terminate a session.
+ *
+ * Connects via WebSocket, resolves the session by name or ID, and sends
+ * a kill_session_request message.
+ */
+
+import {
+  createHello,
+  createKillSessionRequest,
+  createSessionListRequest,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
+
+export interface KillClientOptions {
+  readonly host: string;
+  readonly port: number;
+  /** Session name or ID to kill */
+  readonly target: string;
+  readonly timeout?: number;
+}
+
+export async function runKillClient(opts: KillClientOptions): Promise<void> {
+  const { host, port, target, timeout = 5000 } = opts;
+  const url = `ws://${host}:${port}/ws`;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let authInProgress = false;
+    let sessions: DiscoverableSession[] | null = null;
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      ws.close();
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Timed out connecting to daemon at ${host}:${port}`));
+      }
+    }, timeout);
+
+    function done(err?: Error): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.close();
+      if (err) reject(err);
+      else resolve();
+    }
+
+    function sendHello(): void {
+      const clientId = generateId();
+      ws.send(serialize(createHello(clientId, '1.0.0')));
+    }
+
+    function resolveSession(
+      sessionList: DiscoverableSession[],
+      nameOrId: string,
+    ): DiscoverableSession | null {
+      // Exact name match
+      const byName = sessionList.filter((s) => s.name === nameOrId);
+      if (byName.length === 1) return byName[0] ?? null;
+
+      // Prefix name match
+      const byPrefix = sessionList.filter((s) => s.name?.startsWith(nameOrId));
+      if (byPrefix.length === 1) return byPrefix[0] ?? null;
+      if (byPrefix.length > 1) {
+        const names = byPrefix.map((s) => `  ${s.name ?? s.sessionId.slice(0, 8)}`).join('\n');
+        throw new Error(
+          `Ambiguous session name "${nameOrId}" matches ${byPrefix.length} sessions:\n${names}\nProvide a longer name to disambiguate.`,
+        );
+      }
+
+      // Exact ID match
+      const byId = sessionList.filter((s) => s.sessionId === nameOrId);
+      if (byId.length === 1) return byId[0] ?? null;
+
+      // Prefix ID match
+      const byIdPrefix = sessionList.filter((s) => s.sessionId.startsWith(nameOrId));
+      if (byIdPrefix.length === 1) return byIdPrefix[0] ?? null;
+      if (byIdPrefix.length > 1) {
+        const ids = byIdPrefix.map((s) => `  ${s.sessionId.slice(0, 8)}`).join('\n');
+        throw new Error(
+          `Ambiguous session ID "${nameOrId}" matches ${byIdPrefix.length} sessions:\n${ids}\nProvide a longer prefix to disambiguate.`,
+        );
+      }
+
+      return null;
+    }
+
+    function handleMessage(msg: ProtocolMessage): void {
+      if (msg.type === 'hello_ack') {
+        // Request session list first to resolve the name
+        ws.send(serialize(createSessionListRequest(false)));
+      } else if (msg.type === 'session_list_response') {
+        sessions = msg.sessions as DiscoverableSession[];
+        try {
+          const session = resolveSession(sessions, target);
+          if (!session) {
+            done(
+              new Error(
+                `No session found matching "${target}". Run \`remi ls\` to see live sessions.`,
+              ),
+            );
+            return;
+          }
+          // Send kill request
+          ws.send(serialize(createKillSessionRequest(session.sessionId as UUID)));
+        } catch (err) {
+          done(err instanceof Error ? err : new Error(String(err)));
+        }
+      } else if (msg.type === 'kill_session_response') {
+        if (msg.success) {
+          // Find the session name for a nice message
+          const session =
+            sessions?.find((s) => s.sessionId === target) ??
+            sessions?.find((s) => s.name === target) ??
+            sessions?.find((s) => s.name?.startsWith(target)) ??
+            sessions?.find((s) => s.sessionId.startsWith(target));
+          const displayName = session?.name ?? target;
+          console.log(`Killed session: ${displayName}`);
+          done();
+        } else {
+          done(new Error(`Failed to kill session: ${msg.error ?? 'unknown error'}`));
+        }
+      } else if (msg.type === 'error') {
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        done(new Error(`Daemon error: ${msg.message}`));
+      }
+    }
+
+    ws.onopen = () => {
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      // Handle auth challenge if needed
+      if (msg.type === 'auth_challenge') {
+        authInProgress = true;
+        performAuthHandshake(ws, msg)
+          .then(() => {
+            authInProgress = false;
+            sendHello();
+          })
+          .catch((err) => {
+            done(err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
+      handleMessage(msg);
+    };
+
+    ws.onerror = () => {
+      done(new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    };
+
+    ws.onclose = () => {
+      if (!settled) {
+        done(new Error('Connection closed before kill completed'));
+      }
+    };
+  });
+}

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -266,19 +266,38 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
       continue;
     }
 
-    const header = `  ${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-    console.log(header);
-    console.log(`  ${'-'.repeat(header.length - 2)}`);
+    const hasNames = sessions.some((s) => s.name);
 
-    for (const s of sessions) {
-      const id = s.sessionId.slice(0, 8);
-      const project = path.basename(s.projectPath).slice(0, 28);
-      const age = formatAge(s.lastActivity);
-      const mark = s.canAttach ? ' *' : '';
+    if (hasNames) {
+      const header = `  ${'NAME'.padEnd(30)}${'STATUS'.padEnd(12)}${'ID'.padEnd(10)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
+      console.log(header);
+      console.log(`  ${'-'.repeat(header.length - 2)}`);
 
-      console.log(
-        `  ${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-      );
+      for (const s of sessions) {
+        const id = s.sessionId.slice(0, 8);
+        const name = (s.name ?? path.basename(s.projectPath)).slice(0, 28);
+        const age = formatAge(s.lastActivity);
+        const mark = s.canAttach ? ' *' : '';
+
+        console.log(
+          `  ${name.padEnd(30)}${s.status.padEnd(12)}${id.padEnd(10)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+        );
+      }
+    } else {
+      const header = `  ${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
+      console.log(header);
+      console.log(`  ${'-'.repeat(header.length - 2)}`);
+
+      for (const s of sessions) {
+        const id = s.sessionId.slice(0, 8);
+        const project = path.basename(s.projectPath).slice(0, 28);
+        const age = formatAge(s.lastActivity);
+        const mark = s.canAttach ? ' *' : '';
+
+        console.log(
+          `  ${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+        );
+      }
     }
   }
 
@@ -311,26 +330,45 @@ function renderSessionList(sessions: readonly DiscoverableSession[]): void {
     return;
   }
 
-  const header = `${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-  console.log(header);
-  console.log('-'.repeat(header.length));
+  const hasNames = sessions.some((s) => s.name);
 
-  for (const s of sessions) {
-    const id = s.sessionId.slice(0, 8);
-    const project = path.basename(s.projectPath).slice(0, 28);
-    const age = formatAge(s.lastActivity);
-    const mark = s.canAttach ? ' *' : '';
+  if (hasNames) {
+    const header = `${'NAME'.padEnd(30)}${'STATUS'.padEnd(12)}${'ID'.padEnd(10)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
+    console.log(header);
+    console.log('-'.repeat(header.length));
 
-    console.log(
-      `${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-    );
+    for (const s of sessions) {
+      const id = s.sessionId.slice(0, 8);
+      const name = (s.name ?? path.basename(s.projectPath)).slice(0, 28);
+      const age = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
+
+      console.log(
+        `${name.padEnd(30)}${s.status.padEnd(12)}${id.padEnd(10)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+      );
+    }
+  } else {
+    const header = `${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
+    console.log(header);
+    console.log('-'.repeat(header.length));
+
+    for (const s of sessions) {
+      const id = s.sessionId.slice(0, 8);
+      const project = path.basename(s.projectPath).slice(0, 28);
+      const age = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
+
+      console.log(
+        `${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
+      );
+    }
   }
 
   const attachable = sessions.filter((s) => s.canAttach);
   if (attachable.length > 0) {
     console.log('');
     console.log(
-      `${attachable.length} session(s) available to attach (* marked). Use: remi attach <id>`,
+      `${attachable.length} session(s) available to attach (* marked). Use: remi attach <name-or-id>`,
     );
   }
 }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -266,38 +266,20 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
       continue;
     }
 
-    const hasNames = sessions.some((s) => s.name);
+    const header = `  ${'NAME'.padEnd(28)}${'HOST'.padEnd(18)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+    console.log(header);
+    console.log(`  ${'-'.repeat(header.length - 2)}`);
 
-    if (hasNames) {
-      const header = `  ${'NAME'.padEnd(30)}${'STATUS'.padEnd(12)}${'ID'.padEnd(10)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-      console.log(header);
-      console.log(`  ${'-'.repeat(header.length - 2)}`);
+    for (const s of sessions) {
+      const name = (s.name ?? path.basename(s.projectPath)).slice(0, 26);
+      const host = `${daemon.host}:${daemon.port}`;
+      const duration = formatDuration(s.createdAt);
+      const lastAct = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
 
-      for (const s of sessions) {
-        const id = s.sessionId.slice(0, 8);
-        const name = (s.name ?? path.basename(s.projectPath)).slice(0, 28);
-        const age = formatAge(s.lastActivity);
-        const mark = s.canAttach ? ' *' : '';
-
-        console.log(
-          `  ${name.padEnd(30)}${s.status.padEnd(12)}${id.padEnd(10)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-        );
-      }
-    } else {
-      const header = `  ${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-      console.log(header);
-      console.log(`  ${'-'.repeat(header.length - 2)}`);
-
-      for (const s of sessions) {
-        const id = s.sessionId.slice(0, 8);
-        const project = path.basename(s.projectPath).slice(0, 28);
-        const age = formatAge(s.lastActivity);
-        const mark = s.canAttach ? ' *' : '';
-
-        console.log(
-          `  ${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-        );
-      }
+      console.log(
+        `  ${name.padEnd(28)}${host.padEnd(18)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+      );
     }
   }
 
@@ -310,11 +292,13 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
   if (attachable.length > 0) {
     console.log('');
     for (const a of attachable) {
-      const id = a.sessionId.slice(0, 8);
+      const name = a.name ?? a.sessionId.slice(0, 8);
       if (a.daemon.host === 'localhost') {
-        console.log(`  * ${id}: remi attach ${id}`);
+        console.log(`  * ${name}: remi attach ${name}`);
       } else {
-        console.log(`  * ${id}: remi attach ${a.daemon.host}:${a.daemon.port}/${id}`);
+        console.log(
+          `  * ${name}: remi attach ${a.daemon.host}:${a.daemon.port}/${a.sessionId.slice(0, 8)}`,
+        );
       }
     }
   }
@@ -330,38 +314,19 @@ function renderSessionList(sessions: readonly DiscoverableSession[]): void {
     return;
   }
 
-  const hasNames = sessions.some((s) => s.name);
+  const header = `${'NAME'.padEnd(28)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+  console.log(header);
+  console.log('-'.repeat(header.length));
 
-  if (hasNames) {
-    const header = `${'NAME'.padEnd(30)}${'STATUS'.padEnd(12)}${'ID'.padEnd(10)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-    console.log(header);
-    console.log('-'.repeat(header.length));
+  for (const s of sessions) {
+    const name = (s.name ?? path.basename(s.projectPath)).slice(0, 26);
+    const duration = formatDuration(s.createdAt);
+    const lastAct = formatAge(s.lastActivity);
+    const mark = s.canAttach ? ' *' : '';
 
-    for (const s of sessions) {
-      const id = s.sessionId.slice(0, 8);
-      const name = (s.name ?? path.basename(s.projectPath)).slice(0, 28);
-      const age = formatAge(s.lastActivity);
-      const mark = s.canAttach ? ' *' : '';
-
-      console.log(
-        `${name.padEnd(30)}${s.status.padEnd(12)}${id.padEnd(10)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-      );
-    }
-  } else {
-    const header = `${'ID'.padEnd(10)}${'STATUS'.padEnd(12)}${'PROJECT'.padEnd(30)}${'AGE'.padStart(10)}${'MSGS'.padStart(6)}`;
-    console.log(header);
-    console.log('-'.repeat(header.length));
-
-    for (const s of sessions) {
-      const id = s.sessionId.slice(0, 8);
-      const project = path.basename(s.projectPath).slice(0, 28);
-      const age = formatAge(s.lastActivity);
-      const mark = s.canAttach ? ' *' : '';
-
-      console.log(
-        `${id.padEnd(10)}${s.status.padEnd(12)}${project.padEnd(30)}${age.padStart(10)}${String(s.messageCount).padStart(6)}${mark}`,
-      );
-    }
+    console.log(
+      `${name.padEnd(28)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+    );
   }
 
   const attachable = sessions.filter((s) => s.canAttach);
@@ -373,7 +338,10 @@ function renderSessionList(sessions: readonly DiscoverableSession[]): void {
   }
 }
 
-function formatAge(timestamp: Timestamp): string {
+/**
+ * Format a timestamp as relative time: "30s ago", "5m ago", "2h ago", "3d ago".
+ */
+export function formatAge(timestamp: Timestamp): string {
   const diff = Date.now() - new Date(timestamp).getTime();
   const seconds = Math.floor(diff / 1000);
 
@@ -384,4 +352,27 @@ function formatAge(timestamp: Timestamp): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+/**
+ * Format a timestamp as a duration from creation to now: "30s", "45m", "2h 15m", "3d 2h".
+ * If createdAt is undefined, returns "-".
+ */
+export function formatDuration(createdAt: Timestamp | undefined): string {
+  if (createdAt === undefined) return '-';
+
+  const diff = Date.now() - new Date(createdAt).getTime();
+  const totalSeconds = Math.max(0, Math.floor(diff / 1000));
+
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
 }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -33,6 +33,7 @@ import type {
   BulletExpandRequestMessage,
   CreateSessionRequestMessage,
   HelloMessage,
+  KillSessionRequestMessage,
   PingMessage,
   ProtocolMessage,
   SessionListRequestMessage,
@@ -74,6 +75,9 @@ export interface ConnectionEvents {
 
   /** Terminal resize from attached CLI client */
   onTerminalResize: (cols: number, rows: number) => void;
+
+  /** Kill session request received */
+  onKillSessionRequest: (sessionId: UUID, requestId: UUID) => void;
 
   /** Authentication succeeded */
   onAuthSuccess: (clientFingerprint: string) => void;
@@ -250,6 +254,9 @@ export class Connection {
       case 'terminal_resize':
         this.handleTerminalResize(message);
         break;
+      case 'kill_session_request':
+        this.handleKillSessionRequest(message);
+        break;
       case 'ping':
         this.handlePing(message);
         break;
@@ -408,6 +415,11 @@ export class Connection {
   private handleCreateSessionRequest(message: CreateSessionRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onCreateSessionRequest?.(message.directory, message.id);
+  }
+
+  private handleKillSessionRequest(message: KillSessionRequestMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onKillSessionRequest?.(message.sessionId, message.id);
   }
 
   private handleTerminalResize(message: TerminalResizeMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -71,6 +71,9 @@ export interface ServerEvents {
   /** Terminal resize from attached CLI client */
   onTerminalResize: (connectionId: UUID, cols: number, rows: number) => void;
 
+  /** Kill session request from client */
+  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -308,6 +311,10 @@ export class WebSocketServer {
 
       onTerminalResize: (cols, rows) => {
         this.events.onTerminalResize?.(ws.data.connectionId, cols, rows);
+      },
+
+      onKillSessionRequest: (sessionId, requestId) => {
+        this.events.onKillSessionRequest?.(ws.data.connectionId, sessionId, requestId);
       },
 
       onError: (error) => {

--- a/packages/daemon/src/session/session-name.ts
+++ b/packages/daemon/src/session/session-name.ts
@@ -50,6 +50,8 @@ export function cleanHostname(hostname: string): string {
   return hostname;
 }
 
+let gitNotFoundWarned = false;
+
 /**
  * Detect the current git branch in the given directory.
  * Returns null if not a git repo or git is unavailable.
@@ -67,7 +69,12 @@ function detectGitBranch(cwd: string): string | null {
       return branch;
     }
     return null;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' && !gitNotFoundWarned) {
+      gitNotFoundWarned = true;
+      console.warn('git not found in PATH; session names will not include branch');
+    }
     return null;
   }
 }

--- a/packages/daemon/src/session/session-name.ts
+++ b/packages/daemon/src/session/session-name.ts
@@ -1,0 +1,73 @@
+/**
+ * Session name generation for human-readable session identifiers.
+ *
+ * Format: hostname/dirname/branch (or hostname/dirname if no git)
+ */
+
+import { execSync } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Generate a human-readable session name from the working directory.
+ *
+ * Format: hostname/dirname/branch or hostname/dirname (no git).
+ * The hostname has `.local` suffix stripped if present.
+ */
+export function generateSessionName(cwd: string): string {
+  const hostname = cleanHostname(os.hostname());
+  const dirname = path.basename(cwd) || cwd;
+  const branch = detectGitBranch(cwd);
+
+  if (branch) {
+    return `${hostname}/${dirname}/${branch}`;
+  }
+  return `${hostname}/${dirname}`;
+}
+
+/**
+ * Make a name unique by appending `:2`, `:3`, etc. if it already exists.
+ */
+export function makeUniqueName(baseName: string, existingNames: Set<string>): string {
+  if (!existingNames.has(baseName)) {
+    return baseName;
+  }
+
+  let counter = 2;
+  while (existingNames.has(`${baseName}:${counter}`)) {
+    counter++;
+  }
+  return `${baseName}:${counter}`;
+}
+
+/**
+ * Strip `.local` suffix from hostname (common on macOS).
+ */
+export function cleanHostname(hostname: string): string {
+  if (hostname.endsWith('.local')) {
+    return hostname.slice(0, -6);
+  }
+  return hostname;
+}
+
+/**
+ * Detect the current git branch in the given directory.
+ * Returns null if not a git repo or git is unavailable.
+ */
+function detectGitBranch(cwd: string): string | null {
+  try {
+    const result = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const branch = result.trim();
+    if (branch && branch !== 'HEAD') {
+      return branch;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -75,6 +75,9 @@ export interface ManagedSession {
   /** Message API for structured messages */
   messageApi: MessageAPI;
 
+  /** When session last had activity (message, status change) */
+  lastActivityAt: Timestamp;
+
   /** Currently attached connection ID (null if orphaned) */
   activeConnectionId: UUID | null;
   /** When session was last disconnected (null if connected) */
@@ -128,13 +131,15 @@ export class SessionRegistry {
     const existingNames = this.getExistingNames();
     const name = makeUniqueName(baseName, existingNames);
 
+    const createdAt = now();
     const session: ManagedSession = {
       sessionId,
       name,
-      createdAt: now(),
+      createdAt,
       workingDirectory,
       pty,
       messageApi,
+      lastActivityAt: createdAt,
       activeConnectionId: null,
       lastDisconnectedAt: null,
       orphanTimeoutId: null,
@@ -301,6 +306,7 @@ export class SessionRegistry {
     }
 
     session.messageHistory.push(message);
+    session.lastActivityAt = now();
 
     // If connected, mark as delivered
     if (session.activeConnectionId !== null) {
@@ -318,6 +324,7 @@ export class SessionRegistry {
     const session = this.sessions.get(sessionId);
     if (session !== undefined) {
       session.currentStatus = status;
+      session.lastActivityAt = now();
     }
   }
 
@@ -328,6 +335,7 @@ export class SessionRegistry {
     const session = this.sessions.get(sessionId);
     if (session !== undefined) {
       session.currentQuestion = question;
+      session.lastActivityAt = now();
     }
   }
 
@@ -429,7 +437,8 @@ export class SessionRegistry {
         name: session.name,
         projectPath: session.workingDirectory,
         status,
-        lastActivity: session.lastDisconnectedAt ?? session.createdAt,
+        createdAt: session.createdAt,
+        lastActivity: session.lastActivityAt,
         messageCount: session.messageHistory.length,
         lastMessage,
         source: 'daemon',

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -19,6 +19,7 @@ import type {
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
+import { generateSessionName, makeUniqueName } from './session-name.ts';
 
 /** Configuration for SessionRegistry */
 export interface SessionRegistryConfig {
@@ -62,6 +63,8 @@ export interface SessionRegistryEvents {
 export interface ManagedSession {
   /** Unique session ID */
   readonly sessionId: UUID;
+  /** Human-readable session name (e.g. "hostname/project/branch") */
+  readonly name: string;
   /** When session was created */
   readonly createdAt: Timestamp;
   /** Working directory for Claude Code */
@@ -121,8 +124,13 @@ export class SessionRegistry {
     pty: PTYSession,
     messageApi: MessageAPI,
   ): void {
+    const baseName = generateSessionName(workingDirectory);
+    const existingNames = this.getExistingNames();
+    const name = makeUniqueName(baseName, existingNames);
+
     const session: ManagedSession = {
       sessionId,
+      name,
       createdAt: now(),
       workingDirectory,
       pty,
@@ -364,6 +372,41 @@ export class SessionRegistry {
   }
 
   /**
+   * Resolve a session by its human-readable name.
+   * Supports exact match and prefix match.
+   */
+  resolveByName(name: string): ManagedSession | undefined {
+    // Exact match first
+    for (const session of this.sessions.values()) {
+      if (session.name === name) {
+        return session;
+      }
+    }
+    // Prefix match (e.g. "mac/remi" matches "mac/remi/main")
+    const matches: ManagedSession[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.name.startsWith(name)) {
+        matches.push(session);
+      }
+    }
+    if (matches.length === 1) {
+      return matches[0];
+    }
+    return undefined;
+  }
+
+  /**
+   * Get all existing session names for uniqueness checks.
+   */
+  private getExistingNames(): Set<string> {
+    const names = new Set<string>();
+    for (const session of this.sessions.values()) {
+      names.add(session.name);
+    }
+    return names;
+  }
+
+  /**
    * Get all active session IDs.
    */
   getActiveSessionIds(): UUID[] {
@@ -383,6 +426,7 @@ export class SessionRegistry {
 
       result.push({
         sessionId: session.sessionId,
+        name: session.name,
         projectPath: session.workingDirectory,
         status,
         lastActivity: session.lastDisconnectedAt ?? session.createdAt,

--- a/packages/daemon/tests/cli/kill-client.test.ts
+++ b/packages/daemon/tests/cli/kill-client.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for kill-client session resolution logic.
+ *
+ * These tests verify the session name/ID resolution used by `remi kill`.
+ * The actual WebSocket communication is tested via integration tests.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { DiscoverableSession } from '@remi/shared';
+import { generateId } from '@remi/shared';
+
+// Extract the resolution logic for unit testing
+function resolveSession(
+  sessionList: DiscoverableSession[],
+  nameOrId: string,
+): DiscoverableSession | null {
+  // Exact name match
+  const byName = sessionList.filter((s) => s.name === nameOrId);
+  if (byName.length === 1) return byName[0] ?? null;
+
+  // Prefix name match
+  const byPrefix = sessionList.filter((s) => s.name?.startsWith(nameOrId));
+  if (byPrefix.length === 1) return byPrefix[0] ?? null;
+  if (byPrefix.length > 1) {
+    throw new Error(`Ambiguous session name "${nameOrId}"`);
+  }
+
+  // Exact ID match
+  const byId = sessionList.filter((s) => s.sessionId === nameOrId);
+  if (byId.length === 1) return byId[0] ?? null;
+
+  // Prefix ID match
+  const byIdPrefix = sessionList.filter((s) => s.sessionId.startsWith(nameOrId));
+  if (byIdPrefix.length === 1) return byIdPrefix[0] ?? null;
+  if (byIdPrefix.length > 1) {
+    throw new Error(`Ambiguous session ID "${nameOrId}"`);
+  }
+
+  return null;
+}
+
+function makeSession(name: string, id?: string): DiscoverableSession {
+  return {
+    sessionId: id ?? generateId(),
+    name,
+    projectPath: '/tmp/test',
+    status: 'active',
+    lastActivity: new Date().toISOString(),
+    messageCount: 0,
+    source: 'daemon',
+    canAttach: true,
+  };
+}
+
+describe('kill-client session resolution', () => {
+  test('resolves exact name match', () => {
+    const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/remi/dev')];
+    const result = resolveSession(sessions, 'macbook/remi/main');
+    expect(result?.name).toBe('macbook/remi/main');
+  });
+
+  test('resolves prefix name match', () => {
+    const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/other/dev')];
+    const result = resolveSession(sessions, 'macbook/remi');
+    expect(result?.name).toBe('macbook/remi/main');
+  });
+
+  test('throws on ambiguous name prefix', () => {
+    const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/remi/dev')];
+    expect(() => resolveSession(sessions, 'macbook/remi')).toThrow('Ambiguous');
+  });
+
+  test('resolves exact ID match', () => {
+    const id = generateId();
+    const sessions = [makeSession('test-session', id)];
+    const result = resolveSession(sessions, id);
+    expect(result?.sessionId).toBe(id);
+  });
+
+  test('resolves prefix ID match', () => {
+    const id = 'abcdef12-3456-7890-abcd-ef1234567890';
+    const sessions = [makeSession('test-session', id)];
+    const result = resolveSession(sessions, 'abcdef12');
+    expect(result?.sessionId).toBe(id);
+  });
+
+  test('returns null for no match', () => {
+    const sessions = [makeSession('macbook/remi/main')];
+    const result = resolveSession(sessions, 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  test('returns null for empty session list', () => {
+    const result = resolveSession([], 'anything');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -10,6 +10,8 @@ import {
 } from '@remi/shared';
 import {
   fetchSessions,
+  formatAge,
+  formatDuration,
   getLocalAddresses,
   parseRemoteTarget,
   runLsClient,
@@ -221,5 +223,68 @@ describe('getLocalAddresses', () => {
     const addrs = getLocalAddresses('test');
     expect(addrs.has('8.8.8.8')).toBe(false);
     expect(addrs.has('not-a-host')).toBe(false);
+  });
+});
+
+describe('formatAge', () => {
+  test('formats seconds ago', () => {
+    const ts = new Date(Date.now() - 30 * 1000).toISOString();
+    expect(formatAge(ts)).toBe('30s ago');
+  });
+
+  test('formats minutes ago', () => {
+    const ts = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatAge(ts)).toBe('5m ago');
+  });
+
+  test('formats hours ago', () => {
+    const ts = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    expect(formatAge(ts)).toBe('2h ago');
+  });
+
+  test('formats days ago', () => {
+    const ts = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatAge(ts)).toBe('3d ago');
+  });
+
+  test('formats 0 seconds for just-now timestamp', () => {
+    const ts = new Date().toISOString();
+    expect(formatAge(ts)).toBe('0s ago');
+  });
+});
+
+describe('formatDuration', () => {
+  test('returns "-" for undefined', () => {
+    expect(formatDuration(undefined)).toBe('-');
+  });
+
+  test('formats seconds', () => {
+    const ts = new Date(Date.now() - 45 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('45s');
+  });
+
+  test('formats minutes', () => {
+    const ts = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('45m');
+  });
+
+  test('formats hours and minutes', () => {
+    const ts = new Date(Date.now() - (2 * 60 + 15) * 60 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('2h 15m');
+  });
+
+  test('formats exact hours without minutes', () => {
+    const ts = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('3h');
+  });
+
+  test('formats days and hours', () => {
+    const ts = new Date(Date.now() - 26 * 60 * 60 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('1d 2h');
+  });
+
+  test('formats exact days without hours', () => {
+    const ts = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatDuration(ts)).toBe('2d');
   });
 });

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -9,6 +9,8 @@ import {
   createCreateSessionResponse,
   createHello,
   createHelloAck,
+  createKillSessionRequest,
+  createKillSessionResponse,
   createTerminalResize,
   deserialize,
   serialize,
@@ -213,6 +215,65 @@ describe('Protocol factory functions', () => {
       );
       expect(result).not.toBeNull();
       expect(result?.type).toBe('create_session_response');
+    });
+
+    test('accepts kill_session_request type', () => {
+      const result = deserialize(
+        '{"type":"kill_session_request","id":"1","timestamp":"2024-01-01T00:00:00Z","sessionId":"s1"}',
+      );
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('kill_session_request');
+    });
+
+    test('accepts kill_session_response type', () => {
+      const result = deserialize(
+        '{"type":"kill_session_response","id":"1","timestamp":"2024-01-01T00:00:00Z","success":true,"requestId":"r1"}',
+      );
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('kill_session_response');
+    });
+  });
+
+  describe('createKillSessionRequest', () => {
+    test('creates request with sessionId', () => {
+      const msg = createKillSessionRequest('session-1' as UUID);
+      expect(msg.type).toBe('kill_session_request');
+      expect(msg.sessionId).toBe('session-1');
+      expect(msg.id).toBeTruthy();
+      expect(msg.timestamp).toBeTruthy();
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createKillSessionRequest('session-1' as UUID);
+      const deserialized = deserialize(serialize(original));
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('kill_session_request');
+      expect((deserialized as typeof original).sessionId).toBe('session-1');
+    });
+  });
+
+  describe('createKillSessionResponse', () => {
+    test('creates success response', () => {
+      const msg = createKillSessionResponse(true, 'req-1' as UUID);
+      expect(msg.type).toBe('kill_session_response');
+      expect(msg.success).toBe(true);
+      expect(msg.requestId).toBe('req-1');
+      expect(msg.error).toBeUndefined();
+    });
+
+    test('creates failure response with error', () => {
+      const msg = createKillSessionResponse(false, 'req-1' as UUID, 'Session not found');
+      expect(msg.success).toBe(false);
+      expect(msg.error).toBe('Session not found');
+      expect(msg.requestId).toBe('req-1');
+    });
+
+    test('round-trips through serialize/deserialize', () => {
+      const original = createKillSessionResponse(true, 'req-1' as UUID);
+      const deserialized = deserialize(serialize(original));
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('kill_session_response');
+      expect((deserialized as typeof original).success).toBe(true);
     });
   });
 });

--- a/packages/daemon/tests/session-name.test.ts
+++ b/packages/daemon/tests/session-name.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { cleanHostname, generateSessionName, makeUniqueName } from '../src/session/session-name.ts';
+
+describe('cleanHostname', () => {
+  test('strips .local suffix', () => {
+    expect(cleanHostname('macbook.local')).toBe('macbook');
+  });
+
+  test('leaves hostname without .local unchanged', () => {
+    expect(cleanHostname('server01')).toBe('server01');
+  });
+
+  test('handles empty string', () => {
+    expect(cleanHostname('')).toBe('');
+  });
+
+  test('only strips trailing .local, not embedded', () => {
+    expect(cleanHostname('local.server')).toBe('local.server');
+  });
+});
+
+describe('makeUniqueName', () => {
+  test('returns base name when no duplicates', () => {
+    const existing = new Set<string>();
+    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main');
+  });
+
+  test('appends :2 for first duplicate', () => {
+    const existing = new Set(['mac/remi/main']);
+    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:2');
+  });
+
+  test('appends :3 when :2 also exists', () => {
+    const existing = new Set(['mac/remi/main', 'mac/remi/main:2']);
+    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:3');
+  });
+
+  test('skips to next available counter', () => {
+    const existing = new Set([
+      'mac/remi/main',
+      'mac/remi/main:2',
+      'mac/remi/main:3',
+      'mac/remi/main:4',
+    ]);
+    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:5');
+  });
+});
+
+describe('generateSessionName', () => {
+  test('generates name with hostname, dir, and branch for git repos', () => {
+    // This test runs in the remi repo, so it should have a git branch
+    const name = generateSessionName(process.cwd());
+    const parts = name.split('/');
+    // Should have hostname/dirname/branch format (3 parts)
+    expect(parts.length).toBeGreaterThanOrEqual(2);
+    // First part should be the hostname (without .local)
+    expect(parts[0]).not.toContain('.local');
+    expect(parts[0]?.length).toBeGreaterThan(0);
+  });
+
+  test('generates name without branch for non-git directories', () => {
+    const name = generateSessionName('/tmp');
+    const parts = name.split('/');
+    // /tmp is not a git repo, so should be hostname/dirname (2 parts)
+    expect(parts.length).toBe(2);
+    expect(parts[1]).toBe('tmp');
+  });
+
+  test('uses directory basename', () => {
+    const name = generateSessionName('/some/deep/project');
+    expect(name).toContain('/project');
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -64,6 +64,8 @@ export type {
   AuthChallengeMessage,
   AuthResponseMessage,
   AuthResultMessage,
+  KillSessionRequestMessage,
+  KillSessionResponseMessage,
 } from './protocol.ts';
 
 export {
@@ -97,6 +99,8 @@ export {
   createAuthChallenge,
   createAuthResponse,
   createAuthResult,
+  createKillSessionRequest,
+  createKillSessionResponse,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -89,7 +89,9 @@ export type ProtocolMessage =
   | TerminalResizeMessage
   | AuthChallengeMessage
   | AuthResponseMessage
-  | AuthResultMessage;
+  | AuthResultMessage
+  | KillSessionRequestMessage
+  | KillSessionResponseMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -404,6 +406,28 @@ export interface AuthResultMessage {
   readonly serverSignature?: string;
 }
 
+/** Request to kill (terminate) a session by ID */
+export interface KillSessionRequestMessage {
+  readonly type: 'kill_session_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID to kill */
+  readonly sessionId: UUID;
+}
+
+/** Response after killing a session */
+export interface KillSessionResponseMessage {
+  readonly type: 'kill_session_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Whether the kill succeeded */
+  readonly success: boolean;
+  /** Error message if kill failed */
+  readonly error?: string;
+  /** ID of the original request */
+  readonly requestId: UUID;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -472,6 +496,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'auth_challenge',
     'auth_response',
     'auth_result',
+    'kill_session_request',
+    'kill_session_response',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -914,6 +940,36 @@ export function createAuthResult(
     timestamp: now(),
     success,
     ...(serverSignature !== undefined && { serverSignature }),
+    ...(error !== undefined && { error }),
+  };
+}
+
+/**
+ * Create a kill session request message.
+ */
+export function createKillSessionRequest(sessionId: UUID): KillSessionRequestMessage {
+  return {
+    type: 'kill_session_request',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+  };
+}
+
+/**
+ * Create a kill session response message.
+ */
+export function createKillSessionResponse(
+  success: boolean,
+  requestId: UUID,
+  error?: string,
+): KillSessionResponseMessage {
+  return {
+    type: 'kill_session_response',
+    id: generateId(),
+    timestamp: now(),
+    success,
+    requestId,
     ...(error !== undefined && { error }),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -250,6 +250,9 @@ export interface DiscoverableSession {
   /** Session ID (daemon UUID or Claude Code session ID from transcript path) */
   readonly sessionId: string;
 
+  /** Human-readable session name (e.g. "hostname/project/branch") */
+  readonly name?: string | undefined;
+
   /** Project path this session is working in. For transcript sessions, this is decoded from Claude Code's lossy path encoding and may be inaccurate for paths containing dashes. */
   readonly projectPath: string;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -259,6 +259,9 @@ export interface DiscoverableSession {
   /** Current session status */
   readonly status: DiscoverableSessionStatus;
 
+  /** When the session was created. For daemon sessions: registration time. For transcript sessions: file creation time. */
+  readonly createdAt?: Timestamp | undefined;
+
   /** When the session was last active. For daemon sessions: last disconnection time (or creation time if still connected). For transcript sessions: file modification time. */
   readonly lastActivity: Timestamp;
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -215,12 +215,14 @@ function App() {
         });
 
         // Update session last active time and increment unread if not the active session
+        // Also clear questionPending since new content means the question was resolved
         setSessions((prev) =>
           prev.map((s) =>
             s.id === sessionId
               ? {
                   ...s,
                   lastActiveAt: new Date().toISOString(),
+                  questionPending: false,
                   unreadCount:
                     s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
                   preview: structuredMsg.content?.slice(0, 80) || s.preview,
@@ -300,6 +302,7 @@ function App() {
               ? {
                   ...s,
                   lastActiveAt: new Date().toISOString(),
+                  questionPending: false,
                   unreadCount:
                     s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
                   preview: structuredMsg.content?.slice(0, 80) || s.preview,
@@ -374,7 +377,7 @@ function App() {
         // Map DiscoverableSession[] to UISession[]
         const discovered: UISession[] = message.sessions.map((ds: DiscoverableSession) => ({
           id: ds.sessionId as UUID,
-          name: ds.projectPath.split('/').pop() || 'Session',
+          name: ds.name || ds.projectPath.split('/').pop() || 'Session',
           createdAt: ds.lastActivity,
           lastActiveAt: ds.lastActivity,
           status:
@@ -603,7 +606,7 @@ function App() {
       setSessions((prev) =>
         prev.map((s) =>
           s.connectionStatus === 'connected'
-            ? { ...s, connectionStatus: 'disconnected' as const }
+            ? { ...s, connectionStatus: 'disconnected' as const, questionPending: false }
             : s,
         ),
       );
@@ -905,6 +908,7 @@ function App() {
           },
           onError: (errCode, errMsg) => {
             console.error(`Signaling error [${errCode}]: ${errMsg}`);
+            setError(new Error(`Connection failed: ${errMsg}`));
           },
         });
 
@@ -949,7 +953,9 @@ function App() {
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
-    navigator.clipboard.writeText(text);
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.warn('Failed to copy to clipboard:', err);
+    });
   }, [sessionMessages]);
 
   const handleClearMessages = useCallback(() => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,24 +4,25 @@
  * Main application component wired to real daemon data.
  */
 
-import { ChatView } from '@/components/chat';
+import { ChatView, SessionSwitcher } from '@/components/chat';
 import { AppLayout } from '@/components/layout';
 import { ConnectModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
 import { useWebSocket } from '@/hooks';
-import type { AppSettings, UIBullet, UIMessage, UIQuestion, UISession } from '@/types';
-import { DEFAULT_SETTINGS } from '@/types';
-import { deduplicateMessage } from '@/lib/message-dedup';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
-import type { UnlockedIdentity } from '@remi/shared';
-import {
-  createAuthResponse,
-  fromBase64,
-  importPublicKey,
-  sign,
-  verify,
-} from '@remi/shared';
 import { checkKnownHost, trustHost } from '@/lib/identity-client';
+import { deduplicateMessage } from '@/lib/message-dedup';
+import type {
+  AppSettings,
+  UIBullet,
+  UIMessage,
+  UIQuestion,
+  UIQuestionOption,
+  UISession,
+} from '@/types';
+import { DEFAULT_SETTINGS } from '@/types';
+import type { UnlockedIdentity } from '@remi/shared';
+import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
@@ -44,7 +45,9 @@ function loadSettings(): AppSettings {
   try {
     const stored = localStorage.getItem(LOCALSTORAGE_SETTINGS_KEY);
     if (stored) return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
-  } catch { /* use defaults */ }
+  } catch {
+    /* use defaults */
+  }
   return DEFAULT_SETTINGS;
 }
 
@@ -69,6 +72,7 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
+  const [showSessionSwitcher, setShowSessionSwitcher] = useState(false);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
@@ -106,16 +110,19 @@ function App() {
           }
           // Only create new entry for non-resume (resume expects session to exist)
           if (message.isResume) return prev;
-          return [...prev, {
-            id: message.sessionId,
-            name: 'Claude Code Session',
-            createdAt: new Date().toISOString(),
-            lastActiveAt: new Date().toISOString(),
-            status: 'idle',
-            connectionStatus: 'connected',
-            unreadCount: 0,
-            preview: 'Connected',
-          } satisfies UISession];
+          return [
+            ...prev,
+            {
+              id: message.sessionId,
+              name: 'Claude Code Session',
+              createdAt: new Date().toISOString(),
+              lastActiveAt: new Date().toISOString(),
+              status: 'idle',
+              connectionStatus: 'connected',
+              unreadCount: 0,
+              preview: 'Connected',
+            } satisfies UISession,
+          ];
         });
         setCreatingSession(false);
         setActiveSessionId(message.sessionId);
@@ -207,11 +214,17 @@ function App() {
           return [...prev, uiMessage];
         });
 
-        // Update session last active time
+        // Update session last active time and increment unread if not the active session
         setSessions((prev) =>
           prev.map((s) =>
             s.id === sessionId
-              ? { ...s, lastActiveAt: new Date().toISOString() }
+              ? {
+                  ...s,
+                  lastActiveAt: new Date().toISOString(),
+                  unreadCount:
+                    s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
+                  preview: structuredMsg.content?.slice(0, 80) || s.preview,
+                }
               : s,
           ),
         );
@@ -284,7 +297,13 @@ function App() {
         setSessions((prev) =>
           prev.map((s) =>
             s.id === structuredMsg.sessionId
-              ? { ...s, lastActiveAt: new Date().toISOString() }
+              ? {
+                  ...s,
+                  lastActiveAt: new Date().toISOString(),
+                  unreadCount:
+                    s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
+                  preview: structuredMsg.content?.slice(0, 80) || s.preview,
+                }
               : s,
           ),
         );
@@ -306,11 +325,22 @@ function App() {
         if (q.options.length > 0) {
           const hasYesNo = q.options.some((o) => o.isYes || o.isNo);
           if (hasYesNo) {
-            questionType = 'yes_no';
+            // Check for multi-option (yes/no plus extra options like all/quit)
+            const extraOptions = q.options.filter((o) => !o.isYes && !o.isNo);
+            questionType = extraOptions.length > 0 ? 'multi_option' : 'yes_no';
           } else {
             questionType = 'numbered';
           }
         }
+
+        // Build structured options with full metadata
+        const structuredOptions: UIQuestionOption[] = q.options.map((o) => ({
+          label: o.label,
+          value: o.value,
+          isYes: o.isYes || undefined,
+          isNo: o.isNo || undefined,
+          isRecommended: o.isRecommended || undefined,
+        }));
 
         // Use sessionId from the message when available; fall back to active session
         const questionSessionId = message.sessionId ?? activeSessionIdRef.current ?? ('' as UUID);
@@ -320,9 +350,15 @@ function App() {
           type: questionType,
           prompt: q.text,
           options: q.options.length > 0 ? q.options.map((o) => o.label) : undefined,
+          structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
           timestamp: new Date().toISOString(),
         };
         setQuestion(uiQuestion);
+
+        // Mark session as having a pending question
+        setSessions((prev) =>
+          prev.map((s) => (s.id === questionSessionId ? { ...s, questionPending: true } : s)),
+        );
         break;
       }
 
@@ -341,11 +377,15 @@ function App() {
           name: ds.projectPath.split('/').pop() || 'Session',
           createdAt: ds.lastActivity,
           lastActiveAt: ds.lastActivity,
-          status: ds.status === 'active' ? 'executing' as const :
-                  ds.status === 'idle' ? 'idle' as const :
-                  ds.status === 'orphaned' ? 'idle' as const :
-                  'idle' as const,
-          connectionStatus: ds.canAttach ? 'connected' as const : 'disconnected' as const,
+          status:
+            ds.status === 'active'
+              ? ('executing' as const)
+              : ds.status === 'idle'
+                ? ('idle' as const)
+                : ds.status === 'orphaned'
+                  ? ('idle' as const)
+                  : ('idle' as const),
+          connectionStatus: ds.canAttach ? ('connected' as const) : ('disconnected' as const),
           unreadCount: 0,
           cwd: ds.projectPath,
           preview: ds.lastMessage || `${ds.messageCount} messages`,
@@ -383,9 +423,7 @@ function App() {
       case 'transcript_load_complete': {
         // Mark session as done loading
         setSessions((prev) =>
-          prev.map((s) =>
-            s.id === message.sessionId ? { ...s, isLoadingTranscript: false } : s,
-          ),
+          prev.map((s) => (s.id === message.sessionId ? { ...s, isLoadingTranscript: false } : s)),
         );
         break;
       }
@@ -433,14 +471,18 @@ function App() {
     () => localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null,
   );
 
-  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(null);
+  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(
+    null,
+  );
   const pendingRelayChallengeRef = useRef<{
     challenge: string;
     serverPublicKey: string;
     serverFingerprint: string;
   } | null>(null);
   const [connectionMode, setConnectionMode] = useState<'direct' | 'relay'>('direct');
-  const [relayStatus, setRelayStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
+  const [relayStatus, setRelayStatus] = useState<'disconnected' | 'connecting' | 'connected'>(
+    'disconnected',
+  );
   const [relayError, setRelayError] = useState<Error | null>(null);
 
   /** Set error (works for both direct and relay modes) */
@@ -474,50 +516,78 @@ function App() {
   const effectiveStatus = connectionMode === 'relay' ? relayStatus : connectionStatus;
 
   // Relay-aware send: dispatches through signaling client when in relay mode
-  const relaySend = useCallback((message: ProtocolMessage): boolean => {
-    if (connectionMode === 'relay') {
-      if (signalingClientRef.current?.isConnected) {
-        signalingClientRef.current.sendMessage(message);
-        return true;
+  const relaySend = useCallback(
+    (message: ProtocolMessage): boolean => {
+      if (connectionMode === 'relay') {
+        if (signalingClientRef.current?.isConnected) {
+          signalingClientRef.current.sendMessage(message);
+          return true;
+        }
+        console.warn(`Relay send dropped (not connected): ${message.type}`);
+        return false;
       }
-      console.warn(`Relay send dropped (not connected): ${message.type}`);
       return false;
-    }
-    return false;
-  }, [connectionMode]);
+    },
+    [connectionMode],
+  );
 
   // Relay-aware wrappers for send functions
-  const effectiveSendInput = useCallback((sessionId: UUID, content: string): boolean => {
-    if (connectionMode === 'relay') return relaySend(createUserInput(sessionId, content));
-    return sendInput(sessionId, content);
-  }, [connectionMode, relaySend, sendInput]);
+  const effectiveSendInput = useCallback(
+    (sessionId: UUID, content: string): boolean => {
+      if (connectionMode === 'relay') return relaySend(createUserInput(sessionId, content));
+      return sendInput(sessionId, content);
+    },
+    [connectionMode, relaySend, sendInput],
+  );
 
-  const effectiveSendAnswer = useCallback((questionId: UUID, answer: string): boolean => {
-    if (connectionMode === 'relay') {
-      return relaySend({ type: 'answer', id: generateId(), timestamp: now(), questionId, answer });
-    }
-    return sendAnswer(questionId, answer);
-  }, [connectionMode, relaySend, sendAnswer]);
+  const effectiveSendAnswer = useCallback(
+    (questionId: UUID, answer: string): boolean => {
+      if (connectionMode === 'relay') {
+        return relaySend({
+          type: 'answer',
+          id: generateId(),
+          timestamp: now(),
+          questionId,
+          answer,
+        });
+      }
+      return sendAnswer(questionId, answer);
+    },
+    [connectionMode, relaySend, sendAnswer],
+  );
 
-  const effectiveRequestBulletExpand = useCallback((sessionId: UUID, bulletId: number): boolean => {
-    if (connectionMode === 'relay') return relaySend(createBulletExpandRequest(sessionId, bulletId));
-    return requestBulletExpand(sessionId, bulletId);
-  }, [connectionMode, relaySend, requestBulletExpand]);
+  const effectiveRequestBulletExpand = useCallback(
+    (sessionId: UUID, bulletId: number): boolean => {
+      if (connectionMode === 'relay')
+        return relaySend(createBulletExpandRequest(sessionId, bulletId));
+      return requestBulletExpand(sessionId, bulletId);
+    },
+    [connectionMode, relaySend, requestBulletExpand],
+  );
 
-  const effectiveRequestSessionList = useCallback((includeExternal?: boolean): boolean => {
-    if (connectionMode === 'relay') return relaySend(createSessionListRequest(includeExternal));
-    return requestSessionList(includeExternal);
-  }, [connectionMode, relaySend, requestSessionList]);
+  const effectiveRequestSessionList = useCallback(
+    (includeExternal?: boolean): boolean => {
+      if (connectionMode === 'relay') return relaySend(createSessionListRequest(includeExternal));
+      return requestSessionList(includeExternal);
+    },
+    [connectionMode, relaySend, requestSessionList],
+  );
 
-  const effectiveRequestTranscriptLoad = useCallback((sessionId: string): boolean => {
-    if (connectionMode === 'relay') return relaySend(createTranscriptLoadRequest(sessionId));
-    return requestTranscriptLoad(sessionId);
-  }, [connectionMode, relaySend, requestTranscriptLoad]);
+  const effectiveRequestTranscriptLoad = useCallback(
+    (sessionId: string): boolean => {
+      if (connectionMode === 'relay') return relaySend(createTranscriptLoadRequest(sessionId));
+      return requestTranscriptLoad(sessionId);
+    },
+    [connectionMode, relaySend, requestTranscriptLoad],
+  );
 
-  const effectiveRequestNewSession = useCallback((directory?: string): boolean => {
-    if (connectionMode === 'relay') return relaySend(createCreateSessionRequest(directory));
-    return requestNewSession(directory);
-  }, [connectionMode, relaySend, requestNewSession]);
+  const effectiveRequestNewSession = useCallback(
+    (directory?: string): boolean => {
+      if (connectionMode === 'relay') return relaySend(createCreateSessionRequest(directory));
+      return requestNewSession(directory);
+    },
+    [connectionMode, relaySend, requestNewSession],
+  );
 
   // Close modal and store URL on successful connect
   useEffect(() => {
@@ -543,9 +613,7 @@ function App() {
       if (activeSessionId) {
         setSessions((prev) =>
           prev.map((s) =>
-            s.id === activeSessionId
-              ? { ...s, connectionStatus: 'connected' as const }
-              : s,
+            s.id === activeSessionId ? { ...s, connectionStatus: 'connected' as const } : s,
           ),
         );
       }
@@ -585,20 +653,26 @@ function App() {
   const sessionQuestion = question?.sessionId === activeSessionId ? question : null;
 
   // Handlers
-  const handleSelectSession = useCallback((id: UUID) => {
-    setActiveSessionId(id);
-    localStorage.setItem(LOCALSTORAGE_SESSION_KEY, id);
+  const handleSelectSession = useCallback(
+    (id: UUID) => {
+      setActiveSessionId(id);
+      localStorage.setItem(LOCALSTORAGE_SESSION_KEY, id);
 
-    // If this is an external transcript session we haven't loaded yet, request its history
-    const session = sessions.find((s) => s.id === id);
-    if (session?.source === 'transcript' && !loadedTranscriptsRef.current.has(id)) {
-      loadedTranscriptsRef.current.add(id);
-      setSessions((prev) =>
-        prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
-      );
-      effectiveRequestTranscriptLoad(id);
-    }
-  }, [sessions, effectiveRequestTranscriptLoad]);
+      // Reset unread count for the selected session
+      setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, unreadCount: 0 } : s)));
+
+      // If this is an external transcript session we haven't loaded yet, request its history
+      const session = sessions.find((s) => s.id === id);
+      if (session?.source === 'transcript' && !loadedTranscriptsRef.current.has(id)) {
+        loadedTranscriptsRef.current.add(id);
+        setSessions((prev) =>
+          prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
+        );
+        effectiveRequestTranscriptLoad(id);
+      }
+    },
+    [sessions, effectiveRequestTranscriptLoad],
+  );
 
   const handleBack = useCallback(() => {
     setActiveSessionId(null);
@@ -611,7 +685,13 @@ function App() {
       // If there's an active question, send as answer
       if (sessionQuestion) {
         effectiveSendAnswer(sessionQuestion.id, content);
-        setQuestion(null);
+        // Mark question as answered (card shows collapsed state briefly)
+        setQuestion({ ...sessionQuestion, answeredWith: content });
+        setTimeout(() => setQuestion(null), 1500);
+        // Clear question-pending on the session
+        setSessions((prev) =>
+          prev.map((s) => (s.id === activeSessionId ? { ...s, questionPending: false } : s)),
+        );
         // Add user message to UI
         const userMsg: UIMessage = {
           id: generateId(),
@@ -649,16 +729,19 @@ function App() {
     [activeSessionId, effectiveSendInput, effectiveSendAnswer, sessionQuestion],
   );
 
-  const handlePassphraseSubmit = useCallback(async (passphrase: string) => {
-    try {
-      const identity = await unlockStoredIdentity(passphrase);
-      setUnlockedIdentity(identity);
-      provideIdentity(identity);
-    } catch (err) {
-      console.error('Failed to unlock identity:', err);
-      throw err;
-    }
-  }, [provideIdentity]);
+  const handlePassphraseSubmit = useCallback(
+    async (passphrase: string) => {
+      try {
+        const identity = await unlockStoredIdentity(passphrase);
+        setUnlockedIdentity(identity);
+        provideIdentity(identity);
+      } catch (err) {
+        console.error('Failed to unlock identity:', err);
+        throw err;
+      }
+    },
+    [provideIdentity],
+  );
 
   const handleConnectDirect = useCallback(
     (url: string, directory?: string) => {
@@ -684,151 +767,155 @@ function App() {
 
   const handleConnectCode = useCallback((code: string) => {
     // Dynamic import to avoid bundling when not used
-    import('@/lib/signaling-client').then(({ WebSignalingClient }) => {
-      // Close existing signaling connection if any
-      if (signalingClientRef.current) {
-        signalingClientRef.current.close();
-      }
+    import('@/lib/signaling-client')
+      .then(({ WebSignalingClient }) => {
+        // Close existing signaling connection if any
+        if (signalingClientRef.current) {
+          signalingClientRef.current.close();
+        }
 
-      setConnectionMode('relay');
-      setRelayStatus('connecting');
-      setRelayError(null);
-      pendingRelayChallengeRef.current = null;
+        setConnectionMode('relay');
+        setRelayStatus('connecting');
+        setRelayError(null);
+        pendingRelayChallengeRef.current = null;
 
-      const signalingUrl = 'wss://remi-signaling.dev-941.workers.dev/connect';
-      const client = new WebSignalingClient({
-        onStateChange: (state) => {
-          if (state === 'connected') {
-            setRelayStatus('connected');
-            setShowConnectModal(false);
-            // Send hello via relay with resumeSessionId if reconnecting
-            // (harmless if auth is required; daemon drops it and sends
-            // auth_challenge first, then hello_ack after auth completes)
-            const resumeId = activeSessionIdRef.current ?? undefined;
-            client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
-          } else if (state === 'connecting' || state === 'joined') {
-            setRelayStatus('connecting');
-          } else if (state === 'disconnected' || state === 'error') {
-            setRelayStatus('disconnected');
-          }
-        },
-        onMessage: (message) => {
-          if (!message || typeof message !== 'object' || !('type' in message)) return;
-          const msg = message as ProtocolMessage;
-
-          // Handle auth_challenge: TOFU check, sign, and respond
-          if (msg.type === 'auth_challenge') {
-            const identity = unlockedIdentityRef.current;
-            if (!identity) {
-              setError(new Error(
-                'This daemon requires authentication. Unlock your identity first (Settings > Identity).',
-              ));
+        const signalingUrl = 'wss://remi-signaling.dev-941.workers.dev/connect';
+        const client = new WebSignalingClient({
+          onStateChange: (state) => {
+            if (state === 'connected') {
+              setRelayStatus('connected');
+              setShowConnectModal(false);
+              // Send hello via relay with resumeSessionId if reconnecting
+              // (harmless if auth is required; daemon drops it and sends
+              // auth_challenge first, then hello_ack after auth completes)
+              const resumeId = activeSessionIdRef.current ?? undefined;
+              client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
+            } else if (state === 'connecting' || state === 'joined') {
+              setRelayStatus('connecting');
+            } else if (state === 'disconnected' || state === 'error') {
               setRelayStatus('disconnected');
-              client.close();
-              return;
             }
+          },
+          onMessage: (message) => {
+            if (!message || typeof message !== 'object' || !('type' in message)) return;
+            const msg = message as ProtocolMessage;
 
-            // TOFU: check known hosts for relay server
-            const relayUrl = `relay:${msg.serverFingerprint}`;
-            const tofuResult = checkKnownHost(relayUrl, msg.serverFingerprint);
-            if (tofuResult === 'mismatch') {
-              setError(new Error(
-                'Server fingerprint changed. This could indicate a MITM attack. Connection rejected.',
-              ));
-              setRelayStatus('disconnected');
-              client.close();
-              return;
-            }
-
-            // Store challenge data for mutual auth verification in auth_result
-            pendingRelayChallengeRef.current = {
-              challenge: msg.challenge,
-              serverPublicKey: msg.serverPublicKey,
-              serverFingerprint: msg.serverFingerprint,
-            };
-
-            (async () => {
-              try {
-                const challengeData = fromBase64(msg.challenge);
-                const signature = await sign(identity.privateKey, challengeData);
-                client.sendMessage(createAuthResponse(
-                  identity.publicKeyRaw,
-                  signature,
-                  identity.fingerprint,
-                ));
-              } catch (err) {
-                const detail = err instanceof Error ? err.message : String(err);
-                setError(new Error(`Relay authentication failed: ${detail}`));
+            // Handle auth_challenge: TOFU check, sign, and respond
+            if (msg.type === 'auth_challenge') {
+              const identity = unlockedIdentityRef.current;
+              if (!identity) {
+                setError(
+                  new Error(
+                    'This daemon requires authentication. Unlock your identity first (Settings > Identity).',
+                  ),
+                );
                 setRelayStatus('disconnected');
                 client.close();
+                return;
               }
-            })();
-            return;
-          }
 
-          // Handle auth_result: verify mutual auth, TOFU trust, then send hello
-          if (msg.type === 'auth_result') {
-            if (!msg.success) {
-              setError(new Error(`Relay auth rejected: ${msg.error ?? 'unknown'}`));
-              setRelayStatus('disconnected');
-              client.close();
-              return;
-            }
+              // TOFU: check known hosts for relay server
+              const relayUrl = `relay:${msg.serverFingerprint}`;
+              const tofuResult = checkKnownHost(relayUrl, msg.serverFingerprint);
+              if (tofuResult === 'mismatch') {
+                setError(
+                  new Error(
+                    'Server fingerprint changed. This could indicate a MITM attack. Connection rejected.',
+                  ),
+                );
+                setRelayStatus('disconnected');
+                client.close();
+                return;
+              }
 
-            const pending = pendingRelayChallengeRef.current;
-            if (!msg.serverSignature || !pending) {
-              setError(new Error('Server did not provide mutual authentication signature'));
-              setRelayStatus('disconnected');
-              client.close();
-              return;
-            }
+              // Store challenge data for mutual auth verification in auth_result
+              pendingRelayChallengeRef.current = {
+                challenge: msg.challenge,
+                serverPublicKey: msg.serverPublicKey,
+                serverFingerprint: msg.serverFingerprint,
+              };
 
-            // Verify server signature for mutual auth
-            (async () => {
-              try {
-                const serverPubKey = await importPublicKey(fromBase64(pending.serverPublicKey));
-                const challengeData = fromBase64(pending.challenge);
-                const valid = await verify(serverPubKey, challengeData, msg.serverSignature!);
-                if (!valid) {
-                  setError(new Error('Server signature verification failed'));
+              (async () => {
+                try {
+                  const challengeData = fromBase64(msg.challenge);
+                  const signature = await sign(identity.privateKey, challengeData);
+                  client.sendMessage(
+                    createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint),
+                  );
+                } catch (err) {
+                  const detail = err instanceof Error ? err.message : String(err);
+                  setError(new Error(`Relay authentication failed: ${detail}`));
                   setRelayStatus('disconnected');
                   client.close();
-                  return;
                 }
+              })();
+              return;
+            }
 
-                // TOFU: trust server on first use
-                const relayUrl = `relay:${pending.serverFingerprint}`;
-                trustHost(relayUrl, pending.serverFingerprint, pending.serverPublicKey);
-                pendingRelayChallengeRef.current = null;
-
-                // Auth succeeded; now send hello so the daemon creates our session
-                const resumeId = activeSessionIdRef.current ?? undefined;
-                client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
-              } catch (err) {
-                const detail = err instanceof Error ? err.message : String(err);
-                setError(new Error(`Server verification failed: ${detail}`));
+            // Handle auth_result: verify mutual auth, TOFU trust, then send hello
+            if (msg.type === 'auth_result') {
+              if (!msg.success) {
+                setError(new Error(`Relay auth rejected: ${msg.error ?? 'unknown'}`));
                 setRelayStatus('disconnected');
                 client.close();
+                return;
               }
-            })();
-            return;
-          }
 
-          // Forward all other messages to the existing handler
-          handleMessageRef.current?.(msg);
-        },
-        onError: (errCode, errMsg) => {
-          console.error(`Signaling error [${errCode}]: ${errMsg}`);
-        },
+              const pending = pendingRelayChallengeRef.current;
+              if (!msg.serverSignature || !pending) {
+                setError(new Error('Server did not provide mutual authentication signature'));
+                setRelayStatus('disconnected');
+                client.close();
+                return;
+              }
+
+              // Verify server signature for mutual auth
+              (async () => {
+                try {
+                  const serverPubKey = await importPublicKey(fromBase64(pending.serverPublicKey));
+                  const challengeData = fromBase64(pending.challenge);
+                  const valid = await verify(serverPubKey, challengeData, msg.serverSignature!);
+                  if (!valid) {
+                    setError(new Error('Server signature verification failed'));
+                    setRelayStatus('disconnected');
+                    client.close();
+                    return;
+                  }
+
+                  // TOFU: trust server on first use
+                  const relayUrl = `relay:${pending.serverFingerprint}`;
+                  trustHost(relayUrl, pending.serverFingerprint, pending.serverPublicKey);
+                  pendingRelayChallengeRef.current = null;
+
+                  // Auth succeeded; now send hello so the daemon creates our session
+                  const resumeId = activeSessionIdRef.current ?? undefined;
+                  client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
+                } catch (err) {
+                  const detail = err instanceof Error ? err.message : String(err);
+                  setError(new Error(`Server verification failed: ${detail}`));
+                  setRelayStatus('disconnected');
+                  client.close();
+                }
+              })();
+              return;
+            }
+
+            // Forward all other messages to the existing handler
+            handleMessageRef.current?.(msg);
+          },
+          onError: (errCode, errMsg) => {
+            console.error(`Signaling error [${errCode}]: ${errMsg}`);
+          },
+        });
+
+        signalingClientRef.current = client;
+        client.connect(signalingUrl, code);
+      })
+      .catch((err) => {
+        console.error('Failed to load signaling client:', err);
+        setRelayStatus('disconnected');
+        setConnectionMode('direct');
       });
-
-      signalingClientRef.current = client;
-      client.connect(signalingUrl, code);
-    }).catch((err) => {
-      console.error('Failed to load signaling client:', err);
-      setRelayStatus('disconnected');
-      setConnectionMode('direct');
-    });
   }, []);
 
   const handleBulletExpand = useCallback(
@@ -861,9 +948,7 @@ function App() {
 
   // Menu actions
   const handleCopyConversation = useCallback(() => {
-    const text = sessionMessages
-      .map((m) => `[${m.sender}] ${m.content}`)
-      .join('\n\n');
+    const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
     navigator.clipboard.writeText(text);
   }, [sessionMessages]);
 
@@ -899,6 +984,20 @@ function App() {
     />
   );
 
+  // Compute total unread across non-active sessions
+  const totalUnread = sessions.reduce(
+    (sum, s) => sum + (s.id === activeSessionId ? 0 : s.unreadCount),
+    0,
+  );
+
+  const handleOpenSessions = useCallback(() => {
+    setShowSessionSwitcher(true);
+  }, []);
+
+  const handleCloseSessionSwitcher = useCallback(() => {
+    setShowSessionSwitcher(false);
+  }, []);
+
   // Main content
   const main = activeSession ? (
     <ChatView
@@ -908,6 +1007,9 @@ function App() {
       error={error}
       onSend={handleSend}
       onBack={handleBack}
+      onOpenSessions={handleOpenSessions}
+      sessionCount={sessions.length}
+      totalUnread={totalUnread}
       onCopyConversation={handleCopyConversation}
       onClearMessages={handleClearMessages}
       onExportText={handleExportText}
@@ -922,6 +1024,14 @@ function App() {
   return (
     <>
       <AppLayout sidebar={sidebar} main={main} showSidebar={!activeSessionId} />
+
+      <SessionSwitcher
+        sessions={sessions}
+        activeSessionId={activeSessionId}
+        isOpen={showSessionSwitcher}
+        onSelectSession={handleSelectSession}
+        onClose={handleCloseSessionSwitcher}
+      />
 
       <SettingsPanel
         open={showSettings}

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
+import type { ViewMode } from './ChatView';
 import { clsx } from 'clsx';
 import {
   AlertCircle,
@@ -14,9 +15,11 @@ import {
   Copy,
   FileText,
   Loader2,
+  MessageSquare,
   MoreVertical,
   Terminal,
   Trash2,
+  Type,
   Wifi,
   WifiOff,
 } from 'lucide-react';
@@ -24,6 +27,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface ChatHeaderProps {
   readonly session: UISession;
+  readonly viewMode?: ViewMode;
+  readonly onViewModeChange?: (mode: ViewMode) => void;
   readonly onBack?: () => void;
   readonly onCopyConversation?: () => void;
   readonly onClearMessages?: () => void;
@@ -94,6 +99,8 @@ function AgentStatusIndicator({ status }: { readonly status: AgentStatus }) {
 
 export function ChatHeader({
   session,
+  viewMode = 'compact',
+  onViewModeChange,
   onBack,
   onCopyConversation,
   onClearMessages,
@@ -166,6 +173,30 @@ export function ChatHeader({
           )}
         </div>
       </div>
+
+      {/* View mode toggle */}
+      {onViewModeChange && (
+        <button
+          onClick={() => onViewModeChange(viewMode === 'chat' ? 'compact' : 'chat')}
+          className={clsx(
+            'flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+            viewMode === 'chat'
+              ? 'bg-[--color-primary]/15 text-[--color-primary]'
+              : 'text-[--color-text-secondary] hover:bg-[--color-surface-light] hover:text-[--color-text]',
+          )}
+          aria-label={`Switch to ${viewMode === 'chat' ? 'compact' : 'chat'} view`}
+          title={viewMode === 'chat' ? 'Switch to compact view' : 'Switch to chat view'}
+        >
+          {viewMode === 'chat' ? (
+            <MessageSquare className="size-3.5" />
+          ) : (
+            <Type className="size-3.5" />
+          )}
+          <span className="hidden sm:inline">
+            {viewMode === 'chat' ? 'Chat' : 'Compact'}
+          </span>
+        </button>
+      )}
 
       {/* More button with dropdown */}
       {hasMenuActions && (

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -5,7 +5,6 @@
  */
 
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
-import type { ViewMode } from './ChatView';
 import { clsx } from 'clsx';
 import {
   AlertCircle,
@@ -14,6 +13,7 @@ import {
   Clock,
   Copy,
   FileText,
+  Layers,
   Loader2,
   MessageSquare,
   MoreVertical,
@@ -24,12 +24,16 @@ import {
   WifiOff,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ViewMode } from './ChatView';
 
 interface ChatHeaderProps {
   readonly session: UISession;
   readonly viewMode?: ViewMode;
   readonly onViewModeChange?: (mode: ViewMode) => void;
   readonly onBack?: () => void;
+  readonly onOpenSessions?: () => void;
+  readonly sessionCount?: number;
+  readonly totalUnread?: number;
   readonly onCopyConversation?: () => void;
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
@@ -102,6 +106,9 @@ export function ChatHeader({
   viewMode = 'compact',
   onViewModeChange,
   onBack,
+  onOpenSessions,
+  sessionCount = 0,
+  totalUnread = 0,
   onCopyConversation,
   onClearMessages,
   onExportText,
@@ -155,6 +162,22 @@ export function ChatHeader({
         </button>
       )}
 
+      {/* Sessions button */}
+      {onOpenSessions && sessionCount > 1 && (
+        <button
+          onClick={onOpenSessions}
+          className="relative rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light] hover:text-[--color-text]"
+          aria-label="Open sessions"
+        >
+          <Layers className="size-5" />
+          {totalUnread > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex min-w-[1rem] items-center justify-center rounded-full bg-[--color-primary] px-1 text-[9px] font-bold leading-4 text-white">
+              {totalUnread > 9 ? '9+' : totalUnread}
+            </span>
+          )}
+        </button>
+      )}
+
       {/* Session info */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
@@ -192,9 +215,7 @@ export function ChatHeader({
           ) : (
             <Type className="size-3.5" />
           )}
-          <span className="hidden sm:inline">
-            {viewMode === 'chat' ? 'Chat' : 'Compact'}
-          </span>
+          <span className="hidden sm:inline">{viewMode === 'chat' ? 'Chat' : 'Compact'}</span>
         </button>
       )}
 
@@ -213,7 +234,10 @@ export function ChatHeader({
             <div className="absolute right-0 top-full z-40 mt-1 w-48 rounded-lg border border-[--color-border] bg-[--color-surface-elevated] py-1 shadow-lg">
               {onCopyConversation && (
                 <button
-                  onClick={() => { onCopyConversation(); closeMenu(); }}
+                  onClick={() => {
+                    onCopyConversation();
+                    closeMenu();
+                  }}
                   className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-text] transition-colors hover:bg-[--color-surface-light]"
                 >
                   <Copy className="size-4 text-[--color-text-muted]" />
@@ -222,7 +246,10 @@ export function ChatHeader({
               )}
               {onExportText && (
                 <button
-                  onClick={() => { onExportText(); closeMenu(); }}
+                  onClick={() => {
+                    onExportText();
+                    closeMenu();
+                  }}
                   className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-text] transition-colors hover:bg-[--color-surface-light]"
                 >
                   <FileText className="size-4 text-[--color-text-muted]" />
@@ -233,7 +260,10 @@ export function ChatHeader({
                 <>
                   <div className="my-1 h-px bg-[--color-border]" />
                   <button
-                    onClick={() => { onClearMessages(); closeMenu(); }}
+                    onClick={() => {
+                      onClearMessages();
+                      closeMenu();
+                    }}
                     className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[--color-error] transition-colors hover:bg-[--color-surface-light]"
                   >
                     <Trash2 className="size-4" />

--- a/packages/web/src/components/chat/ChatMessage.tsx
+++ b/packages/web/src/components/chat/ChatMessage.tsx
@@ -1,0 +1,131 @@
+/**
+ * ChatMessage component.
+ *
+ * Renders parsed message content with code blocks, inline formatting,
+ * lists, and tool use cards. Used within MessageBubble for enhanced
+ * chat mode rendering.
+ */
+
+import type { ContentSegment } from "@/lib/parse-content";
+import { parseContent } from "@/lib/parse-content";
+import { clsx } from "clsx";
+import { Copy, Check } from "lucide-react";
+import { useMemo, useState, useCallback } from "react";
+import { ToolUseCard } from "./ToolUseCard";
+
+interface ChatMessageProps {
+  readonly content: string;
+  readonly toolName?: string;
+  readonly isUser?: boolean;
+}
+
+/** Render a single content segment */
+function SegmentRenderer({
+  segment,
+  isUser,
+}: { readonly segment: ContentSegment; readonly isUser: boolean }) {
+  switch (segment.type) {
+    case "text":
+      return (
+        <span className="whitespace-pre-wrap break-words">{segment.text}</span>
+      );
+
+    case "code_block":
+      return <CodeBlock language={segment.language} code={segment.code} />;
+
+    case "inline_code":
+      return (
+        <code
+          className={clsx(
+            "rounded px-1.5 py-0.5 text-[0.85em]",
+            "font-[family-name:--font-mono]",
+            isUser
+              ? "bg-white/15"
+              : "bg-[--color-surface-light] text-[--color-primary]",
+          )}
+        >
+          {segment.code}
+        </code>
+      );
+
+    case "bold":
+      return <strong className="font-semibold">{segment.text}</strong>;
+
+    case "italic":
+      return <em className="italic">{segment.text}</em>;
+
+    case "list_item":
+      return (
+        <div className="flex gap-2 pl-1">
+          <span className="shrink-0 text-[--color-text-muted]">
+            {segment.ordered ? `${segment.index}.` : "-"}
+          </span>
+          <span className="break-words">{segment.text}</span>
+        </div>
+      );
+  }
+}
+
+/** Fenced code block with copy button */
+function CodeBlock({
+  language,
+  code,
+}: { readonly language: string; readonly code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [code]);
+
+  return (
+    <div className="my-2 rounded-lg border border-[--color-border] overflow-hidden bg-[--color-surface]">
+      {/* Header with language label and copy button */}
+      <div className="flex items-center justify-between border-b border-[--color-border] bg-[--color-surface-light] px-3 py-1.5">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-[--color-text-muted]">
+          {language || "code"}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex items-center gap-1 text-[10px] text-[--color-text-muted] hover:text-[--color-text] transition-colors"
+          aria-label="Copy code"
+        >
+          {copied ? (
+            <>
+              <Check className="size-3" />
+              <span>Copied</span>
+            </>
+          ) : (
+            <>
+              <Copy className="size-3" />
+              <span>Copy</span>
+            </>
+          )}
+        </button>
+      </div>
+      {/* Code content */}
+      <pre className="overflow-x-auto p-3 text-xs leading-relaxed font-[family-name:--font-mono] text-[--color-text]">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function ChatMessage({ content, toolName, isUser = false }: ChatMessageProps) {
+  const segments = useMemo(() => parseContent(content), [content]);
+
+  // If this is a tool use message, wrap in a ToolUseCard
+  if (toolName) {
+    return <ToolUseCard toolName={toolName} content={content} />;
+  }
+
+  return (
+    <div className="text-sm leading-relaxed">
+      {segments.map((segment, i) => (
+        <SegmentRenderer key={`${segment.type}-${i}`} segment={segment} isUser={isUser} />
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { ChatHeader } from './ChatHeader';
 import { InputArea } from './InputArea';
 import { MessageList } from './MessageList';
+import { QuestionCard } from './QuestionCard';
 
 /** View mode for the chat interface */
 export type ViewMode = 'compact' | 'chat';
@@ -24,6 +25,9 @@ interface ChatViewProps {
   readonly onCancel?: () => void;
   readonly onRetry?: () => void;
   readonly onBack?: () => void;
+  readonly onOpenSessions?: () => void;
+  readonly sessionCount?: number;
+  readonly totalUnread?: number;
   readonly onCopyConversation?: () => void;
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
@@ -40,6 +44,9 @@ export function ChatView({
   onCancel,
   onRetry,
   onBack,
+  onOpenSessions,
+  sessionCount,
+  totalUnread,
   onCopyConversation,
   onClearMessages,
   onExportText,
@@ -48,6 +55,15 @@ export function ChatView({
 }: ChatViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
+  const isConnected = session.connectionStatus === 'connected';
+
+  // In chat mode, show QuestionCard for active questions (not free_text with no options).
+  // In compact mode, fall back to the InputArea's built-in quick responses.
+  const showQuestionCard = viewMode === 'chat' && question && !question.answeredWith && isConnected;
+  const showAnsweredCard = viewMode === 'chat' && question?.answeredWith != null;
+
+  // Hide InputArea's quick responses when QuestionCard is handling the question
+  const inputQuestion = viewMode === 'chat' ? null : question;
 
   return (
     <div className={clsx('flex h-full flex-col bg-[--color-surface]', className)}>
@@ -56,6 +72,9 @@ export function ChatView({
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         onBack={onBack}
+        onOpenSessions={onOpenSessions}
+        sessionCount={sessionCount}
+        totalUnread={totalUnread}
         onCopyConversation={onCopyConversation}
         onClearMessages={onClearMessages}
         onExportText={onExportText}
@@ -70,16 +89,23 @@ export function ChatView({
         viewMode={viewMode}
       />
 
+      {/* Question card in chat mode */}
+      {(showQuestionCard || showAnsweredCard) && question && (
+        <div className="border-t border-[--color-border] px-3 py-2">
+          <QuestionCard question={question} onAnswer={onSend} />
+        </div>
+      )}
+
       <InputArea
         onSend={onSend}
         onCancel={onCancel}
-        question={question}
+        question={inputQuestion}
         isAgentBusy={isAgentBusy}
-        disabled={session.connectionStatus !== 'connected'}
+        disabled={!isConnected}
         placeholder={
-          session.connectionStatus !== 'connected'
+          !isConnected
             ? 'Connecting...'
-            : question
+            : question && !question.answeredWith
               ? 'Type your response...'
               : 'Type a message...'
         }

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -2,13 +2,18 @@
  * ChatView component.
  *
  * Main chat interface combining header, messages, and input.
+ * Supports two view modes: compact (plain text) and chat (parsed markdown/code).
  */
 
 import type { UIMessage, UIQuestion, UISession } from '@/types';
 import { clsx } from 'clsx';
+import { useState } from 'react';
 import { ChatHeader } from './ChatHeader';
 import { InputArea } from './InputArea';
 import { MessageList } from './MessageList';
+
+/** View mode for the chat interface */
+export type ViewMode = 'compact' | 'chat';
 
 interface ChatViewProps {
   readonly session: UISession;
@@ -41,12 +46,15 @@ export function ChatView({
   onBulletExpand,
   className,
 }: ChatViewProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>('chat');
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
 
   return (
     <div className={clsx('flex h-full flex-col bg-[--color-surface]', className)}>
       <ChatHeader
         session={session}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
         onBack={onBack}
         onCopyConversation={onCopyConversation}
         onClearMessages={onClearMessages}
@@ -59,6 +67,7 @@ export function ChatView({
         error={error}
         onRetry={onRetry}
         onBulletExpand={onBulletExpand}
+        viewMode={viewMode}
       />
 
       <InputArea

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { UIBullet, UIMessage } from '@/types';
+import type { ViewMode } from './ChatView';
 import type { MessageState } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
 import {
@@ -17,11 +18,13 @@ import {
   Pencil,
   Terminal,
 } from 'lucide-react';
+import { ChatMessage } from './ChatMessage';
 
 interface MessageBubbleProps {
   readonly message: UIMessage;
   readonly showTimestamp?: boolean;
   readonly onBulletExpand?: (bulletId: number) => void;
+  readonly viewMode?: ViewMode;
 }
 
 /** Status icon based on message delivery state */
@@ -103,12 +106,40 @@ export function MessageBubble({
   message,
   showTimestamp = true,
   onBulletExpand,
+  viewMode = 'compact',
 }: MessageBubbleProps) {
   const isUser = message.sender === 'user';
   const isSystem = message.sender === 'system';
+  const enhanced = viewMode === 'chat';
 
   // Use bullets if available, otherwise fall back to raw content
   const hasBullets = message.bullets && message.bullets.length > 0;
+
+  // In enhanced chat mode, tool messages render as collapsible cards (not bubbles)
+  if (enhanced && message.tool && !isUser) {
+    return (
+      <div className="flex w-full animate-[slide-up] justify-start">
+        <div className="w-full max-w-[95%]">
+          <ChatMessage content={message.content} toolName={message.tool} />
+          {/* Footer */}
+          <div className="mt-0.5 flex items-center gap-1.5 px-1">
+            {showTimestamp && (
+              <span className="text-[10px] text-[--color-text-muted]">
+                {formatTime(message.timestamp)}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Sender label for enhanced chat mode
+  const senderLabel = enhanced && !isUser && !isSystem
+    ? 'Claude'
+    : enhanced && isUser
+      ? 'You'
+      : null;
 
   return (
     <div
@@ -116,9 +147,11 @@ export function MessageBubble({
     >
       <div
         className={clsx(
-          'max-w-[85%] rounded-2xl px-4 py-2.5',
+          'rounded-2xl px-4 py-2.5',
           'transition-all duration-200',
           'shadow-sm border',
+          // Width: wider in enhanced mode for better code block display
+          enhanced ? 'max-w-[95%]' : 'max-w-[85%]',
           // Bubble colors
           isUser && 'bg-[--color-bubble-user] text-white border-[--color-bubble-user]',
           !isUser && !isSystem && 'bg-[--color-bubble-assistant] border-[--color-border]',
@@ -133,21 +166,39 @@ export function MessageBubble({
           message.isEditing && 'border-[--color-primary] border-dashed',
         )}
       >
-        {/* Tool indicator */}
-        {message.tool && (
+        {/* Sender label in enhanced mode */}
+        {senderLabel && (
+          <div className="mb-1 text-[11px] font-semibold text-[--color-text-muted]">
+            {senderLabel}
+          </div>
+        )}
+
+        {/* Tool indicator (compact mode only; enhanced mode uses ToolUseCard) */}
+        {!enhanced && message.tool && (
           <div className="mb-1 flex items-center gap-1.5 text-xs text-[--color-text-secondary]">
             <Terminal className="size-3" />
             <span>{message.tool}</span>
           </div>
         )}
 
-        {/* Message content - render bullets if available */}
+        {/* Message content */}
         <div className={clsx(isUser ? 'text-white' : 'text-[--color-text]')}>
           {message.isStreaming ? (
             <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
               {message.streamedContent}
               <span className="ml-0.5 inline-block size-1.5 animate-pulse rounded-full bg-current" />
             </div>
+          ) : enhanced ? (
+            /* Enhanced chat mode: parsed content with code blocks and markdown */
+            hasBullets ? (
+              <div className="space-y-2">
+                {message.bullets!.map((bullet) => (
+                  <BulletItem key={bullet.bulletId} bullet={bullet} onExpand={onBulletExpand} />
+                ))}
+              </div>
+            ) : (
+              <ChatMessage content={message.content} isUser={isUser} />
+            )
           ) : hasBullets ? (
             <div className="space-y-2">
               {message.bullets!.map((bullet) => (

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { AgentStatus, UIMessage } from '@/types';
+import type { ViewMode } from './ChatView';
 import { clsx } from 'clsx';
 import { MessageSquare } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
@@ -16,6 +17,7 @@ interface MessageListProps {
   readonly error?: string | null;
   readonly onRetry?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
+  readonly viewMode?: ViewMode;
   readonly className?: string;
 }
 
@@ -63,6 +65,7 @@ export function MessageList({
   error,
   onRetry,
   onBulletExpand,
+  viewMode = 'compact',
   className,
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -113,7 +116,7 @@ export function MessageList({
           return (
             <div key={message.id}>
               {showDateSeparator && <DateSeparator date={formatDate(message.timestamp)} />}
-              <MessageBubble message={message} onBulletExpand={onBulletExpand} />
+              <MessageBubble message={message} onBulletExpand={onBulletExpand} viewMode={viewMode} />
             </div>
           );
         })}

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -1,0 +1,303 @@
+/**
+ * QuestionCard component.
+ *
+ * Renders interactive question cards based on question type.
+ * Supports yes/no, multi-option, numbered selection, and free text.
+ * Designed for mobile with large tap targets (min 44px).
+ */
+
+import type { UIQuestion, UIQuestionOption } from '@/types';
+import { clsx } from 'clsx';
+import { Check, ChevronRight, MessageSquare, Send } from 'lucide-react';
+import { type KeyboardEvent, useCallback, useState } from 'react';
+
+interface QuestionCardProps {
+  readonly question: UIQuestion;
+  readonly onAnswer: (answer: string) => void;
+  readonly className?: string;
+}
+
+/** Resolve the display label for an option value in the answered state */
+function resolveAnswerLabel(question: UIQuestion, answer: string): string {
+  if (question.structuredOptions) {
+    const match = question.structuredOptions.find((o) => o.value === answer);
+    if (match) return match.label;
+  }
+  if (question.options) {
+    // For numbered questions, the answer is the index (1-based)
+    const idx = Number.parseInt(answer, 10);
+    if (!Number.isNaN(idx) && idx >= 1 && idx <= question.options.length) {
+      return question.options[idx - 1];
+    }
+  }
+  return answer;
+}
+
+/** Get a friendly label for common option values */
+function getOptionDisplayLabel(option: UIQuestionOption): string {
+  const lower = option.value.toLowerCase();
+  if (option.isYes) return 'Yes';
+  if (option.isNo) return 'No';
+  if (lower === 'a' || lower === 'all') return 'All';
+  if (lower === 'q' || lower === 'quit') return 'Quit';
+  return option.label;
+}
+
+/** Determine button variant based on option semantics */
+function getOptionVariant(option: UIQuestionOption): 'primary' | 'danger' | 'warning' | 'default' {
+  if (option.isYes || option.isRecommended) return 'primary';
+  if (option.isNo) return 'danger';
+  const lower = option.value.toLowerCase();
+  if (lower === 'q' || lower === 'quit') return 'warning';
+  return 'default';
+}
+
+/** Large tap-friendly button for option selection */
+function OptionButton({
+  label,
+  variant = 'default',
+  onClick,
+  disabled,
+}: {
+  readonly label: string;
+  readonly variant?: 'primary' | 'danger' | 'warning' | 'default';
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx(
+        'flex min-h-[44px] min-w-[44px] items-center justify-center',
+        'rounded-xl px-6 py-3 text-sm font-semibold',
+        'transition-all duration-150 active:scale-[0.97]',
+        'shadow-sm border',
+        disabled && 'pointer-events-none opacity-40',
+        variant === 'primary' && [
+          'bg-[--color-primary] text-white border-[--color-primary]',
+          'hover:bg-[--color-primary-dark]',
+        ],
+        variant === 'danger' && [
+          'bg-[--color-error]/10 text-[--color-error] border-[--color-error]/20',
+          'hover:bg-[--color-error]/20',
+        ],
+        variant === 'warning' && [
+          'bg-[--color-warning]/10 text-[--color-warning] border-[--color-warning]/20',
+          'hover:bg-[--color-warning]/20',
+        ],
+        variant === 'default' && [
+          'bg-[--color-surface-elevated] text-[--color-text] border-[--color-border]',
+          'hover:bg-[--color-surface-light]',
+        ],
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** Yes/No card with two large buttons */
+function YesNoCard({
+  question,
+  onAnswer,
+}: {
+  readonly question: UIQuestion;
+  readonly onAnswer: (answer: string) => void;
+}) {
+  const yesOption = question.structuredOptions?.find((o) => o.isYes);
+  const noOption = question.structuredOptions?.find((o) => o.isNo);
+
+  return (
+    <div className="flex gap-3">
+      <OptionButton
+        label="Yes"
+        variant="primary"
+        onClick={() => onAnswer(yesOption?.value ?? 'yes')}
+      />
+      <OptionButton label="No" variant="danger" onClick={() => onAnswer(noOption?.value ?? 'no')} />
+    </div>
+  );
+}
+
+/** Multi-option card (yes/no + extra options like all/quit) */
+function MultiOptionCard({
+  question,
+  onAnswer,
+}: {
+  readonly question: UIQuestion;
+  readonly onAnswer: (answer: string) => void;
+}) {
+  const options = question.structuredOptions ?? [];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => (
+        <OptionButton
+          key={option.value}
+          label={getOptionDisplayLabel(option)}
+          variant={getOptionVariant(option)}
+          onClick={() => onAnswer(option.value)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Numbered selection card with tap targets */
+function NumberedCard({
+  question,
+  onAnswer,
+}: {
+  readonly question: UIQuestion;
+  readonly onAnswer: (answer: string) => void;
+}) {
+  const options = question.options ?? [];
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {options.map((option, index) => (
+        <button
+          type="button"
+          key={`opt-${index + 1}-${option}`}
+          onClick={() => onAnswer(String(index + 1))}
+          className={clsx(
+            'flex min-h-[44px] items-center gap-3 rounded-xl px-4 py-3',
+            'bg-[--color-surface-elevated] border border-[--color-border]',
+            'text-left text-sm text-[--color-text]',
+            'transition-all duration-150 active:scale-[0.98]',
+            'hover:bg-[--color-surface-light] hover:border-[--color-primary]/30',
+          )}
+        >
+          <span
+            className={clsx(
+              'flex size-7 shrink-0 items-center justify-center rounded-full',
+              'bg-[--color-primary]/10 text-xs font-bold text-[--color-primary]',
+            )}
+          >
+            {index + 1}
+          </span>
+          <span className="flex-1">{option}</span>
+          <ChevronRight className="size-4 shrink-0 text-[--color-text-muted]" />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Free text input card */
+function FreeTextCard({
+  onAnswer,
+}: {
+  readonly onAnswer: (answer: string) => void;
+}) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAnswer(trimmed);
+    setValue('');
+  }, [value, onAnswer]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Type your response..."
+        className={clsx(
+          'min-h-[44px] flex-1 rounded-xl border border-[--color-border]',
+          'bg-[--color-surface-elevated] px-4 py-2.5 text-sm text-[--color-text]',
+          'placeholder:text-[--color-text-muted]',
+          'outline-none focus:ring-2 focus:ring-[--color-primary]/50',
+        )}
+      />
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!value.trim()}
+        className={clsx(
+          'flex size-[44px] items-center justify-center rounded-xl',
+          'transition-all duration-150 active:scale-95',
+          value.trim()
+            ? 'bg-[--color-primary] text-white hover:bg-[--color-primary-dark]'
+            : 'bg-[--color-surface-elevated] text-[--color-text-muted]',
+        )}
+        aria-label="Send response"
+      >
+        <Send className="size-5" />
+      </button>
+    </div>
+  );
+}
+
+/** Answered state: collapsed card showing the selected answer */
+function AnsweredCard({
+  question,
+}: {
+  readonly question: UIQuestion;
+}) {
+  const answerLabel = resolveAnswerLabel(question, question.answeredWith ?? '');
+
+  return (
+    <div
+      className={clsx(
+        'flex items-center gap-2 rounded-xl px-4 py-2.5',
+        'bg-[--color-success]/10 border border-[--color-success]/20',
+        'text-sm text-[--color-text-secondary]',
+        'animate-[fade-in_200ms_ease-out]',
+      )}
+    >
+      <Check className="size-4 shrink-0 text-[--color-success]" />
+      <span>
+        Answered: <span className="font-medium text-[--color-text]">{answerLabel}</span>
+      </span>
+    </div>
+  );
+}
+
+export function QuestionCard({ question, onAnswer, className }: QuestionCardProps) {
+  const isAnswered = question.answeredWith != null;
+
+  return (
+    <div
+      className={clsx(
+        'rounded-2xl border border-[--color-border] bg-[--color-surface]',
+        'shadow-md p-4',
+        'animate-[slide-up_200ms_ease-out]',
+        isAnswered && 'opacity-75',
+        className,
+      )}
+    >
+      {/* Question prompt */}
+      <div className="mb-3 flex items-start gap-2">
+        <MessageSquare className="mt-0.5 size-4 shrink-0 text-[--color-primary]" />
+        <p className="text-sm font-medium text-[--color-text]">{question.prompt}</p>
+      </div>
+
+      {/* Answer area */}
+      {isAnswered ? (
+        <AnsweredCard question={question} />
+      ) : question.type === 'yes_no' ? (
+        <YesNoCard question={question} onAnswer={onAnswer} />
+      ) : question.type === 'multi_option' ? (
+        <MultiOptionCard question={question} onAnswer={onAnswer} />
+      ) : question.type === 'numbered' ? (
+        <NumberedCard question={question} onAnswer={onAnswer} />
+      ) : (
+        <FreeTextCard onAnswer={onAnswer} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/SessionSwitcher.tsx
+++ b/packages/web/src/components/chat/SessionSwitcher.tsx
@@ -5,6 +5,7 @@
  * unread badges, and question-pending markers. Tap a session to switch to it.
  */
 
+import { formatRelativeTime } from '@/lib/format-time';
 import type { UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
@@ -17,26 +18,6 @@ interface SessionSwitcherProps {
   readonly isOpen: boolean;
   readonly onSelectSession: (id: UUID) => void;
   readonly onClose: () => void;
-}
-
-/** Format relative time for session list */
-function formatRelativeTime(timestamp: string): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-
-  return date.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 /** Status dot color based on connection and agent status */

--- a/packages/web/src/components/chat/SessionSwitcher.tsx
+++ b/packages/web/src/components/chat/SessionSwitcher.tsx
@@ -1,0 +1,249 @@
+/**
+ * SessionSwitcher component.
+ *
+ * Slide-out drawer listing all connected sessions with status indicators,
+ * unread badges, and question-pending markers. Tap a session to switch to it.
+ */
+
+import type { UISession } from '@/types';
+import type { UUID } from '@remi/shared/types.ts';
+import { clsx } from 'clsx';
+import { MessageCircleQuestion, X } from 'lucide-react';
+import { useCallback, useEffect, useRef } from 'react';
+
+interface SessionSwitcherProps {
+  readonly sessions: readonly UISession[];
+  readonly activeSessionId: UUID | null;
+  readonly isOpen: boolean;
+  readonly onSelectSession: (id: UUID) => void;
+  readonly onClose: () => void;
+}
+
+/** Format relative time for session list */
+function formatRelativeTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** Status dot color based on connection and agent status */
+function StatusDot({
+  session,
+}: {
+  readonly session: UISession;
+}) {
+  const { connectionStatus, status: agentStatus } = session;
+
+  if (connectionStatus === 'error') {
+    return <span className="inline-block size-2 shrink-0 rounded-full bg-[--color-error]" />;
+  }
+  if (connectionStatus === 'disconnected') {
+    return <span className="inline-block size-2 shrink-0 rounded-full bg-[--color-text-muted]" />;
+  }
+  if (connectionStatus === 'connecting' || connectionStatus === 'reconnecting') {
+    return (
+      <span className="inline-block size-2 shrink-0 animate-pulse rounded-full bg-[--color-warning]" />
+    );
+  }
+
+  // Connected: show agent status
+  switch (agentStatus) {
+    case 'thinking':
+    case 'executing':
+      return (
+        <span className="inline-block size-2 shrink-0 animate-pulse rounded-full bg-[--color-success]" />
+      );
+    case 'waiting':
+      return <span className="inline-block size-2 shrink-0 rounded-full bg-[--color-warning]" />;
+    default:
+      return <span className="inline-block size-2 shrink-0 rounded-full bg-[--color-success]" />;
+  }
+}
+
+export function SessionSwitcher({
+  sessions,
+  activeSessionId,
+  isOpen,
+  onSelectSession,
+  onClose,
+}: SessionSwitcherProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const handleSelect = useCallback(
+    (id: UUID) => {
+      onSelectSession(id);
+      onClose();
+    },
+    [onSelectSession, onClose],
+  );
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  // Close on backdrop click
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (drawerRef.current && !drawerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // Count totals for header
+  const totalUnread = sessions.reduce((sum, s) => sum + s.unreadCount, 0);
+  const totalQuestions = sessions.filter((s) => s.questionPending).length;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={clsx(
+          'fixed inset-0 z-40 bg-black/40 transition-opacity duration-200',
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+        onClick={handleBackdropClick}
+        onKeyDown={undefined}
+        role="presentation"
+      >
+        {/* Drawer */}
+        <div
+          ref={drawerRef}
+          className={clsx(
+            'absolute inset-y-0 left-0 z-50 flex w-72 flex-col',
+            'bg-[--color-surface] shadow-2xl',
+            'transform transition-transform duration-250 ease-out',
+            isOpen ? 'translate-x-0' : '-translate-x-full',
+          )}
+        >
+          {/* Drawer header */}
+          <div className="flex items-center justify-between border-b border-[--color-border] px-4 py-3 safe-area-top">
+            <div className="flex items-center gap-2">
+              <h2 className="text-base font-semibold text-[--color-text]">Sessions</h2>
+              {sessions.length > 0 && (
+                <span className="rounded-full bg-[--color-surface-light] px-2 py-0.5 text-xs text-[--color-text-muted]">
+                  {sessions.length}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full p-1.5 text-[--color-text-secondary] transition-colors hover:bg-[--color-surface-light]"
+              aria-label="Close sessions drawer"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+
+          {/* Summary bar */}
+          {(totalUnread > 0 || totalQuestions > 0) && (
+            <div className="flex items-center gap-3 border-b border-[--color-border] px-4 py-2 text-xs text-[--color-text-secondary]">
+              {totalUnread > 0 && <span>{totalUnread} unread</span>}
+              {totalQuestions > 0 && (
+                <span className="flex items-center gap-1 text-[--color-warning]">
+                  <MessageCircleQuestion className="size-3" />
+                  {totalQuestions} pending
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Session list */}
+          <div className="flex-1 overflow-y-auto">
+            {sessions.length === 0 ? (
+              <div className="flex h-full items-center justify-center px-4 text-center text-sm text-[--color-text-muted]">
+                No sessions connected
+              </div>
+            ) : (
+              <div className="py-1">
+                {sessions.map((session) => (
+                  <button
+                    type="button"
+                    key={session.id}
+                    onClick={() => handleSelect(session.id)}
+                    className={clsx(
+                      'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors',
+                      'hover:bg-[--color-surface-light]',
+                      session.id === activeSessionId &&
+                        'bg-[--color-primary]/10 border-l-2 border-l-[--color-primary]',
+                      session.id !== activeSessionId && 'border-l-2 border-l-transparent',
+                    )}
+                  >
+                    {/* Status dot */}
+                    <div className="mt-1.5">
+                      <StatusDot session={session} />
+                    </div>
+
+                    {/* Session info */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span
+                          className={clsx(
+                            'truncate text-sm',
+                            session.id === activeSessionId
+                              ? 'font-semibold text-[--color-text]'
+                              : 'font-medium text-[--color-text]',
+                          )}
+                        >
+                          {session.name || 'Claude Session'}
+                        </span>
+                        <span className="shrink-0 text-xs text-[--color-text-muted]">
+                          {formatRelativeTime(session.lastActiveAt)}
+                        </span>
+                      </div>
+
+                      {/* Preview text */}
+                      {session.preview && (
+                        <p className="mt-0.5 truncate text-xs text-[--color-text-secondary]">
+                          {session.preview}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Badges column */}
+                    <div className="flex flex-col items-end gap-1">
+                      {/* Question pending indicator */}
+                      {session.questionPending && (
+                        <span className="flex items-center justify-center rounded-full bg-[--color-warning] px-1.5 py-0.5">
+                          <MessageCircleQuestion className="size-3 text-white" />
+                        </span>
+                      )}
+
+                      {/* Unread count badge */}
+                      {session.unreadCount > 0 && !session.questionPending && (
+                        <span className="flex min-w-[1.25rem] items-center justify-center rounded-full bg-[--color-primary] px-1.5 py-0.5 text-[10px] font-bold text-white">
+                          {session.unreadCount > 99 ? '99+' : session.unreadCount}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/components/chat/ToolUseCard.tsx
+++ b/packages/web/src/components/chat/ToolUseCard.tsx
@@ -1,0 +1,110 @@
+/**
+ * ToolUseCard component.
+ *
+ * Collapsible card for tool use messages (Read, Write, Edit, Bash, etc.).
+ * Shows tool name and a summary when collapsed; full details when expanded.
+ */
+
+import { clsx } from "clsx";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileCode,
+  FileEdit,
+  FilePlus,
+  Search,
+  Terminal,
+  Type,
+} from "lucide-react";
+import { useState } from "react";
+
+interface ToolUseCardProps {
+  readonly toolName: string;
+  readonly content: string;
+  readonly defaultExpanded?: boolean;
+}
+
+/** Icon for a given tool name */
+function ToolIcon({
+  name,
+  className,
+}: { readonly name: string; readonly className?: string }) {
+  const lower = name.toLowerCase();
+  if (lower.includes("bash") || lower.includes("terminal"))
+    return <Terminal className={className} />;
+  if (lower.includes("read")) return <FileCode className={className} />;
+  if (lower.includes("edit")) return <FileEdit className={className} />;
+  if (lower.includes("write")) return <FilePlus className={className} />;
+  if (lower.includes("grep") || lower.includes("search") || lower.includes("glob"))
+    return <Search className={className} />;
+  return <Type className={className} />;
+}
+
+/** Extract a short summary from tool content */
+function summarize(_toolName: string, content: string): string {
+  const firstLine = content.split("\n")[0]?.trim() ?? "";
+  if (firstLine.length <= 80) return firstLine;
+  return `${firstLine.slice(0, 77)}...`;
+}
+
+export function ToolUseCard({
+  toolName,
+  content,
+  defaultExpanded = false,
+}: ToolUseCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const summary = summarize(toolName, content);
+
+  return (
+    <div
+      className={clsx(
+        "rounded-lg border border-[--color-border] overflow-hidden",
+        "bg-[--color-surface-light] transition-colors",
+      )}
+    >
+      {/* Header (always visible) */}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className={clsx(
+          "flex w-full items-center gap-2 px-3 py-2 text-left",
+          "hover:bg-[--color-surface-elevated] transition-colors",
+        )}
+      >
+        {expanded ? (
+          <ChevronDown className="size-3.5 shrink-0 text-[--color-text-muted]" />
+        ) : (
+          <ChevronRight className="size-3.5 shrink-0 text-[--color-text-muted]" />
+        )}
+        <ToolIcon
+          name={toolName}
+          className="size-3.5 shrink-0 text-[--color-primary]"
+        />
+        <span className="text-xs font-medium text-[--color-text-secondary]">
+          {toolName}
+        </span>
+        {!expanded && summary && (
+          <span className="truncate text-xs text-[--color-text-muted]">
+            {summary}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="border-t border-[--color-border] px-3 py-2">
+          <pre
+            className={clsx(
+              "whitespace-pre-wrap break-words text-xs leading-relaxed",
+              "text-[--color-text] font-[family-name:--font-mono]",
+              "max-h-64 overflow-y-auto",
+            )}
+          >
+            {content}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/index.ts
+++ b/packages/web/src/components/chat/index.ts
@@ -10,3 +10,5 @@ export { ChatView } from './ChatView';
 export type { ViewMode } from './ChatView';
 export { ChatMessage } from './ChatMessage';
 export { ToolUseCard } from './ToolUseCard';
+export { SessionSwitcher } from './SessionSwitcher';
+export { QuestionCard } from './QuestionCard';

--- a/packages/web/src/components/chat/index.ts
+++ b/packages/web/src/components/chat/index.ts
@@ -7,3 +7,6 @@ export { MessageList } from './MessageList';
 export { InputArea } from './InputArea';
 export { ChatHeader } from './ChatHeader';
 export { ChatView } from './ChatView';
+export type { ViewMode } from './ChatView';
+export { ChatMessage } from './ChatMessage';
+export { ToolUseCard } from './ToolUseCard';

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -5,6 +5,7 @@
  */
 
 // Status icons are rendered via StatusDot, not used directly
+import { formatRelativeTime } from '@/lib/format-time';
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 import { clsx } from 'clsx';
 
@@ -12,26 +13,6 @@ interface SessionCardProps {
   readonly session: UISession;
   readonly isActive: boolean;
   readonly onClick: () => void;
-}
-
-/** Format relative time */
-function formatRelativeTime(timestamp: string): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-
-  return date.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 /** Status dot with color and animation */

--- a/packages/web/src/lib/format-time.ts
+++ b/packages/web/src/lib/format-time.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared time formatting utilities.
+ */
+
+/** Format a timestamp as a human-readable relative time string. */
+export function formatRelativeTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/packages/web/src/lib/parse-content.ts
+++ b/packages/web/src/lib/parse-content.ts
@@ -1,0 +1,164 @@
+/**
+ * Content parser for chat messages.
+ *
+ * Parses message text into structured segments: plain text, code blocks,
+ * inline code, bold, italic, and list items.
+ */
+
+/** Segment types that can appear in parsed content */
+export type ContentSegment =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "code_block";
+      readonly language: string;
+      readonly code: string;
+    }
+  | { readonly type: "inline_code"; readonly code: string }
+  | { readonly type: "bold"; readonly text: string }
+  | { readonly type: "italic"; readonly text: string }
+  | { readonly type: "list_item"; readonly text: string; readonly ordered: boolean; readonly index: number };
+
+/**
+ * Parse message content into structured segments.
+ *
+ * Handles fenced code blocks (triple backtick), then parses remaining
+ * text for inline formatting.
+ */
+export function parseContent(content: string): ContentSegment[] {
+  if (!content) return [];
+
+  const segments: ContentSegment[] = [];
+
+  // Split on fenced code blocks first
+  const codeBlockRegex = /```(\w*)\n?([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+
+  match = codeBlockRegex.exec(content);
+  while (match !== null) {
+    // Text before the code block
+    if (match.index > lastIndex) {
+      const textBefore = content.slice(lastIndex, match.index);
+      segments.push(...parseInlineContent(textBefore));
+    }
+
+    // The code block itself
+    segments.push({
+      type: "code_block",
+      language: match[1] || "",
+      code: match[2].replace(/\n$/, ""),
+    });
+
+    lastIndex = match.index + match[0].length;
+    match = codeBlockRegex.exec(content);
+  }
+
+  // Remaining text after last code block
+  if (lastIndex < content.length) {
+    const remaining = content.slice(lastIndex);
+    segments.push(...parseInlineContent(remaining));
+  }
+
+  return segments;
+}
+
+/**
+ * Parse inline content for formatting: inline code, bold, italic, lists.
+ */
+function parseInlineContent(text: string): ContentSegment[] {
+  if (!text.trim()) {
+    if (text) return [{ type: "text", text }];
+    return [];
+  }
+
+  const segments: ContentSegment[] = [];
+
+  // Process line by line to detect list items
+  const lines = text.split("\n");
+  let currentText = "";
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+
+    // Ordered list: "1. ", "2. ", etc.
+    const orderedMatch = trimmed.match(/^(\d+)\.\s+(.+)$/);
+    if (orderedMatch) {
+      if (currentText) {
+        segments.push(...parseInlineFormatting(currentText));
+        currentText = "";
+      }
+      segments.push({
+        type: "list_item",
+        text: orderedMatch[2],
+        ordered: true,
+        index: Number.parseInt(orderedMatch[1], 10),
+      });
+      continue;
+    }
+
+    // Unordered list: "- ", "* "
+    const unorderedMatch = trimmed.match(/^[-*]\s+(.+)$/);
+    if (unorderedMatch) {
+      if (currentText) {
+        segments.push(...parseInlineFormatting(currentText));
+        currentText = "";
+      }
+      segments.push({
+        type: "list_item",
+        text: unorderedMatch[1],
+        ordered: false,
+        index: 0,
+      });
+      continue;
+    }
+
+    // Regular line
+    currentText += (currentText ? "\n" : "") + line;
+  }
+
+  if (currentText) {
+    segments.push(...parseInlineFormatting(currentText));
+  }
+
+  return segments;
+}
+
+/**
+ * Parse inline formatting: backtick code, bold, italic.
+ */
+function parseInlineFormatting(text: string): ContentSegment[] {
+  if (!text) return [];
+
+  const segments: ContentSegment[] = [];
+  // Match inline code, bold (**text**), italic (*text* but not **text**)
+  const inlineRegex = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+
+  match = inlineRegex.exec(text);
+  while (match !== null) {
+    // Text before the match
+    if (match.index > lastIndex) {
+      segments.push({ type: "text", text: text.slice(lastIndex, match.index) });
+    }
+
+    const matched = match[0];
+    if (matched.startsWith("`")) {
+      segments.push({ type: "inline_code", code: matched.slice(1, -1) });
+    } else if (matched.startsWith("**")) {
+      segments.push({ type: "bold", text: matched.slice(2, -2) });
+    } else if (matched.startsWith("*")) {
+      segments.push({ type: "italic", text: matched.slice(1, -1) });
+    }
+
+    lastIndex = match.index + matched.length;
+    match = inlineRegex.exec(text);
+  }
+
+  // Remaining text
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", text: text.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -90,16 +90,30 @@ export interface UISession {
   readonly source?: 'daemon' | 'transcript';
   /** Whether transcript history is loading */
   readonly isLoadingTranscript?: boolean;
+  /** Whether the session has a pending question requiring user input */
+  readonly questionPending?: boolean;
+}
+
+/** Structured option for a question */
+export interface UIQuestionOption {
+  readonly label: string;
+  readonly value: string;
+  readonly isYes?: boolean;
+  readonly isNo?: boolean;
+  readonly isRecommended?: boolean;
 }
 
 /** Question from the agent requiring user response */
 export interface UIQuestion {
   readonly id: UUID;
   readonly sessionId: UUID;
-  readonly type: 'yes_no' | 'numbered' | 'permission' | 'free_text';
+  readonly type: 'yes_no' | 'multi_option' | 'numbered' | 'permission' | 'free_text';
   readonly prompt: string;
   readonly options?: readonly string[];
+  readonly structuredOptions?: readonly UIQuestionOption[];
   readonly timestamp: Timestamp;
+  /** The answer that was selected (set after answering) */
+  readonly answeredWith?: string;
 }
 
 /** App settings */

--- a/packages/web/tests/lib/parse-content.test.ts
+++ b/packages/web/tests/lib/parse-content.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+import { parseContent, type ContentSegment } from '../../src/lib/parse-content';
+
+describe('parseContent', () => {
+  test('returns empty array for empty string', () => {
+    expect(parseContent('')).toEqual([]);
+  });
+
+  test('returns empty array for undefined-ish input', () => {
+    // @ts-expect-error testing null input
+    expect(parseContent(null)).toEqual([]);
+    // @ts-expect-error testing undefined input
+    expect(parseContent(undefined)).toEqual([]);
+  });
+
+  test('returns text segment for plain text', () => {
+    const result = parseContent('Hello world');
+    expect(result).toEqual([{ type: 'text', text: 'Hello world' }]);
+  });
+
+  test('returns text segment for whitespace-only input', () => {
+    const result = parseContent('   ');
+    expect(result).toEqual([{ type: 'text', text: '   ' }]);
+  });
+
+  describe('fenced code blocks', () => {
+    test('parses code block without language', () => {
+      const result = parseContent('```\nconsole.log("hi")\n```');
+      expect(result).toEqual([
+        { type: 'code_block', language: '', code: 'console.log("hi")' },
+      ]);
+    });
+
+    test('parses code block with language', () => {
+      const result = parseContent('```typescript\nconst x = 1;\n```');
+      expect(result).toEqual([
+        { type: 'code_block', language: 'typescript', code: 'const x = 1;' },
+      ]);
+    });
+
+    test('parses multiple code blocks with text between', () => {
+      const input = 'Before\n```js\nfoo()\n```\nMiddle\n```py\nbar()\n```\nAfter';
+      const result = parseContent(input);
+
+      // Verify structure: text, code, text, code, text
+      const types = result.map((s) => s.type);
+      expect(types).toEqual(['text', 'code_block', 'text', 'code_block', 'text']);
+      expect(result[1]).toEqual({ type: 'code_block', language: 'js', code: 'foo()' });
+      expect(result[3]).toEqual({ type: 'code_block', language: 'py', code: 'bar()' });
+    });
+
+    test('handles unclosed code block as plain text', () => {
+      const result = parseContent('```js\nsome code without closing');
+      // Unclosed block is not matched by regex, treated as inline content
+      expect(result.length).toBeGreaterThan(0);
+      // Should not produce a code_block segment
+      const codeBlocks = result.filter((s) => s.type === 'code_block');
+      expect(codeBlocks).toEqual([]);
+    });
+
+    test('preserves multiline code in block', () => {
+      const code = 'line1\nline2\nline3';
+      const result = parseContent(`\`\`\`\n${code}\n\`\`\``);
+      expect(result).toEqual([{ type: 'code_block', language: '', code }]);
+    });
+  });
+
+  describe('inline code', () => {
+    test('parses single inline code', () => {
+      const result = parseContent('Use `foo()` here');
+      expect(result).toEqual([
+        { type: 'text', text: 'Use ' },
+        { type: 'inline_code', code: 'foo()' },
+        { type: 'text', text: ' here' },
+      ]);
+    });
+
+    test('parses multiple inline codes', () => {
+      const result = parseContent('`a` and `b`');
+      expect(result).toEqual([
+        { type: 'inline_code', code: 'a' },
+        { type: 'text', text: ' and ' },
+        { type: 'inline_code', code: 'b' },
+      ]);
+    });
+  });
+
+  describe('bold and italic', () => {
+    test('parses bold text', () => {
+      const result = parseContent('This is **bold** text');
+      expect(result).toEqual([
+        { type: 'text', text: 'This is ' },
+        { type: 'bold', text: 'bold' },
+        { type: 'text', text: ' text' },
+      ]);
+    });
+
+    test('parses italic text', () => {
+      const result = parseContent('This is *italic* text');
+      expect(result).toEqual([
+        { type: 'text', text: 'This is ' },
+        { type: 'italic', text: 'italic' },
+        { type: 'text', text: ' text' },
+      ]);
+    });
+
+    test('parses bold and italic in same line', () => {
+      const result = parseContent('**bold** and *italic*');
+      expect(result).toEqual([
+        { type: 'bold', text: 'bold' },
+        { type: 'text', text: ' and ' },
+        { type: 'italic', text: 'italic' },
+      ]);
+    });
+  });
+
+  describe('lists', () => {
+    test('parses ordered list', () => {
+      const result = parseContent('1. First\n2. Second\n3. Third');
+      expect(result).toEqual([
+        { type: 'list_item', text: 'First', ordered: true, index: 1 },
+        { type: 'list_item', text: 'Second', ordered: true, index: 2 },
+        { type: 'list_item', text: 'Third', ordered: true, index: 3 },
+      ]);
+    });
+
+    test('parses unordered list with dashes', () => {
+      const result = parseContent('- Apple\n- Banana');
+      expect(result).toEqual([
+        { type: 'list_item', text: 'Apple', ordered: false, index: 0 },
+        { type: 'list_item', text: 'Banana', ordered: false, index: 0 },
+      ]);
+    });
+
+    test('parses unordered list with asterisks', () => {
+      const result = parseContent('* One\n* Two');
+      expect(result).toEqual([
+        { type: 'list_item', text: 'One', ordered: false, index: 0 },
+        { type: 'list_item', text: 'Two', ordered: false, index: 0 },
+      ]);
+    });
+  });
+
+  describe('combined content (realistic Claude output)', () => {
+    test('parses paragraph with code block and list', () => {
+      const input = [
+        'Here is how to do it:',
+        '',
+        '```typescript',
+        'const x = 42;',
+        'console.log(x);',
+        '```',
+        '',
+        'Key points:',
+        '- Use `const` for constants',
+        '- Prefer **strict** mode',
+        '',
+        '1. First step',
+        '2. Second step',
+      ].join('\n');
+
+      const result = parseContent(input);
+
+      // Should contain text, code_block, list items, inline formatting
+      const types = result.map((s) => s.type);
+      expect(types).toContain('text');
+      expect(types).toContain('code_block');
+      expect(types).toContain('list_item');
+
+      // Verify the code block
+      const codeBlock = result.find((s) => s.type === 'code_block') as Extract<
+        ContentSegment,
+        { type: 'code_block' }
+      >;
+      expect(codeBlock.language).toBe('typescript');
+      expect(codeBlock.code).toContain('const x = 42;');
+
+      // Verify ordered list items exist
+      const orderedItems = result.filter(
+        (s) => s.type === 'list_item' && (s as Extract<ContentSegment, { type: 'list_item' }>).ordered,
+      );
+      expect(orderedItems.length).toBe(2);
+
+      // Verify unordered list items exist
+      const unorderedItems = result.filter(
+        (s) => s.type === 'list_item' && !(s as Extract<ContentSegment, { type: 'list_item' }>).ordered,
+      );
+      expect(unorderedItems.length).toBe(2);
+    });
+
+    test('handles text with only newlines', () => {
+      const result = parseContent('\n\n\n');
+      // Should produce text segments (whitespace only lines)
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 2 (Session UX) and Phase 3 (Chat Mode) from the Remi roadmap, making sessions feel like tmux and adding a mobile-friendly chat interface.

- **#45**: Human-readable session names (`hostname/dir/branch` instead of UUIDs)
- **#46**: Explicit `remi new`, `remi detach`, `remi kill` commands
- **#47**: Enhanced `remi ls` with status, duration, and last activity columns
- **#48**: Chat mode view toggle (structured messages, code blocks, tool use cards)
- **#49**: Question cards with tap-to-answer (Yes/No buttons, multi-option, numbered selection)
- **#50**: Session switcher drawer with unread badges and question-pending indicators

## Changes by phase

### Phase 2: Session UX (packages/daemon, packages/shared)
- Session name generator: `os.hostname()/dirname/branch` with `:N` dedup
- Name resolution in attach flow (exact match, prefix match, UUID fallback)
- Kill protocol: `kill_session_request`/`kill_session_response` messages
- Kill client connects to daemon, resolves by name/ID, sends SIGTERM
- `remi ls` table: NAME, STATUS, DURATION, LAST ACTIVITY columns
- `lastActivityAt` tracking in session registry
- `formatDuration()` and `formatAge()` utilities

### Phase 3: Chat Mode (packages/web)
- View mode toggle (compact/chat) in ChatHeader
- ChatMessage component: parses content into text, code blocks, inline code, bold, italic
- ToolUseCard: collapsible cards for tool invocations
- QuestionCard: interactive cards based on question type (YesNo, MultiOption, Numbered, FreeText)
- SessionSwitcher: slide-out drawer with status dots, unread badges, question indicators
- Unread tracking: increment on background session messages, reset on switch
- parse-content.ts: content segmentation for rich rendering

## Test plan
- [x] 891 tests pass, 0 failures
- [x] Web build passes (tsc + vite)
- [x] Biome lint clean
- [ ] Manual: `remi ls` shows session names with timing info
- [ ] Manual: `remi attach macbook/project/branch` resolves by name
- [ ] Manual: `remi kill <name>` terminates session
- [ ] Manual: Toggle between compact and chat mode in web client
- [ ] Manual: Question card appears with tap buttons for Y/n questions
- [ ] Manual: Session switcher shows unread badges

Closes #45, closes #46, closes #47, closes #48, closes #49, closes #50