### PR TITLE
fix: attach name resolution diagnostics and probe timeout

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1072,9 +1072,9 @@ if (cliSubcommand === 'attach') {
             // Run mDNS and VPN discovery in parallel
             const [daemons, vpnPeers] = await Promise.all([
               discoverDaemons({ timeoutMs: 3000 }),
-              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 2000 }).catch((err) => {
+              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 3000 }).catch((err) => {
                 const msg = err instanceof Error ? err.message : String(err);
-                log(`[Attach] VPN discovery failed: ${msg}`);
+                console.error(`\x1b[2m[attach] VPN discovery failed: ${msg}\x1b[0m`);
                 return [] as {
                   peer: import('./mdns/vpn-discovery.ts').VpnPeer;
                   host: string;
@@ -1082,6 +1082,20 @@ if (cliSubcommand === 'attach') {
                 }[];
               }),
             ]);
+
+            // Log discovery results for diagnostics
+            if (daemons.length > 0 || vpnPeers.length > 0) {
+              const mdnsHostnames = [
+                ...new Set(daemons.map((d: { hostname: string }) => d.hostname)),
+              ];
+              const vpnHostnames = [...new Set(vpnPeers.map((v) => v.peer.hostname))];
+              console.error(
+                `\x1b[2mFound ${daemons.length} mDNS, ${vpnPeers.length} VPN daemon(s); ` +
+                  `hosts: [${[...mdnsHostnames, ...vpnHostnames].join(', ')}]\x1b[0m`,
+              );
+            } else {
+              console.error('No daemons discovered (0 mDNS, 0 VPN). Is Tailscale running?');
+            }
 
             // Try mDNS first, fall back to VPN peers
             const mdnsMatch = daemons.find(


### PR DESCRIPTION
## Summary
- Add visible diagnostic output during attach name resolution showing discovered hostnames (mDNS + VPN) so users can see what's found vs what's expected
- Bump VPN probe timeout from 2s to 3s to match mDNS timeout
- When no daemons are discovered, show actionable message about Tailscale

## Context
Name resolution for `remi attach yahyas-mcm:nemar-cli/dev` wasn't working. This adds diagnostics to help identify whether the issue is:
1. VPN discovery not finding peers
2. Hostname mismatch between session name and discovered peer
3. Session not found on discovered host

## Test plan
- [x] 950 tests pass
- [x] Biome lint clean
- [x] TypeScript type check clean
- [ ] Manual test: `remi attach <hostname>:<session>` shows discovery diagnostics