### PR TITLE
fix: attach scrollback and duplicate permission prompts

### DIFF
--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -40,6 +40,8 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let resolved = false;
   let outputBroken = false;
   let authInProgress = false;
+  let receivedRawPty = false;
+  let rawPtyTimer: ReturnType<typeof setTimeout> | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -55,6 +57,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   }
 
   function restoreTerminal(): void {
+    if (rawPtyTimer) {
+      clearTimeout(rawPtyTimer);
+      rawPtyTimer = null;
+    }
     if (resizeNudgeTimer) {
       clearTimeout(resizeNudgeTimer);
       resizeNudgeTimer = null;
@@ -63,8 +69,11 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     if (attachedSessionId) {
       try {
         fs.writeSync(outputFd, '\n');
-      } catch {
-        // ignore write errors during cleanup
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'EBADF' && code !== 'EPIPE') {
+          process.stderr.write(`[remi] warning: cleanup write failed: ${code ?? err}\n`);
+        }
       }
     }
     if (rawModeSet && process.stdin.isTTY) {
@@ -121,6 +130,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   function renderMessage(msg: ProtocolMessage): void {
     switch (msg.type) {
       case 'raw_pty_output':
+        receivedRawPty = true;
         writeRawBytes(msg.data);
         break;
       case 'agent_output':
@@ -223,6 +233,16 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
             sendMessage(createTerminalResize(cols, rows));
           }, 50);
         }
+
+        // Warn if no raw PTY data arrives within a few seconds
+        rawPtyTimer = setTimeout(() => {
+          rawPtyTimer = null;
+          if (!receivedRawPty && !resolved) {
+            process.stderr.write(
+              '[remi] warning: no raw PTY output received; session may not be producing terminal data\n',
+            );
+          }
+        }, 3000);
 
         return;
       }

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -59,15 +59,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       clearTimeout(resizeNudgeTimer);
       resizeNudgeTimer = null;
     }
-    // Exit alternate screen buffer (restores original terminal content)
+    // Print a newline after detach so the user's shell prompt starts clean
     if (attachedSessionId) {
       try {
-        fs.writeSync(outputFd, '\x1b[?1049l');
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code !== 'EBADF' && code !== 'EPIPE') {
-          process.stderr.write(`[remi] warning: failed to exit alternate screen: ${code ?? err}\n`);
-        }
+        fs.writeSync(outputFd, '\n');
+      } catch {
+        // ignore write errors during cleanup
       }
     }
     if (rawModeSet && process.stdin.isTTY) {
@@ -128,15 +125,11 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         break;
       case 'agent_output':
       case 'structured_agent_output':
-        writeOutput(msg.message.content);
+        // Suppress structured output; the raw PTY output already shows everything
         break;
       case 'question':
-        writeOutput(`\n? ${msg.question.text}\n`);
-        if (msg.question.options) {
-          for (const opt of msg.question.options) {
-            writeOutput(`  ${opt.label}\n`);
-          }
-        }
+        // Suppress structured question messages; the raw PTY output already
+        // contains the interactive prompt from Claude Code's TUI
         break;
       case 'session_update':
         // Suppress status badges (raw PTY output provides the full terminal view)
@@ -188,9 +181,9 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         attachedSessionId = msg.sessionId;
         const shortId = msg.sessionId.slice(0, 8);
 
-        // Enter alternate screen buffer (like tmux) first, then show banner
-        // inside the alternate buffer so it doesn't persist in scrollback
-        writeOutput('\x1b[?1049h\x1b[2J\x1b[H');
+        // Clear screen and home cursor; we stay in the primary screen buffer
+        // so the user's terminal emulator provides native scrollback
+        writeOutput('\x1b[2J\x1b[H');
         writeOutput(`[attached to session ${shortId}] (Ctrl+B d to detach)\n`);
 
         // Enter raw terminal mode

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -125,22 +125,15 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         break;
       case 'agent_output':
       case 'structured_agent_output':
-        // Suppress structured output; the raw PTY output already shows everything
-        break;
       case 'question':
-        // Suppress structured question messages; the raw PTY output already
-        // contains the interactive prompt from Claude Code's TUI
-        break;
       case 'session_update':
-        // Suppress status badges (raw PTY output provides the full terminal view)
+      case 'transcript_content':
+        // Suppressed; raw PTY output already provides the full terminal view
         break;
       case 'replay_batch':
         for (const m of msg.messages) {
           renderMessage(m);
         }
-        break;
-      case 'transcript_content':
-        // Suppress transcript content (raw PTY output provides the full terminal view)
         break;
       case 'error':
         writeOutput(`\n[error: ${msg.code} - ${msg.message}]\n`);

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -115,7 +115,7 @@ describe('runAttachClient', () => {
     expect(result.reason).toBe('connection_closed');
   });
 
-  test('renders replay batch messages', async () => {
+  test('suppresses agent_output in replay batch (raw PTY provides full view)', async () => {
     setupOutput();
     const targetSessionId = generateId();
 
@@ -156,7 +156,8 @@ describe('runAttachClient', () => {
     });
 
     const output = readOutput();
-    expect(output).toContain('Hello from replay');
+    // agent_output is suppressed in terminal attach mode; raw PTY provides the view
+    expect(output).not.toContain('Hello from replay');
   });
 
   test('returns error when server is not running', async () => {
@@ -264,7 +265,7 @@ describe('runAttachClient', () => {
     expect(pongMsg).toBeTruthy();
   });
 
-  test('renders question with options', async () => {
+  test('suppresses question messages (raw PTY provides the interactive prompt)', async () => {
     setupOutput();
     const targetSessionId = generateId();
     const question: Question = {
@@ -312,8 +313,8 @@ describe('runAttachClient', () => {
     });
 
     const output = readOutput();
-    expect(output).toContain('Allow file edit?');
-    expect(output).toContain('Yes');
-    expect(output).toContain('No');
+    // Question messages are suppressed in terminal attach mode;
+    // the raw PTY output already contains the interactive prompt
+    expect(output).not.toContain('Allow file edit?');
   });
 });


### PR DESCRIPTION
## Summary

- Remove alternate screen buffer from attach client; use clear screen instead so the user's terminal provides native scrollback
- Suppress `question`, `agent_output`, and `structured_agent_output` protocol messages in terminal attach mode since the raw PTY output already contains the full interactive view
- Update tests to verify suppression behavior

Fixes #56

## Test plan

- [x] 917 tests pass, 0 failures
- [ ] Manual test: attach to session, scroll up to see previous output
- [ ] Manual test: permission prompt appears only once (from raw PTY)