### PR TITLE
fix: resolve shell PATH in daemon + host:path syntax for new

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -305,6 +305,46 @@ function logError(...args: unknown[]): void {
 }
 
 // ---------------------------------------------------------------------------
+// Shell PATH resolution (for LaunchAgent/systemd where PATH is minimal)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the user's full PATH from their login shell.
+ * LaunchAgents and systemd services inherit a minimal PATH that doesn't
+ * include user-installed tools (e.g. ~/.local/bin, Homebrew, ~/.bun/bin).
+ * This runs the login shell to get the real PATH and merges it into process.env.
+ */
+function resolveShellPath(): void {
+  try {
+    const shell = process.env['SHELL'] || '/bin/zsh';
+    const result = Bun.spawnSync([shell, '-l', '-c', 'echo $PATH'], {
+      env: process.env,
+      timeout: 5000,
+    });
+    const shellPath = result.stdout?.toString().trim();
+    if (shellPath && result.exitCode === 0) {
+      const currentPath = process.env['PATH'] || '';
+      // Merge: add any paths from the login shell that aren't already present
+      const currentParts = new Set(currentPath.split(':').filter(Boolean));
+      const shellParts = shellPath.split(':').filter(Boolean);
+      const newParts: string[] = [];
+      for (const p of shellParts) {
+        if (!currentParts.has(p)) {
+          newParts.push(p);
+        }
+      }
+      if (newParts.length > 0) {
+        process.env['PATH'] = currentPath
+          ? `${currentPath}:${newParts.join(':')}`
+          : newParts.join(':');
+      }
+    }
+  } catch {
+    // Non-fatal: if shell resolution fails, continue with existing PATH
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Resolve directory helper
 // ---------------------------------------------------------------------------
 function resolveDirectory(
@@ -334,7 +374,7 @@ function resolveDirectory(
 // ---------------------------------------------------------------------------
 // Parse CLI arguments
 // ---------------------------------------------------------------------------
-import { parseArgs } from './cli/arg-parser.ts';
+import { parseArgs, parseHostPath } from './cli/arg-parser.ts';
 import { formatCommandHelp, formatHelp } from './cli/help.ts';
 
 const parsedArgs = parseArgs(process.argv.slice(2));
@@ -1116,11 +1156,14 @@ if (cliResume !== undefined) {
 
 // remi new --host: create session on remote daemon, then auto-attach
 if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliHost) {
+  // Support host:path syntax (e.g. yahyas-mcm:~/Documents/git/project)
+  const { host: effectiveHost, directory: hostDir } = parseHostPath(cliHost);
+
   const resolvedPort =
     cliPort ??
     (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : DEFAULT_BASE_PORT);
 
-  let directory = cliDir;
+  let directory = cliDir ?? hostDir;
 
   // --recent: fetch remote recent dirs and pick one
   if (cliRecent) {
@@ -1128,7 +1171,7 @@ if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliHost) {
     const { pickDirectory } = await import('./cli/directory-picker.ts');
     let dirs: Awaited<ReturnType<typeof fetchRecentDirectories>>;
     try {
-      dirs = await fetchRecentDirectories(cliHost, resolvedPort);
+      dirs = await fetchRecentDirectories(effectiveHost, resolvedPort);
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
@@ -1148,7 +1191,7 @@ if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliHost) {
   const { runRemoteNew } = await import('./cli/remote-new-client.ts');
   try {
     const result = await runRemoteNew({
-      host: cliHost,
+      host: effectiveHost,
       port: resolvedPort,
       directory,
     });
@@ -2237,6 +2280,8 @@ async function cleanup(): Promise<void> {
 // ---------------------------------------------------------------------------
 if (cliDaemonMode) {
   // Daemon mode: headless server, spawns Claude on WebSocket connect
+  // Resolve user's login shell PATH so spawned sessions can find tools like `claude`
+  resolveShellPath();
   console.log('Starting Remi daemon...');
 
   // Start all adapters. On EADDRINUSE, retry only the WebSocket adapter with next port.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -321,14 +321,23 @@ function resolveShellPath(): void {
       env: process.env,
       timeout: 5000,
     });
-    const shellPath = result.stdout?.toString().trim();
-    if (shellPath && result.exitCode === 0) {
-      // Replace with shell's PATH entirely; it's the authoritative source
-      // and preserves the user's intended priority order
-      process.env['PATH'] = shellPath;
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr?.toString().trim() || '(no stderr)';
+      console.warn(`[PATH] Shell '${shell}' exited with code ${result.exitCode}: ${stderr}`);
+      return;
     }
-  } catch {
-    // Non-fatal: if shell resolution fails, continue with existing PATH
+    const shellPath = result.stdout?.toString().trim();
+    if (!shellPath) {
+      console.warn(`[PATH] Shell '${shell}' returned empty PATH`);
+      return;
+    }
+    // Replace with shell's PATH entirely; it's the authoritative source
+    // and preserves the user's intended priority order
+    process.env['PATH'] = shellPath;
+  } catch (err) {
+    console.warn(
+      `[PATH] Failed to resolve shell PATH: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -323,21 +323,9 @@ function resolveShellPath(): void {
     });
     const shellPath = result.stdout?.toString().trim();
     if (shellPath && result.exitCode === 0) {
-      const currentPath = process.env['PATH'] || '';
-      // Merge: add any paths from the login shell that aren't already present
-      const currentParts = new Set(currentPath.split(':').filter(Boolean));
-      const shellParts = shellPath.split(':').filter(Boolean);
-      const newParts: string[] = [];
-      for (const p of shellParts) {
-        if (!currentParts.has(p)) {
-          newParts.push(p);
-        }
-      }
-      if (newParts.length > 0) {
-        process.env['PATH'] = currentPath
-          ? `${currentPath}:${newParts.join(':')}`
-          : newParts.join(':');
-      }
+      // Replace with shell's PATH entirely; it's the authoritative source
+      // and preserves the user's intended priority order
+      process.env['PATH'] = shellPath;
     }
   } catch {
     // Non-fatal: if shell resolution fails, continue with existing PATH

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -350,3 +350,20 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     error,
   };
 }
+
+/**
+ * Parse host:path syntax for the `new` command.
+ * Supports `host:~/path` and `host:/absolute/path` but not `host:port`.
+ *
+ * Returns { host, directory } where directory is set only if path was found.
+ */
+export function parseHostPath(raw: string): { host: string; directory?: string } {
+  const colonIdx = raw.indexOf(':');
+  if (colonIdx > 0) {
+    const afterColon = raw.slice(colonIdx + 1);
+    if (afterColon.startsWith('/') || afterColon.startsWith('~')) {
+      return { host: raw.slice(0, colonIdx), directory: afterColon };
+    }
+  }
+  return { host: raw };
+}

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -354,10 +354,23 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
 /**
  * Parse host:path syntax for the `new` command.
  * Supports `host:~/path` and `host:/absolute/path` but not `host:port`.
+ * Handles bracketed IPv6: `[::1]:~/path`.
  *
  * Returns { host, directory } where directory is set only if path was found.
  */
 export function parseHostPath(raw: string): { host: string; directory?: string } {
+  // Bracketed IPv6: [::1]:~/path or [fe80::1]:~/path
+  if (raw.startsWith('[')) {
+    const closeBracket = raw.indexOf(']');
+    if (closeBracket > 0 && raw[closeBracket + 1] === ':') {
+      const afterColon = raw.slice(closeBracket + 2);
+      if (afterColon.startsWith('/') || afterColon.startsWith('~')) {
+        return { host: raw.slice(0, closeBracket + 1), directory: afterColon };
+      }
+    }
+    return { host: raw };
+  }
+
   const colonIdx = raw.indexOf(':');
   if (colonIdx > 0) {
     const afterColon = raw.slice(colonIdx + 1);

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -636,4 +636,26 @@ describe('parseHostPath', () => {
       directory: '~',
     });
   });
+
+  test('bracketed IPv6 with path returns host and directory', () => {
+    expect(parseHostPath('[::1]:~/project')).toEqual({
+      host: '[::1]',
+      directory: '~/project',
+    });
+  });
+
+  test('bracketed IPv6 with absolute path returns host and directory', () => {
+    expect(parseHostPath('[fe80::1]:/home/user/project')).toEqual({
+      host: '[fe80::1]',
+      directory: '/home/user/project',
+    });
+  });
+
+  test('bracketed IPv6 with port returns host only', () => {
+    expect(parseHostPath('[::1]:9000')).toEqual({ host: '[::1]:9000' });
+  });
+
+  test('bracketed IPv6 without path returns host only', () => {
+    expect(parseHostPath('[::1]')).toEqual({ host: '[::1]' });
+  });
 });

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseArgs } from '../../src/cli/arg-parser.ts';
+import { parseArgs, parseHostPath } from '../../src/cli/arg-parser.ts';
 
 describe('parseArgs', () => {
   // -------------------------------------------------------------------------
@@ -587,6 +587,53 @@ describe('parseArgs', () => {
       // But the positional path detection only fires for the arg immediately after 'new'
       const r = parseArgs(['new', '--dir', '/a']);
       expect(r.dir).toBe('/a');
+    });
+  });
+});
+
+describe('parseHostPath', () => {
+  test('plain hostname returns host only', () => {
+    expect(parseHostPath('myhost')).toEqual({ host: 'myhost' });
+  });
+
+  test('hostname with tilde path returns host and directory', () => {
+    expect(parseHostPath('myhost:~/Documents/project')).toEqual({
+      host: 'myhost',
+      directory: '~/Documents/project',
+    });
+  });
+
+  test('hostname with absolute path returns host and directory', () => {
+    expect(parseHostPath('myhost:/home/user/project')).toEqual({
+      host: 'myhost',
+      directory: '/home/user/project',
+    });
+  });
+
+  test('hostname with port (numeric) returns host only', () => {
+    // host:9000 should NOT be parsed as host:path
+    expect(parseHostPath('myhost:9000')).toEqual({ host: 'myhost:9000' });
+  });
+
+  test('IP address is returned as host', () => {
+    expect(parseHostPath('192.168.1.1')).toEqual({ host: '192.168.1.1' });
+  });
+
+  test('IP with tilde path works', () => {
+    expect(parseHostPath('192.168.1.1:~/project')).toEqual({
+      host: '192.168.1.1',
+      directory: '~/project',
+    });
+  });
+
+  test('empty string returns host only', () => {
+    expect(parseHostPath('')).toEqual({ host: '' });
+  });
+
+  test('host with just tilde expands correctly', () => {
+    expect(parseHostPath('myhost:~')).toEqual({
+      host: 'myhost',
+      directory: '~',
     });
   });
 });

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -145,13 +145,19 @@ run_test "new --host /tmp parsed as dir" \
 # ---- Test Group 6b: host:path syntax ----
 echo ""
 echo "== host:path syntax tests =="
-# Test that host:~/path is parsed into host + directory
-run_test "new host:~/path parsed correctly" \
-  bash -c "remi_cli new --host $HOST:~/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+# Test that host:~/path is parsed and connects (session shows up in ls)
+run_test "new host:~/path connects and sets directory" \
+  bash -c "remi_cli new --host $HOST:~/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; \
+    OUTPUT=\$(remi_cli ls --host $HOST --port $D1_PORT 2>&1); \
+    kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; \
+    echo \"\$OUTPUT\" | grep -q 'session'"
 
-# Test that host:/absolute/path is parsed correctly
-run_test "new host:/path parsed correctly" \
-  bash -c "remi_cli new --host $HOST:/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+# Test that host:/absolute/path is parsed and connects
+run_test "new host:/path connects and sets directory" \
+  bash -c "remi_cli new --host $HOST:/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; \
+    OUTPUT=\$(remi_cli ls --host $HOST --port $D1_PORT 2>&1); \
+    kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; \
+    echo \"\$OUTPUT\" | grep -q 'session'"
 
 # ---- Test Group 7: SESSION_BUSY detection ----
 echo ""

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -142,6 +142,17 @@ echo "== new /path tests =="
 run_test "new --host /tmp parsed as dir" \
   bash -c "remi_cli new /tmp --host $HOST --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
 
+# ---- Test Group 6b: host:path syntax ----
+echo ""
+echo "== host:path syntax tests =="
+# Test that host:~/path is parsed into host + directory
+run_test "new host:~/path parsed correctly" \
+  bash -c "remi_cli new --host $HOST:~/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+
+# Test that host:/absolute/path is parsed correctly
+run_test "new host:/path parsed correctly" \
+  bash -c "remi_cli new --host $HOST:/tmp --port $D1_PORT &>/dev/null & PID=\$!; sleep 5; kill \$PID 2>/dev/null; wait \$PID 2>/dev/null; exit 0"
+
 # ---- Test Group 7: SESSION_BUSY detection ----
 echo ""
 echo "== session busy tests =="


### PR DESCRIPTION
## Summary

- **Shell PATH resolution**: Daemon now resolves the user's full PATH from their login shell on startup. This fixes `Executable not found in $PATH: "claude"` when the daemon runs as a LaunchAgent/systemd service (which inherits minimal PATH).
- **host:path syntax**: `remi new --host myhost:~/project` now works, parsing SSH-style `host:path` into separate host and directory arguments. Paths are identified by starting with `/` or `~` to distinguish from `host:port`.

Closes #130

## Test plan

- [x] 8 new unit tests for `parseHostPath` (plain host, tilde path, absolute path, port, IP, empty)
- [x] 2 new Docker integration tests for host:path syntax
- [x] All 116 arg-parser tests pass
- [x] All 1081 unit tests pass (10 pre-existing mdns failures from missing bonjour-service)
- [x] Docker integration: new host:path tests (#13, #14) pass