### PR TITLE
fix: deduplicate sessions from LAN and VPN IPs in ls --network

### DIFF
--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -378,35 +378,67 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
     return;
   }
 
-  // Group by machine hostname so multiple daemons on the same host share one table
-  const machineGroups = new Map<
-    string,
-    {
-      label: string;
-      host: string;
-      entries: Array<{ daemon: DaemonSessions['daemon']; session: DiscoverableSession }>;
-    }
-  >();
+  type GroupEntry = { daemon: DaemonSessions['daemon']; session: DiscoverableSession };
+  type MachineGroup = { label: string; hostname: string; hosts: string[]; entries: GroupEntry[] };
+
+  // Step 1: Group by hostname@host (preserves different-machine separation)
+  const rawGroups = new Map<string, MachineGroup>();
 
   for (const { daemon, sessions } of results) {
     const hostname = daemon.hostname || daemon.host;
-    // Group by hostname+host to avoid merging different machines with the same hostname
     const key = daemon.host === 'localhost' ? 'localhost' : `${hostname}@${daemon.host}`;
-    let group = machineGroups.get(key);
+    let group = rawGroups.get(key);
     if (!group) {
       const label = daemon.host === 'localhost' ? 'local' : `${hostname} (${daemon.host})`;
-      group = { label, host: daemon.host, entries: [] };
-      machineGroups.set(key, group);
+      group = { label, hostname, hosts: [daemon.host], entries: [] };
+      rawGroups.set(key, group);
     }
     for (const s of sessions) {
       group.entries.push({ daemon, session: s });
     }
   }
 
-  let totalSessions = 0;
-  const machineCount = machineGroups.size;
+  // Step 2: Merge groups that share the same hostname AND have overlapping
+  // sessionIds (same machine reachable via multiple IPs, e.g., LAN + VPN).
+  // Groups with same hostname but NO overlapping sessions stay separate
+  // (different machines that happen to share a hostname).
+  const mergedGroups: MachineGroup[] = [];
 
-  for (const [, group] of machineGroups) {
+  for (const [, group] of rawGroups) {
+    let merged = false;
+
+    if (group.hostname !== 'localhost') {
+      for (const existing of mergedGroups) {
+        if (existing.hostname !== group.hostname) continue;
+
+        const existingIds = new Set(existing.entries.map((e) => e.session.sessionId));
+        const hasOverlap = group.entries.some((e) => existingIds.has(e.session.sessionId));
+        if (!hasOverlap) continue;
+
+        // Same machine via different IP - merge
+        for (const h of group.hosts) {
+          if (!existing.hosts.includes(h)) existing.hosts.push(h);
+        }
+        for (const entry of group.entries) {
+          if (!existingIds.has(entry.session.sessionId)) {
+            existing.entries.push(entry);
+          }
+        }
+        existing.label = `${group.hostname} (${existing.hosts.join(', ')})`;
+        merged = true;
+        break;
+      }
+    }
+
+    if (!merged) {
+      mergedGroups.push(group);
+    }
+  }
+
+  let totalSessions = 0;
+  const machineCount = mergedGroups.length;
+
+  for (const group of mergedGroups) {
     console.log(`\n== ${group.label} ==`);
 
     totalSessions += group.entries.length;
@@ -433,7 +465,7 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
 
   const daemonCount = results.length;
   if (machineCount === 1) {
-    const machineName = machineGroups.values().next().value?.label ?? 'unknown';
+    const machineName = mergedGroups[0]?.label ?? 'unknown';
     console.log(`\n${totalSessions} session(s) on ${machineName}`);
   } else {
     console.log(
@@ -441,8 +473,15 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
     );
   }
 
+  // Deduplicate attachable sessions (same session may appear from multiple IPs)
+  const seenAttachable = new Set<string>();
   const attachable = results.flatMap((r) =>
-    r.sessions.filter((s) => s.canAttach).map((s) => ({ ...s, daemon: r.daemon })),
+    r.sessions
+      .filter((s) => s.canAttach && !seenAttachable.has(s.sessionId))
+      .map((s) => {
+        seenAttachable.add(s.sessionId);
+        return { ...s, daemon: r.daemon };
+      }),
   );
   if (attachable.length > 0) {
     console.log('');


### PR DESCRIPTION
## Problem

When a machine is reachable via both LAN IP (192.168.0.83) and VPN/Tailscale IP (100.79.39.98), remi ls --network shows the same sessions TWICE.

## Fix

Two-step grouping:
1. Group by hostname@host (preserves different-machine separation)
2. Merge groups with same hostname when they share overlapping sessionIds

This correctly handles:
- Same machine, multiple IPs: merged into one group with combined IPs in header
- Different machines, same hostname: stay separate (no overlapping sessionIds)

## Test plan
- [x] 1131 tests pass
- [x] Typecheck and biome clean
- [x] Preserves same-hostname-different-machine fix (commit 80ff042)
- [ ] Manual test with Tailscale (needs multi-IP machine)

Closes #110