### PR TITLE
fix: deduplicate sessions across LAN and VPN IPs in ls --network

### DIFF
--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -291,7 +291,7 @@ export interface NetworkLsOptions {
   readonly browseTimeoutMs?: number | undefined;
 }
 
-interface DaemonSessions {
+export interface DaemonSessions {
   readonly daemon: {
     readonly name: string;
     readonly host: string;
@@ -371,43 +371,54 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
 // Re-export from session-resolver for backward compatibility
 export { getLocalAddresses } from './session-resolver.ts';
 
-function renderNetworkSessionList(results: DaemonSessions[]): void {
+export function renderNetworkSessionList(results: DaemonSessions[]): void {
   if (results.length === 0) {
     console.log('No daemons found on the network.');
     console.log('Tip: run `remi ls` for local sessions, or ensure a remi daemon is running');
     return;
   }
 
-  // Group by machine hostname so multiple daemons on the same host share one table
+  // Group by machine hostname so multiple daemons on the same host share one table.
+  // When the same hostname is reachable via multiple IPs (e.g. LAN + VPN/Tailscale),
+  // merge those groups and deduplicate sessions by sessionId.
   const machineGroups = new Map<
     string,
     {
-      label: string;
-      host: string;
+      hosts: string[];
       entries: Array<{ daemon: DaemonSessions['daemon']; session: DiscoverableSession }>;
     }
   >();
 
   for (const { daemon, sessions } of results) {
     const hostname = daemon.hostname || daemon.host;
-    // Group by hostname+host to avoid merging different machines with the same hostname
-    const key = daemon.host === 'localhost' ? 'localhost' : `${hostname}@${daemon.host}`;
+    // Group by hostname alone so the same machine with multiple IPs is merged.
+    // Localhost stays separate to avoid merging local with network views.
+    const key = daemon.host === 'localhost' ? 'localhost' : hostname;
     let group = machineGroups.get(key);
     if (!group) {
-      const label = daemon.host === 'localhost' ? 'local' : `${hostname} (${daemon.host})`;
-      group = { label, host: daemon.host, entries: [] };
+      group = { hosts: [], entries: [] };
       machineGroups.set(key, group);
     }
+    // Track unique host IPs for this hostname
+    if (!group.hosts.includes(daemon.host)) {
+      group.hosts.push(daemon.host);
+    }
     for (const s of sessions) {
-      group.entries.push({ daemon, session: s });
+      // Deduplicate: skip if this sessionId is already in the group
+      const isDuplicate = group.entries.some((e) => e.session.sessionId === s.sessionId);
+      if (!isDuplicate) {
+        group.entries.push({ daemon, session: s });
+      }
     }
   }
 
   let totalSessions = 0;
   const machineCount = machineGroups.size;
 
-  for (const [, group] of machineGroups) {
-    console.log(`\n== ${group.label} ==`);
+  for (const [key, group] of machineGroups) {
+    // Build label: "local" for localhost, "hostname (ip1, ip2)" for remote
+    const label = key === 'localhost' ? 'local' : `${key} (${group.hosts.join(', ')})`;
+    console.log(`\n== ${label} ==`);
 
     totalSessions += group.entries.length;
 
@@ -433,7 +444,12 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
 
   const daemonCount = results.length;
   if (machineCount === 1) {
-    const machineName = machineGroups.values().next().value?.label ?? 'unknown';
+    const firstGroup = machineGroups.entries().next().value;
+    const machineName = firstGroup
+      ? firstGroup[0] === 'localhost'
+        ? 'local'
+        : `${firstGroup[0]} (${firstGroup[1].hosts.join(', ')})`
+      : 'unknown';
     console.log(`\n${totalSessions} session(s) on ${machineName}`);
   } else {
     console.log(
@@ -441,17 +457,29 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
     );
   }
 
-  const attachable = results.flatMap((r) =>
-    r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, daemon: r.daemon })),
-  );
+  // Build attachable list from merged groups to avoid duplicates
+  const seenAttachable = new Set<string>();
+  const attachable: Array<{
+    name: string;
+    sessionId: string;
+    daemon: DaemonSessions['daemon'];
+  }> = [];
+  for (const group of machineGroups.values()) {
+    for (const { daemon, session: s } of group.entries) {
+      if (s.canAttach && !seenAttachable.has(s.sessionId)) {
+        seenAttachable.add(s.sessionId);
+        const name = s.name ?? s.sessionId.slice(0, 8);
+        attachable.push({ name, sessionId: s.sessionId, daemon });
+      }
+    }
+  }
   if (attachable.length > 0) {
     console.log('');
     for (const a of attachable) {
-      const name = a.name ?? a.sessionId.slice(0, 8);
       if (a.daemon.host === 'localhost') {
-        console.log(`  * ${name}: remi attach ${name}`);
+        console.log(`  * ${a.name}: remi attach ${a.name}`);
       } else {
-        console.log(`  * ${name}: remi attach ${a.daemon.host}:${a.daemon.port}/${name}`);
+        console.log(`  * ${a.name}: remi attach ${a.daemon.host}:${a.daemon.port}/${a.name}`);
       }
     }
   }

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -10,12 +10,14 @@ import {
   serialize,
 } from '@remi/shared';
 import {
+  type DaemonSessions,
   fetchSessions,
   formatAge,
   formatDuration,
   getLocalAddresses,
   parseHostPort,
   parseRemoteTarget,
+  renderNetworkSessionList,
   runLsClient,
 } from '../../src/cli/ls-client.ts';
 
@@ -441,5 +443,145 @@ describe('formatDuration', () => {
   test('formats exact days without hours', () => {
     const ts = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
     expect(formatDuration(ts)).toBe('2d');
+  });
+});
+
+describe('renderNetworkSessionList', () => {
+  function makeDaemonSessions(
+    hostname: string,
+    host: string,
+    port: number,
+    sessions: DiscoverableSession[],
+  ): DaemonSessions {
+    return {
+      daemon: { name: hostname, host, port, hostname },
+      sessions,
+    };
+  }
+
+  test('deduplicates sessions from same hostname with different IPs', () => {
+    const sharedSessionId = 'shared-session-123';
+    const session = makeSession({
+      sessionId: sharedSessionId,
+      name: 'test-project',
+      status: 'active',
+    });
+
+    const results: DaemonSessions[] = [
+      makeDaemonSessions('yahyas-mcm', '192.168.0.83', 18765, [session]),
+      makeDaemonSessions('yahyas-mcm', '100.79.39.98', 18765, [session]),
+    ];
+
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(' '));
+    try {
+      renderNetworkSessionList(results);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Should show only one group header with both IPs
+    const headers = lines.filter((l) => l.startsWith('\n=='));
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain('192.168.0.83');
+    expect(headers[0]).toContain('100.79.39.98');
+
+    // Session should appear only once (deduplicated by sessionId)
+    const sessionLines = lines.filter((l) => l.includes('test-project'));
+    expect(sessionLines).toHaveLength(1);
+
+    // Summary should show 1 session
+    const summary = lines.find((l) => l.includes('session(s) on'));
+    expect(summary).toContain('1 session(s)');
+  });
+
+  test('keeps sessions from different hostnames separate', () => {
+    const session1 = makeSession({ sessionId: 'sess-1', name: 'project-a' });
+    const session2 = makeSession({ sessionId: 'sess-2', name: 'project-b' });
+
+    const results: DaemonSessions[] = [
+      makeDaemonSessions('machine-a', '192.168.0.1', 18765, [session1]),
+      makeDaemonSessions('machine-b', '192.168.0.2', 18765, [session2]),
+    ];
+
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(' '));
+    try {
+      renderNetworkSessionList(results);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Should have two group headers
+    const headers = lines.filter((l) => l.startsWith('\n=='));
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toContain('machine-a');
+    expect(headers[1]).toContain('machine-b');
+  });
+
+  test('merges multiple IPs for same hostname and deduplicates attach hints', () => {
+    const session = makeSession({
+      sessionId: 'attachable-sess',
+      name: 'my-project',
+      canAttach: true,
+    });
+
+    const results: DaemonSessions[] = [
+      makeDaemonSessions('my-host', '10.0.0.1', 18765, [session]),
+      makeDaemonSessions('my-host', '100.1.2.3', 18765, [session]),
+    ];
+
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(' '));
+    try {
+      renderNetworkSessionList(results);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Attach hint should appear only once
+    const attachHints = lines.filter((l) => l.includes('remi attach'));
+    expect(attachHints).toHaveLength(1);
+  });
+
+  test('localhost group stays separate from network groups', () => {
+    const localSession = makeSession({ sessionId: 'local-1', name: 'local-proj' });
+    const remoteSession = makeSession({ sessionId: 'remote-1', name: 'remote-proj' });
+
+    const results: DaemonSessions[] = [
+      makeDaemonSessions('my-host', 'localhost', 18765, [localSession]),
+      makeDaemonSessions('my-host', '192.168.0.5', 18765, [remoteSession]),
+    ];
+
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(' '));
+    try {
+      renderNetworkSessionList(results);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Should have two groups: local and remote
+    const headers = lines.filter((l) => l.startsWith('\n=='));
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toContain('local');
+    expect(headers[1]).toContain('my-host');
+  });
+
+  test('shows empty state when no results', () => {
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(' '));
+    try {
+      renderNetworkSessionList([]);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(lines[0]).toContain('No daemons found');
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `remi ls --network` showing duplicate sessions when a machine is reachable via both LAN and VPN/Tailscale IPs
- Groups sessions by hostname instead of `hostname@host`, merging entries from the same machine across different IPs
- Deduplicates sessions by `sessionId` within each merged group
- Shows all IPs in the group header (e.g. `yahyas-mcm (192.168.0.83, 100.79.39.98)`)
- Deduplicates attach hints to avoid showing the same session twice

## Test plan

- [x] Added 5 new tests for `renderNetworkSessionList` covering:
  - Deduplication of sessions from same hostname with different IPs
  - Separate groups for different hostnames
  - Merged IPs in group header and deduplicated attach hints
  - Localhost group stays separate from network groups
  - Empty state
- [x] All 1126 tests pass
- [x] biome check passes
- [x] typecheck passes (pre-existing grammy/bonjour-service errors only)

Closes #110