### PR TITLE
fix: remi start fails with EADDRINUSE when wrapper sessions running

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2188,11 +2188,14 @@ if (cliDaemonMode) {
           console.log(`Port ${PORT} in use, trying ${nextPort}...`);
           try {
             await registry.unregister('websocket');
-          } catch {
-            // Adapter may not have started
+          } catch (teardownErr) {
+            const teardownMsg =
+              teardownErr instanceof Error ? teardownErr.message : String(teardownErr);
+            console.error(`Failed to tear down WebSocket adapter on port ${PORT}: ${teardownMsg}`);
           }
           PORT = nextPort;
           STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
+          HOOK_PORT = PORT + 100;
           const retryWsAdapter = new WebSocketAdapter(
             { port: PORT, host: bindHost, authenticator },
             sharedEvents,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -578,8 +578,10 @@ if (
   const dm = await import('./cli/daemon-manager.ts');
 
   if (cliSubcommand === 'start') {
-    const resolvedPort =
-      cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : 18765);
+    // Only pass port if user explicitly set --port flag.
+    // Do NOT inherit REMI_PORT from env (it's set by wrapper sessions and
+    // would conflict). The daemon finds its own free port.
+    const explicitPort = cliPort;
     const extraArgs: string[] = [];
     if (cliBindHost) extraArgs.push('--bind', cliBindHost);
     if (cliAuth === true) extraArgs.push('--auth');
@@ -589,7 +591,7 @@ if (
     if (cliNoTelegram) extraArgs.push('--no-telegram');
     if (cliPermanentCode) extraArgs.push('--permanent-code');
     if (cliSignalingUrl) extraArgs.push('--signaling-url', cliSignalingUrl);
-    dm.startDaemon({ port: resolvedPort, extraArgs });
+    await dm.startDaemon({ port: explicitPort, extraArgs });
   } else if (cliSubcommand === 'stop') {
     dm.stopDaemon();
   } else if (cliSubcommand === 'status') {
@@ -2164,11 +2166,60 @@ async function cleanup(): Promise<void> {
 if (cliDaemonMode) {
   // Daemon mode: headless server, spawns Claude on WebSocket connect
   console.log('Starting Remi daemon...');
-  await registry.startAll();
+
+  // Retry on EADDRINUSE (port may be grabbed by a wrapper starting at the same time)
+  let daemonStarted = false;
+  const maxRetries = portExplicitlySet ? 1 : 3;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await registry.startAll();
+      daemonStarted = true;
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isAddrInUse = msg.includes('EADDRINUSE') || msg.includes('in use');
+
+      if (isAddrInUse && !portExplicitlySet && attempt < maxRetries - 1) {
+        const nextPort = liveSessionsRegistry.findAvailablePort(
+          PORT + 1,
+          DEFAULT_PORT_RANGE - (PORT - DEFAULT_BASE_PORT + 1),
+        );
+        if (nextPort !== null) {
+          console.log(`Port ${PORT} in use, trying ${nextPort}...`);
+          try {
+            await registry.unregister('websocket');
+          } catch {
+            // Adapter may not have started
+          }
+          PORT = nextPort;
+          STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
+          const retryWsAdapter = new WebSocketAdapter(
+            { port: PORT, host: bindHost, authenticator },
+            sharedEvents,
+          );
+          registry.register(retryWsAdapter);
+          continue;
+        }
+      }
+
+      if (isAddrInUse) {
+        console.error(`Port ${PORT} is already in use.`);
+        console.error('Use --port to specify a different port, or stop existing sessions.');
+      } else {
+        console.error(`Failed to start daemon: ${msg}`);
+      }
+      process.exit(1);
+    }
+  }
+
+  if (!daemonStarted) {
+    console.error('Failed to start daemon after retrying available ports.');
+    process.exit(1);
+  }
 
   mdnsPublisher = await startMdnsIfNeeded(console.log);
 
-  // Write status.json so remi status/start can detect running daemon
+  // Write status so remi status/start can detect running daemon
   updateRemiStatus({ wsPort: PORT, sessionStatus: 'starting' });
 
   console.log('');

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -118,7 +118,9 @@ function isPortAvailable(port: number): Promise<boolean> {
     });
     socket.on('error', (err: NodeJS.ErrnoException) => {
       socket.destroy();
-      resolve(err.code === 'ECONNREFUSED'); // Refused = nothing listening = free
+      // ECONNREFUSED = nothing listening = port free
+      // ECONNRESET = connection dropped = nothing stable listening
+      resolve(err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET');
     });
     socket.connect(port, '127.0.0.1');
   });
@@ -176,7 +178,8 @@ export async function startDaemon(opts?: StartOptions): Promise<number> {
   // (unless the user explicitly passed --port, which is in spawnArgs)
   const childEnv = { ...process.env };
   if (!opts?.port) {
-    childEnv['REMI_PORT'] = undefined;
+    // biome-ignore lint/performance/noDelete: must truly remove env var from child process
+    delete childEnv['REMI_PORT'];
   }
 
   const child = spawn(command, spawnArgs, {

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -95,16 +95,50 @@ function resolveRemiCommand(): { command: string; baseArgs: string[] } {
 
 export interface StartOptions {
   /** Port for WebSocket server */
-  port?: number;
+  port?: number | undefined;
   /** Extra args to pass to the daemon */
-  extraArgs?: string[];
+  extraArgs?: string[] | undefined;
+}
+
+const DEFAULT_BASE_PORT = 18765;
+const DEFAULT_PORT_RANGE = 10;
+
+/** Check if a port is available by attempting to connect (if connection refused, port is free). */
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new (require('node:net').Socket)();
+    socket.setTimeout(500);
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(false); // Something is listening, port in use
+    });
+    socket.on('timeout', () => {
+      socket.destroy();
+      resolve(true); // Nothing responded, port likely free
+    });
+    socket.on('error', (err: NodeJS.ErrnoException) => {
+      socket.destroy();
+      resolve(err.code === 'ECONNREFUSED'); // Refused = nothing listening = free
+    });
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+/** Find an available port in the default range. */
+async function findFreePort(): Promise<number | null> {
+  for (let port = DEFAULT_BASE_PORT; port < DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE; port++) {
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  return null;
 }
 
 /**
  * Start the remi daemon in the background.
  * Returns the PID of the spawned process.
  */
-export function startDaemon(opts?: StartOptions): number {
+export async function startDaemon(opts?: StartOptions): Promise<number> {
   ensureRemiDir();
   const existingPid = getRunningDaemonPid();
   if (existingPid) {
@@ -115,11 +149,22 @@ export function startDaemon(opts?: StartOptions): number {
     process.exit(1);
   }
 
-  const { command, baseArgs } = resolveRemiCommand();
-  const spawnArgs = [...baseArgs, '--daemon'];
-  if (opts?.port !== undefined) {
-    spawnArgs.push('--port', String(opts.port));
+  // Find a free port before spawning the daemon to avoid EADDRINUSE
+  let daemonPort = opts?.port;
+  if (!daemonPort) {
+    const freePort = await findFreePort();
+    if (!freePort) {
+      console.error(
+        `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,
+      );
+      console.error('Use --port to specify a different port, or stop an existing remi session.');
+      process.exit(1);
+    }
+    daemonPort = freePort;
   }
+
+  const { command, baseArgs } = resolveRemiCommand();
+  const spawnArgs = [...baseArgs, '--daemon', '--port', String(daemonPort)];
   if (opts?.extraArgs) {
     spawnArgs.push(...opts.extraArgs);
   }
@@ -127,9 +172,17 @@ export function startDaemon(opts?: StartOptions): number {
   const logFd = fs.openSync(LOG_FILE, 'a');
   fs.writeSync(logFd, `\n--- Daemon starting at ${new Date().toISOString()} ---\n`);
 
+  // Strip inherited REMI_PORT so the daemon auto-selects a free port
+  // (unless the user explicitly passed --port, which is in spawnArgs)
+  const childEnv = { ...process.env };
+  if (!opts?.port) {
+    childEnv['REMI_PORT'] = undefined;
+  }
+
   const child = spawn(command, spawnArgs, {
     detached: true,
     stdio: ['ignore', logFd, logFd],
+    env: childEnv,
   });
 
   const pid = child.pid;


### PR DESCRIPTION
## Problem

remi start always failed with 'did not report port within 5s' when wrapper sessions were running. The daemon crashed with EADDRINUSE because:

1. Daemon mode had no port retry logic (wrapper mode had it, daemon mode didn't)
2. remi start inherited REMI_PORT from wrapper session environment
3. The inherited port was already in use by the wrapper that spawned the start command

## Root Cause

Two issues:
- cli.ts line 2167: daemon mode called `await registry.startAll()` with no try/catch, no retry (wrapper mode had a 3-retry loop)
- daemon-manager.ts: child process inherited parent's REMI_PORT env var, locking to an in-use port

## Fix

- daemon-manager.ts: probe ports before spawning to find a free one
- daemon-manager.ts: strip REMI_PORT from child environment
- cli.ts: remi start only passes --port when user explicitly used --port flag
- cli.ts: daemon mode gets EADDRINUSE retry loop matching wrapper mode

## Tested

```
$ remi start
Daemon started (PID 44105, port 18768).

$ remi status
Daemon running (PID 44105)
  Port: 18768
  Connections: 0
  Adapters: telegram, relay, websocket

$ remi stop
Daemon stopped.
```

## Test plan
- [x] 1121 tests pass
- [x] Typecheck clean
- [x] Biome clean
- [x] Manual: remi start/status/stop works with wrapper sessions running
- [x] Manual: daemon finds free port when default range is partially used

Closes #111