### PR TITLE
fix: handle session-busy and kill-with-active-client gracefully

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1667,6 +1667,18 @@ const sharedEvents = {
         return;
       }
 
+      if (result.error === 'Session already has active connection') {
+        log(`Resume failed: session ${resumeSessionId} is busy (another client attached)`);
+        sendToConnection(
+          connectionId,
+          createError(
+            'SESSION_BUSY',
+            `Session is already attached by another client. Wait for them to detach (Ctrl+B d) or use 'remi kill' to force disconnect.`,
+          ),
+        );
+        return;
+      }
+
       log(`Resume failed: ${result.error}, creating new session`);
       sendToConnection(
         connectionId,
@@ -1924,9 +1936,15 @@ const sharedEvents = {
       );
     }
 
+    const hadActiveClient =
+      session.activeConnectionId !== null && session.activeConnectionId !== connectionId;
     sessionRegistry.closeSession(sessionId, 'forced');
     sendToConnection(connectionId, createKillSessionResponse(true, requestId));
-    log(`Session killed: ${sessionName}`);
+    if (hadActiveClient) {
+      log(`Session killed: ${sessionName} (disconnected attached client)`);
+    } else {
+      log(`Session killed: ${sessionName}`);
+    }
   },
 
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -261,6 +261,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         return;
       }
 
+      if (msg.type === 'error' && msg.code === 'SESSION_BUSY') {
+        writeOutput(`\n${msg.message}\n`);
+        finish({ exitCode: 1, reason: 'error' });
+        return;
+      }
+
       renderMessage(msg);
     }
 


### PR DESCRIPTION
## Summary

Two related fixes for session connection handling:

### #103: Attach to busy session
Before: silently creates a new session when the target session is already attached
After: sends SESSION_BUSY error with clear message telling user to wait or force kill

### #105: Kill session with active client
Before: worked but didn't report that a client was disconnected
After: logs "disconnected attached client" and the attached client receives SESSION_ENDED notification before the session is destroyed

## Test plan
- [x] 1131 tests pass
- [x] Typecheck and biome clean
- [ ] Docker test: create session, attach from terminal A, try attach from terminal B (should see SESSION_BUSY)
- [ ] Docker test: create session, attach from terminal A, kill from terminal B (should disconnect A cleanly)

Closes #103, closes #105