### PR TITLE
fix: post-sprint review fixes

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1,15 +1,9 @@
 #!/usr/bin/env bun
 /**
- * Remi CLI - Transparent wrapper around Claude Code.
+ * Remi CLI entry point.
  *
- * Usage:
- *   remi [claude-args...]          Start Claude with remote monitoring
- *   remi --resume [session-id]     Resume a previous session
- *   remi --sessions                List stored sessions
- *   remi --daemon                  Legacy daemon mode (no local PTY)
- *
- * The wrapper spawns Claude immediately, passes through stdin/stdout,
- * and runs a WebSocket server silently for remote phone/browser monitoring.
+ * Routes subcommands (ls, attach, kill, start, stop, status, logs, new)
+ * and wraps Claude Code in the default mode. See --help for full usage.
  */
 
 import * as fs from 'node:fs';
@@ -23,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     return pkg.version as string;
   } catch {
-    return '0.1.0';
+    return '0.3.5';
   }
 })();
 
@@ -1806,6 +1800,15 @@ const sharedEvents = {
 
     const sessionName = session.name;
     log(`Killing session: ${sessionName} (${sessionId})`);
+
+    // Notify attached client before destroying the session
+    if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
+      sendToConnection(
+        session.activeConnectionId,
+        createError('SESSION_ENDED', 'Session killed by remote request'),
+      );
+    }
+
     sessionRegistry.closeSession(sessionId, 'forced');
     sendToConnection(connectionId, createKillSessionResponse(true, requestId));
     log(`Session killed: ${sessionName}`);

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -196,7 +196,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         }
         process.stdin.resume();
 
-        // Use DetachScanner for Ctrl+B d detection (supports both legacy
+        // Use DetachScanner for Ctrl+B d detection (supports both standard
         // raw byte 0x02 and kitty keyboard protocol ESC[98;5u)
         detachScannerInstance = new DetachScanner({
           onDetach: () => {

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -139,17 +139,6 @@ export function startDaemon(opts?: StartOptions): number {
     process.exit(1);
   }
 
-  child.on('error', (err) => {
-    console.error(`Failed to start daemon: ${err.message}`);
-    try {
-      fs.unlinkSync(PID_FILE);
-    } catch {
-      // PID file may not exist yet
-    }
-    fs.closeSync(logFd);
-    process.exit(1);
-  });
-
   try {
     const fd = fs.openSync(PID_FILE, 'wx');
     fs.writeSync(fd, String(pid));

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -3,7 +3,7 @@
  *
  * Uses child_process.spawn with detached:true to launch remi --daemon
  * in the background. Tracks the daemon via a PID file (~/.remi/daemon.pid).
- * The status.json file provides additional runtime info.
+ * The daemon-status.json file provides additional runtime info.
  */
 
 import { execSync, spawn } from 'node:child_process';
@@ -25,23 +25,33 @@ function ensureRemiDir(): void {
  * Returns null if no PID file exists or the process is not running.
  */
 export function getRunningDaemonPid(): number | null {
+  let content: string;
   try {
-    const content = fs.readFileSync(PID_FILE, 'utf-8').trim();
-    const pid = Number.parseInt(content, 10);
-    if (Number.isNaN(pid) || pid <= 0) return null;
-
-    try {
-      process.kill(pid, 0);
-      return pid;
-    } catch {
-      try {
-        fs.unlinkSync(PID_FILE);
-      } catch {
-        // ignore cleanup errors
-      }
-      return null;
+    content = fs.readFileSync(PID_FILE, 'utf-8').trim();
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error(`Warning: cannot read PID file: ${code ?? err}`);
     }
+    return null;
+  }
+
+  const pid = Number.parseInt(content, 10);
+  if (Number.isNaN(pid) || pid <= 0) return null;
+
+  try {
+    process.kill(pid, 0);
+    return pid;
   } catch {
+    // Process not running; clean up stale PID file
+    try {
+      fs.unlinkSync(PID_FILE);
+    } catch (unlinkErr) {
+      const code = (unlinkErr as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        console.error(`Warning: cannot remove stale PID file: ${code}`);
+      }
+    }
     return null;
   }
 }
@@ -50,7 +60,13 @@ function readStatus(): Record<string, unknown> | null {
   try {
     const content = fs.readFileSync(STATUS_FILE, 'utf-8');
     return JSON.parse(content) as Record<string, unknown>;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error(
+        `Warning: cannot read status file: ${err instanceof Error ? err.message : err}`,
+      );
+    }
     return null;
   }
 }
@@ -101,7 +117,7 @@ export function startDaemon(opts?: StartOptions): number {
 
   const { command, baseArgs } = resolveRemiCommand();
   const spawnArgs = [...baseArgs, '--daemon'];
-  if (opts?.port) {
+  if (opts?.port !== undefined) {
     spawnArgs.push('--port', String(opts.port));
   }
   if (opts?.extraArgs) {
@@ -123,6 +139,17 @@ export function startDaemon(opts?: StartOptions): number {
     process.exit(1);
   }
 
+  child.on('error', (err) => {
+    console.error(`Failed to start daemon: ${err.message}`);
+    try {
+      fs.unlinkSync(PID_FILE);
+    } catch {
+      // PID file may not exist yet
+    }
+    fs.closeSync(logFd);
+    process.exit(1);
+  });
+
   try {
     const fd = fs.openSync(PID_FILE, 'wx');
     fs.writeSync(fd, String(pid));
@@ -140,7 +167,7 @@ export function startDaemon(opts?: StartOptions): number {
   child.unref();
   fs.closeSync(logFd);
 
-  // Poll until daemon writes status.json or times out
+  // Poll until daemon writes daemon-status.json or times out
   const startTime = Date.now();
   const timeout = 5000;
   let port: number | string = 'unknown';
@@ -159,14 +186,21 @@ export function startDaemon(opts?: StartOptions): number {
       try {
         fs.unlinkSync(PID_FILE);
       } catch {
-        // ignore
+        // PID file may already be cleaned up
       }
       process.exit(1);
     }
     Bun.sleepSync(100);
   }
 
-  console.log(`Daemon started (PID ${pid}, port ${port}).`);
+  if (port === 'unknown') {
+    console.log(
+      `Daemon started (PID ${pid}) but did not report its port within ${timeout / 1000}s.`,
+    );
+    console.log('The daemon may still be initializing. Check status with: remi status');
+  } else {
+    console.log(`Daemon started (PID ${pid}, port ${port}).`);
+  }
   console.log(`Logs: ${LOG_FILE}`);
   return pid;
 }
@@ -206,8 +240,13 @@ export function stopDaemon(): void {
   console.error('Daemon did not stop gracefully; sending SIGKILL...');
   try {
     process.kill(pid, 'SIGKILL');
-  } catch {
-    // Already dead
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ESRCH') {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Warning: SIGKILL failed: ${msg}`);
+      console.error('The daemon process may still be running.');
+    }
   }
   Bun.sleepSync(200);
   cleanupFiles();
@@ -239,24 +278,28 @@ export function showDaemonStatus(): void {
 }
 
 export function showDaemonLogs(lines = 50): void {
+  if (!fs.existsSync(LOG_FILE)) {
+    console.error(`No daemon log found at ${LOG_FILE}`);
+    return;
+  }
   try {
-    fs.accessSync(LOG_FILE, fs.constants.R_OK);
     const output = execSync(`tail -n ${lines} "${LOG_FILE}"`, { encoding: 'utf-8' });
     console.log(output);
-  } catch {
-    console.error(`No daemon log found at ${LOG_FILE}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to read daemon log: ${msg}`);
   }
 }
 
 function cleanupFiles(): void {
-  try {
-    fs.unlinkSync(PID_FILE);
-  } catch {
-    // ignore
-  }
-  try {
-    fs.unlinkSync(STATUS_FILE);
-  } catch {
-    // ignore
+  for (const file of [PID_FILE, STATUS_FILE]) {
+    try {
+      fs.unlinkSync(file);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        console.error(`Warning: could not remove ${path.basename(file)}: ${code}`);
+      }
+    }
   }
 }

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -165,6 +165,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
         return;
       }
 
+      if (authInProgress) return;
       handleMessage(msg);
     };
 

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -68,7 +68,15 @@ export function getTailscalePeers(): VpnPeer[] {
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    const status = JSON.parse(raw) as TailscaleStatus;
+    let status: TailscaleStatus;
+    try {
+      status = JSON.parse(raw) as TailscaleStatus;
+    } catch {
+      console.error(
+        '[vpn-discovery] Tailscale returned invalid JSON; check `tailscale status --json`',
+      );
+      return [];
+    }
     if (!status.Peer) return [];
 
     const peers: VpnPeer[] = [];

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -63,7 +63,7 @@ export interface SessionRegistryEvents {
 export interface ManagedSession {
   /** Unique session ID */
   readonly sessionId: UUID;
-  /** Human-readable session name (e.g. "hostname/project/branch") */
+  /** Human-readable session name (e.g. "hostname:dirname/branch") */
   readonly name: string;
   /** When session was created */
   readonly createdAt: Timestamp;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -6,9 +6,8 @@
  *
  * Protocol guarantees:
  * - Every message has a unique ID
- * - Every message gets an acknowledgment
+ * - Messages are acknowledged at the application level (e.g. hello -> hello_ack)
  * - Messages are ordered within a session
- * - Duplicates are detected and ignored (but still acked)
  */
 
 import type {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -45,8 +45,8 @@ function loadSettings(): AppSettings {
   try {
     const stored = localStorage.getItem(LOCALSTORAGE_SETTINGS_KEY);
     if (stored) return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
-  } catch {
-    /* use defaults */
+  } catch (err) {
+    console.warn('Failed to load settings, using defaults:', err);
   }
   return DEFAULT_SETTINGS;
 }
@@ -59,6 +59,46 @@ function applyTheme(theme: AppSettings['theme']) {
   } else {
     root.setAttribute('data-theme', theme);
   }
+}
+
+/** Convert shared Bullet[] to UIBullet[] */
+function toBullets(bullets: readonly Bullet[]): UIBullet[] {
+  return bullets.map((b) => ({
+    bulletId: b.bulletId,
+    type: b.type,
+    content: b.content,
+    originalNumber: b.originalNumber,
+    startLine: b.startLine,
+    endLine: b.endLine,
+    hasCodeBlock: b.hasCodeBlock,
+    isTruncated: b.isTruncated,
+    fullLength: b.fullLength,
+  }));
+}
+
+/** Map DiscoverableSession status to UISession agent status */
+function mapSessionStatus(status: string): 'executing' | 'idle' {
+  return status === 'active' ? 'executing' : 'idle';
+}
+
+/** Update a session's last-active time, clear questionPending, and bump unread if not active */
+function updateSessionActivity(
+  sessions: UISession[],
+  sessionId: UUID,
+  activeId: UUID | null,
+  preview?: string,
+): UISession[] {
+  return sessions.map((s) =>
+    s.id === sessionId
+      ? {
+          ...s,
+          lastActiveAt: new Date().toISOString(),
+          questionPending: false,
+          unreadCount: s.id === activeId ? s.unreadCount : s.unreadCount + 1,
+          preview: preview?.slice(0, 80) || s.preview,
+        }
+      : s,
+  );
 }
 
 function App() {
@@ -134,18 +174,7 @@ function App() {
         const { sessionId, entryUuid, role, content, isUpdate } = message;
         const structuredMsg = message.message;
 
-        // Convert bullets
-        const uiBullets: UIBullet[] = structuredMsg.bullets.map((b: Bullet) => ({
-          bulletId: b.bulletId,
-          type: b.type,
-          content: b.content,
-          originalNumber: b.originalNumber,
-          startLine: b.startLine,
-          endLine: b.endLine,
-          hasCodeBlock: b.hasCodeBlock,
-          isTruncated: b.isTruncated,
-          fullLength: b.fullLength,
-        }));
+        const uiBullets = toBullets(structuredMsg.bullets);
 
         setMessages((prev) => {
           // Dedup by entryUuid
@@ -214,21 +243,8 @@ function App() {
           return [...prev, uiMessage];
         });
 
-        // Update session last active time and increment unread if not the active session
-        // Also clear questionPending since new content means the question was resolved
         setSessions((prev) =>
-          prev.map((s) =>
-            s.id === sessionId
-              ? {
-                  ...s,
-                  lastActiveAt: new Date().toISOString(),
-                  questionPending: false,
-                  unreadCount:
-                    s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
-                  preview: structuredMsg.content?.slice(0, 80) || s.preview,
-                }
-              : s,
-          ),
+          updateSessionActivity(prev, sessionId, activeSessionIdRef.current, structuredMsg.content),
         );
         break;
       }
@@ -237,17 +253,7 @@ function App() {
         // Handle structured message with bullets (from PTY stream)
         const structuredMsg = message.message;
 
-        const uiBullets: UIBullet[] = structuredMsg.bullets.map((b: Bullet) => ({
-          bulletId: b.bulletId,
-          type: b.type,
-          content: b.content,
-          originalNumber: b.originalNumber,
-          startLine: b.startLine,
-          endLine: b.endLine,
-          hasCodeBlock: b.hasCodeBlock,
-          isTruncated: b.isTruncated,
-          fullLength: b.fullLength,
-        }));
+        const uiBullets = toBullets(structuredMsg.bullets);
 
         setMessages((prev) => {
           // Same-type dedup by message ID (streaming updates)
@@ -297,17 +303,11 @@ function App() {
         });
 
         setSessions((prev) =>
-          prev.map((s) =>
-            s.id === structuredMsg.sessionId
-              ? {
-                  ...s,
-                  lastActiveAt: new Date().toISOString(),
-                  questionPending: false,
-                  unreadCount:
-                    s.id === activeSessionIdRef.current ? s.unreadCount : s.unreadCount + 1,
-                  preview: structuredMsg.content?.slice(0, 80) || s.preview,
-                }
-              : s,
+          updateSessionActivity(
+            prev,
+            structuredMsg.sessionId,
+            activeSessionIdRef.current,
+            structuredMsg.content,
           ),
         );
         break;
@@ -380,14 +380,7 @@ function App() {
           name: ds.name || ds.projectPath.split('/').pop() || 'Session',
           createdAt: ds.lastActivity,
           lastActiveAt: ds.lastActivity,
-          status:
-            ds.status === 'active'
-              ? ('executing' as const)
-              : ds.status === 'idle'
-                ? ('idle' as const)
-                : ds.status === 'orphaned'
-                  ? ('idle' as const)
-                  : ('idle' as const),
+          status: mapSessionStatus(ds.status),
           connectionStatus: ds.canAttach ? ('connected' as const) : ('disconnected' as const),
           unreadCount: 0,
           cwd: ds.projectPath,
@@ -792,7 +785,7 @@ function App() {
               // (harmless if auth is required; daemon drops it and sends
               // auth_challenge first, then hello_ack after auth completes)
               const resumeId = activeSessionIdRef.current ?? undefined;
-              client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
+              client.sendMessage(createHello(generateId(), '0.1.0', undefined, resumeId));
             } else if (state === 'connecting' || state === 'joined') {
               setRelayStatus('connecting');
             } else if (state === 'disconnected' || state === 'error') {
@@ -892,7 +885,7 @@ function App() {
 
                   // Auth succeeded; now send hello so the daemon creates our session
                   const resumeId = activeSessionIdRef.current ?? undefined;
-                  client.sendMessage(createHello('remi-web', '0.1.0', undefined, resumeId));
+                  client.sendMessage(createHello(generateId(), '0.1.0', undefined, resumeId));
                 } catch (err) {
                   const detail = err instanceof Error ? err.message : String(err);
                   setError(new Error(`Server verification failed: ${detail}`));

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -102,6 +102,50 @@ function BulletItem({
   );
 }
 
+/** Renders the inner content of a message bubble based on mode and content type */
+function MessageContent({
+  message,
+  enhanced,
+  hasBullets,
+  isUser,
+  onBulletExpand,
+}: {
+  readonly message: UIMessage;
+  readonly enhanced: boolean;
+  readonly hasBullets: boolean;
+  readonly isUser: boolean;
+  readonly onBulletExpand?: (bulletId: number) => void;
+}) {
+  if (message.isStreaming) {
+    return (
+      <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+        {message.streamedContent}
+        <span className="ml-0.5 inline-block size-1.5 animate-pulse rounded-full bg-current" />
+      </div>
+    );
+  }
+
+  if (hasBullets) {
+    return (
+      <div className="space-y-2">
+        {message.bullets!.map((bullet) => (
+          <BulletItem key={bullet.bulletId} bullet={bullet} onExpand={onBulletExpand} />
+        ))}
+      </div>
+    );
+  }
+
+  if (enhanced) {
+    return <ChatMessage content={message.content} isUser={isUser} />;
+  }
+
+  return (
+    <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+      {message.content}
+    </div>
+  );
+}
+
 export function MessageBubble({
   message,
   showTimestamp = true,
@@ -135,11 +179,11 @@ export function MessageBubble({
   }
 
   // Sender label for enhanced chat mode
-  const senderLabel = enhanced && !isUser && !isSystem
-    ? 'Claude'
-    : enhanced && isUser
-      ? 'You'
-      : null;
+  let senderLabel: string | null = null;
+  if (enhanced) {
+    if (isUser) senderLabel = 'You';
+    else if (!isSystem) senderLabel = 'Claude';
+  }
 
   return (
     <div
@@ -183,33 +227,13 @@ export function MessageBubble({
 
         {/* Message content */}
         <div className={clsx(isUser ? 'text-white' : 'text-[--color-text]')}>
-          {message.isStreaming ? (
-            <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
-              {message.streamedContent}
-              <span className="ml-0.5 inline-block size-1.5 animate-pulse rounded-full bg-current" />
-            </div>
-          ) : enhanced ? (
-            /* Enhanced chat mode: parsed content with code blocks and markdown */
-            hasBullets ? (
-              <div className="space-y-2">
-                {message.bullets!.map((bullet) => (
-                  <BulletItem key={bullet.bulletId} bullet={bullet} onExpand={onBulletExpand} />
-                ))}
-              </div>
-            ) : (
-              <ChatMessage content={message.content} isUser={isUser} />
-            )
-          ) : hasBullets ? (
-            <div className="space-y-2">
-              {message.bullets!.map((bullet) => (
-                <BulletItem key={bullet.bulletId} bullet={bullet} onExpand={onBulletExpand} />
-              ))}
-            </div>
-          ) : (
-            <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
-              {message.content}
-            </div>
-          )}
+          <MessageContent
+            message={message}
+            enhanced={enhanced}
+            hasBullets={!!hasBullets}
+            isUser={isUser}
+            onBulletExpand={onBulletExpand}
+          />
         </div>
 
         {/* Footer: timestamp and status */}

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -267,6 +267,30 @@ function AnsweredCard({
   );
 }
 
+/** Render the appropriate answer UI based on question type and state */
+function AnswerArea({
+  question,
+  isAnswered,
+  onAnswer,
+}: {
+  readonly question: UIQuestion;
+  readonly isAnswered: boolean;
+  readonly onAnswer: (answer: string) => void;
+}) {
+  if (isAnswered) return <AnsweredCard question={question} />;
+
+  switch (question.type) {
+    case 'yes_no':
+      return <YesNoCard question={question} onAnswer={onAnswer} />;
+    case 'multi_option':
+      return <MultiOptionCard question={question} onAnswer={onAnswer} />;
+    case 'numbered':
+      return <NumberedCard question={question} onAnswer={onAnswer} />;
+    default:
+      return <FreeTextCard onAnswer={onAnswer} />;
+  }
+}
+
 export function QuestionCard({ question, onAnswer, className }: QuestionCardProps) {
   const isAnswered = question.answeredWith != null;
 
@@ -287,17 +311,7 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
       </div>
 
       {/* Answer area */}
-      {isAnswered ? (
-        <AnsweredCard question={question} />
-      ) : question.type === 'yes_no' ? (
-        <YesNoCard question={question} onAnswer={onAnswer} />
-      ) : question.type === 'multi_option' ? (
-        <MultiOptionCard question={question} onAnswer={onAnswer} />
-      ) : question.type === 'numbered' ? (
-        <NumberedCard question={question} onAnswer={onAnswer} />
-      ) : (
-        <FreeTextCard onAnswer={onAnswer} />
-      )}
+      <AnswerArea question={question} isAnswered={isAnswered} onAnswer={onAnswer} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Comprehensive review of all changes from the Phase 2-3 sprint (PRs #52, #55, #59, #61, #62, #63). Five review agents ran in parallel against the full diff (40 files, ~3600 lines). All findings addressed.

### Error handling (daemon-manager.ts, vpn-discovery.ts, App.tsx)
- Replace overly broad `catch {}` blocks with ENOENT-specific handling throughout daemon-manager
- Add `child.on('error')` handler for spawn failures in startDaemon
- SIGKILL catch now distinguishes ESRCH (process dead) from EPERM (permission denied)
- Separate JSON parse error in VPN discovery with actionable error message
- Log warning on settings parse failure in web app

### Bug fixes (cli.ts, App.tsx, kill-client.ts)
- Notify attached client with SESSION_ENDED before destroying a killed session
- Use proper UUID for clientId in web app relay connect (was hardcoded string 'remi-web')
- Add missing `authInProgress` guard in kill-client message handler
- Port 0 no longer silently dropped in daemon start options

### Comment accuracy (cli.ts, daemon-manager.ts, protocol.ts, session-registry.ts)
- Update file-level comments to reflect current subcommands and file names
- Fix session name format in JSDoc (colon-separated, not slash)
- Correct misleading "every message gets ack" protocol claim
- Update version fallback from 0.1.0 to 0.3.5

### Code simplification (App.tsx, MessageBubble.tsx, QuestionCard.tsx)
- Extract shared helpers to eliminate duplicated bullet mapping and session update logic
- Replace nested ternaries with named components and switch statements

## Test plan

- [x] 917 tests pass, 0 failures
- [x] TypeScript compiles cleanly (tsc --noEmit)
- [x] Biome lint passes (pre-commit hook)