### PR TITLE
feat: add dev release support to bump script and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Detect release type
+        id: release-type
+        run: |
+          if [[ "$GITHUB_REF_NAME" == *"-dev"* ]]; then
+            echo "is_dev=true" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=dev" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_dev=false" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -60,6 +71,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ steps.release-type.outputs.is_dev == 'true' }}
           generate_release_notes: true
           files: |
             artifacts/remi-darwin-arm64/remi-darwin-arm64
@@ -67,8 +79,12 @@ jobs:
             artifacts/remi-linux-x64/remi-linux-x64
             artifacts/remi-linux-arm64/remi-linux-arm64
 
+    outputs:
+      is_dev: ${{ steps.release-type.outputs.is_dev }}
+      npm_tag: ${{ steps.release-type.outputs.npm_tag }}
+
   publish-npm:
-    needs: build
+    needs: [build, release]
     runs-on: ubuntu-latest
 
     steps:
@@ -97,7 +113,7 @@ jobs:
             echo "ERROR: Invalid version from tag: '${GITHUB_REF_NAME}'" >&2
             exit 1
           fi
-          echo "Publishing version: $VERSION"
+          echo "Publishing version: $VERSION (tag: ${{ needs.release.outputs.npm_tag }})"
           REPO_ROOT="$(pwd)"
           for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
             mkdir -p npm/remi-$PLAT/bin
@@ -124,18 +140,21 @@ jobs:
         run: |
           set -euo pipefail
           REPO_ROOT="$(pwd)"
+          NPM_TAG="${{ needs.release.outputs.npm_tag }}"
           for PLAT in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
-            echo "Publishing @yooz-labs/remi-$PLAT..."
-            (cd "$REPO_ROOT/npm/remi-$PLAT" && npm publish --access public)
+            echo "Publishing @yooz-labs/remi-$PLAT (tag: $NPM_TAG)..."
+            (cd "$REPO_ROOT/npm/remi-$PLAT" && npm publish --access public --tag "$NPM_TAG")
           done
 
       - name: Publish main package
         run: |
           cd npm/remi
-          npm publish --access public
+          npm publish --access public --tag "${{ needs.release.outputs.npm_tag }}"
 
   update-homebrew:
-    needs: publish-npm
+    needs: [publish-npm, release]
+    # Only update Homebrew for stable releases
+    if: needs.release.outputs.is_dev == 'false'
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,16 +111,16 @@ feature/*   Short-lived branches off develop
 **Always use the bump-version script for releases.** Never manually edit version numbers.
 
 ```bash
-# Bump on develop (pre-release testing)
+# Dev release on develop (publishes to npm with @dev tag, GitHub prerelease)
 git checkout develop
-./scripts/bump-version.sh minor
-git push origin develop && git push origin v0.4.0
+./scripts/bump-version.sh --push dev     # 0.4.3 -> 0.4.4-dev.1
+./scripts/bump-version.sh --push dev     # 0.4.4-dev.1 -> 0.4.4-dev.2
 
 # Promote to main when stable
 git checkout main && git merge develop && git push origin main
 
-# Bump and release (triggers CI: build, npm publish, GitHub release, Homebrew update)
-./scripts/bump-version.sh --push patch   # 0.3.9 -> 0.3.10
+# Stable release (triggers CI: build, npm publish @latest, GitHub release, Homebrew update)
+./scripts/bump-version.sh --push patch   # 0.4.4-dev.2 -> 0.4.4
 ./scripts/bump-version.sh --push minor   # 0.3.9 -> 0.4.0
 ./scripts/bump-version.sh --push major   # 0.3.9 -> 1.0.0
 ./scripts/bump-version.sh --push set 1.0.0  # Explicit version

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -5,8 +5,10 @@
 #   ./scripts/bump-version.sh patch          # 0.2.3 -> 0.2.4
 #   ./scripts/bump-version.sh minor          # 0.2.3 -> 0.3.0
 #   ./scripts/bump-version.sh major          # 0.2.3 -> 1.0.0
+#   ./scripts/bump-version.sh dev            # 0.2.3 -> 0.2.4-dev.1 (or -dev.N+1)
 #   ./scripts/bump-version.sh set 1.0.0      # Set specific version
 #   ./scripts/bump-version.sh --push patch   # Bump and push (triggers release)
+#   ./scripts/bump-version.sh --push dev     # Bump dev and push (triggers dev release)
 
 set -euo pipefail
 
@@ -30,7 +32,7 @@ done
 
 BUMP_TYPE="${1:-}"
 if [[ -z "$BUMP_TYPE" ]]; then
-  echo "Usage: $0 [--push] <patch|minor|major|set <version>>" >&2
+  echo "Usage: $0 [--push] <patch|minor|major|dev|set <version>>" >&2
   exit 1
 fi
 
@@ -38,21 +40,40 @@ fi
 CURRENT_VERSION=$(node -e "process.stdout.write(require('$PKG_JSON').version)")
 echo "Current: v$CURRENT_VERSION"
 
-# Parse version components
-IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+# Extract base version and any prerelease suffix
+BASE_VERSION="${CURRENT_VERSION%%-*}"
+PRERELEASE="${CURRENT_VERSION#"$BASE_VERSION"}"
+
+# Parse base version components
+IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
 
 case "$BUMP_TYPE" in
   major)
     MAJOR=$((MAJOR + 1))
     MINOR=0
     PATCH=0
+    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
     ;;
   minor)
     MINOR=$((MINOR + 1))
     PATCH=0
+    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
     ;;
   patch)
     PATCH=$((PATCH + 1))
+    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    ;;
+  dev)
+    if [[ "$PRERELEASE" =~ ^-dev\.([0-9]+)$ ]]; then
+      # Already a dev version; increment dev number
+      DEV_NUM="${BASH_REMATCH[1]}"
+      DEV_NUM=$((DEV_NUM + 1))
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.$DEV_NUM"
+    else
+      # Stable version; bump patch and start dev.1
+      PATCH=$((PATCH + 1))
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
+    fi
     ;;
   set)
     NEW_VER="${2:-}"
@@ -65,15 +86,13 @@ case "$BUMP_TYPE" in
       echo "Error: version must be semver (e.g. 1.0.0), got: $NEW_VER" >&2
       exit 1
     fi
-    IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VER"
+    NEW_VERSION="$NEW_VER"
     ;;
   *)
-    echo "Usage: $0 [--push] <patch|minor|major|set <version>>" >&2
+    echo "Usage: $0 [--push] <patch|minor|major|dev|set <version>>" >&2
     exit 1
     ;;
 esac
-
-NEW_VERSION="$MAJOR.$MINOR.$PATCH"
 
 if [[ "$NEW_VERSION" == "$CURRENT_VERSION" ]]; then
   echo "Version is already $CURRENT_VERSION, nothing to do." >&2
@@ -101,10 +120,11 @@ if [[ -f "$CLI_TS" ]]; then
     exit 1
   fi
   # Portable sed in-place: macOS uses -i '', GNU uses -i without arg
+  # Pattern matches stable (0.4.3) and prerelease (0.4.4-dev.1) versions
   if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' "s/return '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}'; \/\/ REMI_COMPILED_VERSION/return '$NEW_VERSION'; \/\/ REMI_COMPILED_VERSION/" "$CLI_TS"
+    sed -i '' "s/return '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^']*'; \/\/ REMI_COMPILED_VERSION/return '$NEW_VERSION'; \/\/ REMI_COMPILED_VERSION/" "$CLI_TS"
   else
-    sed -i "s/return '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}'; \/\/ REMI_COMPILED_VERSION/return '$NEW_VERSION'; \/\/ REMI_COMPILED_VERSION/" "$CLI_TS"
+    sed -i "s/return '[0-9]\+\.[0-9]\+\.[0-9]\+[^']*'; \/\/ REMI_COMPILED_VERSION/return '$NEW_VERSION'; \/\/ REMI_COMPILED_VERSION/" "$CLI_TS"
   fi
   if ! grep -q "return '$NEW_VERSION'; // REMI_COMPILED_VERSION" "$CLI_TS"; then
     echo "Error: sed substitution failed; cli.ts version not updated." >&2


### PR DESCRIPTION
## Summary

Add dev/prerelease publishing support so develop branch releases don't pollute the stable npm tag.

### Changes

**scripts/bump-version.sh**
- New `dev` bump type: `0.4.3 -> 0.4.4-dev.1 -> 0.4.4-dev.2`
- Updated sed patterns to handle prerelease version strings in cli.ts

**release.yml**
- Detects `-dev` in tag name to switch behavior
- Dev tags: publishes to npm `@dev` tag, creates GitHub prerelease
- Stable tags: publishes to npm `@latest` tag, creates GitHub release, updates Homebrew
- Homebrew update skipped for dev releases

### Usage

```bash
# On develop branch
./scripts/bump-version.sh --push dev     # 0.4.3 -> 0.4.4-dev.1

# Install dev version
npm i -g @yooz-labs/remi@dev

# Promote to stable later
./scripts/bump-version.sh --push patch   # 0.4.4-dev.2 -> 0.4.4
```

## Test plan

- [x] 1115 tests pass
- [x] Typecheck clean
- [ ] Test dev bump: `./scripts/bump-version.sh dev` produces correct version
- [ ] Test stable bump from dev: `./scripts/bump-version.sh patch` strips -dev suffix

Closes #97