### PR TITLE
fix: render replayed messages on first attach

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -373,9 +373,10 @@ function App() {
       }
 
       case 'replay_batch': {
-        // Re-dispatch each message in the batch through handleMessage
+        // Replay batches can arrive immediately after hello_ack on first attach.
+        // Dispatch them directly so early history is not dropped before refs/effects settle.
         for (const replayMsg of message.messages) {
-          handleMessageRef.current?.(replayMsg);
+          handleMessage(replayMsg);
         }
         break;
       }
@@ -515,10 +516,8 @@ function App() {
     }
   }, []);
 
-  // Keep refs in sync
-  useEffect(() => {
-    handleMessageRef.current = handleMessage;
-  }, [handleMessage]);
+  // Keep the latest message handler available synchronously for relay callbacks.
+  handleMessageRef.current = handleMessage;
 
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId;

--- a/tests/e2e/helpers/daemon.ts
+++ b/tests/e2e/helpers/daemon.ts
@@ -5,7 +5,7 @@ export const DAEMON2_PORT = 19766;
 
 /**
  * Connect to a Remi daemon via the web UI's ConnectModal.
- * Opens the modal, fills in the WebSocket URL, and waits for connection.
+ * Opens the modal, fills in the host, and waits for connection.
  */
 export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): Promise<void> {
   // Click the connect button in the session list header
@@ -14,10 +14,10 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
   // Wait for modal to appear
   await page.waitForSelector('text=Connect to Daemon');
 
-  // Clear the URL input and fill with our daemon URL
-  const urlInput = page.locator('input[placeholder="ws://localhost:3847/ws"]');
-  await urlInput.clear();
-  await urlInput.fill(`ws://localhost:${port}/ws`);
+  // Clear the host input and point it at the requested daemon.
+  const hostInput = page.locator('input[placeholder="localhost"]');
+  await hostInput.clear();
+  await hostInput.fill(`localhost:${port}`);
 
   // Click the Connect button in the modal footer if it's enabled.
   // The app may auto-connect when the URL changes (if previously connected),
@@ -36,18 +36,18 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
     .catch(() => false);
 
   if (!modalClosed) {
-    // Modal still open; should show "Connected!" status
-    await page.waitForSelector('text=Connected!', { timeout: 5_000 });
+    // Modal still open; should show "Connected" status
+    await page.waitForSelector('text=Connected', { timeout: 5_000 });
     await page.locator('[aria-label="Close"]').first().click();
     await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 });
   }
 }
 
 /**
- * Wait for the session list header to appear (indicates connection is active).
+ * Wait for the main Remi shell to appear (indicates connection is active).
  */
 export async function waitForSessionList(page: Page): Promise<void> {
-  await page.waitForSelector('h1:has-text("Sessions")', { timeout: 10_000 });
+  await page.waitForSelector('h1:has-text("Remi")', { timeout: 10_000 });
 }
 
 /**

--- a/tests/e2e/specs/connect.e2e.ts
+++ b/tests/e2e/specs/connect.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { DAEMON1_PORT, connectToDaemon } from '../helpers/daemon';
+import { DAEMON1_PORT, connectToDaemon, waitForSessionList } from '../helpers/daemon';
 
 test.describe('Connection flow', () => {
   test.beforeEach(async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Connection flow', () => {
     await page.click('[aria-label="Connect to daemon"]');
     await expect(page.locator('text=Connect to Daemon')).toBeVisible();
     // Direct tab should be active by default
-    await expect(page.locator('input[placeholder="ws://localhost:3847/ws"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="localhost"]')).toBeVisible();
   });
 
   test('connect modal can be closed', async ({ page }) => {
@@ -37,31 +37,29 @@ test.describe('Connection flow', () => {
     await page.goto('/');
     await connectToDaemon(page, DAEMON1_PORT);
 
-    // After connection, session list should be visible
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
   });
 
   test('connection persists across reload', async ({ page }) => {
     await page.goto('/');
     await connectToDaemon(page, DAEMON1_PORT);
 
-    // Verify connected
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
 
     // Reload the page
     await page.reload();
 
     // Should auto-reconnect from localStorage
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible({ timeout: 10_000 });
+    await waitForSessionList(page);
   });
 
   test('invalid URL shows connection failure', async ({ page }) => {
     await page.goto('/');
     await page.click('[aria-label="Connect to daemon"]');
 
-    const urlInput = page.locator('input[placeholder="ws://localhost:3847/ws"]');
-    await urlInput.clear();
-    await urlInput.fill('ws://localhost:99999/ws');
+    const hostInput = page.locator('input[placeholder="localhost"]');
+    await hostInput.clear();
+    await hostInput.fill('localhost:99999');
 
     const connectButton = page.locator('button:has-text("Connect")').last();
     await connectButton.click();

--- a/tests/e2e/specs/session-list.e2e.ts
+++ b/tests/e2e/specs/session-list.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { DAEMON1_PORT, DAEMON2_PORT, connectToDaemon } from '../helpers/daemon';
+import { DAEMON1_PORT, DAEMON2_PORT, connectToDaemon, waitForSessionList } from '../helpers/daemon';
 
 test.describe('Session list', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,14 +10,14 @@ test.describe('Session list', () => {
 
   test('shows Sessions heading after connection', async ({ page }) => {
     await connectToDaemon(page, DAEMON1_PORT);
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
   });
 
   test('shows session after connecting to daemon (one session per daemon)', async ({ page }) => {
     await connectToDaemon(page, DAEMON1_PORT);
     // With one-session-per-daemon, the daemon always has a session.
     // The session list should show at least one session card.
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
   });
 
   test('connect and settings buttons in header', async ({ page }) => {
@@ -29,10 +29,10 @@ test.describe('Session list', () => {
   test('can switch between daemons', async ({ page }) => {
     // Connect to daemon1
     await connectToDaemon(page, DAEMON1_PORT);
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
 
     // Connect to daemon2 using the helper (handles the full modal flow)
     await connectToDaemon(page, DAEMON2_PORT);
-    await expect(page.locator('h1:has-text("Sessions")')).toBeVisible();
+    await waitForSessionList(page);
   });
 });


### PR DESCRIPTION
Summary
- process replay batches immediately on first attach so chat history is not dropped before refs/effects settle
- update the browser E2E connect helper to the current host-based connect modal
- align the existing connect/session-list specs with the current Remi shell UI

Why
Live verification against fresh Remi wrapper sessions showed a real first-attach failure: the daemon reported replayable history, but the web chat pane stayed on `Waiting for agent output`.

Validation
- `bun run typecheck`
- `cd packages/web && bun run build`
- live browser attach to a fresh wrapper session on `localhost:19770`, confirming replayed messages render in chat

Related
- fixes #190
- advances #192