### PR TITLE
fix: PR review findings for session store, PATH, process-alive

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -312,7 +312,7 @@ function logError(...args: unknown[]): void {
  * Resolve the user's full PATH from their login shell.
  * LaunchAgents and systemd services inherit a minimal PATH that doesn't
  * include user-installed tools (e.g. ~/.local/bin, Homebrew, ~/.bun/bin).
- * This runs the login shell to get the real PATH and merges it into process.env.
+ * This runs the login shell to get the real PATH and replaces process.env.PATH with it.
  */
 function resolveShellPath(): void {
   try {
@@ -323,19 +323,19 @@ function resolveShellPath(): void {
     });
     if (result.exitCode !== 0) {
       const stderr = result.stderr?.toString().trim() || '(no stderr)';
-      console.warn(`[PATH] Shell '${shell}' exited with code ${result.exitCode}: ${stderr}`);
+      logError(`[PATH] Shell '${shell}' exited with code ${result.exitCode}: ${stderr}`);
       return;
     }
     const shellPath = result.stdout?.toString().trim();
     if (!shellPath) {
-      console.warn(`[PATH] Shell '${shell}' returned empty PATH`);
+      logError(`[PATH] Shell '${shell}' returned empty PATH`);
       return;
     }
     // Replace with shell's PATH entirely; it's the authoritative source
     // and preserves the user's intended priority order
     process.env['PATH'] = shellPath;
   } catch (err) {
-    console.warn(
+    logError(
       `[PATH] Failed to resolve shell PATH: ${err instanceof Error ? err.message : String(err)}`,
     );
   }

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -66,8 +66,12 @@ export class SessionStore {
         s.pid ??= null;
       }
       return data.sessions;
-    } catch {
-      // JSON parse failure: corrupt file, treat as empty
+    } catch (err) {
+      if (!(err instanceof SyntaxError)) {
+        console.warn(
+          `[sessions] Unexpected error reading sessions: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       return [];
     }
   }
@@ -132,8 +136,9 @@ export class SessionStore {
     const before = sessions.length;
     const kept = sessions.filter((s) => {
       if (s.exitedAt === null) return true;
-      const exitedAge = now - new Date(s.exitedAt).getTime();
-      return exitedAge < STALE_AGE_MS;
+      const exitedTime = new Date(s.exitedAt).getTime();
+      if (Number.isNaN(exitedTime)) return true; // keep entries with invalid dates
+      return now - exitedTime < STALE_AGE_MS;
     });
 
     if (kept.length !== before) changed = true;
@@ -152,9 +157,15 @@ export class SessionStore {
     try {
       const { sessions } = this.doPurge();
       return sessions.sort((a, b) => (a.startedAt > b.startedAt ? -1 : 1));
-    } catch {
-      // Purge failed (I/O error); fall back to raw read
-      return this.read().sort((a, b) => (a.startedAt > b.startedAt ? -1 : 1));
+    } catch (purgeErr) {
+      console.warn(
+        `[sessions] Purge failed: ${purgeErr instanceof Error ? purgeErr.message : String(purgeErr)}`,
+      );
+      try {
+        return this.read().sort((a, b) => (a.startedAt > b.startedAt ? -1 : 1));
+      } catch {
+        return [];
+      }
     }
   }
 

--- a/packages/daemon/tests/session/process-alive.test.ts
+++ b/packages/daemon/tests/session/process-alive.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { isProcessAlive } from '../../src/session/process-alive.ts';
+
+describe('isProcessAlive', () => {
+  test('returns true for current process', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  test('returns false for PID 0', () => {
+    expect(isProcessAlive(0)).toBe(false);
+  });
+
+  test('returns false for negative PID', () => {
+    expect(isProcessAlive(-1)).toBe(false);
+  });
+
+  test('returns false for non-integer PID', () => {
+    expect(isProcessAlive(1.5)).toBe(false);
+  });
+
+  test('returns false for NaN', () => {
+    expect(isProcessAlive(Number.NaN)).toBe(false);
+  });
+
+  test('returns false for Infinity', () => {
+    expect(isProcessAlive(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  test('returns false for dead PID', () => {
+    expect(isProcessAlive(999999)).toBe(false);
+  });
+
+  test('returns true for PID 1 (EPERM on macOS/Linux)', () => {
+    // PID 1 (init/launchd) exists but is owned by root; kill(1, 0) throws EPERM
+    expect(isProcessAlive(1)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses review findings from PR #132 review:

- **session-store**: `list()` catch logs errors and handles fallback `read()` failure
- **session-store**: NaN guard in `doPurge()` age comparison for invalid dates
- **session-store**: `read()` catch logs non-SyntaxError exceptions
- **cli**: `resolveShellPath()` uses `logError()` for daemon log visibility
- **cli**: JSDoc corrected from "merges" to "replaces"
- **tests**: 8 new unit tests for `isProcessAlive()`

## Test plan

- [x] 1164 tests pass (8 new)
- [x] Biome clean