### PR TITLE
feat: group remi ls --network output by machine hostname

### DIFF
--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -367,37 +367,68 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
     return;
   }
 
-  for (const { daemon, sessions } of results) {
-    const label =
-      daemon.host === 'localhost'
-        ? `local (port ${daemon.port})`
-        : `${daemon.hostname} (${daemon.host}:${daemon.port})`;
-    console.log(`\n== ${label} ==`);
+  // Group by machine hostname so multiple daemons on the same host share one table
+  const machineGroups = new Map<
+    string,
+    {
+      label: string;
+      host: string;
+      entries: Array<{ daemon: DaemonSessions['daemon']; session: DiscoverableSession }>;
+    }
+  >();
 
-    if (sessions.length === 0) {
+  for (const { daemon, sessions } of results) {
+    const key = daemon.host === 'localhost' ? 'localhost' : daemon.hostname;
+    let group = machineGroups.get(key);
+    if (!group) {
+      const label = daemon.host === 'localhost' ? 'local' : `${daemon.hostname} (${daemon.host})`;
+      group = { label, host: daemon.host, entries: [] };
+      machineGroups.set(key, group);
+    }
+    for (const s of sessions) {
+      group.entries.push({ daemon, session: s });
+    }
+  }
+
+  let totalSessions = 0;
+  const machineCount = machineGroups.size;
+
+  for (const [, group] of machineGroups) {
+    console.log(`\n== ${group.label} ==`);
+
+    if (group.entries.length === 0) {
       console.log('  No active sessions');
       continue;
     }
 
-    const header = `  ${'NAME'.padEnd(28)}${'HOST'.padEnd(24)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+    totalSessions += group.entries.length;
+
+    const header = `  ${'NAME'.padEnd(28)}${'PORT'.padEnd(8)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
     console.log(header);
     console.log(`  ${'-'.repeat(header.length - 2)}`);
 
-    for (const s of sessions) {
+    for (const { daemon, session: s } of group.entries) {
       const name = (s.name ?? path.basename(s.projectPath)).slice(0, 26);
-      const host = `${daemon.host}:${daemon.port}`;
+      const port = String(daemon.port);
       const duration = formatDuration(s.createdAt);
       const lastAct = formatAge(s.lastActivity);
       const mark = s.canAttach ? ' *' : '';
 
       console.log(
-        `  ${name.padEnd(28)}${host.padEnd(24)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+        `  ${name.padEnd(28)}${port.padEnd(8)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
       );
     }
   }
 
-  const totalSessions = results.reduce((sum, r) => sum + r.sessions.length, 0);
-  console.log(`\n${totalSessions} session(s) across ${results.length} daemon(s)`);
+  const daemonCount = results.length;
+  if (machineCount === 1) {
+    const machineName = machineGroups.values().next().value?.label ?? 'unknown';
+    console.log(`\n${totalSessions} session(s) on ${machineName}`);
+  } else {
+    console.log(
+      `\n${totalSessions} session(s) across ${daemonCount} daemon(s) on ${machineCount} machine(s)`,
+    );
+  }
 
   const attachable = results.flatMap((r) =>
     r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, daemon: r.daemon })),

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -378,10 +378,11 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
   >();
 
   for (const { daemon, sessions } of results) {
-    const key = daemon.host === 'localhost' ? 'localhost' : daemon.hostname;
+    const hostname = daemon.hostname || daemon.host;
+    const key = daemon.host === 'localhost' ? 'localhost' : hostname;
     let group = machineGroups.get(key);
     if (!group) {
-      const label = daemon.host === 'localhost' ? 'local' : `${daemon.hostname} (${daemon.host})`;
+      const label = daemon.host === 'localhost' ? 'local' : `${hostname} (${daemon.host})`;
       group = { label, host: daemon.host, entries: [] };
       machineGroups.set(key, group);
     }
@@ -395,11 +396,6 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
 
   for (const [, group] of machineGroups) {
     console.log(`\n== ${group.label} ==`);
-
-    if (group.entries.length === 0) {
-      console.log('  No active sessions');
-      continue;
-    }
 
     totalSessions += group.entries.length;
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -379,7 +379,8 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
 
   for (const { daemon, sessions } of results) {
     const hostname = daemon.hostname || daemon.host;
-    const key = daemon.host === 'localhost' ? 'localhost' : hostname;
+    // Group by hostname+host to avoid merging different machines with the same hostname
+    const key = daemon.host === 'localhost' ? 'localhost' : `${hostname}@${daemon.host}`;
     let group = machineGroups.get(key);
     if (!group) {
       const label = daemon.host === 'localhost' ? 'local' : `${hostname} (${daemon.host})`;


### PR DESCRIPTION
## Summary
- Group sessions by machine hostname instead of per-daemon in `remi ls --network` output
- One table per machine with PORT column, replacing redundant section headers
- Single machine shows "7 session(s) on yahyas-mcm" instead of "7 session(s) across 7 daemon(s)"
- Multi-machine shows "N session(s) across M daemon(s) on K machine(s)"

Closes #84

## Before
```
== yahyas-mcm (100.79.39.98:18765) ==
  NAME                        HOST                    STATUS  ...
  yahyas-mcm:secureLSL/main   100.79.39.98:18765      idle    ...

== yahyas-mcm (100.79.39.98:18766) ==
  NAME                        HOST                    STATUS  ...
  yahyas-mcm:eeglab_conversi  100.79.39.98:18766      idle    ...
(x7 headers for 7 sessions on same machine)
```

## After
```
== yahyas-mcm (100.79.39.98) ==
  NAME                        PORT    STATUS     DURATION   LAST ACTIVITY
  -----------------------------------------------------------------------
  secureLSL/main              18765   idle        23h 27m         20h ago
  eeglab_conversi             18766   idle        19h 47m         19h ago
  ...
7 session(s) on yahyas-mcm (100.79.39.98)
```

## Test plan
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] 999 tests pass
- [ ] Manual test with `remi ls --network` on a machine with multiple daemons