### PR TITLE
fix: daemon-mode sessions missing status line

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1617,7 +1617,7 @@ async function createNewSession(
       args: extraArgs,
       cwd: workingDirectory,
       size: termSize,
-      env: passThrough ? { REMI_PORT: String(remiStatus.wsPort) } : {},
+      env: { REMI_PORT: String(remiStatus.wsPort) },
     },
     {
       onRawData: (data: Uint8Array) => {
@@ -2663,6 +2663,7 @@ if (cliDaemonMode) {
   primarySessionId = sessionId;
 
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
+  installStatusLine();
 
   // Start hook server for Claude Code event detection (port 0 = OS-assigned)
   try {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -187,7 +187,12 @@ function installStatusLine(): void {
     const claudeSettingsFile = path.join(os.homedir(), '.claude', 'settings.json');
     let settings: Record<string, unknown> = {};
     if (fs.existsSync(claudeSettingsFile)) {
-      settings = JSON.parse(fs.readFileSync(claudeSettingsFile, 'utf-8'));
+      try {
+        settings = JSON.parse(fs.readFileSync(claudeSettingsFile, 'utf-8'));
+      } catch {
+        console.error(`[warn] Claude settings file is corrupted: ${claudeSettingsFile}`);
+        return;
+      }
     }
     if (!settings['statusLine']) {
       fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
@@ -195,7 +200,8 @@ function installStatusLine(): void {
       fs.writeFileSync(claudeSettingsFile, `${JSON.stringify(settings, null, 2)}\n`);
     }
   } catch (err) {
-    writeToLog(`[warn] Failed to install status line: ${err}`);
+    // console.error works in both wrapper and daemon mode
+    console.error(`[warn] Failed to install status line: ${err}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Always pass `REMI_PORT` env var to Claude in `createNewSession()`, not just in wrapper (passThrough) mode
- Call `installStatusLine()` in daemon mode so the status line script exists even without prior wrapper usage

## Root Cause

Line 1620 in cli.ts had: `env: passThrough ? { REMI_PORT: ... } : {}`

This meant daemon-mode sessions (via `remi new`, `remi --daemon`) spawned Claude without `REMI_PORT`, so the status line script couldn't find the remi status file and fell back to basic model/context output.

## Test plan

- [x] 1231 tests pass
- [x] Type-check clean
- [x] Biome lint clean
- [ ] Manual: `remi new --dir /path` shows full status line
- [ ] Manual: `remi new --host remote --dir /path` shows full status line
- [ ] Manual: `remi` (wrapper) continues to work unchanged

Closes #165