### PR TITLE
fix: utility clients auto-attach, add multi-client Docker tests

### DIFF
--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -99,6 +99,7 @@ export class WebSocketAdapter implements ConnectionAdapter {
           platformData: {
             directory: connection.connectionDirectory,
             resumeSessionId: connection.connectionResumeSessionId,
+            mode: connection.connectionMode,
           },
         };
         this.events.onConnect?.(connection.id, metadata);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1903,33 +1903,39 @@ const sharedEvents = {
     }
 
     // Try to attach to the primary (only) session
+    const isQueryMode = metadata.platformData?.['mode'] === 'query';
     if (primarySessionId) {
-      const targetSession = primarySessionId;
-      const result = sessionRegistry.attachConnection(targetSession, connectionId);
-      if (result.success) {
-        sendToConnection(
-          connectionId,
-          createHelloAck('1.0.0', targetSession, {
-            isResume: result.replayMessages.length > 0,
-            replayCount: result.replayMessages.length,
-            nextBulletId: result.nextBulletId,
-          }),
-        );
-        if (result.replayMessages.length > 0) {
+      // Only auto-attach if the client wants to attach (not a utility client like ls/kill)
+      if (!isQueryMode) {
+        const targetSession = primarySessionId;
+        const result = sessionRegistry.attachConnection(targetSession, connectionId);
+        if (result.success) {
           sendToConnection(
             connectionId,
-            createReplayBatch(targetSession, result.replayMessages, true),
+            createHelloAck('1.0.0', targetSession, {
+              isResume: result.replayMessages.length > 0,
+              replayCount: result.replayMessages.length,
+              nextBulletId: result.nextBulletId,
+            }),
           );
+          if (result.replayMessages.length > 0) {
+            sendToConnection(
+              connectionId,
+              createReplayBatch(targetSession, result.replayMessages, true),
+            );
+          }
+          cancelOrphanTimeout();
+          log(`Attached connection ${connectionId} to session ${targetSession}`);
+          return;
         }
-        cancelOrphanTimeout();
-        log(`Attached connection ${connectionId} to session ${targetSession}`);
-        return;
       }
 
-      // Attach failed (session busy); send hello_ack without attach so
-      // utility clients (ls, kill) can still send requests
+      // Query mode or attach failed (session busy); send hello_ack without attach
+      // so utility clients (ls, kill) can still send requests
       sendToConnection(connectionId, createHelloAck('1.0.0', primarySessionId));
-      log(`Connection ${connectionId} connected without attach (session busy or query client)`);
+      log(
+        `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
+      );
       return;
     }
 

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -61,7 +61,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
 
     function sendHello(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0')));
+      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
     }
 
     function handleMessage(msg: ProtocolMessage): void {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -217,7 +217,7 @@ export async function fetchSessions(
 
     function sendHelloAndRequestList(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0')));
+      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
     }
 
     let sentListRequest = false;

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -65,7 +65,7 @@ export async function fetchRecentDirectories(
 
     function sendHello(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0')));
+      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
     }
 
     function handleMessage(msg: ProtocolMessage): void {

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -129,6 +129,7 @@ export class Connection {
   private sessionId: UUID | null = null;
   private directory: string | null = null;
   private resumeSessionId: UUID | null = null;
+  private _mode: 'query' | undefined = undefined;
 
   private readonly ws: WebSocket;
   private readonly config: Required<ConnectionConfig> & {
@@ -195,6 +196,11 @@ export class Connection {
   /** Get resume session ID (null if not resuming) */
   get connectionResumeSessionId(): UUID | null {
     return this.resumeSessionId;
+  }
+
+  /** Connection mode: 'query' for utility clients that should not auto-attach */
+  get connectionMode(): 'query' | undefined {
+    return this._mode;
   }
 
   /** Check if connection is active */
@@ -357,6 +363,7 @@ export class Connection {
     this.sessionId = this.id;
     this.directory = message.directory ?? null;
     this.resumeSessionId = message.resumeSessionId ?? null;
+    this._mode = message.mode;
     this.state = 'connected';
 
     // Send hello ack (unless skipHelloAck is set, which lets daemon handle it)

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -363,7 +363,7 @@ export class Connection {
     this.sessionId = this.id;
     this.directory = message.directory ?? null;
     this.resumeSessionId = message.resumeSessionId ?? null;
-    this._mode = message.mode;
+    this._mode = message.mode === 'query' ? 'query' : undefined;
     this.state = 'connected';
 
     // Send hello ack (unless skipHelloAck is set, which lets daemon handle it)

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -110,6 +110,8 @@ export interface HelloMessage {
   readonly resumeSessionId?: UUID | undefined;
   /** Index of last received message (for efficient replay) */
   readonly lastReceivedIndex?: number | undefined;
+  /** Connection mode: 'query' for utility clients (ls, kill) that should not auto-attach */
+  readonly mode?: 'query' | undefined;
 }
 
 /** Server hello ack - confirms connection */
@@ -590,6 +592,7 @@ export function createHello(
   directory?: string,
   resumeSessionId?: UUID,
   lastReceivedIndex?: number,
+  mode?: 'query',
 ): HelloMessage {
   return {
     type: 'hello',
@@ -600,6 +603,7 @@ export function createHello(
     ...(directory !== undefined && { directory }),
     ...(resumeSessionId !== undefined && { resumeSessionId }),
     ...(lastReceivedIndex !== undefined && { lastReceivedIndex }),
+    ...(mode !== undefined && { mode }),
   };
 }
 

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -1039,6 +1039,26 @@ describe('Message factory functions', () => {
       expect(msg.resumeSessionId).toBe(sessionId);
       expect(msg.lastReceivedIndex).toBe(10);
     });
+
+    test('includes mode when provided', () => {
+      const msg = createHello('client-1', '1.0.0', undefined, undefined, undefined, 'query');
+      expect(msg.mode).toBe('query');
+    });
+
+    test('omits mode when not provided', () => {
+      const msg = createHello('client-1', '1.0.0');
+      expect(msg.mode).toBeUndefined();
+      expect('mode' in msg).toBe(false);
+    });
+
+    test('mode survives serialize/deserialize round-trip', () => {
+      const msg = createHello('client-1', '1.0.0', undefined, undefined, undefined, 'query');
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('hello');
+      expect((deserialized as typeof msg).mode).toBe('query');
+    });
   });
 
   describe('createHelloAck() with resume info', () => {

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -25,7 +25,7 @@ FROM debian:bookworm-slim
 
 # Install Node.js (required by Claude Code CLI) and git
 RUN apt-get update && \
-    apt-get install -y curl git && \
+    apt-get install -y curl git procps && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -49,6 +49,11 @@ services:
     init: true
     entrypoint: ["sleep"]
     command: ["infinity"]
+    depends_on:
+      daemon1:
+        condition: service_healthy
+      daemon2:
+        condition: service_healthy
     environment:
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
     networks:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: ../..
       dockerfile: tests/integration/Dockerfile
     container_name: remi-test-daemon1
+    init: true
     working_dir: /projects/sample-app
     ports:
       - "19765:18765"
@@ -24,6 +25,7 @@ services:
       context: ../..
       dockerfile: tests/integration/Dockerfile
     container_name: remi-test-daemon2
+    init: true
     working_dir: /projects/api-server
     ports:
       - "19766:18765"
@@ -38,6 +40,20 @@ services:
       timeout: 3s
       retries: 10
       start_period: 5s
+
+  client1:
+    build:
+      context: ../..
+      dockerfile: tests/integration/Dockerfile
+    container_name: remi-test-client1
+    init: true
+    entrypoint: ["sleep"]
+    command: ["infinity"]
+    environment:
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+    networks:
+      remi-test:
+        ipv4_address: 172.28.0.12
 
 networks:
   remi-test:

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -74,6 +74,51 @@ run_test_expect_fail() {
 d1_remi() { docker exec $D1 remi "$@"; }
 d2_remi() { docker exec $D2 remi "$@"; }
 
+# ---- Multi-client helpers ----
+C1=remi-test-client1
+C1_IP=172.28.0.12
+c1_remi() { docker exec $C1 remi "$@"; }
+
+# Start remi attach in background inside a container.
+# Returns the PID of the remi attach process.
+bg_attach() {
+  local ctr=$1; shift
+  docker exec "$ctr" bash -c "sleep infinity | remi attach $* &>/dev/null & echo \$!"
+}
+
+# Kill a process inside a container
+ckill() { docker exec "$1" kill "$2" 2>/dev/null || true; }
+
+# Poll until session becomes occupied (no 'available to attach' in ls)
+wait_occupied() {
+  local ctr=$1 secs=${2:-5}; shift 2 || shift $#
+  for i in $(seq 1 "$secs"); do
+    if ! docker exec "$ctr" remi ls "${@}" 2>&1 | grep -qF 'available to attach'; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+# Poll until session becomes available ('available to attach' in ls)
+wait_available() {
+  local ctr=$1 secs=${2:-5}; shift 2 || shift $#
+  for i in $(seq 1 "$secs"); do
+    if docker exec "$ctr" remi ls "${@}" 2>&1 | grep -qF 'available to attach'; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+# Poll until a process exits inside a container
+wait_exit() {
+  local ctr=$1 pid=$2 secs=${3:-5}
+  for i in $(seq 1 "$secs"); do
+    if ! docker exec "$ctr" kill -0 "$pid" 2>/dev/null; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
 cleanup() {
   echo ""
   echo "Cleaning up Docker containers..."
@@ -151,6 +196,222 @@ run_test "help shows config command" \
 run_test "help shows reload command" \
   bash -c "docker exec $D1 remi --help 2>&1 | grep -q 'reload'"
 run_test "-- separator works" d1_remi ls -- --weird-flag
+
+# ==== Test Group 8: Attach lifecycle ====
+echo ""
+echo "== attach lifecycle =="
+
+PID_A=$(bg_attach $D1)
+wait_occupied $D1 5
+
+run_test "attach process stays alive" \
+  bash -c "docker exec $D1 kill -0 $PID_A"
+
+run_test "attached session shows occupied" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+ckill $D1 $PID_A
+wait_available $D1 5
+
+run_test "session available after disconnect" \
+  bash -c "docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Re-attach to same session
+PID_A2=$(bg_attach $D1)
+wait_occupied $D1 5
+
+run_test "re-attach occupies session again" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+ckill $D1 $PID_A2
+wait_available $D1 5
+
+# ==== Test Group 9: Multi-client local contention ====
+echo ""
+echo "== multi-client local contention =="
+
+PID_MC1=$(bg_attach $D1)
+wait_occupied $D1 5
+
+PID_MC2=$(bg_attach $D1)
+sleep 2
+
+run_test "second client alive but session occupied by first" \
+  bash -c "docker exec $D1 kill -0 $PID_MC2 && ! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+run_test "ls works during multi-client contention" d1_remi ls
+
+# Kill second client; first should retain
+ckill $D1 $PID_MC2
+sleep 1
+
+run_test "first client retains after second disconnects" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Kill first client; session becomes available
+ckill $D1 $PID_MC1
+wait_available $D1 5
+
+run_test "session available after both clients disconnect" \
+  bash -c "docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# New client attaches after contention
+PID_MC3=$(bg_attach $D1)
+wait_occupied $D1 5
+
+run_test "new client attaches after contention resolved" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+ckill $D1 $PID_MC3
+wait_available $D1 5
+
+# ==== Test Group 10: Cross-container attach ====
+echo ""
+echo "== cross-container attach =="
+
+PID_XC=$(bg_attach $C1 --host $D1_IP --port $PORT)
+wait_occupied $D1 5
+
+run_test "cross-container attach process alive" \
+  bash -c "docker exec $C1 kill -0 $PID_XC"
+
+run_test "remote client occupies D1 session" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+run_test "D2 can ls D1 while remote client attached" \
+  d2_remi ls --host $D1_IP --port $PORT
+
+# D1 tries to attach its own session while remote holds it
+PID_XC_LOCAL=$(bg_attach $D1)
+sleep 2
+
+run_test "local client cannot displace remote attach" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+ckill $D1 $PID_XC_LOCAL
+ckill $C1 $PID_XC
+wait_available $D1 5
+
+run_test "D1 session available after remote disconnects" \
+  bash -c "docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# ==== Test Group 11: Three-client contention ====
+echo ""
+echo "== three-client contention =="
+
+# C1 attaches first (remote to D1)
+PID_3A=$(bg_attach $C1 --host $D1_IP --port $PORT)
+wait_occupied $D1 5
+
+# D2 also tries (remote to D1)
+PID_3B=$(bg_attach $D2 --host $D1_IP --port $PORT)
+sleep 2
+
+# D1 tries locally
+PID_3C=$(bg_attach $D1)
+sleep 2
+
+run_test "three clients: all processes alive" \
+  bash -c "docker exec $C1 kill -0 $PID_3A && docker exec $D2 kill -0 $PID_3B && docker exec $D1 kill -0 $PID_3C"
+
+run_test "three clients: session remains occupied" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Kill second and third; first retains
+ckill $D2 $PID_3B
+ckill $D1 $PID_3C
+sleep 1
+
+run_test "three clients: first retains after others disconnect" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Kill first; session available
+ckill $C1 $PID_3A
+wait_available $D1 5
+
+run_test "three clients: session available after all disconnect" \
+  bash -c "docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# New client can take over
+PID_3D=$(bg_attach $D2 --host $D1_IP --port $PORT)
+wait_occupied $D1 5
+
+run_test "new client attaches after three-way contention" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+ckill $D2 $PID_3D
+wait_available $D1 5
+
+# ==== Test Group 12: Edge cases ====
+echo ""
+echo "== edge cases =="
+
+run_test "concurrent ls: D1 local" d1_remi ls
+run_test "concurrent ls: D2 local" d2_remi ls
+run_test "concurrent ls: C1 to D1" c1_remi ls --host $D1_IP --port $PORT
+run_test "concurrent ls: C1 to D2" c1_remi ls --host $D2_IP --port $PORT
+
+# Rapid attach/detach cycles (3 rounds)
+RAPID_OK=true
+for round in 1 2 3; do
+  PID_RAPID=$(bg_attach $D1)
+  if ! wait_occupied $D1 3; then RAPID_OK=false; break; fi
+  ckill $D1 $PID_RAPID
+  if ! wait_available $D1 3; then RAPID_OK=false; break; fi
+done
+
+run_test "session stable after rapid attach/detach cycles" \
+  bash -c "$RAPID_OK && docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Session name visible while occupied
+PID_NAME=$(bg_attach $D1)
+wait_occupied $D1 5
+
+run_test "occupied session still shows project name in ls" \
+  bash -c "docker exec $D1 remi ls 2>&1 | grep -q 'sample-app'"
+
+ckill $D1 $PID_NAME
+wait_available $D1 5
+
+# Cross-container ls sees correct occupancy
+PID_OCC=$(bg_attach $D1)
+wait_occupied $D1 5
+
+run_test "remote ls reflects occupancy (no * for occupied session)" \
+  bash -c "! docker exec $C1 remi ls --host $D1_IP --port $PORT 2>&1 | grep -qF 'available to attach'"
+
+ckill $D1 $PID_OCC
+wait_available $D1 5
+
+run_test "remote ls reflects availability after disconnect" \
+  bash -c "docker exec $C1 remi ls --host $D1_IP --port $PORT 2>&1 | grep -qF 'available to attach'"
+
+# ==== Test Group 13: Kill while attached (destructive, uses D1) ====
+echo ""
+echo "== kill while attached =="
+
+# Attach C1 to D1 (D1 session is in known-good state from prior tests)
+PID_KA=$(bg_attach $C1 --host $D1_IP --port $PORT)
+wait_occupied $D1 10
+
+run_test "client attached before kill" \
+  bash -c "docker exec $C1 kill -0 $PID_KA"
+
+run_test "session occupied before kill" \
+  bash -c "! docker exec $D1 remi ls 2>&1 | grep -qF 'available to attach'"
+
+# Extract session name for kill command
+D1_KILL_SESSION=$(docker exec $D1 remi ls 2>&1 | grep -E 'active|idle' | awk '{print $1}' | head -1)
+
+run_test "kill occupied session from owning daemon" \
+  d1_remi kill "$D1_KILL_SESSION"
+
+wait_exit $C1 $PID_KA 5
+
+run_test "attached client exits after session killed" \
+  bash -c "! docker exec $C1 kill -0 $PID_KA 2>/dev/null"
+
+run_test "daemon still responds after session killed" d1_remi ls
 
 # ---- Results ----
 echo ""

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -83,27 +83,35 @@ c1_remi() { docker exec $C1 remi "$@"; }
 # Returns the PID of the remi attach process.
 bg_attach() {
   local ctr=$1; shift
-  docker exec "$ctr" bash -c "sleep infinity | remi attach $* &>/dev/null & echo \$!"
+  docker exec "$ctr" bash -c 'sleep infinity | remi attach "$@" &>/dev/null & echo $!' -- "$@"
 }
 
 # Kill a process inside a container
 ckill() { docker exec "$1" kill "$2" 2>/dev/null || true; }
 
-# Poll until session becomes occupied (no 'available to attach' in ls)
+# Poll until session becomes occupied (no 'available to attach' in ls).
+# Args after timeout are passed to remi ls (e.g., --host/--port).
 wait_occupied() {
   local ctr=$1 secs=${2:-5}; shift 2 || shift $#
+  local output
   for i in $(seq 1 "$secs"); do
-    if ! docker exec "$ctr" remi ls "${@}" 2>&1 | grep -qF 'available to attach'; then return 0; fi
+    if output=$(docker exec "$ctr" remi ls "${@}" 2>&1); then
+      if ! echo "$output" | grep -qF 'available to attach'; then return 0; fi
+    fi
     sleep 1
   done
   return 1
 }
 
-# Poll until session becomes available ('available to attach' in ls)
+# Poll until session becomes available ('available to attach' in ls).
+# Args after timeout are passed to remi ls (e.g., --host/--port).
 wait_available() {
   local ctr=$1 secs=${2:-5}; shift 2 || shift $#
+  local output
   for i in $(seq 1 "$secs"); do
-    if docker exec "$ctr" remi ls "${@}" 2>&1 | grep -qF 'available to attach'; then return 0; fi
+    if output=$(docker exec "$ctr" remi ls "${@}" 2>&1); then
+      if echo "$output" | grep -qF 'available to attach'; then return 0; fi
+    fi
     sleep 1
   done
   return 1


### PR DESCRIPTION
## Summary

- Fix bug where utility clients (remi ls, kill, recent) auto-attached to sessions, making `canAttach` always report false. Clients could never see `*` markers for available sessions.
- Add `mode` field to hello protocol: utility clients send `mode='query'` to skip auto-attachment
- Add 32 new Docker integration tests covering multi-client scenarios (52 total, was 20)

## Changes

**Protocol fix (the bug):**
- `remi ls` / `remi kill` / `remi recent` now send `mode: 'query'` in their hello message
- Daemon skips auto-attach for query-mode connections
- `canAttach` now correctly reflects whether a real attach client holds the session

**Docker test infrastructure:**
- Add `client1` container (no daemon, pure client for multi-client testing)
- Add `procps` package for process management (`kill`, `ps`)
- Add `init: true` for proper zombie reaping in containers
- Add helpers: `bg_attach`, `ckill`, `wait_occupied`, `wait_available`, `wait_exit`

**New test groups:**
- Attach lifecycle: attach -> verify occupied -> detach -> verify available -> re-attach
- Multi-client local contention: 2 clients, first-wins semantics, cleanup
- Cross-container attach: remote client occupies session, local can't displace
- Three-client contention: 3 containers competing for same session
- Edge cases: rapid attach/detach cycles, concurrent ls, occupancy visibility
- Kill while attached: session kill notifies and disconnects attached client

## Test plan

- [x] 1231 unit tests passing
- [x] 52/52 Docker integration tests passing
- [x] Typecheck clean
- [x] Biome lint clean (pre-existing warning only)