### PR TITLE
Release v0.4.2: session launcher, ls grouping, arg parser fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.git
+dist
+build
+.env
+*.log
+.claude
+.serena
+.context
+.rules
+packages/web/node_modules
+packages/web/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   spelling:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,32 @@ Use **Serena MCP** for efficient code navigation instead of reading entire files
 | `search_for_pattern` | Regex search across codebase |
 | `replace_symbol_body` | Edit entire function/method bodies |
 
+## Branch Strategy
+
+```
+main        Stable release branch; users install from here
+develop     Integration branch; features land here first via PRs
+feature/*   Short-lived branches off develop
+```
+
+- **Feature work**: branch off `develop`, PR back into `develop`
+- **Releases**: when `develop` is stable, merge to `main` and tag
+- **Hotfixes**: branch off `main`, PR to both `main` and `develop`
+- Never push directly to `main` or `develop`
+
 ## Releasing
 
 **Always use the bump-version script for releases.** Never manually edit version numbers.
 
 ```bash
+# Bump on develop (pre-release testing)
+git checkout develop
+./scripts/bump-version.sh minor
+git push origin develop && git push origin v0.4.0
+
+# Promote to main when stable
+git checkout main && git merge develop && git push origin main
+
 # Bump and release (triggers CI: build, npm publish, GitHub release, Homebrew update)
 ./scripts/bump-version.sh --push patch   # 0.3.9 -> 0.3.10
 ./scripts/bump-version.sh --push minor   # 0.3.9 -> 0.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.3.16",
+  "version": "0.4.0",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.0'; // REMI_COMPILED_VERSION
+      return '0.4.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.0'; // REMI_COMPILED_VERSION
+    return '0.4.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.1'; // REMI_COMPILED_VERSION
+      return '0.4.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.1'; // REMI_COMPILED_VERSION
+    return '0.4.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.3.16'; // REMI_COMPILED_VERSION
+      return '0.4.0'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.3.16'; // REMI_COMPILED_VERSION
+    return '0.4.0'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -324,138 +324,20 @@ function resolveDirectory(
 // ---------------------------------------------------------------------------
 // Parse CLI arguments
 // ---------------------------------------------------------------------------
-const args = process.argv.slice(2);
-let cliPort: number | undefined;
-let cliNoTelegram = false;
-let cliMaxBulletLength: number | undefined;
-let cliDaemonMode = false;
-let cliSignalingUrl: string | undefined;
-let cliNoRelay = false;
-let cliResume: string | true | undefined; // true = resume most recent, string = session ID
-let cliShowSessions = false;
-let cliInstall = false;
-let cliUninstall = false;
-let cliSubcommand:
-  | 'ls'
-  | 'attach'
-  | 'code'
-  | 'keygen'
-  | 'export-key'
-  | 'import-key'
-  | 'authorize'
-  | 'keys'
-  | 'new'
-  | 'kill'
-  | 'detach'
-  | 'recent'
-  | 'start'
-  | 'stop'
-  | 'status'
-  | 'logs'
-  | undefined;
-let cliSubcommandArg: string | undefined;
-let cliCodeRefresh = false;
-let cliPermanentCode = false;
-let cliForce = false;
-let cliUsePassphrase = false;
-let cliNoTofu = false;
-let cliAuth: boolean | undefined; // undefined = auto (auth when bind != localhost)
-let cliLabel: string | undefined;
-let cliPublicOnly = false;
-let cliBindHost: string | undefined;
-let cliRemoveFingerprint: string | undefined;
-let cliNoMdns = false;
-let cliNetwork = false;
-let cliHost: string | undefined;
-let cliDir: string | undefined;
-let cliRecent = false;
-const claudeArgs: string[] = [];
+import { parseArgs } from './cli/arg-parser.ts';
 
-for (let i = 0; i < args.length; i++) {
-  const arg = args[i];
-  const nextArg = args[i + 1];
+const parsedArgs = parseArgs(process.argv.slice(2));
 
-  if (arg === '--daemon') {
-    cliDaemonMode = true;
-    wrapperMode = false;
-  } else if (arg === '--resume') {
-    if (nextArg && !nextArg.startsWith('-')) {
-      cliResume = nextArg;
-      i++;
-    } else {
-      cliResume = true;
-    }
-  } else if (arg === '--sessions') {
-    cliShowSessions = true;
-  } else if (arg === '--port' && nextArg) {
-    cliPort = Number.parseInt(nextArg);
-    i++;
-  } else if (arg === '--max-bullet-length' && nextArg) {
-    cliMaxBulletLength = Number.parseInt(nextArg);
-    i++;
-  } else if (arg === '--no-telegram') {
-    cliNoTelegram = true;
-  } else if (arg === '--no-relay') {
-    cliNoRelay = true;
-  } else if (arg === '--permanent-code') {
-    cliPermanentCode = true;
-  } else if (arg === '--signaling-url' && nextArg) {
-    cliSignalingUrl = nextArg;
-    i++;
-  } else if (arg === '--install') {
-    cliInstall = true;
-  } else if (arg === '--uninstall') {
-    cliUninstall = true;
-  } else if (arg === '--force') {
-    cliForce = true;
-  } else if (arg === '--passphrase') {
-    cliUsePassphrase = true;
-  } else if (arg === '--no-tofu') {
-    cliNoTofu = true;
-  } else if (arg === '--auth') {
-    cliAuth = true;
-  } else if (arg === '--no-auth') {
-    cliAuth = false;
-  } else if (arg === '--label' && nextArg) {
-    cliLabel = nextArg;
-    i++;
-  } else if (arg === '--public-only') {
-    cliPublicOnly = true;
-  } else if (arg === '--bind' && nextArg) {
-    cliBindHost = nextArg;
-    i++;
-  } else if (arg === '--remove' && nextArg) {
-    cliRemoveFingerprint = nextArg;
-    i++;
-  } else if (arg === '--local') {
-    cliBindHost = 'localhost';
-    // Don't set cliAuth; auto-detection disables auth for localhost already
-    cliNoMdns = true;
-  } else if (arg === '--no-mdns') {
-    cliNoMdns = true;
-  } else if (arg === '--network') {
-    cliNetwork = true;
-  } else if (arg === '--dir' && nextArg) {
-    if (cliRecent) {
-      console.error('Error: --dir and --recent are mutually exclusive.');
-      process.exit(1);
-    }
-    cliDir = nextArg;
-    i++;
-  } else if (arg === '--recent') {
-    if (cliDir) {
-      console.error('Error: --dir and --recent are mutually exclusive.');
-      process.exit(1);
-    }
-    cliRecent = true;
-  } else if (arg === '--host' && nextArg) {
-    cliHost = nextArg;
-    i++;
-  } else if (arg === '--version' || arg === '-v') {
-    console.log(`remi ${REMI_VERSION}`);
-    process.exit(0);
-  } else if (arg === '--help' || arg === '-h') {
-    console.log(`
+if (parsedArgs.error) {
+  console.error(parsedArgs.error);
+  process.exit(1);
+}
+if (parsedArgs.showVersion) {
+  console.log(`remi ${REMI_VERSION}`);
+  process.exit(0);
+}
+if (parsedArgs.showHelp) {
+  console.log(`
 Remi - Claude Code with remote monitoring
 
 Usage:
@@ -523,68 +405,41 @@ Environment:
 
 Any other arguments are passed through to Claude Code.
 `);
-    process.exit(0);
-  } else if (
-    arg === 'ls' ||
-    arg === 'attach' ||
-    arg === 'code' ||
-    arg === 'keygen' ||
-    arg === 'export-key' ||
-    arg === 'import-key' ||
-    arg === 'authorize' ||
-    arg === 'keys' ||
-    arg === 'new' ||
-    arg === 'kill' ||
-    arg === 'detach' ||
-    arg === 'recent' ||
-    arg === 'start' ||
-    arg === 'stop' ||
-    arg === 'status' ||
-    arg === 'logs'
-  ) {
-    cliSubcommand = arg;
-    if (
-      (arg === 'attach' ||
-        arg === 'import-key' ||
-        arg === 'authorize' ||
-        arg === 'kill' ||
-        arg === 'detach') &&
-      nextArg &&
-      !nextArg.startsWith('-')
-    ) {
-      cliSubcommandArg = nextArg;
-      i++;
-    }
-    if (arg === 'code' && nextArg === '--refresh') {
-      cliCodeRefresh = true;
-      i++;
-    }
-    // For 'new', collect remaining args after '--' as claude args
-    if (arg === 'new') {
-      for (let j = i + 1; j < args.length; j++) {
-        const nextA = args[j];
-        if (nextA === '--') continue; // skip bare '--'
-        if (nextA) claudeArgs.push(nextA);
-      }
-      break; // stop processing args
-    }
-  } else if (
-    cliSubcommand &&
-    (cliSubcommand === 'import-key' ||
-      cliSubcommand === 'authorize' ||
-      cliSubcommand === 'attach' ||
-      cliSubcommand === 'kill' ||
-      cliSubcommand === 'detach') &&
-    !cliSubcommandArg &&
-    arg &&
-    !arg.startsWith('-')
-  ) {
-    // Positional arg for subcommand (supports flags before or after)
-    cliSubcommandArg = arg;
-  } else {
-    // Pass through to Claude
-    if (arg) claudeArgs.push(arg);
-  }
+  process.exit(0);
+}
+
+// Destructure into existing variable names for zero downstream changes
+const cliPort = parsedArgs.port;
+const cliNoTelegram = parsedArgs.noTelegram;
+const cliMaxBulletLength = parsedArgs.maxBulletLength;
+const cliDaemonMode = parsedArgs.daemonMode;
+const cliSignalingUrl = parsedArgs.signalingUrl;
+const cliNoRelay = parsedArgs.noRelay;
+const cliResume = parsedArgs.resume;
+const cliShowSessions = parsedArgs.showSessions;
+const cliInstall = parsedArgs.install;
+const cliUninstall = parsedArgs.uninstall;
+const cliSubcommand = parsedArgs.subcommand;
+const cliSubcommandArg = parsedArgs.subcommandArg;
+const cliCodeRefresh = parsedArgs.codeRefresh;
+const cliPermanentCode = parsedArgs.permanentCode;
+const cliForce = parsedArgs.force;
+const cliUsePassphrase = parsedArgs.usePassphrase;
+const cliNoTofu = parsedArgs.noTofu;
+const cliAuth = parsedArgs.auth;
+const cliLabel = parsedArgs.label;
+const cliPublicOnly = parsedArgs.publicOnly;
+const cliBindHost = parsedArgs.bindHost;
+const cliRemoveFingerprint = parsedArgs.removeFingerprint;
+const cliNoMdns = parsedArgs.noMdns;
+const cliNetwork = parsedArgs.network;
+const cliHost = parsedArgs.host;
+const cliDir = parsedArgs.dir;
+const cliRecent = parsedArgs.recent;
+const claudeArgs = [...parsedArgs.claudeArgs];
+
+if (cliDaemonMode) {
+  wrapperMode = false;
 }
 
 // Handle --install / --uninstall

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -1,0 +1,306 @@
+/**
+ * CLI Argument Parser - Pure function for parsing remi CLI arguments.
+ *
+ * Extracted from cli.ts to enable unit testing. No side effects: no process.exit(),
+ * no console output. Returns a ParsedArgs object that the caller uses to drive behavior.
+ *
+ * Callers MUST check `error` before using any other field.
+ */
+
+const SUBCOMMAND_LIST = [
+  'ls',
+  'attach',
+  'code',
+  'keygen',
+  'export-key',
+  'import-key',
+  'authorize',
+  'keys',
+  'new',
+  'kill',
+  'detach',
+  'recent',
+  'start',
+  'stop',
+  'status',
+  'logs',
+] as const;
+
+export type Subcommand = (typeof SUBCOMMAND_LIST)[number];
+
+const SUBCOMMANDS: ReadonlySet<string> = new Set(SUBCOMMAND_LIST);
+
+const SUBCOMMANDS_WITH_POSITIONAL_ARG: ReadonlySet<Subcommand> = new Set<Subcommand>([
+  'attach',
+  'import-key',
+  'authorize',
+  'kill',
+  'detach',
+]);
+
+export function isSubcommand(s: string): s is Subcommand {
+  return SUBCOMMANDS.has(s);
+}
+
+export interface ParsedArgs {
+  readonly port: number | undefined;
+  readonly noTelegram: boolean;
+  readonly maxBulletLength: number | undefined;
+  readonly daemonMode: boolean;
+  readonly signalingUrl: string | undefined;
+  readonly noRelay: boolean;
+  readonly resume: string | true | undefined;
+  readonly showSessions: boolean;
+  readonly install: boolean;
+  readonly uninstall: boolean;
+  readonly subcommand: Subcommand | undefined;
+  readonly subcommandArg: string | undefined;
+  readonly codeRefresh: boolean;
+  readonly permanentCode: boolean;
+  readonly force: boolean;
+  readonly usePassphrase: boolean;
+  readonly noTofu: boolean;
+  readonly auth: boolean | undefined;
+  readonly label: string | undefined;
+  readonly publicOnly: boolean;
+  readonly bindHost: string | undefined;
+  readonly removeFingerprint: string | undefined;
+  readonly noMdns: boolean;
+  readonly network: boolean;
+  readonly host: string | undefined;
+  readonly dir: string | undefined;
+  readonly recent: boolean;
+  readonly claudeArgs: readonly string[];
+  readonly showVersion: boolean;
+  readonly showHelp: boolean;
+  /** Callers MUST check this before using any other field. */
+  readonly error: string | undefined;
+}
+
+export function parseArgs(args: readonly string[]): ParsedArgs {
+  let port: number | undefined;
+  let noTelegram = false;
+  let maxBulletLength: number | undefined;
+  let daemonMode = false;
+  let signalingUrl: string | undefined;
+  let noRelay = false;
+  let resume: string | true | undefined;
+  let showSessions = false;
+  let install = false;
+  let uninstall = false;
+  let subcommand: Subcommand | undefined;
+  let subcommandArg: string | undefined;
+  let codeRefresh = false;
+  let permanentCode = false;
+  let force = false;
+  let usePassphrase = false;
+  let noTofu = false;
+  let auth: boolean | undefined;
+  let label: string | undefined;
+  let publicOnly = false;
+  let bindHost: string | undefined;
+  let removeFingerprint: string | undefined;
+  let noMdns = false;
+  let network = false;
+  let host: string | undefined;
+  let dir: string | undefined;
+  let recent = false;
+  let showVersion = false;
+  let showHelp = false;
+  let error: string | undefined;
+  const claudeArgs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    // Standard Unix: everything after '--' is passthrough
+    if (arg === '--') {
+      for (let j = i + 1; j < args.length; j++) {
+        const a = args[j];
+        if (a) claudeArgs.push(a);
+      }
+      break;
+    }
+
+    if (arg === '--daemon') {
+      daemonMode = true;
+    } else if (arg === '--resume') {
+      if (nextArg && !nextArg.startsWith('-')) {
+        resume = nextArg;
+        i++;
+      } else {
+        resume = true;
+      }
+    } else if (arg === '--sessions') {
+      showSessions = true;
+    } else if (arg === '--port') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --port requires a value.';
+      } else {
+        const parsed = Number.parseInt(nextArg);
+        if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+          error = `Error: Invalid port "${nextArg}". Must be 1-65535.`;
+        } else {
+          port = parsed;
+        }
+        i++;
+      }
+    } else if (arg === '--max-bullet-length') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --max-bullet-length requires a value.';
+      } else {
+        const parsed = Number.parseInt(nextArg);
+        if (Number.isNaN(parsed) || parsed < 0) {
+          error = `Error: Invalid max-bullet-length "${nextArg}". Must be a non-negative integer.`;
+        } else {
+          maxBulletLength = parsed;
+        }
+        i++;
+      }
+    } else if (arg === '--no-telegram') {
+      noTelegram = true;
+    } else if (arg === '--no-relay') {
+      noRelay = true;
+    } else if (arg === '--permanent-code') {
+      permanentCode = true;
+    } else if (arg === '--signaling-url') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --signaling-url requires a value.';
+      } else {
+        signalingUrl = nextArg;
+        i++;
+      }
+    } else if (arg === '--install') {
+      if (uninstall) {
+        error = 'Error: --install and --uninstall are mutually exclusive.';
+      }
+      install = true;
+    } else if (arg === '--uninstall') {
+      if (install) {
+        error = 'Error: --install and --uninstall are mutually exclusive.';
+      }
+      uninstall = true;
+    } else if (arg === '--force') {
+      force = true;
+    } else if (arg === '--passphrase') {
+      usePassphrase = true;
+    } else if (arg === '--no-tofu') {
+      noTofu = true;
+    } else if (arg === '--auth') {
+      auth = true;
+    } else if (arg === '--no-auth') {
+      auth = false;
+    } else if (arg === '--label') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --label requires a value.';
+      } else {
+        label = nextArg;
+        i++;
+      }
+    } else if (arg === '--public-only') {
+      publicOnly = true;
+    } else if (arg === '--bind') {
+      if (!nextArg) {
+        error = 'Error: --bind requires a value.';
+      } else {
+        bindHost = nextArg;
+        i++;
+      }
+    } else if (arg === '--remove') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --remove requires a value.';
+      } else {
+        removeFingerprint = nextArg;
+        i++;
+      }
+    } else if (arg === '--local') {
+      bindHost = 'localhost';
+      noMdns = true;
+    } else if (arg === '--no-mdns') {
+      noMdns = true;
+    } else if (arg === '--network') {
+      network = true;
+    } else if (arg === '--dir') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --dir requires a value.';
+      } else {
+        if (recent) {
+          error = 'Error: --dir and --recent are mutually exclusive.';
+        }
+        dir = nextArg;
+        i++;
+      }
+    } else if (arg === '--recent') {
+      if (dir) {
+        error = 'Error: --dir and --recent are mutually exclusive.';
+      }
+      recent = true;
+    } else if (arg === '--host') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --host requires a value.';
+      } else {
+        host = nextArg;
+        i++;
+      }
+    } else if (arg === '--version' || arg === '-v') {
+      showVersion = true;
+    } else if (arg === '--help' || arg === '-h') {
+      showHelp = true;
+    } else if (isSubcommand(arg as string)) {
+      subcommand = arg as Subcommand;
+      if (SUBCOMMANDS_WITH_POSITIONAL_ARG.has(subcommand) && nextArg && !nextArg.startsWith('-')) {
+        subcommandArg = nextArg;
+        i++;
+      }
+      if (arg === 'code' && nextArg === '--refresh') {
+        codeRefresh = true;
+        i++;
+      }
+    } else if (
+      subcommand &&
+      SUBCOMMANDS_WITH_POSITIONAL_ARG.has(subcommand) &&
+      !subcommandArg &&
+      arg &&
+      !arg.startsWith('-')
+    ) {
+      subcommandArg = arg;
+    } else {
+      if (arg) claudeArgs.push(arg);
+    }
+  }
+
+  return {
+    port,
+    noTelegram,
+    maxBulletLength,
+    daemonMode,
+    signalingUrl,
+    noRelay,
+    resume,
+    showSessions,
+    install,
+    uninstall,
+    subcommand,
+    subcommandArg,
+    codeRefresh,
+    permanentCode,
+    force,
+    usePassphrase,
+    noTofu,
+    auth,
+    label,
+    publicOnly,
+    bindHost,
+    removeFingerprint,
+    noMdns,
+    network,
+    host,
+    dir,
+    recent,
+    claudeArgs,
+    showVersion,
+    showHelp,
+    error,
+  };
+}

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -367,37 +367,65 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
     return;
   }
 
-  for (const { daemon, sessions } of results) {
-    const label =
-      daemon.host === 'localhost'
-        ? `local (port ${daemon.port})`
-        : `${daemon.hostname} (${daemon.host}:${daemon.port})`;
-    console.log(`\n== ${label} ==`);
-
-    if (sessions.length === 0) {
-      console.log('  No active sessions');
-      continue;
+  // Group by machine hostname so multiple daemons on the same host share one table
+  const machineGroups = new Map<
+    string,
+    {
+      label: string;
+      host: string;
+      entries: Array<{ daemon: DaemonSessions['daemon']; session: DiscoverableSession }>;
     }
+  >();
 
-    const header = `  ${'NAME'.padEnd(28)}${'HOST'.padEnd(24)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+  for (const { daemon, sessions } of results) {
+    const hostname = daemon.hostname || daemon.host;
+    // Group by hostname+host to avoid merging different machines with the same hostname
+    const key = daemon.host === 'localhost' ? 'localhost' : `${hostname}@${daemon.host}`;
+    let group = machineGroups.get(key);
+    if (!group) {
+      const label = daemon.host === 'localhost' ? 'local' : `${hostname} (${daemon.host})`;
+      group = { label, host: daemon.host, entries: [] };
+      machineGroups.set(key, group);
+    }
+    for (const s of sessions) {
+      group.entries.push({ daemon, session: s });
+    }
+  }
+
+  let totalSessions = 0;
+  const machineCount = machineGroups.size;
+
+  for (const [, group] of machineGroups) {
+    console.log(`\n== ${group.label} ==`);
+
+    totalSessions += group.entries.length;
+
+    const header = `  ${'NAME'.padEnd(28)}${'PORT'.padEnd(8)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
     console.log(header);
     console.log(`  ${'-'.repeat(header.length - 2)}`);
 
-    for (const s of sessions) {
+    for (const { daemon, session: s } of group.entries) {
       const name = (s.name ?? path.basename(s.projectPath)).slice(0, 26);
-      const host = `${daemon.host}:${daemon.port}`;
+      const port = String(daemon.port);
       const duration = formatDuration(s.createdAt);
       const lastAct = formatAge(s.lastActivity);
       const mark = s.canAttach ? ' *' : '';
 
       console.log(
-        `  ${name.padEnd(28)}${host.padEnd(24)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+        `  ${name.padEnd(28)}${port.padEnd(8)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
       );
     }
   }
 
-  const totalSessions = results.reduce((sum, r) => sum + r.sessions.length, 0);
-  console.log(`\n${totalSessions} session(s) across ${results.length} daemon(s)`);
+  const daemonCount = results.length;
+  if (machineCount === 1) {
+    const machineName = machineGroups.values().next().value?.label ?? 'unknown';
+    console.log(`\n${totalSessions} session(s) on ${machineName}`);
+  } else {
+    console.log(
+      `\n${totalSessions} session(s) across ${daemonCount} daemon(s) on ${machineCount} machine(s)`,
+    );
+  }
 
   const attachable = results.flatMap((r) =>
     r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, daemon: r.daemon })),

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, test } from 'bun:test';
+import { parseArgs } from '../../src/cli/arg-parser.ts';
+
+describe('parseArgs', () => {
+  // -------------------------------------------------------------------------
+  // The main bug fix: remi new + flags
+  // -------------------------------------------------------------------------
+  describe('remi new with flags (bug fix)', () => {
+    test('remi new --host X parses host', () => {
+      const r = parseArgs(['new', '--host', '192.168.1.1']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('192.168.1.1');
+      expect(r.claudeArgs).toEqual([]);
+    });
+
+    test('remi new --dir /path parses dir', () => {
+      const r = parseArgs(['new', '--dir', '/tmp/test']);
+      expect(r.subcommand).toBe('new');
+      expect(r.dir).toBe('/tmp/test');
+      expect(r.claudeArgs).toEqual([]);
+    });
+
+    test('remi new --recent sets recent flag', () => {
+      const r = parseArgs(['new', '--recent']);
+      expect(r.subcommand).toBe('new');
+      expect(r.recent).toBe(true);
+      expect(r.claudeArgs).toEqual([]);
+    });
+
+    test('remi new --host X --recent parses both', () => {
+      const r = parseArgs(['new', '--host', '10.0.0.1', '--recent']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('10.0.0.1');
+      expect(r.recent).toBe(true);
+    });
+
+    test('remi new --host X --dir /path parses both', () => {
+      const r = parseArgs(['new', '--host', '10.0.0.1', '--dir', '/tmp']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('10.0.0.1');
+      expect(r.dir).toBe('/tmp');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // -- separator (standard Unix behavior)
+  // -------------------------------------------------------------------------
+  describe('-- separator', () => {
+    test('remi new -- --resume passes --resume to claude', () => {
+      const r = parseArgs(['new', '--', '--resume']);
+      expect(r.subcommand).toBe('new');
+      expect(r.claudeArgs).toEqual(['--resume']);
+      expect(r.resume).toBeUndefined();
+    });
+
+    test('remi new --host X -- --resume parses host and passes --resume', () => {
+      const r = parseArgs(['new', '--host', 'myhost', '--', '--resume']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('myhost');
+      expect(r.claudeArgs).toEqual(['--resume']);
+    });
+
+    test('remi -- --resume passes --resume to claude without parsing', () => {
+      const r = parseArgs(['--', '--resume']);
+      expect(r.subcommand).toBeUndefined();
+      expect(r.claudeArgs).toEqual(['--resume']);
+      expect(r.resume).toBeUndefined();
+    });
+
+    test('remi ls -- --weird stops parsing after --', () => {
+      const r = parseArgs(['ls', '--', '--weird']);
+      expect(r.subcommand).toBe('ls');
+      expect(r.claudeArgs).toEqual(['--weird']);
+    });
+
+    test('multiple args after -- all go to claudeArgs', () => {
+      const r = parseArgs(['new', '--', '--model', 'opus', '--verbose']);
+      expect(r.claudeArgs).toEqual(['--model', 'opus', '--verbose']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Backward compatibility: flags before subcommand
+  // -------------------------------------------------------------------------
+  describe('flags before subcommand', () => {
+    test('remi --host X new parses host before new', () => {
+      const r = parseArgs(['--host', 'myhost', 'new']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('myhost');
+    });
+
+    test('remi --port 9000 ls parses port before ls', () => {
+      const r = parseArgs(['--port', '9000', 'ls']);
+      expect(r.subcommand).toBe('ls');
+      expect(r.port).toBe(9000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Other subcommands with --host
+  // -------------------------------------------------------------------------
+  describe('other subcommands with --host', () => {
+    test('remi ls --host X', () => {
+      const r = parseArgs(['ls', '--host', 'myhost']);
+      expect(r.subcommand).toBe('ls');
+      expect(r.host).toBe('myhost');
+    });
+
+    test('remi recent --host X', () => {
+      const r = parseArgs(['recent', '--host', 'myhost']);
+      expect(r.subcommand).toBe('recent');
+      expect(r.host).toBe('myhost');
+    });
+
+    test('remi kill session-name --host X', () => {
+      const r = parseArgs(['kill', 'session-name', '--host', 'myhost']);
+      expect(r.subcommand).toBe('kill');
+      expect(r.subcommandArg).toBe('session-name');
+      expect(r.host).toBe('myhost');
+    });
+
+    test('remi attach abc --host X', () => {
+      const r = parseArgs(['attach', 'abc', '--host', 'myhost']);
+      expect(r.subcommand).toBe('attach');
+      expect(r.subcommandArg).toBe('abc');
+      expect(r.host).toBe('myhost');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown args pass through to claudeArgs
+  // -------------------------------------------------------------------------
+  describe('passthrough to claude', () => {
+    test('remi new unknown-thing goes to claudeArgs', () => {
+      const r = parseArgs(['new', 'unknown-thing']);
+      expect(r.subcommand).toBe('new');
+      expect(r.claudeArgs).toEqual(['unknown-thing']);
+    });
+
+    test('unknown flags in wrapper mode go to claudeArgs', () => {
+      const r = parseArgs(['--model', 'opus']);
+      expect(r.claudeArgs).toEqual(['--model', 'opus']);
+    });
+
+    test('positional args in wrapper mode go to claudeArgs', () => {
+      const r = parseArgs(['my-project']);
+      expect(r.claudeArgs).toEqual(['my-project']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutual exclusion
+  // -------------------------------------------------------------------------
+  describe('mutual exclusion', () => {
+    test('--dir and --recent together produces error', () => {
+      const r = parseArgs(['new', '--dir', '/tmp', '--recent']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--recent and --dir together produces error', () => {
+      const r = parseArgs(['new', '--recent', '--dir', '/tmp']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--dir alone has no error', () => {
+      const r = parseArgs(['new', '--dir', '/tmp']);
+      expect(r.error).toBeUndefined();
+    });
+
+    test('--recent alone has no error', () => {
+      const r = parseArgs(['new', '--recent']);
+      expect(r.error).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Subcommand detection
+  // -------------------------------------------------------------------------
+  describe('subcommand detection', () => {
+    test('no args returns undefined subcommand', () => {
+      const r = parseArgs([]);
+      expect(r.subcommand).toBeUndefined();
+    });
+
+    for (const cmd of [
+      'ls',
+      'attach',
+      'code',
+      'keygen',
+      'export-key',
+      'import-key',
+      'authorize',
+      'keys',
+      'new',
+      'kill',
+      'detach',
+      'recent',
+      'start',
+      'stop',
+      'status',
+      'logs',
+    ] as const) {
+      test(`${cmd} is detected as subcommand`, () => {
+        const r = parseArgs([cmd]);
+        expect(r.subcommand).toBe(cmd);
+      });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Subcommand positional args
+  // -------------------------------------------------------------------------
+  describe('subcommand positional args', () => {
+    test('attach session-id', () => {
+      const r = parseArgs(['attach', 'session-id']);
+      expect(r.subcommand).toBe('attach');
+      expect(r.subcommandArg).toBe('session-id');
+    });
+
+    test('kill session-name', () => {
+      const r = parseArgs(['kill', 'my-session']);
+      expect(r.subcommand).toBe('kill');
+      expect(r.subcommandArg).toBe('my-session');
+    });
+
+    test('detach session-name', () => {
+      const r = parseArgs(['detach', 'my-session']);
+      expect(r.subcommand).toBe('detach');
+      expect(r.subcommandArg).toBe('my-session');
+    });
+
+    test('import-key file.json', () => {
+      const r = parseArgs(['import-key', 'identity.json']);
+      expect(r.subcommand).toBe('import-key');
+      expect(r.subcommandArg).toBe('identity.json');
+    });
+
+    test('authorize key-file.json', () => {
+      const r = parseArgs(['authorize', 'client-key.json']);
+      expect(r.subcommand).toBe('authorize');
+      expect(r.subcommandArg).toBe('client-key.json');
+    });
+
+    test('positional arg after flags (e.g. kill --host X session)', () => {
+      const r = parseArgs(['kill', '--host', 'myhost', 'session-name']);
+      expect(r.subcommand).toBe('kill');
+      expect(r.host).toBe('myhost');
+      expect(r.subcommandArg).toBe('session-name');
+    });
+
+    test('code --refresh', () => {
+      const r = parseArgs(['code', '--refresh']);
+      expect(r.subcommand).toBe('code');
+      expect(r.codeRefresh).toBe(true);
+    });
+
+    test('ls has no positional arg', () => {
+      const r = parseArgs(['ls', 'something']);
+      expect(r.subcommand).toBe('ls');
+      expect(r.subcommandArg).toBeUndefined();
+      expect(r.claudeArgs).toEqual(['something']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Global flags
+  // -------------------------------------------------------------------------
+  describe('global flags', () => {
+    test('--daemon', () => {
+      expect(parseArgs(['--daemon']).daemonMode).toBe(true);
+    });
+
+    test('--port 9000', () => {
+      expect(parseArgs(['--port', '9000']).port).toBe(9000);
+    });
+
+    test('--resume without arg', () => {
+      expect(parseArgs(['--resume']).resume).toBe(true);
+    });
+
+    test('--resume with session-id', () => {
+      expect(parseArgs(['--resume', 'abc123']).resume).toBe('abc123');
+    });
+
+    test('--sessions', () => {
+      expect(parseArgs(['--sessions']).showSessions).toBe(true);
+    });
+
+    test('--version', () => {
+      expect(parseArgs(['--version']).showVersion).toBe(true);
+    });
+
+    test('-v', () => {
+      expect(parseArgs(['-v']).showVersion).toBe(true);
+    });
+
+    test('--help', () => {
+      expect(parseArgs(['--help']).showHelp).toBe(true);
+    });
+
+    test('-h', () => {
+      expect(parseArgs(['-h']).showHelp).toBe(true);
+    });
+
+    test('--local sets bindHost and noMdns', () => {
+      const r = parseArgs(['--local']);
+      expect(r.bindHost).toBe('localhost');
+      expect(r.noMdns).toBe(true);
+    });
+
+    test('--bind HOST', () => {
+      expect(parseArgs(['--bind', '0.0.0.0']).bindHost).toBe('0.0.0.0');
+    });
+
+    test('--auth', () => {
+      expect(parseArgs(['--auth']).auth).toBe(true);
+    });
+
+    test('--no-auth', () => {
+      expect(parseArgs(['--no-auth']).auth).toBe(false);
+    });
+
+    test('--no-relay', () => {
+      expect(parseArgs(['--no-relay']).noRelay).toBe(true);
+    });
+
+    test('--network', () => {
+      expect(parseArgs(['--network']).network).toBe(true);
+    });
+
+    test('--force', () => {
+      expect(parseArgs(['--force']).force).toBe(true);
+    });
+
+    test('--permanent-code', () => {
+      expect(parseArgs(['--permanent-code']).permanentCode).toBe(true);
+    });
+
+    test('--install', () => {
+      expect(parseArgs(['--install']).install).toBe(true);
+    });
+
+    test('--uninstall', () => {
+      expect(parseArgs(['--uninstall']).uninstall).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Complex combinations
+  // -------------------------------------------------------------------------
+  describe('complex combinations', () => {
+    test('remi new --host X --port 9000 --recent', () => {
+      const r = parseArgs(['new', '--host', '10.0.0.1', '--port', '9000', '--recent']);
+      expect(r.subcommand).toBe('new');
+      expect(r.host).toBe('10.0.0.1');
+      expect(r.port).toBe(9000);
+      expect(r.recent).toBe(true);
+    });
+
+    test('remi --port 9000 ls --host X --network', () => {
+      const r = parseArgs(['--port', '9000', 'ls', '--host', 'myhost', '--network']);
+      expect(r.subcommand).toBe('ls');
+      expect(r.port).toBe(9000);
+      expect(r.host).toBe('myhost');
+      expect(r.network).toBe(true);
+    });
+
+    test('remi new --dir /tmp -- --model opus', () => {
+      const r = parseArgs(['new', '--dir', '/tmp', '--', '--model', 'opus']);
+      expect(r.subcommand).toBe('new');
+      expect(r.dir).toBe('/tmp');
+      expect(r.claudeArgs).toEqual(['--model', 'opus']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Input validation (from review findings)
+  // -------------------------------------------------------------------------
+  describe('input validation', () => {
+    test('--port without value produces error', () => {
+      const r = parseArgs(['--port']);
+      expect(r.error).toBeDefined();
+      expect(r.port).toBeUndefined();
+    });
+
+    test('--port abc produces error', () => {
+      const r = parseArgs(['--port', 'abc']);
+      expect(r.error).toBeDefined();
+      expect(r.port).toBeUndefined();
+    });
+
+    test('--port 0 produces error (below range)', () => {
+      const r = parseArgs(['--port', '0']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--port 99999 produces error (above range)', () => {
+      const r = parseArgs(['--port', '99999']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--host without value produces error', () => {
+      const r = parseArgs(['--host']);
+      expect(r.error).toBeDefined();
+      expect(r.host).toBeUndefined();
+    });
+
+    test('--dir without value produces error', () => {
+      const r = parseArgs(['--dir']);
+      expect(r.error).toBeDefined();
+      expect(r.dir).toBeUndefined();
+    });
+
+    test('--max-bullet-length abc produces error', () => {
+      const r = parseArgs(['--max-bullet-length', 'abc']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--max-bullet-length 0 is valid (disables truncation)', () => {
+      const r = parseArgs(['--max-bullet-length', '0']);
+      expect(r.error).toBeUndefined();
+      expect(r.maxBulletLength).toBe(0);
+    });
+
+    test('--install and --uninstall are mutually exclusive', () => {
+      const r = parseArgs(['--install', '--uninstall']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--signaling-url without value produces error', () => {
+      const r = parseArgs(['--signaling-url']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--label without value produces error', () => {
+      const r = parseArgs(['--label']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--bind without value produces error', () => {
+      const r = parseArgs(['--bind']);
+      expect(r.error).toBeDefined();
+    });
+
+    test('--remove without value produces error', () => {
+      const r = parseArgs(['--remove']);
+      expect(r.error).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Previously untested flags (from review findings)
+  // -------------------------------------------------------------------------
+  describe('remaining flags', () => {
+    test('--no-telegram', () => {
+      expect(parseArgs(['--no-telegram']).noTelegram).toBe(true);
+    });
+
+    test('--max-bullet-length 200', () => {
+      expect(parseArgs(['--max-bullet-length', '200']).maxBulletLength).toBe(200);
+    });
+
+    test('--signaling-url URL', () => {
+      expect(parseArgs(['--signaling-url', 'wss://example.com']).signalingUrl).toBe(
+        'wss://example.com',
+      );
+    });
+
+    test('--passphrase', () => {
+      expect(parseArgs(['--passphrase']).usePassphrase).toBe(true);
+    });
+
+    test('--no-tofu', () => {
+      expect(parseArgs(['--no-tofu']).noTofu).toBe(true);
+    });
+
+    test('--label NAME', () => {
+      expect(parseArgs(['--label', 'My Phone']).label).toBe('My Phone');
+    });
+
+    test('--public-only', () => {
+      expect(parseArgs(['--public-only']).publicOnly).toBe(true);
+    });
+
+    test('--remove FINGERPRINT', () => {
+      expect(parseArgs(['--remove', 'abc123']).removeFingerprint).toBe('abc123');
+    });
+
+    test('--no-mdns standalone', () => {
+      expect(parseArgs(['--no-mdns']).noMdns).toBe(true);
+    });
+
+    test('--resume followed by a flag does not consume the flag', () => {
+      const r = parseArgs(['--resume', '--daemon']);
+      expect(r.resume).toBe(true);
+      expect(r.daemonMode).toBe(true);
+    });
+  });
+});

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,33 @@
+FROM oven/bun:latest
+
+# Install Node.js for Claude Code CLI (requires npm)
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /app
+
+# Copy package files first for layer caching
+COPY package.json bun.lock ./
+COPY packages/daemon/package.json packages/daemon/
+COPY packages/shared/package.json packages/shared/
+COPY packages/signaling/package.json packages/signaling/
+COPY packages/web/package.json packages/web/
+
+# Install dependencies (--ignore-scripts to skip lefthook which needs git)
+RUN bun install --frozen-lockfile --ignore-scripts
+
+# Copy source
+COPY packages/shared/ packages/shared/
+COPY packages/daemon/ packages/daemon/
+
+# Create a working directory for sessions
+RUN mkdir -p /projects/test-project
+
+# Default: run daemon bound to all interfaces, no auth, no relay
+ENTRYPOINT ["bun", "run", "packages/daemon/src/cli.ts"]
+CMD ["--daemon", "--bind", "0.0.0.0", "--no-auth", "--no-relay", "--no-mdns"]

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  daemon1:
+    build:
+      context: ../..
+      dockerfile: tests/integration/Dockerfile
+    container_name: remi-test-daemon1
+    ports:
+      - "19765:18765"
+    environment:
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+    networks:
+      remi-test:
+        ipv4_address: 172.28.0.10
+    healthcheck:
+      test: ["CMD", "bun", "run", "packages/daemon/src/cli.ts", "ls"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  daemon2:
+    build:
+      context: ../..
+      dockerfile: tests/integration/Dockerfile
+    container_name: remi-test-daemon2
+    ports:
+      - "19766:18765"
+    environment:
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+    networks:
+      remi-test:
+        ipv4_address: 172.28.0.11
+    healthcheck:
+      test: ["CMD", "bun", "run", "packages/daemon/src/cli.ts", "ls"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+networks:
+  remi-test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Integration tests for remi CLI remote commands.
+# Spins up Docker containers running remi daemons, then tests
+# ls, recent, new, kill against them from the host.
+#
+# Usage:
+#   ./tests/integration/run-tests.sh
+#
+# Prerequisites:
+#   - Docker and docker compose
+#   - CLAUDE_CODE_OAUTH_TOKEN set (or in ~/.zshrc)
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/../.."
+
+# Must run from project root for bun workspace resolution
+cd "$PROJECT_ROOT"
+
+remi_cli() {
+  bun run packages/daemon/src/cli.ts "$@"
+}
+export -f remi_cli
+
+# Use non-standard ports to avoid conflicts with local daemons
+D1_PORT=19765
+D2_PORT=19766
+HOST=localhost
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Load CLAUDE_CODE_OAUTH_TOKEN if not set
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  # Extract token from ~/.zshrc (may be commented out with "# export")
+  TOKEN=$(grep 'CLAUDE_CODE_OAUTH_TOKEN=' ~/.zshrc 2>/dev/null | head -1 | sed 's/.*CLAUDE_CODE_OAUTH_TOKEN=//')
+  if [ -n "$TOKEN" ]; then
+    export CLAUDE_CODE_OAUTH_TOKEN="$TOKEN"
+    echo "Loaded CLAUDE_CODE_OAUTH_TOKEN from ~/.zshrc"
+  else
+    echo "WARNING: CLAUDE_CODE_OAUTH_TOKEN not set. Session creation tests may fail."
+  fi
+fi
+
+run_test() {
+  local name="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  echo -n "  [$TOTAL] $name ... "
+  local output
+  if output=$("$@" 2>&1); then
+    echo "PASS"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL"
+    echo "    Output: ${output:0:200}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Expect failure (exit code != 0)
+run_test_expect_fail() {
+  local name="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  echo -n "  [$TOTAL] $name ... "
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL (expected failure but succeeded)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS (failed as expected)"
+    PASS=$((PASS + 1))
+  fi
+}
+
+cleanup() {
+  echo ""
+  echo "Cleaning up Docker containers..."
+  docker compose -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---- Start containers ----
+echo "Building and starting Docker containers..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d --build --wait 2>&1
+
+echo ""
+echo "Containers ready. Running integration tests..."
+echo ""
+
+# ---- Test Group 1: remi ls ----
+echo "== ls tests =="
+run_test "ls --host --port daemon1" remi_cli ls --host $HOST --port $D1_PORT
+run_test "ls --host --port daemon2" remi_cli ls --host $HOST --port $D2_PORT
+run_test "ls --port (no --host, defaults to localhost)" remi_cli ls --port $D1_PORT
+
+# ---- Test Group 2: remi recent ----
+echo ""
+echo "== recent tests =="
+run_test "recent --host --port daemon1" remi_cli recent --host $HOST --port $D1_PORT
+run_test "recent --host --port daemon2" remi_cli recent --host $HOST --port $D2_PORT
+
+# ---- Test Group 3: remi new (arg parsing - the main bug fix) ----
+echo ""
+echo "== new --host tests (arg parsing fix) =="
+
+# These test that --host is actually parsed after 'new'.
+# Session creation connects to the daemon and spawns Claude.
+# We run in background, wait briefly, then kill -- success = connection worked.
+run_test "new --host --port daemon1 connects" \
+  bash -c "remi_cli new --host $HOST --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+
+run_test "new --host --port --dir connects" \
+  bash -c "remi_cli new --host $HOST --port $D1_PORT --dir /tmp &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+
+# Verify --recent flag is parsed (may show "no recent dirs" which is expected on fresh container)
+run_test "new --host --port --recent parsed" \
+  bash -c "remi_cli new --host $HOST --port $D1_PORT --recent 2>&1 | grep -q 'No recent\|Creating session\|Select directory'"
+
+# ---- Test Group 4: flags before subcommand (backward compat) ----
+echo ""
+echo "== flags before subcommand (backward compat) =="
+run_test "flags before: --host X ls" remi_cli --host $HOST --port $D1_PORT ls
+
+# ---- Test Group 5: remi kill ----
+echo ""
+echo "== kill tests =="
+run_test_expect_fail "kill nonexistent session" \
+  remi_cli kill nonexistent --host $HOST --port $D1_PORT
+
+# ---- Test Group 6: -- separator ----
+echo ""
+echo "== -- separator tests =="
+# Verify that -- stops remi flag parsing. --weird-flag should NOT cause a remi error.
+run_test "ls with -- separator" remi_cli ls --port $D1_PORT -- --weird-flag
+
+# ---- Results ----
+echo ""
+echo "==============================="
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Promotes develop to main for v0.4.2 release. Includes all changes since v0.3.16.

### v0.4.0 - Session launcher and remote session management (#83)
- New protocol: `session_history_request`/`session_history_response` with `RecentDirectory` type
- New CLI commands: `remi recent`, `remi new --host/--dir/--recent`
- New CLI commands: `remi kill`, `remi detach`
- Web app: recent projects section in session list
- Remote session creation and auto-attach

### v0.4.1 - Group ls --network output by machine (#85)
- Group sessions by machine hostname instead of per-daemon headers
- One table per machine with PORT column
- Composite grouping key prevents same-hostname different-IP merge

### v0.4.2 - Fix arg parser break bug (#87)
- Fix: `remi new --host/--dir/--recent` flags were not parsed (break bug)
- Extract arg parser into testable `parseArgs()` function (93 unit tests)
- Add standard Unix `--` separator support for all subcommands
- Validate port range, missing flag values, mutual exclusion
- Docker integration test infrastructure (2 daemon containers, 11 tests)
- Add `.dockerignore`
- Add branch strategy documentation to CLAUDE.md

## Test plan
- [x] 1092 unit tests pass
- [x] 11/11 Docker integration tests pass
- [x] Typecheck clean
- [x] Biome clean
- [x] Web build clean
- [x] Manual testing of all remote commands against Docker containers