### PR TITLE
fix: session listing regression and version mismatch handling

### DIFF
--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -23,10 +23,39 @@ if (!pkg) {
   process.exit(1);
 }
 
+/**
+ * Auto-upgrade the platform binary when the wrapper version doesn't match.
+ * This handles package managers (e.g. bun --force) that upgrade the main
+ * package but skip optionalDependencies.
+ */
+function autoUpgradePlatformBinary(wrapperVersion) {
+  console.error(`[remi] Binary outdated, upgrading ${pkg} to ${wrapperVersion}...`);
+
+  // Try npm first (most reliable for global installs), then bun
+  const managers = [
+    { cmd: "npm", args: ["install", "-g", `${pkg}@${wrapperVersion}`] },
+    { cmd: "bun", args: ["install", "-g", `${pkg}@${wrapperVersion}`] },
+  ];
+
+  for (const { cmd, args } of managers) {
+    try {
+      const r = spawnSync(cmd, args, { stdio: "pipe", timeout: 30000 });
+      if (r.status === 0) {
+        console.error(`[remi] Upgraded ${pkg} to ${wrapperVersion} via ${cmd}`);
+        return true;
+      }
+    } catch (_) {
+      // Try next manager
+    }
+  }
+  return false;
+}
+
 let binPath;
+let platPkgDir;
 try {
-  const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
-  binPath = path.join(pkgDir, "bin", "remi");
+  platPkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+  binPath = path.join(platPkgDir, "bin", "remi");
 } catch (err) {
   if (err.code === "MODULE_NOT_FOUND") {
     console.error(`Platform package ${pkg} is not installed.`);
@@ -41,6 +70,34 @@ if (!fs.existsSync(binPath)) {
   console.error(`Remi binary not found at: ${binPath}`);
   console.error("Try reinstalling: npm install -g @yooz-labs/remi");
   process.exit(1);
+}
+
+// Check if the platform binary version matches the wrapper package version.
+// If mismatched, attempt an automatic upgrade before falling through to the
+// (possibly stale) binary so the user isn't stuck.
+try {
+  const wrapperPkg = require(path.resolve(__dirname, "..", "package.json"));
+  const platPkg = require(path.join(platPkgDir, "package.json"));
+  if (wrapperPkg.version && platPkg.version && wrapperPkg.version !== platPkg.version) {
+    if (autoUpgradePlatformBinary(wrapperPkg.version)) {
+      // Re-resolve after upgrade
+      try {
+        delete require.cache[require.resolve(`${pkg}/package.json`)];
+        platPkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+        binPath = path.join(platPkgDir, "bin", "remi");
+      } catch (_) {
+        // Fall through to original binPath
+      }
+    } else {
+      console.error(
+        `[remi] Version mismatch: wrapper is ${wrapperPkg.version} but binary is ${platPkg.version}.`
+      );
+      console.error(`[remi] Auto-upgrade failed. Fix manually:`);
+      console.error(`[remi]   npm install -g @yooz-labs/remi@${wrapperPkg.version}`);
+    }
+  }
+} catch (_) {
+  // Non-fatal; skip version check if package.json is unreadable
 }
 
 const result = spawnSync(binPath, process.argv.slice(2), {

--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -44,8 +44,15 @@ function autoUpgradePlatformBinary(wrapperVersion) {
         console.error(`[remi] Upgraded ${pkg} to ${wrapperVersion} via ${cmd}`);
         return true;
       }
-    } catch (_) {
-      // Try next manager
+      const stderr = r.stderr?.toString().trim();
+      if (stderr) {
+        console.error(`[remi] ${cmd} upgrade failed (exit ${r.status}): ${stderr.split("\n")[0]}`);
+      }
+    } catch (err) {
+      // ENOENT = command not found (expected if npm/bun not installed); log anything else
+      if (err.code !== "ENOENT") {
+        console.error(`[remi] ${cmd} upgrade error: ${err.message}`);
+      }
     }
   }
   return false;
@@ -80,13 +87,16 @@ try {
   const platPkg = require(path.join(platPkgDir, "package.json"));
   if (wrapperPkg.version && platPkg.version && wrapperPkg.version !== platPkg.version) {
     if (autoUpgradePlatformBinary(wrapperPkg.version)) {
-      // Re-resolve after upgrade
+      // Re-resolve after upgrade to use the new binary
       try {
         delete require.cache[require.resolve(`${pkg}/package.json`)];
         platPkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
         binPath = path.join(platPkgDir, "bin", "remi");
-      } catch (_) {
-        // Fall through to original binPath
+      } catch (resolveErr) {
+        console.error(
+          `[remi] Upgrade succeeded but failed to resolve new binary: ${resolveErr.message}`
+        );
+        console.error(`[remi] Running previously resolved binary at: ${binPath}`);
       }
     } else {
       console.error(
@@ -96,8 +106,8 @@ try {
       console.error(`[remi]   npm install -g @yooz-labs/remi@${wrapperPkg.version}`);
     }
   }
-} catch (_) {
-  // Non-fatal; skip version check if package.json is unreadable
+} catch (err) {
+  console.error(`[remi] Version check skipped: ${err.message}`);
 }
 
 const result = spawnSync(binPath, process.argv.slice(2), {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -345,8 +345,12 @@ if (parsedArgs.error) {
 }
 if (parsedArgs.showVersion) {
   console.log(`remi ${REMI_VERSION}`);
-  // Show binary location to help diagnose PATH conflicts (e.g., old binary shadowing new install)
-  console.log(`binary: ${process.argv[0]}`);
+  // Show binary location to help diagnose PATH conflicts (e.g., old binary shadowing new install).
+  // In compiled binaries, argv[0] is the binary itself. When running from source via
+  // `bun packages/daemon/src/cli.ts`, argv[0] is the bun runtime and argv[1] is the script.
+  const binaryPath =
+    typeof Bun !== 'undefined' ? Bun.argv[0] : (process.argv[1] ?? process.argv[0]);
+  console.log(`binary: ${binaryPath}`);
   process.exit(0);
 }
 if (parsedArgs.showHelp) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -345,6 +345,8 @@ if (parsedArgs.error) {
 }
 if (parsedArgs.showVersion) {
   console.log(`remi ${REMI_VERSION}`);
+  // Show binary location to help diagnose PATH conflicts (e.g., old binary shadowing new install)
+  console.log(`binary: ${process.argv[0]}`);
   process.exit(0);
 }
 if (parsedArgs.showHelp) {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -587,6 +587,7 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
   // This handles cases where live-sessions files were cleaned up (PID died,
   // SIGHUP timeout expired) but a daemon is still reachable on a default port.
   if (ports.length === 0) {
+    console.error('No live session files found, probing default ports...');
     const fallbackPorts = getDefaultPortRange();
     const fallbackResults = await queryMultiplePorts({
       host: 'localhost',

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -8,7 +8,11 @@ import {
   serialize,
 } from '@remi/shared';
 import type { DiscoverableSession, ProtocolMessage, Timestamp } from '@remi/shared';
-import type { SessionRegistryFile } from '../session/session-registry-file.ts';
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_PORT_RANGE,
+  type SessionRegistryFile,
+} from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
 import {
   FETCH_SESSIONS_TIMEOUT_MS,
@@ -308,8 +312,10 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     browseTimeoutMs: mdnsTimeout = MDNS_BROWSE_TIMEOUT_MS,
   } = opts;
 
-  // Query all local daemons (multi-port support)
-  const allLocalPorts = [...new Set([localPort, ...(opts.localPorts ?? [])])];
+  // Query all local daemons: combine live registry ports with the default port range
+  // so that daemons are discoverable even if their live-sessions files were cleaned up.
+  const defaultRange = Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
+  const allLocalPorts = [...new Set([localPort, ...(opts.localPorts ?? []), ...defaultRange])];
   const localResults = await queryMultiplePorts({
     host: 'localhost',
     ports: allLocalPorts,
@@ -561,13 +567,35 @@ export interface MultiPortLsOptions {
 /**
  * Discover all local remi sessions by reading the live sessions registry
  * and querying each unique port.
+ *
+ * If the registry has no live entries (e.g. stale files were cleaned up),
+ * falls back to probing the default port range on localhost so that
+ * running daemons are still discoverable.
  */
 export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
   const { registry, timeout = FETCH_SESSIONS_TIMEOUT_MS } = opts;
 
   const ports = registry.getLivePorts();
 
+  // Fallback: probe the default port range when the registry is empty.
+  // This handles cases where live-sessions files were cleaned up (PID died,
+  // SIGHUP timeout expired) but a daemon is still reachable on a default port.
   if (ports.length === 0) {
+    const fallbackPorts = Array.from(
+      { length: DEFAULT_PORT_RANGE },
+      (_, i) => DEFAULT_BASE_PORT + i,
+    );
+    const fallbackResults = await queryMultiplePorts({
+      host: 'localhost',
+      ports: fallbackPorts,
+      timeoutMs: timeout,
+      logLabel: 'ls',
+    });
+    const fallbackSessions = fallbackResults.flatMap((r) => r.sessions);
+    if (fallbackSessions.length > 0) {
+      renderSessionList(fallbackSessions);
+      return;
+    }
     console.log('No active sessions. Start one with: remi [claude-args...]');
     return;
   }

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -26,6 +26,11 @@ function getTerminalWidth(): number {
   return process.stdout.columns ?? 100;
 }
 
+/** Generate the default port range array (18765-18774). */
+function getDefaultPortRange(): number[] {
+  return Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
+}
+
 /** Minimum name column width to keep output readable even on very narrow terminals. */
 const MIN_NAME_WIDTH = 20;
 
@@ -312,10 +317,11 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     browseTimeoutMs: mdnsTimeout = MDNS_BROWSE_TIMEOUT_MS,
   } = opts;
 
-  // Query all local daemons: combine live registry ports with the default port range
-  // so that daemons are discoverable even if their live-sessions files were cleaned up.
-  const defaultRange = Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
-  const allLocalPorts = [...new Set([localPort, ...(opts.localPorts ?? []), ...defaultRange])];
+  // Query all local daemons. If the registry has no live entries, include the default
+  // port range so daemons are discoverable even when live-sessions files were cleaned up.
+  const registryPorts = opts.localPorts ?? [];
+  const extraPorts = registryPorts.length === 0 ? getDefaultPortRange() : [];
+  const allLocalPorts = [...new Set([localPort, ...registryPorts, ...extraPorts])];
   const localResults = await queryMultiplePorts({
     host: 'localhost',
     ports: allLocalPorts,
@@ -581,10 +587,7 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
   // This handles cases where live-sessions files were cleaned up (PID died,
   // SIGHUP timeout expired) but a daemon is still reachable on a default port.
   if (ports.length === 0) {
-    const fallbackPorts = Array.from(
-      { length: DEFAULT_PORT_RANGE },
-      (_, i) => DEFAULT_BASE_PORT + i,
-    );
+    const fallbackPorts = getDefaultPortRange();
     const fallbackResults = await queryMultiplePorts({
       host: 'localhost',
       ports: fallbackPorts,


### PR DESCRIPTION
## Summary

- `remi ls` (no flags) now probes the default port range (18765-18774) as a fallback when live-sessions files are missing, fixing the regression where local sessions became invisible after PID cleanup
- `remi ls --network` also includes the default port range for local discovery
- `remi -v` now shows the binary path to help diagnose PATH conflicts
- npm wrapper script auto-upgrades the platform binary when it detects a version mismatch (happens when `bun install -g --force` upgrades the main package but skips optionalDependencies)

## Root Causes

**Session listing regression**: `remi ls` relied exclusively on `~/.remi/live-sessions/*.json` files to discover which ports to query. When those files were cleaned up (PID died after SIGHUP 30-minute timeout, process crash, etc.), `remi ls` reported "No active sessions" even though daemons were still responding on default ports. Remote discovery (`--host`, `--network`) worked because it probes ports directly.

**Version mismatch**: `bun install -g @yooz-labs/remi@0.4.7 --force` upgraded the main wrapper package to 0.4.7 but left the platform binary (`@yooz-labs/remi-darwin-arm64`) at 0.4.5. The wrapper script now detects this and auto-upgrades.

## Test plan

- [x] All 1164 tests pass
- [x] Lint clean (0 errors)  
- [x] Typecheck clean (0 errors, excluding optional deps grammy/bonjour-service)
- [x] Verified `remi -v` shows binary path
- [x] Verified npm binary at v0.4.7 tag has correct REMI_COMPILED_VERSION
- [x] Fixed version mismatch on both MBA and MCM machines