### PR TITLE
feat: default bind 0.0.0.0 and VPN peer discovery

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -867,21 +867,30 @@ if (cliSubcommand === 'attach') {
             // Run mDNS and VPN discovery in parallel
             const [daemons, vpnPeers] = await Promise.all([
               discoverDaemons({ timeoutMs: 3000 }),
-              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 2000 }).catch(() => []),
+              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 2000 }).catch((err) => {
+                const msg = err instanceof Error ? err.message : String(err);
+                log(`[Attach] VPN discovery failed: ${msg}`);
+                return [] as {
+                  peer: import('./mdns/vpn-discovery.ts').VpnPeer;
+                  host: string;
+                  port: number;
+                }[];
+              }),
             ]);
 
-            // Try mDNS first
-            const daemon = daemons.find((d: { hostname: string }) => d.hostname === targetHostname);
+            // Try mDNS first, fall back to VPN peers
+            const mdnsMatch = daemons.find(
+              (d: { hostname: string }) => d.hostname === targetHostname,
+            );
+            const vpnMatch = mdnsMatch
+              ? null
+              : vpnPeers.find((v) => v.peer.hostname === targetHostname);
 
-            // If not found via mDNS, check VPN peers
-            const resolvedDaemon = daemon
-              ? { host: daemon.host, port: daemon.port, hostname: daemon.hostname }
-              : (() => {
-                  const vpnMatch = vpnPeers.find((v) => v.peer.hostname === targetHostname);
-                  return vpnMatch
-                    ? { host: vpnMatch.host, port: vpnMatch.port, hostname: vpnMatch.peer.hostname }
-                    : null;
-                })();
+            const resolvedDaemon = mdnsMatch
+              ? { host: mdnsMatch.host, port: mdnsMatch.port, hostname: mdnsMatch.hostname }
+              : vpnMatch
+                ? { host: vpnMatch.host, port: vpnMatch.port, hostname: vpnMatch.peer.hostname }
+                : null;
 
             if (resolvedDaemon) {
               const sessions = await fetchSessions(resolvedDaemon.host, resolvedDaemon.port, 3000);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -397,7 +397,7 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (arg === '--local') {
     cliBindHost = 'localhost';
-    cliAuth = false;
+    // Don't set cliAuth; auto-detection disables auth for localhost already
     cliNoMdns = true;
   } else if (arg === '--no-mdns') {
     cliNoMdns = true;
@@ -446,7 +446,7 @@ Options:
   --auth                   Force enable authentication (default: auto based on --bind)
   --no-auth                Disable authentication (even when binding to all interfaces)
   --no-tofu                Reject unknown clients (disable Trust On First Use)
-  --local                  Localhost-only mode (--bind localhost --no-auth --no-mdns)
+  --local                  Localhost-only mode (--bind localhost --no-mdns)
   --no-mdns                Disable mDNS network advertising
   --host HOST              Connect to daemon at HOST (for ls/attach; default: localhost)
   --label NAME             Label for authorized key (authorize)

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -395,6 +395,10 @@ for (let i = 0; i < args.length; i++) {
   } else if (arg === '--remove' && nextArg) {
     cliRemoveFingerprint = nextArg;
     i++;
+  } else if (arg === '--local') {
+    cliBindHost = 'localhost';
+    cliAuth = false;
+    cliNoMdns = true;
   } else if (arg === '--no-mdns') {
     cliNoMdns = true;
   } else if (arg === '--network') {
@@ -436,12 +440,13 @@ Options:
   --no-relay               Disable signaling relay (no remote access via connection code)
   --permanent-code         Use a persistent connection code (requires Ed25519 auth over relay)
   --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
-  --bind HOST              Bind WebSocket to HOST (default: localhost; use 0.0.0.0 for all interfaces)
+  --bind HOST              Bind WebSocket to HOST (default: 0.0.0.0; use --local for localhost-only)
   --force                  Overwrite existing identity (keygen/import-key)
   --passphrase             Encrypt identity with a passphrase (keygen)
   --auth                   Force enable authentication (default: auto based on --bind)
   --no-auth                Disable authentication (even when binding to all interfaces)
   --no-tofu                Reject unknown clients (disable Trust On First Use)
+  --local                  Localhost-only mode (--bind localhost --no-auth --no-mdns)
   --no-mdns                Disable mDNS network advertising
   --host HOST              Connect to daemon at HOST (for ls/attach; default: localhost)
   --label NAME             Label for authorized key (authorize)
@@ -845,7 +850,7 @@ if (cliSubcommand === 'attach') {
         console.error('Provide a longer prefix to disambiguate.');
         process.exit(1);
       } else if (!cliHost) {
-        // Not found locally; extract hostname from session name and discover via mDNS.
+        // Not found locally; discover via mDNS + VPN (Tailscale, etc.).
         // Session names are "hostname:dir/branch" (possibly with ":N" dedup suffix).
         // The first colon always separates the hostname.
         const target = targetSessionId as string;
@@ -855,25 +860,46 @@ if (cliSubcommand === 'attach') {
           const targetHostname = target.slice(0, nameColonIdx);
           try {
             const { discoverDaemons } = await import('./mdns/mdns-browser.ts');
+            const { discoverVpnPeers } = await import('./mdns/vpn-discovery.ts');
             const { fetchSessions } = await import('./cli/ls-client.ts');
             console.error(`Resolving "${target}" via network discovery...`);
-            const daemons = await discoverDaemons({ timeoutMs: 3000 });
+
+            // Run mDNS and VPN discovery in parallel
+            const [daemons, vpnPeers] = await Promise.all([
+              discoverDaemons({ timeoutMs: 3000 }),
+              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 2000 }).catch(() => []),
+            ]);
+
+            // Try mDNS first
             const daemon = daemons.find((d: { hostname: string }) => d.hostname === targetHostname);
-            if (daemon) {
-              const sessions = await fetchSessions(daemon.host, daemon.port, 3000);
+
+            // If not found via mDNS, check VPN peers
+            const resolvedDaemon = daemon
+              ? { host: daemon.host, port: daemon.port, hostname: daemon.hostname }
+              : (() => {
+                  const vpnMatch = vpnPeers.find((v) => v.peer.hostname === targetHostname);
+                  return vpnMatch
+                    ? { host: vpnMatch.host, port: vpnMatch.port, hostname: vpnMatch.peer.hostname }
+                    : null;
+                })();
+
+            if (resolvedDaemon) {
+              const sessions = await fetchSessions(resolvedDaemon.host, resolvedDaemon.port, 3000);
               const remoteMatches = sessions.filter(
                 (s) => s.name === target || s.name?.startsWith(target),
               );
               if (remoteMatches.length === 1) {
                 // biome-ignore lint/style/noNonNullAssertion: length checked above
                 targetSessionId = remoteMatches[0]!.sessionId;
-                resolvedHost = daemon.host;
-                resolvedPort = daemon.port;
+                resolvedHost = resolvedDaemon.host;
+                resolvedPort = resolvedDaemon.port;
                 foundRemote = true;
-                console.error(`Found on ${daemon.hostname} (${daemon.host}:${daemon.port})`);
+                console.error(
+                  `Found on ${resolvedDaemon.hostname} (${resolvedDaemon.host}:${resolvedDaemon.port})`,
+                );
               } else if (remoteMatches.length > 1) {
                 console.error(
-                  `Ambiguous: ${remoteMatches.length} sessions match on ${daemon.hostname}`,
+                  `Ambiguous: ${remoteMatches.length} sessions match on ${resolvedDaemon.hostname}`,
                 );
                 for (const m of remoteMatches) {
                   console.error(`  ${m.name ?? m.sessionId.slice(0, 8)}`);
@@ -881,17 +907,19 @@ if (cliSubcommand === 'attach') {
                 process.exit(1);
               } else {
                 console.error(
-                  `Daemon found on ${daemon.hostname} (${daemon.host}:${daemon.port}) but no session matches "${target}".`,
+                  `Daemon found on ${resolvedDaemon.hostname} (${resolvedDaemon.host}:${resolvedDaemon.port}) but no session matches "${target}".`,
                 );
                 const available = sessions.map((s) => s.name ?? s.sessionId.slice(0, 8)).join(', ');
                 if (available) console.error(`  Available sessions: ${available}`);
               }
             } else {
-              console.error(`No daemon found for hostname "${targetHostname}" on the network.`);
+              console.error(
+                `No daemon found for hostname "${targetHostname}" on the network or VPN.`,
+              );
             }
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
-            log(`[Attach] mDNS discovery error for "${targetHostname}": ${reason}`);
+            log(`[Attach] Network discovery error for "${targetHostname}": ${reason}`);
             console.error(`Network discovery failed: ${reason}`);
           }
         }
@@ -1746,9 +1774,9 @@ const sharedEvents = {
 };
 
 // ---------------------------------------------------------------------------
-// Auth setup: auto based on bind host (localhost=off, 0.0.0.0=on), --auth/--no-auth override
+// Auth setup: auto based on bind host (default 0.0.0.0=on, localhost=off), --auth/--no-auth override
 // ---------------------------------------------------------------------------
-const bindHost = cliBindHost ?? 'localhost';
+const bindHost = cliBindHost ?? '0.0.0.0';
 const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1' || bindHost === '::1';
 
 // Determine whether auth should be enabled

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -192,7 +192,15 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   // Run mDNS and VPN discovery in parallel
   const [daemons, vpnPeers] = await Promise.all([
     discoverDaemons({ timeoutMs: mdnsTimeout }),
-    discoverVpnPeers({ port: localPort, probeTimeoutMs: timeout }).catch(() => []),
+    discoverVpnPeers({ port: localPort, probeTimeoutMs: timeout }).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[ls] VPN discovery failed: ${msg}`);
+      return [] as {
+        peer: import('../mdns/vpn-discovery.ts').VpnPeer;
+        host: string;
+        port: number;
+      }[];
+    }),
   ]);
 
   const results: DaemonSessions[] = [];
@@ -210,12 +218,11 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   const remoteDaemons = daemons.filter((d) => !(d.port === localPort && localAddrs.has(d.host)));
 
   // Track hosts already discovered via mDNS to deduplicate VPN results
-  const discoveredHosts = new Set<string>();
+  const discoveredHosts = new Set(remoteDaemons.map((d) => d.host));
 
   const remoteResults = await Promise.allSettled(
     remoteDaemons.map(async (daemon) => {
       const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
-      discoveredHosts.add(daemon.host);
       return {
         daemon: {
           name: daemon.name,
@@ -264,8 +271,16 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
       const r = vpnResults[i];
       if (r?.status === 'fulfilled') {
         results.push(r.value);
+      } else if (r?.status === 'rejected') {
+        // Connection refused is expected (peer has no remi); log other errors
+        const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
+          const vpnPeer = newVpnPeers[i];
+          console.error(
+            `[ls] VPN peer ${vpnPeer?.peer.hostname ?? 'unknown'} at ${vpnPeer?.host ?? '?'}:${vpnPeer?.port ?? '?'}: ${reason}`,
+          );
+        }
       }
-      // VPN probe failures are expected (peer online but no remi); skip silently
     }
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -187,7 +187,13 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
 
   console.error('Scanning network for Remi daemons...');
   const { discoverDaemons } = await import('../mdns/mdns-browser.ts');
-  const daemons = await discoverDaemons({ timeoutMs: mdnsTimeout });
+  const { discoverVpnPeers } = await import('../mdns/vpn-discovery.ts');
+
+  // Run mDNS and VPN discovery in parallel
+  const [daemons, vpnPeers] = await Promise.all([
+    discoverDaemons({ timeoutMs: mdnsTimeout }),
+    discoverVpnPeers({ port: localPort, probeTimeoutMs: timeout }).catch(() => []),
+  ]);
 
   const results: DaemonSessions[] = [];
   const myHostname = os.hostname();
@@ -199,13 +205,17 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     });
   }
 
-  // Query remote daemons in parallel, filtering out self
+  // Query remote daemons (mDNS) in parallel, filtering out self
   const localAddrs = getLocalAddresses(myHostname);
   const remoteDaemons = daemons.filter((d) => !(d.port === localPort && localAddrs.has(d.host)));
+
+  // Track hosts already discovered via mDNS to deduplicate VPN results
+  const discoveredHosts = new Set<string>();
 
   const remoteResults = await Promise.allSettled(
     remoteDaemons.map(async (daemon) => {
       const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
+      discoveredHosts.add(daemon.host);
       return {
         daemon: {
           name: daemon.name,
@@ -228,6 +238,34 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
       console.error(
         `[ls] Failed to query daemon ${daemon?.name ?? 'unknown'} at ${daemon?.host ?? '?'}:${daemon?.port ?? '?'}: ${reason}`,
       );
+    }
+  }
+
+  // Query VPN peers not already found via mDNS
+  const newVpnPeers = vpnPeers.filter(
+    (v) => !localAddrs.has(v.host) && !discoveredHosts.has(v.host),
+  );
+  if (newVpnPeers.length > 0) {
+    const vpnResults = await Promise.allSettled(
+      newVpnPeers.map(async ({ peer, host, port }) => {
+        const sessions = await fetchSessions(host, port, timeout);
+        return {
+          daemon: {
+            name: `vpn:${peer.hostname}`,
+            host,
+            port,
+            hostname: peer.hostname,
+          },
+          sessions,
+        } satisfies DaemonSessions;
+      }),
+    );
+    for (let i = 0; i < vpnResults.length; i++) {
+      const r = vpnResults[i];
+      if (r?.status === 'fulfilled') {
+        results.push(r.value);
+      }
+      // VPN probe failures are expected (peer online but no remi); skip silently
     }
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -303,7 +303,7 @@ export function getLocalAddresses(hostname: string): Set<string> {
 function renderNetworkSessionList(results: DaemonSessions[]): void {
   if (results.length === 0) {
     console.log('No daemons found on the network.');
-    console.log('Tip: run `remi ls` for local sessions, or start a daemon with `--bind 0.0.0.0`');
+    console.log('Tip: run `remi ls` for local sessions, or ensure a remi daemon is running');
     return;
   }
 

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -49,13 +49,12 @@ export async function discoverVpnPeers(
     }),
   );
 
-  const found: { peer: VpnPeer; host: string; port: number }[] = [];
-  for (const r of results) {
-    if (r.status === 'fulfilled') {
-      found.push(r.value);
-    }
-  }
-  return found;
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<{ peer: VpnPeer; host: string; port: number }> =>
+        r.status === 'fulfilled',
+    )
+    .map((r) => r.value);
 }
 
 /**
@@ -90,8 +89,13 @@ export function getTailscalePeers(): VpnPeer[] {
       peers.push({ hostname, ip, os: peer.OS ?? 'unknown' });
     }
     return peers;
-  } catch {
-    // Tailscale CLI not available or not running
+  } catch (err) {
+    // ENOENT = tailscale not installed; other errors worth logging
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[vpn-discovery] Tailscale query failed: ${msg}`);
+    }
     return [];
   }
 }

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -1,0 +1,110 @@
+/**
+ * VPN-aware peer discovery for finding remi daemons across VPN networks.
+ *
+ * Supports Tailscale (and extensible to ZeroTier, etc.). Checks if the
+ * VPN CLI is available, queries for online peers, and probes each for
+ * a running remi daemon on the default port.
+ */
+
+import { execSync } from 'node:child_process';
+
+export interface VpnPeer {
+  /** Hostname of the peer machine */
+  readonly hostname: string;
+  /** VPN IP address (IPv4 preferred) */
+  readonly ip: string;
+  /** OS of the peer (e.g., "macOS", "linux") */
+  readonly os: string;
+}
+
+export interface VpnDiscoveryOptions {
+  /** Port to probe for remi daemons. Default: 18765 */
+  readonly port?: number | undefined;
+  /** Timeout per probe in ms. Default: 2000 */
+  readonly probeTimeoutMs?: number | undefined;
+}
+
+/**
+ * Discover remi daemons running on VPN peers.
+ *
+ * Returns peers that responded to a remi session list request.
+ * Currently supports Tailscale; extensible to other VPN providers.
+ */
+export async function discoverVpnPeers(
+  opts?: VpnDiscoveryOptions,
+): Promise<{ peer: VpnPeer; host: string; port: number }[]> {
+  const port = opts?.port ?? 18765;
+  const probeTimeout = opts?.probeTimeoutMs ?? 2000;
+
+  const peers = getTailscalePeers();
+  if (peers.length === 0) return [];
+
+  const { fetchSessions } = await import('../cli/ls-client.ts');
+
+  const results = await Promise.allSettled(
+    peers.map(async (peer) => {
+      // Quick probe: try to fetch sessions from this peer
+      await fetchSessions(peer.ip, port, probeTimeout);
+      return { peer, host: peer.ip, port };
+    }),
+  );
+
+  const found: { peer: VpnPeer; host: string; port: number }[] = [];
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      found.push(r.value);
+    }
+  }
+  return found;
+}
+
+/**
+ * Get online Tailscale peers, filtering out mobile devices.
+ * Returns empty array if Tailscale CLI is not available.
+ */
+export function getTailscalePeers(): VpnPeer[] {
+  try {
+    const raw = execSync('tailscale status --json', {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const status = JSON.parse(raw) as TailscaleStatus;
+    if (!status.Peer) return [];
+
+    const peers: VpnPeer[] = [];
+    for (const peer of Object.values(status.Peer)) {
+      // Skip offline peers and mobile devices
+      if (!peer.Online) continue;
+      if (peer.OS === 'iOS' || peer.OS === 'android') continue;
+
+      // Prefer IPv4 address
+      const ipv4 = peer.TailscaleIPs?.find((ip: string) => !ip.includes(':'));
+      const ip = ipv4 ?? peer.TailscaleIPs?.[0];
+      if (!ip) continue;
+
+      // Clean hostname: Tailscale sometimes uses "localhost" for mobile,
+      // and may include special characters in hostnames like "Yahya's MCM"
+      const hostname = peer.DNSName?.split('.')[0] ?? peer.HostName ?? 'unknown';
+
+      peers.push({ hostname, ip, os: peer.OS ?? 'unknown' });
+    }
+    return peers;
+  } catch {
+    // Tailscale CLI not available or not running
+    return [];
+  }
+}
+
+// Minimal Tailscale status JSON types
+interface TailscalePeerInfo {
+  readonly HostName?: string;
+  readonly DNSName?: string;
+  readonly OS?: string;
+  readonly Online?: boolean;
+  readonly TailscaleIPs?: string[];
+}
+
+interface TailscaleStatus {
+  readonly Peer?: Record<string, TailscalePeerInfo>;
+}

--- a/packages/daemon/tests/mdns/vpn-discovery.test.ts
+++ b/packages/daemon/tests/mdns/vpn-discovery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { getTailscalePeers } from '../../src/mdns/vpn-discovery.ts';
+
+describe('getTailscalePeers', () => {
+  test('returns array (empty if tailscale not available)', () => {
+    const peers = getTailscalePeers();
+    expect(Array.isArray(peers)).toBe(true);
+    // Each peer should have the expected shape
+    for (const peer of peers) {
+      expect(typeof peer.hostname).toBe('string');
+      expect(typeof peer.ip).toBe('string');
+      expect(typeof peer.os).toBe('string');
+      // IP should not be empty
+      expect(peer.ip.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('filters out mobile devices', () => {
+    const peers = getTailscalePeers();
+    for (const peer of peers) {
+      expect(peer.os).not.toBe('iOS');
+      expect(peer.os).not.toBe('android');
+    }
+  });
+
+  test('excludes offline peers', () => {
+    // We can only verify the shape; offline peers should not appear
+    const peers = getTailscalePeers();
+    // All returned peers are online (we can't verify this directly,
+    // but the function filters on Online: true)
+    expect(peers.length).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Default bind changed from `localhost` to `0.0.0.0` so remi is network-accessible out of the box
- Added `--local` shorthand for `--bind localhost --no-auth --no-mdns` for users who want local-only
- Added Tailscale-aware peer discovery: `remi ls --network` and `remi attach` now find daemons across Tailscale VPN, not just local LAN
- VPN discovery runs in parallel with mDNS, deduplicates results
- Extensible provider pattern for future ZeroTier support

## Changes

- `packages/daemon/src/cli.ts`: Default bind to 0.0.0.0, add --local flag, integrate VPN discovery into attach flow
- `packages/daemon/src/cli/ls-client.ts`: Run VPN discovery alongside mDNS in ls --network
- `packages/daemon/src/mdns/vpn-discovery.ts`: New module for Tailscale peer discovery
- `packages/daemon/tests/mdns/vpn-discovery.test.ts`: Tests for VPN discovery

## Test plan

- [x] 913 tests pass
- [x] Lint clean
- [x] Type check passes
- [x] Tailscale peer discovery finds 3 online peers (filters iOS, offline)
- [x] VPN probe correctly returns empty when no remi daemons on peers
- [ ] End-to-end: install remi on MBA via Tailscale, verify `remi ls --network` discovers it

Fixes #57, fixes #60