### PR TITLE
feat: session launcher and remote session management

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -60,6 +60,9 @@ export interface AdapterEvents {
   /** Kill session request received */
   onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
 
+  /** Session history request received */
+  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -140,6 +140,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onKillSessionRequest?.(connectionId, sessionId, requestId);
       },
 
+      onSessionHistoryRequest: (connectionId, requestId, limit) => {
+        this.events.onSessionHistoryRequest?.(connectionId, requestId, limit);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -436,9 +436,17 @@ for (let i = 0; i < args.length; i++) {
   } else if (arg === '--network') {
     cliNetwork = true;
   } else if (arg === '--dir' && nextArg) {
+    if (cliRecent) {
+      console.error('Error: --dir and --recent are mutually exclusive.');
+      process.exit(1);
+    }
     cliDir = nextArg;
     i++;
   } else if (arg === '--recent') {
+    if (cliDir) {
+      console.error('Error: --dir and --recent are mutually exclusive.');
+      process.exit(1);
+    }
     cliRecent = true;
   } else if (arg === '--host' && nextArg) {
     cliHost = nextArg;
@@ -493,9 +501,9 @@ Options:
   --no-tofu                Reject unknown clients (disable Trust On First Use)
   --local                  Localhost-only mode (--bind localhost --no-mdns)
   --no-mdns                Disable mDNS network advertising
-  --host HOST              Connect to daemon at HOST (for ls/attach/new; default: localhost)
-  --dir PATH               Working directory for new session
-  --recent                 Pick from recent project directories (new subcommand)
+  --host HOST              Connect to daemon at HOST (for ls/attach/new/recent; default: localhost)
+  --dir PATH               Working directory for new session (mutually exclusive with --recent)
+  --recent                 Pick from recent project directories (for new/recent subcommands)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
   --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
@@ -1298,7 +1306,13 @@ if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliHost) {
   if (cliRecent) {
     const { fetchRecentDirectories } = await import('./cli/recent-client.ts');
     const { pickDirectory } = await import('./cli/directory-picker.ts');
-    const dirs = await fetchRecentDirectories(cliHost, resolvedPort);
+    let dirs: Awaited<ReturnType<typeof fetchRecentDirectories>>;
+    try {
+      dirs = await fetchRecentDirectories(cliHost, resolvedPort);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
     if (dirs.length === 0) {
       console.error('No recent directories found on remote daemon.');
       process.exit(1);
@@ -2130,8 +2144,14 @@ const sharedEvents = {
 
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {
     log(`Session history request from ${connectionId}, limit: ${limit ?? 'default'}`);
-    const directories = getRecentDirectories(sessionStore, limit ?? 20);
-    sendToConnection(connectionId, createSessionHistoryResponse(directories, requestId));
+    try {
+      const clampedLimit = Math.max(1, limit ?? 20);
+      const directories = getRecentDirectories(sessionStore, clampedLimit);
+      sendToConnection(connectionId, createSessionHistoryResponse(directories, requestId));
+    } catch (err) {
+      log(`Failed to get recent directories: ${err instanceof Error ? err.message : err}`);
+      sendToConnection(connectionId, createSessionHistoryResponse([], requestId));
+    }
   },
 
   onTerminalResize: (connectionId: UUID, cols: number, rows: number) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -231,12 +231,19 @@ import {
   createKillSessionResponse,
   createRawPtyOutput,
   createReplayBatch,
+  createSessionHistoryResponse,
   createSessionListResponse,
   createTranscriptLoadComplete,
   generateId,
   now,
 } from '@remi/shared';
-import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
+import type {
+  AgentStatus,
+  ProtocolMessage,
+  RecentDirectory,
+  UUID,
+  UnlockedIdentity,
+} from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
 import {
   type AdapterMetadata,
@@ -340,6 +347,7 @@ let cliSubcommand:
   | 'new'
   | 'kill'
   | 'detach'
+  | 'recent'
   | 'start'
   | 'stop'
   | 'status'
@@ -359,6 +367,8 @@ let cliRemoveFingerprint: string | undefined;
 let cliNoMdns = false;
 let cliNetwork = false;
 let cliHost: string | undefined;
+let cliDir: string | undefined;
+let cliRecent = false;
 const claudeArgs: string[] = [];
 
 for (let i = 0; i < args.length; i++) {
@@ -425,6 +435,11 @@ for (let i = 0; i < args.length; i++) {
     cliNoMdns = true;
   } else if (arg === '--network') {
     cliNetwork = true;
+  } else if (arg === '--dir' && nextArg) {
+    cliDir = nextArg;
+    i++;
+  } else if (arg === '--recent') {
+    cliRecent = true;
   } else if (arg === '--host' && nextArg) {
     cliHost = nextArg;
     i++;
@@ -438,12 +453,16 @@ Remi - Claude Code with remote monitoring
 Usage:
   remi [claude-args...]          Start Claude with WebSocket monitoring
   remi new [-- claude-args...]   Explicit session creation (alias for remi [args])
+  remi new --dir <path>          Start session in a specific directory
+  remi new --recent              Pick from recent directories
+  remi new --host <ip>           Create session on remote daemon and attach
   remi kill <name>               Kill a session by name or ID
   remi detach [name]             Detach from current or named session
   remi start                     Start daemon in background
   remi stop                      Stop background daemon
   remi status                    Show daemon status
   remi logs                      Show recent daemon logs
+  remi recent                    Browse recent project directories
   remi ls                        List live sessions from running daemon
   remi ls --network              Discover and list sessions across the network
   remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
@@ -474,7 +493,9 @@ Options:
   --no-tofu                Reject unknown clients (disable Trust On First Use)
   --local                  Localhost-only mode (--bind localhost --no-mdns)
   --no-mdns                Disable mDNS network advertising
-  --host HOST              Connect to daemon at HOST (for ls/attach; default: localhost)
+  --host HOST              Connect to daemon at HOST (for ls/attach/new; default: localhost)
+  --dir PATH               Working directory for new session
+  --recent                 Pick from recent project directories (new subcommand)
   --label NAME             Label for authorized key (authorize)
   --public-only            Export only public key (export-key)
   --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
@@ -507,6 +528,7 @@ Any other arguments are passed through to Claude Code.
     arg === 'new' ||
     arg === 'kill' ||
     arg === 'detach' ||
+    arg === 'recent' ||
     arg === 'start' ||
     arg === 'stop' ||
     arg === 'status' ||
@@ -800,6 +822,33 @@ if (cliSubcommand === 'ls') {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
+  }
+  process.exit(0);
+}
+
+// Handle 'recent' subcommand: browse recent project directories
+if (cliSubcommand === 'recent') {
+  const explicitPort =
+    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined);
+
+  if (cliHost || explicitPort) {
+    // Remote mode: query a daemon via WebSocket
+    const { runRecentClient } = await import('./cli/recent-client.ts');
+    try {
+      await runRecentClient({
+        host: cliHost ?? 'localhost',
+        port: explicitPort ?? DEFAULT_BASE_PORT,
+      });
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  } else {
+    // Local mode: read SessionStore directly
+    const store = new SessionStore();
+    const { renderRecentDirectories } = await import('./cli/recent-client.ts');
+    const directories = getRecentDirectories(store, 20);
+    renderRecentDirectories(directories);
   }
   process.exit(0);
 }
@@ -1234,6 +1283,80 @@ if (cliResume !== undefined) {
 }
 
 // ---------------------------------------------------------------------------
+// Handle 'new' subcommand enhancements: --host, --dir, --recent
+// ---------------------------------------------------------------------------
+
+// remi new --host: create session on remote daemon, then auto-attach
+if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliHost) {
+  const resolvedPort =
+    cliPort ??
+    (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : DEFAULT_BASE_PORT);
+
+  let directory = cliDir;
+
+  // --recent: fetch remote recent dirs and pick one
+  if (cliRecent) {
+    const { fetchRecentDirectories } = await import('./cli/recent-client.ts');
+    const { pickDirectory } = await import('./cli/directory-picker.ts');
+    const dirs = await fetchRecentDirectories(cliHost, resolvedPort);
+    if (dirs.length === 0) {
+      console.error('No recent directories found on remote daemon.');
+      process.exit(1);
+    }
+    const picked = await pickDirectory(dirs);
+    if (!picked) {
+      process.exit(0);
+    }
+    directory = picked;
+  }
+
+  // Create session on remote daemon and auto-attach
+  const { runRemoteNew } = await import('./cli/remote-new-client.ts');
+  try {
+    const result = await runRemoteNew({
+      host: cliHost,
+      port: resolvedPort,
+      directory,
+    });
+    process.exit(result.exitCode);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+// remi new --recent (local): pick directory from recent, chdir, then fall through to wrapper
+if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliRecent && !cliHost) {
+  const store = new SessionStore();
+  const directories = getRecentDirectories(store, 20);
+  if (directories.length === 0) {
+    console.error('No recent directories found.');
+    process.exit(1);
+  }
+  const { pickDirectory } = await import('./cli/directory-picker.ts');
+  const picked = await pickDirectory(directories);
+  if (!picked) {
+    process.exit(0);
+  }
+  const dirResult = resolveDirectory(picked);
+  if ('error' in dirResult) {
+    console.error(dirResult.error);
+    process.exit(1);
+  }
+  process.chdir(dirResult.resolved);
+}
+
+// remi new --dir (local): chdir to specified directory, then fall through to wrapper
+if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliDir && !cliHost) {
+  const dirResult = resolveDirectory(cliDir);
+  if ('error' in dirResult) {
+    console.error(dirResult.error);
+    process.exit(1);
+  }
+  process.chdir(dirResult.resolved);
+}
+
+// ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 const portExplicitlySet = !!(cliPort || process.env['REMI_PORT']);
@@ -1641,6 +1764,36 @@ const registry = new AdapterRegistry({
   },
 });
 
+function getRecentDirectories(store: SessionStore, limit: number): RecentDirectory[] {
+  const sessions = store.list();
+  const dirMap = new Map<string, { count: number; lastUsed: string }>();
+
+  for (const s of sessions) {
+    const dir = s.projectPath;
+    const existing = dirMap.get(dir);
+    if (existing) {
+      existing.count++;
+      if (s.startedAt > existing.lastUsed) {
+        existing.lastUsed = s.startedAt;
+      }
+    } else {
+      dirMap.set(dir, { count: 1, lastUsed: s.startedAt });
+    }
+  }
+
+  const entries = Array.from(dirMap.entries())
+    .map(([directory, { count, lastUsed }]) => ({
+      directory,
+      lastUsed,
+      sessionCount: count,
+      displayName: path.basename(directory),
+    }))
+    .sort((a, b) => (a.lastUsed > b.lastUsed ? -1 : 1))
+    .slice(0, limit);
+
+  return entries;
+}
+
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): void => {
   registry.sendRaw(connectionId, message);
 };
@@ -1973,6 +2126,12 @@ const sharedEvents = {
     sessionRegistry.closeSession(sessionId, 'forced');
     sendToConnection(connectionId, createKillSessionResponse(true, requestId));
     log(`Session killed: ${sessionName}`);
+  },
+
+  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {
+    log(`Session history request from ${connectionId}, limit: ${limit ?? 'default'}`);
+    const directories = getRecentDirectories(sessionStore, limit ?? 20);
+    sendToConnection(connectionId, createSessionHistoryResponse(directories, requestId));
   },
 
   onTerminalResize: (connectionId: UUID, cols: number, rows: number) => {

--- a/packages/daemon/src/cli/directory-picker.ts
+++ b/packages/daemon/src/cli/directory-picker.ts
@@ -1,0 +1,62 @@
+/**
+ * Directory Picker - Interactive numbered list for selecting a recent directory.
+ *
+ * Shows a numbered list and reads one line from stdin.
+ * Must cleanly release stdin before wrapper mode re-opens it in raw mode.
+ */
+
+import * as os from 'node:os';
+import * as readline from 'node:readline';
+import type { RecentDirectory } from '@remi/shared';
+import { formatAge } from './ls-client.ts';
+
+/**
+ * Display a numbered list of directories and prompt the user to pick one.
+ * Returns the selected directory path, or null if the user cancels (empty input / EOF).
+ */
+export async function pickDirectory(
+  directories: readonly RecentDirectory[],
+): Promise<string | null> {
+  if (directories.length === 0) return null;
+
+  const home = os.homedir();
+  const shortPath = (p: string): string => (p.startsWith(home) ? `~${p.slice(home.length)}` : p);
+
+  console.log('');
+  for (let i = 0; i < directories.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: index within bounds
+    const d = directories[i]!;
+    const num = `${i + 1}`.padStart(3);
+    const dir = shortPath(d.directory);
+    const age = formatAge(d.lastUsed);
+    console.log(`  ${num}  ${dir}  (${age})`);
+  }
+  console.log('');
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    terminal: process.stdin.isTTY ?? false,
+  });
+
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question('Select directory [1]: ', (ans) => {
+        resolve(ans.trim());
+      });
+    });
+
+    if (answer === '') {
+      return directories[0]?.directory ?? null;
+    }
+
+    const num = Number.parseInt(answer, 10);
+    if (Number.isNaN(num) || num < 1 || num > directories.length) {
+      console.error(`Invalid selection: ${answer}`);
+      return null;
+    }
+    return directories[num - 1]?.directory ?? null;
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/daemon/src/cli/directory-picker.ts
+++ b/packages/daemon/src/cli/directory-picker.ts
@@ -12,7 +12,8 @@ import { formatAge } from './ls-client.ts';
 
 /**
  * Display a numbered list of directories and prompt the user to pick one.
- * Returns the selected directory path, or null if the user cancels (empty input / EOF).
+ * Returns the selected directory path. Empty input defaults to the first item.
+ * Returns null if the user enters an invalid number or EOF/SIGINT occurs.
  */
 export async function pickDirectory(
   directories: readonly RecentDirectory[],
@@ -40,11 +41,19 @@ export async function pickDirectory(
   });
 
   try {
-    const answer = await new Promise<string>((resolve) => {
+    const answer = await new Promise<string>((resolve, reject) => {
       rl.question('Select directory [1]: ', (ans) => {
         resolve(ans.trim());
       });
-    });
+      // Handle EOF (Ctrl+D) or SIGINT (Ctrl+C) closing the interface
+      process.stdin.once('end', () => {
+        reject(new Error('EOF'));
+      });
+    }).catch(() => null);
+
+    if (answer === null) {
+      return null;
+    }
 
     if (answer === '') {
       return directories[0]?.directory ?? null;

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -29,7 +29,7 @@ export async function fetchRecentDirectories(
   host: string,
   port: number,
   timeout = 5000,
-  limit?: number,
+  limit?: number | undefined,
 ): Promise<RecentDirectory[]> {
   const url = `ws://${host}:${port}/ws`;
 
@@ -40,8 +40,9 @@ export async function fetchRecentDirectories(
 
     try {
       ws = new WebSocket(url);
-    } catch {
-      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));
       return;
     }
 
@@ -71,9 +72,9 @@ export async function fetchRecentDirectories(
       if (msg.type === 'hello_ack') {
         ws.send(serialize(createSessionHistoryRequest(limit)));
       } else if (msg.type === 'session_history_response') {
-        done(msg.directories as RecentDirectory[]);
+        done([...msg.directories]);
       } else if (msg.type === 'error') {
-        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        if (msg.code === 'AUTH_REQUIRED') return;
         if (msg.code === 'NO_SESSION') return;
         done(undefined, new Error(`Daemon error: ${msg.message}`));
       }
@@ -89,6 +90,7 @@ export async function fetchRecentDirectories(
       if (!msg) return;
 
       if (msg.type === 'auth_challenge') {
+        if (authInProgress) return;
         authInProgress = true;
         performAuthHandshake(ws, msg)
           .then(() => {
@@ -105,8 +107,12 @@ export async function fetchRecentDirectories(
       handleMessage(msg);
     };
 
-    ws.onerror = () => {
-      done(undefined, new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    ws.onerror = (event) => {
+      const detail = 'message' in event ? `: ${(event as ErrorEvent).message}` : '';
+      done(
+        undefined,
+        new Error(`WebSocket error connecting to daemon at ${host}:${port}${detail}`),
+      );
     };
 
     ws.onclose = () => {

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -1,0 +1,160 @@
+/**
+ * Recent Client - Fetches and renders recent project directories.
+ *
+ * Two modes:
+ * - Local: called with pre-computed directories (from SessionStore)
+ * - Remote: connects via WebSocket to query a daemon's session history
+ */
+
+import * as os from 'node:os';
+import {
+  createHello,
+  createSessionHistoryRequest,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { ProtocolMessage, RecentDirectory } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
+import { formatAge } from './ls-client.ts';
+
+export interface RecentClientOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly limit?: number;
+  readonly timeout?: number;
+}
+
+export async function fetchRecentDirectories(
+  host: string,
+  port: number,
+  timeout = 5000,
+  limit?: number,
+): Promise<RecentDirectory[]> {
+  const url = `ws://${host}:${port}/ws`;
+
+  return new Promise<RecentDirectory[]>((resolve, reject) => {
+    let settled = false;
+    let authInProgress = false;
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      ws.close();
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Timed out connecting to daemon at ${host}:${port}`));
+      }
+    }, timeout);
+
+    function done(result?: RecentDirectory[], err?: Error): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.close();
+      if (err) reject(err);
+      else resolve(result ?? []);
+    }
+
+    function sendHello(): void {
+      const clientId = generateId();
+      ws.send(serialize(createHello(clientId, '1.0.0')));
+    }
+
+    function handleMessage(msg: ProtocolMessage): void {
+      if (msg.type === 'hello_ack') {
+        ws.send(serialize(createSessionHistoryRequest(limit)));
+      } else if (msg.type === 'session_history_response') {
+        done(msg.directories as RecentDirectory[]);
+      } else if (msg.type === 'error') {
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        if (msg.code === 'NO_SESSION') return;
+        done(undefined, new Error(`Daemon error: ${msg.message}`));
+      }
+    }
+
+    ws.onopen = () => {
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      if (msg.type === 'auth_challenge') {
+        authInProgress = true;
+        performAuthHandshake(ws, msg)
+          .then(() => {
+            authInProgress = false;
+            sendHello();
+          })
+          .catch((err) => {
+            done(undefined, err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
+      if (authInProgress) return;
+      handleMessage(msg);
+    };
+
+    ws.onerror = () => {
+      done(undefined, new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    };
+
+    ws.onclose = () => {
+      if (!settled) {
+        done(undefined, new Error('Connection closed before response received'));
+      }
+    };
+  });
+}
+
+export async function runRecentClient(opts: RecentClientOptions): Promise<void> {
+  const { host, port, limit, timeout } = opts;
+  const directories = await fetchRecentDirectories(host, port, timeout, limit);
+  renderRecentDirectories(directories);
+}
+
+export function renderRecentDirectories(directories: readonly RecentDirectory[]): void {
+  if (directories.length === 0) {
+    console.log('No recent directories found.');
+    return;
+  }
+
+  const home = os.homedir();
+  const shortPath = (p: string): string => (p.startsWith(home) ? `~${p.slice(home.length)}` : p);
+
+  // Column widths
+  const numWidth = String(directories.length).length + 1;
+  const dirPaths = directories.map((d) => shortPath(d.directory));
+  const maxDirLen = Math.min(Math.max(...dirPaths.map((p) => p.length)), 50);
+  const sessWidth = 10;
+  const ageWidth = 12;
+
+  // Header
+  const header =
+    '  #'.padEnd(numWidth + 2) +
+    '  DIRECTORY'.padEnd(maxDirLen + 4) +
+    'SESSIONS'.padStart(sessWidth) +
+    '   LAST USED'.padStart(ageWidth);
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (let i = 0; i < directories.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: index within bounds
+    const d = directories[i]!;
+    const num = `${i + 1}`.padStart(numWidth);
+    const dir = (dirPaths[i] ?? d.directory).padEnd(maxDirLen + 2);
+    const count = String(d.sessionCount).padStart(sessWidth);
+    const age = formatAge(d.lastUsed).padStart(ageWidth);
+    console.log(`  ${num}  ${dir}${count}   ${age}`);
+  }
+}

--- a/packages/daemon/src/cli/remote-new-client.ts
+++ b/packages/daemon/src/cli/remote-new-client.ts
@@ -41,8 +41,9 @@ async function createRemoteSession(
 
     try {
       ws = new WebSocket(url);
-    } catch {
-      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));
       return;
     }
 
@@ -79,8 +80,7 @@ async function createRemoteSession(
           done(undefined, new Error(`Failed to create session: ${msg.error ?? 'unknown error'}`));
         }
       } else if (msg.type === 'error') {
-        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
-        if (msg.code === 'NO_SESSION') return;
+        if (msg.code === 'AUTH_REQUIRED') return;
         done(undefined, new Error(`Daemon error: ${msg.message}`));
       }
     }
@@ -95,6 +95,7 @@ async function createRemoteSession(
       if (!msg) return;
 
       if (msg.type === 'auth_challenge') {
+        if (authInProgress) return;
         authInProgress = true;
         performAuthHandshake(ws, msg)
           .then(() => {
@@ -111,8 +112,12 @@ async function createRemoteSession(
       handleMessage(msg);
     };
 
-    ws.onerror = () => {
-      done(undefined, new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    ws.onerror = (event) => {
+      const detail = 'message' in event ? `: ${(event as ErrorEvent).message}` : '';
+      done(
+        undefined,
+        new Error(`WebSocket error connecting to daemon at ${host}:${port}${detail}`),
+      );
     };
 
     ws.onclose = () => {

--- a/packages/daemon/src/cli/remote-new-client.ts
+++ b/packages/daemon/src/cli/remote-new-client.ts
@@ -1,0 +1,135 @@
+/**
+ * Remote New Client - Creates a session on a remote daemon and auto-attaches.
+ *
+ * Flow:
+ * 1. Open temporary WebSocket, authenticate, send create_session_request
+ * 2. Wait for create_session_response with sessionId
+ * 3. Close temporary WebSocket
+ * 4. Call runAttachClient for the full attach lifecycle
+ */
+
+import {
+  createCreateSessionRequest,
+  createHello,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { runAttachClient } from './attach-client.ts';
+import { performAuthHandshake } from './auth-helper.ts';
+
+export interface RemoteNewOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly directory?: string | undefined;
+  readonly timeout?: number;
+}
+
+async function createRemoteSession(
+  host: string,
+  port: number,
+  directory?: string,
+  timeout = 10000,
+): Promise<UUID> {
+  const url = `ws://${host}:${port}/ws`;
+
+  return new Promise<UUID>((resolve, reject) => {
+    let settled = false;
+    let authInProgress = false;
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      ws.close();
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Timed out creating session on ${host}:${port}`));
+      }
+    }, timeout);
+
+    function done(sessionId?: UUID, err?: Error): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.close();
+      if (err) reject(err);
+      else if (sessionId) resolve(sessionId);
+      else reject(new Error('No session ID returned'));
+    }
+
+    function sendHello(): void {
+      const clientId = generateId();
+      ws.send(serialize(createHello(clientId, '1.0.0')));
+    }
+
+    function handleMessage(msg: ProtocolMessage): void {
+      if (msg.type === 'hello_ack') {
+        ws.send(serialize(createCreateSessionRequest(directory)));
+      } else if (msg.type === 'create_session_response') {
+        if (msg.success && msg.sessionId) {
+          done(msg.sessionId);
+        } else {
+          done(undefined, new Error(`Failed to create session: ${msg.error ?? 'unknown error'}`));
+        }
+      } else if (msg.type === 'error') {
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        if (msg.code === 'NO_SESSION') return;
+        done(undefined, new Error(`Daemon error: ${msg.message}`));
+      }
+    }
+
+    ws.onopen = () => {
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) return;
+
+      if (msg.type === 'auth_challenge') {
+        authInProgress = true;
+        performAuthHandshake(ws, msg)
+          .then(() => {
+            authInProgress = false;
+            sendHello();
+          })
+          .catch((err) => {
+            done(undefined, err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
+      if (authInProgress) return;
+      handleMessage(msg);
+    };
+
+    ws.onerror = () => {
+      done(undefined, new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    };
+
+    ws.onclose = () => {
+      if (!settled) {
+        done(undefined, new Error('Connection closed before session was created'));
+      }
+    };
+  });
+}
+
+export async function runRemoteNew(opts: RemoteNewOptions): Promise<{ exitCode: number }> {
+  const { host, port, directory, timeout } = opts;
+
+  console.error(`Creating session on ${host}:${port}...`);
+  const sessionId = await createRemoteSession(host, port, directory, timeout);
+  console.error(`Session created: ${sessionId.slice(0, 8)}`);
+  console.error('Attaching...');
+
+  return runAttachClient({ host, port, sessionId });
+}

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -36,6 +36,7 @@ import type {
   KillSessionRequestMessage,
   PingMessage,
   ProtocolMessage,
+  SessionHistoryRequestMessage,
   SessionListRequestMessage,
   TerminalResizeMessage,
   TranscriptLoadRequestMessage,
@@ -78,6 +79,9 @@ export interface ConnectionEvents {
 
   /** Kill session request received */
   onKillSessionRequest: (sessionId: UUID, requestId: UUID) => void;
+
+  /** Session history request received */
+  onSessionHistoryRequest: (requestId: UUID, limit: number | undefined) => void;
 
   /** Authentication succeeded */
   onAuthSuccess: (clientFingerprint: string) => void;
@@ -257,6 +261,9 @@ export class Connection {
       case 'kill_session_request':
         this.handleKillSessionRequest(message);
         break;
+      case 'session_history_request':
+        this.handleSessionHistoryRequest(message);
+        break;
       case 'ping':
         this.handlePing(message);
         break;
@@ -423,6 +430,11 @@ export class Connection {
   private handleKillSessionRequest(message: KillSessionRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onKillSessionRequest?.(message.sessionId, message.id);
+  }
+
+  private handleSessionHistoryRequest(message: SessionHistoryRequestMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onSessionHistoryRequest?.(message.id, message.limit);
   }
 
   private handleTerminalResize(message: TerminalResizeMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -74,6 +74,9 @@ export interface ServerEvents {
   /** Kill session request from client */
   onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
 
+  /** Session history request from client */
+  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -315,6 +318,10 @@ export class WebSocketServer {
 
       onKillSessionRequest: (sessionId, requestId) => {
         this.events.onKillSessionRequest?.(ws.data.connectionId, sessionId, requestId);
+      },
+
+      onSessionHistoryRequest: (requestId, limit) => {
+        this.events.onSessionHistoryRequest?.(ws.data.connectionId, requestId, limit);
       },
 
       onError: (error) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -67,6 +67,9 @@ export type {
   KillSessionRequestMessage,
   KillSessionResponseMessage,
   RawPtyOutputMessage,
+  RecentDirectory,
+  SessionHistoryRequestMessage,
+  SessionHistoryResponseMessage,
 } from './protocol.ts';
 
 export {
@@ -103,6 +106,8 @@ export {
   createKillSessionRequest,
   createKillSessionResponse,
   createRawPtyOutput,
+  createSessionHistoryRequest,
+  createSessionHistoryResponse,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -91,7 +91,9 @@ export type ProtocolMessage =
   | AuthResultMessage
   | KillSessionRequestMessage
   | KillSessionResponseMessage
-  | RawPtyOutputMessage;
+  | RawPtyOutputMessage
+  | SessionHistoryRequestMessage
+  | SessionHistoryResponseMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -441,6 +443,36 @@ export interface KillSessionResponseMessage {
   readonly requestId: UUID;
 }
 
+/** A recent project directory aggregated from session history */
+export interface RecentDirectory {
+  /** Absolute path */
+  readonly directory: string;
+  /** ISO timestamp of last use */
+  readonly lastUsed: Timestamp;
+  /** Number of sessions that used this directory */
+  readonly sessionCount: number;
+  /** basename(directory) for display */
+  readonly displayName: string;
+}
+
+/** Request session history (recent directories) */
+export interface SessionHistoryRequestMessage {
+  readonly type: 'session_history_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Max number of directories to return */
+  readonly limit?: number;
+}
+
+/** Response with recent directories */
+export interface SessionHistoryResponseMessage {
+  readonly type: 'session_history_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  readonly directories: readonly RecentDirectory[];
+  readonly requestId: UUID;
+}
+
 /**
  * Serialize a protocol message to JSON string.
  * Throws if message is invalid.
@@ -512,6 +544,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'kill_session_request',
     'kill_session_response',
     'raw_pty_output',
+    'session_history_request',
+    'session_history_response',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -999,6 +1033,34 @@ export function createRawPtyOutput(data: string, sessionId: UUID): RawPtyOutputM
     timestamp: now(),
     data,
     sessionId,
+  };
+}
+
+/**
+ * Create a session history request.
+ */
+export function createSessionHistoryRequest(limit?: number): SessionHistoryRequestMessage {
+  return {
+    type: 'session_history_request',
+    id: generateId(),
+    timestamp: now(),
+    ...(limit !== undefined && { limit }),
+  };
+}
+
+/**
+ * Create a session history response with recent directories.
+ */
+export function createSessionHistoryResponse(
+  directories: readonly RecentDirectory[],
+  requestId: UUID,
+): SessionHistoryResponseMessage {
+  return {
+    type: 'session_history_response',
+    id: generateId(),
+    timestamp: now(),
+    directories,
+    requestId,
   };
 }
 

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -17,6 +17,8 @@ import {
   createPong,
   createQuestion,
   createReplayBatch,
+  createSessionHistoryRequest,
+  createSessionHistoryResponse,
   createSessionListRequest,
   createSessionListResponse,
   createSessionUpdate,
@@ -667,6 +669,74 @@ describe('Message factory functions', () => {
       const requestId = generateId();
       const msg = createSessionListResponse([], requestId);
       expect(msg.sessions.length).toBe(0);
+    });
+  });
+
+  describe('createSessionHistoryRequest()', () => {
+    test('creates request without limit', () => {
+      const msg = createSessionHistoryRequest();
+      expect(msg.type).toBe('session_history_request');
+      expect(msg.limit).toBeUndefined();
+    });
+
+    test('creates request with limit', () => {
+      const msg = createSessionHistoryRequest(10);
+      expect(msg.type).toBe('session_history_request');
+      expect(msg.limit).toBe(10);
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createSessionHistoryRequest(5);
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('session_history_request');
+    });
+  });
+
+  describe('createSessionHistoryResponse()', () => {
+    test('creates response with directories', () => {
+      const requestId = generateId();
+      const directories = [
+        {
+          directory: '/home/user/project',
+          lastUsed: now(),
+          sessionCount: 3,
+          displayName: 'project',
+        },
+      ];
+
+      const msg = createSessionHistoryResponse(directories, requestId);
+      expect(msg.type).toBe('session_history_response');
+      expect(msg.directories.length).toBe(1);
+      expect(msg.directories[0]?.directory).toBe('/home/user/project');
+      expect(msg.directories[0]?.sessionCount).toBe(3);
+      expect(msg.requestId).toBe(requestId);
+    });
+
+    test('creates response with empty directories', () => {
+      const requestId = generateId();
+      const msg = createSessionHistoryResponse([], requestId);
+      expect(msg.directories.length).toBe(0);
+    });
+
+    test('serializes and deserializes', () => {
+      const requestId = generateId();
+      const msg = createSessionHistoryResponse(
+        [
+          {
+            directory: '/tmp/test',
+            lastUsed: now(),
+            sessionCount: 1,
+            displayName: 'test',
+          },
+        ],
+        requestId,
+      );
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('session_history_response');
     });
   });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
   const [showSessionSwitcher, setShowSessionSwitcher] = useState(false);
-  const [recentDirectories, setRecentDirectories] = useState<RecentDirectory[]>([]);
+  const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
@@ -406,7 +406,7 @@ function App() {
       }
 
       case 'session_history_response': {
-        setRecentDirectories(message.directories as RecentDirectory[]);
+        setRecentDirectories([...message.directories]);
         break;
       }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,11 +23,12 @@ import type {
 import { DEFAULT_SETTINGS } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
-import type { ProtocolMessage } from '@remi/shared/protocol.ts';
+import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
   createCreateSessionRequest,
   createHello,
+  createSessionHistoryRequest,
   createSessionListRequest,
   createTranscriptLoadRequest,
   createUserInput,
@@ -113,6 +114,7 @@ function App() {
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
   const [showSessionSwitcher, setShowSessionSwitcher] = useState(false);
+  const [recentDirectories, setRecentDirectories] = useState<RecentDirectory[]>([]);
 
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
@@ -403,6 +405,11 @@ function App() {
         break;
       }
 
+      case 'session_history_response': {
+        setRecentDirectories(message.directories as RecentDirectory[]);
+        break;
+      }
+
       case 'bullet_expand_response': {
         const { bulletId, fullContent } = message;
         setMessages((prev) =>
@@ -502,6 +509,7 @@ function App() {
     requestSessionList,
     requestTranscriptLoad,
     requestNewSession,
+    requestSessionHistory,
     needsPassphrase,
     serverFingerprint,
     provideIdentity,
@@ -590,6 +598,14 @@ function App() {
     [connectionMode, relaySend, requestNewSession],
   );
 
+  const effectiveRequestSessionHistory = useCallback(
+    (limit?: number): boolean => {
+      if (connectionMode === 'relay') return relaySend(createSessionHistoryRequest(limit));
+      return requestSessionHistory(limit);
+    },
+    [connectionMode, relaySend, requestSessionHistory],
+  );
+
   // Close modal and store URL on successful connect
   useEffect(() => {
     if (connectionStatus === 'connected') {
@@ -621,19 +637,27 @@ function App() {
     }
   }, [effectiveStatus, activeSessionId]);
 
-  // Request session list after direct connection
+  // Request session list and history after direct connection
   useEffect(() => {
     if (connectionStatus === 'connected') {
       effectiveRequestSessionList(true);
+      effectiveRequestSessionHistory();
     }
-  }, [connectionStatus, effectiveRequestSessionList]);
+  }, [connectionStatus, effectiveRequestSessionList, effectiveRequestSessionHistory]);
 
-  // Request session list after relay connection (hello_ack received)
+  // Request session list and history after relay connection (hello_ack received)
   useEffect(() => {
     if (connectionMode === 'relay' && relayStatus === 'connected' && activeSessionId) {
       effectiveRequestSessionList(true);
+      effectiveRequestSessionHistory();
     }
-  }, [connectionMode, relayStatus, activeSessionId, effectiveRequestSessionList]);
+  }, [
+    connectionMode,
+    relayStatus,
+    activeSessionId,
+    effectiveRequestSessionList,
+    effectiveRequestSessionHistory,
+  ]);
 
   // Auto-connect from localStorage on mount (run once)
   const connectRef = useRef(connect);
@@ -942,11 +966,14 @@ function App() {
     [activeSessionId, effectiveRequestBulletExpand],
   );
 
-  const handleNewSession = useCallback(() => {
-    if (creatingSession) return;
-    setCreatingSession(true);
-    effectiveRequestNewSession();
-  }, [effectiveRequestNewSession, creatingSession]);
+  const handleNewSession = useCallback(
+    (directory?: string) => {
+      if (creatingSession) return;
+      setCreatingSession(true);
+      effectiveRequestNewSession(directory);
+    },
+    [effectiveRequestNewSession, creatingSession],
+  );
 
   // Menu actions
   const handleCopyConversation = useCallback(() => {
@@ -985,6 +1012,7 @@ function App() {
       onNewSession={canCreateSession ? handleNewSession : undefined}
       onConnect={() => setShowConnectModal(true)}
       onSettings={() => setShowSettings(true)}
+      recentDirectories={recentDirectories}
     />
   );
 

--- a/packages/web/src/components/session/RecentProjects.tsx
+++ b/packages/web/src/components/session/RecentProjects.tsx
@@ -1,0 +1,107 @@
+/**
+ * RecentProjects component.
+ *
+ * Shows recent project directories with a "Start" button to create
+ * a new session in that directory, plus a text input for custom paths.
+ */
+
+import type { RecentDirectory } from '@remi/shared/protocol.ts';
+import { FolderOpen, Play } from 'lucide-react';
+import { useState } from 'react';
+
+interface RecentProjectsProps {
+  readonly directories: readonly RecentDirectory[];
+  readonly onStartSession: (directory: string) => void;
+}
+
+function formatAge(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function RecentProjects({ directories, onStartSession }: RecentProjectsProps) {
+  const [customPath, setCustomPath] = useState('');
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleDirs = expanded ? directories : directories.slice(0, 5);
+
+  return (
+    <div className="border-t border-[--color-border] px-3 py-2">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[--color-text-muted]">
+        Recent Projects
+      </h3>
+
+      <div className="space-y-1">
+        {visibleDirs.map((dir) => (
+          <div
+            key={dir.directory}
+            className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-[--color-surface-light]"
+          >
+            <FolderOpen className="size-4 shrink-0 text-[--color-text-muted]" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-medium text-[--color-text]">
+                {dir.displayName}
+              </div>
+              <div className="truncate text-xs text-[--color-text-muted]">
+                {formatAge(dir.lastUsed)} - {dir.sessionCount} session
+                {dir.sessionCount !== 1 ? 's' : ''}
+              </div>
+            </div>
+            <button
+              onClick={() => onStartSession(dir.directory)}
+              className="invisible rounded p-1 text-[--color-primary] transition-colors hover:bg-[--color-primary]/10 group-hover:visible"
+              aria-label={`Start session in ${dir.displayName}`}
+            >
+              <Play className="size-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {directories.length > 5 && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-1 w-full text-center text-xs text-[--color-text-muted] hover:text-[--color-text]"
+        >
+          {expanded ? 'Show less' : `Show ${directories.length - 5} more`}
+        </button>
+      )}
+
+      {/* Custom directory input */}
+      <div className="mt-2 flex gap-1">
+        <input
+          type="text"
+          value={customPath}
+          onChange={(e) => setCustomPath(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && customPath.trim()) {
+              onStartSession(customPath.trim());
+              setCustomPath('');
+            }
+          }}
+          placeholder="Custom path..."
+          className="min-w-0 flex-1 rounded border border-[--color-border] bg-[--color-surface] px-2 py-1 text-xs text-[--color-text] placeholder:text-[--color-text-muted] focus:border-[--color-primary] focus:outline-none"
+        />
+        <button
+          onClick={() => {
+            if (customPath.trim()) {
+              onStartSession(customPath.trim());
+              setCustomPath('');
+            }
+          }}
+          disabled={!customPath.trim()}
+          className="rounded bg-[--color-primary] px-2 py-1 text-xs text-white disabled:opacity-50"
+        >
+          Start
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -5,19 +5,22 @@
  */
 
 import type { UISession } from '@/types';
+import type { RecentDirectory } from '@remi/shared/protocol.ts';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
 import { Link2, Plus, Settings } from 'lucide-react';
+import { RecentProjects } from './RecentProjects';
 import { SessionCard } from './SessionCard';
 
 interface SessionListProps {
   readonly sessions: readonly UISession[];
   readonly activeSessionId: UUID | null;
   readonly onSelectSession: (id: UUID) => void;
-  readonly onNewSession?: () => void;
+  readonly onNewSession?: ((directory?: string) => void) | undefined;
   readonly onConnect?: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
+  readonly recentDirectories?: readonly RecentDirectory[];
 }
 
 export function SessionList({
@@ -28,6 +31,7 @@ export function SessionList({
   onConnect,
   onSettings,
   className,
+  recentDirectories,
 }: SessionListProps) {
   return (
     <div className={clsx('flex h-full flex-col bg-[--color-surface]', className)}>
@@ -91,11 +95,19 @@ export function SessionList({
         )}
       </div>
 
+      {/* Recent projects */}
+      {onNewSession && recentDirectories && recentDirectories.length > 0 && (
+        <RecentProjects
+          directories={recentDirectories}
+          onStartSession={(dir) => onNewSession(dir)}
+        />
+      )}
+
       {/* New session button (floating) */}
       {onNewSession && sessions.length > 0 && (
         <div className="absolute bottom-20 right-4 safe-area-bottom">
           <button
-            onClick={onNewSession}
+            onClick={() => onNewSession()}
             className="flex size-14 items-center justify-center rounded-full bg-[--color-primary] text-white shadow-lg transition-transform hover:scale-105 active:scale-95"
             aria-label="New session"
           >

--- a/packages/web/src/components/session/index.ts
+++ b/packages/web/src/components/session/index.ts
@@ -5,3 +5,4 @@
 export { SessionCard } from './SessionCard';
 export { SessionList } from './SessionList';
 export { ConnectModal } from './ConnectModal';
+export { RecentProjects } from './RecentProjects';

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -28,6 +28,7 @@ import {
   createCreateSessionRequest,
   createHello,
   createPing,
+  createSessionHistoryRequest,
   createSessionListRequest,
   createTranscriptLoadRequest,
   createUserInput,
@@ -61,6 +62,8 @@ export interface UseWebSocketReturn {
   requestTranscriptLoad: (sessionId: string) => boolean;
   /** Request creation of a new Claude Code session */
   requestNewSession: (directory?: string) => boolean;
+  /** Request recent directories from session history */
+  requestSessionHistory: (limit?: number) => boolean;
   /** Current session ID (after hello_ack) */
   sessionId: UUID | null;
   /** Whether the daemon requires authentication */
@@ -438,6 +441,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     return clientRef.current.send(createCreateSessionRequest(directory));
   }, []);
 
+  // Request recent directories from session history
+  const requestSessionHistory = useCallback((limit?: number): boolean => {
+    if (!clientRef.current) return false;
+    return clientRef.current.send(createSessionHistoryRequest(limit));
+  }, []);
+
   // Clean up on unmount
   useEffect(() => {
     return () => {
@@ -468,6 +477,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     requestSessionList,
     requestTranscriptLoad,
     requestNewSession,
+    requestSessionHistory,
     sessionId,
     authRequired,
     serverFingerprint,


### PR DESCRIPTION
## Summary

- Add `session_history_request`/`session_history_response` protocol messages with `RecentDirectory` type for browsing project history from SessionStore
- Add `remi recent` CLI command to browse recent project directories (local or remote via `--host`)
- Add `remi new --dir <path>`, `remi new --host <ip>`, `remi new --recent` for flexible session creation
- Add `RecentProjects` component in web app showing recent directories with start buttons
- Route session history messages through all 4 message routing files (connection, adapter, server, ws-adapter)

## Changes

### Protocol (packages/shared)
- `RecentDirectory` interface: directory, lastUsed, sessionCount, displayName
- `SessionHistoryRequestMessage` and `SessionHistoryResponseMessage` with factory functions
- Added to `ProtocolMessage` union and `isValidMessage()` validation

### CLI (packages/daemon)
- `remi recent`: local (reads SessionStore) or remote (WebSocket query)
- `remi new --dir <path>`: chdir then wrapper mode
- `remi new --host <ip>`: create remote session + auto-attach via `runAttachClient`
- `remi new --recent`: interactive numbered picker
- `remi new --host --recent`: remote picker + create + attach
- New files: `recent-client.ts`, `directory-picker.ts`, `remote-new-client.ts`
- `getRecentDirectories()`: aggregates SessionStore by projectPath

### Web (packages/web)
- `requestSessionHistory()` method in `useWebSocket` hook
- Auto-request session history on connect (alongside session list)
- `session_history_response` handler populates `recentDirectories` state
- `RecentProjects` component: directory list with Play buttons + custom path input
- `handleNewSession(directory?)` now accepts optional directory
- `SessionList` integrates RecentProjects section

### Message routing (4 files, same pattern as existing messages)
- `connection.ts`: ConnectionEvents, switch case, handler
- `connection-adapter.ts`: AdapterEvents
- `websocket-server.ts`: ServerEvents + bridge
- `websocket-adapter.ts`: Bridge event

## Test plan
- [x] `bun test` - 999 tests pass (6 new protocol tests)
- [x] `bun run typecheck` - clean
- [x] `bunx biome check` - clean
- [x] `bun run build` (web) - clean
- [ ] Manual: `remi start`, then `remi recent` shows directories
- [ ] Manual: `remi recent --host <ip>` queries remote daemon
- [ ] Manual: `remi new --host <ip>` creates session and drops into attached PTY
- [ ] Manual: `remi new --recent` shows picker, creates session in selected dir
- [ ] Manual: web app shows recent projects section after connecting

Closes #82