### PR TITLE
feat: redesign CLI help with grouped use cases and color

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -325,6 +325,7 @@ function resolveDirectory(
 // Parse CLI arguments
 // ---------------------------------------------------------------------------
 import { parseArgs } from './cli/arg-parser.ts';
+import { formatHelp } from './cli/help.ts';
 
 const parsedArgs = parseArgs(process.argv.slice(2));
 
@@ -337,74 +338,7 @@ if (parsedArgs.showVersion) {
   process.exit(0);
 }
 if (parsedArgs.showHelp) {
-  console.log(`
-Remi - Claude Code with remote monitoring
-
-Usage:
-  remi [claude-args...]          Start Claude with WebSocket monitoring
-  remi new [-- claude-args...]   Explicit session creation (alias for remi [args])
-  remi new --dir <path>          Start session in a specific directory
-  remi new --recent              Pick from recent directories
-  remi new --host <ip>           Create session on remote daemon and attach
-  remi kill <name>               Kill a session by name or ID
-  remi detach [name]             Detach from current or named session
-  remi start                     Start daemon in background
-  remi stop                      Stop background daemon
-  remi status                    Show daemon status
-  remi logs                      Show recent daemon logs
-  remi recent                    Browse recent project directories
-  remi ls                        List live sessions from running daemon
-  remi ls --network              Discover and list sessions across the network
-  remi attach [session-id]       Attach to a session (detach: Ctrl+B d)
-  remi attach host:port/id       Attach to a remote session
-  remi code                      Show remote access connection code
-  remi code --refresh            Generate a new connection code
-  remi keygen                    Generate Ed25519 identity keypair
-  remi export-key                Export identity JSON (for sharing across devices)
-  remi import-key [file]         Import identity from file or stdin
-  remi authorize <key-file>      Add a client's public key to authorized keys
-  remi keys                      List authorized keys
-  remi --resume [session-id]     Resume a previous session
-  remi --sessions                List stored sessions
-  remi --daemon                  Daemon mode (headless server, prefer remi start)
-
-Options:
-  --port PORT              WebSocket port (default: 18765, env: REMI_PORT)
-  --max-bullet-length N    Truncate bullets longer than N chars (default: 500, 0=disabled)
-  --no-telegram            Disable Telegram adapter
-  --no-relay               Disable signaling relay (no remote access via connection code)
-  --permanent-code         Use a persistent connection code (requires Ed25519 auth over relay)
-  --signaling-url URL      Signaling server URL (default: wss://remi-signaling.dev-941.workers.dev/connect)
-  --bind HOST              Bind WebSocket to HOST (default: 0.0.0.0; use --local for localhost-only)
-  --force                  Overwrite existing identity (keygen/import-key)
-  --passphrase             Encrypt identity with a passphrase (keygen)
-  --auth                   Force enable authentication (default: auto based on --bind)
-  --no-auth                Disable authentication (even when binding to all interfaces)
-  --no-tofu                Reject unknown clients (disable Trust On First Use)
-  --local                  Localhost-only mode (--bind localhost --no-mdns)
-  --no-mdns                Disable mDNS network advertising
-  --host HOST              Connect to daemon at HOST (for ls/attach/new/recent; default: localhost)
-  --dir PATH               Working directory for new session (mutually exclusive with --recent)
-  --recent                 Pick from recent project directories (for new/recent subcommands)
-  --label NAME             Label for authorized key (authorize)
-  --public-only            Export only public key (export-key)
-  --remove FINGERPRINT     Remove authorized key by fingerprint (authorize)
-  --install                Install as autostart service
-  --uninstall              Remove autostart service
-  --version, -v            Show version
-  --help, -h               Show this help
-
-Environment:
-  REMI_PORT                WebSocket port
-  REMI_MAX_BULLET_LENGTH   Max bullet length before truncation (default: 500, 0=disabled)
-  TELEGRAM_BOT_TOKEN       Telegram bot token (enables Telegram adapter)
-  REMI_PASSPHRASE              Passphrase for identity operations (avoids interactive prompt)
-  TELEGRAM_ENABLED              Set to 'false' to disable Telegram
-  TELEGRAM_AUTHORIZED_CHAT_IDS  Comma-separated authorized chat IDs
-  TELEGRAM_AUTHORIZED_USER_IDS  Comma-separated authorized user IDs
-
-Any other arguments are passed through to Claude Code.
-`);
+  console.log(formatHelp(REMI_VERSION));
   process.exit(0);
 }
 

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -1,0 +1,93 @@
+/**
+ * CLI help text with grouped use cases and subtle ANSI color.
+ *
+ * Respects the NO_COLOR env var (https://no-color.org/) and disables
+ * color when stdout is not a TTY (piped output).
+ */
+
+// ---------------------------------------------------------------------------
+// Minimal ANSI color helpers
+// ---------------------------------------------------------------------------
+
+function supportsColor(): boolean {
+  if (process.env['NO_COLOR'] !== undefined) return false;
+  if (!process.stdout.isTTY) return false;
+  return true;
+}
+
+const ESC = '\x1b[';
+
+function bold(text: string): string {
+  return supportsColor() ? `${ESC}1m${text}${ESC}0m` : text;
+}
+
+function dim(text: string): string {
+  return supportsColor() ? `${ESC}2m${text}${ESC}0m` : text;
+}
+
+// ---------------------------------------------------------------------------
+// Help text sections
+// ---------------------------------------------------------------------------
+
+/** Pad command to fixed width and dim the description. */
+function entry(cmd: string, desc: string, width = 30): string {
+  return `  ${cmd.padEnd(width)}${dim(desc)}`;
+}
+
+export function formatHelp(version: string): string {
+  const lines: string[] = [
+    '',
+    bold(`Remi v${version}`) + dim(' - Claude Code with remote monitoring'),
+    '',
+    bold('Quick Start:'),
+    entry('remi', 'Start Claude with monitoring'),
+    entry('remi ls', 'List running sessions'),
+    entry('remi attach [name]', 'Attach to a session (Ctrl+B d to detach)'),
+    '',
+    bold('Remote Access:'),
+    entry('remi ls --host <ip>', 'List sessions on remote machine'),
+    entry('remi ls --network', 'Discover sessions across the network'),
+    entry('remi new --host <ip>', 'Create session on remote daemon'),
+    entry('remi attach host:port/name', 'Attach to remote session'),
+    entry('remi kill host:port/name', 'Kill a remote session'),
+    entry('remi code', 'Show connection code for phone/browser'),
+    '',
+    bold('Session Management:'),
+    entry('remi new --dir <path>', 'Start session in directory'),
+    entry('remi new /path', 'Start session in directory (shorthand)'),
+    entry('remi new --recent', 'Pick from recent directories'),
+    entry('remi recent', 'Browse recent project directories'),
+    entry('remi kill <name>', 'Kill a session'),
+    entry('remi --resume [id]', 'Resume a previous session'),
+    entry('remi --sessions', 'List stored sessions'),
+    '',
+    bold('Service:'),
+    entry('remi start', 'Start daemon in background'),
+    entry('remi stop', 'Stop background daemon'),
+    entry('remi status', 'Show daemon status'),
+    entry('remi logs', 'Show daemon logs'),
+    entry('remi --daemon', 'Run in headless daemon mode'),
+    entry('remi --install / --uninstall', 'Autostart service'),
+    '',
+    bold('Identity & Auth:'),
+    entry('remi keygen', 'Generate Ed25519 keypair'),
+    entry('remi authorize <key>', 'Add client public key'),
+    entry('remi keys', 'List authorized keys'),
+    entry('remi export-key', 'Export identity JSON'),
+    entry('remi import-key [file]', 'Import identity from file or stdin'),
+    '',
+    bold('Options:'),
+    entry('--port PORT', 'WebSocket port (default: 18765, env: REMI_PORT)'),
+    entry('--host HOST', 'Remote daemon host (default: localhost)'),
+    entry('--bind HOST', 'Bind address (default: 0.0.0.0)'),
+    entry('--local', 'Localhost-only mode'),
+    entry('--auth / --no-auth', 'Authentication control'),
+    entry('--no-relay', 'Disable relay'),
+    entry('--permanent-code', 'Persistent connection code'),
+    '',
+    dim("Run 'remi <command> --help' for more details."),
+    '',
+  ];
+
+  return lines.join('\n');
+}

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -51,6 +51,7 @@ export function formatHelp(version: string): string {
     entry('remi attach host:port/name', 'Attach to remote session'),
     entry('remi kill host:port/name', 'Kill a remote session'),
     entry('remi code', 'Show connection code for phone/browser'),
+    entry('remi code --refresh', 'Generate a new connection code'),
     '',
     bold('Session Management:'),
     entry('remi new --dir <path>', 'Start session in directory'),
@@ -58,6 +59,7 @@ export function formatHelp(version: string): string {
     entry('remi new --recent', 'Pick from recent directories'),
     entry('remi recent', 'Browse recent project directories'),
     entry('remi kill <name>', 'Kill a session'),
+    entry('remi detach [name]', 'Detach from session'),
     entry('remi --resume [id]', 'Resume a previous session'),
     entry('remi --sessions', 'List stored sessions'),
     '',
@@ -85,7 +87,11 @@ export function formatHelp(version: string): string {
     entry('--no-relay', 'Disable relay'),
     entry('--permanent-code', 'Persistent connection code'),
     '',
-    dim("Run 'remi <command> --help' for more details."),
+    entry('--version, -v', 'Show version'),
+    entry('--help, -h', 'Show this help'),
+    '',
+    dim('  Pass -- to separate remi flags from Claude Code arguments.'),
+    dim('  Unrecognized flags are passed through to Claude Code.'),
     '',
   ];
 

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -41,7 +41,7 @@ describe('formatHelp', () => {
 
   test('includes footer hint', () => {
     const output = formatHelp('0.0.0');
-    expect(output).toContain('remi <command> --help');
+    expect(output).toContain('passed through to Claude Code');
   });
 
   test('contains no ANSI escapes when NO_COLOR is set', () => {

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { formatHelp } from '../../src/cli/help.ts';
+
+describe('formatHelp', () => {
+  const originalEnv = process.env['NO_COLOR'];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env['NO_COLOR'] = undefined as unknown as string;
+    } else {
+      process.env['NO_COLOR'] = originalEnv;
+    }
+  });
+
+  test('includes version in output', () => {
+    const output = formatHelp('1.2.3');
+    expect(output).toContain('Remi v1.2.3');
+  });
+
+  test('includes all section headers', () => {
+    const output = formatHelp('0.0.0');
+    expect(output).toContain('Quick Start:');
+    expect(output).toContain('Remote Access:');
+    expect(output).toContain('Session Management:');
+    expect(output).toContain('Service:');
+    expect(output).toContain('Identity & Auth:');
+    expect(output).toContain('Options:');
+  });
+
+  test('includes key commands', () => {
+    const output = formatHelp('0.0.0');
+    expect(output).toContain('remi ls');
+    expect(output).toContain('remi attach');
+    expect(output).toContain('remi new');
+    expect(output).toContain('remi kill');
+    expect(output).toContain('remi start');
+    expect(output).toContain('remi stop');
+    expect(output).toContain('remi keygen');
+    expect(output).toContain('remi code');
+  });
+
+  test('includes footer hint', () => {
+    const output = formatHelp('0.0.0');
+    expect(output).toContain('remi <command> --help');
+  });
+
+  test('contains no ANSI escapes when NO_COLOR is set', () => {
+    process.env['NO_COLOR'] = '1';
+    const output = formatHelp('0.0.0');
+    expect(output).not.toContain('\x1b[');
+  });
+
+  test('returns a string', () => {
+    const output = formatHelp('0.0.0');
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

- Redesign remi --help from a flat wall of text into grouped sections: Quick Start, Remote Access, Session Management, Service, Identity & Auth, Options
- Add subtle ANSI color (bold headers, dim descriptions) respecting NO_COLOR and non-TTY
- Extract help text into dedicated help.ts module (no dependencies)

## Test plan

- [x] 1121 tests pass (6 new)
- [x] Typecheck and biome clean
- [x] NO_COLOR=1 remi --help produces plain text
- [x] remi --help | cat produces plain text (pipe detection)

Closes #92