### PR TITLE
fix: ls --host probes all ports and suppress session-creation noise

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -772,11 +772,30 @@ if (cliSubcommand === 'ls') {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
-  } else if (explicitPort || cliHost) {
-    // Explicit host/port: query single daemon (original behavior)
+  } else if (explicitPort && cliHost) {
+    // Explicit host + port: query single daemon
     const { runLsClient } = await import('./cli/ls-client.ts');
     try {
-      await runLsClient({ host: cliHost ?? 'localhost', port: explicitPort ?? DEFAULT_BASE_PORT });
+      await runLsClient({ host: cliHost, port: explicitPort });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  } else if (explicitPort) {
+    // Explicit port only: query localhost on that port
+    const { runLsClient } = await import('./cli/ls-client.ts');
+    try {
+      await runLsClient({ host: 'localhost', port: explicitPort });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  } else if (cliHost) {
+    // Host without port: probe the standard port range on that host
+    const { runHostLs } = await import('./cli/ls-client.ts');
+    try {
+      const ports = Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
+      await runHostLs({ host: cliHost, ports });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -772,20 +772,11 @@ if (cliSubcommand === 'ls') {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
-  } else if (explicitPort && cliHost) {
-    // Explicit host + port: query single daemon
-    const { runLsClient } = await import('./cli/ls-client.ts');
-    try {
-      await runLsClient({ host: cliHost, port: explicitPort });
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
   } else if (explicitPort) {
-    // Explicit port only: query localhost on that port
+    // Explicit port: query single daemon on given (or default) host
     const { runLsClient } = await import('./cli/ls-client.ts');
     try {
-      await runLsClient({ host: 'localhost', port: explicitPort });
+      await runLsClient({ host: cliHost ?? 'localhost', port: explicitPort });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -76,6 +76,73 @@ export async function runLsClient(opts: LsClientOptions): Promise<void> {
   renderSessionList(sessions);
 }
 
+// ---------------------------------------------------------------------------
+// Host-based multi-port discovery (remi ls --host <addr>)
+// ---------------------------------------------------------------------------
+
+export interface HostLsOptions {
+  readonly host: string;
+  readonly ports: readonly number[];
+  readonly timeout?: number;
+}
+
+/**
+ * Query a specific host across a range of ports, rendering all discovered sessions.
+ * Used when --host is specified without --port.
+ */
+export async function runHostLs(opts: HostLsOptions): Promise<void> {
+  const { host, ports, timeout = FETCH_SESSIONS_TIMEOUT_MS } = opts;
+
+  const results = await queryMultiplePorts({
+    host,
+    ports,
+    timeoutMs: timeout,
+    logLabel: 'ls',
+  });
+
+  const allSessions = results.flatMap((r) => r.sessions);
+  if (allSessions.length === 0) {
+    console.log(`No active sessions on ${host}.`);
+    return;
+  }
+
+  // Single port: render flat list (same as --host --port)
+  if (results.length === 1) {
+    renderSessionList(allSessions);
+    return;
+  }
+
+  // Multiple ports: show port column
+  const header = `${'NAME'.padEnd(28)}${'PORT'.padEnd(8)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (const r of results) {
+    for (const s of r.sessions) {
+      const name = (s.name ?? path.basename(s.projectPath)).slice(0, 26);
+      const port = String(r.port);
+      const duration = formatDuration(s.createdAt);
+      const lastAct = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
+
+      console.log(
+        `${name.padEnd(28)}${port.padEnd(8)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+      );
+    }
+  }
+
+  const attachable = results.flatMap((r) =>
+    r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, port: r.port })),
+  );
+  if (attachable.length > 0) {
+    console.log('');
+    for (const a of attachable) {
+      const name = a.name ?? a.sessionId.slice(0, 8);
+      console.log(`  * ${name}: remi attach ${host}:${a.port}/${name}`);
+    }
+  }
+}
+
 export async function fetchSessions(
   host: string,
   port: number,
@@ -123,12 +190,14 @@ export async function fetchSessions(
         resolve(msg.sessions as DiscoverableSession[]);
       } else if (msg.type === 'error') {
         if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
-        // After first hello_ack, ignore session-creation errors (we only care about the list)
+        // Ignore session-creation errors — ls only cares about the session list.
+        // These can arrive at any point (before or after hello_ack) depending on
+        // daemon timing, so we unconditionally ignore them.
         if (
-          sentListRequest &&
-          (msg.code === 'SESSION_CREATE_FAILED' ||
-            msg.code === 'ATTACH_FAILED' ||
-            msg.code === 'INVALID_DIRECTORY')
+          msg.code === 'SESSION_CREATE_FAILED' ||
+          msg.code === 'ATTACH_FAILED' ||
+          msg.code === 'INVALID_DIRECTORY' ||
+          msg.code === 'NO_SESSION'
         ) {
           return;
         }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -100,6 +100,15 @@ export async function runHostLs(opts: HostLsOptions): Promise<void> {
     logLabel: 'ls',
   });
 
+  if (results.length === 0) {
+    // No port responded at all — host is unreachable or has no daemons
+    const lo = ports[0];
+    const hi = ports[ports.length - 1];
+    console.error(`Cannot reach any remi daemon on ${host} (ports ${lo}-${hi}).`);
+    console.error('Check that the host is reachable and a remi daemon is running.');
+    return;
+  }
+
   const allSessions = results.flatMap((r) => r.sessions);
   if (allSessions.length === 0) {
     console.log(`No active sessions on ${host}.`);

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -38,8 +38,7 @@ export function classifyQueryError(reason: string): QueryErrorClass {
     reason.includes('Cannot connect') ||
     reason.includes('closed unexpectedly') ||
     reason.includes('ECONNREFUSED') ||
-    reason.includes('ECONNRESET') ||
-    reason.includes('Timed out')
+    reason.includes('ECONNRESET')
   ) {
     return 'connection';
   }
@@ -109,7 +108,12 @@ export async function queryMultiplePorts(
       if (errorClass === 'expected') {
         console.error(`\x1b[2m[${logLabel}] ${host}:${ports[i]}: ${reason}\x1b[0m`);
       } else if (errorClass === 'unexpected') {
-        console.error(`[${logLabel}] Failed to query ${host}:${ports[i]}: ${reason}`);
+        // Suppress timeouts when probing multiple ports (most won't have daemons)
+        if (ports.length > 1 && reason.includes('Timed out')) {
+          // Normal: timeout on one of many probed ports
+        } else {
+          console.error(`[${logLabel}] Failed to query ${host}:${ports[i]}: ${reason}`);
+        }
       }
       // 'connection' errors are suppressed
     }

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -38,7 +38,8 @@ export function classifyQueryError(reason: string): QueryErrorClass {
     reason.includes('Cannot connect') ||
     reason.includes('closed unexpectedly') ||
     reason.includes('ECONNREFUSED') ||
-    reason.includes('ECONNRESET')
+    reason.includes('ECONNRESET') ||
+    reason.includes('Timed out')
   ) {
     return 'connection';
   }
@@ -47,7 +48,9 @@ export function classifyQueryError(reason: string): QueryErrorClass {
   if (
     reason.includes('not found') ||
     reason.includes('ENOENT') ||
-    reason.includes('SESSION_CREATE_FAILED')
+    reason.includes('SESSION_CREATE_FAILED') ||
+    reason.includes('Failed to create session') ||
+    reason.includes('No active session')
   ) {
     return 'expected';
   }

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
   type DiscoverableSession,
+  createError,
   createHelloAck,
   createSessionListResponse,
   deserialize,
@@ -165,6 +166,113 @@ describe('fetchSessions', () => {
 
   test('rejects when server is unreachable', async () => {
     await expect(fetchSessions('localhost', 9876, 1000)).rejects.toThrow(/Cannot connect/);
+  });
+
+  test('ignores SESSION_CREATE_FAILED error and returns session list', async () => {
+    const sessions = [makeSession({ status: 'idle' })];
+
+    server = Bun.serve({
+      port: FETCH_PORT,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            const sessionId = generateId();
+            // Send error BEFORE hello_ack (tests guard removal)
+            ws.send(
+              serialize(
+                createError(
+                  'SESSION_CREATE_FAILED',
+                  'Failed to create session: Executable not found in $PATH: "claude"',
+                ),
+              ),
+            );
+            ws.send(serialize(createHelloAck('1.0.0', sessionId)));
+          } else if (msg.type === 'session_list_request') {
+            ws.send(serialize(createSessionListResponse(sessions, msg.id)));
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await fetchSessions('localhost', FETCH_PORT, 3000);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('idle');
+  });
+
+  test('ignores NO_SESSION error and returns session list', async () => {
+    const sessions = [makeSession({ status: 'active' })];
+
+    server = Bun.serve({
+      port: FETCH_PORT,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            // Send NO_SESSION error (wrapper mode with no primary session)
+            ws.send(serialize(createError('NO_SESSION', 'No active session available')));
+            // Then send hello_ack anyway
+            ws.send(serialize(createHelloAck('1.0.0', generateId())));
+          } else if (msg.type === 'session_list_request') {
+            ws.send(serialize(createSessionListResponse(sessions, msg.id)));
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await fetchSessions('localhost', FETCH_PORT, 3000);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('active');
+  });
+
+  test('ignores ATTACH_FAILED error after hello_ack', async () => {
+    const sessions = [makeSession({ status: 'idle' })];
+
+    server = Bun.serve({
+      port: FETCH_PORT,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', generateId())));
+          } else if (msg.type === 'session_list_request') {
+            // Send error after list request (daemon processing race)
+            ws.send(serialize(createError('ATTACH_FAILED', 'Session busy')));
+            ws.send(serialize(createSessionListResponse(sessions, msg.id)));
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await fetchSessions('localhost', FETCH_PORT, 3000);
+    expect(result).toHaveLength(1);
   });
 });
 

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -85,8 +85,20 @@ describe('classifyQueryError', () => {
     expect(classifyQueryError('Something went wrong')).toBe('unexpected');
   });
 
-  test('classifies timeout as unexpected', () => {
-    expect(classifyQueryError('Timed out connecting to daemon')).toBe('unexpected');
+  test('classifies timeout as connection error (suppressed)', () => {
+    expect(classifyQueryError('Timed out connecting to daemon')).toBe('connection');
+  });
+
+  test('classifies "Failed to create session" as expected', () => {
+    expect(
+      classifyQueryError(
+        'Daemon error: Failed to create session: Executable not found in $PATH: "claude"',
+      ),
+    ).toBe('expected');
+  });
+
+  test('classifies "No active session" as expected', () => {
+    expect(classifyQueryError('Daemon error: No active session available')).toBe('expected');
   });
 
   test('classifies empty string as unexpected', () => {

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -85,8 +85,8 @@ describe('classifyQueryError', () => {
     expect(classifyQueryError('Something went wrong')).toBe('unexpected');
   });
 
-  test('classifies timeout as connection error (suppressed)', () => {
-    expect(classifyQueryError('Timed out connecting to daemon')).toBe('connection');
+  test('classifies timeout as unexpected', () => {
+    expect(classifyQueryError('Timed out connecting to daemon')).toBe('unexpected');
   });
 
   test('classifies "Failed to create session" as expected', () => {


### PR DESCRIPTION
## Summary

- `remi ls --host <addr>` without `--port` now probes the full port range (18765-18774) instead of only the default port, making it consistent with `--network` discovery
- Suppresses irrelevant session-creation errors (e.g., "Failed to create session: Executable not found") that leaked into `--network` and `--host` output from localhost daemons
- Timeouts during port probing are now silently suppressed instead of shown as errors

## Test plan

- [x] All 990 tests pass
- [x] Biome lint clean
- [x] TypeScript typecheck passes
- [ ] Manual test: `remi ls --host <tailscale-ip>` discovers sessions across multiple ports
- [ ] Manual test: `remi ls --network` no longer shows localhost "Failed to create session" error
- [ ] Manual test: `remi ls --host <ip> --port 18766` still queries only that specific port