### PR TITLE
fix: network discovery scans all ports on discovered hosts

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1092,10 +1092,9 @@ if (cliSubcommand === 'attach') {
             const hostEndpoints = findEndpointsByHostname(discovery, targetHostname);
 
             if (hostEndpoints.length > 0) {
-              // Query all ports on this host (the host may have multiple remi instances)
-              const allHostPorts = [...new Set(hostEndpoints.map((e) => e.port))].sort(
-                (a, b) => a - b,
-              );
+              // Query all ports on this host, not just the ones discovery found
+              const { getDefaultPortRange } = await import('./cli/ls-client.ts');
+              const allHostPorts = getDefaultPortRange();
               const remoteHost = hostEndpoints[0]?.host ?? targetHostname;
               const remoteHostname = hostEndpoints[0]?.hostname ?? targetHostname;
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -822,10 +822,9 @@ if (cliSubcommand === 'ls') {
     }
   } else if (cliHost) {
     // Host without port: probe the standard port range on that host
-    const { runHostLs } = await import('./cli/ls-client.ts');
+    const { runHostLs, getDefaultPortRange } = await import('./cli/ls-client.ts');
     try {
-      const ports = Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
-      await runHostLs({ host: cliHost, ports });
+      await runHostLs({ host: cliHost, ports: getDefaultPortRange() });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -15,6 +15,7 @@ import {
 } from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
 import {
+  type DiscoveredEndpoint,
   FETCH_SESSIONS_TIMEOUT_MS,
   MDNS_BROWSE_TIMEOUT_MS,
   discoverNetworkDaemons,
@@ -26,8 +27,8 @@ function getTerminalWidth(): number {
   return process.stdout.columns ?? 100;
 }
 
-/** Generate the default port range array (18765-18774). */
-function getDefaultPortRange(): number[] {
+/** Generate the default port range array (18765-18784). */
+export function getDefaultPortRange(): number[] {
   return Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
 }
 
@@ -348,12 +349,21 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     logLabel: 'ls',
   });
 
-  // Query all discovered endpoints in parallel
+  // Group discovered endpoints by unique host so we scan all ports on each host,
+  // not just the port that discovery happened to find. This matches --host behavior.
+  const hostMap = new Map<string, DiscoveredEndpoint>();
+  for (const endpoint of discovery.endpoints) {
+    if (!hostMap.has(endpoint.host)) {
+      hostMap.set(endpoint.host, endpoint);
+    }
+  }
+
+  const allPorts = getDefaultPortRange();
   const endpointResults = await Promise.allSettled(
-    discovery.endpoints.map(async (endpoint) => {
+    [...hostMap.entries()].map(async ([host, endpoint]) => {
       const portResults = await queryMultiplePorts({
-        host: endpoint.host,
-        ports: [endpoint.port],
+        host,
+        ports: allPorts,
         timeoutMs: timeout,
         logLabel: 'ls',
       });
@@ -362,14 +372,14 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   );
   for (const er of endpointResults) {
     if (er.status === 'fulfilled') {
+      const ep = er.value.endpoint;
       for (const r of er.value.portResults) {
         results.push({
           daemon: {
-            name:
-              er.value.endpoint.name ?? `${er.value.endpoint.source}:${er.value.endpoint.hostname}`,
-            host: er.value.endpoint.host,
-            port: er.value.endpoint.port,
-            hostname: er.value.endpoint.hostname,
+            name: ep.name ?? `${ep.source}:${ep.hostname}`,
+            host: ep.host,
+            port: r.port,
+            hostname: ep.hostname,
           },
           sessions: r.sessions,
         });

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -384,6 +384,9 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
           sessions: r.sessions,
         });
       }
+    } else {
+      const reason = er.reason instanceof Error ? er.reason.message : String(er.reason);
+      console.error(`\x1b[2m[ls] Failed to query discovered host: ${reason}\x1b[0m`);
     }
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -32,6 +32,22 @@ export function getDefaultPortRange(): number[] {
   return Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
 }
 
+/**
+ * Deduplicate discovered endpoints by host, keeping the first endpoint per unique host IP.
+ * This allows scanning all ports on each host rather than just the discovered port.
+ */
+export function groupEndpointsByHost(
+  endpoints: readonly DiscoveredEndpoint[],
+): Map<string, DiscoveredEndpoint> {
+  const hostMap = new Map<string, DiscoveredEndpoint>();
+  for (const endpoint of endpoints) {
+    if (!hostMap.has(endpoint.host)) {
+      hostMap.set(endpoint.host, endpoint);
+    }
+  }
+  return hostMap;
+}
+
 /** Minimum name column width to keep output readable even on very narrow terminals. */
 const MIN_NAME_WIDTH = 20;
 
@@ -351,12 +367,7 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
 
   // Group discovered endpoints by unique host so we scan all ports on each host,
   // not just the port that discovery happened to find. This matches --host behavior.
-  const hostMap = new Map<string, DiscoveredEndpoint>();
-  for (const endpoint of discovery.endpoints) {
-    if (!hostMap.has(endpoint.host)) {
-      hostMap.set(endpoint.host, endpoint);
-    }
-  }
+  const hostMap = groupEndpointsByHost(discovery.endpoints);
 
   const allPorts = getDefaultPortRange();
   const endpointResults = await Promise.allSettled(

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -285,9 +285,9 @@ export async function discoverNetworkDaemons(
   const myHostname = os.hostname();
   const localAddrs = getLocalAddresses(myHostname);
 
-  // Convert mDNS daemons to endpoints, filtering out self
+  // Convert mDNS daemons to endpoints, filtering out self (any local address, any port)
   const mdnsEndpoints: DiscoveredEndpoint[] = daemons
-    .filter((d) => !(d.port === defaultPort && localAddrs.has(d.host)))
+    .filter((d) => !localAddrs.has(d.host))
     .map((d) => ({
       host: d.host,
       port: d.port,

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -16,6 +16,7 @@
 
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import { DEFAULT_BASE_PORT, DEFAULT_PORT_RANGE } from '../session/session-registry-file.ts';
 
 export interface VpnPeer {
   /** Hostname of the peer machine */
@@ -31,7 +32,7 @@ export interface VpnPeer {
 export interface VpnDiscoveryOptions {
   /** Base port to probe for remi daemons. Default: 18765 */
   readonly port?: number | undefined;
-  /** Number of ports to probe starting from base port. Default: 10 */
+  /** Number of ports to probe starting from base port. Default: DEFAULT_PORT_RANGE */
   readonly portRange?: number | undefined;
   /** Timeout per probe in ms. Default: 2000 */
   readonly probeTimeoutMs?: number | undefined;
@@ -46,8 +47,8 @@ export interface VpnDiscoveryOptions {
 export async function discoverVpnPeers(
   opts?: VpnDiscoveryOptions,
 ): Promise<{ peer: VpnPeer; host: string; port: number }[]> {
-  const basePort = opts?.port ?? 18765;
-  const portRange = opts?.portRange ?? 10;
+  const basePort = opts?.port ?? DEFAULT_BASE_PORT;
+  const portRange = opts?.portRange ?? DEFAULT_PORT_RANGE;
   const probeTimeout = opts?.probeTimeoutMs ?? 2000;
 
   const peers = getAllVpnPeers();

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -463,7 +463,8 @@ describe('getDefaultPortRange', () => {
   test('returns sequential ports with no gaps', () => {
     const ports = getDefaultPortRange();
     for (let i = 1; i < ports.length; i++) {
-      expect(ports[i]).toBe(ports[i - 1]! + 1);
+      const prev = ports[i - 1] ?? 0;
+      expect(ports[i]).toBe(prev + 1);
     }
   });
 });

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -13,11 +13,14 @@ import {
   fetchSessions,
   formatAge,
   formatDuration,
+  getDefaultPortRange,
   getLocalAddresses,
+  groupEndpointsByHost,
   parseHostPort,
   parseRemoteTarget,
   runLsClient,
 } from '../../src/cli/ls-client.ts';
+import type { DiscoveredEndpoint } from '../../src/cli/session-resolver.ts';
 
 const TEST_PORT = 9871;
 
@@ -442,5 +445,68 @@ describe('formatDuration', () => {
   test('formats exact days without hours', () => {
     const ts = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
     expect(formatDuration(ts)).toBe('2d');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultPortRange
+// ---------------------------------------------------------------------------
+
+describe('getDefaultPortRange', () => {
+  test('returns 20 ports starting at 18765', () => {
+    const ports = getDefaultPortRange();
+    expect(ports).toHaveLength(20);
+    expect(ports[0]).toBe(18765);
+    expect(ports[19]).toBe(18784);
+  });
+
+  test('returns sequential ports with no gaps', () => {
+    const ports = getDefaultPortRange();
+    for (let i = 1; i < ports.length; i++) {
+      expect(ports[i]).toBe(ports[i - 1]! + 1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupEndpointsByHost
+// ---------------------------------------------------------------------------
+
+describe('groupEndpointsByHost', () => {
+  function ep(host: string, port: number, source: 'mdns' | 'vpn' = 'mdns'): DiscoveredEndpoint {
+    return { host, port, hostname: `host-${host}`, source };
+  }
+
+  test('returns empty map for empty input', () => {
+    expect(groupEndpointsByHost([])).toEqual(new Map());
+  });
+
+  test('keeps one endpoint per unique host', () => {
+    const endpoints = [ep('192.168.1.1', 18765), ep('192.168.1.2', 18770)];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(2);
+    expect(result.get('192.168.1.1')?.port).toBe(18765);
+    expect(result.get('192.168.1.2')?.port).toBe(18770);
+  });
+
+  test('deduplicates same host on different ports, keeping the first', () => {
+    const endpoints = [
+      ep('192.168.1.1', 18765, 'mdns'),
+      ep('192.168.1.1', 18770, 'vpn'),
+      ep('192.168.1.1', 18775, 'mdns'),
+    ];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(1);
+    expect(result.get('192.168.1.1')?.port).toBe(18765);
+    expect(result.get('192.168.1.1')?.source).toBe('mdns');
+  });
+
+  test('treats different IPs for same hostname as separate hosts', () => {
+    const endpoints = [
+      { host: '192.168.1.1', port: 18765, hostname: 'myhost', source: 'mdns' as const },
+      { host: '100.79.39.98', port: 18765, hostname: 'myhost', source: 'vpn' as const },
+    ];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(2);
   });
 });

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -12,6 +12,7 @@ import {
   type PortQueryResult,
   classifyQueryError,
   findEndpointsByHostname,
+  getLocalAddresses,
   resolveSession,
 } from '../../src/cli/session-resolver.ts';
 
@@ -329,5 +330,35 @@ describe('findEndpointsByHostname', () => {
     const empty: NetworkDiscoveryResult = { endpoints: [] };
     const matches = findEndpointsByHostname(empty, 'macbook');
     expect(matches).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLocalAddresses (mDNS self-filter foundation)
+// ---------------------------------------------------------------------------
+
+describe('getLocalAddresses', () => {
+  test('includes loopback addresses', () => {
+    const addrs = getLocalAddresses('test-host');
+    expect(addrs.has('127.0.0.1')).toBe(true);
+    expect(addrs.has('::1')).toBe(true);
+    expect(addrs.has('localhost')).toBe(true);
+  });
+
+  test('includes the provided hostname', () => {
+    const addrs = getLocalAddresses('my-machine');
+    expect(addrs.has('my-machine')).toBe(true);
+  });
+
+  test('self-filter should use address only, not port', () => {
+    // The mDNS self-filter uses localAddrs.has(d.host) without port checks.
+    // Verify that a local address is filtered regardless of what port a daemon runs on.
+    const addrs = getLocalAddresses('test-host');
+    // If 127.0.0.1 is in the set, any daemon at 127.0.0.1 (any port) should be filtered.
+    // This tests the contract that discoverNetworkDaemons relies on.
+    expect(addrs.has('127.0.0.1')).toBe(true);
+    // The set contains IPs, not host:port pairs, confirming port-independent filtering.
+    expect(addrs.has('127.0.0.1:18765')).toBe(false);
+    expect(addrs.has('127.0.0.1:18770')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- VPN discovery now uses `DEFAULT_PORT_RANGE` (20) instead of hardcoded 10, finding sessions on ports 18775+
- `runNetworkLs` groups discovered hosts and scans all ports on each (matching `--host` behavior), instead of querying only the single discovered port
- mDNS self-filter now excludes all local addresses regardless of port, preventing local daemons from appearing as remote duplicates
- Exported `getDefaultPortRange()` to deduplicate port range construction in `cli.ts`

## Test plan

- [x] All 1222 tests pass
- [x] Type-check passes
- [x] Biome lint passes
- [ ] Manual: `remi ls --network` should find the same sessions as `remi ls --host <hostname>` for any host with daemons on non-default ports

Closes #162