### PR TITLE
release: merge develop into main for 0.4.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,44 @@ jobs:
       - run: bunx playwright install chromium --with-deps
       - run: bun run test:e2e
 
+  # Auto-bump dev version on every push to develop.
+  # Skips version-bump commits to avoid infinite loops.
+  auto-bump-dev:
+    name: Auto Bump Dev
+    needs: [spelling, lint, typecheck, test, e2e]
+    if: >-
+      github.ref == 'refs/heads/develop'
+      && github.event_name == 'push'
+      && !startsWith(github.event.head_commit.message, 'chore: bump version')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Bump dev version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bun install --frozen-lockfile
+          ./scripts/bump-version.sh --push dev
+
+  # Auto-release stable version when develop merges into main.
+  # Strips -dev suffix, commits, tags, and pushes to trigger release.yml.
   auto-release:
     name: Auto Release
     needs: [spelling, lint, typecheck, test, e2e]
@@ -77,8 +115,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Generate a GitHub App token so the tag push triggers release.yml.
-      # GITHUB_TOKEN pushes cannot trigger downstream workflows (GitHub security policy).
       - name: Generate App Token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -115,4 +151,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           bun install --frozen-lockfile
-          ./scripts/bump-version.sh --push stable
+          ./scripts/bump-version.sh --push --force stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,14 @@ jobs:
       - run: bun run test:e2e
 
   # Auto-bump dev version on every push to develop.
-  # Skips version-bump commits to avoid infinite loops.
+  # Skips commits from github-actions[bot] to avoid infinite loops.
   auto-bump-dev:
     name: Auto Bump Dev
     needs: [spelling, lint, typecheck, test, e2e]
     if: >-
       github.ref == 'refs/heads/develop'
       && github.event_name == 'push'
-      && !startsWith(github.event.head_commit.message, 'chore: bump version')
+      && github.event.head_commit.author.username != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.serena/memories/network_discovery_and_ls_command.md
+++ b/.serena/memories/network_discovery_and_ls_command.md
@@ -1,0 +1,400 @@
+# Remi Network Discovery & `ls` Command Implementation
+
+## Overview
+The Remi project has three distinct paths for discovering and listing Claude Code sessions:
+
+1. **`remi ls`** - Local session discovery via live registry
+2. **`remi ls --network`** - Network-wide discovery via mDNS + VPN peers
+3. **`remi ls --host <host[:port]>`** - Direct connection to specific daemon
+4. **`remi attach --host <host>`** - Similar resolution pattern for attachment
+
+## Architecture Diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                    CLI Entry (packages/daemon/src/cli.ts)           │
+│  Parses flags: --network, --host, --port                            │
+└────────────────────┬─────────────────────────────────────────────────┘
+                     │
+        ┌────────────┴────────────┬──────────────────┐
+        │                         │                  │
+        ▼                         ▼                  ▼
+   cliNetwork=true          cliHost set      no flags (default)
+        │                         │                  │
+        ▼                         ▼                  ▼
+  runNetworkLs()            runLsClient()    runMultiPortLs()
+        │                         │                  │
+        └────────────────────┬────┴──────────────────┘
+                             │
+                             ▼
+                    fetchSessions(host, port)
+                    (packages/daemon/src/cli/ls-client.ts)
+                             │
+                    ┌────────┴────────┐
+                    ▼                 ▼
+              performAuthHandshake  (session_list_response)
+              (if auth_challenge)
+```
+
+## Detailed Implementation
+
+### 1. CLI Flag Parsing (cli.ts, lines ~365-437)
+
+**Flag Variables:**
+- `cliNetwork` (boolean) - Enable network discovery mode
+- `cliHost` (string | undefined) - Target host for direct connection
+- `cliPort` (number | undefined) - Target port (default: 18765)
+- `cliNoMdns` (boolean) - Disable mDNS advertising (daemon-side)
+
+**Flag Handling:**
+```
+--network     → cliNetwork = true
+--host HOST   → cliHost = HOST (next arg consumed)
+--port PORT   → cliPort = PORT (next arg consumed)
+--local       → cliBindHost = 'localhost', cliNoMdns = true
+--no-mdns     → cliNoMdns = true (daemon: disables mDNS publishing)
+```
+
+### 2. Three Execution Paths for `remi ls` (cli.ts, lines 767-801)
+
+#### Path A: Network Discovery (`cliNetwork === true`)
+```typescript
+if (cliNetwork) {
+  await runNetworkLs({
+    localPort: explicitPort ?? DEFAULT_BASE_PORT,
+    localPorts: liveSessionsRegistry.getLivePorts()
+  });
+}
+```
+
+**Flow:**
+1. Query all local daemon ports from live registry
+2. Run mDNS discovery (Bonjour/mDNS)
+3. Run VPN discovery (Tailscale, WireGuard)
+4. Filter out self (hostname + local addresses)
+5. Deduplicate hosts discovered via both mDNS and VPN
+6. Query remote daemons in parallel
+7. Render combined results
+
+**Key Function:** `runNetworkLs()` (ls-client.ts, lines 191-328)
+
+#### Path B: Direct Host/Port Connection (`explicitPort || cliHost`)
+```typescript
+} else if (explicitPort || cliHost) {
+  await runLsClient({
+    host: cliHost ?? 'localhost',
+    port: explicitPort ?? DEFAULT_BASE_PORT
+  });
+}
+```
+
+**Flow:**
+1. Single WebSocket connection to specified host:port
+2. Send hello, then session_list_request
+3. Await session_list_response
+4. Render local format
+
+**Key Function:** `runLsClient()` (ls-client.ts, lines 50-53)
+
+#### Path C: Local Multi-Port Discovery (Default)
+```typescript
+} else {
+  await runMultiPortLs({
+    registry: liveSessionsRegistry
+  });
+}
+```
+
+**Flow:**
+1. Read live sessions registry (tracks all active daemon ports)
+2. Query each unique port in parallel
+3. Aggregate results
+4. Render local format
+
+**Key Function:** `runMultiPortLs()` (ls-client.ts, lines 461-502)
+
+### 3. WebSocket Connection & Session Fetching
+
+**Function:** `fetchSessions(host, port, timeout)` (ls-client.ts, lines 55-165)
+
+**Protocol:**
+1. Connect: `ws://host:port/ws`
+2. On open: Send `createHello(clientId, version)`
+3. Server responds with `hello_ack`
+4. Send `createSessionListRequest(false)` (false = don't create session)
+5. Wait for `session_list_response` or `auth_challenge`
+6. If `auth_challenge`: Run `performAuthHandshake()` then retry steps 2-5
+7. Close connection on error or success
+
+**Error Handling:**
+- Catches connection errors (ECONNREFUSED, timeout)
+- Ignores expected errors after session list received (SESSION_CREATE_FAILED, etc.)
+- Timeout: 5000ms default
+
+### 4. Authentication Flow (auth-helper.ts, lines 37-142)
+
+**Trigger:** Daemon sends `auth_challenge` message after `hello`
+
+**Flow:**
+1. Load identity from `~/.remi/identity.json`
+2. Auto-generate if missing (first use)
+3. If encrypted: unlock using `REMI_PASSPHRASE` env var
+4. Sign challenge with private key
+5. Send `auth_response` (public key + signature + fingerprint)
+6. Wait for `auth_result` (success/failure)
+7. Timeout: 10 seconds
+
+**Auth Enable/Disable (cli.ts, lines 1365-1380):**
+```
+Auto-enabled: binding to 0.0.0.0 (network accessible)
+Auto-disabled: binding to localhost (127.0.0.1 only)
+Explicit override: --auth or --no-auth flags
+```
+
+### 5. Network Discovery Mechanisms
+
+#### mDNS Discovery (mdns-browser.ts, lines 22-63)
+
+**Service Type:** `_remi._tcp.local`
+**TXT Records:**
+- `version` - Remi version
+- `auth` - 'true'/'false' (auth enabled)
+- `hostname` - OS hostname
+- `fingerprint` (optional) - Daemon's public key fingerprint
+
+**Discovery:**
+1. Create Bonjour instance
+2. Browse for `_remi._tcp` services
+3. Collect all found services (3s default timeout)
+4. Extract IPv4 addresses (fallback to IPv6)
+5. Return list of DiscoveredDaemon objects
+
+**Used By:** `runNetworkLs()` and `attach` with hostname resolution
+
+#### VPN Peer Discovery (vpn-discovery.ts, lines 46-89)
+
+**Supported VPNs:**
+- Tailscale: `tailscale status --json`
+- WireGuard: `wg show all dump`
+- NOT supported: ZeroTier (CLI doesn't expose VPN IPs)
+
+**Tailscale Flow (lines 188-221):**
+1. Find `tailscale` binary (PATH or fallback path)
+2. Run `tailscale status --json`
+3. Filter peers: Online=true, not iOS/Android
+4. Extract IPv4 (preferred) or first Tailscale IP
+5. Hostname from DNSName or HostName field
+
+**WireGuard Flow (lines 231-272):**
+1. Find `wg` binary (PATH or fallback paths)
+2. Run `wg show all dump`
+3. Parse tab-separated output (8-9 fields per peer)
+4. Filter: recent handshake (< 5 minutes old)
+5. Extract first allowed IP, strip CIDR notation
+
+**Deduplication:** By IP address, prefers Tailscale > WireGuard
+
+**Port Probing:** For each peer, try base port ± portRange (default: 18765-18774)
+
+### 6. Attach Command Resolution (cli.ts, lines 860-1200)
+
+**Pattern Matching (lines 868-881):**
+
+1. **Remote Format** (`host:port/session-id`):
+   - Last colon before first slash
+   - Port between colon and slash (numeric)
+   - Parse with `parseRemoteTarget()`
+
+2. **Host:Port Format** (no slash):
+   - Regex: `(.+):(\d+)$`
+   - Port > 1024 (avoid session name confusion)
+   - Auto-fetch sessions, pick attachable or most recent
+
+3. **Session Name/ID:**
+   - Check live registry (fast, local)
+   - Query all local ports (registry + default)
+   - Prefix matching (name or ID)
+
+4. **Hostname Resolution:**
+   - Extract hostname from session name (before first `:`)
+   - Run mDNS + VPN discovery in parallel
+   - Try mDNS first, fallback to VPN
+   - Query all ports on resolved host
+
+**Session Resolution Order:**
+1. Live registry (name/ID) - no network
+2. Query all local ports - local network only
+3. Session store (backward compat) - no network
+4. mDNS + VPN discovery - full network
+
+**Duplicate/Inconsistent Logic Areas:**
+- **Port resolution:** Both `attach` and `ls --network` rediscover VPN peers
+- **Session querying:** `attach` manually queries ports, `ls --network` uses shared logic
+- **Name resolution:** `attach` has inline code, `ls --host` uses single-port logic
+- **Error handling:** Different messages in different paths
+- **Timeout handling:** Different timeouts (3000ms for attach name resolution, 5000ms for ls)
+
+## Key Data Structures
+
+### DiscoverableSession (from @remi/shared)
+```typescript
+interface DiscoverableSession {
+  sessionId: UUID;
+  projectPath: string;
+  status: 'active' | 'idle' | 'completed';
+  lastActivity: Timestamp;
+  messageCount?: number;
+  model?: string;
+  lastMessage?: string;
+  source?: 'live' | 'transcript' | 'daemon';
+  canAttach?: boolean;
+  name?: string;
+  createdAt?: Timestamp;
+}
+```
+
+### DiscoveredDaemon (mdns-browser.ts)
+```typescript
+interface DiscoveredDaemon {
+  name: string;        // mDNS service name
+  host: string;        // IP to connect to
+  port: number;
+  version: string;
+  authEnabled: boolean;
+  fingerprint?: string;
+  hostname: string;    // OS hostname
+}
+```
+
+### VpnPeer (vpn-discovery.ts)
+```typescript
+interface VpnPeer {
+  hostname: string;
+  ip: string;          // VPN IP address
+  os: string;
+  provider: 'tailscale' | 'wireguard';
+}
+```
+
+## Constants & Defaults
+
+- **Default Port:** 18765 (DEFAULT_BASE_PORT)
+- **Port Range:** 10 ports (18765-18774) for VPN probing
+- **mDNS Service Type:** `_remi._tcp.local`
+- **Fetch Timeout:** 5000ms
+- **mDNS Browse Timeout:** 3000ms
+- **VPN Probe Timeout:** 2000ms per probe
+- **Auth Handshake Timeout:** 10000ms
+- **Hostname Resolution (attach):** 3000ms mDNS, 2000ms VPN
+
+## Flow Variants
+
+### `remi ls`
+1. Query live registry for local ports
+2. Query each port in parallel
+3. Render results (local format, no host column)
+
+### `remi ls --network`
+1. Query all local ports
+2. mDNS discover + VPN discover (parallel)
+3. Query remote daemons (parallel)
+4. Render results (network format, host column, attach hints)
+
+### `remi ls --host 192.168.1.5`
+1. Single WebSocket to `192.168.1.5:18765`
+2. Render results (local format)
+
+### `remi ls --host 192.168.1.5 --port 18766`
+1. Single WebSocket to `192.168.1.5:18766`
+2. Render results (local format)
+
+### `remi attach session-name`
+1. Check live registry
+2. Query all local ports
+3. Check session store
+4. If not found locally, extract hostname from name
+5. mDNS + VPN discovery for hostname
+6. Query all ports on resolved host
+7. Connect and attach
+
+### `remi attach 192.168.1.5:18765/session-name`
+1. Parse remote format
+2. Single WebSocket to `192.168.1.5:18765`
+3. Resolve session by name
+4. Attach
+
+### `remi attach 192.168.1.5:18765`
+1. Parse host:port (no session ID)
+2. Fetch sessions from `192.168.1.5:18765`
+3. Auto-pick attachable or most recent
+4. Attach
+
+## Inconsistencies & Duplicate Logic
+
+### 1. VPN Discovery
+- Runs in both `runNetworkLs()` and `attach` command
+- Same discovery logic duplicated
+- Different timeout configurations (3000ms vs 2000ms)
+- No shared function; each implements filtering
+
+### 2. Port Resolution
+- `runNetworkLs()`: Uses `liveSessionsRegistry.getLivePorts()`
+- `attach`: Uses `cliPort || cliHost ? [port] : getLivePorts()`
+- Logic slightly different in condition order
+
+### 3. Session Querying
+- `runNetworkLs()`: Filters local daemons, then queries all
+- `attach`: Manual loop through `portsToQuery`, different error messages
+- `runLsClient()`: Single port, simple flow
+- `runMultiPortLs()`: All ports from registry, shared rendering
+
+### 4. Error Handling
+- `runNetworkLs()`: Dims expected errors with `\x1b[2m` (dimmed)
+- `attach`: No dimming, different messages
+- Different classification of "expected" errors
+- Inconsistent logging prefixes (`[ls]` vs `[attach]`)
+
+### 5. Timeout Configurations
+- Fetch timeout: 5000ms (ls), 3000ms (attach name resolution)
+- mDNS timeout: 3000ms (ls), 3000ms (attach)
+- VPN probe timeout: 2000ms (both)
+
+### 6. Deduplication
+- `runNetworkLs()`: Tracks via `discoveredHosts` Set
+- `attach`: Deduplication inline within `allHostPorts` Set
+- VPN result filtering: Different logic paths
+
+### 7. Session Name vs ID Resolution
+- `attach`: Inline resolution with multiple fallback stages
+- `kill`: Similar but separate implementation in kill-client.ts
+- `ls`: No name resolution (not needed, just lists)
+
+## Files Involved
+
+### Core CLI
+- `packages/daemon/src/cli.ts` (2500+ lines, main entry)
+
+### Client Operations
+- `packages/daemon/src/cli/ls-client.ts` - runLsClient, runNetworkLs, runMultiPortLs, fetchSessions
+- `packages/daemon/src/cli/kill-client.ts` - runKillClient
+- `packages/daemon/src/cli/auth-helper.ts` - performAuthHandshake
+- `packages/daemon/src/cli/detach-scanner.ts` - DetachScanner
+
+### Discovery
+- `packages/daemon/src/mdns/mdns-browser.ts` - discoverDaemons
+- `packages/daemon/src/mdns/mdns-publisher.ts` - MdnsPublisher
+- `packages/daemon/src/mdns/vpn-discovery.ts` - discoverVpnPeers, getAllVpnPeers, getTailscalePeers, getWireGuardPeers
+- `packages/daemon/src/mdns/constants.ts` - MDNS_SERVICE_TYPE
+
+### Session Management
+- `packages/daemon/src/session/session-registry-file.ts` - Live sessions registry
+- `packages/daemon/src/transcript/transcript-discovery.ts` - TranscriptDiscovery
+- `packages/daemon/src/transcript/transcript-watcher.ts` - TranscriptWatcher
+
+### Shared Protocol
+- `packages/shared/src/protocol.ts` - Message types
+- `packages/shared/src/types.ts` - DiscoverableSession, etc.
+
+## Testing
+- `packages/daemon/tests/cli/ls-client.test.ts` - Tests for ls client operations
+- `packages/daemon/tests/mdns/*` - mDNS tests (if present)

--- a/.serena/memories/session_and_connection_architecture.md
+++ b/.serena/memories/session_and_connection_architecture.md
@@ -1,0 +1,340 @@
+# Remi Session and Connection Architecture - Deep Dive
+
+## Overview
+Remi manages Claude Code sessions with a clear separation between **session lifecycle** (independent of connections) and **connection management** (clients attaching/detaching from sessions).
+
+---
+
+## 1. SESSION REGISTRY (session-registry.ts)
+
+### Key Concepts
+- **Sessions survive connection drops** via orphan timeout mechanism
+- **Orphaned state**: When a connection detaches, non-locally-owned sessions enter orphan state for 5 minutes (default), then timeout/cleanup
+- **Locally-owned sessions** (wrapper mode): Never timeout while connected or locally owned, remain alive indefinitely until PTY exits
+- **One active connection per session**: Only one client can have an attached connection at any time
+
+### ManagedSession State
+```
+sessionId             - Unique session ID (UUID)
+name                  - Human-readable name (e.g., "hostname:dirname/branch")
+createdAt             - When session was created
+workingDirectory      - Working directory for Claude Code
+
+PTY & MessageAPI      - References to running PTY and message processor
+lastActivityAt        - Timestamp of last message/status change
+
+activeConnectionId    - Current attached connection ID (null if none)
+lastDisconnectedAt    - When last connection detached (null if connected)
+orphanTimeoutId       - Timeout handle for cleanup on orphan timeout
+
+messageHistory[]      - Messages for replay (capped at 1000)
+lastDeliveredIndex    - Index of last delivered message
+currentStatus         - Agent status (idle, running, etc.)
+currentQuestion       - Current pending question (if any)
+
+locallyOwned          - TRUE for wrapper mode sessions (NEVER timeout)
+```
+
+### Session Lifecycle
+
+#### Creation
+1. `sessionRegistry.createSessionId()` generates new UUID
+2. `registerSession(sessionId, pty, messageApi, locallyOwned)` stores session with:
+   - `activeConnectionId = null` (no one attached yet)
+   - `lastDisconnectedAt = null` (not orphaned)
+   - `orphanTimeoutId = null` (no timeout)
+   - `locallyOwned = false` (daemon mode) or `true` (wrapper mode)
+
+#### Connection Attach
+- `attachConnection(sessionId, connectionId)` called when client connects
+- **Exclusive Lock**: Returns error if `activeConnectionId !== null` (session already has client!)
+- On success:
+  - `activeConnectionId = connectionId`
+  - `lastDisconnectedAt = null`
+  - Clears orphan timeout if resuming
+  - Marks all history as delivered
+  - Returns `replayMessages` (history since last delivery)
+
+#### Detach (Connection closes)
+- `detachConnection(connectionId)` called when client disconnects
+- Sets `activeConnectionId = null`
+- Sets `lastDisconnectedAt = now()`
+- **For non-locally-owned sessions**: Starts orphan timeout → cleanup after 5 min
+- **For locally-owned sessions** (wrapper): No timeout, stays alive indefinitely
+
+#### Cleanup
+- `closeSession(sessionId, reason)` removes session from registry
+- Closes PTY (unless reason is 'pty_exit')
+- Reason: 'timeout', 'pty_exit', or 'forced'
+
+### Multi-Attach Behavior
+**Current behavior**: Session rejects second attach attempt with error "Session already has active connection"
+
+```typescript
+if (session.activeConnectionId !== null) {
+  return {
+    success: false,
+    error: 'Session already has active connection',
+  };
+}
+```
+
+This enforces **exclusive connection ownership**. Second client must wait for first to detach.
+
+---
+
+## 2. CONNECTION CLASS (connection.ts)
+
+### Connection State Machine
+```
+Without auth:
+  connecting -> connected -> disconnected
+
+With auth enabled:
+  authenticating -> connecting -> connected -> disconnected
+```
+
+### Key Properties
+```
+id                    - Connection UUID
+state                 - Current connection state
+sessionId             - Session ID assigned from hello message
+directory             - Working directory (null if not specified)
+resumeSessionId       - Session to resume (null if creating new)
+
+ws                    - WebSocket reference
+messageTracker        - Deduplication tracker (message ID tracking)
+pingTimer             - Keep-alive ping interval
+connectionTimer       - Timeout for auth/hello phase
+```
+
+### Connection Lifecycle
+
+#### 1. WebSocket Handshake
+- Starts in `connecting` state
+- If authenticator configured: becomes `authenticating` state, sends challenge
+- Default timeout: 10 seconds (auth: 60 seconds)
+
+#### 2. Authentication Phase (if enabled)
+- Daemon sends `auth_challenge`
+- Client sends `auth_response`
+- On success: transitions to `connecting` (waiting for hello)
+- On failure: closes connection
+
+#### 3. Hello Exchange
+- Client sends `hello` with optional `resumeSessionId`
+- `sessionId = connection.id` (connection ID is the session ID)
+- Server responds with `hello_ack` containing session ID
+- Transitions to `connected` state
+- Starts ping timer (30-second intervals)
+
+#### 4. Active Session
+- Receives user input, answers, requests, etc.
+- All messages checked for duplicates via `messageTracker`
+- Sessions can be idle (connected but not running)
+
+#### 5. Disconnection
+- WebSocket closes → `handleClose()` → `cleanup()`
+- Triggers `onDisconnect` event
+- Connection unlinks from session via `detachConnection()`
+
+### Message Handling
+- **Valid only in connected state**: user_input, answer, bullet_expand_request, terminal_resize
+- **Allowed before connected**: session_list_request, transcript_load_request, create_session_request, ping
+- **Deduplication**: Same message ID within dedup window is acknowledged but not processed
+
+---
+
+## 3. DAEMON VS WRAPPER MODE
+
+### Port Allocation (SessionRegistryFile)
+Each wrapper process writes a JSON entry to `~/.remi/live-sessions/<session-id>.json`:
+```json
+{
+  "sessionId": "uuid",
+  "pid": 12345,
+  "wsPort": 18765,
+  "hookPort": 18865,
+  "projectPath": "/path/to/project",
+  "name": "project-name",
+  "startedAt": "2026-03-20T..."
+}
+```
+
+**Port Range**: Default 18765-18774 (10 ports)
+- **Daemon mode** (--daemon): Uses explicit port or single port
+- **Wrapper mode**: Auto-selects available port from range
+  - `findAvailablePort()` checks live entries to avoid conflicts
+  - Checks PID liveness (stale entries auto-cleaned)
+  - Max 3 retry attempts on EADDRINUSE race
+
+### Daemon Mode (`--daemon`)
+1. **No auto-session**: Waits for client `create_session_request`
+2. **Headless**: No local PTY attached, no terminal I/O
+3. **Multi-session**: Single daemon can host multiple sessions (different connections)
+4. **Port**: Explicit or single fixed port
+5. **Startup**:
+   - Starts WebSocket server on specified port
+   - Advertises via mDNS (if not localhost)
+   - Ready to accept connections
+
+```typescript
+if (!wrapperMode) {
+  sendToConnection(connectionId, createHelloAck('1.0.0', '' as UUID));
+  log(`Connection ${connectionId} accepted in daemon mode (no auto-session)`);
+}
+```
+
+### Wrapper Mode (Default)
+1. **Auto-create primary session**: Creates PTY immediately on startup
+2. **One session per process**: Local terminal + remote clients all share ONE session
+3. **Pass-through terminal**: Local terminal I/O flows through PTY directly
+4. **Port auto-selection**: Finds available port from range, retries on collision
+5. **Locally owned**: Primary session marked `locallyOwned = true` (no orphan timeout)
+6. **Detach support**: Ctrl+B d detaches local terminal, keeps PTY alive
+7. **Startup**:
+   - Auto-selects port from 18765-18774
+   - Creates primary session with `locallyOwned = true`
+   - Starts hook server (Claude Code event detection)
+   - Spawns Claude Code PTY with pass-through enabled
+   - Writes session file to live-sessions dir
+   - When client connects → auto-attach to primary session
+
+```typescript
+if (wrapperMode && primarySessionId && !resumeSessionId) {
+  const result = sessionRegistry.attachConnection(primarySessionId, connectionId);
+  if (result.success) {
+    sendToConnection(connectionId, createHelloAck(...));
+    // Client auto-attached to primary session
+  }
+}
+```
+
+---
+
+## 4. ATTACH FLOW (attach-client.ts)
+
+### Multi-Attach Behavior
+
+When a second client tries to attach:
+
+1. **Connection established** → sends `hello` with session ID
+2. **Daemon receives hello** → calls `onConnect` event handler
+3. **Check primary session**: `wrapperMode && primarySessionId`
+   - If primary session has `activeConnectionId !== null`: attach fails
+   - Returns "Session already has active connection" error
+4. **Result**: Client receives error and must wait for first client to detach
+
+### Attach Sequence
+1. Client connects WebSocket
+2. Optional: auth handshake if auth enabled
+3. Client sends `hello(clientId, version, resumeSessionId)`
+4. Server:
+   - If resuming: calls `canResume(resumeSessionId)` → checks `activeConnectionId === null`
+   - If successful: calls `attachConnection()` → sets `activeConnectionId = connectionId`
+   - Sends `hello_ack` with session ID and `replayCount`
+5. Client receives `replay_batch` with message history
+6. Client enters raw terminal mode (if CLI attach)
+7. Client sends raw PTY bytes to server
+8. Server forwards to `session.activeConnectionId`
+
+### Session Resume After Detach
+1. Client detaches (WebSocket closes)
+2. `detachConnection(connectionId)` → `activeConnectionId = null`
+3. Client reconnects with same `resumeSessionId`
+4. `canResume(sessionId)` checks if `activeConnectionId === null` → TRUE
+5. `attachConnection(resumeSessionId, newConnectionId)` succeeds
+6. Replay messages sent to restore state
+
+### Example: Re-attach Same Session
+```
+Client 1 attaches    → Connection A, activeConnectionId = A
+Client 1 detaches    → activeConnectionId = null, orphan timeout started
+Client 1 re-attaches → canResume(sessionId) = true
+                     → attachConnection succeeds, Connection B, activeConnectionId = B
+Client 2 tries attach → canResume(sessionId) = false (because activeConnectionId = B)
+                      → attach fails with "Session already has active connection"
+```
+
+---
+
+## 5. SESSION STATE DIAGRAM
+
+```
+Created:
+  activeConnectionId = null
+  lastDisconnectedAt = null
+  orphanTimeoutId = null
+  
+    ↓
+    
+Client Attaches:
+  activeConnectionId = connectionId
+  lastDisconnectedAt = null
+  orphanTimeoutId = null
+  (exclusive lock established)
+  
+    ↓
+    
+Client Detaches:
+  activeConnectionId = null
+  lastDisconnectedAt = now()
+  
+  ├─ If locallyOwned: no timeout (stays alive)
+  └─ If not: orphanTimeoutId = setTimeout(5 min)
+  
+    ↓
+    
+If Orphan Timeout Expires:
+  closeSession('timeout')
+  (removed from registry)
+  
+OR
+  
+If PTY Exits:
+  closeSession('pty_exit')
+  (removed from registry)
+  
+OR
+  
+If Client Re-attaches:
+  activeConnectionId = newConnectionId
+  lastDisconnectedAt = null
+  orphanTimeoutId = null (cleared)
+  (exclusive lock re-established)
+```
+
+---
+
+## 6. KEY FINDINGS
+
+### Session Uniqueness
+- Session ID = Connection ID for new sessions (set in hello)
+- Same session ID can have multiple connections over time (via resume)
+- But only ONE active connection at any time (exclusive lock)
+
+### Multi-Attach Prevention
+- `attachConnection()` checks `activeConnectionId !== null`
+- Returns error if already attached
+- Second client must wait for first to detach
+- No queue or multi-client support
+
+### Port Selection
+- **Wrapper mode**: Auto-selects from 18765-18774 (10 ports max)
+- **Daemon mode**: Single explicit/fixed port
+- **File-based registry**: `~/.remi/live-sessions/<sessionId>.json`
+- **PID liveness checks**: Stale entries auto-cleaned
+
+### Locally-Owned Sessions
+- Marked in `registerSession(locallyOwned = true/false)`
+- In wrapper mode: primary session is `locallyOwned = true`
+- In daemon mode: sessions are `locallyOwned = false` (default)
+- Locally-owned: **NO orphan timeout**, survives indefinitely until PTY exit
+- Non-locally-owned: **5-minute timeout** after detach
+
+### Connection vs Session
+- **Connection**: WebSocket transport, state machine, message handling
+- **Session**: PTY process, message history, active connection tracking
+- Sessions persist after connection closes (orphan timeout)
+- Connections don't persist after detach
+- 1:1 mapping for active connections; many:1 for resume lifetime

--- a/.serena/memories/web_session_handling_deep_dive.md
+++ b/.serena/memories/web_session_handling_deep_dive.md
@@ -1,0 +1,520 @@
+# Remi Web App Session Handling - Comprehensive Deep Dive
+
+## Overview
+The Remi web app provides a React-based interface for monitoring and interacting with Claude Code sessions. Session handling spans:
+1. **Session Discovery & Listing** - discovering sessions from daemon and transcripts
+2. **Session UI Display** - session lists, session cards, switchers
+3. **Session Selection & Switching** - active session tracking
+4. **Recent Projects** - quick-start from recent directories
+5. **Session Persistence** - localStorage state management
+
+---
+
+## 1. SESSION DISCOVERY & LISTING
+
+### Protocol Messages
+**SessionListRequestMessage** (in `packages/shared/src/protocol.ts`)
+```typescript
+export interface SessionListRequestMessage {
+  readonly type: 'session_list_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  readonly includeExternal?: boolean; // Include transcript sessions
+}
+```
+
+**SessionListResponseMessage**
+```typescript
+export interface SessionListResponseMessage {
+  readonly type: 'session_list_response';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  readonly sessions: readonly DiscoverableSession[];
+  readonly requestId: UUID;
+}
+```
+
+### Daemon Side (cli.ts, line 1783)
+Handler: `onSessionListRequest`
+
+Process:
+1. Get daemon-managed sessions: `sessionRegistry.listSessions()`
+2. If `includeExternal=true`: add transcript-discovered sessions
+3. Send `session_list_response` with all sessions
+
+```typescript
+onSessionListRequest: (connectionId, requestId, includeExternal) => {
+  const daemonSessions = sessionRegistry.listSessions();
+  let allSessions = [...daemonSessions];
+  
+  if (includeExternal) {
+    const managedIds = new Set(sessionRegistry.getActiveSessionIds());
+    const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
+    allSessions = [...daemonSessions, ...externalSessions];
+  }
+  
+  sendToConnection(connectionId, createSessionListResponse(allSessions, requestId));
+};
+```
+
+### DiscoverableSession Fields
+(From shared types)
+- `sessionId` - UUID
+- `status` - 'active' | 'idle'
+- `projectPath` - working directory
+- `lastActivity` - ISO timestamp
+- `messageCount` - total messages in session
+- `lastMessage` - preview of last message
+- `canAttach` - boolean (session has no active connection)
+- `source` - 'daemon' | 'transcript'
+
+### Web App Side (App.tsx, line 384)
+Handler: `session_list_response`
+
+Mapping to UISession:
+```typescript
+case 'session_list_response': {
+  const discovered: UISession[] = message.sessions.map((ds) => ({
+    id: ds.sessionId as UUID,
+    name: ds.name || ds.projectPath.split('/').pop() || 'Session',
+    createdAt: ds.lastActivity,
+    lastActiveAt: ds.lastActivity,
+    status: mapSessionStatus(ds.status),           // 'active' -> 'executing', 'idle' -> 'idle'
+    connectionStatus: ds.canAttach ? 'connected' : 'disconnected',
+    unreadCount: 0,
+    cwd: ds.projectPath,
+    preview: ds.lastMessage || `${ds.messageCount} messages`,
+    source: ds.source,
+  }));
+
+  setSessions((prev) => {
+    // Merge: keep existing, add new from discovery
+    const existingIds = new Set(prev.map((s) => s.id));
+    const newSessions = discovered.filter((s) => !existingIds.has(s.id));
+    return [...prev, ...newSessions];
+  });
+};
+```
+
+---
+
+## 2. SESSION UI COMPONENTS
+
+### SessionList (components/session/SessionList.tsx)
+Main sidebar component showing all sessions.
+
+**Props:**
+```typescript
+interface SessionListProps {
+  readonly sessions: readonly UISession[];
+  readonly activeSessionId: UUID | null;
+  readonly onSelectSession: (id: UUID) => void;
+  readonly onNewSession?: (directory?: string) => void;
+  readonly onConnect?: () => void;
+  readonly onSettings?: () => void;
+  readonly recentDirectories?: readonly RecentDirectory[];
+}
+```
+
+**Features:**
+- Empty state with "Connect to daemon" button
+- SessionCard list (maps each session)
+- RecentProjects component
+- Floating "New session" button
+
+### SessionCard (components/session/SessionCard.tsx)
+Individual session display in the list.
+
+**Shows:**
+- Status dot (color/animation based on connection + agent status)
+- Session name
+- Last active timestamp (relative time)
+- Preview text or status message
+- Working directory (cwd)
+- Unread count badge (9+ clamped)
+
+**Status Dot Logic:**
+1. Connection status takes priority:
+   - `error` -> red
+   - `disconnected` -> gray
+   - `connecting/reconnecting` -> yellow (pulsing)
+2. Then agent status when connected:
+   - `thinking/executing` -> blue (pulsing)
+   - `waiting` -> yellow
+   - `idle` -> gray
+
+### SessionSwitcher (components/chat/SessionSwitcher.tsx)
+Slide-out drawer showing all sessions with quick-switch capability.
+
+**Features:**
+- Drawer animation (slide from left)
+- Session count badge
+- Summary bar: unread count + pending questions count
+- Per-session info:
+  - Status dot (same logic as SessionCard)
+  - Session name
+  - Last active time
+  - Preview text
+  - Question pending indicator (warning badge)
+  - Unread count badge (clamped to 99+)
+- Active session highlighted with blue left border
+
+**Key Detail:** `totalUnread` and `totalQuestions` computed at render time:
+```typescript
+const totalUnread = sessions.reduce((sum, s) => sum + s.unreadCount, 0);
+const totalQuestions = sessions.filter((s) => s.questionPending).length;
+```
+
+### RecentProjects (components/session/RecentProjects.tsx)
+Shows recently-used project directories for quick-start.
+
+**Input:**
+```typescript
+interface RecentProjectsProps {
+  readonly directories: readonly RecentDirectory[];
+  readonly onStartSession: (directory: string) => void;
+}
+```
+
+**Features:**
+- Shows top 5 directories (expands to show more)
+- Per-directory display:
+  - Folder icon
+  - Display name (basename)
+  - Age (e.g., "3m ago")
+  - Session count
+  - Play button (hidden until hover)
+- "Show N more" toggle
+- Custom directory input at bottom (Enter key or Start button)
+
+---
+
+## 3. SESSION PERSISTENCE & STATE MANAGEMENT
+
+### App.tsx Session State
+```typescript
+// State
+const [sessions, setSessions] = useState<UISession[]>([]);
+const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
+const [showSessionSwitcher, setShowSessionSwitcher] = useState(false);
+const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
+
+// Refs
+const activeSessionIdRef = useRef<UUID | null>(null);
+const loadedTranscriptsRef = useRef<Set<string>>(new Set());
+```
+
+### localStorage Keys
+```typescript
+const LOCALSTORAGE_URL_KEY = 'remi-last-url';        // Last daemon URL
+const LOCALSTORAGE_SESSION_KEY = 'remi-last-session'; // Last active session ID
+const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';    // User settings (theme, font, etc.)
+```
+
+### Session Restoration on App Load
+(App.tsx)
+```typescript
+// Restore session ID from localStorage for reconnect after page reload
+const [storedSessionId] = useState<UUID | null>(() => {
+  try {
+    const stored = localStorage.getItem(LOCALSTORAGE_SESSION_KEY);
+    return stored ? (JSON.parse(stored) as UUID) : null;
+  } catch {
+    return null;
+  }
+});
+```
+
+This is read once on mount to set `activeSessionId`.
+
+### updateSessionActivity Function (App.tsx, line 86)
+Updates a session's state when activity occurs:
+```typescript
+function updateSessionActivity(
+  sessions: UISession[],
+  sessionId: UUID,
+  activeId: UUID | null,
+  preview?: string,
+): UISession[] {
+  return sessions.map((s) =>
+    s.id === sessionId
+      ? {
+          ...s,
+          lastActiveAt: new Date().toISOString(),
+          questionPending: false,  // Clear pending question indicator
+          unreadCount: s.id === activeId ? s.unreadCount : s.unreadCount + 1,  // Increment if not active
+          preview: preview?.slice(0, 80) || s.preview,  // Update preview
+        }
+      : s,
+  );
+}
+```
+
+---
+
+## 4. RECENT DIRECTORIES / SESSION HISTORY
+
+### SessionHistoryRequestMessage (protocol.ts)
+```typescript
+export interface SessionHistoryRequestMessage {
+  readonly type: 'session_history_request';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  readonly limit?: number;
+}
+```
+
+### RecentDirectory Type (protocol.ts)
+```typescript
+export interface RecentDirectory {
+  readonly directory: string;        // Absolute path
+  readonly lastUsed: Timestamp;      // ISO timestamp
+  readonly sessionCount: number;     // Number of sessions in this directory
+  readonly displayName: string;      // basename(directory)
+}
+```
+
+### Daemon Side (cli.ts, line 1958)
+Handler: `onSessionHistoryRequest`
+
+Process:
+```typescript
+onSessionHistoryRequest: (connectionId, requestId, limit) => {
+  const clampedLimit = Math.max(1, limit ?? 20);
+  const directories = getRecentDirectories(sessionStore, clampedLimit);
+  sendToConnection(connectionId, createSessionHistoryResponse(directories, requestId));
+};
+```
+
+Implementation (line 1572):
+```typescript
+function getRecentDirectories(store: SessionStore, limit: number): RecentDirectory[] {
+  const sessions = store.list();
+  const dirMap = new Map<string, { count: number; lastUsed: string }>();
+
+  // Aggregate sessions by directory
+  for (const s of sessions) {
+    const dir = s.projectPath;
+    const existing = dirMap.get(dir);
+    if (existing) {
+      existing.count++;
+      if (s.startedAt > existing.lastUsed) {
+        existing.lastUsed = s.startedAt;
+      }
+    } else {
+      dirMap.set(dir, { count: 1, lastUsed: s.startedAt });
+    }
+  }
+
+  // Sort by last used (newest first), limit results
+  const entries = Array.from(dirMap.entries())
+    .map(([directory, { count, lastUsed }]) => ({
+      directory,
+      lastUsed,
+      sessionCount: count,
+      displayName: path.basename(directory),
+    }))
+    .sort((a, b) => (a.lastUsed > b.lastUsed ? -1 : 1))
+    .slice(0, limit);
+
+  return entries;
+}
+```
+
+**Key:** Aggregates all session records from SessionStore, groups by directory, keeps newest timestamp per directory.
+
+### Web App Side (App.tsx, line 408)
+Handler: `session_history_response`
+
+```typescript
+case 'session_history_response': {
+  setRecentDirectories([...message.directories]);
+  break;
+}
+```
+
+These are then passed to `RecentProjects` component via props.
+
+---
+
+## 5. SESSION SELECTION & SWITCHING
+
+### handleSelectSession (App.tsx)
+```typescript
+const handleSelectSession = useCallback((sessionId: UUID) => {
+  setActiveSessionId(sessionId);
+  setShowSessionSwitcher(false);  // Close switcher
+  localStorage.setItem(LOCALSTORAGE_SESSION_KEY, JSON.stringify(sessionId));
+  // Load messages for this session
+}, []);
+```
+
+### handleOpenSessions
+Opens the SessionSwitcher drawer:
+```typescript
+const handleOpenSessions = useCallback(
+  () => setShowSessionSwitcher(true),
+  []
+);
+
+const handleCloseSessionSwitcher = useCallback(
+  () => setShowSessionSwitcher(false),
+  []
+);
+```
+
+### handleBack
+Returns from chat view to session list (mobile):
+```typescript
+const handleBack = useCallback(() => {
+  setActiveSessionId(null);
+}, []);
+```
+
+---
+
+## 6. NEW SESSION CREATION
+
+### handleConnectCode / handleConnectDirect
+Initiate connections to daemon.
+
+### handleNewSession (implied from props)
+Triggers `onNewSession` callback which:
+1. Sends `create_session_request` to daemon
+2. Daemon creates new PTY session
+3. Web app receives `create_session_response` with new `sessionId`
+4. New session is auto-attached and loaded
+
+### Session Creation Flow
+```
+Client: createCreateSessionRequest(directory)
+  ↓
+Daemon: onCreateSessionRequest handler (line 1864)
+  - Resolves directory
+  - Creates sessionId: sessionRegistry.createSessionId()
+  - Spawns PTY: createNewSession()
+  - Registers session: sessionRegistry.registerSession()
+  - Attaches connection: sessionRegistry.attachConnection()
+  - Sends createCreateSessionResponse(success, sessionId)
+  ↓
+Client: case 'create_session_response'
+  - If success: add new session to state
+  - Attach to new session
+  - Load messages
+```
+
+---
+
+## 7. MESSAGE DELIVERY & UPDATES
+
+### Session Update Flow
+As messages arrive from daemon:
+1. **Per-message:** `updateSessionActivity()` bumps `lastActiveAt`, updates preview, increments unread count (if not active session)
+2. **On question:** Sets `questionPending: true`
+3. **On new message:** Sets `preview` to last output
+
+### Unread Count Logic
+- Incremented for each message on sessions that are NOT active
+- Reset when switching to that session (via activity update)
+- Also cleared when status updates occur
+
+---
+
+## 8. EXISTING SESSION-RELATED FEATURES
+
+### What's Already Implemented
+1. **Session Discovery** - list daemon + transcript sessions
+2. **Session Selection** - switch between sessions (single active)
+3. **Session Persistence** - last session ID to localStorage
+4. **Session Status Display** - connection + agent status dots
+5. **Session Preview** - last message preview per session
+6. **Recent Projects** - quick-start from history
+7. **Unread Count Tracking** - per-session message counts
+8. **Question Pending Indicator** - marks session with pending question
+9. **Session Metadata** - name, cwd, last activity, message count
+10. **Multi-Source Sessions** - daemon + transcript sources in same list
+
+### Session Limitations / Gaps
+1. **No Session Grouping** - all sessions in flat list (no workspaces/projects)
+2. **No Session Filtering/Search** - no way to filter sessions by name/path
+3. **No Session Sorting Options** - fixed sort (discovery order)
+4. **No Custom Session Labeling** - can't rename or tag sessions
+5. **No Session Archiving** - no hide/delete from list
+6. **No Session Sharing** - can't share session state between devices (except via transcript)
+7. **No Session Sync** - no cross-device session sync
+8. **No Favorites/Pinning** - can't pin frequently-used sessions to top
+9. **No Session Statistics** - no time spent, message count history
+10. **No Session Export** - no bulk export of session history
+11. **No Multi-Tab Session Persistence** - localStorage only, single browser
+12. **No Session Collaboration** - no real-time multi-user session viewing (except Telegram adapter)
+13. **No Session Snapshot/Checkpoint** - can't save session state at a point in time
+14. **No Session Diff** - can't compare session states across time
+15. **No Session Restoration UI** - resuming sessions is automatic, no explicit UI
+
+---
+
+## 9. DATA FLOW DIAGRAM
+
+```
+┌─────────────────┐
+│  Web App State  │
+│  - sessions[]   │
+│  - activeId     │
+│  - messages[]   │
+│  - recent[]     │
+└────────┬────────┘
+         │
+         ├─ SessionList (displays sessions)
+         │  └─ SessionCard (per session)
+         │  └─ RecentProjects (quick-start)
+         │
+         ├─ SessionSwitcher (drawer)
+         │  └─ Per-session buttons
+         │
+         └─ ChatView (active session)
+            └─ MessageList
+            └─ InputArea
+
+Protocol:
+  ┌──────────────────────────────────────┐
+  │ session_list_request                 │
+  │ session_history_request              │
+  │ create_session_request               │
+  └──────────────────────────────────────┘
+           │                 ↑
+           ↓                 │
+  ┌──────────────────────────────────────┐
+  │ Daemon (SessionRegistry + Stores)    │
+  │ - listSessions()                     │
+  │ - getRecentDirectories()             │
+  │ - createSession()                    │
+  └──────────────────────────────────────┘
+           │
+           └─ session_list_response
+             session_history_response
+             create_session_response
+```
+
+---
+
+## 10. FILES INVOLVED
+
+### Web App
+- **App.tsx** - Main app state, message handling, session logic
+- **SessionList.tsx** - Session list component
+- **SessionCard.tsx** - Individual session card
+- **SessionSwitcher.tsx** - Session drawer switcher
+- **RecentProjects.tsx** - Recent directories component
+- **types/index.ts** - UISession, UIMessage, etc. types
+- **hooks/useWebSocket.ts** - WebSocket connection management
+
+### Daemon
+- **cli.ts** - Main event handlers, session requests
+- **session/session-registry.ts** - Session lifecycle management
+- **server/websocket-server.ts** - WebSocket server
+- **server/connection.ts** - Connection state machine
+
+### Shared
+- **protocol.ts** - SessionListRequest/Response, SessionHistoryRequest/Response, etc.
+- **types.ts** - DiscoverableSession, RecentDirectory types
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.10-dev.1",
+  "version": "0.4.10-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.9",
+  "version": "0.4.10-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.9'; // REMI_COMPILED_VERSION
+      return '0.4.10-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.9'; // REMI_COMPILED_VERSION
+    return '0.4.10-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -315,21 +315,25 @@ function logError(...args: unknown[]): void {
  * include user-installed tools (e.g. ~/.local/bin, Homebrew, ~/.bun/bin).
  *
  * Strategy:
- * 1. Run login shell (`zsh -l -c`) which sources .zprofile
- * 2. If that returns a suspiciously short PATH (missing Homebrew/bun),
- *    try interactive login shell (`zsh -l -i -c`) which also sources .zshrc
+ * 1. Run both login shell (`zsh -l`) and interactive login shell (`zsh -l -i`)
+ * 2. Merge all discovered entries (login shell may have .zprofile paths,
+ *    interactive may have .zshrc paths like Homebrew or nvm)
  * 3. Merge well-known tool directories as a final fallback
+ * 4. Verify `claude` is findable; warn if not
  */
 function resolveShellPath(): void {
   const shell = process.env['SHELL'] || '/bin/zsh';
-  const currentPath = process.env['PATH'] || '';
+  const currentEntries = (process.env['PATH'] || '').split(':').filter(Boolean);
+  const allEntries = new Set(currentEntries);
 
-  // Try login shell first, then interactive login shell
+  // Run both shells and merge all discovered PATH entries.
+  // Login shell sources .zprofile; interactive login shell also sources .zshrc.
   const attempts: Array<{ flags: string[]; label: string }> = [
     { flags: ['-l', '-c', 'echo $PATH'], label: 'login' },
     { flags: ['-l', '-i', '-c', 'echo $PATH'], label: 'interactive login' },
   ];
 
+  let anyShellSucceeded = false;
   for (const { flags, label } of attempts) {
     try {
       const result = Bun.spawnSync([shell, ...flags], {
@@ -347,45 +351,48 @@ function resolveShellPath(): void {
         continue;
       }
 
-      // Merge: use the shell PATH as the base, then append any entries from the
-      // current PATH that the shell didn't include (e.g., tool-injected directories).
-      // This ensures we never lose entries that were already available.
-      const shellEntries = shellPath.split(':');
-      const shellSet = new Set(shellEntries);
-      const extraFromCurrent = currentPath.split(':').filter((e) => e && !shellSet.has(e));
-      const merged = [...shellEntries, ...extraFromCurrent].join(':');
-      if (merged === currentPath) {
-        log(`[PATH] ${label} shell returned no new entries`);
-        continue;
+      anyShellSucceeded = true;
+      for (const entry of shellPath.split(':')) {
+        if (entry) allEntries.add(entry);
       }
-
-      process.env['PATH'] = merged;
-      log(
-        `[PATH] Resolved via ${label} shell (${shellEntries.length} shell + ${extraFromCurrent.length} existing)`,
-      );
-      return;
     } catch (err) {
       logError(`[PATH] ${label} shell failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  // Fallback: merge well-known directories into the current PATH
-  const home = os.homedir();
-  const wellKnownDirs = [
-    '/opt/homebrew/bin',
-    '/opt/homebrew/sbin',
-    `${home}/.bun/bin`,
-    `${home}/.local/bin`,
-    '/usr/local/bin',
-  ];
+  // Fallback: merge well-known directories if no shell succeeded
+  if (!anyShellSucceeded) {
+    const home = os.homedir();
+    const wellKnownDirs = [
+      '/opt/homebrew/bin',
+      '/opt/homebrew/sbin',
+      `${home}/.bun/bin`,
+      `${home}/.local/bin`,
+      '/usr/local/bin',
+    ];
+    for (const d of wellKnownDirs) {
+      if (!allEntries.has(d) && fs.existsSync(d)) allEntries.add(d);
+    }
+    log('[PATH] Shell resolution failed, merged well-known directories');
+  }
 
-  const pathSet = new Set(currentPath.split(':'));
-  const missing = wellKnownDirs.filter((d) => !pathSet.has(d) && fs.existsSync(d));
-  if (missing.length > 0) {
-    process.env['PATH'] = [...missing, currentPath].join(':');
-    log(`[PATH] Shell resolution failed, merged ${missing.length} well-known directories`);
-  } else {
-    logError('[PATH] Shell resolution failed and no well-known directories to add');
+  const merged = [...allEntries].join(':');
+  if (merged !== (process.env['PATH'] || '')) {
+    process.env['PATH'] = merged;
+    log(`[PATH] Resolved ${allEntries.size} entries (was ${currentEntries.length})`);
+  }
+
+  // Verify claude is findable after PATH resolution
+  try {
+    const which = Bun.spawnSync(['which', 'claude'], { env: process.env, timeout: 2000 });
+    if (which.exitCode !== 0) {
+      logError(
+        '[PATH] WARNING: "claude" not found in PATH after resolution. ' +
+          'Session creation will fail. Ensure claude is installed and in PATH.',
+      );
+    }
+  } catch {
+    // which command itself failed; non-fatal
   }
 }
 
@@ -2611,8 +2618,20 @@ if (cliDaemonMode) {
 
   try {
     logFd = openLogFile();
-  } catch {
-    // Cannot open log file; all output will be silently dropped
+  } catch (logErr) {
+    // Fall back to a temp file so diagnostics are not completely lost
+    try {
+      const tmpLog = path.join(os.tmpdir(), `remi-${process.pid}.log`);
+      logFd = fs.openSync(tmpLog, 'a');
+      fs.writeSync(
+        logFd,
+        `[remi] Primary log file failed: ${logErr instanceof Error ? logErr.message : String(logErr)}\n`,
+      );
+      fs.writeSync(2, `[remi] Logging to ${tmpLog} (primary log unavailable)\n`);
+    } catch {
+      // Last resort: write one message to stderr before it gets overridden
+      fs.writeSync(2, '[remi] WARNING: All logging disabled (cannot open any log file)\n');
+    }
   }
 
   // Layer 1: Override console methods (catches Bun's native console path)

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.10-dev.1'; // REMI_COMPILED_VERSION
+      return '0.4.10-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.10-dev.1'; // REMI_COMPILED_VERSION
+    return '0.4.10-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -115,7 +115,15 @@ export class SessionRegistryFile {
         const raw = fs.readFileSync(filePath, 'utf-8');
         const data: unknown = JSON.parse(raw);
 
-        if (!isValidEntry(data)) continue;
+        if (!isValidEntry(data)) {
+          console.error(`[live-sessions] Invalid entry in ${fileName}, removing`);
+          try {
+            fs.unlinkSync(filePath);
+          } catch {
+            // best-effort cleanup
+          }
+          continue;
+        }
 
         if (isProcessAlive(data.pid)) {
           entries.push(data);
@@ -133,13 +141,21 @@ export class SessionRegistryFile {
           }
         }
       } catch (err) {
-        // Only silence ENOENT (file removed between readdir and read) and JSON parse errors
         const code = (err as NodeJS.ErrnoException).code;
-        if (code && code !== 'ENOENT') {
-          console.error(
-            `[live-sessions] Failed to read ${fileName}: ${err instanceof Error ? err.message : String(err)}`,
-          );
+        if (code === 'ENOENT') continue; // file removed between readdir and read
+        if (err instanceof SyntaxError) {
+          // Corrupt JSON; remove the invalid file
+          console.error(`[live-sessions] Corrupt JSON in ${fileName}, removing`);
+          try {
+            fs.unlinkSync(filePath);
+          } catch {
+            // best-effort cleanup
+          }
+          continue;
         }
+        console.error(
+          `[live-sessions] Failed to read ${fileName}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 # bump-version.sh - Bump version, commit, tag, and optionally push to trigger release
 #
+# Versioning rules:
+#   - develop branch always has -dev.N versions (never stable)
+#   - main branch has stable versions (CI auto-strips dev suffix on merge)
+#   - patch/minor/major on develop: bump + reset to -dev.1
+#   - dev on develop: increment dev counter (dev.1 -> dev.2)
+#   - stable: only allowed on main (CI use) or with --force
+#
 # Usage:
-#   ./scripts/bump-version.sh patch          # 0.2.3 -> 0.2.4
-#   ./scripts/bump-version.sh minor          # 0.2.3 -> 0.3.0
-#   ./scripts/bump-version.sh major          # 0.2.3 -> 1.0.0
-#   ./scripts/bump-version.sh dev            # 0.2.3 -> 0.2.4-dev.1 (or -dev.N+1)
-#   ./scripts/bump-version.sh stable         # 0.2.4-dev.6 -> 0.2.4 (strip dev suffix)
+#   ./scripts/bump-version.sh dev            # 0.4.9-dev.1 -> 0.4.9-dev.2
+#   ./scripts/bump-version.sh patch          # 0.4.9-dev.3 -> 0.4.10-dev.1 (on develop)
+#   ./scripts/bump-version.sh minor          # 0.4.9-dev.3 -> 0.5.0-dev.1  (on develop)
+#   ./scripts/bump-version.sh major          # 0.4.9-dev.3 -> 1.0.0-dev.1  (on develop)
+#   ./scripts/bump-version.sh stable         # 0.4.10-dev.1 -> 0.4.10 (main/CI only)
 #   ./scripts/bump-version.sh set 1.0.0      # Set specific version
 #   ./scripts/bump-version.sh --push patch   # Bump and push (triggers release)
-#   ./scripts/bump-version.sh --push dev     # Bump dev and push (triggers dev release)
 
 set -euo pipefail
 
@@ -24,22 +30,29 @@ fi
 
 # Parse flags
 PUSH=false
+FORCE=false
 while [[ "${1:-}" == --* ]]; do
   case "$1" in
     --push) PUSH=true; shift ;;
+    --force) FORCE=true; shift ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
 
 BUMP_TYPE="${1:-}"
 if [[ -z "$BUMP_TYPE" ]]; then
-  echo "Usage: $0 [--push] <patch|minor|major|dev|stable|set <version>>" >&2
+  echo "Usage: $0 [--push] [--force] <patch|minor|major|dev|stable|set <version>>" >&2
   exit 1
 fi
 
+# Detect current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+IS_DEVELOP=$([[ "$CURRENT_BRANCH" == "develop" ]] && echo true || echo false)
+IS_MAIN=$([[ "$CURRENT_BRANCH" == "main" ]] && echo true || echo false)
+
 # Read current version from package.json
 CURRENT_VERSION=$(node -e "process.stdout.write(require('$PKG_JSON').version)")
-echo "Current: v$CURRENT_VERSION"
+echo "Current: v$CURRENT_VERSION (branch: $CURRENT_BRANCH)"
 
 # Extract base version and any prerelease suffix
 BASE_VERSION="${CURRENT_VERSION%%-*}"
@@ -53,22 +66,50 @@ case "$BUMP_TYPE" in
     MAJOR=$((MAJOR + 1))
     MINOR=0
     PATCH=0
-    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    if [[ "$IS_DEVELOP" == true ]]; then
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
+    else
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    fi
     ;;
   minor)
     MINOR=$((MINOR + 1))
     PATCH=0
-    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    if [[ "$IS_DEVELOP" == true ]]; then
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
+    else
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    fi
     ;;
   patch)
-    PATCH=$((PATCH + 1))
-    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    # On develop with a dev version: bump patch, reset to dev.1
+    # On develop with a stable version: bump patch, add dev.1
+    # On main or other: just bump patch (stable)
+    if [[ "$IS_DEVELOP" == true ]]; then
+      if [[ -n "$PRERELEASE" ]]; then
+        # 0.4.9-dev.3 -> 0.4.10-dev.1
+        PATCH=$((PATCH + 1))
+      else
+        # 0.4.9 -> 0.4.10-dev.1 (shouldn't happen but handle gracefully)
+        PATCH=$((PATCH + 1))
+      fi
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
+    else
+      PATCH=$((PATCH + 1))
+      NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    fi
     ;;
   stable)
-    # Strip prerelease suffix: 0.4.4-dev.6 -> 0.4.4
+    # Strip prerelease suffix: 0.4.10-dev.1 -> 0.4.10
     if [[ -z "$PRERELEASE" ]]; then
       echo "Already a stable version ($CURRENT_VERSION). Nothing to do." >&2
       exit 0
+    fi
+    if [[ "$IS_DEVELOP" == true && "$FORCE" == false ]]; then
+      echo "Error: 'stable' is not allowed on the develop branch." >&2
+      echo "Stable versions are created by CI when develop merges into main." >&2
+      echo "Use --force to override (not recommended)." >&2
+      exit 1
     fi
     NEW_VERSION="$MAJOR.$MINOR.$PATCH"
     ;;
@@ -98,7 +139,7 @@ case "$BUMP_TYPE" in
     NEW_VERSION="$NEW_VER"
     ;;
   *)
-    echo "Usage: $0 [--push] <patch|minor|major|dev|stable|set <version>>" >&2
+    echo "Usage: $0 [--push] [--force] <patch|minor|major|dev|stable|set <version>>" >&2
     exit 1
     ;;
 esac

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -86,13 +86,8 @@ case "$BUMP_TYPE" in
     # On develop with a stable version: bump patch, add dev.1
     # On main or other: just bump patch (stable)
     if [[ "$IS_DEVELOP" == true ]]; then
-      if [[ -n "$PRERELEASE" ]]; then
-        # 0.4.9-dev.3 -> 0.4.10-dev.1
-        PATCH=$((PATCH + 1))
-      else
-        # 0.4.9 -> 0.4.10-dev.1 (shouldn't happen but handle gracefully)
-        PATCH=$((PATCH + 1))
-      fi
+      # 0.4.9-dev.3 -> 0.4.10-dev.1 (or 0.4.9 -> 0.4.10-dev.1 if stable on develop)
+      PATCH=$((PATCH + 1))
       NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
     else
       PATCH=$((PATCH + 1))

--- a/scripts/install/com.yooz.remi.plist
+++ b/scripts/install/com.yooz.remi.plist
@@ -9,6 +9,11 @@
         <string>__REMI_BINARY__</string>
         <string>--daemon</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:__HOME__/.bun/bin:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>


### PR DESCRIPTION
## Summary

Merge develop into main to release 0.4.10 with critical fixes:

- Session listing regression: `remi ls` now falls back to port probing when live-sessions files are missing
- Daemon PATH resolution: `resolveShellPath()` handles LaunchAgent context with fallback strategy
- npm wrapper auto-upgrade: detects installer, tries correct package manager first
- Version workflow: develop always uses -dev.N, CI auto-bumps on push, auto-releases stable on main merge
- E2E test infrastructure (Docker + Playwright)
- Session resume protocol support

## CI will auto-release

When merged, the auto-release job will strip the -dev suffix and publish 0.4.10 to npm and Homebrew.