### PR TITLE
fix: parse numbered options from hook permission prompts

### DIFF
--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -8,6 +8,7 @@
 
 import { generateId } from '@remi/shared';
 import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
+import { parseNumberedOptions } from '../parser/question-parser.ts';
 import type { HookServerEvents } from './hook-server.ts';
 import type {
   NotificationHookInput,
@@ -81,6 +82,35 @@ export class HookEventBridge {
   }
 
   private buildPermissionQuestion(message: string): Question {
+    // Try to parse numbered options from the message text.
+    // Claude Code sends messages like:
+    //   "Do you want to proceed?\n1) Yes\n2) Yes, and don't ask again\n3) No"
+    // or inline: "Allow? (1) Yes (2) Always (3) No"
+    const parsed = message ? parseNumberedOptions(message) : null;
+
+    if (parsed) {
+      // Tag yes/no semantics on parsed options
+      const taggedOptions: QuestionOption[] = parsed.options.map((opt) => {
+        const lower = opt.label.toLowerCase();
+        const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
+        const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
+        return {
+          ...opt,
+          isYes,
+          isNo,
+        };
+      });
+
+      return {
+        id: generateId(),
+        text: parsed.questionText,
+        options: taggedOptions,
+        allowsFreeText: false,
+        isAnswered: false,
+      };
+    }
+
+    // Fallback: simple Yes/No when no numbered options found
     const yesOption: QuestionOption = {
       label: 'Yes',
       value: 'y',

--- a/packages/daemon/src/parser/question-parser.ts
+++ b/packages/daemon/src/parser/question-parser.ts
@@ -50,8 +50,8 @@ const PATTERNS = {
     /proceed with\s+\w+.*\?\s*$/i,
   ],
 
-  // Numbered option patterns
-  numberedOption: /^\s*(\d+)\.\s+(.+)$/,
+  // Numbered option patterns: "1. Option" or "1) Option"
+  numberedOption: /^\s*(\d+)[.)]\s+(.+)$/,
 
   // Option with marker (arrow, bullet)
   markedOption: /^\s*[►▸•●]\s+(.+)$/,
@@ -292,6 +292,105 @@ function createOption(
     isYes,
     isNo,
   };
+}
+
+/**
+ * Inline numbered option pattern: "(1) Yes (2) Always (3) No"
+ * Matches sequences like (N) text within a single line.
+ */
+const INLINE_NUMBERED = /\((\d+)\)\s+([^(]+)/g;
+
+/**
+ * Result of parsing numbered options from plain text.
+ */
+export interface NumberedParseResult {
+  /** The question/prompt text before the options */
+  readonly questionText: string;
+  /** Parsed options */
+  readonly options: readonly QuestionOption[];
+}
+
+/**
+ * Parse numbered options from plain text (no ANSI stripping).
+ *
+ * Handles multiple formats:
+ * - Line-per-option with dot:    "1. Yes\n2. No"
+ * - Line-per-option with paren:  "1) Yes\n2) No"
+ * - Inline with parens:          "(1) Yes (2) Always (3) No"
+ *
+ * Returns null if fewer than 2 options are found.
+ */
+export function parseNumberedOptions(text: string): NumberedParseResult | null {
+  if (!text || text.trim().length === 0) {
+    return null;
+  }
+
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+
+  // First, try line-per-option format: "N. text" or "N) text"
+  const lineOptions: QuestionOption[] = [];
+  let firstOptionIndex = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]?.trim() ?? '';
+    const match = PATTERNS.numberedOption.exec(line);
+
+    if (match) {
+      if (firstOptionIndex === -1) {
+        firstOptionIndex = i;
+      }
+      const num = match[1] ?? '';
+      const label = match[2]?.trim() ?? '';
+
+      lineOptions.push(createOption(label, num, lineOptions.length === 0, false, false));
+    }
+  }
+
+  if (lineOptions.length >= 2) {
+    let questionText = '';
+    if (firstOptionIndex > 0) {
+      questionText = lines.slice(0, firstOptionIndex).join(' ').trim();
+    }
+    return {
+      questionText: questionText || 'Select an option:',
+      options: lineOptions,
+    };
+  }
+
+  // Then, try inline format: "(1) Yes (2) Always (3) No"
+  const fullText = lines.join(' ');
+  const inlineOptions: QuestionOption[] = [];
+  let firstMatchStart = -1;
+
+  // Reset lastIndex for global regex
+  INLINE_NUMBERED.lastIndex = 0;
+  let inlineMatch = INLINE_NUMBERED.exec(fullText);
+  while (inlineMatch !== null) {
+    if (firstMatchStart === -1) {
+      firstMatchStart = inlineMatch.index;
+    }
+    const num = inlineMatch[1] ?? '';
+    const label = inlineMatch[2]?.trim() ?? '';
+    inlineOptions.push(createOption(label, num, inlineOptions.length === 0, false, false));
+    inlineMatch = INLINE_NUMBERED.exec(fullText);
+  }
+
+  if (inlineOptions.length >= 2 && firstMatchStart > 0) {
+    const questionText = fullText.slice(0, firstMatchStart).trim();
+    return {
+      questionText: questionText || 'Select an option:',
+      options: inlineOptions,
+    };
+  }
+
+  if (inlineOptions.length >= 2) {
+    return {
+      questionText: 'Select an option:',
+      options: inlineOptions,
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -153,4 +153,160 @@ describe('HookEventBridge', () => {
 
     expect(statuses).toEqual([{ status: 'executing', context: 'Edit' }]);
   });
+
+  describe('numbered option parsing in permission_prompt', () => {
+    it('parses multiline numbered options with parenthesis format', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: "Do you want to proceed?\n1) Yes\n2) Yes, and don't ask again\n3) No",
+      } as NotificationHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.text).toBe('Do you want to proceed?');
+      expect(questions[0]?.options.length).toBe(3);
+      expect(questions[0]?.options[0]?.label).toBe('Yes');
+      expect(questions[0]?.options[0]?.value).toBe('1');
+      expect(questions[0]?.options[0]?.isYes).toBe(true);
+      expect(questions[0]?.options[1]?.label).toBe("Yes, and don't ask again");
+      expect(questions[0]?.options[1]?.value).toBe('2');
+      expect(questions[0]?.options[1]?.isYes).toBe(true);
+      expect(questions[0]?.options[2]?.label).toBe('No');
+      expect(questions[0]?.options[2]?.value).toBe('3');
+      expect(questions[0]?.options[2]?.isNo).toBe(true);
+    });
+
+    it('parses multiline numbered options with dot format', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Allow Bash?\n1. Yes\n2. Always\n3. No',
+      } as NotificationHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.text).toBe('Allow Bash?');
+      expect(questions[0]?.options.length).toBe(3);
+      expect(questions[0]?.options[0]?.label).toBe('Yes');
+      expect(questions[0]?.options[1]?.label).toBe('Always');
+      expect(questions[0]?.options[1]?.isYes).toBe(true);
+      expect(questions[0]?.options[2]?.label).toBe('No');
+      expect(questions[0]?.options[2]?.isNo).toBe(true);
+    });
+
+    it('parses inline numbered options', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Allow? (1) Yes (2) Always (3) No',
+      } as NotificationHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.options.length).toBe(3);
+      expect(questions[0]?.options[0]?.label).toBe('Yes');
+      expect(questions[0]?.options[0]?.value).toBe('1');
+      expect(questions[0]?.options[1]?.label).toBe('Always');
+      expect(questions[0]?.options[2]?.label).toBe('No');
+    });
+
+    it('falls back to Yes/No when no numbered options in message', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Allow Bash: npm test?',
+      } as NotificationHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.text).toBe('Allow Bash: npm test?');
+      expect(questions[0]?.options.length).toBe(2);
+      expect(questions[0]?.options[0]?.label).toBe('Yes');
+      expect(questions[0]?.options[0]?.isYes).toBe(true);
+      expect(questions[0]?.options[1]?.label).toBe('No');
+      expect(questions[0]?.options[1]?.isNo).toBe(true);
+    });
+
+    it('falls back to Yes/No for empty message', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: '',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.text).toBe('Allow this action?');
+      expect(questions[0]?.options.length).toBe(2);
+    });
+
+    it('falls back to Yes/No when only one numbered option', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Something\n1) Only one option here',
+      } as NotificationHookInput);
+
+      // Single option should not be treated as numbered; fall back
+      expect(questions[0]?.options.length).toBe(2);
+      expect(questions[0]?.options[0]?.label).toBe('Yes');
+    });
+
+    it('tags deny/reject as isNo', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Confirm?\n1) Allow\n2) Deny',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.options[0]?.isYes).toBe(true);
+      expect(questions[0]?.options[0]?.isNo).toBe(false);
+      expect(questions[0]?.options[1]?.isYes).toBe(false);
+      expect(questions[0]?.options[1]?.isNo).toBe(true);
+    });
+
+    it('sets allowsFreeText to false for numbered permission options', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Proceed?\n1) Yes\n2) No',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.allowsFreeText).toBe(false);
+    });
+
+    it('marks first option as recommended', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Allow?\n1) Yes\n2) Yes, always\n3) No',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.options[0]?.isRecommended).toBe(true);
+      expect(questions[0]?.options[1]?.isRecommended).toBe(false);
+      expect(questions[0]?.options[2]?.isRecommended).toBe(false);
+    });
+  });
 });

--- a/packages/daemon/tests/question-parser.test.ts
+++ b/packages/daemon/tests/question-parser.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { hasQuestionIndicator, parseQuestion } from '../src/parser/question-parser.ts';
+import {
+  hasQuestionIndicator,
+  parseNumberedOptions,
+  parseQuestion,
+} from '../src/parser/question-parser.ts';
 
 describe('parseQuestion()', () => {
   describe('Yes/No questions', () => {
@@ -260,5 +264,94 @@ describe('hasQuestionIndicator()', () => {
 
   test('handles ANSI codes', () => {
     expect(hasQuestionIndicator('\x1b[31mQuestion?\x1b[0m')).toBe(true);
+  });
+});
+
+describe('parseQuestion() with parenthesis numbered format', () => {
+  test('detects N) format numbered list', () => {
+    const input = `Select a framework:
+1) React
+2) Vue
+3) Angular`;
+    const result = parseQuestion(input);
+    expect(result.detected).toBe(true);
+    expect(result.type).toBe('numbered');
+    expect(result.question?.options.length).toBe(3);
+    expect(result.question?.options[0]?.label).toBe('React');
+    expect(result.question?.options[1]?.label).toBe('Vue');
+    expect(result.question?.options[2]?.label).toBe('Angular');
+  });
+
+  test('N) format option values are the numbers', () => {
+    const input = `1) Option A
+2) Option B`;
+    const result = parseQuestion(input);
+    expect(result.question?.options[0]?.value).toBe('1');
+    expect(result.question?.options[1]?.value).toBe('2');
+  });
+
+  test('hasQuestionIndicator detects N) format', () => {
+    expect(hasQuestionIndicator('1) First\n2) Second')).toBe(true);
+  });
+});
+
+describe('parseNumberedOptions()', () => {
+  test('parses multiline N) format', () => {
+    const result = parseNumberedOptions('Question?\n1) Yes\n2) No');
+    expect(result).not.toBeNull();
+    expect(result?.questionText).toBe('Question?');
+    expect(result?.options.length).toBe(2);
+    expect(result?.options[0]?.label).toBe('Yes');
+    expect(result?.options[0]?.value).toBe('1');
+    expect(result?.options[1]?.label).toBe('No');
+    expect(result?.options[1]?.value).toBe('2');
+  });
+
+  test('parses multiline N. format', () => {
+    const result = parseNumberedOptions('Pick one:\n1. Alpha\n2. Beta');
+    expect(result).not.toBeNull();
+    expect(result?.questionText).toBe('Pick one:');
+    expect(result?.options.length).toBe(2);
+    expect(result?.options[0]?.label).toBe('Alpha');
+    expect(result?.options[1]?.label).toBe('Beta');
+  });
+
+  test('parses inline (N) format', () => {
+    const result = parseNumberedOptions('Allow? (1) Yes (2) Always (3) No');
+    expect(result).not.toBeNull();
+    expect(result?.questionText).toBe('Allow?');
+    expect(result?.options.length).toBe(3);
+    expect(result?.options[0]?.label).toBe('Yes');
+    expect(result?.options[1]?.label).toBe('Always');
+    expect(result?.options[2]?.label).toBe('No');
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseNumberedOptions('')).toBeNull();
+  });
+
+  test('returns null for text without numbered options', () => {
+    expect(parseNumberedOptions('Just some plain text')).toBeNull();
+  });
+
+  test('returns null for single option', () => {
+    expect(parseNumberedOptions('1) Only one')).toBeNull();
+  });
+
+  test('first option is marked recommended', () => {
+    const result = parseNumberedOptions('Choose:\n1) A\n2) B');
+    expect(result?.options[0]?.isRecommended).toBe(true);
+    expect(result?.options[1]?.isRecommended).toBe(false);
+  });
+
+  test('handles three options with long labels', () => {
+    const msg =
+      "Do you want to proceed?\n1) Yes\n2) Yes, and don't ask again for this session\n3) No";
+    const result = parseNumberedOptions(msg);
+    expect(result).not.toBeNull();
+    expect(result?.options.length).toBe(3);
+    expect(result?.options[0]?.label).toBe('Yes');
+    expect(result?.options[1]?.label).toBe("Yes, and don't ask again for this session");
+    expect(result?.options[2]?.label).toBe('No');
   });
 });


### PR DESCRIPTION
## Summary
- Parse numbered options (1/2/3) from permission_prompt message text in `buildPermissionQuestion()`
- Add exported `parseNumberedOptions()` to `question-parser.ts` for reuse from hook bridge
- Support three formats: `N. text` (dot), `N) text` (parenthesis), and inline `(N) text`
- Tag parsed options with yes/no semantics based on label content
- Fall back to hardcoded Yes/No when no numbered options found in message
- Update `PATTERNS.numberedOption` regex to also accept `N)` format (was only `N.`)
- Add 8 new tests in hook-event-bridge.test.ts and 10 new tests in question-parser.test.ts

## Root cause
When Claude Code sends a `permission_prompt` notification via hooks, the message text contains numbered options like `1) Yes 2) Yes, and don't ask again 3) No`. But `HookEventBridge.buildPermissionQuestion()` ignored these and hardcoded a simple Yes/No question. The PTY-based parser in `question-parser.ts` had `tryParseNumbered()` that handled numbered formats, but it was never called from the hook path, and it only supported `N.` format (not `N)` which Claude Code uses).

## Test plan
- [x] All 68 tests in hook-event-bridge.test.ts and question-parser.test.ts pass
- [x] Existing tests unchanged (backward compatible)
- [x] biome lint/format clean

Fixes #178 (Phase 1)