### PR TITLE
feat: add remi start/stop/status/logs commands

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -32,6 +32,7 @@ const REMI_VERSION = (() => {
 // ---------------------------------------------------------------------------
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const LOG_FILE = path.join(REMI_DIR, 'remi.log');
+const DAEMON_STATUS_FILE = path.join(REMI_DIR, 'daemon-status.json');
 const STATUS_FILE = path.join(REMI_DIR, 'status.json');
 let logFd: number | null = null;
 
@@ -122,12 +123,14 @@ function scheduleStatusWrite(): void {
 }
 
 function writeStatus(): void {
-  if (!wrapperMode) return;
+  if (!wrapperMode && !cliDaemonMode) return;
+  // Daemon mode writes to daemon-status.json; wrapper writes to status.json
+  const targetFile = cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE;
   // Atomic write: write to temp file then rename to avoid readers seeing partial JSON
-  const tmpFile = `${STATUS_FILE}.tmp`;
+  const tmpFile = `${targetFile}.tmp`;
   try {
     fs.writeFileSync(tmpFile, JSON.stringify(remiStatus));
-    fs.renameSync(tmpFile, STATUS_FILE);
+    fs.renameSync(tmpFile, targetFile);
     statusWriteErrorLogged = false;
   } catch (err) {
     if (!statusWriteErrorLogged) {
@@ -138,8 +141,9 @@ function writeStatus(): void {
 }
 
 function cleanupStatusFile(): void {
+  const targetFile = cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE;
   try {
-    fs.unlinkSync(STATUS_FILE);
+    fs.unlinkSync(targetFile);
   } catch {
     // File may not exist during cleanup
   }
@@ -322,6 +326,10 @@ let cliSubcommand:
   | 'new'
   | 'kill'
   | 'detach'
+  | 'start'
+  | 'stop'
+  | 'status'
+  | 'logs'
   | undefined;
 let cliSubcommandArg: string | undefined;
 let cliCodeRefresh = false;
@@ -418,6 +426,10 @@ Usage:
   remi new [-- claude-args...]   Explicit session creation (alias for remi [args])
   remi kill <name>               Kill a session by name or ID
   remi detach [name]             Detach from current or named session
+  remi start                     Start daemon in background
+  remi stop                      Stop background daemon
+  remi status                    Show daemon status
+  remi logs                      Show recent daemon logs
   remi ls                        List live sessions from running daemon
   remi ls --network              Discover and list sessions across the network
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
@@ -431,7 +443,7 @@ Usage:
   remi keys                      List authorized keys
   remi --resume [session-id]     Resume a previous session
   remi --sessions                List stored sessions
-  remi --daemon                  Legacy daemon mode (headless server)
+  remi --daemon                  Daemon mode (headless server, prefer remi start)
 
 Options:
   --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
@@ -480,7 +492,11 @@ Any other arguments are passed through to Claude Code.
     arg === 'keys' ||
     arg === 'new' ||
     arg === 'kill' ||
-    arg === 'detach'
+    arg === 'detach' ||
+    arg === 'start' ||
+    arg === 'stop' ||
+    arg === 'status' ||
+    arg === 'logs'
   ) {
     cliSubcommand = arg;
     if (
@@ -687,6 +703,42 @@ if (cliSubcommand === 'code') {
   }
   console.log('\nNote: By default, codes rotate on each reconnect. Use --permanent-code to');
   console.log('persist a fixed code (requires Ed25519 authentication for relay connections).');
+  process.exit(0);
+}
+
+// Handle daemon lifecycle commands: start, stop, status, logs
+if (cliSubcommand === 'start') {
+  const { startDaemon } = await import('./cli/daemon-manager.ts');
+  const resolvedPort =
+    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+  const extraArgs: string[] = [];
+  if (cliBindHost) extraArgs.push('--bind', cliBindHost);
+  if (cliAuth === true) extraArgs.push('--auth');
+  if (cliAuth === false) extraArgs.push('--no-auth');
+  if (cliNoMdns) extraArgs.push('--no-mdns');
+  if (cliNoRelay) extraArgs.push('--no-relay');
+  if (cliNoTelegram) extraArgs.push('--no-telegram');
+  if (cliPermanentCode) extraArgs.push('--permanent-code');
+  if (cliSignalingUrl) extraArgs.push('--signaling-url', cliSignalingUrl);
+  startDaemon({ port: resolvedPort, extraArgs });
+  process.exit(0);
+}
+
+if (cliSubcommand === 'stop') {
+  const { stopDaemon } = await import('./cli/daemon-manager.ts');
+  stopDaemon();
+  process.exit(0);
+}
+
+if (cliSubcommand === 'status') {
+  const { showDaemonStatus } = await import('./cli/daemon-manager.ts');
+  showDaemonStatus();
+  process.exit(0);
+}
+
+if (cliSubcommand === 'logs') {
+  const { showDaemonLogs } = await import('./cli/daemon-manager.ts');
+  showDaemonLogs();
   process.exit(0);
 }
 
@@ -1984,11 +2036,14 @@ async function cleanup(): Promise<void> {
 // Main: Start in wrapper or daemon mode
 // ---------------------------------------------------------------------------
 if (cliDaemonMode) {
-  // Legacy daemon mode: headless server, spawns Claude on WebSocket connect
+  // Daemon mode: headless server, spawns Claude on WebSocket connect
   console.log('Starting Remi daemon...');
   await registry.startAll();
 
   mdnsPublisher = await startMdnsIfNeeded(console.log);
+
+  // Write status.json so remi status/start can detect running daemon
+  updateRemiStatus({ wsPort: PORT, sessionStatus: 'starting' });
 
   console.log('');
   console.log('Remi daemon ready!');
@@ -2009,11 +2064,13 @@ if (cliDaemonMode) {
 
   process.on('SIGINT', async () => {
     console.log('\nShutting down gracefully...');
+    cleanupStatusFile();
     await cleanup();
     process.exit(0);
   });
   process.on('SIGTERM', async () => {
     console.log('\nShutting down gracefully...');
+    cleanupStatusFile();
     await cleanup();
     process.exit(0);
   });

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -707,38 +707,35 @@ if (cliSubcommand === 'code') {
 }
 
 // Handle daemon lifecycle commands: start, stop, status, logs
-if (cliSubcommand === 'start') {
-  const { startDaemon } = await import('./cli/daemon-manager.ts');
-  const resolvedPort =
-    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
-  const extraArgs: string[] = [];
-  if (cliBindHost) extraArgs.push('--bind', cliBindHost);
-  if (cliAuth === true) extraArgs.push('--auth');
-  if (cliAuth === false) extraArgs.push('--no-auth');
-  if (cliNoMdns) extraArgs.push('--no-mdns');
-  if (cliNoRelay) extraArgs.push('--no-relay');
-  if (cliNoTelegram) extraArgs.push('--no-telegram');
-  if (cliPermanentCode) extraArgs.push('--permanent-code');
-  if (cliSignalingUrl) extraArgs.push('--signaling-url', cliSignalingUrl);
-  startDaemon({ port: resolvedPort, extraArgs });
-  process.exit(0);
-}
+if (
+  cliSubcommand === 'start' ||
+  cliSubcommand === 'stop' ||
+  cliSubcommand === 'status' ||
+  cliSubcommand === 'logs'
+) {
+  const dm = await import('./cli/daemon-manager.ts');
 
-if (cliSubcommand === 'stop') {
-  const { stopDaemon } = await import('./cli/daemon-manager.ts');
-  stopDaemon();
-  process.exit(0);
-}
+  if (cliSubcommand === 'start') {
+    const resolvedPort =
+      cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+    const extraArgs: string[] = [];
+    if (cliBindHost) extraArgs.push('--bind', cliBindHost);
+    if (cliAuth === true) extraArgs.push('--auth');
+    if (cliAuth === false) extraArgs.push('--no-auth');
+    if (cliNoMdns) extraArgs.push('--no-mdns');
+    if (cliNoRelay) extraArgs.push('--no-relay');
+    if (cliNoTelegram) extraArgs.push('--no-telegram');
+    if (cliPermanentCode) extraArgs.push('--permanent-code');
+    if (cliSignalingUrl) extraArgs.push('--signaling-url', cliSignalingUrl);
+    dm.startDaemon({ port: resolvedPort, extraArgs });
+  } else if (cliSubcommand === 'stop') {
+    dm.stopDaemon();
+  } else if (cliSubcommand === 'status') {
+    dm.showDaemonStatus();
+  } else {
+    dm.showDaemonLogs();
+  }
 
-if (cliSubcommand === 'status') {
-  const { showDaemonStatus } = await import('./cli/daemon-manager.ts');
-  showDaemonStatus();
-  process.exit(0);
-}
-
-if (cliSubcommand === 'logs') {
-  const { showDaemonLogs } = await import('./cli/daemon-manager.ts');
-  showDaemonLogs();
   process.exit(0);
 }
 

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -6,27 +6,18 @@
  * The status.json file provides additional runtime info.
  */
 
-import { execFileSync, spawn } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-function getRemiDir(): string {
-  const dir = path.join(os.homedir(), '.remi');
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
-}
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
+const STATUS_FILE = path.join(REMI_DIR, 'daemon-status.json');
+const LOG_FILE = path.join(REMI_DIR, 'daemon.log');
 
-function pidFile(): string {
-  return path.join(getRemiDir(), 'daemon.pid');
-}
-
-function statusFile(): string {
-  return path.join(getRemiDir(), 'daemon-status.json');
-}
-
-function daemonLogFile(): string {
-  return path.join(getRemiDir(), 'daemon.log');
+function ensureRemiDir(): void {
+  fs.mkdirSync(REMI_DIR, { recursive: true });
 }
 
 /**
@@ -35,18 +26,16 @@ function daemonLogFile(): string {
  */
 export function getRunningDaemonPid(): number | null {
   try {
-    const content = fs.readFileSync(pidFile(), 'utf-8').trim();
+    const content = fs.readFileSync(PID_FILE, 'utf-8').trim();
     const pid = Number.parseInt(content, 10);
     if (Number.isNaN(pid) || pid <= 0) return null;
 
-    // Check if the process is actually running
     try {
       process.kill(pid, 0);
       return pid;
     } catch {
-      // Process not running; clean up stale PID file
       try {
-        fs.unlinkSync(pidFile());
+        fs.unlinkSync(PID_FILE);
       } catch {
         // ignore cleanup errors
       }
@@ -57,12 +46,9 @@ export function getRunningDaemonPid(): number | null {
   }
 }
 
-/**
- * Read status.json for daemon runtime information.
- */
 function readStatus(): Record<string, unknown> | null {
   try {
-    const content = fs.readFileSync(statusFile(), 'utf-8');
+    const content = fs.readFileSync(STATUS_FILE, 'utf-8');
     return JSON.parse(content) as Record<string, unknown>;
   } catch {
     return null;
@@ -103,6 +89,7 @@ export interface StartOptions {
  * Returns the PID of the spawned process.
  */
 export function startDaemon(opts?: StartOptions): number {
+  ensureRemiDir();
   const existingPid = getRunningDaemonPid();
   if (existingPid) {
     const status = readStatus();
@@ -113,9 +100,6 @@ export function startDaemon(opts?: StartOptions): number {
   }
 
   const { command, baseArgs } = resolveRemiCommand();
-  const logPath = daemonLogFile();
-
-  // Build args: [script-if-needed] --daemon [--port N] [extra...]
   const spawnArgs = [...baseArgs, '--daemon'];
   if (opts?.port) {
     spawnArgs.push('--port', String(opts.port));
@@ -124,15 +108,12 @@ export function startDaemon(opts?: StartOptions): number {
     spawnArgs.push(...opts.extraArgs);
   }
 
-  // Open log file for stdout/stderr redirection
-  const logFd = fs.openSync(logPath, 'a');
+  const logFd = fs.openSync(LOG_FILE, 'a');
   fs.writeSync(logFd, `\n--- Daemon starting at ${new Date().toISOString()} ---\n`);
 
-  // Spawn detached process
   const child = spawn(command, spawnArgs, {
     detached: true,
     stdio: ['ignore', logFd, logFd],
-    env: { ...process.env },
   });
 
   const pid = child.pid;
@@ -142,14 +123,24 @@ export function startDaemon(opts?: StartOptions): number {
     process.exit(1);
   }
 
-  // Write PID file
-  fs.writeFileSync(pidFile(), String(pid), 'utf-8');
-
-  // Detach from parent so the daemon survives
+  try {
+    const fd = fs.openSync(PID_FILE, 'wx');
+    fs.writeSync(fd, String(pid));
+    fs.closeSync(fd);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      console.error('Another daemon appears to be starting. Check with `remi status`.');
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to write PID file: ${msg}`);
+    }
+    fs.closeSync(logFd);
+    process.exit(1);
+  }
   child.unref();
   fs.closeSync(logFd);
 
-  // Wait briefly for the daemon to initialize and write status.json
+  // Poll until daemon writes status.json or times out
   const startTime = Date.now();
   const timeout = 5000;
   let port: number | string = 'unknown';
@@ -160,31 +151,26 @@ export function startDaemon(opts?: StartOptions): number {
       port = status['wsPort'] as number;
       break;
     }
-    // Verify the process is still alive
     try {
       process.kill(pid, 0);
     } catch {
       console.error('Daemon process exited unexpectedly. Check logs:');
-      console.error(`  ${logPath}`);
+      console.error(`  ${LOG_FILE}`);
       try {
-        fs.unlinkSync(pidFile());
+        fs.unlinkSync(PID_FILE);
       } catch {
         // ignore
       }
       process.exit(1);
     }
-    // Small sync sleep to avoid busy loop
-    execFileSync('sleep', ['0.1']);
+    Bun.sleepSync(100);
   }
 
   console.log(`Daemon started (PID ${pid}, port ${port}).`);
-  console.log(`Logs: ${logPath}`);
+  console.log(`Logs: ${LOG_FILE}`);
   return pid;
 }
 
-/**
- * Stop the running remi daemon.
- */
 export function stopDaemon(): void {
   const pid = getRunningDaemonPid();
   if (!pid) {
@@ -194,7 +180,6 @@ export function stopDaemon(): void {
 
   console.log(`Stopping daemon (PID ${pid})...`);
 
-  // Send SIGTERM for graceful shutdown
   try {
     process.kill(pid, 'SIGTERM');
   } catch (err) {
@@ -203,37 +188,32 @@ export function stopDaemon(): void {
     process.exit(1);
   }
 
-  // Wait for the process to exit (up to 5 seconds)
+  // Wait up to 5 seconds for graceful exit
   const startTime = Date.now();
   const timeout = 5000;
 
   while (Date.now() - startTime < timeout) {
     try {
       process.kill(pid, 0);
-      // Still running; wait
-      execFileSync('sleep', ['0.2']);
+      Bun.sleepSync(200);
     } catch {
-      // Process exited
       cleanupFiles();
       console.log('Daemon stopped.');
       return;
     }
   }
 
-  // Force kill if still running
   console.error('Daemon did not stop gracefully; sending SIGKILL...');
   try {
     process.kill(pid, 'SIGKILL');
   } catch {
     // Already dead
   }
+  Bun.sleepSync(200);
   cleanupFiles();
   console.log('Daemon killed.');
 }
 
-/**
- * Show daemon status.
- */
 export function showDaemonStatus(): void {
   const pid = getRunningDaemonPid();
   if (!pid) {
@@ -255,32 +235,27 @@ export function showDaemonStatus(): void {
     console.log(`Daemon running (PID ${pid}), no status info available.`);
   }
 
-  console.log(`  Logs: ${daemonLogFile()}`);
+  console.log(`  Logs: ${LOG_FILE}`);
 }
 
-/**
- * Show recent daemon log output.
- */
 export function showDaemonLogs(lines = 50): void {
-  const logPath = daemonLogFile();
   try {
-    const content = fs.readFileSync(logPath, 'utf-8');
-    const allLines = content.split('\n');
-    const tail = allLines.slice(-lines);
-    console.log(tail.join('\n'));
+    fs.accessSync(LOG_FILE, fs.constants.R_OK);
+    const output = execSync(`tail -n ${lines} "${LOG_FILE}"`, { encoding: 'utf-8' });
+    console.log(output);
   } catch {
-    console.error(`No daemon log found at ${logPath}`);
+    console.error(`No daemon log found at ${LOG_FILE}`);
   }
 }
 
 function cleanupFiles(): void {
   try {
-    fs.unlinkSync(pidFile());
+    fs.unlinkSync(PID_FILE);
   } catch {
     // ignore
   }
   try {
-    fs.unlinkSync(statusFile());
+    fs.unlinkSync(STATUS_FILE);
   } catch {
     // ignore
   }

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -1,0 +1,287 @@
+/**
+ * Background daemon lifecycle management for remi start/stop/status.
+ *
+ * Uses child_process.spawn with detached:true to launch remi --daemon
+ * in the background. Tracks the daemon via a PID file (~/.remi/daemon.pid).
+ * The status.json file provides additional runtime info.
+ */
+
+import { execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function getRemiDir(): string {
+  const dir = path.join(os.homedir(), '.remi');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function pidFile(): string {
+  return path.join(getRemiDir(), 'daemon.pid');
+}
+
+function statusFile(): string {
+  return path.join(getRemiDir(), 'daemon-status.json');
+}
+
+function daemonLogFile(): string {
+  return path.join(getRemiDir(), 'daemon.log');
+}
+
+/**
+ * Read the daemon PID from the PID file.
+ * Returns null if no PID file exists or the process is not running.
+ */
+export function getRunningDaemonPid(): number | null {
+  try {
+    const content = fs.readFileSync(pidFile(), 'utf-8').trim();
+    const pid = Number.parseInt(content, 10);
+    if (Number.isNaN(pid) || pid <= 0) return null;
+
+    // Check if the process is actually running
+    try {
+      process.kill(pid, 0);
+      return pid;
+    } catch {
+      // Process not running; clean up stale PID file
+      try {
+        fs.unlinkSync(pidFile());
+      } catch {
+        // ignore cleanup errors
+      }
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read status.json for daemon runtime information.
+ */
+function readStatus(): Record<string, unknown> | null {
+  try {
+    const content = fs.readFileSync(statusFile(), 'utf-8');
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the command and args to invoke remi.
+ * Handles both compiled binary and bun/node script execution.
+ */
+function resolveRemiCommand(): { command: string; baseArgs: string[] } {
+  const argv0 = process.argv[0] ?? '';
+  const argv1 = process.argv[1] ?? '';
+
+  // Compiled binary: argv[0] is the remi binary itself
+  if (argv0.endsWith('/remi') || argv0.endsWith('\\remi')) {
+    return { command: argv0, baseArgs: [] };
+  }
+
+  // Running via bun/node: argv[0] is the runtime, argv[1] is the script
+  if (argv1 && (argv0.includes('bun') || argv0.includes('node'))) {
+    return { command: argv0, baseArgs: [argv1] };
+  }
+
+  // Fallback: assume 'remi' is on PATH
+  return { command: 'remi', baseArgs: [] };
+}
+
+export interface StartOptions {
+  /** Port for WebSocket server */
+  port?: number;
+  /** Extra args to pass to the daemon */
+  extraArgs?: string[];
+}
+
+/**
+ * Start the remi daemon in the background.
+ * Returns the PID of the spawned process.
+ */
+export function startDaemon(opts?: StartOptions): number {
+  const existingPid = getRunningDaemonPid();
+  if (existingPid) {
+    const status = readStatus();
+    const port = status?.['wsPort'] ?? 'unknown';
+    console.error(`Daemon already running (PID ${existingPid}, port ${port}).`);
+    console.error('Use `remi stop` to stop it first.');
+    process.exit(1);
+  }
+
+  const { command, baseArgs } = resolveRemiCommand();
+  const logPath = daemonLogFile();
+
+  // Build args: [script-if-needed] --daemon [--port N] [extra...]
+  const spawnArgs = [...baseArgs, '--daemon'];
+  if (opts?.port) {
+    spawnArgs.push('--port', String(opts.port));
+  }
+  if (opts?.extraArgs) {
+    spawnArgs.push(...opts.extraArgs);
+  }
+
+  // Open log file for stdout/stderr redirection
+  const logFd = fs.openSync(logPath, 'a');
+  fs.writeSync(logFd, `\n--- Daemon starting at ${new Date().toISOString()} ---\n`);
+
+  // Spawn detached process
+  const child = spawn(command, spawnArgs, {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: { ...process.env },
+  });
+
+  const pid = child.pid;
+  if (!pid) {
+    console.error('Failed to start daemon process.');
+    fs.closeSync(logFd);
+    process.exit(1);
+  }
+
+  // Write PID file
+  fs.writeFileSync(pidFile(), String(pid), 'utf-8');
+
+  // Detach from parent so the daemon survives
+  child.unref();
+  fs.closeSync(logFd);
+
+  // Wait briefly for the daemon to initialize and write status.json
+  const startTime = Date.now();
+  const timeout = 5000;
+  let port: number | string = 'unknown';
+
+  while (Date.now() - startTime < timeout) {
+    const status = readStatus();
+    if (status && status['pid'] === pid && status['wsPort']) {
+      port = status['wsPort'] as number;
+      break;
+    }
+    // Verify the process is still alive
+    try {
+      process.kill(pid, 0);
+    } catch {
+      console.error('Daemon process exited unexpectedly. Check logs:');
+      console.error(`  ${logPath}`);
+      try {
+        fs.unlinkSync(pidFile());
+      } catch {
+        // ignore
+      }
+      process.exit(1);
+    }
+    // Small sync sleep to avoid busy loop
+    execFileSync('sleep', ['0.1']);
+  }
+
+  console.log(`Daemon started (PID ${pid}, port ${port}).`);
+  console.log(`Logs: ${logPath}`);
+  return pid;
+}
+
+/**
+ * Stop the running remi daemon.
+ */
+export function stopDaemon(): void {
+  const pid = getRunningDaemonPid();
+  if (!pid) {
+    console.error('No running daemon found.');
+    process.exit(1);
+  }
+
+  console.log(`Stopping daemon (PID ${pid})...`);
+
+  // Send SIGTERM for graceful shutdown
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to send SIGTERM: ${msg}`);
+    process.exit(1);
+  }
+
+  // Wait for the process to exit (up to 5 seconds)
+  const startTime = Date.now();
+  const timeout = 5000;
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      process.kill(pid, 0);
+      // Still running; wait
+      execFileSync('sleep', ['0.2']);
+    } catch {
+      // Process exited
+      cleanupFiles();
+      console.log('Daemon stopped.');
+      return;
+    }
+  }
+
+  // Force kill if still running
+  console.error('Daemon did not stop gracefully; sending SIGKILL...');
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already dead
+  }
+  cleanupFiles();
+  console.log('Daemon killed.');
+}
+
+/**
+ * Show daemon status.
+ */
+export function showDaemonStatus(): void {
+  const pid = getRunningDaemonPid();
+  if (!pid) {
+    console.log('Daemon is not running.');
+    return;
+  }
+
+  const status = readStatus();
+  if (status && status['pid'] === pid) {
+    console.log(`Daemon running (PID ${pid})`);
+    console.log(`  Port: ${status['wsPort']}`);
+    console.log(`  Connections: ${status['connections']}`);
+    console.log(`  Status: ${status['sessionStatus']}`);
+    const adapters = status['adapters'];
+    if (Array.isArray(adapters) && adapters.length > 0) {
+      console.log(`  Adapters: ${adapters.join(', ')}`);
+    }
+  } else {
+    console.log(`Daemon running (PID ${pid}), no status info available.`);
+  }
+
+  console.log(`  Logs: ${daemonLogFile()}`);
+}
+
+/**
+ * Show recent daemon log output.
+ */
+export function showDaemonLogs(lines = 50): void {
+  const logPath = daemonLogFile();
+  try {
+    const content = fs.readFileSync(logPath, 'utf-8');
+    const allLines = content.split('\n');
+    const tail = allLines.slice(-lines);
+    console.log(tail.join('\n'));
+  } catch {
+    console.error(`No daemon log found at ${logPath}`);
+  }
+}
+
+function cleanupFiles(): void {
+  try {
+    fs.unlinkSync(pidFile());
+  } catch {
+    // ignore
+  }
+  try {
+    fs.unlinkSync(statusFile());
+  } catch {
+    // ignore
+  }
+}

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getRunningDaemonPid } from '../../src/cli/daemon-manager.ts';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
+
+describe('getRunningDaemonPid', () => {
+  afterEach(() => {
+    // Clean up test PID files
+    try {
+      if (fs.existsSync(PID_FILE)) {
+        const content = fs.readFileSync(PID_FILE, 'utf-8').trim();
+        const pid = Number.parseInt(content, 10);
+        // Only clean up if it's a fake PID we created
+        if (pid === 999999) {
+          fs.unlinkSync(PID_FILE);
+        }
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  test('returns null when no PID file exists', () => {
+    // Rename existing PID file if present to avoid interference
+    const backup = `${PID_FILE}.backup`;
+    let hadExisting = false;
+    try {
+      if (fs.existsSync(PID_FILE)) {
+        fs.renameSync(PID_FILE, backup);
+        hadExisting = true;
+      }
+    } catch {
+      // ignore
+    }
+
+    try {
+      const pid = getRunningDaemonPid();
+      // Could be null (no file) or a real PID if daemon is running
+      // When we removed the file, it should be null
+      expect(pid).toBeNull();
+    } finally {
+      if (hadExisting) {
+        try {
+          fs.renameSync(backup, PID_FILE);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  });
+
+  test('returns null for stale PID file with non-running process', () => {
+    // Write a PID that definitely doesn't exist
+    fs.mkdirSync(REMI_DIR, { recursive: true });
+    fs.writeFileSync(PID_FILE, '999999', 'utf-8');
+    const pid = getRunningDaemonPid();
+    expect(pid).toBeNull();
+    // Should have cleaned up the stale file
+    expect(fs.existsSync(PID_FILE)).toBe(false);
+  });
+
+  test('returns null for invalid PID file content', () => {
+    fs.mkdirSync(REMI_DIR, { recursive: true });
+    fs.writeFileSync(PID_FILE, 'not-a-number', 'utf-8');
+    const pid = getRunningDaemonPid();
+    expect(pid).toBeNull();
+  });
+
+  test('returns PID for running process', () => {
+    // Use our own PID as a known-running process
+    fs.mkdirSync(REMI_DIR, { recursive: true });
+    const ourPid = process.pid;
+    fs.writeFileSync(PID_FILE, String(ourPid), 'utf-8');
+    const pid = getRunningDaemonPid();
+    expect(pid).toBe(ourPid);
+    // Clean up
+    fs.unlinkSync(PID_FILE);
+  });
+});


### PR DESCRIPTION
## Summary

- `remi start` launches the daemon in the background (detached process, stdout/stderr to daemon.log)
- `remi stop` sends SIGTERM for graceful shutdown (5s timeout, then SIGKILL)
- `remi status` shows PID, port, connections, adapters
- `remi logs` shows recent daemon log output
- PID tracked in ~/.remi/daemon.pid, daemon status in daemon-status.json (separate from wrapper mode's status.json)
- All daemon flags forwarded: --port, --bind, --auth, --no-relay, etc.

## Changes

- `packages/daemon/src/cli.ts`: Add start/stop/status/logs subcommands, daemon mode writes to daemon-status.json
- `packages/daemon/src/cli/daemon-manager.ts`: New module for daemon lifecycle management
- `packages/daemon/tests/cli/daemon-manager.test.ts`: Tests for PID file management

## Test plan

- [x] 917 tests pass
- [x] `remi start --port 19999 --local` starts daemon, shows PID and port
- [x] `remi status` shows running daemon info (PID, port, connections, adapters)
- [x] `remi start` when already running shows error with PID
- [x] `remi stop` gracefully shuts down daemon
- [x] `remi status` after stop shows "not running"
- [x] `remi logs` shows daemon log output
- [x] Stale PID file (non-running process) is cleaned up automatically

Fixes #53