### PR TITLE
fix: prevent ls queries from killing wrapper-mode sessions

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1524,8 +1524,13 @@ async function createNewSession(
           } catch (err) {
             const code = (err as NodeJS.ErrnoException).code;
             if (code === 'EPIPE' || code === 'EIO') {
-              logError(`Terminal write failed (${code}), initiating shutdown`);
-              cleanup().then(() => process.exit(1));
+              // Terminal pipe broken (SSH disconnect, terminal closed, etc.)
+              // Stop writing but keep daemon alive for remote clients.
+              ptyStdoutFd = null;
+              if (!wrapperDetached) {
+                wrapperDetached = true;
+                logError(`Terminal write failed (${code}), detaching local terminal`);
+              }
             }
           }
         }
@@ -1558,7 +1563,7 @@ async function createNewSession(
     },
   );
 
-  sessionRegistry.registerSession(sessionId, workingDirectory, ptySession, messageApi);
+  sessionRegistry.registerSession(sessionId, workingDirectory, ptySession, messageApi, passThrough);
   await ptySession.start();
 
   sessionStore.save({
@@ -1745,65 +1750,15 @@ const sharedEvents = {
       );
     }
 
-    // In daemon mode, create new session on connect
+    // In daemon mode, accept the connection without auto-creating a session.
+    // Sessions are created only via explicit create_session_request.
     if (!wrapperMode) {
-      // Send hello_ack immediately so utility clients (ls, kill, attach) can
-      // proceed with queries even if session creation fails later.
       sendToConnection(connectionId, createHelloAck('1.0.0', '' as UUID));
       log(`Connection ${connectionId} accepted in daemon mode`);
+      return;
+    }
 
-      const requestedDir = metadata.platformData?.['directory'] as string | undefined;
-      const dirResult = resolveDirectory(requestedDir);
-
-      if ('error' in dirResult) {
-        logError(`Directory error: ${dirResult.error}`);
-        sendToConnection(connectionId, createError('INVALID_DIRECTORY', dirResult.error));
-        return;
-      }
-
-      const workingDirectory = dirResult.resolved;
-      const sessionId = sessionRegistry.createSessionId();
-
-      log(`Creating new session ${sessionId} in ${workingDirectory}...`);
-
-      try {
-        await createNewSession(sessionId, workingDirectory, (sid, msg) => {
-          const session = sessionRegistry.getSession(sid);
-          if (session?.activeConnectionId) {
-            sendToConnection(session.activeConnectionId, msg);
-          }
-        });
-
-        const result = sessionRegistry.attachConnection(sessionId, connectionId);
-
-        if (result.success) {
-          // Send updated hello_ack with real session ID
-          sendToConnection(
-            connectionId,
-            createHelloAck('1.0.0', sessionId, {
-              isResume: false,
-              replayCount: 0,
-              nextBulletId: 1,
-            }),
-          );
-          log(`Session ${sessionId} created and attached to connection ${connectionId}`);
-        } else {
-          logError(`Failed to attach connection: ${result.error}`);
-          sessionRegistry.closeSession(sessionId, 'forced');
-          sendToConnection(
-            connectionId,
-            createError('ATTACH_FAILED', result.error ?? 'Failed to attach connection'),
-          );
-        }
-      } catch (error) {
-        const errMsg = error instanceof Error ? error.message : String(error);
-        logError('Failed to create session:', errMsg);
-        sendToConnection(
-          connectionId,
-          createError('SESSION_CREATE_FAILED', `Failed to create session: ${errMsg}`),
-        );
-      }
-    } else if (wrapperMode && primarySessionId) {
+    if (wrapperMode && primarySessionId) {
       // Wrapper mode: resume failed but session exists; send hello_ack
       // so the client can still send queries (ls, kill, etc.)
       sendToConnection(connectionId, createHelloAck('1.0.0', primarySessionId));

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1085,13 +1085,15 @@ if (cliSubcommand === 'attach') {
 
             // Log discovery results for diagnostics
             if (daemons.length > 0 || vpnPeers.length > 0) {
-              const mdnsHostnames = [
-                ...new Set(daemons.map((d: { hostname: string }) => d.hostname)),
+              const hosts = [
+                ...new Set([
+                  ...daemons.map((d: { hostname: string }) => d.hostname),
+                  ...vpnPeers.map((v) => v.peer.hostname),
+                ]),
               ];
-              const vpnHostnames = [...new Set(vpnPeers.map((v) => v.peer.hostname))];
               console.error(
                 `\x1b[2mFound ${daemons.length} mDNS, ${vpnPeers.length} VPN daemon(s); ` +
-                  `hosts: [${[...mdnsHostnames, ...vpnHostnames].join(', ')}]\x1b[0m`,
+                  `hosts: [${hosts.join(', ')}]\x1b[0m`,
               );
             } else {
               console.error('No daemons discovered (0 mDNS, 0 VPN). Is Tailscale running?');
@@ -1546,31 +1548,27 @@ async function createNewSession(
             fs.writeSync(ptyStdoutFd, data);
           } catch (err) {
             const code = (err as NodeJS.ErrnoException).code;
+            ptyStdoutFd = null;
+            wrapperDetached = true;
             if (code === 'EPIPE' || code === 'EIO') {
-              // Terminal pipe broken (SSH disconnect, terminal closed, etc.)
-              // Stop writing but keep daemon alive for remote clients.
-              ptyStdoutFd = null;
-              wrapperDetached = true;
               logError(`Terminal write failed (${code}), detaching local terminal`);
-              // Clean up stdin to avoid dangling raw-mode reader
-              if (process.stdin.isTTY) {
-                try {
-                  process.stdin.setRawMode(false);
-                } catch {
-                  // stdin may already be unusable
-                }
-              }
-              process.stdin.pause();
-              process.stdin.removeAllListeners('data');
-              process.stdin.unref();
             } else {
               logError(
                 `Unexpected terminal write error (${code}):`,
                 err instanceof Error ? err.message : String(err),
               );
-              ptyStdoutFd = null;
-              wrapperDetached = true;
             }
+            // Clean up stdin to avoid dangling raw-mode reader
+            if (process.stdin.isTTY) {
+              try {
+                process.stdin.setRawMode(false);
+              } catch {
+                // stdin may already be unusable
+              }
+            }
+            process.stdin.pause();
+            process.stdin.removeAllListeners('data');
+            process.stdin.unref();
           }
         }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1527,10 +1527,14 @@ async function createNewSession(
               // Terminal pipe broken (SSH disconnect, terminal closed, etc.)
               // Stop writing but keep daemon alive for remote clients.
               ptyStdoutFd = null;
-              if (!wrapperDetached) {
-                wrapperDetached = true;
-                logError(`Terminal write failed (${code}), detaching local terminal`);
-              }
+              wrapperDetached = true;
+              logError(`Terminal write failed (${code}), detaching local terminal`);
+            } else {
+              logError(
+                `Unexpected terminal write error (${code}):`,
+                err instanceof Error ? err.message : String(err),
+              );
+              ptyStdoutFd = null;
             }
           }
         }
@@ -1563,7 +1567,14 @@ async function createNewSession(
     },
   );
 
-  sessionRegistry.registerSession(sessionId, workingDirectory, ptySession, messageApi, passThrough);
+  const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
+  sessionRegistry.registerSession(
+    sessionId,
+    workingDirectory,
+    ptySession,
+    messageApi,
+    locallyOwned,
+  );
   await ptySession.start();
 
   sessionStore.save({

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1364,7 +1364,12 @@ const sessionRegistry = new SessionRegistry(
       }
     },
     onSessionOrphaned: (sessionId) => {
-      log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
+      const session = sessionRegistry.getSession(sessionId);
+      if (session?.locallyOwned) {
+        log(`Session detached: ${sessionId} (locally owned, no timeout)`);
+      } else {
+        log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
+      }
     },
     onSessionResumed: (sessionId, connectionId) => {
       log(`Session resumed: ${sessionId} by connection ${connectionId}`);
@@ -1547,12 +1552,24 @@ async function createNewSession(
               ptyStdoutFd = null;
               wrapperDetached = true;
               logError(`Terminal write failed (${code}), detaching local terminal`);
+              // Clean up stdin to avoid dangling raw-mode reader
+              if (process.stdin.isTTY) {
+                try {
+                  process.stdin.setRawMode(false);
+                } catch {
+                  // stdin may already be unusable
+                }
+              }
+              process.stdin.pause();
+              process.stdin.removeAllListeners('data');
+              process.stdin.unref();
             } else {
               logError(
                 `Unexpected terminal write error (${code}):`,
                 err instanceof Error ? err.message : String(err),
               );
               ptyStdoutFd = null;
+              wrapperDetached = true;
             }
           }
         }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -54,12 +54,9 @@ export function parseHostPort(
   if (!match) return null;
   const port = Number(match[2]);
   if (port <= 1024 || port > 65535) return null;
-  const result: { host: string; port: number; cleaned?: string } = {
-    host: match[1] as string,
-    port,
-  };
-  if (match[3]) result.cleaned = match[3];
-  return result;
+  const host = match[1] as string;
+  if (match[3]) return { host, port, cleaned: match[3] };
+  return { host, port };
 }
 
 export interface LsClientOptions {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -54,7 +54,8 @@ export interface SessionRegistryEvents {
   onSessionCreated?: (sessionId: UUID) => void;
   /** Session was closed (timeout or PTY exit) */
   onSessionClosed?: (sessionId: UUID, reason: 'timeout' | 'pty_exit' | 'forced') => void;
-  /** Session became orphaned (connection detached) */
+  /** Connection detached from session. For non-locally-owned sessions,
+   * this means the session is now orphaned; locally-owned sessions remain active. */
   onSessionOrphaned?: (sessionId: UUID) => void;
   /** Session was resumed (connection reattached) */
   onSessionResumed?: (sessionId: UUID, connectionId: UUID) => void;
@@ -196,14 +197,14 @@ export class SessionRegistry {
 
   /**
    * Check if a session can be resumed.
-   * Returns true if session exists, is orphaned, and hasn't timed out.
+   * Returns true if session exists and has no active connection.
    */
   canResume(sessionId: UUID): boolean {
     const session = this.sessions.get(sessionId);
     if (session === undefined) {
       return false;
     }
-    // Can only resume orphaned sessions
+    // Can only resume sessions with no active connection
     return session.activeConnectionId === null;
   }
 
@@ -371,8 +372,9 @@ export class SessionRegistry {
 
     // Close PTY if not already closed
     if (reason !== 'pty_exit') {
-      session.pty.close().catch(() => {
-        // Ignore close errors
+      session.pty.close().catch((err) => {
+        // Log but don't throw; we're already cleaning up
+        console.error(`Failed to close PTY for session ${sessionId}:`, err);
       });
     }
 

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -124,8 +124,7 @@ export class SessionRegistry {
   }
 
   /**
-   * Register a new session with its PTY and processors.
-   * Called after spawning Claude Code.
+   * Register a new session with its PTY and message API.
    */
   registerSession(
     sessionId: UUID,
@@ -163,7 +162,7 @@ export class SessionRegistry {
 
   /**
    * Create a new session ID for a fresh connection.
-   * The actual session components (PTY, processor, messageApi) must be
+   * The actual session components (PTY, messageApi) must be
    * registered separately via registerSession.
    */
   createSessionId(): UUID {
@@ -370,7 +369,7 @@ export class SessionRegistry {
       this.connectionToSession.delete(session.activeConnectionId);
     }
 
-    // Close PTY if not already closed
+    // Close PTY unless the closure was triggered by PTY exit
     if (reason !== 'pty_exit') {
       session.pty.close().catch((err) => {
         // Log but don't throw; we're already cleaning up

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -94,6 +94,10 @@ export interface ManagedSession {
   currentStatus: AgentStatus;
   /** Current pending question */
   currentQuestion: Question | null;
+
+  /** Whether this session is owned by the local process (wrapper mode).
+   * Locally-owned sessions are never killed by orphan timeout. */
+  locallyOwned: boolean;
 }
 
 /**
@@ -126,6 +130,7 @@ export class SessionRegistry {
     workingDirectory: string,
     pty: PTYSession,
     messageApi: MessageAPI,
+    locallyOwned = false,
   ): void {
     const baseName = generateSessionName(workingDirectory);
     const existingNames = this.getExistingNames();
@@ -147,6 +152,7 @@ export class SessionRegistry {
       lastDeliveredIndex: -1,
       currentStatus: 'idle',
       currentQuestion: null,
+      locallyOwned,
     };
 
     this.sessions.set(sessionId, session);
@@ -287,10 +293,13 @@ export class SessionRegistry {
     session.lastDisconnectedAt = now();
     this.connectionToSession.delete(connectionId);
 
-    // Start orphan timeout
-    session.orphanTimeoutId = setTimeout(() => {
-      this.closeSession(sessionId, 'timeout');
-    }, this.orphanTimeoutMs);
+    // Start orphan timeout (skip for locally-owned sessions; they stay alive
+    // until PTY exits, explicit kill, or daemon shutdown)
+    if (!session.locallyOwned) {
+      session.orphanTimeoutId = setTimeout(() => {
+        this.closeSession(sessionId, 'timeout');
+      }, this.orphanTimeoutMs);
+    }
 
     this.events.onSessionOrphaned?.(sessionId);
   }
@@ -454,7 +463,7 @@ export class SessionRegistry {
    */
   private getDiscoverableStatus(session: ManagedSession): 'active' | 'idle' | 'orphaned' {
     if (session.activeConnectionId === null) {
-      return 'orphaned';
+      return session.locallyOwned ? 'active' : 'orphaned';
     }
     if (session.currentStatus === 'idle') {
       return 'idle';

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -4,6 +4,7 @@
  * Key concepts:
  * - Sessions survive connection drops (orphaned state)
  * - Orphaned sessions timeout after configurable period (default 5 minutes)
+ * - Locally-owned sessions (wrapper mode) are exempt from orphan timeout
  * - Connections can resume existing sessions within timeout window
  * - Message history is tracked for replay on reconnect
  */
@@ -78,7 +79,7 @@ export interface ManagedSession {
   /** When session last had activity (message, status change) */
   lastActivityAt: Timestamp;
 
-  /** Currently attached connection ID (null if orphaned) */
+  /** Currently attached connection ID (null if no connection is attached) */
   activeConnectionId: UUID | null;
   /** When session was last disconnected (null if connected) */
   lastDisconnectedAt: Timestamp | null;
@@ -97,7 +98,7 @@ export interface ManagedSession {
 
   /** Whether this session is owned by the local process (wrapper mode).
    * Locally-owned sessions are never killed by orphan timeout. */
-  locallyOwned: boolean;
+  readonly locallyOwned: boolean;
 }
 
 /**
@@ -274,7 +275,8 @@ export class SessionRegistry {
 
   /**
    * Detach a connection from its session.
-   * The session becomes orphaned and starts the timeout countdown.
+   * Non-locally-owned sessions become orphaned and start the timeout countdown.
+   * Locally-owned sessions remain active without a timeout.
    */
   detachConnection(connectionId: UUID): void {
     const sessionId = this.connectionToSession.get(connectionId);
@@ -515,7 +517,7 @@ export class SessionRegistry {
   get orphanedCount(): number {
     let count = 0;
     for (const session of this.sessions.values()) {
-      if (session.activeConnectionId === null) {
+      if (session.activeConnectionId === null && !session.locallyOwned) {
         count++;
       }
     }

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -354,23 +354,7 @@ describe('SessionRegistry', () => {
       expect(events.onSessionClosed).not.toHaveBeenCalled();
     });
 
-    test('non-locally-owned session is still killed after orphan timeout', async () => {
-      const sessionId = generateId();
-      const connectionId = generateId();
-      const pty = createMockPTY();
-
-      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false);
-      registry.attachConnection(sessionId, connectionId);
-      registry.detachConnection(connectionId);
-
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      expect(registry.getSession(sessionId)).toBeUndefined();
-      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
-      expect(pty.close).toHaveBeenCalled();
-    });
-
-    test('locally owned session reports active status without connection', () => {
+    test('locally owned session reports active status and canAttach without connection', () => {
       const sessionId = generateId();
       registry.registerSession(
         sessionId,
@@ -383,6 +367,37 @@ describe('SessionRegistry', () => {
       const sessions = registry.listSessions();
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.status).toBe('active');
+      expect(sessions[0]?.canAttach).toBe(true);
+    });
+
+    test('orphanedCount excludes locally-owned sessions', () => {
+      const localSessionId = generateId();
+      registry.registerSession(
+        localSessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        true,
+      );
+
+      // Locally-owned session with no connection should not count as orphaned
+      expect(registry.orphanedCount).toBe(0);
+
+      // Add a non-locally-owned detached session
+      const remoteSessionId = generateId();
+      const connectionId = generateId();
+      registry.registerSession(
+        remoteSessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+      );
+      registry.attachConnection(remoteSessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      // Only the non-locally-owned session counts
+      expect(registry.orphanedCount).toBe(1);
     });
 
     test('non-locally-owned session reports orphaned status without connection', () => {

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -391,7 +391,6 @@ describe('SessionRegistry', () => {
         '/test/dir',
         createMockPTY(),
         createMockMessageAPI(),
-        false,
       );
       registry.attachConnection(remoteSessionId, connectionId);
       registry.detachConnection(connectionId);
@@ -403,13 +402,7 @@ describe('SessionRegistry', () => {
     test('non-locally-owned session reports orphaned status without connection', () => {
       const sessionId = generateId();
       const connectionId = generateId();
-      registry.registerSession(
-        sessionId,
-        '/test/dir',
-        createMockPTY(),
-        createMockMessageAPI(),
-        false,
-      );
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, connectionId);
       registry.detachConnection(connectionId);
 

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -334,6 +334,76 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('locallyOwned sessions', () => {
+    test('locally owned session skips orphan timeout on detach', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), true);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      // Wait well past the orphan timeout (100ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Session should still exist (not killed by timeout)
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(events.onSessionClosed).not.toHaveBeenCalled();
+    });
+
+    test('non-locally-owned session is still killed after orphan timeout', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(registry.getSession(sessionId)).toBeUndefined();
+      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
+      expect(pty.close).toHaveBeenCalled();
+    });
+
+    test('locally owned session reports active status without connection', () => {
+      const sessionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        true,
+      );
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('active');
+    });
+
+    test('non-locally-owned session reports orphaned status without connection', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+      );
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('orphaned');
+    });
+  });
+
   describe('shutdown()', () => {
     test('closes all sessions', async () => {
       const pty1 = createMockPTY();

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -141,6 +141,11 @@ function App() {
   const handleMessage = useCallback((message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
+        // Daemon mode sends empty sessionId; skip session creation
+        if (!message.sessionId) {
+          setCreatingSession(false);
+          break;
+        }
         setSessions((prev) => {
           const exists = prev.some((s) => s.id === message.sessionId);
           if (exists) {
@@ -496,7 +501,6 @@ function App() {
     requestSessionList,
     requestTranscriptLoad,
     requestNewSession,
-    sessionId: wsSessionId,
     needsPassphrase,
     serverFingerprint,
     provideIdentity,
@@ -618,10 +622,10 @@ function App() {
 
   // Request session list after direct connection
   useEffect(() => {
-    if (connectionStatus === 'connected' && wsSessionId) {
+    if (connectionStatus === 'connected') {
       effectiveRequestSessionList(true);
     }
-  }, [connectionStatus, wsSessionId, effectiveRequestSessionList]);
+  }, [connectionStatus, effectiveRequestSessionList]);
 
   // Request session list after relay connection (hello_ack received)
   useEffect(() => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -141,8 +141,10 @@ function App() {
   const handleMessage = useCallback((message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
-        // Daemon mode sends empty sessionId; skip session creation
+        // Daemon mode sends empty sessionId on initial connect.
+        // No session is attached yet; user will select or create one from the session list.
         if (!message.sessionId) {
+          console.log('[hello_ack] Daemon mode: no default session, awaiting session list');
           setCreatingSession(false);
           break;
         }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -141,10 +141,9 @@ function App() {
   const handleMessage = useCallback((message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
-        // Daemon mode sends empty sessionId on initial connect.
+        // Daemon mode sends an empty-string sessionId on initial connect.
         // No session is attached yet; user will select or create one from the session list.
         if (!message.sessionId) {
-          console.log('[hello_ack] Daemon mode: no default session, awaiting session list');
           setCreatingSession(false);
           break;
         }


### PR DESCRIPTION
## Summary

- Wrapper-mode sessions now have a `locallyOwned` flag that prevents orphan timeout from killing them when query clients (ls, kill) disconnect
- Daemon mode no longer auto-creates Claude processes on every connection; sessions require explicit `create_session_request`
- EPIPE/EIO in wrapper mode gracefully detaches local terminal instead of killing the daemon

## Problem

Every `remi ls` query to a wrapper-mode daemon silently killed the session within 5 minutes:
1. `onConnect` auto-attached the ls connection to the primary session
2. When ls disconnected seconds later, `detachConnection()` started a 5-minute orphan timeout
3. After 5 minutes, `closeSession()` killed the PTY (the Claude Code process)

Additionally, daemon mode created a new Claude process for every connection, causing "Executable not found in PATH: claude" errors on ls queries.

## Changes

| File | Change |
|------|--------|
| `session-registry.ts` | Added `locallyOwned` flag to `ManagedSession`; skip orphan timeout for locally-owned sessions; report active (not orphaned) status |
| `cli.ts` | Thread `locallyOwned` via `passThrough` param; remove daemon-mode auto-session-creation from `onConnect`; graceful EPIPE/EIO handling |
| `App.tsx` | Handle empty sessionId in `hello_ack`; request session list without requiring sessionId |
| `session-registry.test.ts` | 4 new tests for locallyOwned behavior |

## Test plan

- [x] 945 tests pass (4 new, 941 existing unchanged)
- [x] Web app builds clean (`tsc -b && vite build`)
- [x] Biome lint clean on all changed files
- [ ] Manual: start `remi -- claude`, run `remi ls` 3 times, wait 10 minutes, verify session alive
- [ ] Manual: start `remi --daemon`, connect web app, verify session list and creation work

Closes #78