### PR TITLE
feat: session resume - resurrect dead Claude Code sessions

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -60,6 +60,9 @@ export interface AdapterEvents {
   /** Kill session request received */
   onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
 
+  /** Resume session request received */
+  onResumeSessionRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
+
   /** Session history request received */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -140,6 +140,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onKillSessionRequest?.(connectionId, sessionId, requestId);
       },
 
+      onResumeSessionRequest: (connectionId, sessionId, requestId) => {
+        this.events.onResumeSessionRequest?.(connectionId, sessionId, requestId);
+      },
+
       onSessionHistoryRequest: (connectionId, requestId, limit) => {
         this.events.onSessionHistoryRequest?.(connectionId, requestId, limit);
       },

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -231,6 +231,7 @@ import {
   createKillSessionResponse,
   createRawPtyOutput,
   createReplayBatch,
+  createResumeSessionResponse,
   createSessionHistoryResponse,
   createSessionListResponse,
   createTranscriptLoadComplete,
@@ -1952,6 +1953,146 @@ const sharedEvents = {
       log(`Session killed: ${sessionName} (disconnected attached client)`);
     } else {
       log(`Session killed: ${sessionName}`);
+    }
+  },
+
+  onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {
+    log(`Resume session request from ${connectionId} for session ${targetSessionId}`);
+
+    // Check if this session is still alive in the registry
+    const existingSession = sessionRegistry.getSession(targetSessionId as UUID);
+    if (existingSession) {
+      const result = sessionRegistry.attachConnection(targetSessionId as UUID, connectionId);
+      if (result.success) {
+        sendToConnection(
+          connectionId,
+          createResumeSessionResponse(true, requestId, targetSessionId as UUID),
+        );
+        sendToConnection(
+          connectionId,
+          createHelloAck('1.0.0', targetSessionId as UUID, {
+            isResume: true,
+            replayCount: result.replayMessages.length,
+            nextBulletId: result.nextBulletId,
+          }),
+        );
+        if (result.replayMessages.length > 0) {
+          sendToConnection(
+            connectionId,
+            createReplayBatch(targetSessionId as UUID, result.replayMessages, true),
+          );
+        }
+        log(`Session ${targetSessionId} still alive; attached connection`);
+        return;
+      }
+      sendToConnection(
+        connectionId,
+        createResumeSessionResponse(false, requestId, undefined, result.error),
+      );
+      return;
+    }
+
+    // Look up Claude session ID from SessionStore
+    let claudeSessionId: string | null = null;
+    let projectPath: string | null = null;
+
+    const storedByRemi = sessionStore.findByRemiSessionId(targetSessionId as UUID);
+    if (storedByRemi) {
+      claudeSessionId = storedByRemi.claudeSessionId;
+      projectPath = storedByRemi.projectPath;
+    }
+
+    if (!claudeSessionId) {
+      const storedByClaude = sessionStore.findByClaudeSessionId(targetSessionId);
+      if (storedByClaude) {
+        claudeSessionId = storedByClaude.claudeSessionId;
+        projectPath = storedByClaude.projectPath;
+      }
+    }
+
+    // For transcript-only sessions: the sessionId IS the Claude session ID
+    if (!claudeSessionId) {
+      const transcriptPath = transcriptDiscovery.findTranscriptBySessionId(targetSessionId);
+      if (transcriptPath) {
+        claudeSessionId = targetSessionId;
+        // Decode project path from transcript directory name
+        const dirName = path.basename(path.dirname(transcriptPath));
+        projectPath = dirName.replace(/-/g, '/');
+      }
+    }
+
+    if (!claudeSessionId) {
+      sendToConnection(
+        connectionId,
+        createResumeSessionResponse(
+          false,
+          requestId,
+          undefined,
+          `Session ${targetSessionId} not found. No Claude session ID available for resume.`,
+        ),
+      );
+      return;
+    }
+
+    // Validate project path exists
+    const dirResult = resolveDirectory(projectPath);
+    if ('error' in dirResult) {
+      sendToConnection(
+        connectionId,
+        createResumeSessionResponse(
+          false,
+          requestId,
+          undefined,
+          `Project directory no longer exists: ${projectPath}`,
+        ),
+      );
+      return;
+    }
+    const workingDirectory = dirResult.resolved;
+
+    // Spawn new PTY with --resume
+    const newSessionId = sessionRegistry.createSessionId();
+    log(
+      `Resuming Claude session ${claudeSessionId} as new Remi session ${newSessionId} in ${workingDirectory}`,
+    );
+
+    try {
+      await createNewSession(
+        newSessionId,
+        workingDirectory,
+        (sid, msg) => {
+          const session = sessionRegistry.getSession(sid);
+          if (session?.activeConnectionId) {
+            sendToConnection(session.activeConnectionId, msg);
+          }
+        },
+        ['--resume', claudeSessionId],
+      );
+
+      const result = sessionRegistry.attachConnection(newSessionId, connectionId);
+
+      if (result.success) {
+        sendToConnection(connectionId, createResumeSessionResponse(true, requestId, newSessionId));
+        sendToConnection(
+          connectionId,
+          createHelloAck('1.0.0', newSessionId, {
+            isResume: false,
+            replayCount: 0,
+            nextBulletId: 1,
+          }),
+        );
+        log(`Session ${newSessionId} created via resume (claude: ${claudeSessionId})`);
+      } else {
+        sessionRegistry.closeSession(newSessionId, 'forced');
+        sendToConnection(
+          connectionId,
+          createResumeSessionResponse(false, requestId, undefined, result.error),
+        );
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logError('Failed to resume session:', msg);
+      sendToConnection(connectionId, createResumeSessionResponse(false, requestId, undefined, msg));
     }
   },
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2010,12 +2010,15 @@ const sharedEvents = {
       }
     }
 
-    // For transcript-only sessions: the sessionId IS the Claude session ID
+    // For transcript-only sessions: the sessionId IS the Claude session ID.
+    // The project path is decoded from the transcript directory name, but this
+    // encoding is lossy (Claude Code replaces "/" with "-", so paths containing
+    // dashes like "/Users/dev/my-project" become indistinguishable from
+    // "/Users/dev/my/project"). The decoded path may be wrong.
     if (!claudeSessionId) {
       const transcriptPath = transcriptDiscovery.findTranscriptBySessionId(targetSessionId);
       if (transcriptPath) {
         claudeSessionId = targetSessionId;
-        // Decode project path from transcript directory name
         const dirName = path.basename(path.dirname(transcriptPath));
         projectPath = dirName.replace(/-/g, '/');
       }
@@ -2037,13 +2040,18 @@ const sharedEvents = {
     // Validate project path exists
     const dirResult = resolveDirectory(projectPath);
     if ('error' in dirResult) {
+      // For transcript-only sessions, the decoded path may be wrong due to
+      // lossy encoding (dashes in paths are indistinguishable from separators).
+      const hint = projectPath?.includes('/')
+        ? ' Path may be inaccurate for projects with dashes in their name.'
+        : '';
       sendToConnection(
         connectionId,
         createResumeSessionResponse(
           false,
           requestId,
           undefined,
-          `Project directory no longer exists: ${projectPath}`,
+          `Project directory not found: ${projectPath}.${hint}`,
         ),
       );
       return;

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -289,6 +289,13 @@ export class RelayAdapter implements ConnectionAdapter {
           msg['id'],
         );
         break;
+      case 'resume_session_request':
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid resume_session_request payload: missing sessionId or id');
+          return;
+        }
+        this.events.onResumeSessionRequest?.(connectionId, msg['sessionId'], msg['id']);
+        break;
       case 'bullet_expand_request':
         if (
           typeof msg['sessionId'] !== 'string' ||

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -36,6 +36,7 @@ import type {
   KillSessionRequestMessage,
   PingMessage,
   ProtocolMessage,
+  ResumeSessionRequestMessage,
   SessionHistoryRequestMessage,
   SessionListRequestMessage,
   TerminalResizeMessage,
@@ -79,6 +80,9 @@ export interface ConnectionEvents {
 
   /** Kill session request received */
   onKillSessionRequest: (sessionId: UUID, requestId: UUID) => void;
+
+  /** Resume session request received */
+  onResumeSessionRequest: (sessionId: string, requestId: UUID) => void;
 
   /** Session history request received */
   onSessionHistoryRequest: (requestId: UUID, limit: number | undefined) => void;
@@ -261,6 +265,9 @@ export class Connection {
       case 'kill_session_request':
         this.handleKillSessionRequest(message);
         break;
+      case 'resume_session_request':
+        this.handleResumeSessionRequest(message);
+        break;
       case 'session_history_request':
         this.handleSessionHistoryRequest(message);
         break;
@@ -430,6 +437,11 @@ export class Connection {
   private handleKillSessionRequest(message: KillSessionRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onKillSessionRequest?.(message.sessionId, message.id);
+  }
+
+  private handleResumeSessionRequest(message: ResumeSessionRequestMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onResumeSessionRequest?.(message.sessionId, message.id);
   }
 
   private handleSessionHistoryRequest(message: SessionHistoryRequestMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -74,6 +74,9 @@ export interface ServerEvents {
   /** Kill session request from client */
   onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
 
+  /** Resume session request from client */
+  onResumeSessionRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
+
   /** Session history request from client */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 
@@ -318,6 +321,10 @@ export class WebSocketServer {
 
       onKillSessionRequest: (sessionId, requestId) => {
         this.events.onKillSessionRequest?.(ws.data.connectionId, sessionId, requestId);
+      },
+
+      onResumeSessionRequest: (sessionId, requestId) => {
+        this.events.onResumeSessionRequest?.(ws.data.connectionId, sessionId, requestId);
       },
 
       onSessionHistoryRequest: (requestId, limit) => {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -456,6 +456,7 @@ export class SessionRegistry {
         lastMessage,
         source: 'daemon',
         canAttach: session.activeConnectionId === null,
+        canResume: false, // Daemon-managed sessions are alive; use canAttach instead
       });
     }
 

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -250,7 +250,7 @@ export class TranscriptDiscovery {
       lastMessage: tailInfo.lastMessage,
       source: 'transcript',
       canAttach: false, // External sessions can't be attached to via daemon
-      canResume: true, // Transcript sessions always have a Claude session ID
+      canResume: status !== 'active', // Only offer resume for idle/completed sessions, not actively running ones
     };
   }
 

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -250,6 +250,7 @@ export class TranscriptDiscovery {
       lastMessage: tailInfo.lastMessage,
       source: 'transcript',
       canAttach: false, // External sessions can't be attached to via daemon
+      canResume: true, // Transcript sessions always have a Claude session ID
     };
   }
 

--- a/packages/daemon/tests/cli/kill-client.test.ts
+++ b/packages/daemon/tests/cli/kill-client.test.ts
@@ -20,6 +20,7 @@ function makeSession(name: string, id?: string): DiscoverableSession {
     messageCount: 0,
     source: 'daemon',
     canAttach: true,
+    canResume: false,
   };
 }
 

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -30,6 +30,7 @@ function makeSession(overrides: Partial<DiscoverableSession> = {}): Discoverable
     messageCount: 10,
     source: 'daemon',
     canAttach: false,
+    canResume: false,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -25,6 +25,7 @@ function makeSession(name: string | undefined, id?: string): DiscoverableSession
     messageCount: 0,
     source: 'daemon',
     canAttach: true,
+    canResume: false,
   };
 }
 

--- a/packages/daemon/tests/telegram-ui.test.ts
+++ b/packages/daemon/tests/telegram-ui.test.ts
@@ -220,6 +220,7 @@ describe('formatSessionList', () => {
       messageCount: 42,
       source: 'daemon',
       canAttach: true,
+      canResume: false,
       ...overrides,
     };
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -70,6 +70,8 @@ export type {
   RecentDirectory,
   SessionHistoryRequestMessage,
   SessionHistoryResponseMessage,
+  ResumeSessionRequestMessage,
+  ResumeSessionResponseMessage,
 } from './protocol.ts';
 
 export {
@@ -108,6 +110,8 @@ export {
   createRawPtyOutput,
   createSessionHistoryRequest,
   createSessionHistoryResponse,
+  createResumeSessionRequest,
+  createResumeSessionResponse,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -387,7 +387,7 @@ export interface ResumeSessionResponseMessage {
   readonly type: 'resume_session_response';
   readonly id: UUID;
   readonly timestamp: Timestamp;
-  /** New session ID of the resumed session (present on success) */
+  /** Session ID to use (existing if still alive, or newly created). Present on success. */
   readonly sessionId?: UUID;
   /** Whether resume succeeded */
   readonly success: boolean;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -93,7 +93,9 @@ export type ProtocolMessage =
   | KillSessionResponseMessage
   | RawPtyOutputMessage
   | SessionHistoryRequestMessage
-  | SessionHistoryResponseMessage;
+  | SessionHistoryResponseMessage
+  | ResumeSessionRequestMessage
+  | ResumeSessionResponseMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -371,6 +373,30 @@ export interface CreateSessionResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Request to resume a dead/ended Claude Code session */
+export interface ResumeSessionRequestMessage {
+  readonly type: 'resume_session_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session ID or Claude session ID of the session to resume */
+  readonly sessionId: string;
+}
+
+/** Response after attempting to resume a session */
+export interface ResumeSessionResponseMessage {
+  readonly type: 'resume_session_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** New session ID of the resumed session (present on success) */
+  readonly sessionId?: UUID;
+  /** Whether resume succeeded */
+  readonly success: boolean;
+  /** Error message if resume failed */
+  readonly error?: string;
+  /** ID of the original request */
+  readonly requestId: UUID;
+}
+
 /** Authentication challenge from server to client */
 export interface AuthChallengeMessage {
   readonly type: 'auth_challenge';
@@ -546,6 +572,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'raw_pty_output',
     'session_history_request',
     'session_history_response',
+    'resume_session_request',
+    'resume_session_response',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1061,6 +1089,38 @@ export function createSessionHistoryResponse(
     timestamp: now(),
     directories,
     requestId,
+  };
+}
+
+/**
+ * Create a request to resume a dead/ended Claude Code session.
+ */
+export function createResumeSessionRequest(sessionId: string): ResumeSessionRequestMessage {
+  return {
+    type: 'resume_session_request',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+  };
+}
+
+/**
+ * Create a response for a resume session request.
+ */
+export function createResumeSessionResponse(
+  success: boolean,
+  requestId: UUID,
+  sessionId?: UUID,
+  error?: string,
+): ResumeSessionResponseMessage {
+  return {
+    type: 'resume_session_response',
+    id: generateId(),
+    timestamp: now(),
+    success,
+    requestId,
+    ...(sessionId !== undefined && { sessionId }),
+    ...(error !== undefined && { error }),
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -279,4 +279,7 @@ export interface DiscoverableSession {
 
   /** Whether this session can be attached to (daemon-managed only) */
   readonly canAttach: boolean;
+
+  /** Whether this dead session can be resumed via Claude Code --resume */
+  readonly canResume: boolean;
 }

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -17,6 +17,8 @@ import {
   createPong,
   createQuestion,
   createReplayBatch,
+  createResumeSessionRequest,
+  createResumeSessionResponse,
   createSessionHistoryRequest,
   createSessionHistoryResponse,
   createSessionListRequest,
@@ -654,6 +656,7 @@ describe('Message factory functions', () => {
           lastActivity: now(),
           messageCount: 5,
           canAttach: true,
+          canResume: false,
           source: 'daemon' as const,
         },
       ];
@@ -737,6 +740,56 @@ describe('Message factory functions', () => {
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
       expect(deserialized?.type).toBe('session_history_response');
+    });
+  });
+
+  describe('createResumeSessionRequest()', () => {
+    test('creates request with session ID', () => {
+      const msg = createResumeSessionRequest('session-abc-123');
+      expect(msg.type).toBe('resume_session_request');
+      expect(msg.sessionId).toBe('session-abc-123');
+      expect(msg.id).toBeDefined();
+      expect(msg.timestamp).toBeDefined();
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createResumeSessionRequest('session-abc-123');
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('resume_session_request');
+    });
+  });
+
+  describe('createResumeSessionResponse()', () => {
+    test('creates successful response with new session ID', () => {
+      const requestId = generateId();
+      const newSessionId = generateId();
+      const msg = createResumeSessionResponse(true, requestId, newSessionId);
+      expect(msg.type).toBe('resume_session_response');
+      expect(msg.success).toBe(true);
+      expect(msg.sessionId).toBe(newSessionId);
+      expect(msg.requestId).toBe(requestId);
+      expect(msg.error).toBeUndefined();
+    });
+
+    test('creates failed response with error', () => {
+      const requestId = generateId();
+      const msg = createResumeSessionResponse(false, requestId, undefined, 'Session not found');
+      expect(msg.type).toBe('resume_session_response');
+      expect(msg.success).toBe(false);
+      expect(msg.sessionId).toBeUndefined();
+      expect(msg.error).toBe('Session not found');
+      expect(msg.requestId).toBe(requestId);
+    });
+
+    test('serializes and deserializes', () => {
+      const requestId = generateId();
+      const msg = createResumeSessionResponse(true, requestId, generateId());
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('resume_session_response');
     });
   });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -28,6 +28,7 @@ import {
   createBulletExpandRequest,
   createCreateSessionRequest,
   createHello,
+  createResumeSessionRequest,
   createSessionHistoryRequest,
   createSessionListRequest,
   createTranscriptLoadRequest,
@@ -110,6 +111,7 @@ function App() {
   const [question, setQuestion] = useState<UIQuestion | null>(null);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [creatingSession, setCreatingSession] = useState(false);
+  const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
@@ -394,6 +396,7 @@ function App() {
           cwd: ds.projectPath,
           preview: ds.lastMessage || `${ds.messageCount} messages`,
           source: ds.source,
+          canResume: !ds.canAttach && ds.canResume,
         }));
 
         setSessions((prev) => {
@@ -456,6 +459,26 @@ function App() {
         break;
       }
 
+      case 'resume_session_response': {
+        setResumingSession(null);
+        if (message.success && message.sessionId) {
+          setActiveSessionId(message.sessionId);
+        } else {
+          console.error(`Failed to resume session: ${message.error}`);
+          const errorMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            sender: 'system',
+            content: `Failed to resume session: ${message.error ?? 'Unknown error'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        }
+        break;
+      }
+
       case 'error':
         console.error('Daemon error:', message);
         break;
@@ -509,6 +532,7 @@ function App() {
     requestSessionList,
     requestTranscriptLoad,
     requestNewSession,
+    requestResumeSession,
     requestSessionHistory,
     needsPassphrase,
     serverFingerprint,
@@ -596,6 +620,14 @@ function App() {
       return requestNewSession(directory);
     },
     [connectionMode, relaySend, requestNewSession],
+  );
+
+  const effectiveRequestResumeSession = useCallback(
+    (sessionId: string): boolean => {
+      if (connectionMode === 'relay') return relaySend(createResumeSessionRequest(sessionId));
+      return requestResumeSession(sessionId);
+    },
+    [connectionMode, relaySend, requestResumeSession],
   );
 
   const effectiveRequestSessionHistory = useCallback(
@@ -975,6 +1007,15 @@ function App() {
     [effectiveRequestNewSession, creatingSession],
   );
 
+  const handleResumeSession = useCallback(
+    (sessionId: string) => {
+      if (resumingSession) return;
+      setResumingSession(sessionId);
+      effectiveRequestResumeSession(sessionId);
+    },
+    [effectiveRequestResumeSession, resumingSession],
+  );
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -1010,6 +1051,8 @@ function App() {
       activeSessionId={activeSessionId}
       onSelectSession={handleSelectSession}
       onNewSession={canCreateSession ? handleNewSession : undefined}
+      onResumeSession={effectiveStatus === 'connected' ? handleResumeSession : undefined}
+      resumingSessionId={resumingSession}
       onConnect={() => setShowConnectModal(true)}
       onSettings={() => setShowSettings(true)}
       recentDirectories={recentDirectories}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -121,6 +121,7 @@ function App() {
   // Refs for stable callbacks
   const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
   const activeSessionIdRef = useRef<UUID | null>(null);
+  const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
   const unlockedIdentityRef = useRef<UnlockedIdentity | null>(null);
 
@@ -460,14 +461,19 @@ function App() {
       }
 
       case 'resume_session_response': {
+        const targetSessionId = resumingSessionRef.current;
         setResumingSession(null);
         if (message.success && message.sessionId) {
           setActiveSessionId(message.sessionId);
         } else {
           console.error(`Failed to resume session: ${message.error}`);
+          // Use the target session ID so the error appears in the right session's chat
+          const errorSessionId = (targetSessionId ??
+            activeSessionIdRef.current ??
+            '') as UUID;
           const errorMsg: UIMessage = {
             id: generateId(),
-            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            sessionId: errorSessionId,
             sender: 'system',
             content: `Failed to resume session: ${message.error ?? 'Unknown error'}`,
             timestamp: new Date().toISOString(),
@@ -493,6 +499,10 @@ function App() {
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId]);
+
+  useEffect(() => {
+    resumingSessionRef.current = resumingSession;
+  }, [resumingSession]);
 
   useEffect(() => {
     unlockedIdentityRef.current = unlockedIdentity;
@@ -1011,7 +1021,10 @@ function App() {
     (sessionId: string) => {
       if (resumingSession) return;
       setResumingSession(sessionId);
-      effectiveRequestResumeSession(sessionId);
+      const sent = effectiveRequestResumeSession(sessionId);
+      if (!sent) {
+        setResumingSession(null);
+      }
     },
     [effectiveRequestResumeSession, resumingSession],
   );

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -8,11 +8,14 @@
 import { formatRelativeTime } from '@/lib/format-time';
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 import { clsx } from 'clsx';
+import { RotateCcw } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
   readonly isActive: boolean;
   readonly onClick: () => void;
+  readonly onResume?: ((sessionId: string) => void) | undefined;
+  readonly isResuming?: boolean;
 }
 
 /** Status dot with color and animation */
@@ -47,7 +50,18 @@ function StatusDot({
   }
 }
 
-export function SessionCard({ session, isActive, onClick }: SessionCardProps) {
+export function SessionCard({
+  session,
+  isActive,
+  onClick,
+  onResume,
+  isResuming,
+}: SessionCardProps) {
+  const showResume =
+    onResume &&
+    session.canResume &&
+    session.connectionStatus === 'disconnected';
+
   return (
     <button
       onClick={onClick}
@@ -82,6 +96,27 @@ export function SessionCard({ session, isActive, onClick }: SessionCardProps) {
           {/* CWD if available */}
           {session.cwd && (
             <p className="mt-1 truncate text-xs text-[--color-text-muted]">{session.cwd}</p>
+          )}
+
+          {/* Resume button for dead sessions */}
+          {showResume && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onResume(session.id);
+              }}
+              disabled={isResuming}
+              className={clsx(
+                'mt-2 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                isResuming
+                  ? 'bg-[--color-surface-light] text-[--color-text-muted] cursor-wait'
+                  : 'bg-[--color-primary]/10 text-[--color-primary] hover:bg-[--color-primary]/20',
+              )}
+            >
+              <RotateCcw className={clsx('size-3', isResuming && 'animate-spin')} />
+              {isResuming ? 'Resuming...' : 'Resume'}
+            </button>
           )}
         </div>
 

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -17,6 +17,8 @@ interface SessionListProps {
   readonly activeSessionId: UUID | null;
   readonly onSelectSession: (id: UUID) => void;
   readonly onNewSession?: ((directory?: string) => void) | undefined;
+  readonly onResumeSession?: ((sessionId: string) => void) | undefined;
+  readonly resumingSessionId?: string | null;
   readonly onConnect?: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
@@ -28,6 +30,8 @@ export function SessionList({
   activeSessionId,
   onSelectSession,
   onNewSession,
+  onResumeSession,
+  resumingSessionId,
   onConnect,
   onSettings,
   className,
@@ -89,6 +93,8 @@ export function SessionList({
                 session={session}
                 isActive={session.id === activeSessionId}
                 onClick={() => onSelectSession(session.id)}
+                onResume={onResumeSession}
+                isResuming={resumingSessionId === session.id}
               />
             ))}
           </div>

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -28,6 +28,7 @@ import {
   createCreateSessionRequest,
   createHello,
   createPing,
+  createResumeSessionRequest,
   createSessionHistoryRequest,
   createSessionListRequest,
   createTranscriptLoadRequest,
@@ -62,6 +63,8 @@ export interface UseWebSocketReturn {
   requestTranscriptLoad: (sessionId: string) => boolean;
   /** Request creation of a new Claude Code session */
   requestNewSession: (directory?: string) => boolean;
+  /** Request resume of a dead Claude Code session */
+  requestResumeSession: (sessionId: string) => boolean;
   /** Request recent directories from session history */
   requestSessionHistory: (limit?: number) => boolean;
   /** Current session ID (after hello_ack) */
@@ -441,6 +444,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     return clientRef.current.send(createCreateSessionRequest(directory));
   }, []);
 
+  // Request resume of a dead Claude Code session
+  const requestResumeSession = useCallback((sessionId: string): boolean => {
+    if (!clientRef.current) return false;
+    return clientRef.current.send(createResumeSessionRequest(sessionId));
+  }, []);
+
   // Request recent directories from session history
   const requestSessionHistory = useCallback((limit?: number): boolean => {
     if (!clientRef.current) return false;
@@ -477,6 +486,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     requestSessionList,
     requestTranscriptLoad,
     requestNewSession,
+    requestResumeSession,
     requestSessionHistory,
     sessionId,
     authRequired,

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -92,6 +92,8 @@ export interface UISession {
   readonly isLoadingTranscript?: boolean;
   /** Whether the session has a pending question requiring user input */
   readonly questionPending?: boolean;
+  /** Whether this dead session can be resumed via Claude Code --resume */
+  readonly canResume?: boolean;
 }
 
 /** Structured option for a question */


### PR DESCRIPTION
## Summary
- Add `resume_session_request`/`resume_session_response` protocol messages to the shared protocol
- Daemon handler looks up Claude session ID from SessionStore or transcript files, spawns new PTY with `--resume` flag
- Web UI shows "Resume" button on dead sessions (transcript-discovered sessions with `canResume: true`)
- Add `canResume` field to `DiscoverableSession` type across the stack
- 5 new protocol serialization/deserialization tests (1140 total, all passing)

## Changes

### Protocol (packages/shared)
- New message types: `ResumeSessionRequestMessage`, `ResumeSessionResponseMessage`
- New field: `canResume: boolean` on `DiscoverableSession`
- Factory functions: `createResumeSessionRequest()`, `createResumeSessionResponse()`
- Added to `ProtocolMessage` union, `validTypes`, and exports

### Daemon (packages/daemon)
- Full event plumbing: connection.ts -> websocket-server.ts -> websocket-adapter.ts -> relay-adapter.ts
- Handler in cli.ts: session lookup (by remi ID, claude ID, or transcript), directory validation, PTY spawn with `--resume`, connection attach
- Session registry and transcript discovery return `canResume` field

### Web (packages/web)
- `useWebSocket` hook: `requestResumeSession()` function
- App.tsx: `resume_session_response` handler, `resumingSession` state, `effectiveRequestResumeSession` callback
- SessionCard: "Resume" button with spinner when `canResume && disconnected`
- SessionList: passes resume props through

## Test plan
- [x] All 1140 tests pass (`bun test`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Biome lint passes (11 pre-existing warnings only)
- [x] Web builds clean (`bun run build`)
- [ ] Manual test: start daemon, create session, kill it, verify Resume button appears
- [ ] Manual test: click Resume, verify session resurrects with conversation context
- [ ] Docker integration test for resume flow

Closes #128