### PR TITLE
Release v0.4.7: auto-release CI with GitHub App token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Generate a GitHub App token so the tag push triggers release.yml.
+      # GITHUB_TOKEN pushes cannot trigger downstream workflows (GitHub security policy).
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.6-dev.1",
+  "version": "0.4.6-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.6-dev.1'; // REMI_COMPILED_VERSION
+      return '0.4.6-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.6-dev.1'; // REMI_COMPILED_VERSION
+    return '0.4.6-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 


### PR DESCRIPTION
## Summary

- **fix: use GitHub App token for auto-release tag push** (#136) - Auto-release CI now uses a GitHub App token so tag pushes trigger the release workflow
- **fix: PR review findings** (#135) - Error logging, NaN guards, isProcessAlive tests

## Test plan

- [x] CI green on develop
- [x] This merge tests the full auto-release pipeline end-to-end