### PR TITLE
feat: multi-session discovery with auto-port and shared registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -37,7 +37,9 @@ const REMI_VERSION = (() => {
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const LOG_FILE = path.join(REMI_DIR, 'remi.log');
 const DAEMON_STATUS_FILE = path.join(REMI_DIR, 'daemon-status.json');
-const STATUS_FILE = path.join(REMI_DIR, 'status.json');
+// Status file is per-port so multiple wrapper sessions don't overwrite each other.
+// The statusline script uses $REMI_PORT to read the correct file.
+let STATUS_FILE = path.join(REMI_DIR, 'status.json'); // Updated after PORT is resolved
 let logFd: number | null = null;
 
 // In wrapper mode, we save the real stdout file descriptor before overriding.
@@ -160,9 +162,10 @@ function cleanupStatusFile(): void {
 const STATUSLINE_SCRIPT = `#!/bin/bash
 input=$(cat)
 REMI=""
-# REMI_PORT is set by remi when spawning Claude; only show remi info for remi-managed sessions
-if [ -n "\$REMI_PORT" ] && [ -f "${STATUS_FILE}" ]; then
-  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // ""] | @tsv' "${STATUS_FILE}" 2>/dev/null)
+# REMI_PORT is set by remi when spawning Claude; status file is per-port
+REMI_STATUS_FILE="${REMI_DIR}/status-\$REMI_PORT.json"
+if [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
+  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // ""] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
   if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
     CLIENT_INFO="no clients"
     [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
@@ -233,7 +236,13 @@ import {
   generateId,
   now,
 } from '@remi/shared';
-import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
+import type {
+  AgentStatus,
+  DiscoverableSession,
+  ProtocolMessage,
+  UUID,
+  UnlockedIdentity,
+} from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
 import {
   type AdapterMetadata,
@@ -247,7 +256,14 @@ import { IdentityStore } from './auth/identity-store.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
 import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
-import { SessionRegistry, SessionStore, type StoredSession } from './session/index.ts';
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_PORT_RANGE,
+  SessionRegistry,
+  SessionRegistryFile,
+  SessionStore,
+  type StoredSession,
+} from './session/index.ts';
 import {
   TranscriptDiscovery,
   TranscriptMessageBridge,
@@ -743,22 +759,39 @@ if (
   process.exit(0);
 }
 
-// Handle 'ls' subcommand: query live sessions from running daemon
+// Live sessions registry: shared by subcommands and daemon/wrapper mode.
+// Instantiated early so subcommand handlers (ls, attach, kill) can use it.
+const liveSessionsRegistry = new SessionRegistryFile();
+
+// Handle 'ls' subcommand: query live sessions from running daemon(s)
 if (cliSubcommand === 'ls') {
-  const resolvedPort =
-    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+  const explicitPort =
+    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined);
   if (cliNetwork) {
     const { runNetworkLs } = await import('./cli/ls-client.ts');
     try {
-      await runNetworkLs({ localPort: resolvedPort });
+      await runNetworkLs({
+        localPort: explicitPort ?? DEFAULT_BASE_PORT,
+        localPorts: liveSessionsRegistry.getLivePorts(),
+      });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  } else if (explicitPort || cliHost) {
+    // Explicit host/port: query single daemon (original behavior)
+    const { runLsClient } = await import('./cli/ls-client.ts');
+    try {
+      await runLsClient({ host: cliHost ?? 'localhost', port: explicitPort ?? DEFAULT_BASE_PORT });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
   } else {
-    const { runLsClient } = await import('./cli/ls-client.ts');
+    // No explicit port: discover all local remi sessions via live registry
+    const { runMultiPortLs } = await import('./cli/ls-client.ts');
     try {
-      await runLsClient({ host: cliHost ?? 'localhost', port: resolvedPort });
+      await runMultiPortLs({ registry: liveSessionsRegistry });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
@@ -774,9 +807,20 @@ if (cliSubcommand === 'kill') {
     console.error('Run `remi ls` to see live sessions.');
     process.exit(1);
   }
-  const resolvedPort =
-    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+  let resolvedPort =
+    cliPort ??
+    (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : DEFAULT_BASE_PORT);
   const resolvedHost = cliHost ?? 'localhost';
+
+  // Resolve port from live registry if target matches a known session
+  if (!cliPort && !cliHost) {
+    const liveMatch =
+      liveSessionsRegistry.findByName(cliSubcommandArg) ??
+      liveSessionsRegistry.findBySessionId(cliSubcommandArg);
+    if (liveMatch) {
+      resolvedPort = liveMatch.wsPort;
+    }
+  }
 
   const { runKillClient } = await import('./cli/kill-client.ts');
   try {
@@ -837,38 +881,79 @@ if (cliSubcommand === 'attach') {
       process.exit(1);
     }
   } else if (!targetSessionId) {
-    // Auto-attach to most recent active (non-exited) session
-    const sessions = store.list();
-    const active = sessions.filter((s) => s.exitedAt === null);
-    if (active.length === 0) {
-      console.error('No active sessions found. Run `remi ls` to see live sessions.');
-      process.exit(1);
+    // Auto-attach: prefer live registry, fall back to session store
+    const liveSessions = liveSessionsRegistry.listLive();
+    if (liveSessions.length > 0) {
+      // Pick most recent live session
+      // biome-ignore lint/style/noNonNullAssertion: length checked above
+      const latest = liveSessions[0]!; // Already sorted by startedAt desc
+      targetSessionId = latest.sessionId;
+      resolvedPort = cliPort ?? latest.wsPort;
+    } else {
+      // Fall back to session store (for backward compat)
+      const sessions = store.list();
+      const active = sessions.filter((s) => s.exitedAt === null);
+      if (active.length === 0) {
+        console.error('No active sessions found. Run `remi ls` to see live sessions.');
+        process.exit(1);
+      }
+      const latest = active.reduce((a, b) =>
+        new Date(b.startedAt).getTime() > new Date(a.startedAt).getTime() ? b : a,
+      );
+      targetSessionId = latest.remiSessionId;
+      resolvedPort = cliPort ?? latest.port;
     }
-    // Pick the most recently started session
-    const latest = active.reduce((a, b) =>
-      new Date(b.startedAt).getTime() > new Date(a.startedAt).getTime() ? b : a,
-    );
-    targetSessionId = latest.remiSessionId;
-    resolvedPort = cliPort ?? latest.port;
   } else {
-    // Try name-based resolution first by querying the daemon
+    // Try name-based resolution: first check live registry for port, then query daemon(s)
     let resolvedByName = false;
+
+    // Check live registry for name match (fast, no network)
+    const liveMatch = liveSessionsRegistry.findByName(targetSessionId);
+    if (liveMatch) {
+      resolvedPort = cliPort ?? liveMatch.wsPort;
+    }
+
+    // Query all live ports (or single port if explicitly set) for session name resolution
+    const portsToQuery = cliPort || cliHost ? [resolvedPort] : liveSessionsRegistry.getLivePorts();
+
+    if (portsToQuery.length === 0) {
+      portsToQuery.push(resolvedPort); // fall back to default
+    }
+
     try {
       const { fetchSessions } = await import('./cli/ls-client.ts');
-      const sessions = await fetchSessions(resolvedHost, resolvedPort, 3000);
-      const nameMatches = sessions.filter(
-        (s) => s.name === targetSessionId || s.name?.startsWith(targetSessionId as string),
+      const allSessions: Array<{ session: DiscoverableSession; port: number }> = [];
+
+      const results = await Promise.allSettled(
+        portsToQuery.map(async (port) => {
+          const sessions = await fetchSessions(resolvedHost, port, 3000);
+          return sessions.map((s) => ({ session: s, port }));
+        }),
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          allSessions.push(...result.value);
+        }
+      }
+
+      const nameMatches = allSessions.filter(
+        (entry) =>
+          entry.session.name === targetSessionId ||
+          entry.session.name?.startsWith(targetSessionId as string),
       );
       if (nameMatches.length === 1) {
         // biome-ignore lint/style/noNonNullAssertion: length checked above
-        targetSessionId = nameMatches[0]!.sessionId;
+        const match = nameMatches[0]!;
+        targetSessionId = match.session.sessionId;
+        resolvedPort = cliPort ?? match.port;
         resolvedByName = true;
       } else if (nameMatches.length > 1) {
         console.error(
           `Ambiguous session name "${targetSessionId}" matches ${nameMatches.length} sessions:`,
         );
         for (const m of nameMatches) {
-          console.error(`  ${m.name ?? m.sessionId.slice(0, 8)}`);
+          console.error(`  ${m.session.name ?? m.session.sessionId.slice(0, 8)} (port ${m.port})`);
         }
         console.error('Provide a longer name to disambiguate.');
         process.exit(1);
@@ -1000,6 +1085,11 @@ if (cliSubcommand === 'attach') {
     }
   }
 
+  if (!targetSessionId) {
+    console.error('No session to attach to. Run `remi ls` to see live sessions.');
+    process.exit(1);
+  }
+
   const { runAttachClient } = await import('./cli/attach-client.ts');
   try {
     const result = await runAttachClient({
@@ -1085,8 +1175,24 @@ if (cliResume !== undefined) {
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-const PORT =
-  cliPort || (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+const portExplicitlySet = !!(cliPort || process.env['REMI_PORT']);
+let PORT = cliPort || (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 0);
+
+// Auto-select port if not explicitly set
+if (!portExplicitlySet) {
+  const autoPort = liveSessionsRegistry.findAvailablePort(DEFAULT_BASE_PORT, DEFAULT_PORT_RANGE);
+  if (autoPort === null) {
+    console.error(
+      `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,
+    );
+    console.error('Use --port to specify a different port, or stop an existing remi session.');
+    process.exit(1);
+  }
+  PORT = autoPort;
+}
+// Update per-port status file path now that PORT is finalized
+STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
+
 const MAX_BULLET_LENGTH =
   cliMaxBulletLength ??
   (process.env['REMI_MAX_BULLET_LENGTH']
@@ -1140,7 +1246,7 @@ const sessionRegistry = new SessionRegistry(
 let primarySessionId: UUID | null = null;
 
 // Hook infrastructure (initialized in wrapper mode when hooks are enabled)
-const HOOK_PORT = PORT + 1;
+const HOOK_PORT = PORT + 100; // Offset by 100 to avoid collisions with other remi WS ports
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
 
@@ -2040,6 +2146,11 @@ async function cleanup(): Promise<void> {
   await registry.stopAll();
   await sessionRegistry.shutdown();
   cleanupStatusFile();
+
+  // Remove from live sessions directory
+  if (primarySessionId) {
+    liveSessionsRegistry.unregister(primarySessionId);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2139,21 +2250,61 @@ if (cliDaemonMode) {
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
 
   // Start WebSocket server silently in the background
-  // In wrapper mode, don't crash if port is busy - Claude still works locally
-  try {
-    await registry.startAll();
-    log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
+  // With auto-port: retry on EADDRINUSE (race condition with another remi starting simultaneously)
+  let wsStarted = false;
+  const maxPortRetries = portExplicitlySet ? 1 : 3;
+  for (let attempt = 0; attempt < maxPortRetries; attempt++) {
+    try {
+      await registry.startAll();
+      log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
+      mdnsPublisher = await startMdnsIfNeeded(log);
+      wsStarted = true;
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isAddrInUse = msg.includes('EADDRINUSE') || msg.includes('in use');
 
-    mdnsPublisher = await startMdnsIfNeeded(log);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('EADDRINUSE') || msg.includes('in use')) {
-      logError(
-        `Port ${PORT} is in use. Remote monitoring disabled. Use --port to specify a different port.`,
-      );
-    } else {
-      logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
+      if (isAddrInUse && !portExplicitlySet && attempt < maxPortRetries - 1) {
+        // Auto-port race: another remi grabbed this port. Try next available.
+        const nextPort = liveSessionsRegistry.findAvailablePort(
+          PORT + 1,
+          DEFAULT_PORT_RANGE - (PORT - DEFAULT_BASE_PORT + 1),
+        );
+        if (nextPort !== null) {
+          log(`Port ${PORT} taken, retrying with ${nextPort}`);
+          PORT = nextPort;
+          // Registry needs to be re-created with new port; stopAll first
+          try {
+            await registry.stopAll();
+          } catch {
+            /* ignore */
+          }
+          continue;
+        }
+      }
+
+      if (isAddrInUse) {
+        logError(
+          `Port ${PORT} is in use. Remote monitoring disabled. Use --port to specify a different port.`,
+        );
+      } else {
+        logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
+      }
+      break;
     }
+  }
+
+  // Register this session in the live sessions directory
+  if (wsStarted) {
+    liveSessionsRegistry.register({
+      sessionId,
+      pid: process.pid,
+      wsPort: PORT,
+      hookPort: HOOK_PORT,
+      projectPath: workingDirectory,
+      name: path.basename(workingDirectory),
+      startedAt: new Date().toISOString(),
+    });
   }
 
   // Start hook server for Claude Code event detection

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -931,9 +931,16 @@ if (cliSubcommand === 'attach') {
         }),
       );
 
-      for (const result of results) {
-        if (result.status === 'fulfilled') {
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (result?.status === 'fulfilled') {
           allSessions.push(...result.value);
+        } else if (result?.status === 'rejected') {
+          const reason =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
+            console.error(`[attach] Failed to query port ${portsToQuery[i]}: ${reason}`);
+          }
         }
       }
 
@@ -2273,7 +2280,13 @@ if (cliDaemonMode) {
         if (nextPort !== null) {
           log(`Port ${PORT} taken, retrying with ${nextPort}`);
           // Tear down old adapter before rebinding
-          await registry.unregister('websocket');
+          try {
+            await registry.unregister('websocket');
+          } catch (teardownErr) {
+            const teardownMsg =
+              teardownErr instanceof Error ? teardownErr.message : String(teardownErr);
+            logError(`Failed to tear down WebSocket adapter on port ${PORT}: ${teardownMsg}`);
+          }
           PORT = nextPort;
           STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
           HOOK_PORT = PORT + 100;

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1246,7 +1246,7 @@ const sessionRegistry = new SessionRegistry(
 let primarySessionId: UUID | null = null;
 
 // Hook infrastructure (initialized in wrapper mode when hooks are enabled)
-const HOOK_PORT = PORT + 100; // Offset by 100 to avoid collisions with other remi WS ports
+let HOOK_PORT = PORT + 100; // Offset by 100 to avoid collisions with other remi WS ports
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
 
@@ -2272,13 +2272,17 @@ if (cliDaemonMode) {
         );
         if (nextPort !== null) {
           log(`Port ${PORT} taken, retrying with ${nextPort}`);
+          // Tear down old adapter before rebinding
+          await registry.unregister('websocket');
           PORT = nextPort;
-          // Registry needs to be re-created with new port; stopAll first
-          try {
-            await registry.stopAll();
-          } catch {
-            /* ignore */
-          }
+          STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
+          HOOK_PORT = PORT + 100;
+          // Create new WS adapter with updated port
+          const retryWsAdapter = new WebSocketAdapter(
+            { port: PORT, host: bindHost, authenticator },
+            sharedEvents,
+          );
+          registry.register(retryWsAdapter);
           continue;
         }
       }
@@ -2294,8 +2298,9 @@ if (cliDaemonMode) {
     }
   }
 
-  // Register this session in the live sessions directory
+  // After port retry, update status with finalized port values
   if (wsStarted) {
+    updateRemiStatus({ wsPort: PORT });
     liveSessionsRegistry.register({
       sessionId,
       pid: process.pid,

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -8,6 +8,7 @@ import {
   serialize,
 } from '@remi/shared';
 import type { DiscoverableSession, ProtocolMessage, Timestamp } from '@remi/shared';
+import type { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
 
 export interface RemoteTarget {
@@ -154,6 +155,8 @@ export async function fetchSessions(
 
 export interface NetworkLsOptions {
   readonly localPort: number;
+  /** Additional local ports to query (from live sessions registry). */
+  readonly localPorts?: readonly number[];
   /** Timeout for WebSocket session fetches, in ms. Default: 5000 */
   readonly fetchTimeoutMs?: number | undefined;
   /** Timeout for mDNS network browse, in ms. Default: 3000 */
@@ -173,15 +176,18 @@ interface DaemonSessions {
 export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   const { localPort, fetchTimeoutMs: timeout = 5000, browseTimeoutMs: mdnsTimeout = 3000 } = opts;
 
-  // Try local daemon first
-  let localSessions: DiscoverableSession[] = [];
-  try {
-    localSessions = await fetchSessions('localhost', localPort, timeout);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // Connection refused is expected when no local daemon is running
-    if (!msg.includes('Cannot connect') && !msg.includes('closed unexpectedly')) {
-      console.error(`Warning: local daemon error: ${msg}`);
+  // Try all local daemons (multi-port support)
+  const allLocalPorts = new Set([localPort, ...(opts.localPorts ?? [])]);
+  const localSessions: DiscoverableSession[] = [];
+  const localResults = await Promise.allSettled(
+    [...allLocalPorts].map(async (port) => {
+      const sessions = await fetchSessions('localhost', port, timeout);
+      return { port, sessions };
+    }),
+  );
+  for (const result of localResults) {
+    if (result.status === 'fulfilled') {
+      localSessions.push(...result.value.sessions);
     }
   }
 
@@ -403,6 +409,48 @@ export function formatAge(timestamp: Timestamp): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-port local discovery
+// ---------------------------------------------------------------------------
+
+export interface MultiPortLsOptions {
+  readonly registry: SessionRegistryFile;
+  readonly timeout?: number;
+}
+
+/**
+ * Discover all local remi sessions by reading the live sessions registry
+ * and querying each unique port.
+ */
+export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
+  const { registry, timeout = 5000 } = opts;
+
+  const ports = registry.getLivePorts();
+
+  if (ports.length === 0) {
+    console.log('No active sessions. Start one with: remi [claude-args...]');
+    return;
+  }
+
+  // Query each port in parallel
+  const results = await Promise.allSettled(
+    ports.map(async (port) => {
+      const sessions = await fetchSessions('localhost', port, timeout);
+      return { port, sessions };
+    }),
+  );
+
+  const allSessions: DiscoverableSession[] = [];
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      allSessions.push(...result.value.sessions);
+    }
+    // Silently skip unreachable ports (process may have just exited)
+  }
+
+  renderSessionList(allSessions);
 }
 
 /**

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -185,9 +185,16 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
       return { port, sessions };
     }),
   );
-  for (const result of localResults) {
-    if (result.status === 'fulfilled') {
+  const localPortsArr = [...allLocalPorts];
+  for (let i = 0; i < localResults.length; i++) {
+    const result = localResults[i];
+    if (result?.status === 'fulfilled') {
       localSessions.push(...result.value.sessions);
+    } else if (result?.status === 'rejected') {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
+        console.error(`[ls] Failed to query local port ${localPortsArr[i]}: ${reason}`);
+      }
     }
   }
 
@@ -443,11 +450,17 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
   );
 
   const allSessions: DiscoverableSession[] = [];
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result?.status === 'fulfilled') {
       allSessions.push(...result.value.sessions);
+    } else if (result?.status === 'rejected') {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      // Connection refused is expected (process may have just exited); log others
+      if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
+        console.error(`[ls] Failed to query local port ${ports[i]}: ${reason}`);
+      }
     }
-    // Silently skip unreachable ports (process may have just exited)
   }
 
   renderSessionList(allSessions);

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -29,8 +29,10 @@ export interface VpnPeer {
 }
 
 export interface VpnDiscoveryOptions {
-  /** Port to probe for remi daemons. Default: 18765 */
+  /** Base port to probe for remi daemons. Default: 18765 */
   readonly port?: number | undefined;
+  /** Number of ports to probe starting from base port. Default: 10 */
+  readonly portRange?: number | undefined;
   /** Timeout per probe in ms. Default: 2000 */
   readonly probeTimeoutMs?: number | undefined;
 }
@@ -39,12 +41,13 @@ export interface VpnDiscoveryOptions {
  * Discover remi daemons running on VPN peers.
  *
  * Queries Tailscale and WireGuard sequentially (synchronous CLI calls),
- * then probes each discovered peer for a running remi daemon.
+ * then probes each discovered peer across the port range for running remi daemons.
  */
 export async function discoverVpnPeers(
   opts?: VpnDiscoveryOptions,
 ): Promise<{ peer: VpnPeer; host: string; port: number }[]> {
-  const port = opts?.port ?? 18765;
+  const basePort = opts?.port ?? 18765;
+  const portRange = opts?.portRange ?? 10;
   const probeTimeout = opts?.probeTimeoutMs ?? 2000;
 
   const peers = getAllVpnPeers();
@@ -52,12 +55,22 @@ export async function discoverVpnPeers(
 
   const { fetchSessions } = await import('../cli/ls-client.ts');
 
-  const results = await Promise.allSettled(
-    peers.map(async (peer) => {
-      await fetchSessions(peer.ip, port, probeTimeout);
-      return { peer, host: peer.ip, port };
-    }),
-  );
+  // Probe all peers across the port range in parallel
+  const probes: Promise<{ peer: VpnPeer; host: string; port: number }>[] = [];
+  for (const peer of peers) {
+    for (let offset = 0; offset < portRange; offset++) {
+      const port = basePort + offset;
+      probes.push(
+        fetchSessions(peer.ip, port, probeTimeout).then(() => ({
+          peer,
+          host: peer.ip,
+          port,
+        })),
+      );
+    }
+  }
+
+  const results = await Promise.allSettled(probes);
 
   const reachable = results
     .filter(
@@ -67,9 +80,8 @@ export async function discoverVpnPeers(
     .map((r) => r.value);
 
   if (reachable.length === 0 && peers.length > 0) {
-    const failCount = results.filter((r) => r.status === 'rejected').length;
     console.error(
-      `[vpn-discovery] Found ${peers.length} VPN peer(s) but none responded on port ${port} (${failCount} unreachable)`,
+      `[vpn-discovery] Found ${peers.length} VPN peer(s) but none responded on ports ${basePort}-${basePort + portRange - 1}`,
     );
   }
 

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -12,3 +12,10 @@ export {
 } from './session-registry.ts';
 
 export { SessionStore, type StoredSession } from './session-store.ts';
+
+export {
+  SessionRegistryFile,
+  type LiveSessionEntry,
+  DEFAULT_BASE_PORT,
+  DEFAULT_PORT_RANGE,
+} from './session-registry-file.ts';

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -1,0 +1,170 @@
+/**
+ * SessionRegistryFile - File-based registry for live remi sessions.
+ *
+ * Each remi wrapper process writes a JSON file to ~/.remi/live-sessions/<session-id>.json
+ * so that `remi ls` and `remi attach` can discover all running sessions across
+ * multiple remi processes (each on a different port).
+ *
+ * Stale entries (from crashed processes) are detected via PID liveness checks.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const LIVE_SESSIONS_DIR = path.join(REMI_DIR, 'live-sessions');
+
+/** A live session entry written by each remi wrapper process. */
+export interface LiveSessionEntry {
+  readonly sessionId: string;
+  readonly pid: number;
+  readonly wsPort: number;
+  readonly hookPort: number;
+  readonly projectPath: string;
+  readonly name: string;
+  readonly startedAt: string;
+}
+
+/** Default port range for auto-selection. */
+export const DEFAULT_BASE_PORT = 18765;
+export const DEFAULT_PORT_RANGE = 10;
+
+export class SessionRegistryFile {
+  private readonly dir: string;
+
+  constructor(dir?: string) {
+    this.dir = dir ?? LIVE_SESSIONS_DIR;
+  }
+
+  /** Ensure the live-sessions directory exists. */
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dir)) {
+      fs.mkdirSync(this.dir, { recursive: true });
+    }
+  }
+
+  /** Register a live session (atomic write). */
+  register(entry: LiveSessionEntry): void {
+    this.ensureDir();
+    const filePath = path.join(this.dir, `${entry.sessionId}.json`);
+    const tmpPath = `${filePath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  }
+
+  /** Unregister a session (delete its file). */
+  unregister(sessionId: string): void {
+    const filePath = path.join(this.dir, `${sessionId}.json`);
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // File may already be removed
+    }
+  }
+
+  /**
+   * List all live sessions, removing stale entries (dead PIDs).
+   * Returns entries sorted by startedAt (most recent first).
+   */
+  listLive(): LiveSessionEntry[] {
+    if (!fs.existsSync(this.dir)) {
+      return [];
+    }
+
+    const entries: LiveSessionEntry[] = [];
+    let dirEntries: string[];
+    try {
+      dirEntries = fs.readdirSync(this.dir);
+    } catch {
+      return [];
+    }
+
+    for (const fileName of dirEntries) {
+      if (!fileName.endsWith('.json') || fileName.endsWith('.tmp')) continue;
+
+      const filePath = path.join(this.dir, fileName);
+      try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        const entry = JSON.parse(raw) as LiveSessionEntry;
+
+        if (!entry.sessionId || !entry.pid || !entry.wsPort) continue;
+
+        if (isProcessAlive(entry.pid)) {
+          entries.push(entry);
+        } else {
+          // Stale entry; clean up
+          try {
+            fs.unlinkSync(filePath);
+          } catch {
+            // Ignore cleanup errors
+          }
+        }
+      } catch {
+        // Corrupt or unreadable file; skip
+      }
+    }
+
+    entries.sort((a, b) => (a.startedAt > b.startedAt ? -1 : 1));
+    return entries;
+  }
+
+  /**
+   * Find the first available port in the given range.
+   * Checks live entries to avoid conflicts.
+   * Returns null if all ports are exhausted.
+   */
+  findAvailablePort(
+    basePort: number = DEFAULT_BASE_PORT,
+    range: number = DEFAULT_PORT_RANGE,
+  ): number | null {
+    const live = this.listLive();
+    const usedPorts = new Set(live.map((e) => e.wsPort));
+
+    for (let offset = 0; offset < range; offset++) {
+      const candidate = basePort + offset;
+      if (!usedPorts.has(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  /** Find a live session by session ID. */
+  findBySessionId(sessionId: string): LiveSessionEntry | null {
+    const live = this.listLive();
+    return live.find((e) => e.sessionId === sessionId) ?? null;
+  }
+
+  /** Find a live session by name (exact or prefix match). */
+  findByName(name: string): LiveSessionEntry | null {
+    const live = this.listLive();
+
+    // Exact match first
+    const exact = live.find((e) => e.name === name);
+    if (exact) return exact;
+
+    // Prefix match (only if unambiguous)
+    const prefixMatches = live.filter((e) => e.name.startsWith(name));
+    if (prefixMatches.length === 1) return prefixMatches[0]!;
+
+    return null;
+  }
+
+  /** Get unique wsPort values from all live sessions. */
+  getLivePorts(): number[] {
+    const live = this.listLive();
+    return [...new Set(live.map((e) => e.wsPort))];
+  }
+}
+
+/** Check if a process is alive by sending signal 0. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -30,6 +30,21 @@ export interface LiveSessionEntry {
 export const DEFAULT_BASE_PORT = 18765;
 export const DEFAULT_PORT_RANGE = 10;
 
+/** Type guard for LiveSessionEntry after JSON.parse. */
+function isValidEntry(data: unknown): data is LiveSessionEntry {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj['sessionId'] === 'string' &&
+    obj['sessionId'].length > 0 &&
+    typeof obj['pid'] === 'number' &&
+    obj['pid'] > 0 &&
+    typeof obj['wsPort'] === 'number' &&
+    obj['wsPort'] > 0 &&
+    obj['wsPort'] <= 65535
+  );
+}
+
 export class SessionRegistryFile {
   private readonly dir: string;
 
@@ -58,8 +73,13 @@ export class SessionRegistryFile {
     const filePath = path.join(this.dir, `${sessionId}.json`);
     try {
       fs.unlinkSync(filePath);
-    } catch {
-      // File may already be removed
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        console.error(
+          `[live-sessions] Failed to unregister ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 
@@ -76,7 +96,13 @@ export class SessionRegistryFile {
     let dirEntries: string[];
     try {
       dirEntries = fs.readdirSync(this.dir);
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        console.error(
+          `[live-sessions] Cannot read directory ${this.dir}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       return [];
     }
 
@@ -86,22 +112,33 @@ export class SessionRegistryFile {
       const filePath = path.join(this.dir, fileName);
       try {
         const raw = fs.readFileSync(filePath, 'utf-8');
-        const entry = JSON.parse(raw) as LiveSessionEntry;
+        const data: unknown = JSON.parse(raw);
 
-        if (!entry.sessionId || !entry.pid || !entry.wsPort) continue;
+        if (!isValidEntry(data)) continue;
 
-        if (isProcessAlive(entry.pid)) {
-          entries.push(entry);
+        if (isProcessAlive(data.pid)) {
+          entries.push(data);
         } else {
           // Stale entry; clean up
           try {
             fs.unlinkSync(filePath);
-          } catch {
-            // Ignore cleanup errors
+          } catch (cleanupErr) {
+            const code = (cleanupErr as NodeJS.ErrnoException).code;
+            if (code !== 'ENOENT') {
+              console.error(
+                `[live-sessions] Failed to remove stale entry ${fileName}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+              );
+            }
           }
         }
-      } catch {
-        // Corrupt or unreadable file; skip
+      } catch (err) {
+        // Only silence ENOENT (file removed between readdir and read) and JSON parse errors
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code && code !== 'ENOENT') {
+          console.error(
+            `[live-sessions] Failed to read ${fileName}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
     }
 
@@ -159,12 +196,17 @@ export class SessionRegistryFile {
   }
 }
 
-/** Check if a process is alive by sending signal 0. */
+/**
+ * Check if a process is alive by sending signal 0.
+ * EPERM means the process exists but is owned by a different user.
+ */
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    // EPERM: process exists but we lack permission to signal it
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') return true;
     return false;
   }
 }

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  DEFAULT_BASE_PORT,
+  type LiveSessionEntry,
+  SessionRegistryFile,
+} from '../src/session/session-registry-file.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-registry-test-'));
+}
+
+function makeEntry(overrides: Partial<LiveSessionEntry> = {}): LiveSessionEntry {
+  return {
+    sessionId: `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    pid: process.pid, // current process is alive
+    wsPort: DEFAULT_BASE_PORT,
+    hookPort: DEFAULT_BASE_PORT + 100,
+    projectPath: '/tmp/test-project',
+    name: 'test:project/main',
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('SessionRegistryFile', () => {
+  let tmpDir: string;
+  let registry: SessionRegistryFile;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    registry = new SessionRegistryFile(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('register and list round-trip', () => {
+    const entry = makeEntry();
+    registry.register(entry);
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.sessionId).toBe(entry.sessionId);
+    expect(live[0]!.wsPort).toBe(entry.wsPort);
+  });
+
+  test('register multiple sessions', () => {
+    const e1 = makeEntry({ sessionId: 'sess-1', wsPort: 18765 });
+    const e2 = makeEntry({ sessionId: 'sess-2', wsPort: 18766 });
+    const e3 = makeEntry({ sessionId: 'sess-3', wsPort: 18767 });
+
+    registry.register(e1);
+    registry.register(e2);
+    registry.register(e3);
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(3);
+  });
+
+  test('unregister removes session', () => {
+    const entry = makeEntry({ sessionId: 'to-remove' });
+    registry.register(entry);
+    expect(registry.listLive()).toHaveLength(1);
+
+    registry.unregister('to-remove');
+    expect(registry.listLive()).toHaveLength(0);
+  });
+
+  test('unregister non-existent session is no-op', () => {
+    registry.unregister('does-not-exist');
+    // No error thrown
+  });
+
+  test('listLive removes stale entries with dead PIDs', () => {
+    // Use a PID that is almost certainly not running
+    const staleEntry = makeEntry({ sessionId: 'stale', pid: 999999 });
+    const liveEntry = makeEntry({ sessionId: 'live', pid: process.pid });
+
+    registry.register(staleEntry);
+    registry.register(liveEntry);
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.sessionId).toBe('live');
+
+    // Stale file should have been cleaned up
+    const staleFile = path.join(tmpDir, 'stale.json');
+    expect(fs.existsSync(staleFile)).toBe(false);
+  });
+
+  test('listLive sorts by startedAt descending (most recent first)', () => {
+    const older = makeEntry({
+      sessionId: 'older',
+      startedAt: '2025-01-01T00:00:00.000Z',
+    });
+    const newer = makeEntry({
+      sessionId: 'newer',
+      startedAt: '2026-06-01T00:00:00.000Z',
+    });
+
+    registry.register(older);
+    registry.register(newer);
+
+    const live = registry.listLive();
+    expect(live[0]!.sessionId).toBe('newer');
+    expect(live[1]!.sessionId).toBe('older');
+  });
+
+  test('listLive handles corrupt JSON files', () => {
+    const entry = makeEntry({ sessionId: 'valid' });
+    registry.register(entry);
+
+    // Write a corrupt file
+    fs.writeFileSync(path.join(tmpDir, 'corrupt.json'), '{{not json');
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.sessionId).toBe('valid');
+  });
+
+  test('listLive skips .tmp files', () => {
+    const entry = makeEntry({ sessionId: 'valid' });
+    registry.register(entry);
+
+    // Write a leftover temp file
+    fs.writeFileSync(path.join(tmpDir, 'leftover.json.tmp'), '{}');
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+  });
+
+  test('listLive returns empty when directory does not exist', () => {
+    const nonExistent = new SessionRegistryFile('/tmp/remi-does-not-exist-xyz');
+    expect(nonExistent.listLive()).toEqual([]);
+  });
+
+  test('findAvailablePort returns first port when no sessions', () => {
+    const port = registry.findAvailablePort(18765, 10);
+    expect(port).toBe(18765);
+  });
+
+  test('findAvailablePort skips used ports', () => {
+    registry.register(makeEntry({ sessionId: 'a', wsPort: 18765 }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: 18766 }));
+
+    const port = registry.findAvailablePort(18765, 10);
+    expect(port).toBe(18767);
+  });
+
+  test('findAvailablePort returns null when all ports exhausted', () => {
+    for (let i = 0; i < 3; i++) {
+      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: 18765 + i }));
+    }
+
+    const port = registry.findAvailablePort(18765, 3);
+    expect(port).toBeNull();
+  });
+
+  test('findBySessionId returns matching entry', () => {
+    const entry = makeEntry({ sessionId: 'target-id' });
+    registry.register(entry);
+    registry.register(makeEntry({ sessionId: 'other' }));
+
+    const found = registry.findBySessionId('target-id');
+    expect(found).not.toBeNull();
+    expect(found!.sessionId).toBe('target-id');
+  });
+
+  test('findBySessionId returns null for unknown ID', () => {
+    expect(registry.findBySessionId('unknown')).toBeNull();
+  });
+
+  test('findByName returns exact match', () => {
+    registry.register(makeEntry({ sessionId: 'a', name: 'host:project/main' }));
+    registry.register(makeEntry({ sessionId: 'b', name: 'host:project/dev' }));
+
+    const found = registry.findByName('host:project/main');
+    expect(found).not.toBeNull();
+    expect(found!.sessionId).toBe('a');
+  });
+
+  test('findByName returns unambiguous prefix match', () => {
+    registry.register(makeEntry({ sessionId: 'a', name: 'host:project/main' }));
+
+    const found = registry.findByName('host:project');
+    expect(found).not.toBeNull();
+    expect(found!.sessionId).toBe('a');
+  });
+
+  test('findByName returns null for ambiguous prefix', () => {
+    registry.register(makeEntry({ sessionId: 'a', name: 'host:project/main' }));
+    registry.register(makeEntry({ sessionId: 'b', name: 'host:project/dev' }));
+
+    expect(registry.findByName('host:project')).toBeNull();
+  });
+
+  test('getLivePorts returns unique ports', () => {
+    registry.register(makeEntry({ sessionId: 'a', wsPort: 18765 }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: 18766 }));
+    registry.register(makeEntry({ sessionId: 'c', wsPort: 18767 }));
+
+    const ports = registry.getLivePorts();
+    expect(ports).toHaveLength(3);
+    expect(ports).toContain(18765);
+    expect(ports).toContain(18766);
+    expect(ports).toContain(18767);
+  });
+
+  test('register creates directory if it does not exist', () => {
+    const newDir = path.join(tmpDir, 'nested', 'dir');
+    const reg = new SessionRegistryFile(newDir);
+
+    reg.register(makeEntry({ sessionId: 'first' }));
+
+    expect(fs.existsSync(newDir)).toBe(true);
+    expect(reg.listLive()).toHaveLength(1);
+  });
+
+  test('register overwrites existing entry for same session', () => {
+    const entry = makeEntry({ sessionId: 'same', wsPort: 18765 });
+    registry.register(entry);
+
+    const updated = makeEntry({ sessionId: 'same', wsPort: 18770 });
+    registry.register(updated);
+
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.wsPort).toBe(18770);
+  });
+});

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -151,6 +151,15 @@ describe('SessionRegistryFile', () => {
     expect(port).toBe(18767);
   });
 
+  test('findAvailablePort fills non-contiguous gaps', () => {
+    // Use ports 18765 and 18767, leaving 18766 as a gap
+    registry.register(makeEntry({ sessionId: 'a', wsPort: 18765 }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: 18767 }));
+
+    const port = registry.findAvailablePort(18765, 10);
+    expect(port).toBe(18766);
+  });
+
   test('findAvailablePort returns null when all ports exhausted', () => {
     for (let i = 0; i < 3; i++) {
       registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: 18765 + i }));
@@ -208,6 +217,33 @@ describe('SessionRegistryFile', () => {
     expect(ports).toContain(18765);
     expect(ports).toContain(18766);
     expect(ports).toContain(18767);
+  });
+
+  test('listLive skips entries with missing required fields', () => {
+    // Write entries missing required fields directly to disk
+    const missingSessionId = path.join(tmpDir, 'no-sid.json');
+    fs.writeFileSync(missingSessionId, JSON.stringify({ pid: process.pid, wsPort: 18765 }));
+
+    const missingPid = path.join(tmpDir, 'no-pid.json');
+    fs.writeFileSync(missingPid, JSON.stringify({ sessionId: 'x', wsPort: 18765 }));
+
+    const missingPort = path.join(tmpDir, 'no-port.json');
+    fs.writeFileSync(missingPort, JSON.stringify({ sessionId: 'y', pid: process.pid }));
+
+    const invalidPort = path.join(tmpDir, 'bad-port.json');
+    fs.writeFileSync(
+      invalidPort,
+      JSON.stringify({ sessionId: 'z', pid: process.pid, wsPort: 99999 }),
+    );
+
+    const emptySessionId = path.join(tmpDir, 'empty-sid.json');
+    fs.writeFileSync(
+      emptySessionId,
+      JSON.stringify({ sessionId: '', pid: process.pid, wsPort: 18765 }),
+    );
+
+    // All should be skipped
+    expect(registry.listLive()).toEqual([]);
   });
 
   test('register creates directory if it does not exist', () => {


### PR DESCRIPTION
## Summary

- Each remi wrapper now auto-selects a unique port (18765-18774) instead of all fighting for 18765
- Live sessions registered in `~/.remi/live-sessions/<session-id>.json` with PID-based stale detection
- `remi ls` queries all live ports to show all sessions across multiple remi processes
- `remi attach` resolves the correct port for any session via the live registry
- VPN discovery probes the full port range (18765-18774) per peer
- Per-port status files prevent multiple wrappers from overwriting each other's statusline data
- Hook port offset changed from +1 to +100 to avoid collision with the WS port range

## Test plan

- [x] 939 tests pass (20 new for SessionRegistryFile)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual: run 4 `remi` sessions simultaneously, verify `remi ls` shows all 4
- [ ] Manual: `remi attach <name>` connects to correct session regardless of port
- [ ] Manual: `remi ls --network` discovers multi-port sessions on remote machines

Closes #70