### PR TITLE
fix: use GitHub App token for auto-release tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Generate a GitHub App token so the tag push triggers release.yml.
+      # GITHUB_TOKEN pushes cannot trigger downstream workflows (GitHub security policy).
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Use `actions/create-github-app-token@v1` to generate a GitHub App token for the auto-release job
- The App token (unlike GITHUB_TOKEN) can trigger downstream workflows when pushing tags
- This fixes the issue where `release.yml` was not triggered after auto-release stripped the dev suffix and pushed a version tag

## Test plan

- [x] Merge to develop, then to main
- [x] Verify auto-release job generates App token, pushes tag, and release.yml triggers