### PR TITLE
fix: prevent duplicate user messages in chat view

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -239,8 +239,12 @@ function App() {
           };
 
           if (dedup.action === 'replace') {
-            // Replace the PTY-sourced duplicate with the transcript version
-            return prev.map((m, i) => (i === dedup.replaceIndex ? uiMessage : m));
+            // Replace the optimistic/PTY duplicate with the transcript version,
+            // preserving the original id as React key to prevent remount flicker
+            const replaced = dedup.preserveId
+              ? { ...uiMessage, id: dedup.preserveId }
+              : uiMessage;
+            return prev.map((m, i) => (i === dedup.replaceIndex ? replaced : m));
           }
 
           return [...prev, uiMessage];
@@ -770,6 +774,7 @@ function App() {
           timestamp: new Date().toISOString(),
           state: 'sent',
           isEditing: false,
+          source: 'optimistic',
         };
         setMessages((prev) => [...prev, userMsg]);
         return;
@@ -784,6 +789,7 @@ function App() {
         timestamp: new Date().toISOString(),
         state: 'sending',
         isEditing: false,
+        source: 'optimistic',
       };
 
       setMessages((prev) => [...prev, newMessage]);

--- a/packages/web/src/lib/message-dedup.ts
+++ b/packages/web/src/lib/message-dedup.ts
@@ -15,7 +15,7 @@
 
 import type { UIMessage } from '../types';
 
-export type MessageSource = 'pty' | 'transcript';
+export type MessageSource = 'optimistic' | 'pty' | 'transcript';
 
 export interface IncomingMessage {
   readonly sessionId: string;
@@ -27,20 +27,27 @@ export interface IncomingMessage {
 
 export type DedupResult =
   | { readonly action: 'add' }
-  | { readonly action: 'replace'; readonly replaceIndex: number }
+  | { readonly action: 'replace'; readonly replaceIndex: number; readonly preserveId?: string }
   | { readonly action: 'skip' };
 
 /**
  * Determine whether an incoming message should be added, should replace
  * an existing message, or should be skipped entirely.
+ *
+ * Three-way dedup handles: optimistic (user-sent) + PTY echo + transcript.
+ *
+ * When replacing an optimistic or PTY message, `preserveId` is set to the
+ * original message's `id` so the caller can keep the same React key and
+ * avoid a remount/flicker.
  */
 export function deduplicateMessage(
   existingMessages: readonly UIMessage[],
   incoming: IncomingMessage,
 ): DedupResult {
   if (incoming.source === 'transcript') {
-    // Transcript message arriving: look for a PTY-sourced duplicate
-    // (no entryUuid, same sessionId+sender+content)
+    // Transcript is the authoritative source. Look for any non-transcript
+    // duplicate (optimistic or PTY) with matching sessionId+sender+content
+    // and no entryUuid yet.
     const dupIdx = existingMessages.findIndex(
       (m) =>
         !m.entryUuid &&
@@ -50,23 +57,46 @@ export function deduplicateMessage(
         m.content === incoming.content,
     );
     if (dupIdx >= 0) {
-      return { action: 'replace', replaceIndex: dupIdx };
+      return {
+        action: 'replace',
+        replaceIndex: dupIdx,
+        preserveId: existingMessages[dupIdx].id,
+      };
     }
     return { action: 'add' };
   }
 
-  // PTY message arriving: check if transcript already delivered this content
-  const hasTranscriptDup = existingMessages.some(
-    (m) =>
-      m.entryUuid &&
-      m.source === 'transcript' &&
-      m.sessionId === incoming.sessionId &&
-      m.sender === incoming.sender &&
-      m.content === incoming.content,
-  );
-  if (hasTranscriptDup) {
-    return { action: 'skip' };
+  if (incoming.source === 'pty') {
+    // PTY echo arriving: skip if an optimistic message already exists with
+    // matching sessionId+sender+content (the optimistic version is already
+    // displayed; the transcript version will replace it later).
+    const hasOptimisticDup = existingMessages.some(
+      (m) =>
+        m.source === 'optimistic' &&
+        m.sessionId === incoming.sessionId &&
+        m.sender === incoming.sender &&
+        m.content === incoming.content,
+    );
+    if (hasOptimisticDup) {
+      return { action: 'skip' };
+    }
+
+    // Also skip if transcript already delivered this content
+    const hasTranscriptDup = existingMessages.some(
+      (m) =>
+        m.entryUuid &&
+        m.source === 'transcript' &&
+        m.sessionId === incoming.sessionId &&
+        m.sender === incoming.sender &&
+        m.content === incoming.content,
+    );
+    if (hasTranscriptDup) {
+      return { action: 'skip' };
+    }
+
+    return { action: 'add' };
   }
 
+  // Optimistic or unknown source: just add
   return { action: 'add' };
 }

--- a/packages/web/src/lib/message-dedup.ts
+++ b/packages/web/src/lib/message-dedup.ts
@@ -13,9 +13,9 @@
  *    PTY message entirely since the transcript version is already present.
  */
 
-import type { UIMessage } from '../types';
+import type { MessageSource, UIMessage } from '../types';
 
-export type MessageSource = 'optimistic' | 'pty' | 'transcript';
+export type { MessageSource } from '../types';
 
 export interface IncomingMessage {
   readonly sessionId: string;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -7,7 +7,7 @@
 import type { MessageState, Timestamp, UUID } from '@remi/shared/types.ts';
 
 /** Source that produced a UI message */
-export type MessageSource = 'pty' | 'transcript';
+export type MessageSource = 'optimistic' | 'pty' | 'transcript';
 
 /** Peer role in WebRTC connection */
 export type PeerRole = 'host' | 'client';

--- a/packages/web/tests/lib/message-dedup.test.ts
+++ b/packages/web/tests/lib/message-dedup.test.ts
@@ -17,6 +17,8 @@ function makeUIMessage(overrides: Partial<UIMessage> = {}): UIMessage {
 }
 
 describe('deduplicateMessage', () => {
+  // --- Transcript arriving ---
+
   test('transcript arriving with no existing messages returns add', () => {
     const incoming: IncomingMessage = {
       sessionId: 'session-1',
@@ -41,7 +43,22 @@ describe('deduplicateMessage', () => {
       source: 'transcript',
     };
     const result = deduplicateMessage(existing, incoming);
-    expect(result).toEqual({ action: 'replace', replaceIndex: 0 });
+    expect(result).toEqual({ action: 'replace', replaceIndex: 0, preserveId: 'msg-1' });
+  });
+
+  test('transcript arriving replaces optimistic duplicate and preserves its id', () => {
+    const existing = [
+      makeUIMessage({ id: 'optimistic-abc' as UIMessage['id'], sender: 'user', source: 'optimistic', entryUuid: undefined }),
+    ];
+    const incoming: IncomingMessage = {
+      sessionId: 'session-1',
+      sender: 'user',
+      content: 'Hello world',
+      entryUuid: 'entry-1',
+      source: 'transcript',
+    };
+    const result = deduplicateMessage(existing, incoming);
+    expect(result).toEqual({ action: 'replace', replaceIndex: 0, preserveId: 'optimistic-abc' });
   });
 
   test('transcript arriving does not replace message with different content', () => {
@@ -89,6 +106,40 @@ describe('deduplicateMessage', () => {
     expect(result).toEqual({ action: 'add' });
   });
 
+  test('transcript replaces correct index among multiple messages', () => {
+    const existing = [
+      makeUIMessage({ id: 'msg-0' as UIMessage['id'], content: 'First', source: 'pty' }),
+      makeUIMessage({ id: 'msg-1' as UIMessage['id'], content: 'Hello world', entryUuid: undefined, source: 'pty' }),
+      makeUIMessage({ id: 'msg-2' as UIMessage['id'], content: 'Third', source: 'pty' }),
+    ];
+    const incoming: IncomingMessage = {
+      sessionId: 'session-1',
+      sender: 'agent',
+      content: 'Hello world',
+      entryUuid: 'entry-1',
+      source: 'transcript',
+    };
+    const result = deduplicateMessage(existing, incoming);
+    expect(result).toEqual({ action: 'replace', replaceIndex: 1, preserveId: 'msg-1' });
+  });
+
+  test('sender mismatch prevents dedup', () => {
+    const existing = [
+      makeUIMessage({ sender: 'user', entryUuid: undefined, source: 'pty' }),
+    ];
+    const incoming: IncomingMessage = {
+      sessionId: 'session-1',
+      sender: 'agent',
+      content: 'Hello world',
+      entryUuid: 'entry-1',
+      source: 'transcript',
+    };
+    const result = deduplicateMessage(existing, incoming);
+    expect(result).toEqual({ action: 'add' });
+  });
+
+  // --- PTY arriving ---
+
   test('PTY arriving skips when transcript duplicate exists', () => {
     const existing = [
       makeUIMessage({ entryUuid: 'entry-1', source: 'transcript' }),
@@ -131,35 +182,70 @@ describe('deduplicateMessage', () => {
     expect(result).toEqual({ action: 'add' });
   });
 
-  test('transcript replaces correct index among multiple messages', () => {
+  test('PTY arriving skips when optimistic duplicate exists', () => {
     const existing = [
-      makeUIMessage({ id: 'msg-0' as UIMessage['id'], content: 'First', source: 'pty' }),
-      makeUIMessage({ id: 'msg-1' as UIMessage['id'], content: 'Hello world', entryUuid: undefined, source: 'pty' }),
-      makeUIMessage({ id: 'msg-2' as UIMessage['id'], content: 'Third', source: 'pty' }),
+      makeUIMessage({ id: 'opt-1' as UIMessage['id'], sender: 'user', source: 'optimistic', entryUuid: undefined }),
     ];
     const incoming: IncomingMessage = {
       sessionId: 'session-1',
-      sender: 'agent',
+      sender: 'user',
       content: 'Hello world',
-      entryUuid: 'entry-1',
-      source: 'transcript',
+      source: 'pty',
     };
     const result = deduplicateMessage(existing, incoming);
-    expect(result).toEqual({ action: 'replace', replaceIndex: 1 });
+    expect(result).toEqual({ action: 'skip' });
   });
 
-  test('sender mismatch prevents dedup', () => {
+  test('PTY arriving adds when optimistic message has different content', () => {
     const existing = [
-      makeUIMessage({ sender: 'user', entryUuid: undefined, source: 'pty' }),
+      makeUIMessage({ sender: 'user', source: 'optimistic', content: 'Different text' }),
     ];
     const incoming: IncomingMessage = {
       sessionId: 'session-1',
-      sender: 'agent',
+      sender: 'user',
       content: 'Hello world',
-      entryUuid: 'entry-1',
-      source: 'transcript',
+      source: 'pty',
     };
     const result = deduplicateMessage(existing, incoming);
     expect(result).toEqual({ action: 'add' });
+  });
+
+  // --- Full three-way lifecycle ---
+
+  test('three-way lifecycle: optimistic -> PTY skip -> transcript replace preserves id', () => {
+    // Step 1: optimistic message is already in the list
+    const optimisticMsg = makeUIMessage({
+      id: 'opt-xyz' as UIMessage['id'],
+      sender: 'user',
+      source: 'optimistic',
+      entryUuid: undefined,
+    });
+    const messages = [optimisticMsg];
+
+    // Step 2: PTY echo arrives and should be skipped
+    const ptyIncoming: IncomingMessage = {
+      sessionId: 'session-1',
+      sender: 'user',
+      content: 'Hello world',
+      source: 'pty',
+    };
+    const ptyResult = deduplicateMessage(messages, ptyIncoming);
+    expect(ptyResult).toEqual({ action: 'skip' });
+
+    // Step 3: transcript arrives and should replace the optimistic message,
+    // preserving its id for stable React keys
+    const transcriptIncoming: IncomingMessage = {
+      sessionId: 'session-1',
+      sender: 'user',
+      content: 'Hello world',
+      entryUuid: 'entry-abc',
+      source: 'transcript',
+    };
+    const transcriptResult = deduplicateMessage(messages, transcriptIncoming);
+    expect(transcriptResult).toEqual({
+      action: 'replace',
+      replaceIndex: 0,
+      preserveId: 'opt-xyz',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Tag optimistic messages (from handleSend) with `source: 'optimistic'` so the dedup logic can distinguish them from PTY and transcript messages
- Update `deduplicateMessage()` to handle three-way dedup: optimistic + PTY echo + transcript
- When a PTY echo arrives and an optimistic message already exists with matching content, skip it
- When a transcript message replaces an optimistic/PTY message, preserve the original `id` as `preserveId` so the caller can keep the same React key, preventing remount flicker
- Updated tests to cover optimistic source, PTY-skip-on-optimistic, preserveId on replace, and full three-way lifecycle

## Changes
- `packages/web/src/types/index.ts` -- added `'optimistic'` to `MessageSource` union
- `packages/web/src/lib/message-dedup.ts` -- added `'optimistic'` to `MessageSource`, added `preserveId` to `DedupResult` replace variant, rewrote `deduplicateMessage()` with three-way logic
- `packages/web/src/App.tsx` -- tagged both optimistic user messages with `source: 'optimistic'`, used `preserveId` in transcript_content replace path
- `packages/web/tests/lib/message-dedup.test.ts` -- added tests for optimistic dedup, preserveId, PTY-skip-on-optimistic, three-way lifecycle

## Test plan
- [x] All 1238 tests pass (0 failures)
- [x] TypeScript typecheck passes
- [x] Web package builds successfully
- [x] ESLint passes (only pre-existing warnings)

Fixes #179