### PR TITLE
fix: restructure port selection and adapter startup for reliability

### DIFF
--- a/packages/daemon/src/adapters/adapter-registry.ts
+++ b/packages/daemon/src/adapters/adapter-registry.ts
@@ -81,7 +81,7 @@ export class AdapterRegistry {
   }
 
   /**
-   * Start all registered adapters.
+   * Start all registered adapters in parallel.
    */
   async startAll(): Promise<void> {
     const startPromises = Array.from(this.adapters.entries()).map(async ([type, adapter]) => {
@@ -93,6 +93,41 @@ export class AdapterRegistry {
         throw error;
       }
     });
+
+    await Promise.all(startPromises);
+  }
+
+  /**
+   * Start a single adapter by type.
+   * Throws if the adapter is not registered or fails to start.
+   */
+  async startAdapter(adapterType: string): Promise<void> {
+    const adapter = this.adapters.get(adapterType);
+    if (!adapter) {
+      throw new Error(`Adapter type '${adapterType}' not registered`);
+    }
+    await adapter.start();
+    this.events.onAdapterStart?.(adapterType);
+  }
+
+  /**
+   * Start all adapters except the specified types.
+   * Used to start non-port-binding adapters (Relay, Telegram) before
+   * port selection, so they are started exactly once.
+   */
+  async startAllExcept(excludeTypes: readonly string[]): Promise<void> {
+    const exclude = new Set(excludeTypes);
+    const startPromises = Array.from(this.adapters.entries())
+      .filter(([type]) => !exclude.has(type))
+      .map(async ([type, adapter]) => {
+        try {
+          await adapter.start();
+          this.events.onAdapterStart?.(type);
+        } catch (error) {
+          console.error(`Failed to start adapter '${type}':`, error);
+          throw error;
+        }
+      });
 
     await Promise.all(startPromises);
   }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -266,6 +266,7 @@ import {
   SessionStore,
   type StoredSession,
 } from './session/index.ts';
+import { findAvailableTcpPort } from './session/port-utils.ts';
 import {
   TranscriptDiscovery,
   TranscriptMessageBridge,
@@ -1299,7 +1300,10 @@ let PORT = cliPort || (process.env['REMI_PORT'] ? Number.parseInt(process.env['R
 
 // Auto-select port if not explicitly set
 if (!portExplicitlySet) {
-  const autoPort = liveSessionsRegistry.findAvailablePort(DEFAULT_BASE_PORT, DEFAULT_PORT_RANGE);
+  const autoPort = await liveSessionsRegistry.findAvailablePort(
+    DEFAULT_BASE_PORT,
+    DEFAULT_PORT_RANGE,
+  );
   if (autoPort === null) {
     console.error(
       `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,
@@ -1371,7 +1375,7 @@ const sessionRegistry = new SessionRegistry(
 let primarySessionId: UUID | null = null;
 
 // Hook infrastructure (initialized in wrapper mode when hooks are enabled)
-let HOOK_PORT = PORT + 100; // Offset by 100 to avoid collisions with other remi WS ports
+let HOOK_PORT = 0; // OS-assigned; actual port read from hookServer.port after start
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
 
@@ -2510,68 +2514,47 @@ resolveShellPath();
 if (cliDaemonMode) {
   console.log('Starting Remi daemon...');
 
-  // Start all adapters. On EADDRINUSE, retry only the WebSocket adapter with next port.
-  // Other adapters (Telegram, Relay) start once and stay running across retries.
+  // Phase 1: Start non-port-binding adapters (Relay, Telegram) once
   try {
-    await registry.startAll();
+    await registry.startAllExcept(['websocket']);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    const isAddrInUse = msg.includes('EADDRINUSE') || msg.includes('in use');
+    console.error(`Failed to start adapters: ${msg}`);
+    process.exit(1);
+  }
 
-    if (!isAddrInUse || portExplicitlySet) {
-      if (isAddrInUse) {
-        console.error(`Port ${PORT} is already in use.`);
-        console.error('Use --port to specify a different port, or stop existing sessions.');
-      } else {
-        console.error(`Failed to start daemon: ${msg}`);
-      }
+  // Phase 2: Probe for available WebSocket port, then start
+  if (!portExplicitlySet) {
+    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE);
+    if (probed === null) {
+      console.error(
+        `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,
+      );
+      console.error('Use --port to specify a different port, or stop existing sessions.');
+      await registry.stopAll();
       process.exit(1);
     }
-
-    // EADDRINUSE with auto-port: retry WebSocket adapter on next available port
-    let wsStarted = false;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const nextPort = liveSessionsRegistry.findAvailablePort(
-        PORT + 1,
-        DEFAULT_PORT_RANGE - (PORT - DEFAULT_BASE_PORT + 1),
-      );
-      if (nextPort === null) break;
-
-      console.log(`Port ${PORT} in use, trying ${nextPort}...`);
-      try {
-        await registry.unregister('websocket');
-      } catch (teardownErr) {
-        const teardownMsg =
-          teardownErr instanceof Error ? teardownErr.message : String(teardownErr);
-        console.error(`Failed to tear down WebSocket adapter on port ${PORT}: ${teardownMsg}`);
-      }
-      PORT = nextPort;
+    if (probed !== PORT) {
+      console.log(`Port ${PORT} in use, using ${probed}`);
+      await registry.unregister('websocket');
+      PORT = probed;
       STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
-      HOOK_PORT = PORT + 100;
-      const retryWsAdapter = new WebSocketAdapter(
+      const newWsAdapter = new WebSocketAdapter(
         { port: PORT, host: bindHost, authenticator },
         sharedEvents,
       );
-      registry.register(retryWsAdapter);
-
-      try {
-        await retryWsAdapter.start();
-        wsStarted = true;
-        break;
-      } catch (retryErr) {
-        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-        if (!retryMsg.includes('EADDRINUSE') && !retryMsg.includes('in use')) {
-          console.error(`Failed to start daemon: ${retryMsg}`);
-          process.exit(1);
-        }
-      }
+      registry.register(newWsAdapter);
     }
+  }
 
-    if (!wsStarted) {
-      console.error('All ports in range are in use.');
-      console.error('Use --port to specify a different port, or stop existing sessions.');
-      process.exit(1);
-    }
+  try {
+    await registry.startAdapter('websocket');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to start WebSocket on port ${PORT}: ${msg}`);
+    console.error('Use --port to specify a different port, or stop existing sessions.');
+    await registry.stopAll();
+    process.exit(1);
   }
 
   mdnsPublisher = await startMdnsIfNeeded(console.log);
@@ -2674,58 +2657,43 @@ if (cliDaemonMode) {
 
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
 
-  // Start WebSocket server silently in the background
-  // With auto-port: retry on EADDRINUSE (race condition with another remi starting simultaneously)
+  // Phase 1: Start non-port-binding adapters (Relay, Telegram) once
+  try {
+    await registry.startAllExcept(['websocket']);
+  } catch (err) {
+    logError(
+      `Failed to start background adapters: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Phase 2: Probe for available WebSocket port, then start
   let wsStarted = false;
-  const maxPortRetries = portExplicitlySet ? 1 : 3;
-  for (let attempt = 0; attempt < maxPortRetries; attempt++) {
+  if (!portExplicitlySet) {
+    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE);
+    if (probed !== null && probed !== PORT) {
+      log(`Port ${PORT} in use, using ${probed}`);
+      await registry.unregister('websocket');
+      PORT = probed;
+      STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
+      const newWsAdapter = new WebSocketAdapter(
+        { port: PORT, host: bindHost, authenticator },
+        sharedEvents,
+      );
+      registry.register(newWsAdapter);
+    } else if (probed === null) {
+      logError('All ports in range are in use. Remote monitoring disabled.');
+    }
+  }
+
+  if (PORT > 0) {
     try {
-      await registry.startAll();
+      await registry.startAdapter('websocket');
       log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
       mdnsPublisher = await startMdnsIfNeeded(log);
       wsStarted = true;
-      break;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      const isAddrInUse = msg.includes('EADDRINUSE') || msg.includes('in use');
-
-      if (isAddrInUse && !portExplicitlySet && attempt < maxPortRetries - 1) {
-        // Auto-port race: another remi grabbed this port. Try next available.
-        const nextPort = liveSessionsRegistry.findAvailablePort(
-          PORT + 1,
-          DEFAULT_PORT_RANGE - (PORT - DEFAULT_BASE_PORT + 1),
-        );
-        if (nextPort !== null) {
-          log(`Port ${PORT} taken, retrying with ${nextPort}`);
-          // Tear down old adapter before rebinding
-          try {
-            await registry.unregister('websocket');
-          } catch (teardownErr) {
-            const teardownMsg =
-              teardownErr instanceof Error ? teardownErr.message : String(teardownErr);
-            logError(`Failed to tear down WebSocket adapter on port ${PORT}: ${teardownMsg}`);
-          }
-          PORT = nextPort;
-          STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
-          HOOK_PORT = PORT + 100;
-          // Create new WS adapter with updated port
-          const retryWsAdapter = new WebSocketAdapter(
-            { port: PORT, host: bindHost, authenticator },
-            sharedEvents,
-          );
-          registry.register(retryWsAdapter);
-          continue;
-        }
-      }
-
-      if (isAddrInUse) {
-        logError(
-          `Port ${PORT} is in use. Remote monitoring disabled. Use --port to specify a different port.`,
-        );
-      } else {
-        logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
-      }
-      break;
+      logError(`WebSocket server failed to start: ${msg}. Remote monitoring disabled.`);
     }
   }
 
@@ -2743,16 +2711,17 @@ if (cliDaemonMode) {
     });
   }
 
-  // Start hook server for Claude Code event detection
+  // Start hook server for Claude Code event detection (port 0 = OS-assigned)
   try {
     hookServer = new HookServer(
-      { port: HOOK_PORT },
+      { port: 0 },
       {
         onError: (err) => logError(`[HookServer] ${err.message}`),
       },
     );
     hookServer.start();
-    log(`Hook server listening on ${hookServer.url}`);
+    HOOK_PORT = hookServer.port;
+    log(`Hook server listening on ${hookServer.url} (port ${HOOK_PORT})`);
 
     // Configure Claude Code hooks to POST to our server
     hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2520,12 +2520,14 @@ if (cliDaemonMode) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`Failed to start adapters: ${msg}`);
+    await registry.stopAll();
     process.exit(1);
   }
 
   // Phase 2: Probe for available WebSocket port, then start
   if (!portExplicitlySet) {
-    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE);
+    const liveUsed = new Set(liveSessionsRegistry.listLive().map((e) => e.wsPort));
+    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE, liveUsed);
     if (probed === null) {
       console.error(
         `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,
@@ -2668,11 +2670,19 @@ if (cliDaemonMode) {
 
   // Phase 2: Probe for available WebSocket port, then start
   let wsStarted = false;
+  let wsProbeSucceeded = true;
   if (!portExplicitlySet) {
-    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE);
+    const liveUsed = new Set(liveSessionsRegistry.listLive().map((e) => e.wsPort));
+    const probed = await findAvailableTcpPort(PORT, DEFAULT_PORT_RANGE, liveUsed);
     if (probed !== null && probed !== PORT) {
       log(`Port ${PORT} in use, using ${probed}`);
-      await registry.unregister('websocket');
+      try {
+        await registry.unregister('websocket');
+      } catch (teardownErr) {
+        logError(
+          `Failed to tear down WebSocket adapter: ${teardownErr instanceof Error ? teardownErr.message : String(teardownErr)}`,
+        );
+      }
       PORT = probed;
       STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
       const newWsAdapter = new WebSocketAdapter(
@@ -2682,10 +2692,11 @@ if (cliDaemonMode) {
       registry.register(newWsAdapter);
     } else if (probed === null) {
       logError('All ports in range are in use. Remote monitoring disabled.');
+      wsProbeSucceeded = false;
     }
   }
 
-  if (PORT > 0) {
+  if (wsProbeSucceeded) {
     try {
       await registry.startAdapter('websocket');
       log(`WebSocket server listening on ws://${bindHost}:${PORT}/ws`);
@@ -2697,18 +2708,9 @@ if (cliDaemonMode) {
     }
   }
 
-  // After port retry, update status with finalized port values
+  // Update status with finalized WS port
   if (wsStarted) {
     updateRemiStatus({ wsPort: PORT });
-    liveSessionsRegistry.register({
-      sessionId,
-      pid: process.pid,
-      wsPort: PORT,
-      hookPort: HOOK_PORT,
-      projectPath: workingDirectory,
-      name: path.basename(workingDirectory),
-      startedAt: new Date().toISOString(),
-    });
   }
 
   // Start hook server for Claude Code event detection (port 0 = OS-assigned)
@@ -2730,10 +2732,23 @@ if (cliDaemonMode) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logError(
-      `Hook server failed to start on port ${HOOK_PORT}: ${msg}. Status detection and question forwarding disabled.`,
+      `Hook server failed to start: ${msg}. Status detection and question forwarding disabled.`,
     );
     hookServer = null;
     hookConfigManager = null;
+  }
+
+  // Register in live-sessions AFTER hook server starts so hookPort has real value
+  if (wsStarted) {
+    liveSessionsRegistry.register({
+      sessionId,
+      pid: process.pid,
+      wsPort: PORT,
+      hookPort: HOOK_PORT,
+      projectPath: workingDirectory,
+      name: path.basename(workingDirectory),
+      startedAt: new Date().toISOString(),
+    });
   }
 
   // Create and start the primary PTY session

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -100,41 +100,10 @@ export interface StartOptions {
   extraArgs?: string[] | undefined;
 }
 
+import { findAvailableTcpPort } from '../session/port-utils.ts';
+
 const DEFAULT_BASE_PORT = 18765;
 const DEFAULT_PORT_RANGE = 10;
-
-/** Check if a port is available by attempting to connect (if connection refused, port is free). */
-function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = new (require('node:net').Socket)();
-    socket.setTimeout(500);
-    socket.on('connect', () => {
-      socket.destroy();
-      resolve(false); // Something is listening, port in use
-    });
-    socket.on('timeout', () => {
-      socket.destroy();
-      resolve(true); // Nothing responded, port likely free
-    });
-    socket.on('error', (err: NodeJS.ErrnoException) => {
-      socket.destroy();
-      // ECONNREFUSED = nothing listening = port free
-      // ECONNRESET = connection dropped = nothing stable listening
-      resolve(err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET');
-    });
-    socket.connect(port, '127.0.0.1');
-  });
-}
-
-/** Find an available port in the default range. */
-async function findFreePort(): Promise<number | null> {
-  for (let port = DEFAULT_BASE_PORT; port < DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE; port++) {
-    if (await isPortAvailable(port)) {
-      return port;
-    }
-  }
-  return null;
-}
 
 /**
  * Start the remi daemon in the background.
@@ -154,7 +123,7 @@ export async function startDaemon(opts?: StartOptions): Promise<number> {
   // Find a free port before spawning the daemon to avoid EADDRINUSE
   let daemonPort = opts?.port;
   if (!daemonPort) {
-    const freePort = await findFreePort();
+    const freePort = await findAvailableTcpPort(DEFAULT_BASE_PORT, DEFAULT_PORT_RANGE);
     if (freePort === null) {
       console.error(
         `All remi ports in range ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1} are in use.`,

--- a/packages/daemon/src/session/port-utils.ts
+++ b/packages/daemon/src/session/port-utils.ts
@@ -16,8 +16,9 @@ export function isPortAvailable(port: number, hostname = '0.0.0.0'): Promise<boo
   const net = require('node:net') as any;
   return new Promise<boolean>((resolve) => {
     const srv = net.createServer();
-    srv.once('error', (err: NodeJS.ErrnoException) => {
-      resolve(err.code !== 'EADDRINUSE');
+    srv.once('error', () => {
+      // Any bind error means the port is not usable (EADDRINUSE, EACCES, etc.)
+      resolve(false);
     });
     srv.listen({ port, host: hostname, exclusive: true }, () => {
       srv.close(() => resolve(true));

--- a/packages/daemon/src/session/port-utils.ts
+++ b/packages/daemon/src/session/port-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * TCP port availability utilities.
+ *
+ * Uses net.createServer bind-probe to determine whether a port is available.
+ * This detects ports occupied by non-remi processes (system services, etc.).
+ * For remi-to-remi conflicts, the live-sessions file registry is the primary
+ * mechanism since Bun's SO_REUSEPORT allows multiple Bun servers on the same port.
+ */
+
+/**
+ * Check if a TCP port is available by attempting to bind a TCP server.
+ * Returns true if the port can be bound, false if EADDRINUSE.
+ */
+export function isPortAvailable(port: number, hostname = '0.0.0.0'): Promise<boolean> {
+  // biome-ignore lint/suspicious/noExplicitAny: dynamic require for net module
+  const net = require('node:net') as any;
+  return new Promise<boolean>((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', (err: NodeJS.ErrnoException) => {
+      resolve(err.code !== 'EADDRINUSE');
+    });
+    srv.listen({ port, host: hostname, exclusive: true }, () => {
+      srv.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Find an available port in the given range.
+ * Combines file-registry filtering (skip known remi sessions) with
+ * TCP bind-probe (detect non-remi processes occupying ports).
+ * Returns the first available port, or null if all are occupied.
+ */
+export async function findAvailableTcpPort(
+  basePort: number,
+  range: number,
+  knownUsedPorts: Set<number> = new Set(),
+  hostname = '0.0.0.0',
+): Promise<number | null> {
+  for (let offset = 0; offset < range; offset++) {
+    const candidate = basePort + offset;
+    if (knownUsedPorts.has(candidate)) continue;
+    if (await isPortAvailable(candidate, hostname)) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -11,6 +11,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { findAvailableTcpPort } from './port-utils.ts';
 import { isProcessAlive } from './process-alive.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
@@ -165,24 +166,17 @@ export class SessionRegistryFile {
 
   /**
    * Find the first available port in the given range.
-   * Checks live entries to avoid conflicts.
+   * Combines file-registry check (skip known sessions) with real TCP
+   * bind-probe (detect ports occupied by non-remi processes).
    * Returns null if all ports are exhausted.
    */
-  findAvailablePort(
+  async findAvailablePort(
     basePort: number = DEFAULT_BASE_PORT,
     range: number = DEFAULT_PORT_RANGE,
-  ): number | null {
+  ): Promise<number | null> {
     const live = this.listLive();
     const usedPorts = new Set(live.map((e) => e.wsPort));
-
-    for (let offset = 0; offset < range; offset++) {
-      const candidate = basePort + offset;
-      if (!usedPorts.has(candidate)) {
-        return candidate;
-      }
-    }
-
-    return null;
+    return findAvailableTcpPort(basePort, range, usedPorts);
   }
 
   /** Find a live session by session ID. */

--- a/packages/daemon/tests/adapter-registry.test.ts
+++ b/packages/daemon/tests/adapter-registry.test.ts
@@ -524,5 +524,47 @@ describe('AdapterRegistry', () => {
       expect(tg.isRunning).toBe(false);
       expect(relay.isRunning).toBe(true);
     });
+
+    test('propagates error when a non-excluded adapter fails', async () => {
+      const registry = new AdapterRegistry();
+      const good = new TestAdapter('relay');
+      const bad = new TestAdapter('telegram');
+      // Override start to throw
+      bad.start = async () => {
+        throw new Error('Simulated telegram start failure');
+      };
+      registry.register(good);
+      registry.register(bad);
+
+      await expect(registry.startAllExcept(['ws'])).rejects.toThrow(
+        'Simulated telegram start failure',
+      );
+    });
+  });
+
+  describe('startAdapter() error propagation', () => {
+    test('propagates error from adapter.start()', async () => {
+      const registry = new AdapterRegistry();
+      const adapter = new TestAdapter('ws');
+      adapter.start = async () => {
+        throw new Error('listen EADDRINUSE :::18765');
+      };
+      registry.register(adapter);
+
+      await expect(registry.startAdapter('ws')).rejects.toThrow('EADDRINUSE');
+    });
+
+    test('does not emit onAdapterStart when start fails', async () => {
+      const started: string[] = [];
+      const registry = new AdapterRegistry({ onAdapterStart: (t) => started.push(t) });
+      const adapter = new TestAdapter('ws');
+      adapter.start = async () => {
+        throw new Error('start failure');
+      };
+      registry.register(adapter);
+
+      await expect(registry.startAdapter('ws')).rejects.toThrow();
+      expect(started).toEqual([]);
+    });
   });
 });

--- a/packages/daemon/tests/adapter-registry.test.ts
+++ b/packages/daemon/tests/adapter-registry.test.ts
@@ -440,4 +440,89 @@ describe('AdapterRegistry', () => {
       expect(registry.getAdapter('unknown')).toBeUndefined();
     });
   });
+
+  describe('startAdapter()', () => {
+    test('starts a single adapter by type', async () => {
+      const registry = new AdapterRegistry();
+      const adapter = new TestAdapter('ws');
+      registry.register(adapter);
+      await registry.startAdapter('ws');
+      expect(adapter.isRunning).toBe(true);
+    });
+
+    test('throws for unregistered type', async () => {
+      const registry = new AdapterRegistry();
+      await expect(registry.startAdapter('unknown')).rejects.toThrow('not registered');
+    });
+
+    test('emits onAdapterStart event', async () => {
+      const started: string[] = [];
+      const registry = new AdapterRegistry({ onAdapterStart: (t) => started.push(t) });
+      registry.register(new TestAdapter('ws'));
+      await registry.startAdapter('ws');
+      expect(started).toEqual(['ws']);
+    });
+
+    test('does not affect other adapters', async () => {
+      const registry = new AdapterRegistry();
+      const ws = new TestAdapter('ws');
+      const relay = new TestAdapter('relay');
+      registry.register(ws);
+      registry.register(relay);
+      await registry.startAdapter('ws');
+      expect(ws.isRunning).toBe(true);
+      expect(relay.isRunning).toBe(false);
+    });
+  });
+
+  describe('startAllExcept()', () => {
+    test('starts all except excluded types', async () => {
+      const registry = new AdapterRegistry();
+      const ws = new TestAdapter('ws');
+      const tg = new TestAdapter('telegram');
+      const relay = new TestAdapter('relay');
+      registry.register(ws);
+      registry.register(tg);
+      registry.register(relay);
+
+      await registry.startAllExcept(['ws']);
+
+      expect(ws.isRunning).toBe(false);
+      expect(tg.isRunning).toBe(true);
+      expect(relay.isRunning).toBe(true);
+    });
+
+    test('starts all when exclude list is empty', async () => {
+      const registry = new AdapterRegistry();
+      const ws = new TestAdapter('ws');
+      registry.register(ws);
+      await registry.startAllExcept([]);
+      expect(ws.isRunning).toBe(true);
+    });
+
+    test('emits onAdapterStart for started adapters only', async () => {
+      const started: string[] = [];
+      const registry = new AdapterRegistry({ onAdapterStart: (t) => started.push(t) });
+      registry.register(new TestAdapter('ws'));
+      registry.register(new TestAdapter('relay'));
+      await registry.startAllExcept(['ws']);
+      expect(started).toEqual(['relay']);
+    });
+
+    test('can exclude multiple types', async () => {
+      const registry = new AdapterRegistry();
+      const ws = new TestAdapter('ws');
+      const tg = new TestAdapter('telegram');
+      const relay = new TestAdapter('relay');
+      registry.register(ws);
+      registry.register(tg);
+      registry.register(relay);
+
+      await registry.startAllExcept(['ws', 'telegram']);
+
+      expect(ws.isRunning).toBe(false);
+      expect(tg.isRunning).toBe(false);
+      expect(relay.isRunning).toBe(true);
+    });
+  });
 });

--- a/packages/daemon/tests/hooks/hook-server-port0.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-port0.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { HookServer } from '../../src/hooks/hook-server.ts';
+
+describe('HookServer with port 0 (OS-assigned)', () => {
+  let server: HookServer | null = null;
+
+  afterEach(() => {
+    if (server) {
+      server.stop();
+      server = null;
+    }
+  });
+
+  test('starts on OS-assigned port', () => {
+    server = new HookServer({ port: 0 });
+    server.start();
+    expect(server.port).toBeGreaterThan(0);
+  });
+
+  test('url contains the actual assigned port', () => {
+    server = new HookServer({ port: 0 });
+    server.start();
+    expect(server.url).toContain(String(server.port));
+    expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/hooks$/);
+  });
+
+  test('two servers get different ports', () => {
+    server = new HookServer({ port: 0 });
+    server.start();
+    const port1 = server.port;
+
+    const server2 = new HookServer({ port: 0 });
+    server2.start();
+    const port2 = server2.port;
+
+    expect(port1).not.toBe(port2);
+    server2.stop();
+  });
+
+  test('accepts hook events on OS-assigned port', async () => {
+    const events: string[] = [];
+    server = new HookServer(
+      { port: 0 },
+      {
+        onStop: () => events.push('stop'),
+      },
+    );
+    server.start();
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/hooks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hook_event_name: 'Stop',
+        session_id: 'test-session',
+        transcript_path: '/tmp/test.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(events).toContain('stop');
+  });
+});

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -138,34 +138,36 @@ describe('SessionRegistryFile', () => {
     expect(nonExistent.listLive()).toEqual([]);
   });
 
-  test('findAvailablePort returns first port when no sessions', () => {
-    const port = registry.findAvailablePort(18765, 10);
-    expect(port).toBe(18765);
+  // Use high test ports to avoid conflicts with running remi instances
+  const TEST_PORT_BASE = 44000 + Math.floor(Math.random() * 1000);
+
+  test('findAvailablePort returns first port when no sessions', async () => {
+    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
+    expect(port).toBe(TEST_PORT_BASE);
   });
 
-  test('findAvailablePort skips used ports', () => {
-    registry.register(makeEntry({ sessionId: 'a', wsPort: 18765 }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: 18766 }));
+  test('findAvailablePort skips used ports', async () => {
+    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 1 }));
 
-    const port = registry.findAvailablePort(18765, 10);
-    expect(port).toBe(18767);
+    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
+    expect(port).toBe(TEST_PORT_BASE + 2);
   });
 
-  test('findAvailablePort fills non-contiguous gaps', () => {
-    // Use ports 18765 and 18767, leaving 18766 as a gap
-    registry.register(makeEntry({ sessionId: 'a', wsPort: 18765 }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: 18767 }));
+  test('findAvailablePort fills non-contiguous gaps', async () => {
+    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 2 }));
 
-    const port = registry.findAvailablePort(18765, 10);
-    expect(port).toBe(18766);
+    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
+    expect(port).toBe(TEST_PORT_BASE + 1);
   });
 
-  test('findAvailablePort returns null when all ports exhausted', () => {
+  test('findAvailablePort returns null when all ports exhausted', async () => {
     for (let i = 0; i < 3; i++) {
-      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: 18765 + i }));
+      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: TEST_PORT_BASE + i }));
     }
 
-    const port = registry.findAvailablePort(18765, 3);
+    const port = await registry.findAvailablePort(TEST_PORT_BASE, 3);
     expect(port).toBeNull();
   });
 

--- a/packages/daemon/tests/session/port-utils.test.ts
+++ b/packages/daemon/tests/session/port-utils.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as net from 'node:net';
+import { findAvailableTcpPort, isPortAvailable } from '../../src/session/port-utils.ts';
+
+// Use high random base ports to avoid conflicts with running services
+const TEST_BASE = 45000 + Math.floor(Math.random() * 5000);
+
+/** Bind a real TCP server to a port (blocks that port for net.createServer probes). */
+function occupyPort(port: number): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen({ port, host: '0.0.0.0', exclusive: true }, () => resolve(srv));
+  });
+}
+
+describe('isPortAvailable', () => {
+  const servers: net.Server[] = [];
+
+  afterEach(() => {
+    for (const s of servers) s.close();
+    servers.length = 0;
+  });
+
+  test('returns true for an unused port', async () => {
+    expect(await isPortAvailable(TEST_BASE)).toBe(true);
+  });
+
+  test('returns false for an occupied port', async () => {
+    const srv = await occupyPort(TEST_BASE + 100);
+    servers.push(srv);
+    expect(await isPortAvailable(TEST_BASE + 100)).toBe(false);
+  });
+
+  test('returns true after server is stopped', async () => {
+    const srv = await occupyPort(TEST_BASE + 200);
+    await new Promise<void>((resolve) => srv.close(() => resolve()));
+    expect(await isPortAvailable(TEST_BASE + 200)).toBe(true);
+  });
+});
+
+describe('findAvailableTcpPort', () => {
+  const servers: net.Server[] = [];
+
+  afterEach(() => {
+    for (const s of servers) s.close();
+    servers.length = 0;
+  });
+
+  test('returns first port when all free', async () => {
+    const port = await findAvailableTcpPort(TEST_BASE + 300, 5);
+    expect(port).toBe(TEST_BASE + 300);
+  });
+
+  test('skips known-used ports without probing', async () => {
+    const used = new Set([TEST_BASE + 400, TEST_BASE + 401]);
+    const port = await findAvailableTcpPort(TEST_BASE + 400, 5, used);
+    expect(port).toBe(TEST_BASE + 402);
+  });
+
+  test('skips actually occupied ports via TCP probe', async () => {
+    const srv = await occupyPort(TEST_BASE + 500);
+    servers.push(srv);
+    const port = await findAvailableTcpPort(TEST_BASE + 500, 5);
+    expect(port).toBe(TEST_BASE + 501);
+  });
+
+  test('returns null when all ports occupied', async () => {
+    const base = TEST_BASE + 600;
+    for (let i = 0; i < 3; i++) {
+      servers.push(await occupyPort(base + i));
+    }
+    const port = await findAvailableTcpPort(base, 3);
+    expect(port).toBeNull();
+  });
+
+  test('returns null when all in known-used set', async () => {
+    const base = TEST_BASE + 700;
+    const used = new Set([base, base + 1, base + 2]);
+    const port = await findAvailableTcpPort(base, 3, used);
+    expect(port).toBeNull();
+  });
+
+  test('combines known-used and TCP probe', async () => {
+    const base = TEST_BASE + 800;
+    const used = new Set([base]);
+    servers.push(await occupyPort(base + 1));
+    const port = await findAvailableTcpPort(base, 5, used);
+    expect(port).toBe(base + 2);
+  });
+});

--- a/packages/daemon/tests/version-sync.test.ts
+++ b/packages/daemon/tests/version-sync.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dir, '..', '..', '..');
+const PKG = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+const CLI = fs.readFileSync(path.join(ROOT, 'packages/daemon/src/cli.ts'), 'utf-8');
+
+describe('Version synchronization', () => {
+  test('REMI_COMPILED_VERSION in cli.ts matches package.json version', () => {
+    const matches = CLI.match(/return '([^']+)'; \/\/ REMI_COMPILED_VERSION/g);
+    expect(matches).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: checked above
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+
+    // biome-ignore lint/style/noNonNullAssertion: checked above
+    for (const m of matches!) {
+      const version = m.match(/return '([^']+)'/)?.[1];
+      expect(version).toBe(PKG.version);
+    }
+  });
+
+  test('REMI_COMPILED_VERSION marker exists in cli.ts', () => {
+    expect(CLI).toContain('// REMI_COMPILED_VERSION');
+  });
+
+  test('npm wrapper optionalDependencies are self-consistent', () => {
+    const npmPkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'npm/remi/package.json'), 'utf-8'));
+    const deps = npmPkg.optionalDependencies ?? {};
+    const versions = Object.values(deps) as string[];
+    if (versions.length > 0) {
+      const first = versions[0];
+      for (const v of versions) {
+        expect(v).toBe(first);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the root cause of silent monitoring failure when running multiple remi sessions (wrapper + daemon, or multiple wrappers).

**Port selection**: Real TCP bind-probe instead of file-only check. Detects ports occupied by non-remi processes.

**Adapter startup**: Two-phase pattern for both daemon and wrapper modes:
1. Start non-port-binding adapters (Relay, Telegram) ONCE
2. Probe for available port, start WebSocket individually

**Hook server**: Uses port 0 (OS-assigned) instead of PORT+100. Eliminates all hook port conflicts.

**24 new tests** covering port probing, adapter lifecycle, version sync, and hook server.

## Root Cause

The wrapper startup called `registry.startAll()` in a retry loop. On EADDRINUSE, it unregistered only the WebSocket adapter and re-registered a new one, then called `startAll()` again -- which restarted already-running Relay/Telegram adapters, causing them to throw "already running" and killing the entire retry.

## Test plan

- [x] 1193 tests pass (24 new)
- [x] Lint clean (0 new errors)
- [x] Typecheck clean

Closes #146