### PR TITLE
fix: network discovery and CI auto-sync develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      released: ${{ steps.check.outputs.is_dev }}
     steps:
       - name: Generate App Token
         id: app-token
@@ -124,3 +126,55 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           bun install --frozen-lockfile
           ./scripts/bump-version.sh --push --force stable
+
+  # After a stable release on main, merge main back into develop and
+  # bump to the next patch dev version (e.g. 0.4.13 -> 0.4.14-dev.1).
+  sync-develop:
+    name: Sync Develop After Release
+    needs: [auto-release]
+    if: needs.auto-release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Merge main into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          # Merge main; if version files conflict, take ours since bump overwrites them
+          git merge origin/main --no-edit || {
+            git checkout --ours package.json packages/daemon/src/cli.ts
+            git add package.json packages/daemon/src/cli.ts
+            # Fail if there are still unresolved conflicts beyond version files
+            if git diff --name-only --diff-filter=U | grep -q .; then
+              echo "Error: unresolved merge conflicts beyond version files" >&2
+              git diff --name-only --diff-filter=U
+              exit 1
+            fi
+            git commit --no-edit
+          }
+
+      - name: Bump to next dev version
+        run: |
+          bun install --frozen-lockfile
+          ./scripts/bump-version.sh dev
+          # Push branch only (no tag to avoid triggering a dev release)
+          git push origin develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,18 +159,27 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
-          # Merge main; if version files conflict, take ours since bump overwrites them
-          git merge origin/main --no-edit || {
+          if git merge origin/main --no-edit; then
+            echo "Merge succeeded cleanly"
+          else
+            # Verify this is actually a merge conflict, not a different failure
+            if ! git diff --name-only --diff-filter=U | grep -q .; then
+              echo "Error: merge failed but no conflicts detected. Aborting." >&2
+              git merge --abort || true
+              exit 1
+            fi
+            echo "Resolving version file conflicts (bump-version.sh will overwrite)..."
             git checkout --ours package.json packages/daemon/src/cli.ts
             git add package.json packages/daemon/src/cli.ts
             # Fail if there are still unresolved conflicts beyond version files
             if git diff --name-only --diff-filter=U | grep -q .; then
-              echo "Error: unresolved merge conflicts beyond version files" >&2
-              git diff --name-only --diff-filter=U
+              echo "Error: unresolved merge conflicts beyond version files:" >&2
+              git diff --name-only --diff-filter=U >&2
+              git merge --abort || true
               exit 1
             fi
             git commit --no-edit
-          }
+          fi
 
       - name: Bump to next dev version
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.13-dev.1",
+  "version": "0.4.14-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.13-dev.1'; // REMI_COMPILED_VERSION
+      return '0.4.14-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.13-dev.1'; // REMI_COMPILED_VERSION
+    return '0.4.14-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -822,10 +822,9 @@ if (cliSubcommand === 'ls') {
     }
   } else if (cliHost) {
     // Host without port: probe the standard port range on that host
-    const { runHostLs } = await import('./cli/ls-client.ts');
+    const { runHostLs, getDefaultPortRange } = await import('./cli/ls-client.ts');
     try {
-      const ports = Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
-      await runHostLs({ host: cliHost, ports });
+      await runHostLs({ host: cliHost, ports: getDefaultPortRange() });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
@@ -1093,10 +1092,9 @@ if (cliSubcommand === 'attach') {
             const hostEndpoints = findEndpointsByHostname(discovery, targetHostname);
 
             if (hostEndpoints.length > 0) {
-              // Query all ports on this host (the host may have multiple remi instances)
-              const allHostPorts = [...new Set(hostEndpoints.map((e) => e.port))].sort(
-                (a, b) => a - b,
-              );
+              // Query all ports on this host, not just the ones discovery found
+              const { getDefaultPortRange } = await import('./cli/ls-client.ts');
+              const allHostPorts = getDefaultPortRange();
               const remoteHost = hostEndpoints[0]?.host ?? targetHostname;
               const remoteHostname = hostEndpoints[0]?.hostname ?? targetHostname;
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1092,9 +1092,12 @@ if (cliSubcommand === 'attach') {
             const hostEndpoints = findEndpointsByHostname(discovery, targetHostname);
 
             if (hostEndpoints.length > 0) {
-              // Query all ports on this host, not just the ones discovery found
+              // Scan default range plus any non-default ports discovery reported
               const { getDefaultPortRange } = await import('./cli/ls-client.ts');
-              const allHostPorts = getDefaultPortRange();
+              const discoveredPorts = hostEndpoints.map((e) => e.port);
+              const allHostPorts = [
+                ...new Set([...getDefaultPortRange(), ...discoveredPorts]),
+              ].sort((a, b) => a - b);
               const remoteHost = hostEndpoints[0]?.host ?? targetHostname;
               const remoteHostname = hostEndpoints[0]?.hostname ?? targetHostname;
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -15,6 +15,7 @@ import {
 } from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
 import {
+  type DiscoveredEndpoint,
   FETCH_SESSIONS_TIMEOUT_MS,
   MDNS_BROWSE_TIMEOUT_MS,
   discoverNetworkDaemons,
@@ -26,9 +27,25 @@ function getTerminalWidth(): number {
   return process.stdout.columns ?? 100;
 }
 
-/** Generate the default port range array (18765-18774). */
-function getDefaultPortRange(): number[] {
+/** Generate the default port range array (18765-18784). */
+export function getDefaultPortRange(): number[] {
   return Array.from({ length: DEFAULT_PORT_RANGE }, (_, i) => DEFAULT_BASE_PORT + i);
+}
+
+/**
+ * Deduplicate discovered endpoints by host, keeping the first endpoint per unique host IP.
+ * This allows scanning all ports on each host rather than just the discovered port.
+ */
+export function groupEndpointsByHost(
+  endpoints: readonly DiscoveredEndpoint[],
+): Map<string, DiscoveredEndpoint> {
+  const hostMap = new Map<string, DiscoveredEndpoint>();
+  for (const endpoint of endpoints) {
+    if (!hostMap.has(endpoint.host)) {
+      hostMap.set(endpoint.host, endpoint);
+    }
+  }
+  return hostMap;
 }
 
 /** Minimum name column width to keep output readable even on very narrow terminals. */
@@ -348,12 +365,16 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
     logLabel: 'ls',
   });
 
-  // Query all discovered endpoints in parallel
+  // Group discovered endpoints by unique host so we scan all ports on each host,
+  // not just the port that discovery happened to find. This matches --host behavior.
+  const hostMap = groupEndpointsByHost(discovery.endpoints);
+
+  const allPorts = getDefaultPortRange();
   const endpointResults = await Promise.allSettled(
-    discovery.endpoints.map(async (endpoint) => {
+    [...hostMap.entries()].map(async ([host, endpoint]) => {
       const portResults = await queryMultiplePorts({
-        host: endpoint.host,
-        ports: [endpoint.port],
+        host,
+        ports: allPorts,
         timeoutMs: timeout,
         logLabel: 'ls',
       });
@@ -362,18 +383,21 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   );
   for (const er of endpointResults) {
     if (er.status === 'fulfilled') {
+      const ep = er.value.endpoint;
       for (const r of er.value.portResults) {
         results.push({
           daemon: {
-            name:
-              er.value.endpoint.name ?? `${er.value.endpoint.source}:${er.value.endpoint.hostname}`,
-            host: er.value.endpoint.host,
-            port: er.value.endpoint.port,
-            hostname: er.value.endpoint.hostname,
+            name: ep.name ?? `${ep.source}:${ep.hostname}`,
+            host: ep.host,
+            port: r.port,
+            hostname: ep.hostname,
           },
           sessions: r.sessions,
         });
       }
+    } else {
+      const reason = er.reason instanceof Error ? er.reason.message : String(er.reason);
+      console.error(`\x1b[2m[ls] Failed to query discovered host: ${reason}\x1b[0m`);
     }
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -370,8 +370,9 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
   const hostMap = groupEndpointsByHost(discovery.endpoints);
 
   const allPorts = getDefaultPortRange();
+  const hostEntries = [...hostMap.entries()];
   const endpointResults = await Promise.allSettled(
-    [...hostMap.entries()].map(async ([host, endpoint]) => {
+    hostEntries.map(async ([host, endpoint]) => {
       const portResults = await queryMultiplePorts({
         host,
         ports: allPorts,
@@ -381,8 +382,9 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
       return { endpoint, portResults };
     }),
   );
-  for (const er of endpointResults) {
-    if (er.status === 'fulfilled') {
+  for (let i = 0; i < endpointResults.length; i++) {
+    const er = endpointResults[i];
+    if (er?.status === 'fulfilled') {
       const ep = er.value.endpoint;
       for (const r of er.value.portResults) {
         results.push({
@@ -395,9 +397,12 @@ export async function runNetworkLs(opts: NetworkLsOptions): Promise<void> {
           sessions: r.sessions,
         });
       }
-    } else {
+    } else if (er?.status === 'rejected') {
+      const [failedHost] = hostEntries[i] ?? [];
       const reason = er.reason instanceof Error ? er.reason.message : String(er.reason);
-      console.error(`\x1b[2m[ls] Failed to query discovered host: ${reason}\x1b[0m`);
+      console.error(
+        `\x1b[2m[ls] Failed to query ${failedHost ?? 'unknown host'}: ${reason}\x1b[0m`,
+      );
     }
   }
 

--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -285,9 +285,9 @@ export async function discoverNetworkDaemons(
   const myHostname = os.hostname();
   const localAddrs = getLocalAddresses(myHostname);
 
-  // Convert mDNS daemons to endpoints, filtering out self
+  // Convert mDNS daemons to endpoints, filtering out self (any local address, any port)
   const mdnsEndpoints: DiscoveredEndpoint[] = daemons
-    .filter((d) => !(d.port === defaultPort && localAddrs.has(d.host)))
+    .filter((d) => !localAddrs.has(d.host))
     .map((d) => ({
       host: d.host,
       port: d.port,

--- a/packages/daemon/src/mdns/vpn-discovery.ts
+++ b/packages/daemon/src/mdns/vpn-discovery.ts
@@ -16,6 +16,7 @@
 
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import { DEFAULT_BASE_PORT, DEFAULT_PORT_RANGE } from '../session/session-registry-file.ts';
 
 export interface VpnPeer {
   /** Hostname of the peer machine */
@@ -31,7 +32,7 @@ export interface VpnPeer {
 export interface VpnDiscoveryOptions {
   /** Base port to probe for remi daemons. Default: 18765 */
   readonly port?: number | undefined;
-  /** Number of ports to probe starting from base port. Default: 10 */
+  /** Number of ports to probe starting from base port. Default: DEFAULT_PORT_RANGE */
   readonly portRange?: number | undefined;
   /** Timeout per probe in ms. Default: 2000 */
   readonly probeTimeoutMs?: number | undefined;
@@ -46,8 +47,8 @@ export interface VpnDiscoveryOptions {
 export async function discoverVpnPeers(
   opts?: VpnDiscoveryOptions,
 ): Promise<{ peer: VpnPeer; host: string; port: number }[]> {
-  const basePort = opts?.port ?? 18765;
-  const portRange = opts?.portRange ?? 10;
+  const basePort = opts?.port ?? DEFAULT_BASE_PORT;
+  const portRange = opts?.portRange ?? DEFAULT_PORT_RANGE;
   const probeTimeout = opts?.probeTimeoutMs ?? 2000;
 
   const peers = getAllVpnPeers();

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -13,11 +13,14 @@ import {
   fetchSessions,
   formatAge,
   formatDuration,
+  getDefaultPortRange,
   getLocalAddresses,
+  groupEndpointsByHost,
   parseHostPort,
   parseRemoteTarget,
   runLsClient,
 } from '../../src/cli/ls-client.ts';
+import type { DiscoveredEndpoint } from '../../src/cli/session-resolver.ts';
 
 const TEST_PORT = 9871;
 
@@ -442,5 +445,69 @@ describe('formatDuration', () => {
   test('formats exact days without hours', () => {
     const ts = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
     expect(formatDuration(ts)).toBe('2d');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultPortRange
+// ---------------------------------------------------------------------------
+
+describe('getDefaultPortRange', () => {
+  test('returns 20 ports starting at 18765', () => {
+    const ports = getDefaultPortRange();
+    expect(ports).toHaveLength(20);
+    expect(ports[0]).toBe(18765);
+    expect(ports[19]).toBe(18784);
+  });
+
+  test('returns sequential ports with no gaps', () => {
+    const ports = getDefaultPortRange();
+    for (let i = 1; i < ports.length; i++) {
+      const prev = ports[i - 1] ?? 0;
+      expect(ports[i]).toBe(prev + 1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupEndpointsByHost
+// ---------------------------------------------------------------------------
+
+describe('groupEndpointsByHost', () => {
+  function ep(host: string, port: number, source: 'mdns' | 'vpn' = 'mdns'): DiscoveredEndpoint {
+    return { host, port, hostname: `host-${host}`, source };
+  }
+
+  test('returns empty map for empty input', () => {
+    expect(groupEndpointsByHost([])).toEqual(new Map());
+  });
+
+  test('keeps one endpoint per unique host', () => {
+    const endpoints = [ep('192.168.1.1', 18765), ep('192.168.1.2', 18770)];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(2);
+    expect(result.get('192.168.1.1')?.port).toBe(18765);
+    expect(result.get('192.168.1.2')?.port).toBe(18770);
+  });
+
+  test('deduplicates same host on different ports, keeping the first', () => {
+    const endpoints = [
+      ep('192.168.1.1', 18765, 'mdns'),
+      ep('192.168.1.1', 18770, 'vpn'),
+      ep('192.168.1.1', 18775, 'mdns'),
+    ];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(1);
+    expect(result.get('192.168.1.1')?.port).toBe(18765);
+    expect(result.get('192.168.1.1')?.source).toBe('mdns');
+  });
+
+  test('treats different IPs for same hostname as separate hosts', () => {
+    const endpoints = [
+      { host: '192.168.1.1', port: 18765, hostname: 'myhost', source: 'mdns' as const },
+      { host: '100.79.39.98', port: 18765, hostname: 'myhost', source: 'vpn' as const },
+    ];
+    const result = groupEndpointsByHost(endpoints);
+    expect(result.size).toBe(2);
   });
 });

--- a/packages/daemon/tests/cli/session-resolver.test.ts
+++ b/packages/daemon/tests/cli/session-resolver.test.ts
@@ -12,6 +12,7 @@ import {
   type PortQueryResult,
   classifyQueryError,
   findEndpointsByHostname,
+  getLocalAddresses,
   resolveSession,
 } from '../../src/cli/session-resolver.ts';
 
@@ -329,5 +330,35 @@ describe('findEndpointsByHostname', () => {
     const empty: NetworkDiscoveryResult = { endpoints: [] };
     const matches = findEndpointsByHostname(empty, 'macbook');
     expect(matches).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLocalAddresses (mDNS self-filter foundation)
+// ---------------------------------------------------------------------------
+
+describe('getLocalAddresses', () => {
+  test('includes loopback addresses', () => {
+    const addrs = getLocalAddresses('test-host');
+    expect(addrs.has('127.0.0.1')).toBe(true);
+    expect(addrs.has('::1')).toBe(true);
+    expect(addrs.has('localhost')).toBe(true);
+  });
+
+  test('includes the provided hostname', () => {
+    const addrs = getLocalAddresses('my-machine');
+    expect(addrs.has('my-machine')).toBe(true);
+  });
+
+  test('self-filter should use address only, not port', () => {
+    // The mDNS self-filter uses localAddrs.has(d.host) without port checks.
+    // Verify that a local address is filtered regardless of what port a daemon runs on.
+    const addrs = getLocalAddresses('test-host');
+    // If 127.0.0.1 is in the set, any daemon at 127.0.0.1 (any port) should be filtered.
+    // This tests the contract that discoverNetworkDaemons relies on.
+    expect(addrs.has('127.0.0.1')).toBe(true);
+    // The set contains IPs, not host:port pairs, confirming port-independent filtering.
+    expect(addrs.has('127.0.0.1:18765')).toBe(false);
+    expect(addrs.has('127.0.0.1:18770')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Network discovery fix (#162):** `remi ls --network` now finds all sessions on discovered hosts, not just the port that mDNS/VPN happened to report. VPN probes the full 20-port range, and each discovered host is scanned across all default ports (matching `--host` behavior). Also fixes attach flow and mDNS self-filter.
- **CI auto-sync:** New `sync-develop` job merges main back into develop after a stable release and bumps to next dev version automatically.
- **Version bump:** 0.4.13-dev.1 -> 0.4.14-dev.1

## Changes

### Network discovery (Closes #162)
- VPN discovery uses `DEFAULT_PORT_RANGE` (20) instead of hardcoded 10
- `runNetworkLs` groups endpoints by host, scans all ports per host
- mDNS self-filter excludes all local addresses regardless of port
- Attach flow scans full port range on discovered hosts
- Rejected promises in network ls are now logged
- Extracted `groupEndpointsByHost()` and `getDefaultPortRange()` as testable exports

### CI
- `auto-release` job now outputs `released` flag
- New `sync-develop` job: merges main into develop, bumps next dev version

### Tests (9 new)
- `getDefaultPortRange`: range length, boundaries, sequential
- `groupEndpointsByHost`: empty input, dedup same-host, multi-IP same-hostname
- `getLocalAddresses`: loopback, hostname, address-only filtering

## Test plan

- [x] 1231 tests pass, 0 failures
- [x] Type-check clean
- [x] Biome lint clean
- [x] PR review toolkit ran on #163 (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer)
- [ ] Manual: verify `remi ls --network` matches `remi ls --host` on multi-port hosts
- [ ] CI: verify `sync-develop` job runs after next main release