### PR TITLE
fix: move SESSION_BUSY check before canResume guard (was unreachable)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1644,6 +1644,22 @@ const sharedEvents = {
       return;
     }
 
+    // Check if resume target exists but is busy (another client attached)
+    if (resumeSessionId) {
+      const resumeTarget = sessionRegistry.getSession(resumeSessionId);
+      if (resumeTarget && resumeTarget.activeConnectionId !== null) {
+        log(`Resume failed: session ${resumeSessionId} is busy (another client attached)`);
+        sendToConnection(
+          connectionId,
+          createError(
+            'SESSION_BUSY',
+            "Session is already attached by another client. Wait for them to detach (Ctrl+B d) or use 'remi kill' to force disconnect.",
+          ),
+        );
+        return;
+      }
+    }
+
     if (resumeSessionId && sessionRegistry.canResume(resumeSessionId)) {
       log(`Resuming session ${resumeSessionId}...`);
       const result = sessionRegistry.attachConnection(resumeSessionId, connectionId);
@@ -1667,18 +1683,6 @@ const sharedEvents = {
 
         log(
           `Session ${resumeSessionId} resumed with ${result.replayMessages.length} messages replayed`,
-        );
-        return;
-      }
-
-      if (result.error === 'Session already has active connection') {
-        log(`Resume failed: session ${resumeSessionId} is busy (another client attached)`);
-        sendToConnection(
-          connectionId,
-          createError(
-            'SESSION_BUSY',
-            `Session is already attached by another client. Wait for them to detach (Ctrl+B d) or use 'remi kill' to force disconnect.`,
-          ),
         );
         return;
       }


### PR DESCRIPTION
## Problem

PR #119 placed the SESSION_BUSY check inside the canResume() block, but canResume() returns false when a session has an active connection. The SESSION_BUSY error was never sent to clients.

## Fix

Move the busy-session detection BEFORE the canResume guard. Now when a client tries to resume a session that has an active connection, it gets a clear SESSION_BUSY error instead of silently falling through.

## Test plan
- [x] 1135 tests pass
- [x] Typecheck and biome clean
- [ ] Manual: attach to session from terminal A, try attach from terminal B, verify SESSION_BUSY error

Fixes #103