### PR TITLE
fix: update signaling URL to yooz.workers.dev

### DIFF
--- a/.context/plan.md
+++ b/.context/plan.md
@@ -120,7 +120,7 @@ Four phases: signaling server hardening, daemon always-on signaling, web client 
 
 | Service | URL | Deploy Command |
 |---------|-----|----------------|
-| Signaling | `wss://remi-signaling.dev-941.workers.dev` | `cd packages/signaling && npx cfman wrangler --account yooz-labs deploy` |
+| Signaling | `wss://remi-signaling.yooz.workers.dev` | `cd packages/signaling && npx cfman wrangler --account yooz-labs deploy` |
 | Web App | `https://remi-app.pages.dev` | `cd packages/web && bun run build && npx cfman wrangler --account yooz-labs pages deploy dist --project-name remi-app --branch main` |
 
 ## Key Files

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2410,7 +2410,7 @@ if (TELEGRAM_ENABLED && TELEGRAM_TOKEN) {
 if (!cliNoRelay) {
   const { RelayAdapter } = await import('./remote/relay-adapter.ts');
   const { generateConnectionCode } = await import('./remote/signaling-client.ts');
-  const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.dev-941.workers.dev/connect';
+  const signalingUrl = cliSignalingUrl ?? 'wss://remi-signaling.yooz.workers.dev/connect';
 
   let relayAdapter: InstanceType<typeof RelayAdapter>;
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -848,7 +848,7 @@ function App() {
         setRelayError(null);
         pendingRelayChallengeRef.current = null;
 
-        const signalingUrl = 'wss://remi-signaling.dev-941.workers.dev/connect';
+        const signalingUrl = 'wss://remi-signaling.yooz.workers.dev/connect';
         const client = new WebSignalingClient({
           onStateChange: (state) => {
             if (state === 'connected') {


### PR DESCRIPTION
## Summary

- Update hardcoded signaling server URL from `remi-signaling.dev-941.workers.dev` to `remi-signaling.yooz.workers.dev`
- The signaling worker was migrated to the yooz Cloudflare account

## Changes

- `packages/daemon/src/cli.ts`: default signaling URL for relay adapter
- `packages/web/src/App.tsx`: hardcoded signaling URL for web relay connection
- `.context/plan.md`: deployment table URL

## Test plan

- [x] Typecheck passes
- [ ] Verify relay connection works with new URL (manual test with `remi new --relay`)