### PR TITLE
feat: Playwright E2E tests for web interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
   auto-release:
     name: Auto Release
-    needs: [spelling, lint, typecheck, test]
+    needs: [spelling, lint, typecheck, test, e2e]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,19 @@ jobs:
             exit 1
           fi
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bunx playwright install chromium --with-deps
+      - run: bun run test:e2e
+
   auto-release:
     name: Auto Release
     needs: [spelling, lint, typecheck, test]

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ logs/
 *.db
 *.sqlite
 *.sqlite3
+test-results/
+playwright-report/

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "remi",
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
+        "@playwright/test": "^1.58.2",
         "@types/bun": "^1.1.0",
         "lefthook": "^2.1.3",
         "typescript": "^5.7.0",
@@ -316,6 +317,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -849,6 +852,10 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -1088,6 +1095,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "bun test --coverage",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
+    "test:e2e": "bunx playwright test --config tests/e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "@playwright/test": "^1.58.2",
     "@types/bun": "^1.1.0",
     "lefthook": "^2.1.3",
     "typescript": "^5.7.0"

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+
+const COMPOSE_FILE = path.resolve(__dirname, '../integration/docker-compose.yml');
+const MAX_WAIT_MS = 60_000;
+const POLL_INTERVAL_MS = 2_000;
+
+export default async function globalSetup() {
+  console.log('Starting Docker daemons for E2E tests...');
+
+  try {
+    execSync(`docker compose -f ${COMPOSE_FILE} up -d --build --wait`, {
+      stdio: 'inherit',
+      timeout: MAX_WAIT_MS,
+      env: { ...process.env },
+    });
+  } catch {
+    console.error('Failed to start Docker daemons. Is Docker running?');
+    throw new Error('Docker compose up failed');
+  }
+
+  // Wait for daemon1 to be healthy via WebSocket health endpoint
+  const start = Date.now();
+  let healthy = false;
+
+  while (Date.now() - start < MAX_WAIT_MS) {
+    try {
+      const res = await fetch('http://localhost:19765/health');
+      if (res.ok) {
+        healthy = true;
+        break;
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  if (!healthy) {
+    throw new Error('Daemon health check timed out after 60s');
+  }
+
+  console.log('Docker daemons ready.');
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,42 +2,20 @@ import { execSync } from 'node:child_process';
 import * as path from 'node:path';
 
 const COMPOSE_FILE = path.resolve(__dirname, '../integration/docker-compose.yml');
-const MAX_WAIT_MS = 60_000;
-const POLL_INTERVAL_MS = 2_000;
 
 export default async function globalSetup() {
   console.log('Starting Docker daemons for E2E tests...');
 
   try {
+    // --wait blocks until all services with healthchecks report healthy
     execSync(`docker compose -f ${COMPOSE_FILE} up -d --build --wait`, {
       stdio: 'inherit',
-      timeout: MAX_WAIT_MS,
+      timeout: 120_000,
       env: { ...process.env },
     });
   } catch {
     console.error('Failed to start Docker daemons. Is Docker running?');
     throw new Error('Docker compose up failed');
-  }
-
-  // Wait for daemon1 to be healthy via WebSocket health endpoint
-  const start = Date.now();
-  let healthy = false;
-
-  while (Date.now() - start < MAX_WAIT_MS) {
-    try {
-      const res = await fetch('http://localhost:19765/health');
-      if (res.ok) {
-        healthy = true;
-        break;
-      }
-    } catch {
-      // Not ready yet
-    }
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-  }
-
-  if (!healthy) {
-    throw new Error('Daemon health check timed out after 60s');
   }
 
   console.log('Docker daemons ready.');

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+
+const COMPOSE_FILE = path.resolve(__dirname, '../integration/docker-compose.yml');
+
+export default async function globalTeardown() {
+  console.log('Stopping Docker daemons...');
+
+  try {
+    execSync(`docker compose -f ${COMPOSE_FILE} down --remove-orphans`, {
+      stdio: 'inherit',
+      timeout: 30_000,
+    });
+  } catch {
+    console.warn('Failed to stop Docker daemons cleanly.');
+  }
+
+  console.log('Docker daemons stopped.');
+}

--- a/tests/e2e/helpers/daemon.ts
+++ b/tests/e2e/helpers/daemon.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test';
+
+export const DAEMON1_PORT = 19765;
+export const DAEMON2_PORT = 19766;
+
+/**
+ * Connect to a Remi daemon via the web UI's ConnectModal.
+ * Opens the modal, fills in the WebSocket URL, and waits for connection.
+ */
+export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): Promise<void> {
+  // Click the connect button in the session list header
+  await page.click('[aria-label="Connect to daemon"]');
+
+  // Wait for modal to appear
+  await page.waitForSelector('text=Connect to Daemon');
+
+  // Clear the URL input and fill with our daemon URL
+  const urlInput = page.locator('input[placeholder="ws://localhost:3847/ws"]');
+  await urlInput.clear();
+  await urlInput.fill(`ws://localhost:${port}/ws`);
+
+  // The app may auto-connect when URL changes, or we need to click Connect
+  // Try clicking Connect if the button is enabled
+  const connectButton = page.locator('button:has-text("Connect")').last();
+  try {
+    await connectButton.click({ timeout: 1_000 });
+  } catch {
+    // Button may be disabled because auto-connect already happened
+  }
+
+  // Wait for the modal to close (connection success auto-closes it)
+  // OR close it manually if it shows "Connected!" but stays open
+  try {
+    await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 5_000 });
+  } catch {
+    // Modal still open -- close it manually (it may show "Connected!" status)
+    const closeButton = page.locator('[aria-label="Close"]').first();
+    await closeButton.click();
+    await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 });
+  }
+}
+
+/**
+ * Wait for the session list header to appear (indicates connection is active).
+ */
+export async function waitForSessionList(page: Page): Promise<void> {
+  await page.waitForSelector('h1:has-text("Sessions")', { timeout: 10_000 });
+}
+
+/**
+ * Open the settings panel.
+ */
+export async function openSettings(page: Page): Promise<void> {
+  await page.click('[aria-label="Settings"]');
+  await page.waitForSelector('text=Settings');
+}
+
+/**
+ * Close the settings panel.
+ */
+export async function closeSettings(page: Page): Promise<void> {
+  await page.click('[aria-label="Close settings"]');
+  await page.waitForSelector('[aria-label="Close settings"]', { state: 'hidden' });
+}

--- a/tests/e2e/helpers/daemon.ts
+++ b/tests/e2e/helpers/daemon.ts
@@ -19,23 +19,26 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
   await urlInput.clear();
   await urlInput.fill(`ws://localhost:${port}/ws`);
 
-  // The app may auto-connect when URL changes, or we need to click Connect
-  // Try clicking Connect if the button is enabled
+  // Click the Connect button in the modal footer if it's enabled.
+  // The app may auto-connect when the URL changes (if previously connected),
+  // in which case the button is already disabled and "Connected!" is shown.
   const connectButton = page.locator('button:has-text("Connect")').last();
-  try {
-    await connectButton.click({ timeout: 1_000 });
-  } catch {
-    // Button may be disabled because auto-connect already happened
+  const isEnabled = await connectButton.isEnabled().catch(() => false);
+  if (isEnabled) {
+    await connectButton.click();
   }
 
-  // Wait for the modal to close (connection success auto-closes it)
-  // OR close it manually if it shows "Connected!" but stays open
-  try {
-    await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 5_000 });
-  } catch {
-    // Modal still open -- close it manually (it may show "Connected!" status)
-    const closeButton = page.locator('[aria-label="Close"]').first();
-    await closeButton.click();
+  // Wait for the modal to close (auto-closes on first connection)
+  // or wait for "Connected!" and close manually (when switching daemons)
+  const modalClosed = await page
+    .waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!modalClosed) {
+    // Modal still open; should show "Connected!" status
+    await page.waitForSelector('text=Connected!', { timeout: 5_000 });
+    await page.locator('[aria-label="Close"]').first().click();
     await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 });
   }
 }

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,38 @@
+import * as path from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+export default defineConfig({
+  testDir: './specs',
+  testMatch: '**/*.e2e.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: `cd ${ROOT}/packages/web && bun run build && bunx vite preview --port 4173`,
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
+});

--- a/tests/e2e/specs/connect.e2e.ts
+++ b/tests/e2e/specs/connect.e2e.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import { DAEMON1_PORT, connectToDaemon } from '../helpers/daemon';
+
+test.describe('Connection flow', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage to start fresh
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test('app loads with empty state', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'No Sessions' })).toBeVisible();
+    await expect(page.locator('[aria-label="Connect to daemon"]')).toBeVisible();
+  });
+
+  test('connect modal opens on click', async ({ page }) => {
+    await page.goto('/');
+    await page.click('[aria-label="Connect to daemon"]');
+    await expect(page.locator('text=Connect to Daemon')).toBeVisible();
+    // Direct tab should be active by default
+    await expect(page.locator('input[placeholder="ws://localhost:3847/ws"]')).toBeVisible();
+  });
+
+  test('connect modal can be closed', async ({ page }) => {
+    await page.goto('/');
+    await page.click('[aria-label="Connect to daemon"]');
+    await expect(page.locator('text=Connect to Daemon')).toBeVisible();
+
+    // Click close button
+    await page.click('[aria-label="Close"]');
+    await expect(page.locator('text=Connect to Daemon')).toBeHidden();
+  });
+
+  test('direct connection to daemon succeeds', async ({ page }) => {
+    await page.goto('/');
+    await connectToDaemon(page, DAEMON1_PORT);
+
+    // After connection, session list should be visible
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+  });
+
+  test('connection persists across reload', async ({ page }) => {
+    await page.goto('/');
+    await connectToDaemon(page, DAEMON1_PORT);
+
+    // Verify connected
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+
+    // Reload the page
+    await page.reload();
+
+    // Should auto-reconnect from localStorage
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('invalid URL shows connection failure', async ({ page }) => {
+    await page.goto('/');
+    await page.click('[aria-label="Connect to daemon"]');
+
+    const urlInput = page.locator('input[placeholder="ws://localhost:3847/ws"]');
+    await urlInput.clear();
+    await urlInput.fill('ws://localhost:99999/ws');
+
+    const connectButton = page.locator('button:has-text("Connect")').last();
+    await connectButton.click();
+
+    // Modal should remain open (connection failed)
+    await expect(page.locator('text=Connect to Daemon')).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/tests/e2e/specs/session-list.e2e.ts
+++ b/tests/e2e/specs/session-list.e2e.ts
@@ -13,11 +13,12 @@ test.describe('Session list', () => {
     await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
   });
 
-  test('empty state shows connect prompt when no sessions exist', async ({ page }) => {
+  test('empty state visible with fresh daemon (no Claude sessions)', async ({ page }) => {
     await connectToDaemon(page, DAEMON1_PORT);
-    // With a fresh daemon and no Claude sessions, the session list is empty
-    // The empty state text should be visible (within the sidebar)
+    // Fresh Docker daemons have no Claude sessions, so the session list is empty.
+    // The empty state heading and connect prompt should be visible in the sidebar.
     await expect(page.getByRole('heading', { name: 'No Sessions' })).toBeVisible();
+    await expect(page.getByText('Connect to a Claude daemon to start monitoring')).toBeVisible();
   });
 
   test('connect and settings buttons in header', async ({ page }) => {

--- a/tests/e2e/specs/session-list.e2e.ts
+++ b/tests/e2e/specs/session-list.e2e.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import { DAEMON1_PORT, DAEMON2_PORT, connectToDaemon } from '../helpers/daemon';
+
+test.describe('Session list', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test('shows Sessions heading after connection', async ({ page }) => {
+    await connectToDaemon(page, DAEMON1_PORT);
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+  });
+
+  test('empty state shows connect prompt when no sessions exist', async ({ page }) => {
+    await connectToDaemon(page, DAEMON1_PORT);
+    // With a fresh daemon and no Claude sessions, the session list is empty
+    // The empty state text should be visible (within the sidebar)
+    await expect(page.getByRole('heading', { name: 'No Sessions' })).toBeVisible();
+  });
+
+  test('connect and settings buttons in header', async ({ page }) => {
+    await connectToDaemon(page, DAEMON1_PORT);
+    await expect(page.locator('[aria-label="Connect to daemon"]')).toBeVisible();
+    await expect(page.locator('[aria-label="Settings"]')).toBeVisible();
+  });
+
+  test('can switch between daemons', async ({ page }) => {
+    // Connect to daemon1
+    await connectToDaemon(page, DAEMON1_PORT);
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+
+    // Connect to daemon2 using the helper (handles the full modal flow)
+    await connectToDaemon(page, DAEMON2_PORT);
+    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/settings.e2e.ts
+++ b/tests/e2e/specs/settings.e2e.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { DAEMON1_PORT, connectToDaemon, openSettings } from '../helpers/daemon';
+
+test.describe('Settings panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await connectToDaemon(page, DAEMON1_PORT);
+  });
+
+  test('settings panel opens and closes', async ({ page }) => {
+    await openSettings(page);
+    await expect(page.getByRole('heading', { name: 'Theme' })).toBeVisible();
+
+    await page.click('[aria-label="Close settings"]');
+    // Settings heading should no longer be visible
+    await expect(page.locator('[aria-label="Close settings"]')).toBeHidden();
+  });
+
+  test('theme switching to dark mode', async ({ page }) => {
+    await openSettings(page);
+
+    // Click Dark theme button
+    await page.click('button:has-text("Dark")');
+
+    // Verify data-theme attribute on html element
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+  });
+
+  test('theme switching to light mode', async ({ page }) => {
+    await openSettings(page);
+
+    // Click Light theme button
+    await page.click('button:has-text("Light")');
+
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('light');
+  });
+
+  test('theme persists across reload', async ({ page }) => {
+    await openSettings(page);
+    await page.click('button:has-text("Dark")');
+
+    // Verify dark theme applied
+    let theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+
+    // Reload
+    await page.reload();
+
+    // Theme should persist from localStorage
+    theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+  });
+
+  test('font size changes', async ({ page }) => {
+    await openSettings(page);
+
+    // Get initial font size
+    const initialSize = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--font-size-base').trim(),
+    );
+
+    // Click Large font size
+    await page.click('button:has-text("Large")');
+
+    // Font size CSS variable should change
+    const newSize = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--font-size-base').trim(),
+    );
+
+    // The sizes should differ (exact values depend on implementation)
+    expect(newSize).not.toBe(initialSize);
+  });
+});


### PR DESCRIPTION
## Summary
- 15 Playwright E2E tests across 3 spec files testing the web interface against real Docker daemons
- Tests cover: connection flow (6), session list (4), settings panel (5)
- All Tier 1 tests (no OAuth token required), using real WebSocket connections to Docker-hosted daemons
- CI job added to GitHub Actions (runs after unit tests pass)

## Test Coverage

### connect.e2e.ts (6 tests)
- [x] App loads with empty state (No Sessions heading visible)
- [x] ConnectModal opens on click
- [x] ConnectModal can be closed
- [x] Direct connection to daemon succeeds
- [x] Connection persists across page reload (localStorage)
- [x] Invalid URL shows connection failure

### session-list.e2e.ts (4 tests)
- [x] Sessions heading appears after connection
- [x] Empty state visible with fresh daemon
- [x] Connect and Settings buttons visible in header
- [x] Can switch between two daemons

### settings.e2e.ts (5 tests)
- [x] Settings panel opens and closes
- [x] Theme switching to dark mode
- [x] Theme switching to light mode
- [x] Theme persists across reload
- [x] Font size changes

## Infrastructure
- Playwright config with global setup/teardown for Docker lifecycle
- Reuses existing `tests/integration/docker-compose.yml` (no changes to daemon Docker setup)
- Vite preview serves the built web app on port 4173
- Helper functions for connecting to daemons via the UI
- `.e2e.ts` file extension to avoid Bun test runner interference

## Test plan
- [x] All 15 E2E tests pass locally (`bun run test:e2e`)
- [x] All 1140 unit tests still pass (`bun test`)
- [x] Biome lint clean
- [x] No mocks; all tests connect to real Docker daemons via WebSocket

Closes #127