### PR TITLE
Release v0.4.7: auto-release pipeline test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.6-dev.2",
+  "version": "0.4.7-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.6-dev.2'; // REMI_COMPILED_VERSION
+      return '0.4.7-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.6-dev.2'; // REMI_COMPILED_VERSION
+    return '0.4.7-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 


### PR DESCRIPTION
## Summary

Tests the auto-release pipeline with GitHub App token. On merge, CI should:
1. Detect dev version 0.4.7-dev.1
2. Strip to 0.4.7 using bump-version.sh stable
3. Push tag v0.4.7 using App token
4. Tag push triggers release.yml (build, npm publish, GitHub release, Homebrew)

## Changes since v0.4.6

- fix: GitHub App token for auto-release (#136)
- fix: PR review findings (#135)