### PR TITLE
fix: daemon PATH resolution and wrapper auto-upgrade

### DIFF
--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -24,18 +24,34 @@ if (!pkg) {
 }
 
 /**
+ * Detect which package manager owns the current installation by checking
+ * if the resolved platform package lives under bun's or npm's global prefix.
+ */
+function detectPackageManager(resolvedPkgDir) {
+  const bunGlobal = path.join(os.homedir(), ".bun");
+  if (resolvedPkgDir.startsWith(bunGlobal)) return "bun";
+  return "npm";
+}
+
+/**
  * Auto-upgrade the platform binary when the wrapper version doesn't match.
  * This handles package managers (e.g. bun --force) that upgrade the main
  * package but skip optionalDependencies.
+ *
+ * Tries the detected installer first, then falls back to the other manager,
+ * since npm and bun use different global directories.
  */
-function autoUpgradePlatformBinary(wrapperVersion) {
+function autoUpgradePlatformBinary(wrapperVersion, installedVia) {
   console.error(`[remi] Binary outdated, upgrading ${pkg} to ${wrapperVersion}...`);
 
-  // Try npm first (most reliable for global installs), then bun
-  const managers = [
-    { cmd: "npm", args: ["install", "-g", `${pkg}@${wrapperVersion}`] },
+  // Try the detected installer first so the upgrade lands in the same directory
+  const allManagers = [
     { cmd: "bun", args: ["install", "-g", `${pkg}@${wrapperVersion}`] },
+    { cmd: "npm", args: ["install", "-g", `${pkg}@${wrapperVersion}`] },
   ];
+  const managers = installedVia === "npm"
+    ? allManagers.reverse()
+    : allManagers;
 
   for (const { cmd, args } of managers) {
     try {
@@ -86,12 +102,27 @@ try {
   const wrapperPkg = require(path.resolve(__dirname, "..", "package.json"));
   const platPkg = require(path.join(platPkgDir, "package.json"));
   if (wrapperPkg.version && platPkg.version && wrapperPkg.version !== platPkg.version) {
-    if (autoUpgradePlatformBinary(wrapperPkg.version)) {
-      // Re-resolve after upgrade to use the new binary
+    const installedVia = detectPackageManager(platPkgDir);
+    if (autoUpgradePlatformBinary(wrapperPkg.version, installedVia)) {
+      // Re-resolve after upgrade to use the new binary.
+      // Clear require cache so we get the freshly installed package.
       try {
-        delete require.cache[require.resolve(`${pkg}/package.json`)];
+        const cacheKey = require.resolve(`${pkg}/package.json`);
+        delete require.cache[cacheKey];
+      } catch (_) {
+        // cache entry may not exist
+      }
+      try {
         platPkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
         binPath = path.join(platPkgDir, "bin", "remi");
+        // Verify the upgrade actually took effect at this path
+        const newPlatPkg = JSON.parse(fs.readFileSync(path.join(platPkgDir, "package.json"), "utf8"));
+        if (newPlatPkg.version !== wrapperPkg.version) {
+          console.error(
+            `[remi] Upgrade ran but binary is still ${newPlatPkg.version} (expected ${wrapperPkg.version})`
+          );
+          console.error(`[remi] Fix: bun install -g ${pkg}@${wrapperPkg.version}`);
+        }
       } catch (resolveErr) {
         console.error(
           `[remi] Upgrade succeeded but failed to resolve new binary: ${resolveErr.message}`
@@ -103,7 +134,7 @@ try {
         `[remi] Version mismatch: wrapper is ${wrapperPkg.version} but binary is ${platPkg.version}.`
       );
       console.error(`[remi] Auto-upgrade failed. Fix manually:`);
-      console.error(`[remi]   npm install -g @yooz-labs/remi@${wrapperPkg.version}`);
+      console.error(`[remi]   bun install -g ${pkg}@${wrapperPkg.version}`);
     }
   }
 } catch (err) {

--- a/npm/remi/bin/remi
+++ b/npm/remi/bin/remi
@@ -109,8 +109,8 @@ try {
       try {
         const cacheKey = require.resolve(`${pkg}/package.json`);
         delete require.cache[cacheKey];
-      } catch (_) {
-        // cache entry may not exist
+      } catch (cacheErr) {
+        console.error(`[remi] Cache clear failed: ${cacheErr.message}`);
       }
       try {
         platPkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
@@ -122,6 +122,7 @@ try {
             `[remi] Upgrade ran but binary is still ${newPlatPkg.version} (expected ${wrapperPkg.version})`
           );
           console.error(`[remi] Fix: bun install -g ${pkg}@${wrapperPkg.version}`);
+          console.error(`[remi] Continuing with outdated binary...`);
         }
       } catch (resolveErr) {
         console.error(
@@ -138,7 +139,7 @@ try {
     }
   }
 } catch (err) {
-  console.error(`[remi] Version check skipped: ${err.message}`);
+  console.error(`[remi] Version check/upgrade failed: ${err.message}`);
 }
 
 const result = spawnSync(binPath, process.argv.slice(2), {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -336,9 +336,16 @@ function resolveShellPath(): void {
         env: process.env,
         timeout: 5000,
       });
-      if (result.exitCode !== 0) continue;
+      if (result.exitCode !== 0) {
+        const stderr = result.stderr?.toString().trim() || '(no stderr)';
+        log(`[PATH] ${label} shell exited with code ${result.exitCode}: ${stderr}`);
+        continue;
+      }
       const shellPath = result.stdout?.toString().trim();
-      if (!shellPath) continue;
+      if (!shellPath) {
+        log(`[PATH] ${label} shell returned empty PATH`);
+        continue;
+      }
 
       // Merge: use the shell PATH as the base, then append any entries from the
       // current PATH that the shell didn't include (e.g., tool-injected directories).
@@ -347,15 +354,18 @@ function resolveShellPath(): void {
       const shellSet = new Set(shellEntries);
       const extraFromCurrent = currentPath.split(':').filter((e) => e && !shellSet.has(e));
       const merged = [...shellEntries, ...extraFromCurrent].join(':');
-      if (merged === currentPath) continue; // no improvement
+      if (merged === currentPath) {
+        log(`[PATH] ${label} shell returned no new entries`);
+        continue;
+      }
 
       process.env['PATH'] = merged;
       log(
         `[PATH] Resolved via ${label} shell (${shellEntries.length} shell + ${extraFromCurrent.length} existing)`,
       );
       return;
-    } catch {
-      // Try next attempt
+    } catch (err) {
+      logError(`[PATH] ${label} shell failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -313,32 +313,58 @@ function logError(...args: unknown[]): void {
  * Resolve the user's full PATH from their login shell.
  * LaunchAgents and systemd services inherit a minimal PATH that doesn't
  * include user-installed tools (e.g. ~/.local/bin, Homebrew, ~/.bun/bin).
- * This runs the login shell to get the real PATH and replaces process.env.PATH with it.
+ *
+ * Strategy:
+ * 1. Run login shell (`zsh -l -c`) which sources .zprofile
+ * 2. If that returns a suspiciously short PATH (missing Homebrew/bun),
+ *    try interactive login shell (`zsh -l -i -c`) which also sources .zshrc
+ * 3. Merge well-known tool directories as a final fallback
  */
 function resolveShellPath(): void {
-  try {
-    const shell = process.env['SHELL'] || '/bin/zsh';
-    const result = Bun.spawnSync([shell, '-l', '-c', 'echo $PATH'], {
-      env: process.env,
-      timeout: 5000,
-    });
-    if (result.exitCode !== 0) {
-      const stderr = result.stderr?.toString().trim() || '(no stderr)';
-      logError(`[PATH] Shell '${shell}' exited with code ${result.exitCode}: ${stderr}`);
+  const shell = process.env['SHELL'] || '/bin/zsh';
+  const currentPath = process.env['PATH'] || '';
+
+  // Try login shell first, then interactive login shell
+  const attempts: Array<{ flags: string[]; label: string }> = [
+    { flags: ['-l', '-c', 'echo $PATH'], label: 'login' },
+    { flags: ['-l', '-i', '-c', 'echo $PATH'], label: 'interactive login' },
+  ];
+
+  for (const { flags, label } of attempts) {
+    try {
+      const result = Bun.spawnSync([shell, ...flags], {
+        env: process.env,
+        timeout: 5000,
+      });
+      if (result.exitCode !== 0) continue;
+      const shellPath = result.stdout?.toString().trim();
+      if (!shellPath || shellPath.split(':').length <= currentPath.split(':').length) continue;
+
+      process.env['PATH'] = shellPath;
+      log(`[PATH] Resolved via ${label} shell (${shellPath.split(':').length} entries)`);
       return;
+    } catch {
+      // Try next attempt
     }
-    const shellPath = result.stdout?.toString().trim();
-    if (!shellPath) {
-      logError(`[PATH] Shell '${shell}' returned empty PATH`);
-      return;
-    }
-    // Replace with shell's PATH entirely; it's the authoritative source
-    // and preserves the user's intended priority order
-    process.env['PATH'] = shellPath;
-  } catch (err) {
-    logError(
-      `[PATH] Failed to resolve shell PATH: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  }
+
+  // Fallback: merge well-known directories into the current PATH
+  const home = os.homedir();
+  const wellKnownDirs = [
+    '/opt/homebrew/bin',
+    '/opt/homebrew/sbin',
+    `${home}/.bun/bin`,
+    `${home}/.local/bin`,
+    '/usr/local/bin',
+  ];
+
+  const pathSet = new Set(currentPath.split(':'));
+  const missing = wellKnownDirs.filter((d) => !pathSet.has(d) && fs.existsSync(d));
+  if (missing.length > 0) {
+    process.env['PATH'] = [...missing, currentPath].join(':');
+    log(`[PATH] Shell resolution failed, merged ${missing.length} well-known directories`);
+  } else {
+    logError('[PATH] Shell resolution failed and no well-known directories to add');
   }
 }
 
@@ -2446,10 +2472,14 @@ async function cleanup(): Promise<void> {
 // ---------------------------------------------------------------------------
 // Main: Start in wrapper or daemon mode
 // ---------------------------------------------------------------------------
+// Ensure PATH includes user-installed tools (claude, bun, etc.).
+// In daemon mode this is critical (LaunchAgent/systemd have minimal PATH).
+// In wrapper mode the terminal provides the PATH, but resolveShellPath is
+// safe to call (it only upgrades, never downgrades the PATH) and ensures
+// remote session creation works even after the terminal is detached (SIGHUP).
+resolveShellPath();
+
 if (cliDaemonMode) {
-  // Daemon mode: headless server, spawns Claude on WebSocket connect
-  // Resolve user's login shell PATH so spawned sessions can find tools like `claude`
-  resolveShellPath();
   console.log('Starting Remi daemon...');
 
   // Start all adapters. On EADDRINUSE, retry only the WebSocket adapter with next port.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -338,10 +338,21 @@ function resolveShellPath(): void {
       });
       if (result.exitCode !== 0) continue;
       const shellPath = result.stdout?.toString().trim();
-      if (!shellPath || shellPath.split(':').length <= currentPath.split(':').length) continue;
+      if (!shellPath) continue;
 
-      process.env['PATH'] = shellPath;
-      log(`[PATH] Resolved via ${label} shell (${shellPath.split(':').length} entries)`);
+      // Merge: use the shell PATH as the base, then append any entries from the
+      // current PATH that the shell didn't include (e.g., tool-injected directories).
+      // This ensures we never lose entries that were already available.
+      const shellEntries = shellPath.split(':');
+      const shellSet = new Set(shellEntries);
+      const extraFromCurrent = currentPath.split(':').filter((e) => e && !shellSet.has(e));
+      const merged = [...shellEntries, ...extraFromCurrent].join(':');
+      if (merged === currentPath) continue; // no improvement
+
+      process.env['PATH'] = merged;
+      log(
+        `[PATH] Resolved via ${label} shell (${shellEntries.length} shell + ${extraFromCurrent.length} existing)`,
+      );
       return;
     } catch {
       // Try next attempt
@@ -2474,8 +2485,8 @@ async function cleanup(): Promise<void> {
 // ---------------------------------------------------------------------------
 // Ensure PATH includes user-installed tools (claude, bun, etc.).
 // In daemon mode this is critical (LaunchAgent/systemd have minimal PATH).
-// In wrapper mode the terminal provides the PATH, but resolveShellPath is
-// safe to call (it only upgrades, never downgrades the PATH) and ensures
+// In wrapper mode the terminal provides the PATH, but resolveShellPath
+// merges (never drops existing entries) so it's safe to call, and ensures
 // remote session creation works even after the terminal is detached (SIGHUP).
 resolveShellPath();
 


### PR DESCRIPTION
## Summary

- Fix `resolveShellPath()` to work in LaunchAgent/systemd contexts by falling back to interactive login shell, then merging well-known tool directories
- Move `resolveShellPath()` to run in both wrapper and daemon modes (was daemon-only), so remote session creation works after terminal detach
- npm wrapper detects installer (bun vs npm) and tries that one first for auto-upgrades, with post-upgrade verification

## Root Cause

The daemon's `resolveShellPath()` ran `zsh -l -c 'echo $PATH'` which only sources `.zprofile`. On macOS, Homebrew's PATH setup (`eval "$(/opt/homebrew/bin/brew shellenv)"`) is often in `.zshrc`, which requires `-i` (interactive) flag. In LaunchAgent context, the PATH stayed at the minimal `/usr/bin:/bin:/usr/sbin:/sbin`, making `claude` unfindable.

## Test plan

- [x] All 1169 tests pass
- [x] Lint clean (0 errors)
- [x] Typecheck clean
- [x] Verified LaunchAgent daemon on MCM gets correct PATH after plist fix
- [x] Verified `zsh -l -i -c 'echo $PATH'` returns full PATH including /opt/homebrew/bin