### PR TITLE
fix: purge stale hooks, limit session list to connected daemon

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2699,7 +2699,7 @@ if (cliDaemonMode) {
   if (hookServer) {
     try {
       hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
-      hookConfigManager.install();
+      await hookConfigManager.install();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`Hook config install failed: ${msg}. Question forwarding may not work.`);
@@ -2918,7 +2918,7 @@ if (cliDaemonMode) {
 
     // Configure Claude Code hooks to POST to our server
     hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
-    hookConfigManager.install();
+    await hookConfigManager.install();
     log('[Hooks] Claude Code hooks configured');
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -42,7 +42,8 @@ export class HookConfigManager {
 
   /**
    * Write Remi hook configuration into Claude settings.
-   * Purges stale hooks from dead daemons first, then adds ours.
+   * Purges stale hooks from dead daemons first, then merges ours
+   * alongside any existing user hooks without overwriting them.
    */
   async install(): Promise<void> {
     const dir = path.dirname(this.settingsPath);
@@ -50,8 +51,13 @@ export class HookConfigManager {
       fs.mkdirSync(dir, { recursive: true });
     }
 
-    // Purge stale hooks from dead daemons before adding ours
-    await this.purgeStaleHooks();
+    try {
+      await this.purgeStaleHooks();
+    } catch (err) {
+      console.warn(
+        `Failed to purge stale hooks: ${err instanceof Error ? err.message : String(err)}. Continuing with install.`,
+      );
+    }
 
     const settings = this.readSettings();
     if (!settings.hooks) {
@@ -93,53 +99,31 @@ export class HookConfigManager {
     const settings = this.readSettings();
     if (!settings.hooks) return;
 
-    let modified = false;
-    const hooks = settings.hooks;
-    for (const event of Object.keys(hooks)) {
-      const matchers = hooks[event];
-      if (!matchers) continue;
-      const filtered = matchers.filter(
-        (m) => !m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
-      );
-      if (filtered.length !== matchers.length) {
-        hooks[event] = filtered;
-        modified = true;
-      }
-    }
-
-    // Clean up empty event arrays
-    for (const event of Object.keys(hooks)) {
-      if (hooks[event]?.length === 0) {
-        Reflect.deleteProperty(hooks, event);
-      }
-    }
-
-    // Remove hooks key if empty
-    let hooksEmpty = false;
-    if (settings.hooks && Object.keys(settings.hooks).length === 0) {
-      hooksEmpty = true;
-    }
+    const modified = this.removeHooksWhere(
+      settings,
+      (h) => h.type === 'http' && h.url === this.hookUrl,
+    );
 
     if (modified) {
-      // Build clean settings without empty hooks
-      const cleanSettings: ClaudeSettings = {};
-      for (const [key, value] of Object.entries(settings)) {
-        if (key === 'hooks' && hooksEmpty) continue;
-        cleanSettings[key] = value;
-      }
-
-      if (Object.keys(cleanSettings).length === 0) {
-        // Settings file is empty; remove it
-        try {
-          fs.unlinkSync(this.settingsPath);
-        } catch (err) {
-          console.error(
-            `Warning: failed to remove ${this.settingsPath}; stale hooks may remain: ${err}`,
-          );
+      if (
+        Object.keys(settings).length === 0 ||
+        (Object.keys(settings).length === 1 && !settings.hooks)
+      ) {
+        // Settings effectively empty after removing hooks
+        const remaining = { ...settings };
+        Reflect.deleteProperty(remaining, 'hooks');
+        if (Object.keys(remaining).length === 0) {
+          try {
+            fs.unlinkSync(this.settingsPath);
+          } catch (err) {
+            console.error(
+              `Warning: failed to remove ${this.settingsPath}; stale hooks may remain: ${err}`,
+            );
+          }
+          return;
         }
-      } else {
-        this.writeSettings(cleanSettings);
       }
+      this.writeSettings(settings);
     }
   }
 
@@ -161,7 +145,7 @@ export class HookConfigManager {
   /**
    * Remove hook entries whose HTTP servers are no longer reachable.
    * Probes each localhost HTTP hook URL with a TCP connect.
-   * Only removes localhost HTTP hooks (the kind Remi installs).
+   * Only probes localhost HTTP hooks; non-localhost or non-HTTP hooks are never touched.
    */
   private async purgeStaleHooks(): Promise<void> {
     if (!fs.existsSync(this.settingsPath)) return;
@@ -169,34 +153,33 @@ export class HookConfigManager {
     const settings = this.readSettings();
     if (!settings.hooks) return;
 
-    // Collect all unique localhost HTTP hook URLs (excluding our own)
-    const localhostUrls = new Set<string>();
+    // Collect all unique localhost HTTP hook URLs with their ports (excluding our own)
+    const localhostHooks = new Map<string, number>();
     for (const matchers of Object.values(settings.hooks)) {
       if (!matchers) continue;
       for (const m of matchers) {
+        if (!Array.isArray(m.hooks)) continue;
         for (const h of m.hooks) {
           if (h.type !== 'http') continue;
           if (h.url === this.hookUrl) continue;
           try {
             const parsed = new URL(h.url);
             if (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost') {
-              localhostUrls.add(h.url);
+              const port = Number(parsed.port);
+              if (port) localhostHooks.set(h.url, port);
             }
           } catch {
-            // Skip malformed URLs
+            // Malformed URL; leave it alone (not our concern)
           }
         }
       }
     }
 
-    if (localhostUrls.size === 0) return;
+    if (localhostHooks.size === 0) return;
 
     // Probe all URLs in parallel
     const probeResults = await Promise.all(
-      [...localhostUrls].map(async (url) => {
-        const parsed = new URL(url);
-        const port = Number.parseInt(parsed.port, 10);
-        if (!port) return { url, alive: true }; // Skip if no port
+      [...localhostHooks.entries()].map(async ([url, port]) => {
         const alive = await isPortReachable(port);
         return { url, alive };
       }),
@@ -205,14 +188,31 @@ export class HookConfigManager {
     const deadUrls = new Set(probeResults.filter((r) => !r.alive).map((r) => r.url));
     if (deadUrls.size === 0) return;
 
-    // Remove dead hook entries
+    const modified = this.removeHooksWhere(
+      settings,
+      (h) => h.type === 'http' && deadUrls.has(h.url),
+    );
+    if (modified) {
+      this.writeSettings(settings);
+    }
+  }
+
+  /**
+   * Remove hook matchers where any hook entry matches the predicate.
+   * Cleans up empty event arrays and the hooks key itself.
+   * Returns true if any matchers were removed.
+   */
+  private removeHooksWhere(
+    settings: ClaudeSettings,
+    predicate: (h: HookEntry) => boolean,
+  ): boolean {
+    if (!settings.hooks) return false;
+
     let modified = false;
     for (const event of Object.keys(settings.hooks)) {
       const matchers = settings.hooks[event];
       if (!matchers) continue;
-      const filtered = matchers.filter(
-        (m) => !m.hooks.some((h) => h.type === 'http' && deadUrls.has(h.url)),
-      );
+      const filtered = matchers.filter((m) => !Array.isArray(m.hooks) || !m.hooks.some(predicate));
       if (filtered.length !== matchers.length) {
         settings.hooks[event] = filtered;
         modified = true;
@@ -220,7 +220,6 @@ export class HookConfigManager {
     }
 
     if (modified) {
-      // Clean up empty event arrays
       for (const event of Object.keys(settings.hooks)) {
         if (settings.hooks[event]?.length === 0) {
           Reflect.deleteProperty(settings.hooks, event);
@@ -229,8 +228,9 @@ export class HookConfigManager {
       if (Object.keys(settings.hooks).length === 0) {
         Reflect.deleteProperty(settings, 'hooks');
       }
-      this.writeSettings(settings);
     }
+
+    return modified;
   }
 
   private readSettings(): ClaudeSettings {
@@ -262,23 +262,18 @@ export class HookConfigManager {
   }
 }
 
-/** TCP connect probe with 500ms timeout. */
+/** TCP connect probe; resolves false on connection failure or timeout. */
 function isPortReachable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = new net.Socket();
     socket.setTimeout(500);
-    socket.on('connect', () => {
+    function done(reachable: boolean): void {
       socket.destroy();
-      resolve(true);
-    });
-    socket.on('error', () => {
-      socket.destroy();
-      resolve(false);
-    });
-    socket.on('timeout', () => {
-      socket.destroy();
-      resolve(false);
-    });
+      resolve(reachable);
+    }
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+    socket.once('timeout', () => done(false));
     socket.connect(port, '127.0.0.1');
   });
 }

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -10,6 +10,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as net from 'node:net';
 import * as path from 'node:path';
 import { HOOK_EVENT_NAMES } from './hook-types.ts';
 
@@ -41,13 +42,16 @@ export class HookConfigManager {
 
   /**
    * Write Remi hook configuration into Claude settings.
-   * Merges with existing user hooks; does not overwrite them.
+   * Purges stale hooks from dead daemons first, then adds ours.
    */
-  install(): void {
+  async install(): Promise<void> {
     const dir = path.dirname(this.settingsPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
+
+    // Purge stale hooks from dead daemons before adding ours
+    await this.purgeStaleHooks();
 
     const settings = this.readSettings();
     if (!settings.hooks) {
@@ -106,7 +110,7 @@ export class HookConfigManager {
     // Clean up empty event arrays
     for (const event of Object.keys(hooks)) {
       if (hooks[event]?.length === 0) {
-        delete hooks[event];
+        Reflect.deleteProperty(hooks, event);
       }
     }
 
@@ -154,6 +158,81 @@ export class HookConfigManager {
     });
   }
 
+  /**
+   * Remove hook entries whose HTTP servers are no longer reachable.
+   * Probes each localhost HTTP hook URL with a TCP connect.
+   * Only removes localhost HTTP hooks (the kind Remi installs).
+   */
+  private async purgeStaleHooks(): Promise<void> {
+    if (!fs.existsSync(this.settingsPath)) return;
+
+    const settings = this.readSettings();
+    if (!settings.hooks) return;
+
+    // Collect all unique localhost HTTP hook URLs (excluding our own)
+    const localhostUrls = new Set<string>();
+    for (const matchers of Object.values(settings.hooks)) {
+      if (!matchers) continue;
+      for (const m of matchers) {
+        for (const h of m.hooks) {
+          if (h.type !== 'http') continue;
+          if (h.url === this.hookUrl) continue;
+          try {
+            const parsed = new URL(h.url);
+            if (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost') {
+              localhostUrls.add(h.url);
+            }
+          } catch {
+            // Skip malformed URLs
+          }
+        }
+      }
+    }
+
+    if (localhostUrls.size === 0) return;
+
+    // Probe all URLs in parallel
+    const probeResults = await Promise.all(
+      [...localhostUrls].map(async (url) => {
+        const parsed = new URL(url);
+        const port = Number.parseInt(parsed.port, 10);
+        if (!port) return { url, alive: true }; // Skip if no port
+        const alive = await isPortReachable(port);
+        return { url, alive };
+      }),
+    );
+
+    const deadUrls = new Set(probeResults.filter((r) => !r.alive).map((r) => r.url));
+    if (deadUrls.size === 0) return;
+
+    // Remove dead hook entries
+    let modified = false;
+    for (const event of Object.keys(settings.hooks)) {
+      const matchers = settings.hooks[event];
+      if (!matchers) continue;
+      const filtered = matchers.filter(
+        (m) => !m.hooks.some((h) => h.type === 'http' && deadUrls.has(h.url)),
+      );
+      if (filtered.length !== matchers.length) {
+        settings.hooks[event] = filtered;
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      // Clean up empty event arrays
+      for (const event of Object.keys(settings.hooks)) {
+        if (settings.hooks[event]?.length === 0) {
+          Reflect.deleteProperty(settings.hooks, event);
+        }
+      }
+      if (Object.keys(settings.hooks).length === 0) {
+        Reflect.deleteProperty(settings, 'hooks');
+      }
+      this.writeSettings(settings);
+    }
+  }
+
   private readSettings(): ClaudeSettings {
     let content: string;
     try {
@@ -181,4 +260,25 @@ export class HookConfigManager {
   private writeSettings(settings: ClaudeSettings): void {
     fs.writeFileSync(this.settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
   }
+}
+
+/** TCP connect probe with 500ms timeout. */
+function isPortReachable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(500);
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on('error', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.on('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.connect(port, '127.0.0.1');
+  });
 }

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -30,13 +30,13 @@ describe('HookConfigManager', () => {
     fs.writeFileSync(path.join(dir, 'settings.local.json'), JSON.stringify(settings, null, 2));
   }
 
-  it('creates .claude directory if it does not exist', () => {
-    manager.install();
+  it('creates .claude directory if it does not exist', async () => {
+    await manager.install();
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
   });
 
-  it('writes hook config with all required events', () => {
-    manager.install();
+  it('writes hook config with all required events', async () => {
+    await manager.install();
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
 
     expect(settings.hooks).toBeDefined();
@@ -48,8 +48,8 @@ describe('HookConfigManager', () => {
     expect(events).toContain('SessionStart');
   });
 
-  it('each event has an HTTP hook entry with the correct URL', () => {
-    manager.install();
+  it('each event has an HTTP hook entry with the correct URL', async () => {
+    await manager.install();
     const settings = readSettings() as {
       hooks: Record<
         string,
@@ -72,9 +72,9 @@ describe('HookConfigManager', () => {
     }
   });
 
-  it('does not duplicate hooks on repeated install', () => {
-    manager.install();
-    manager.install();
+  it('does not duplicate hooks on repeated install', async () => {
+    await manager.install();
+    await manager.install();
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
 
     for (const event of ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'SessionStart']) {
@@ -82,7 +82,7 @@ describe('HookConfigManager', () => {
     }
   });
 
-  it('preserves existing user hooks', () => {
+  it('preserves existing user hooks', async () => {
     writeSettings({
       hooks: {
         PreToolUse: [
@@ -95,7 +95,7 @@ describe('HookConfigManager', () => {
       someOtherSetting: 'value',
     });
 
-    manager.install();
+    await manager.install();
     const settings = readSettings() as {
       hooks: Record<string, unknown[]>;
       someOtherSetting: string;
@@ -106,7 +106,7 @@ describe('HookConfigManager', () => {
     expect(settings.someOtherSetting).toBe('value');
   });
 
-  it('uninstall removes only Remi hooks', () => {
+  it('uninstall removes only Remi hooks', async () => {
     writeSettings({
       hooks: {
         PreToolUse: [
@@ -118,7 +118,7 @@ describe('HookConfigManager', () => {
       },
     });
 
-    manager.install();
+    await manager.install();
     manager.uninstall();
 
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
@@ -128,8 +128,8 @@ describe('HookConfigManager', () => {
     expect(settings.hooks['PostToolUse']).toBeUndefined();
   });
 
-  it('uninstall removes settings file if empty', () => {
-    manager.install();
+  it('uninstall removes settings file if empty', async () => {
+    await manager.install();
     manager.uninstall();
 
     const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
@@ -141,15 +141,70 @@ describe('HookConfigManager', () => {
     expect(() => manager.uninstall()).not.toThrow();
   });
 
-  it('isInstalled returns true after install', () => {
+  it('isInstalled returns true after install', async () => {
     expect(manager.isInstalled()).toBe(false);
-    manager.install();
+    await manager.install();
     expect(manager.isInstalled()).toBe(true);
   });
 
-  it('isInstalled returns false after uninstall', () => {
-    manager.install();
+  it('isInstalled returns false after uninstall', async () => {
+    await manager.install();
     manager.uninstall();
     expect(manager.isInstalled()).toBe(false);
+  });
+
+  it('purges stale hooks from dead ports on install', async () => {
+    // Pre-seed settings with a hook pointing to a dead port
+    writeSettings({
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ type: 'http', url: 'http://127.0.0.1:19999/hooks', timeout: 5 }] },
+        ],
+        PostToolUse: [
+          { hooks: [{ type: 'http', url: 'http://127.0.0.1:19999/hooks', timeout: 5 }] },
+        ],
+      },
+    });
+
+    await manager.install();
+    const settings = readSettings() as { hooks: Record<string, unknown[]> };
+
+    // Dead hook should be purged, only our hook remains
+    for (const event of ['PreToolUse', 'PostToolUse']) {
+      expect(settings.hooks[event]?.length).toBe(1);
+    }
+  });
+
+  it('preserves hooks on reachable ports during purge', async () => {
+    // Start a real TCP server on a port
+    const server = Bun.listen({
+      hostname: '127.0.0.1',
+      port: 0,
+      socket: {
+        data() {},
+        open() {},
+        close() {},
+      },
+    });
+
+    const liveUrl = `http://127.0.0.1:${server.port}/hooks`;
+    writeSettings({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: 'http', url: liveUrl, timeout: 5 }] }],
+      },
+    });
+
+    await manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, Array<{ hooks: Array<{ url: string }> }>>;
+    };
+
+    // Live hook should be preserved alongside our hook
+    expect(settings.hooks['PreToolUse']?.length).toBe(2);
+    const urls = settings.hooks['PreToolUse'].flatMap((m) => m.hooks.map((h) => h.url));
+    expect(urls).toContain(liveUrl);
+    expect(urls).toContain(hookUrl);
+
+    server.stop();
   });
 });

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -201,10 +201,67 @@ describe('HookConfigManager', () => {
 
     // Live hook should be preserved alongside our hook
     expect(settings.hooks['PreToolUse']?.length).toBe(2);
-    const urls = settings.hooks['PreToolUse'].flatMap((m) => m.hooks.map((h) => h.url));
+    const urls = settings.hooks['PreToolUse']!.flatMap((m) => m.hooks.map((h) => h.url));
     expect(urls).toContain(liveUrl);
     expect(urls).toContain(hookUrl);
 
     server.stop();
+  });
+
+  it('purges dead hooks while preserving live ones in mixed scenario', async () => {
+    const server = Bun.listen({
+      hostname: '127.0.0.1',
+      port: 0,
+      socket: { data() {}, open() {}, close() {} },
+    });
+
+    const liveUrl = `http://127.0.0.1:${server.port}/hooks`;
+    const deadUrl = 'http://127.0.0.1:19998/hooks';
+    writeSettings({
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ type: 'http', url: deadUrl, timeout: 5 }] },
+          { hooks: [{ type: 'http', url: liveUrl, timeout: 5 }] },
+        ],
+        PostToolUse: [{ hooks: [{ type: 'http', url: deadUrl, timeout: 5 }] }],
+      },
+    });
+
+    await manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, Array<{ hooks: Array<{ url: string }> }>>;
+    };
+
+    // PreToolUse: dead removed, live preserved, ours added = 2
+    const preUrls = settings.hooks['PreToolUse']!.flatMap((m) => m.hooks.map((h) => h.url));
+    expect(preUrls).toContain(liveUrl);
+    expect(preUrls).toContain(hookUrl);
+    expect(preUrls).not.toContain(deadUrl);
+
+    // PostToolUse: dead removed, ours added = 1
+    const postUrls = settings.hooks['PostToolUse']!.flatMap((m) => m.hooks.map((h) => h.url));
+    expect(postUrls).toContain(hookUrl);
+    expect(postUrls).not.toContain(deadUrl);
+
+    server.stop();
+  });
+
+  it('preserves non-localhost and non-HTTP hooks during purge', async () => {
+    writeSettings({
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ type: 'http', url: 'http://10.0.0.5:9999/hooks', timeout: 5 }] },
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo blocked' }] },
+        ],
+      },
+    });
+
+    await manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, Array<{ hooks: Array<{ url?: string; command?: string }> }>>;
+    };
+
+    // Both non-localhost HTTP and command hooks preserved, plus ours = 3
+    expect(settings.hooks['PreToolUse']?.length).toBe(3);
   });
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -683,8 +683,9 @@ function App() {
   }, [effectiveStatus, activeSessionId]);
 
   // Request session list after direct connection
-  // Use includeExternal=false to only show sessions from THIS daemon
-  // (external transcript sessions can't receive messages)
+  // Use includeExternal=false so only sessions owned by THIS daemon are listed.
+  // External transcript sessions belong to other daemons and cannot receive
+  // input from this connection.
   useEffect(() => {
     if (connectionStatus === 'connected') {
       effectiveRequestSessionList(false);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -683,16 +683,18 @@ function App() {
   }, [effectiveStatus, activeSessionId]);
 
   // Request session list after direct connection
+  // Use includeExternal=false to only show sessions from THIS daemon
+  // (external transcript sessions can't receive messages)
   useEffect(() => {
     if (connectionStatus === 'connected') {
-      effectiveRequestSessionList(true);
+      effectiveRequestSessionList(false);
     }
   }, [connectionStatus, effectiveRequestSessionList]);
 
   // Request session list after relay connection (hello_ack received)
   useEffect(() => {
     if (connectionMode === 'relay' && relayStatus === 'connected' && activeSessionId) {
-      effectiveRequestSessionList(true);
+      effectiveRequestSessionList(false);
     }
   }, [connectionMode, relayStatus, activeSessionId, effectiveRequestSessionList]);
 


### PR DESCRIPTION
## Summary
- HookConfigManager.install() now probes all localhost HTTP hook URLs with TCP connect and removes entries for dead ports, preventing ECONNREFUSED errors from accumulating after daemon crashes
- Web app session list uses includeExternal=false so only the connected daemon's own sessions are shown, preventing cross-daemon message routing bugs
- Added 2 new tests for stale hook purging (dead port removal + live port preservation)

## Test plan
- [x] 1236/1236 tests pass (including 2 new hook purge tests)
- [x] Biome lint clean
- [x] Type check clean
- [x] Verified on iOS simulator: session list shows only connected daemon's sessions
- [x] Verified message round-trip: sent from app, received in correct Claude session
- [x] Verified stale hook cleanup: dead port 49866 entry removed, live port 50661 preserved

Closes #172