### PR TITLE
feat: add per-command help (remi ls --help, remi kill --help, etc.)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -325,7 +325,7 @@ function resolveDirectory(
 // Parse CLI arguments
 // ---------------------------------------------------------------------------
 import { parseArgs } from './cli/arg-parser.ts';
-import { formatHelp } from './cli/help.ts';
+import { formatCommandHelp, formatHelp } from './cli/help.ts';
 
 const parsedArgs = parseArgs(process.argv.slice(2));
 
@@ -338,7 +338,11 @@ if (parsedArgs.showVersion) {
   process.exit(0);
 }
 if (parsedArgs.showHelp) {
-  console.log(formatHelp(REMI_VERSION));
+  if (parsedArgs.subcommand) {
+    console.log(formatCommandHelp(parsedArgs.subcommand));
+  } else {
+    console.log(formatHelp(REMI_VERSION));
+  }
   process.exit(0);
 }
 

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -38,7 +38,9 @@ function entry(cmd: string, desc: string, width = 30): string {
 // Per-command help
 // ---------------------------------------------------------------------------
 
-const commandHelp: Record<string, string[]> = {
+import type { Subcommand } from './arg-parser.ts';
+
+const commandHelp: Record<Subcommand, string[]> = {
   ls: [
     'List running sessions from a Remi daemon.',
     '',
@@ -128,7 +130,7 @@ const commandHelp: Record<string, string[]> = {
     bold('Options:'),
     entry('--port PORT', 'WebSocket port'),
     entry('--bind HOST', 'Bind address (default: 0.0.0.0)'),
-    entry('--no-auth', 'Disable authentication'),
+    entry('--auth / --no-auth', 'Authentication control'),
     entry('--no-relay', 'Disable signaling relay'),
     entry('--no-mdns', 'Disable mDNS advertising'),
     '',
@@ -203,10 +205,10 @@ const commandHelp: Record<string, string[]> = {
 };
 
 export function formatCommandHelp(command: string): string {
-  const lines = commandHelp[command];
-  if (!lines) {
+  if (!(command in commandHelp)) {
     return `No help available for '${command}'. Run 'remi --help' for all commands.`;
   }
+  const lines = commandHelp[command as Subcommand];
   return ['', bold(`remi ${command}`), '', ...lines, ''].join('\n');
 }
 

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -34,6 +34,186 @@ function entry(cmd: string, desc: string, width = 30): string {
   return `  ${cmd.padEnd(width)}${dim(desc)}`;
 }
 
+// ---------------------------------------------------------------------------
+// Per-command help
+// ---------------------------------------------------------------------------
+
+const commandHelp: Record<string, string[]> = {
+  ls: [
+    'List running sessions from a Remi daemon.',
+    '',
+    bold('Usage:'),
+    entry('remi ls', 'List sessions on local daemon'),
+    entry('remi ls --host <ip>', 'List sessions on remote daemon'),
+    entry('remi ls --network', 'Discover sessions across the network'),
+    '',
+    bold('Options:'),
+    entry('--host HOST', 'Remote daemon host (default: localhost)'),
+    entry('--port PORT', 'Daemon port (default: 18765)'),
+    entry('--network', 'Use mDNS/VPN discovery'),
+  ],
+  attach: [
+    'Attach your terminal to a running session.',
+    '',
+    bold('Usage:'),
+    entry('remi attach', 'Attach to the most recent session'),
+    entry('remi attach <name>', 'Attach to a session by name (prefix match)'),
+    entry('remi attach host:port/name', 'Attach to a remote session'),
+    entry('remi attach host:port', 'Auto-attach to session on that port'),
+    '',
+    bold('Options:'),
+    entry('--host HOST', 'Remote daemon host'),
+    entry('--port PORT', 'Daemon port'),
+    '',
+    dim('  Detach with Ctrl+B d (like tmux).'),
+  ],
+  kill: [
+    'Kill a running session by name or ID.',
+    '',
+    bold('Usage:'),
+    entry('remi kill <name>', 'Kill by session name (prefix match)'),
+    entry('remi kill host:port/name', 'Kill a remote session'),
+    entry('remi kill <name> --host <ip>', 'Kill on remote daemon'),
+    '',
+    bold('Options:'),
+    entry('--host HOST', 'Remote daemon host'),
+    entry('--port PORT', 'Daemon port'),
+  ],
+  new: [
+    'Create a new Claude Code session.',
+    '',
+    bold('Usage:'),
+    entry('remi new', 'Start session in current directory'),
+    entry('remi new /path', 'Start session in directory'),
+    entry('remi new --dir <path>', 'Start session in directory'),
+    entry('remi new --recent', 'Pick from recent directories'),
+    entry('remi new --host <ip>', 'Create on remote daemon and attach'),
+    entry('remi new --host <ip> --recent', 'Pick remote dir and create'),
+    entry('remi new -- --resume', 'Pass flags to Claude Code'),
+    '',
+    bold('Options:'),
+    entry('--dir PATH', 'Working directory (mutually exclusive with --recent)'),
+    entry('--recent', 'Pick from recent project directories'),
+    entry('--host HOST', 'Create session on remote daemon'),
+    entry('--port PORT', 'Remote daemon port'),
+  ],
+  recent: [
+    'Browse recent project directories from session history.',
+    '',
+    bold('Usage:'),
+    entry('remi recent', 'Show recent directories (local)'),
+    entry('remi recent --host <ip>', 'Show recent directories on remote daemon'),
+    '',
+    bold('Options:'),
+    entry('--host HOST', 'Remote daemon host'),
+    entry('--port PORT', 'Daemon port'),
+  ],
+  code: [
+    'Show or refresh the remote access connection code.',
+    '',
+    bold('Usage:'),
+    entry('remi code', 'Show current connection code'),
+    entry('remi code --refresh', 'Generate a new code'),
+    '',
+    dim('  Use the code in the Remi web/mobile app to connect remotely.'),
+    dim('  Codes rotate by default. Use --permanent-code for a fixed code.'),
+  ],
+  start: [
+    'Start the Remi daemon in the background.',
+    '',
+    bold('Usage:'),
+    entry('remi start', 'Start daemon (auto-selects free port)'),
+    entry('remi start --port 9000', 'Start on specific port'),
+    '',
+    bold('Options:'),
+    entry('--port PORT', 'WebSocket port'),
+    entry('--bind HOST', 'Bind address (default: 0.0.0.0)'),
+    entry('--no-auth', 'Disable authentication'),
+    entry('--no-relay', 'Disable signaling relay'),
+    entry('--no-mdns', 'Disable mDNS advertising'),
+    '',
+    dim('  Logs: ~/.remi/daemon.log'),
+  ],
+  stop: [
+    'Stop the background daemon.',
+    '',
+    bold('Usage:'),
+    entry('remi stop', 'Stop the running daemon'),
+  ],
+  status: [
+    'Show daemon status.',
+    '',
+    bold('Usage:'),
+    entry('remi status', 'Show PID, port, connections, adapters'),
+  ],
+  logs: [
+    'Show recent daemon logs.',
+    '',
+    bold('Usage:'),
+    entry('remi logs', 'Tail ~/.remi/daemon.log'),
+  ],
+  keygen: [
+    'Generate an Ed25519 identity keypair.',
+    '',
+    bold('Usage:'),
+    entry('remi keygen', 'Generate keypair (prompted for passphrase)'),
+    entry('remi keygen --force', 'Overwrite existing identity'),
+    entry('remi keygen --passphrase', 'Encrypt with a passphrase'),
+    '',
+    dim('  Identity stored at ~/.remi/identity.json'),
+  ],
+  authorize: [
+    'Add a client public key to authorized keys.',
+    '',
+    bold('Usage:'),
+    entry('remi authorize <key-file>', 'Authorize a client'),
+    entry('remi authorize <key> --label "name"', 'With a label'),
+    entry('remi authorize --remove <fp>', 'Remove by fingerprint'),
+  ],
+  keys: [
+    'List authorized client keys.',
+    '',
+    bold('Usage:'),
+    entry('remi keys', 'Show fingerprints, labels, dates'),
+  ],
+  'export-key': [
+    'Export your identity for sharing across devices.',
+    '',
+    bold('Usage:'),
+    entry('remi export-key', 'Export full identity (encrypted)'),
+    entry('remi export-key --public-only', 'Export only public key'),
+  ],
+  'import-key': [
+    'Import an identity from a file or stdin.',
+    '',
+    bold('Usage:'),
+    entry('remi import-key <file>', 'Import from file'),
+    entry('remi import-key --force', 'Overwrite existing identity'),
+    entry('cat key.json | remi import-key', 'Import from stdin'),
+  ],
+  detach: [
+    'Detach from a session.',
+    '',
+    bold('Usage:'),
+    entry('remi detach', 'Detach from current session'),
+    entry('remi detach <name>', 'Detach a named session'),
+    '',
+    dim('  In practice, use Ctrl+B d to detach interactively.'),
+  ],
+};
+
+export function formatCommandHelp(command: string): string {
+  const lines = commandHelp[command];
+  if (!lines) {
+    return `No help available for '${command}'. Run 'remi --help' for all commands.`;
+  }
+  return ['', bold(`remi ${command}`), '', ...lines, ''].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Global help
+// ---------------------------------------------------------------------------
+
 export function formatHelp(version: string): string {
   const lines: string[] = [
     '',

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { formatHelp } from '../../src/cli/help.ts';
+import { formatCommandHelp, formatHelp } from '../../src/cli/help.ts';
 
 describe('formatHelp', () => {
   const originalEnv = process.env['NO_COLOR'];
@@ -55,5 +55,87 @@ describe('formatHelp', () => {
     const output = formatHelp('0.0.0');
     expect(typeof output).toBe('string');
     expect(output.length).toBeGreaterThan(100);
+  });
+});
+
+describe('formatCommandHelp', () => {
+  test('ls help includes usage and options', () => {
+    const output = formatCommandHelp('ls');
+    expect(output).toContain('remi ls');
+    expect(output).toContain('--host');
+    expect(output).toContain('--network');
+  });
+
+  test('attach help includes detach hint', () => {
+    const output = formatCommandHelp('attach');
+    expect(output).toContain('Ctrl+B d');
+    expect(output).toContain('host:port/name');
+  });
+
+  test('kill help includes remote format', () => {
+    const output = formatCommandHelp('kill');
+    expect(output).toContain('host:port/name');
+    expect(output).toContain('--host');
+  });
+
+  test('new help includes all creation modes', () => {
+    const output = formatCommandHelp('new');
+    expect(output).toContain('--dir');
+    expect(output).toContain('--recent');
+    expect(output).toContain('--host');
+    expect(output).toContain('/path');
+  });
+
+  test('recent help includes remote option', () => {
+    const output = formatCommandHelp('recent');
+    expect(output).toContain('--host');
+  });
+
+  test('code help includes refresh', () => {
+    const output = formatCommandHelp('code');
+    expect(output).toContain('--refresh');
+  });
+
+  test('start help includes port and bind', () => {
+    const output = formatCommandHelp('start');
+    expect(output).toContain('--port');
+    expect(output).toContain('--bind');
+  });
+
+  test('keygen help includes force and passphrase', () => {
+    const output = formatCommandHelp('keygen');
+    expect(output).toContain('--force');
+    expect(output).toContain('--passphrase');
+  });
+
+  test('all subcommands have help entries', () => {
+    const commands = [
+      'ls',
+      'attach',
+      'kill',
+      'new',
+      'recent',
+      'code',
+      'start',
+      'stop',
+      'status',
+      'logs',
+      'keygen',
+      'authorize',
+      'keys',
+      'export-key',
+      'import-key',
+      'detach',
+    ];
+    for (const cmd of commands) {
+      const output = formatCommandHelp(cmd);
+      expect(output).toContain(`remi ${cmd}`);
+    }
+  });
+
+  test('unknown command returns fallback message', () => {
+    const output = formatCommandHelp('nonexistent');
+    expect(output).toContain('No help available');
+    expect(output).toContain('remi --help');
   });
 });


### PR DESCRIPTION
## Summary

Each subcommand now has its own concise help. remi ls --help shows ls-specific usage, not the global help wall.

All 16 subcommands covered: ls, attach, kill, new, recent, code, start, stop, status, logs, keygen, authorize, keys, export-key, import-key, detach.

## Before
remi ls --help -> shows full global help (same as remi --help)

## After
remi ls --help -> shows ls-specific help with usage patterns and options

## Test plan
- [x] 1131 tests pass (10 new)
- [x] Typecheck and biome clean
- [x] Manual: remi ls --help, remi kill --help, remi new --help show correct content
- [x] remi --help still shows global help (no regression)
- [x] Unknown subcommand help shows fallback message

Closes #112