### PR TITLE
fix: session name format and remote attach resolution

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -758,15 +758,15 @@ if (cliSubcommand === 'attach') {
   let resolvedHost = cliHost ?? 'localhost';
 
   // Check for remote attach: host:port/session-id (e.g., 192.168.0.83:18765/name)
-  // Remote targets have a numeric port after the colon (host:PORT/...).
-  // Session names use hostname:dir/branch where dir is not numeric.
+  // Remote targets have a numeric port between the last colon and first slash.
+  // Session names (hostname:dir/branch) have a non-numeric directory segment there.
+  // Note: a purely numeric directory name (e.g., "8765") would be misidentified as a port.
   const firstSlash = targetSessionId?.indexOf('/') ?? -1;
-  const colonBeforeSlash =
-    firstSlash > 0 ? targetSessionId?.slice(0, firstSlash).lastIndexOf(':') : -1;
+  const colonIdx = firstSlash > 0 ? targetSessionId?.lastIndexOf(':', firstSlash - 1) : -1;
   const hasRemoteFormat =
-    colonBeforeSlash != null &&
-    colonBeforeSlash > 0 &&
-    /^\d+$/.test(targetSessionId?.slice(colonBeforeSlash + 1, firstSlash) ?? '');
+    colonIdx != null &&
+    colonIdx > 0 &&
+    /^\d+$/.test(targetSessionId?.slice(colonIdx + 1, firstSlash) ?? '');
   if (targetSessionId && hasRemoteFormat) {
     try {
       const { parseRemoteTarget } = await import('./cli/ls-client.ts');
@@ -846,22 +846,23 @@ if (cliSubcommand === 'attach') {
         process.exit(1);
       } else if (!cliHost) {
         // Not found locally; extract hostname from session name and discover via mDNS.
-        // Session names are formatted as "hostname:dir/branch", so the part before
-        // the first colon identifies the remote machine.
+        // Session names are "hostname:dir/branch" (possibly with ":N" dedup suffix).
+        // The first colon always separates the hostname.
+        const target = targetSessionId as string;
         let foundRemote = false;
-        const colonIdx = (targetSessionId as string).indexOf(':');
-        if (colonIdx > 0) {
-          const targetHostname = (targetSessionId as string).slice(0, colonIdx);
+        const nameColonIdx = target.indexOf(':');
+        if (nameColonIdx > 0) {
+          const targetHostname = target.slice(0, nameColonIdx);
           try {
             const { discoverDaemons } = await import('./mdns/mdns-browser.ts');
             const { fetchSessions } = await import('./cli/ls-client.ts');
-            console.error(`Resolving "${targetSessionId}" via network discovery...`);
+            console.error(`Resolving "${target}" via network discovery...`);
             const daemons = await discoverDaemons({ timeoutMs: 3000 });
             const daemon = daemons.find((d: { hostname: string }) => d.hostname === targetHostname);
             if (daemon) {
               const sessions = await fetchSessions(daemon.host, daemon.port, 3000);
               const remoteMatches = sessions.filter(
-                (s) => s.name === targetSessionId || s.name?.startsWith(targetSessionId as string),
+                (s) => s.name === target || s.name?.startsWith(target),
               );
               if (remoteMatches.length === 1) {
                 // biome-ignore lint/style/noNonNullAssertion: length checked above
@@ -878,15 +879,25 @@ if (cliSubcommand === 'attach') {
                   console.error(`  ${m.name ?? m.sessionId.slice(0, 8)}`);
                 }
                 process.exit(1);
+              } else {
+                console.error(
+                  `Daemon found on ${daemon.hostname} (${daemon.host}:${daemon.port}) but no session matches "${target}".`,
+                );
+                const available = sessions.map((s) => s.name ?? s.sessionId.slice(0, 8)).join(', ');
+                if (available) console.error(`  Available sessions: ${available}`);
               }
+            } else {
+              console.error(`No daemon found for hostname "${targetHostname}" on the network.`);
             }
-          } catch {
-            // mDNS discovery failed; fall through to error
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            log(`[Attach] mDNS discovery error for "${targetHostname}": ${reason}`);
+            console.error(`Network discovery failed: ${reason}`);
           }
         }
         if (!foundRemote) {
           console.error(
-            `No session found matching "${targetSessionId}". Run \`remi ls --network\` to see available sessions.`,
+            `No session found matching "${target}". Run \`remi ls --network\` to see available sessions.`,
           );
           process.exit(1);
         }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -757,11 +757,16 @@ if (cliSubcommand === 'attach') {
     cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
   let resolvedHost = cliHost ?? 'localhost';
 
-  // Check for remote attach: host:port/session-id
-  // Remote targets have a colon before the first slash (port separator).
-  // Session names (hostname/dir/branch) do not have a colon before the first slash.
+  // Check for remote attach: host:port/session-id (e.g., 192.168.0.83:18765/name)
+  // Remote targets have a numeric port after the colon (host:PORT/...).
+  // Session names use hostname:dir/branch where dir is not numeric.
   const firstSlash = targetSessionId?.indexOf('/') ?? -1;
-  const hasRemoteFormat = firstSlash > 0 && targetSessionId?.slice(0, firstSlash).includes(':');
+  const colonBeforeSlash =
+    firstSlash > 0 ? targetSessionId?.slice(0, firstSlash).lastIndexOf(':') : -1;
+  const hasRemoteFormat =
+    colonBeforeSlash != null &&
+    colonBeforeSlash > 0 &&
+    /^\d+$/.test(targetSessionId?.slice(colonBeforeSlash + 1, firstSlash) ?? '');
   if (targetSessionId && hasRemoteFormat) {
     try {
       const { parseRemoteTarget } = await import('./cli/ls-client.ts');
@@ -818,7 +823,7 @@ if (cliSubcommand === 'attach') {
     }
 
     if (!resolvedByName) {
-      // Prefix-match session ID, look up port
+      // Prefix-match session ID from local store
       const all = store.list();
       const matches = all.filter(
         (s) =>
@@ -839,6 +844,52 @@ if (cliSubcommand === 'attach') {
         }
         console.error('Provide a longer prefix to disambiguate.');
         process.exit(1);
+      } else if (!cliHost) {
+        // Not found locally; extract hostname from session name and discover via mDNS.
+        // Session names are formatted as "hostname:dir/branch", so the part before
+        // the first colon identifies the remote machine.
+        let foundRemote = false;
+        const colonIdx = (targetSessionId as string).indexOf(':');
+        if (colonIdx > 0) {
+          const targetHostname = (targetSessionId as string).slice(0, colonIdx);
+          try {
+            const { discoverDaemons } = await import('./mdns/mdns-browser.ts');
+            const { fetchSessions } = await import('./cli/ls-client.ts');
+            console.error(`Resolving "${targetSessionId}" via network discovery...`);
+            const daemons = await discoverDaemons({ timeoutMs: 3000 });
+            const daemon = daemons.find((d: { hostname: string }) => d.hostname === targetHostname);
+            if (daemon) {
+              const sessions = await fetchSessions(daemon.host, daemon.port, 3000);
+              const remoteMatches = sessions.filter(
+                (s) => s.name === targetSessionId || s.name?.startsWith(targetSessionId as string),
+              );
+              if (remoteMatches.length === 1) {
+                // biome-ignore lint/style/noNonNullAssertion: length checked above
+                targetSessionId = remoteMatches[0]!.sessionId;
+                resolvedHost = daemon.host;
+                resolvedPort = daemon.port;
+                foundRemote = true;
+                console.error(`Found on ${daemon.hostname} (${daemon.host}:${daemon.port})`);
+              } else if (remoteMatches.length > 1) {
+                console.error(
+                  `Ambiguous: ${remoteMatches.length} sessions match on ${daemon.hostname}`,
+                );
+                for (const m of remoteMatches) {
+                  console.error(`  ${m.name ?? m.sessionId.slice(0, 8)}`);
+                }
+                process.exit(1);
+              }
+            }
+          } catch {
+            // mDNS discovery failed; fall through to error
+          }
+        }
+        if (!foundRemote) {
+          console.error(
+            `No session found matching "${targetSessionId}". Run \`remi ls --network\` to see available sessions.`,
+          );
+          process.exit(1);
+        }
       } else {
         console.error(
           `No session found matching "${targetSessionId}". Run \`remi ls\` to see live sessions.`,

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -296,9 +296,7 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
       if (a.daemon.host === 'localhost') {
         console.log(`  * ${name}: remi attach ${name}`);
       } else {
-        console.log(
-          `  * ${name}: remi attach ${a.daemon.host}:${a.daemon.port}/${a.sessionId.slice(0, 8)}`,
-        );
+        console.log(`  * ${name}: remi attach ${a.daemon.host}:${a.daemon.port}/${name}`);
       }
     }
   }

--- a/packages/daemon/src/session/session-name.ts
+++ b/packages/daemon/src/session/session-name.ts
@@ -1,7 +1,9 @@
 /**
  * Session name generation for human-readable session identifiers.
  *
- * Format: hostname/dirname/branch (or hostname/dirname if no git)
+ * Format: hostname:dirname/branch (or hostname:dirname if no git).
+ * Uses colon after hostname so names don't conflict with the
+ * host:port/session remote attach URL format.
  */
 
 import { execSync } from 'node:child_process';
@@ -11,7 +13,7 @@ import * as path from 'node:path';
 /**
  * Generate a human-readable session name from the working directory.
  *
- * Format: hostname/dirname/branch or hostname/dirname (no git).
+ * Format: hostname:dirname/branch or hostname:dirname (no git).
  * The hostname has `.local` suffix stripped if present.
  */
 export function generateSessionName(cwd: string): string {
@@ -20,9 +22,9 @@ export function generateSessionName(cwd: string): string {
   const branch = detectGitBranch(cwd);
 
   if (branch) {
-    return `${hostname}/${dirname}/${branch}`;
+    return `${hostname}:${dirname}/${branch}`;
   }
-  return `${hostname}/${dirname}`;
+  return `${hostname}:${dirname}`;
 }
 
 /**

--- a/packages/daemon/src/session/session-name.ts
+++ b/packages/daemon/src/session/session-name.ts
@@ -2,8 +2,9 @@
  * Session name generation for human-readable session identifiers.
  *
  * Format: hostname:dirname/branch (or hostname:dirname if no git).
- * Uses colon after hostname so names don't conflict with the
- * host:port/session remote attach URL format.
+ * Colon separates hostname from path. Disambiguation from the
+ * host:port/session remote URL format relies on checking whether
+ * the segment after the colon is a numeric port.
  */
 
 import { execSync } from 'node:child_process';

--- a/packages/daemon/tests/session-name.test.ts
+++ b/packages/daemon/tests/session-name.test.ts
@@ -64,14 +64,16 @@ describe('generateSessionName', () => {
     const name = generateSessionName('/tmp');
     // Should be hostname:tmp (no branch)
     expect(name).toContain(':');
-    const [_hostname, rest] = name.split(':');
+    const colonIdx = name.indexOf(':');
+    const rest = name.slice(colonIdx + 1);
     expect(rest).toBe('tmp');
     expect(rest).not.toContain('/');
   });
 
   test('uses directory basename', () => {
     const name = generateSessionName('/some/deep/project');
-    const [_hostname, rest] = name.split(':');
+    const colonIdx = name.indexOf(':');
+    const rest = name.slice(colonIdx + 1);
     expect(rest).toMatch(/^project/);
   });
 });

--- a/packages/daemon/tests/session-name.test.ts
+++ b/packages/daemon/tests/session-name.test.ts
@@ -22,52 +22,55 @@ describe('cleanHostname', () => {
 describe('makeUniqueName', () => {
   test('returns base name when no duplicates', () => {
     const existing = new Set<string>();
-    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main');
+    expect(makeUniqueName('mac:remi/main', existing)).toBe('mac:remi/main');
   });
 
   test('appends :2 for first duplicate', () => {
-    const existing = new Set(['mac/remi/main']);
-    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:2');
+    const existing = new Set(['mac:remi/main']);
+    expect(makeUniqueName('mac:remi/main', existing)).toBe('mac:remi/main:2');
   });
 
   test('appends :3 when :2 also exists', () => {
-    const existing = new Set(['mac/remi/main', 'mac/remi/main:2']);
-    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:3');
+    const existing = new Set(['mac:remi/main', 'mac:remi/main:2']);
+    expect(makeUniqueName('mac:remi/main', existing)).toBe('mac:remi/main:3');
   });
 
   test('skips to next available counter', () => {
     const existing = new Set([
-      'mac/remi/main',
-      'mac/remi/main:2',
-      'mac/remi/main:3',
-      'mac/remi/main:4',
+      'mac:remi/main',
+      'mac:remi/main:2',
+      'mac:remi/main:3',
+      'mac:remi/main:4',
     ]);
-    expect(makeUniqueName('mac/remi/main', existing)).toBe('mac/remi/main:5');
+    expect(makeUniqueName('mac:remi/main', existing)).toBe('mac:remi/main:5');
   });
 });
 
 describe('generateSessionName', () => {
-  test('generates name with hostname, dir, and branch for git repos', () => {
+  test('generates name with hostname:dir/branch for git repos', () => {
     // This test runs in the remi repo, so it should have a git branch
     const name = generateSessionName(process.cwd());
-    const parts = name.split('/');
-    // Should have hostname/dirname/branch format (3 parts)
-    expect(parts.length).toBeGreaterThanOrEqual(2);
-    // First part should be the hostname (without .local)
-    expect(parts[0]).not.toContain('.local');
-    expect(parts[0]?.length).toBeGreaterThan(0);
+    // Should have hostname:dir/branch format (colon separates hostname)
+    expect(name).toContain(':');
+    const [hostname, rest] = name.split(':');
+    expect(hostname).not.toContain('.local');
+    expect(hostname!.length).toBeGreaterThan(0);
+    // rest should be dir/branch
+    expect(rest).toContain('/');
   });
 
   test('generates name without branch for non-git directories', () => {
     const name = generateSessionName('/tmp');
-    const parts = name.split('/');
-    // /tmp is not a git repo, so should be hostname/dirname (2 parts)
-    expect(parts.length).toBe(2);
-    expect(parts[1]).toBe('tmp');
+    // Should be hostname:tmp (no branch)
+    expect(name).toContain(':');
+    const [_hostname, rest] = name.split(':');
+    expect(rest).toBe('tmp');
+    expect(rest).not.toContain('/');
   });
 
   test('uses directory basename', () => {
     const name = generateSessionName('/some/deep/project');
-    expect(name).toContain('/project');
+    const [_hostname, rest] = name.split(':');
+    expect(rest).toMatch(/^project/);
   });
 });

--- a/packages/daemon/tests/session-name.test.ts
+++ b/packages/daemon/tests/session-name.test.ts
@@ -47,16 +47,17 @@ describe('makeUniqueName', () => {
 });
 
 describe('generateSessionName', () => {
-  test('generates name with hostname:dir/branch for git repos', () => {
-    // This test runs in the remi repo, so it should have a git branch
+  test('generates name with hostname:dir format', () => {
     const name = generateSessionName(process.cwd());
-    // Should have hostname:dir/branch format (colon separates hostname)
+    // Should have hostname:dir or hostname:dir/branch format
     expect(name).toContain(':');
-    const [hostname, rest] = name.split(':');
+    const colonIdx = name.indexOf(':');
+    const hostname = name.slice(0, colonIdx);
+    const rest = name.slice(colonIdx + 1);
     expect(hostname).not.toContain('.local');
-    expect(hostname!.length).toBeGreaterThan(0);
-    // rest should be dir/branch
-    expect(rest).toContain('/');
+    expect(hostname.length).toBeGreaterThan(0);
+    // rest should be at minimum the directory name
+    expect(rest.length).toBeGreaterThan(0);
   });
 
   test('generates name without branch for non-git directories', () => {


### PR DESCRIPTION
## Summary

- Change session name separator to use colon after hostname: `hostname:dir/branch` (was `hostname/dir/branch`)
- Add automatic mDNS-based remote session resolution in `remi attach`
- Show copy-pastable attach commands in `remi ls --network`

## Problem

`remi ls --network` showed session names like `yahyas-mcm/osa/develop`, but `remi attach yahyas-mcm/osa/develop` couldn't find the session because:
1. The `/` in the name conflicted with the `host:port/session` remote URL format
2. Attach only looked locally, never discovering remote daemons

## Solution

1. Session names now use `:` after hostname: `yahyas-mcm:osa/develop`
2. When attach can't find a session locally and the name contains `:`, it extracts the hostname, discovers daemons via mDNS, and resolves the session on the matching remote daemon
3. Remote format detection now requires numeric port after colon to distinguish `192.168.0.83:18765/session` from `hostname:dir/branch`

## Workflow after this change

```bash
# On remote machine
remi ls --network
# Shows: yahyas-mcm:osa/develop

# Directly attach (auto-discovers via mDNS)
remi attach yahyas-mcm:osa/develop
```

## Test plan

- [x] 910 tests pass (including updated session name tests)
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual: `remi ls --network` shows new name format
- [ ] Manual: `remi attach hostname:dir/branch` auto-discovers and attaches

Fixes #58