### PR TITLE
refactor: unify network discovery and session resolution

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -995,7 +995,8 @@ if (cliSubcommand === 'attach') {
         process.exit(1);
       }
       const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes('connect') && !msg.includes('timeout') && !msg.includes('ECONNREFUSED')) {
+      const { classifyQueryError } = await import('./cli/session-resolver.ts');
+      if (classifyQueryError(msg) === 'unexpected') {
         log(`[Attach] Failed to query daemon for name resolution: ${msg}`);
       }
     }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -236,13 +236,7 @@ import {
   generateId,
   now,
 } from '@remi/shared';
-import type {
-  AgentStatus,
-  DiscoverableSession,
-  ProtocolMessage,
-  UUID,
-  UnlockedIdentity,
-} from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
 import {
   type AdapterMetadata,
@@ -957,6 +951,15 @@ if (cliSubcommand === 'attach') {
     }
   } else {
     // Try name-based resolution: first check live registry for port, then query daemon(s)
+    const {
+      AmbiguousSessionError,
+      FETCH_SESSIONS_TIMEOUT_MS,
+      discoverNetworkDaemons,
+      findEndpointsByHostname,
+      queryMultiplePorts,
+      resolveSession,
+    } = await import('./cli/session-resolver.ts');
+
     let resolvedByName = false;
 
     // Check live registry for name match (fast, no network)
@@ -973,59 +976,24 @@ if (cliSubcommand === 'attach') {
     }
 
     try {
-      const { fetchSessions } = await import('./cli/ls-client.ts');
-      const allSessions: Array<{ session: DiscoverableSession; port: number }> = [];
+      const queryResults = await queryMultiplePorts({
+        host: resolvedHost,
+        ports: portsToQuery,
+        timeoutMs: FETCH_SESSIONS_TIMEOUT_MS,
+        logLabel: 'attach',
+      });
 
-      const results = await Promise.allSettled(
-        portsToQuery.map(async (port) => {
-          const sessions = await fetchSessions(resolvedHost, port, 3000);
-          return sessions.map((s) => ({ session: s, port }));
-        }),
-      );
-
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
-        if (result?.status === 'fulfilled') {
-          allSessions.push(...result.value);
-        } else if (result?.status === 'rejected') {
-          const reason =
-            result.reason instanceof Error ? result.reason.message : String(result.reason);
-          if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
-            const isExpected =
-              reason.includes('not found') ||
-              reason.includes('ENOENT') ||
-              reason.includes('SESSION_CREATE_FAILED');
-            if (isExpected) {
-              console.error(`\x1b[2m[attach] local port ${portsToQuery[i]}: ${reason}\x1b[0m`);
-            } else {
-              console.error(`[attach] Failed to query port ${portsToQuery[i]}: ${reason}`);
-            }
-          }
-        }
-      }
-
-      const nameMatches = allSessions.filter(
-        (entry) =>
-          entry.session.name === targetSessionId ||
-          entry.session.name?.startsWith(targetSessionId as string),
-      );
-      if (nameMatches.length === 1) {
-        // biome-ignore lint/style/noNonNullAssertion: length checked above
-        const match = nameMatches[0]!;
-        targetSessionId = match.session.sessionId;
-        resolvedPort = cliPort ?? match.port;
+      const resolved = resolveSession(queryResults, targetSessionId as string);
+      if (resolved) {
+        targetSessionId = resolved.session.sessionId;
+        resolvedPort = cliPort ?? resolved.port;
         resolvedByName = true;
-      } else if (nameMatches.length > 1) {
-        console.error(
-          `Ambiguous session name "${targetSessionId}" matches ${nameMatches.length} sessions:`,
-        );
-        for (const m of nameMatches) {
-          console.error(`  ${m.session.name ?? m.session.sessionId.slice(0, 8)} (port ${m.port})`);
-        }
-        console.error('Provide a longer name to disambiguate.');
-        process.exit(1);
       }
     } catch (err) {
+      if (err instanceof AmbiguousSessionError) {
+        console.error(err.message);
+        process.exit(1);
+      }
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('connect') && !msg.includes('timeout') && !msg.includes('ECONNREFUSED')) {
         log(`[Attach] Failed to query daemon for name resolution: ${msg}`);
@@ -1064,132 +1032,79 @@ if (cliSubcommand === 'attach') {
         if (nameColonIdx > 0) {
           const targetHostname = target.slice(0, nameColonIdx);
           try {
-            const { discoverDaemons } = await import('./mdns/mdns-browser.ts');
-            const { discoverVpnPeers } = await import('./mdns/vpn-discovery.ts');
-            const { fetchSessions } = await import('./cli/ls-client.ts');
             console.error(`Resolving "${target}" via network discovery...`);
 
-            // Run mDNS and VPN discovery in parallel
-            const [daemons, vpnPeers] = await Promise.all([
-              discoverDaemons({ timeoutMs: 3000 }),
-              discoverVpnPeers({ port: resolvedPort, probeTimeoutMs: 3000 }).catch((err) => {
-                const msg = err instanceof Error ? err.message : String(err);
-                console.error(`\x1b[2m[attach] VPN discovery failed: ${msg}\x1b[0m`);
-                return [] as {
-                  peer: import('./mdns/vpn-discovery.ts').VpnPeer;
-                  host: string;
-                  port: number;
-                }[];
-              }),
-            ]);
+            const discovery = await discoverNetworkDaemons({
+              defaultPort: resolvedPort,
+              logLabel: 'attach',
+            });
 
             // Log discovery results for diagnostics
-            if (daemons.length > 0 || vpnPeers.length > 0) {
-              const hosts = [
-                ...new Set([
-                  ...daemons.map((d: { hostname: string }) => d.hostname),
-                  ...vpnPeers.map((v) => v.peer.hostname),
-                ]),
-              ];
+            if (discovery.endpoints.length > 0) {
+              const hosts = [...new Set(discovery.endpoints.map((e) => e.hostname))];
               console.error(
-                `\x1b[2mFound ${daemons.length} mDNS, ${vpnPeers.length} VPN daemon(s); ` +
+                `\x1b[2mFound ${discovery.endpoints.length} daemon(s); ` +
                   `hosts: [${hosts.join(', ')}]\x1b[0m`,
               );
             } else {
               console.error('No daemons discovered (0 mDNS, 0 VPN). Is Tailscale running?');
             }
 
-            // Try mDNS first, fall back to VPN peers
-            const mdnsMatch = daemons.find(
-              (d: { hostname: string }) => d.hostname === targetHostname,
-            );
-            const vpnMatch = mdnsMatch
-              ? null
-              : vpnPeers.find((v) => v.peer.hostname === targetHostname);
+            const hostEndpoints = findEndpointsByHostname(discovery, targetHostname);
 
-            const resolvedDaemon = mdnsMatch
-              ? { host: mdnsMatch.host, port: mdnsMatch.port, hostname: mdnsMatch.hostname }
-              : vpnMatch
-                ? { host: vpnMatch.host, port: vpnMatch.port, hostname: vpnMatch.peer.hostname }
-                : null;
-
-            if (resolvedDaemon) {
+            if (hostEndpoints.length > 0) {
               // Query all ports on this host (the host may have multiple remi instances)
-              const hostPorts = vpnPeers
-                .filter((v) => v.host === resolvedDaemon.host)
-                .map((v) => v.port);
-              const mdnsPorts = daemons
-                .filter((d: { host: string }) => d.host === resolvedDaemon.host)
-                .map((d: { port: number }) => d.port);
-              const allHostPorts = [...new Set([...mdnsPorts, ...hostPorts])].sort((a, b) => a - b);
-              if (allHostPorts.length === 0) allHostPorts.push(resolvedDaemon.port);
-
-              // Fetch sessions from all ports on this host
-              const portResults = await Promise.allSettled(
-                allHostPorts.map(async (port) => {
-                  const sessions = await fetchSessions(resolvedDaemon.host, port, 3000);
-                  return { port, sessions };
-                }),
+              const allHostPorts = [...new Set(hostEndpoints.map((e) => e.port))].sort(
+                (a, b) => a - b,
               );
-              const allRemoteSessions: Array<{
-                session: DiscoverableSession;
-                port: number;
-              }> = [];
-              let remoteRejections = 0;
-              for (const r of portResults) {
-                if (r.status === 'fulfilled') {
-                  for (const s of r.value.sessions) {
-                    allRemoteSessions.push({ session: s, port: r.value.port });
-                  }
-                } else {
-                  remoteRejections++;
-                  const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-                  if (
-                    !reason.includes('Cannot connect') &&
-                    !reason.includes('closed unexpectedly')
-                  ) {
-                    log(`[attach] remote port query failed: ${reason}`);
-                  }
-                }
-              }
-              if (remoteRejections === portResults.length) {
+              const remoteHost = hostEndpoints[0]?.host ?? targetHostname;
+              const remoteHostname = hostEndpoints[0]?.hostname ?? targetHostname;
+
+              const portResults = await queryMultiplePorts({
+                host: remoteHost,
+                ports: allHostPorts,
+                timeoutMs: FETCH_SESSIONS_TIMEOUT_MS,
+                logLabel: 'attach',
+              });
+
+              if (portResults.length === 0) {
                 console.error(
-                  `Daemon found on ${resolvedDaemon.hostname} but could not query any port. Check connectivity to ${resolvedDaemon.host}.`,
+                  `Daemon found on ${remoteHostname} but could not query any port. Check connectivity to ${remoteHost}.`,
                 );
                 process.exit(1);
               }
 
-              const remoteMatches = allRemoteSessions.filter(
-                (entry) => entry.session.name === target || entry.session.name?.startsWith(target),
-              );
-              if (remoteMatches.length === 1) {
-                // biome-ignore lint/style/noNonNullAssertion: length checked above
-                const match = remoteMatches[0]!;
-                targetSessionId = match.session.sessionId;
-                resolvedHost = resolvedDaemon.host;
-                resolvedPort = match.port;
-                foundRemote = true;
-                console.error(
-                  `Found on ${resolvedDaemon.hostname} (${resolvedDaemon.host}:${match.port})`,
-                );
-              } else if (remoteMatches.length > 1) {
-                console.error(
-                  `Ambiguous: ${remoteMatches.length} sessions match on ${resolvedDaemon.hostname}`,
-                );
-                for (const m of remoteMatches) {
+              try {
+                const remoteResolved = resolveSession(portResults, target);
+                if (remoteResolved) {
+                  targetSessionId = remoteResolved.session.sessionId;
+                  resolvedHost = remoteResolved.host;
+                  resolvedPort = remoteResolved.port;
+                  foundRemote = true;
                   console.error(
-                    `  ${m.session.name ?? m.session.sessionId.slice(0, 8)} (port ${m.port})`,
+                    `Found on ${remoteHostname} (${remoteResolved.host}:${remoteResolved.port})`,
                   );
+                } else {
+                  console.error(
+                    `Daemon found on ${remoteHostname} but no session matches "${target}".`,
+                  );
+                  const available = portResults
+                    .flatMap((r) => r.sessions)
+                    .map((s) => s.name ?? s.sessionId.slice(0, 8))
+                    .join(', ');
+                  if (available) console.error(`  Available sessions: ${available}`);
                 }
-                process.exit(1);
-              } else {
-                console.error(
-                  `Daemon found on ${resolvedDaemon.hostname} but no session matches "${target}".`,
-                );
-                const available = allRemoteSessions
-                  .map((e) => e.session.name ?? e.session.sessionId.slice(0, 8))
-                  .join(', ');
-                if (available) console.error(`  Available sessions: ${available}`);
+              } catch (resolveErr) {
+                if (resolveErr instanceof AmbiguousSessionError) {
+                  console.error(
+                    `Ambiguous: ${resolveErr.matches.length} sessions match on ${remoteHostname}`,
+                  );
+                  for (const m of resolveErr.matches) {
+                    console.error(`  ${m.name} (port ${m.port})`);
+                  }
+                  process.exit(1);
+                }
+                throw resolveErr;
               }
             } else {
               console.error(
@@ -1197,6 +1112,9 @@ if (cliSubcommand === 'attach') {
               );
             }
           } catch (err) {
+            if (err instanceof AmbiguousSessionError) {
+              throw err; // Already handled above
+            }
             const reason = err instanceof Error ? err.message : String(err);
             log(`[Attach] Network discovery error for "${targetHostname}": ${reason}`);
             console.error(`Network discovery failed: ${reason}`);

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -15,6 +15,7 @@ import {
 } from '@remi/shared';
 import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
+import { resolveSession as sharedResolveSession } from './session-resolver.ts';
 
 export interface KillClientOptions {
   readonly host: string;
@@ -63,41 +64,6 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
       ws.send(serialize(createHello(clientId, '1.0.0')));
     }
 
-    function resolveSession(
-      sessionList: DiscoverableSession[],
-      nameOrId: string,
-    ): DiscoverableSession | null {
-      // Exact name match
-      const byName = sessionList.filter((s) => s.name === nameOrId);
-      if (byName.length === 1) return byName[0] ?? null;
-
-      // Prefix name match
-      const byPrefix = sessionList.filter((s) => s.name?.startsWith(nameOrId));
-      if (byPrefix.length === 1) return byPrefix[0] ?? null;
-      if (byPrefix.length > 1) {
-        const names = byPrefix.map((s) => `  ${s.name ?? s.sessionId.slice(0, 8)}`).join('\n');
-        throw new Error(
-          `Ambiguous session name "${nameOrId}" matches ${byPrefix.length} sessions:\n${names}\nProvide a longer name to disambiguate.`,
-        );
-      }
-
-      // Exact ID match
-      const byId = sessionList.filter((s) => s.sessionId === nameOrId);
-      if (byId.length === 1) return byId[0] ?? null;
-
-      // Prefix ID match
-      const byIdPrefix = sessionList.filter((s) => s.sessionId.startsWith(nameOrId));
-      if (byIdPrefix.length === 1) return byIdPrefix[0] ?? null;
-      if (byIdPrefix.length > 1) {
-        const ids = byIdPrefix.map((s) => `  ${s.sessionId.slice(0, 8)}`).join('\n');
-        throw new Error(
-          `Ambiguous session ID "${nameOrId}" matches ${byIdPrefix.length} sessions:\n${ids}\nProvide a longer prefix to disambiguate.`,
-        );
-      }
-
-      return null;
-    }
-
     function handleMessage(msg: ProtocolMessage): void {
       if (msg.type === 'hello_ack') {
         // Request session list first to resolve the name
@@ -105,8 +71,8 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
       } else if (msg.type === 'session_list_response') {
         sessions = msg.sessions as DiscoverableSession[];
         try {
-          const session = resolveSession(sessions, target);
-          if (!session) {
+          const resolved = sharedResolveSession([{ host, port, sessions }], target);
+          if (!resolved) {
             done(
               new Error(
                 `No session found matching "${target}". Run \`remi ls\` to see live sessions.`,
@@ -115,7 +81,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
             return;
           }
           // Send kill request
-          ws.send(serialize(createKillSessionRequest(session.sessionId as UUID)));
+          ws.send(serialize(createKillSessionRequest(resolved.session.sessionId as UUID)));
         } catch (err) {
           done(err instanceof Error ? err : new Error(String(err)));
         }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -10,6 +10,12 @@ import {
 import type { DiscoverableSession, ProtocolMessage, Timestamp } from '@remi/shared';
 import type { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
+import {
+  FETCH_SESSIONS_TIMEOUT_MS,
+  MDNS_BROWSE_TIMEOUT_MS,
+  discoverNetworkDaemons,
+  queryMultiplePorts,
+} from './session-resolver.ts';
 
 export interface RemoteTarget {
   readonly host: string;
@@ -207,56 +213,22 @@ interface DaemonSessions {
 }
 
 export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
-  const { localPort, fetchTimeoutMs: timeout = 5000, browseTimeoutMs: mdnsTimeout = 3000 } = opts;
+  const {
+    localPort,
+    fetchTimeoutMs: timeout = FETCH_SESSIONS_TIMEOUT_MS,
+    browseTimeoutMs: mdnsTimeout = MDNS_BROWSE_TIMEOUT_MS,
+  } = opts;
 
-  // Try all local daemons (multi-port support)
-  const allLocalPorts = new Set([localPort, ...(opts.localPorts ?? [])]);
-  const localSessions: DiscoverableSession[] = [];
-  const localResults = await Promise.allSettled(
-    [...allLocalPorts].map(async (port) => {
-      const sessions = await fetchSessions('localhost', port, timeout);
-      return { port, sessions };
-    }),
-  );
-  const localPortsArr = [...allLocalPorts];
-  for (let i = 0; i < localResults.length; i++) {
-    const result = localResults[i];
-    if (result?.status === 'fulfilled') {
-      localSessions.push(...result.value.sessions);
-    } else if (result?.status === 'rejected') {
-      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
-      if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
-        const isExpected =
-          reason.includes('not found') ||
-          reason.includes('ENOENT') ||
-          reason.includes('SESSION_CREATE_FAILED');
-        if (isExpected) {
-          console.error(`\x1b[2m[ls] local port ${localPortsArr[i]}: ${reason}\x1b[0m`);
-        } else {
-          console.error(`[ls] Failed to query local port ${localPortsArr[i]}: ${reason}`);
-        }
-      }
-    }
-  }
+  // Query all local daemons (multi-port support)
+  const allLocalPorts = [...new Set([localPort, ...(opts.localPorts ?? [])])];
+  const localResults = await queryMultiplePorts({
+    host: 'localhost',
+    ports: allLocalPorts,
+    timeoutMs: timeout,
+    logLabel: 'ls',
+  });
 
-  console.error('Scanning network for Remi daemons...');
-  const { discoverDaemons } = await import('../mdns/mdns-browser.ts');
-  const { discoverVpnPeers } = await import('../mdns/vpn-discovery.ts');
-
-  // Run mDNS and VPN discovery in parallel
-  const [daemons, vpnPeers] = await Promise.all([
-    discoverDaemons({ timeoutMs: mdnsTimeout }),
-    discoverVpnPeers({ port: localPort, probeTimeoutMs: timeout }).catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[ls] VPN discovery failed: ${msg}`);
-      return [] as {
-        peer: import('../mdns/vpn-discovery.ts').VpnPeer;
-        host: string;
-        port: number;
-      }[];
-    }),
-  ]);
-
+  const localSessions: DiscoverableSession[] = localResults.flatMap((r) => r.sessions);
   const results: DaemonSessions[] = [];
   const myHostname = os.hostname();
 
@@ -267,96 +239,40 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     });
   }
 
-  // Query remote daemons (mDNS) in parallel, filtering out self
-  const localAddrs = getLocalAddresses(myHostname);
-  const remoteDaemons = daemons.filter((d) => !(d.port === localPort && localAddrs.has(d.host)));
+  console.error('Scanning network for Remi daemons...');
+  const discovery = await discoverNetworkDaemons({
+    defaultPort: localPort,
+    browseTimeoutMs: mdnsTimeout,
+    probeTimeoutMs: timeout,
+    logLabel: 'ls',
+  });
 
-  // Track hosts already discovered via mDNS to deduplicate VPN results
-  const discoveredHosts = new Set(remoteDaemons.map((d) => d.host));
-
-  const remoteResults = await Promise.allSettled(
-    remoteDaemons.map(async (daemon) => {
-      const sessions = await fetchSessions(daemon.host, daemon.port, timeout);
-      return {
+  // Query each discovered endpoint
+  for (const endpoint of discovery.endpoints) {
+    const portResults = await queryMultiplePorts({
+      host: endpoint.host,
+      ports: [endpoint.port],
+      timeoutMs: timeout,
+      logLabel: 'ls',
+    });
+    for (const r of portResults) {
+      results.push({
         daemon: {
-          name: daemon.name,
-          host: daemon.host,
-          port: daemon.port,
-          hostname: daemon.hostname,
+          name: endpoint.name ?? `${endpoint.source}:${endpoint.hostname}`,
+          host: endpoint.host,
+          port: endpoint.port,
+          hostname: endpoint.hostname,
         },
-        sessions,
-      } satisfies DaemonSessions;
-    }),
-  );
-
-  for (let i = 0; i < remoteResults.length; i++) {
-    const r = remoteResults[i];
-    if (r?.status === 'fulfilled') {
-      results.push(r.value);
-    } else if (r?.status === 'rejected') {
-      const daemon = remoteDaemons[i];
-      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-      const label = `${daemon?.name ?? 'unknown'} at ${daemon?.host ?? '?'}:${daemon?.port ?? '?'}`;
-      const isTimeout = reason.includes('Timed out') || reason.includes('timeout');
-      if (isTimeout) {
-        console.error(`\x1b[2m[ls] ${label}: ${reason}\x1b[0m`);
-      } else {
-        console.error(`[ls] Failed to query ${label}: ${reason}`);
-      }
-    }
-  }
-
-  // Query VPN peers not already found via mDNS
-  const newVpnPeers = vpnPeers.filter(
-    (v) => !localAddrs.has(v.host) && !discoveredHosts.has(v.host),
-  );
-  if (newVpnPeers.length > 0) {
-    const vpnResults = await Promise.allSettled(
-      newVpnPeers.map(async ({ peer, host, port }) => {
-        const sessions = await fetchSessions(host, port, timeout);
-        return {
-          daemon: {
-            name: `vpn:${peer.hostname}`,
-            host,
-            port,
-            hostname: peer.hostname,
-          },
-          sessions,
-        } satisfies DaemonSessions;
-      }),
-    );
-    for (let i = 0; i < vpnResults.length; i++) {
-      const r = vpnResults[i];
-      if (r?.status === 'fulfilled') {
-        results.push(r.value);
-      } else if (r?.status === 'rejected') {
-        // Connection refused is expected (peer has no remi); log other errors
-        const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-        if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
-          const vpnPeer = newVpnPeers[i];
-          console.error(
-            `[ls] VPN peer ${vpnPeer?.peer.hostname ?? 'unknown'} at ${vpnPeer?.host ?? '?'}:${vpnPeer?.port ?? '?'}: ${reason}`,
-          );
-        }
-      }
+        sessions: r.sessions,
+      });
     }
   }
 
   renderNetworkSessionList(results);
 }
 
-export function getLocalAddresses(hostname: string): Set<string> {
-  const addrs = new Set(['127.0.0.1', '::1', 'localhost', hostname]);
-  const interfaces = os.networkInterfaces();
-  for (const ifaces of Object.values(interfaces)) {
-    if (ifaces) {
-      for (const iface of ifaces) {
-        addrs.add(iface.address);
-      }
-    }
-  }
-  return addrs;
-}
+// Re-export from session-resolver for backward compatibility
+export { getLocalAddresses } from './session-resolver.ts';
 
 function renderNetworkSessionList(results: DaemonSessions[]): void {
   if (results.length === 0) {
@@ -477,7 +393,7 @@ export interface MultiPortLsOptions {
  * and querying each unique port.
  */
 export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
-  const { registry, timeout = 5000 } = opts;
+  const { registry, timeout = FETCH_SESSIONS_TIMEOUT_MS } = opts;
 
   const ports = registry.getLivePorts();
 
@@ -486,36 +402,14 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
     return;
   }
 
-  // Query each port in parallel
-  const results = await Promise.allSettled(
-    ports.map(async (port) => {
-      const sessions = await fetchSessions('localhost', port, timeout);
-      return { port, sessions };
-    }),
-  );
+  const results = await queryMultiplePorts({
+    host: 'localhost',
+    ports,
+    timeoutMs: timeout,
+    logLabel: 'ls',
+  });
 
-  const allSessions: DiscoverableSession[] = [];
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result?.status === 'fulfilled') {
-      allSessions.push(...result.value.sessions);
-    } else if (result?.status === 'rejected') {
-      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
-      // Connection refused is expected (process may have just exited); log others
-      if (!reason.includes('Cannot connect') && !reason.includes('closed unexpectedly')) {
-        const isExpected =
-          reason.includes('not found') ||
-          reason.includes('ENOENT') ||
-          reason.includes('SESSION_CREATE_FAILED');
-        if (isExpected) {
-          console.error(`\x1b[2m[ls] local port ${ports[i]}: ${reason}\x1b[0m`);
-        } else {
-          console.error(`[ls] Failed to query local port ${ports[i]}: ${reason}`);
-        }
-      }
-    }
-  }
-
+  const allSessions: DiscoverableSession[] = results.flatMap((r) => r.sessions);
   renderSessionList(allSessions);
 }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -247,24 +247,32 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     logLabel: 'ls',
   });
 
-  // Query each discovered endpoint
-  for (const endpoint of discovery.endpoints) {
-    const portResults = await queryMultiplePorts({
-      host: endpoint.host,
-      ports: [endpoint.port],
-      timeoutMs: timeout,
-      logLabel: 'ls',
-    });
-    for (const r of portResults) {
-      results.push({
-        daemon: {
-          name: endpoint.name ?? `${endpoint.source}:${endpoint.hostname}`,
-          host: endpoint.host,
-          port: endpoint.port,
-          hostname: endpoint.hostname,
-        },
-        sessions: r.sessions,
+  // Query all discovered endpoints in parallel
+  const endpointResults = await Promise.allSettled(
+    discovery.endpoints.map(async (endpoint) => {
+      const portResults = await queryMultiplePorts({
+        host: endpoint.host,
+        ports: [endpoint.port],
+        timeoutMs: timeout,
+        logLabel: 'ls',
       });
+      return { endpoint, portResults };
+    }),
+  );
+  for (const er of endpointResults) {
+    if (er.status === 'fulfilled') {
+      for (const r of er.value.portResults) {
+        results.push({
+          daemon: {
+            name:
+              er.value.endpoint.name ?? `${er.value.endpoint.source}:${er.value.endpoint.hostname}`,
+            host: er.value.endpoint.host,
+            port: er.value.endpoint.port,
+            hostname: er.value.endpoint.hostname,
+          },
+          sessions: r.sessions,
+        });
+      }
     }
   }
 

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -1,0 +1,333 @@
+/**
+ * Unified session discovery and resolution utilities.
+ *
+ * Consolidates duplicated logic from ls-client, kill-client, and cli.ts (attach)
+ * into composable functions: error classification, multi-port querying,
+ * session resolution, and network daemon discovery.
+ */
+
+import * as os from 'node:os';
+import type { DiscoverableSession } from '@remi/shared';
+
+// ---------------------------------------------------------------------------
+// Timeout constants (unified across all commands)
+// ---------------------------------------------------------------------------
+
+/** Timeout for fetchSessions WebSocket calls (ms) */
+export const FETCH_SESSIONS_TIMEOUT_MS = 5000;
+/** Timeout for VPN peer probing (ms) */
+export const VPN_PROBE_TIMEOUT_MS = 3000;
+/** Timeout for mDNS browsing (ms) */
+export const MDNS_BROWSE_TIMEOUT_MS = 3000;
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+export type QueryErrorClass = 'connection' | 'expected' | 'unexpected';
+
+/**
+ * Classify a query error into one of three categories:
+ * - `'connection'`: daemon unreachable (suppressed entirely)
+ * - `'expected'`: benign errors like not-found or session-create-failed (dimmed)
+ * - `'unexpected'`: everything else (full error)
+ */
+export function classifyQueryError(reason: string): QueryErrorClass {
+  // Connection failures: daemon not running or unreachable
+  if (
+    reason.includes('Cannot connect') ||
+    reason.includes('closed unexpectedly') ||
+    reason.includes('ECONNREFUSED') ||
+    reason.includes('ECONNRESET')
+  ) {
+    return 'connection';
+  }
+
+  // Expected/benign errors
+  if (
+    reason.includes('not found') ||
+    reason.includes('ENOENT') ||
+    reason.includes('SESSION_CREATE_FAILED')
+  ) {
+    return 'expected';
+  }
+
+  return 'unexpected';
+}
+
+// ---------------------------------------------------------------------------
+// Multi-port querying
+// ---------------------------------------------------------------------------
+
+export interface PortQueryResult {
+  readonly port: number;
+  readonly host: string;
+  readonly sessions: DiscoverableSession[];
+}
+
+export interface QueryMultiplePortsOptions {
+  readonly host: string;
+  readonly ports: readonly number[];
+  readonly timeoutMs?: number;
+  /** Label prefix for log messages (e.g. "ls", "attach") */
+  readonly logLabel?: string;
+}
+
+/**
+ * Query multiple daemon ports in parallel, returning successful results.
+ * Failed queries are classified and logged uniformly.
+ */
+export async function queryMultiplePorts(
+  opts: QueryMultiplePortsOptions,
+): Promise<PortQueryResult[]> {
+  const { host, ports, timeoutMs = FETCH_SESSIONS_TIMEOUT_MS, logLabel = 'remi' } = opts;
+
+  if (ports.length === 0) return [];
+
+  const { fetchSessions } = await import('./ls-client.ts');
+
+  const results = await Promise.allSettled(
+    ports.map(async (port) => {
+      const sessions = await fetchSessions(host, port, timeoutMs);
+      return { port, host, sessions } satisfies PortQueryResult;
+    }),
+  );
+
+  const successful: PortQueryResult[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result?.status === 'fulfilled') {
+      successful.push(result.value);
+    } else if (result?.status === 'rejected') {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      const errorClass = classifyQueryError(reason);
+
+      if (errorClass === 'expected') {
+        console.error(`\x1b[2m[${logLabel}] ${host}:${ports[i]}: ${reason}\x1b[0m`);
+      } else if (errorClass === 'unexpected') {
+        console.error(`[${logLabel}] Failed to query ${host}:${ports[i]}: ${reason}`);
+      }
+      // 'connection' errors are suppressed
+    }
+  }
+
+  return successful;
+}
+
+// ---------------------------------------------------------------------------
+// Session resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolvedSession {
+  readonly session: DiscoverableSession;
+  readonly port: number;
+  readonly host: string;
+}
+
+export class AmbiguousSessionError extends Error {
+  readonly matches: ReadonlyArray<{ name: string; port: number }>;
+
+  constructor(target: string, matches: ReadonlyArray<{ name: string; port: number }>) {
+    const list = matches.map((m) => `  ${m.name} (port ${m.port})`).join('\n');
+    super(
+      `Ambiguous session "${target}" matches ${matches.length} sessions:\n${list}\nProvide a longer name or ID to disambiguate.`,
+    );
+    this.name = 'AmbiguousSessionError';
+    this.matches = matches;
+  }
+}
+
+/**
+ * Resolve a session by name or ID from query results.
+ *
+ * Resolution order: exact name -> prefix name -> exact ID -> prefix ID.
+ * Throws `AmbiguousSessionError` if multiple prefix matches exist.
+ * Returns null if no match found.
+ */
+export function resolveSession(
+  results: readonly PortQueryResult[],
+  nameOrId: string,
+): ResolvedSession | null {
+  // Flatten results into entries with host/port context
+  const entries: Array<{ session: DiscoverableSession; host: string; port: number }> = [];
+  for (const r of results) {
+    for (const session of r.sessions) {
+      entries.push({ session, host: r.host, port: r.port });
+    }
+  }
+
+  function toResult(arr: typeof entries): ResolvedSession | null {
+    if (arr.length !== 1) return null;
+    const match = arr[0] as (typeof entries)[0];
+    return { session: match.session, port: match.port, host: match.host };
+  }
+
+  // 1. Exact name match
+  const exactName = entries.filter((e) => e.session.name === nameOrId);
+  const exactNameResult = toResult(exactName);
+  if (exactNameResult) return exactNameResult;
+  if (exactName.length > 1) {
+    throw new AmbiguousSessionError(
+      nameOrId,
+      exactName.map((e) => ({
+        name: e.session.name ?? e.session.sessionId.slice(0, 8),
+        port: e.port,
+      })),
+    );
+  }
+
+  // 2. Prefix name match
+  const prefixName = entries.filter((e) => e.session.name?.startsWith(nameOrId));
+  const prefixNameResult = toResult(prefixName);
+  if (prefixNameResult) return prefixNameResult;
+  if (prefixName.length > 1) {
+    throw new AmbiguousSessionError(
+      nameOrId,
+      prefixName.map((e) => ({
+        name: e.session.name ?? e.session.sessionId.slice(0, 8),
+        port: e.port,
+      })),
+    );
+  }
+
+  // 3. Exact ID match
+  const exactId = entries.filter((e) => e.session.sessionId === nameOrId);
+  const exactIdResult = toResult(exactId);
+  if (exactIdResult) return exactIdResult;
+
+  // 4. Prefix ID match
+  const prefixId = entries.filter((e) => e.session.sessionId.startsWith(nameOrId));
+  const prefixIdResult = toResult(prefixId);
+  if (prefixIdResult) return prefixIdResult;
+  if (prefixId.length > 1) {
+    throw new AmbiguousSessionError(
+      nameOrId,
+      prefixId.map((e) => ({
+        name: e.session.sessionId.slice(0, 8),
+        port: e.port,
+      })),
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Network daemon discovery
+// ---------------------------------------------------------------------------
+
+export interface DiscoveredEndpoint {
+  readonly host: string;
+  readonly port: number;
+  readonly hostname: string;
+  readonly source: 'mdns' | 'vpn';
+  readonly name?: string;
+}
+
+export interface NetworkDiscoveryResult {
+  readonly endpoints: readonly DiscoveredEndpoint[];
+  /** Hosts found via mDNS (for dedup) */
+  readonly mdnsHosts: ReadonlySet<string>;
+}
+
+export interface NetworkDiscoveryOptions {
+  readonly defaultPort: number;
+  readonly browseTimeoutMs?: number;
+  readonly probeTimeoutMs?: number;
+  readonly logLabel?: string;
+}
+
+/**
+ * Discover remi daemons on the network via mDNS and VPN.
+ * Deduplicates VPN results that overlap with mDNS discoveries.
+ * Filters out local addresses.
+ */
+export async function discoverNetworkDaemons(
+  opts: NetworkDiscoveryOptions,
+): Promise<NetworkDiscoveryResult> {
+  const {
+    defaultPort,
+    browseTimeoutMs = MDNS_BROWSE_TIMEOUT_MS,
+    probeTimeoutMs = VPN_PROBE_TIMEOUT_MS,
+    logLabel = 'remi',
+  } = opts;
+
+  const { discoverDaemons } = await import('../mdns/mdns-browser.ts');
+  const { discoverVpnPeers } = await import('../mdns/vpn-discovery.ts');
+
+  const [daemons, vpnPeers] = await Promise.all([
+    discoverDaemons({ timeoutMs: browseTimeoutMs }),
+    discoverVpnPeers({ port: defaultPort, probeTimeoutMs }).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${logLabel}] VPN discovery failed: ${msg}`);
+      return [] as {
+        peer: { hostname: string; ip: string; os: string; provider: string };
+        host: string;
+        port: number;
+      }[];
+    }),
+  ]);
+
+  const myHostname = os.hostname();
+  const localAddrs = getLocalAddresses(myHostname);
+
+  // Convert mDNS daemons to endpoints, filtering out self
+  const mdnsEndpoints: DiscoveredEndpoint[] = daemons
+    .filter((d) => !(d.port === defaultPort && localAddrs.has(d.host)))
+    .map((d) => ({
+      host: d.host,
+      port: d.port,
+      hostname: d.hostname,
+      source: 'mdns' as const,
+      name: d.name,
+    }));
+
+  const mdnsHosts = new Set(mdnsEndpoints.map((e) => e.host));
+
+  // Convert VPN peers to endpoints, filtering out self and mDNS duplicates
+  const vpnEndpoints: DiscoveredEndpoint[] = vpnPeers
+    .filter((v) => !localAddrs.has(v.host) && !mdnsHosts.has(v.host))
+    .map((v) => ({
+      host: v.host,
+      port: v.port,
+      hostname: v.peer.hostname,
+      source: 'vpn' as const,
+    }));
+
+  return {
+    endpoints: [...mdnsEndpoints, ...vpnEndpoints],
+    mdnsHosts,
+  };
+}
+
+/**
+ * Find all endpoints matching a given hostname from discovery results.
+ * Collects all unique ports across mDNS and VPN for the matched host.
+ */
+export function findEndpointsByHostname(
+  result: NetworkDiscoveryResult,
+  hostname: string,
+): DiscoveredEndpoint[] {
+  return result.endpoints.filter((e) => e.hostname === hostname);
+}
+
+// ---------------------------------------------------------------------------
+// Local address helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all local addresses (for filtering out self in network discovery).
+ */
+export function getLocalAddresses(hostname: string): Set<string> {
+  const addrs = new Set(['127.0.0.1', '::1', 'localhost', hostname]);
+  const interfaces = os.networkInterfaces();
+  for (const ifaces of Object.values(interfaces)) {
+    if (ifaces) {
+      for (const iface of ifaces) {
+        addrs.add(iface.address);
+      }
+    }
+  }
+  return addrs;
+}

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -62,7 +62,7 @@ export function classifyQueryError(reason: string): QueryErrorClass {
 export interface PortQueryResult {
   readonly port: number;
   readonly host: string;
-  readonly sessions: DiscoverableSession[];
+  readonly sessions: readonly DiscoverableSession[];
 }
 
 export interface QueryMultiplePortsOptions {
@@ -142,7 +142,9 @@ export class AmbiguousSessionError extends Error {
  * Resolve a session by name or ID from query results.
  *
  * Resolution order: exact name -> prefix name -> exact ID -> prefix ID.
- * Throws `AmbiguousSessionError` if multiple prefix matches exist.
+ * Throws `AmbiguousSessionError` if multiple matches exist at any resolution
+ * level (exact name, prefix name, or prefix ID). Multiple exact ID matches
+ * fall through to prefix ID matching (UUID collisions are near-impossible).
  * Returns null if no match found.
  */
 export function resolveSession(
@@ -218,8 +220,10 @@ export function resolveSession(
 // ---------------------------------------------------------------------------
 
 export interface DiscoveredEndpoint {
+  /** IP address or resolvable network address */
   readonly host: string;
   readonly port: number;
+  /** Human-readable machine name (e.g., OS hostname) */
   readonly hostname: string;
   readonly source: 'mdns' | 'vpn';
   readonly name?: string;
@@ -227,8 +231,6 @@ export interface DiscoveredEndpoint {
 
 export interface NetworkDiscoveryResult {
   readonly endpoints: readonly DiscoveredEndpoint[];
-  /** Hosts found via mDNS (for dedup) */
-  readonly mdnsHosts: ReadonlySet<string>;
 }
 
 export interface NetworkDiscoveryOptions {
@@ -257,7 +259,11 @@ export async function discoverNetworkDaemons(
   const { discoverVpnPeers } = await import('../mdns/vpn-discovery.ts');
 
   const [daemons, vpnPeers] = await Promise.all([
-    discoverDaemons({ timeoutMs: browseTimeoutMs }),
+    discoverDaemons({ timeoutMs: browseTimeoutMs }).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${logLabel}] mDNS discovery failed: ${msg}`);
+      return [] as import('../mdns/mdns-browser.ts').DiscoveredDaemon[];
+    }),
     discoverVpnPeers({ port: defaultPort, probeTimeoutMs }).catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[${logLabel}] VPN discovery failed: ${msg}`);
@@ -297,13 +303,11 @@ export async function discoverNetworkDaemons(
 
   return {
     endpoints: [...mdnsEndpoints, ...vpnEndpoints],
-    mdnsHosts,
   };
 }
 
 /**
- * Find all endpoints matching a given hostname from discovery results.
- * Collects all unique ports across mDNS and VPN for the matched host.
+ * Filter endpoints matching a given hostname from discovery results.
  */
 export function findEndpointsByHostname(
   result: NetworkDiscoveryResult,

--- a/packages/daemon/tests/cli/kill-client.test.ts
+++ b/packages/daemon/tests/cli/kill-client.test.ts
@@ -1,43 +1,14 @@
 /**
  * Tests for kill-client session resolution logic.
  *
- * These tests verify the session name/ID resolution used by `remi kill`.
- * The actual WebSocket communication is tested via integration tests.
+ * These tests verify the session name/ID resolution used by `remi kill`,
+ * now delegated to the shared resolveSession utility.
  */
 
 import { describe, expect, test } from 'bun:test';
 import type { DiscoverableSession } from '@remi/shared';
 import { generateId } from '@remi/shared';
-
-// Extract the resolution logic for unit testing
-function resolveSession(
-  sessionList: DiscoverableSession[],
-  nameOrId: string,
-): DiscoverableSession | null {
-  // Exact name match
-  const byName = sessionList.filter((s) => s.name === nameOrId);
-  if (byName.length === 1) return byName[0] ?? null;
-
-  // Prefix name match
-  const byPrefix = sessionList.filter((s) => s.name?.startsWith(nameOrId));
-  if (byPrefix.length === 1) return byPrefix[0] ?? null;
-  if (byPrefix.length > 1) {
-    throw new Error(`Ambiguous session name "${nameOrId}"`);
-  }
-
-  // Exact ID match
-  const byId = sessionList.filter((s) => s.sessionId === nameOrId);
-  if (byId.length === 1) return byId[0] ?? null;
-
-  // Prefix ID match
-  const byIdPrefix = sessionList.filter((s) => s.sessionId.startsWith(nameOrId));
-  if (byIdPrefix.length === 1) return byIdPrefix[0] ?? null;
-  if (byIdPrefix.length > 1) {
-    throw new Error(`Ambiguous session ID "${nameOrId}"`);
-  }
-
-  return null;
-}
+import { type PortQueryResult, resolveSession } from '../../src/cli/session-resolver.ts';
 
 function makeSession(name: string, id?: string): DiscoverableSession {
   return {
@@ -52,46 +23,50 @@ function makeSession(name: string, id?: string): DiscoverableSession {
   };
 }
 
-describe('kill-client session resolution', () => {
+function wrapSessions(sessions: DiscoverableSession[]): PortQueryResult[] {
+  return [{ host: 'localhost', port: 18765, sessions }];
+}
+
+describe('kill-client session resolution (via shared resolver)', () => {
   test('resolves exact name match', () => {
     const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/remi/dev')];
-    const result = resolveSession(sessions, 'macbook/remi/main');
-    expect(result?.name).toBe('macbook/remi/main');
+    const result = resolveSession(wrapSessions(sessions), 'macbook/remi/main');
+    expect(result?.session.name).toBe('macbook/remi/main');
   });
 
   test('resolves prefix name match', () => {
     const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/other/dev')];
-    const result = resolveSession(sessions, 'macbook/remi');
-    expect(result?.name).toBe('macbook/remi/main');
+    const result = resolveSession(wrapSessions(sessions), 'macbook/remi');
+    expect(result?.session.name).toBe('macbook/remi/main');
   });
 
   test('throws on ambiguous name prefix', () => {
     const sessions = [makeSession('macbook/remi/main'), makeSession('macbook/remi/dev')];
-    expect(() => resolveSession(sessions, 'macbook/remi')).toThrow('Ambiguous');
+    expect(() => resolveSession(wrapSessions(sessions), 'macbook/remi')).toThrow('Ambiguous');
   });
 
   test('resolves exact ID match', () => {
     const id = generateId();
     const sessions = [makeSession('test-session', id)];
-    const result = resolveSession(sessions, id);
-    expect(result?.sessionId).toBe(id);
+    const result = resolveSession(wrapSessions(sessions), id);
+    expect(result?.session.sessionId).toBe(id);
   });
 
   test('resolves prefix ID match', () => {
     const id = 'abcdef12-3456-7890-abcd-ef1234567890';
     const sessions = [makeSession('test-session', id)];
-    const result = resolveSession(sessions, 'abcdef12');
-    expect(result?.sessionId).toBe(id);
+    const result = resolveSession(wrapSessions(sessions), 'abcdef12');
+    expect(result?.session.sessionId).toBe(id);
   });
 
   test('returns null for no match', () => {
     const sessions = [makeSession('macbook/remi/main')];
-    const result = resolveSession(sessions, 'nonexistent');
+    const result = resolveSession(wrapSessions(sessions), 'nonexistent');
     expect(result).toBeNull();
   });
 
   test('returns null for empty session list', () => {
-    const result = resolveSession([], 'anything');
+    const result = resolveSession(wrapSessions([]), 'anything');
     expect(result).toBeNull();
   });
 });

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for unified session resolution and discovery utilities.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { DiscoverableSession } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import {
+  AmbiguousSessionError,
+  type PortQueryResult,
+  classifyQueryError,
+  resolveSession,
+} from '../../src/cli/session-resolver.ts';
+
+function makeSession(name: string, id?: string): DiscoverableSession {
+  return {
+    sessionId: id ?? generateId(),
+    name,
+    projectPath: '/tmp/test',
+    status: 'active',
+    lastActivity: new Date().toISOString(),
+    messageCount: 0,
+    source: 'daemon',
+    canAttach: true,
+  };
+}
+
+function makeQueryResult(
+  host: string,
+  port: number,
+  sessions: DiscoverableSession[],
+): PortQueryResult {
+  return { host, port, sessions };
+}
+
+// ---------------------------------------------------------------------------
+// classifyQueryError
+// ---------------------------------------------------------------------------
+
+describe('classifyQueryError', () => {
+  test('classifies "Cannot connect" as connection', () => {
+    expect(classifyQueryError('Cannot connect to daemon at localhost:18765')).toBe('connection');
+  });
+
+  test('classifies "closed unexpectedly" as connection', () => {
+    expect(classifyQueryError('Connection to daemon closed unexpectedly')).toBe('connection');
+  });
+
+  test('classifies "ECONNREFUSED" as connection', () => {
+    expect(classifyQueryError('connect ECONNREFUSED 127.0.0.1:18765')).toBe('connection');
+  });
+
+  test('classifies "ECONNRESET" as connection', () => {
+    expect(classifyQueryError('read ECONNRESET')).toBe('connection');
+  });
+
+  test('classifies "not found" as expected', () => {
+    expect(classifyQueryError('Session not found')).toBe('expected');
+  });
+
+  test('classifies "ENOENT" as expected', () => {
+    expect(classifyQueryError('ENOENT: no such file or directory')).toBe('expected');
+  });
+
+  test('classifies "SESSION_CREATE_FAILED" as expected', () => {
+    expect(classifyQueryError('Daemon error: SESSION_CREATE_FAILED')).toBe('expected');
+  });
+
+  test('classifies unknown errors as unexpected', () => {
+    expect(classifyQueryError('Something went wrong')).toBe('unexpected');
+  });
+
+  test('classifies timeout as unexpected', () => {
+    expect(classifyQueryError('Timed out connecting to daemon')).toBe('unexpected');
+  });
+
+  test('classifies empty string as unexpected', () => {
+    expect(classifyQueryError('')).toBe('unexpected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSession
+// ---------------------------------------------------------------------------
+
+describe('resolveSession', () => {
+  test('resolves exact name match', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession('macbook/remi/main'),
+        makeSession('macbook/remi/dev'),
+      ]),
+    ];
+    const resolved = resolveSession(results, 'macbook/remi/main');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.name).toBe('macbook/remi/main');
+    expect(resolved!.port).toBe(18765);
+    expect(resolved!.host).toBe('localhost');
+  });
+
+  test('resolves prefix name match (single)', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession('macbook/remi/main'),
+        makeSession('macbook/other/dev'),
+      ]),
+    ];
+    const resolved = resolveSession(results, 'macbook/remi');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.name).toBe('macbook/remi/main');
+  });
+
+  test('throws AmbiguousSessionError on ambiguous name prefix', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession('macbook/remi/main'),
+        makeSession('macbook/remi/dev'),
+      ]),
+    ];
+    expect(() => resolveSession(results, 'macbook/remi')).toThrow(AmbiguousSessionError);
+  });
+
+  test('resolves exact ID match', () => {
+    const id = 'abcdef12-3456-7890-abcd-ef1234567890';
+    const results = [makeQueryResult('localhost', 18765, [makeSession('test-session', id)])];
+    const resolved = resolveSession(results, id);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.sessionId).toBe(id);
+  });
+
+  test('resolves prefix ID match', () => {
+    const id = 'abcdef12-3456-7890-abcd-ef1234567890';
+    const results = [makeQueryResult('localhost', 18765, [makeSession('test-session', id)])];
+    const resolved = resolveSession(results, 'abcdef12');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.sessionId).toBe(id);
+  });
+
+  test('throws AmbiguousSessionError on ambiguous ID prefix', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession('session-a', 'abcdef12-1111-1111-1111-111111111111'),
+        makeSession('session-b', 'abcdef12-2222-2222-2222-222222222222'),
+      ]),
+    ];
+    expect(() => resolveSession(results, 'abcdef12')).toThrow(AmbiguousSessionError);
+  });
+
+  test('returns null when no match found', () => {
+    const results = [makeQueryResult('localhost', 18765, [makeSession('macbook/remi/main')])];
+    const resolved = resolveSession(results, 'nonexistent');
+    expect(resolved).toBeNull();
+  });
+
+  test('returns null for empty results', () => {
+    const resolved = resolveSession([], 'anything');
+    expect(resolved).toBeNull();
+  });
+
+  test('returns null for results with no sessions', () => {
+    const results = [makeQueryResult('localhost', 18765, [])];
+    const resolved = resolveSession(results, 'anything');
+    expect(resolved).toBeNull();
+  });
+
+  test('resolves across multiple port results', () => {
+    const id = generateId();
+    const results = [
+      makeQueryResult('localhost', 18765, [makeSession('macbook/remi/main')]),
+      makeQueryResult('localhost', 18766, [makeSession('macbook/other/dev', id)]),
+    ];
+    const resolved = resolveSession(results, id);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.port).toBe(18766);
+  });
+
+  test('prefers exact name over prefix name', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [makeSession('mac'), makeSession('macbook/remi/main')]),
+    ];
+    const resolved = resolveSession(results, 'mac');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.name).toBe('mac');
+  });
+
+  test('prefers name match over ID match', () => {
+    const id = 'myproject';
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession('myproject', 'aaaa-1111'),
+        makeSession('other', `${id}-suffix-session`),
+      ]),
+    ];
+    const resolved = resolveSession(results, 'myproject');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.session.name).toBe('myproject');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AmbiguousSessionError
+// ---------------------------------------------------------------------------
+
+describe('AmbiguousSessionError', () => {
+  test('has correct name', () => {
+    const err = new AmbiguousSessionError('test', [{ name: 'a', port: 1 }]);
+    expect(err.name).toBe('AmbiguousSessionError');
+  });
+
+  test('includes match count in message', () => {
+    const err = new AmbiguousSessionError('test', [
+      { name: 'a', port: 1 },
+      { name: 'b', port: 2 },
+    ]);
+    expect(err.message).toContain('matches 2 sessions');
+  });
+
+  test('preserves matches array', () => {
+    const matches = [
+      { name: 'a', port: 18765 },
+      { name: 'b', port: 18766 },
+    ];
+    const err = new AmbiguousSessionError('test', matches);
+    expect(err.matches).toEqual(matches);
+  });
+
+  test('includes disambiguation hint', () => {
+    const err = new AmbiguousSessionError('test', [{ name: 'a', port: 1 }]);
+    expect(err.message).toContain('disambiguate');
+  });
+});

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -7,12 +7,15 @@ import type { DiscoverableSession } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import {
   AmbiguousSessionError,
+  type DiscoveredEndpoint,
+  type NetworkDiscoveryResult,
   type PortQueryResult,
   classifyQueryError,
+  findEndpointsByHostname,
   resolveSession,
 } from '../../src/cli/session-resolver.ts';
 
-function makeSession(name: string, id?: string): DiscoverableSession {
+function makeSession(name: string | undefined, id?: string): DiscoverableSession {
   return {
     sessionId: id ?? generateId(),
     name,
@@ -31,6 +34,18 @@ function makeQueryResult(
   sessions: DiscoverableSession[],
 ): PortQueryResult {
   return { host, port, sessions };
+}
+
+function makeEndpoint(
+  host: string,
+  port: number,
+  hostname: string,
+  source: 'mdns' | 'vpn',
+  name?: string,
+): DiscoveredEndpoint {
+  const base = { host, port, hostname, source };
+  if (name !== undefined) return { ...base, name };
+  return base;
 }
 
 // ---------------------------------------------------------------------------
@@ -93,9 +108,9 @@ describe('resolveSession', () => {
     ];
     const resolved = resolveSession(results, 'macbook/remi/main');
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.name).toBe('macbook/remi/main');
-    expect(resolved!.port).toBe(18765);
-    expect(resolved!.host).toBe('localhost');
+    expect(resolved?.session.name).toBe('macbook/remi/main');
+    expect(resolved?.port).toBe(18765);
+    expect(resolved?.host).toBe('localhost');
   });
 
   test('resolves prefix name match (single)', () => {
@@ -107,7 +122,7 @@ describe('resolveSession', () => {
     ];
     const resolved = resolveSession(results, 'macbook/remi');
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.name).toBe('macbook/remi/main');
+    expect(resolved?.session.name).toBe('macbook/remi/main');
   });
 
   test('throws AmbiguousSessionError on ambiguous name prefix', () => {
@@ -120,12 +135,20 @@ describe('resolveSession', () => {
     expect(() => resolveSession(results, 'macbook/remi')).toThrow(AmbiguousSessionError);
   });
 
+  test('throws AmbiguousSessionError on ambiguous exact name across ports', () => {
+    const results = [
+      makeQueryResult('localhost', 18765, [makeSession('my-session')]),
+      makeQueryResult('localhost', 18766, [makeSession('my-session')]),
+    ];
+    expect(() => resolveSession(results, 'my-session')).toThrow(AmbiguousSessionError);
+  });
+
   test('resolves exact ID match', () => {
     const id = 'abcdef12-3456-7890-abcd-ef1234567890';
     const results = [makeQueryResult('localhost', 18765, [makeSession('test-session', id)])];
     const resolved = resolveSession(results, id);
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.sessionId).toBe(id);
+    expect(resolved?.session.sessionId).toBe(id);
   });
 
   test('resolves prefix ID match', () => {
@@ -133,7 +156,7 @@ describe('resolveSession', () => {
     const results = [makeQueryResult('localhost', 18765, [makeSession('test-session', id)])];
     const resolved = resolveSession(results, 'abcdef12');
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.sessionId).toBe(id);
+    expect(resolved?.session.sessionId).toBe(id);
   });
 
   test('throws AmbiguousSessionError on ambiguous ID prefix', () => {
@@ -171,7 +194,7 @@ describe('resolveSession', () => {
     ];
     const resolved = resolveSession(results, id);
     expect(resolved).not.toBeNull();
-    expect(resolved!.port).toBe(18766);
+    expect(resolved?.port).toBe(18766);
   });
 
   test('prefers exact name over prefix name', () => {
@@ -180,7 +203,7 @@ describe('resolveSession', () => {
     ];
     const resolved = resolveSession(results, 'mac');
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.name).toBe('mac');
+    expect(resolved?.session.name).toBe('mac');
   });
 
   test('prefers name match over ID match', () => {
@@ -193,7 +216,29 @@ describe('resolveSession', () => {
     ];
     const resolved = resolveSession(results, 'myproject');
     expect(resolved).not.toBeNull();
-    expect(resolved!.session.name).toBe('myproject');
+    expect(resolved?.session.name).toBe('myproject');
+  });
+
+  test('skips sessions with undefined name during name matching', () => {
+    const id = 'abcd1234-5678-9012-abcd-ef1234567890';
+    const results = [
+      makeQueryResult('localhost', 18765, [
+        makeSession(undefined, id),
+        makeSession('named-session'),
+      ]),
+    ];
+    // Should not match the undefined-name session by name
+    const resolved = resolveSession(results, 'named-session');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.session.name).toBe('named-session');
+  });
+
+  test('resolves session with undefined name by ID', () => {
+    const id = 'abcd1234-5678-9012-abcd-ef1234567890';
+    const results = [makeQueryResult('localhost', 18765, [makeSession(undefined, id)])];
+    const resolved = resolveSession(results, id);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.session.sessionId).toBe(id);
   });
 });
 
@@ -227,5 +272,49 @@ describe('AmbiguousSessionError', () => {
   test('includes disambiguation hint', () => {
     const err = new AmbiguousSessionError('test', [{ name: 'a', port: 1 }]);
     expect(err.message).toContain('disambiguate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findEndpointsByHostname
+// ---------------------------------------------------------------------------
+
+describe('findEndpointsByHostname', () => {
+  const discovery: NetworkDiscoveryResult = {
+    endpoints: [
+      makeEndpoint('192.168.1.10', 18765, 'macbook', 'mdns', 'remi-macbook'),
+      makeEndpoint('192.168.1.10', 18766, 'macbook', 'mdns', 'remi-macbook-2'),
+      makeEndpoint('100.79.1.5', 18765, 'linux-server', 'vpn'),
+      makeEndpoint('192.168.1.20', 18765, 'desktop', 'mdns', 'remi-desktop'),
+    ],
+  };
+
+  test('returns matching endpoints by exact hostname', () => {
+    const matches = findEndpointsByHostname(discovery, 'macbook');
+    expect(matches).toHaveLength(2);
+    expect(matches[0]?.port).toBe(18765);
+    expect(matches[1]?.port).toBe(18766);
+  });
+
+  test('returns empty array for non-matching hostname', () => {
+    const matches = findEndpointsByHostname(discovery, 'nonexistent');
+    expect(matches).toHaveLength(0);
+  });
+
+  test('does not return partial hostname matches', () => {
+    const matches = findEndpointsByHostname(discovery, 'mac');
+    expect(matches).toHaveLength(0);
+  });
+
+  test('returns VPN endpoints', () => {
+    const matches = findEndpointsByHostname(discovery, 'linux-server');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.source).toBe('vpn');
+  });
+
+  test('returns empty for empty discovery results', () => {
+    const empty: NetworkDiscoveryResult = { endpoints: [] };
+    const matches = findEndpointsByHostname(empty, 'macbook');
+    expect(matches).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Extract duplicated discovery/resolution logic from `ls-client.ts`, `kill-client.ts`, and `cli.ts` (attach) into a new shared `session-resolver.ts` module
- Four composable utilities replace 13+ copies of duplicated code: `classifyQueryError`, `queryMultiplePorts`, `resolveSession`, `discoverNetworkDaemons`
- Unify timeouts across commands (fetchSessions: 5000ms, VPN probe: 3000ms, mDNS browse: 3000ms)
- Net reduction of ~250 lines; attach command now supports ID-based matching (previously name-only)

Closes #75

## Test plan

- [x] All 980 existing tests pass (0 failures)
- [x] 26 new unit tests for session-resolver utilities
- [x] `bunx biome check` passes with 0 errors
- [x] `tsc --noEmit` passes
- [ ] Manual: `remi ls --network` finds same daemons as `remi ls --host <ip>`
- [ ] Manual: `remi attach <name>` resolves sessions correctly
- [ ] Manual: `remi kill <name>` resolves sessions correctly