### PR TITLE
fix: skip stale transcript fallback replay

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1784,11 +1784,31 @@ async function createNewSession(
     if (Date.now() - startupTime > 30000) {
       clearInterval(fallbackInterval);
       transcriptFallbackTimers.delete(sessionId);
-      logError('[Hooks] Transcript fallback timed out. Using latest available file.');
       if (transcriptPath) {
-        startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
-        extractClaudeSessionId(transcriptPath, sessionId);
+        try {
+          const stat = fs.statSync(transcriptPath);
+          if (stat.mtimeMs >= startupTime) {
+            logError(
+              '[Hooks] Transcript fallback timed out, but a fresh transcript was found on the final check.',
+            );
+            startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
+            extractClaudeSessionId(transcriptPath, sessionId);
+            return;
+          }
+
+          logError(
+            `[Hooks] Transcript fallback timed out without a fresh transcript. Skipping stale file: ${transcriptPath}`,
+          );
+          return;
+        } catch {
+          logError(
+            '[Hooks] Transcript fallback timed out and transcript stat failed on final check.',
+          );
+          return;
+        }
       }
+
+      logError('[Hooks] Transcript fallback timed out without any transcript file.');
     }
   }, 2000);
   transcriptFallbackTimers.set(sessionId, fallbackInterval);


### PR DESCRIPTION
## Summary
- stop the transcript fallback from attaching an older Claude transcript after the 30s timeout
- keep a final freshness check before starting the watcher on the timeout path
- log explicit timeout outcomes for fresh, stale, missing, and stat-failure cases

## Verification
- bun run typecheck
- live wrapper session on localhost with existing older transcripts in ~/.claude/projects
- raw WebSocket attach after fallback timeout returned only ack + hello_ack and no replay_batch

Closes #194