### PR TITLE
fix: surface pty-only failures remotely

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1547,7 +1547,17 @@ async function createNewSession(
         }
       },
       onMessageFinalized: (msgId) => {
-        log(`Message ${msgId} finalized`);
+        const structured = messageApi.getMessage(msgId);
+        if (!structured) {
+          log(`Message ${msgId} finalized`);
+          return;
+        }
+
+        try {
+          sendAndRecord(createStructuredAgentOutput(structured, true, []));
+        } catch (err) {
+          logError(`[Session ${sessionId}] Failed to send finalized structured message:`, err);
+        }
       },
       onQuestion: (question) => {
         log(`Question detected: ${question.text.substring(0, 50)}...`);
@@ -1589,8 +1599,32 @@ async function createNewSession(
     },
   );
 
-  // PTY output parser: status-only mode (content comes from transcript for clean results)
-  const outputProcessor = new OutputProcessor({ sessionId, streamStatusOnly: true }, {});
+  // PTY output parser: keep streaming structured PTY messages so terminal-only
+  // failures still surface in remote clients when transcript updates never arrive.
+  const outputProcessor = new OutputProcessor(
+    { sessionId },
+    {
+      onMessage: (message) => {
+        messageApi.handleMessage(message);
+      },
+      onMessageUpdate: (messageId, content, tool) => {
+        messageApi.handleMessageUpdate(messageId, content, tool);
+      },
+      onMessageFinalized: (messageId) => {
+        messageApi.finalizeMessage(messageId);
+      },
+      onQuestion: (question) => {
+        if (!hookServer) {
+          messageApi.handleQuestion(question);
+        }
+      },
+      onStatusChange: (status, context) => {
+        if (!hookServer) {
+          messageApi.handleStatusChange(status, context);
+        }
+      },
+    },
+  );
 
   // Hook-based event bridge for status/question detection
   if (hookServer) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1547,17 +1547,7 @@ async function createNewSession(
         }
       },
       onMessageFinalized: (msgId) => {
-        const structured = messageApi.getMessage(msgId);
-        if (!structured) {
-          log(`Message ${msgId} finalized`);
-          return;
-        }
-
-        try {
-          sendAndRecord(createStructuredAgentOutput(structured, true, []));
-        } catch (err) {
-          logError(`[Session ${sessionId}] Failed to send finalized structured message:`, err);
-        }
+        log(`Message ${msgId} finalized`);
       },
       onQuestion: (question) => {
         log(`Question detected: ${question.text.substring(0, 50)}...`);
@@ -1599,19 +1589,15 @@ async function createNewSession(
     },
   );
 
-  // PTY output parser: keep streaming structured PTY messages so terminal-only
-  // failures still surface in remote clients when transcript updates never arrive.
+  // PTY output parser: streamStatusOnly suppresses regular agent content (comes
+  // from transcript). Tool-output errors (e.g. "OAuth token revoked") bypass the
+  // guard so terminal-only failures still reach remote clients.
   const outputProcessor = new OutputProcessor(
-    { sessionId },
+    { sessionId, streamStatusOnly: true },
     {
       onMessage: (message) => {
+        // Only fires for tool-output errors that bypass streamStatusOnly.
         messageApi.handleMessage(message);
-      },
-      onMessageUpdate: (messageId, content, tool) => {
-        messageApi.handleMessageUpdate(messageId, content, tool);
-      },
-      onMessageFinalized: (messageId) => {
-        messageApi.finalizeMessage(messageId);
       },
       onQuestion: (question) => {
         if (!hookServer) {

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -239,12 +239,21 @@ export class OutputProcessor {
         const filteredLine = cleanAndFilterOutput(rawLine);
         const contentLine = cleanMessageLine(filteredLine);
         if (contentLine.trim().length > 0) {
-          if (this.currentMessageId === null) {
-            this.appendContentLine(contentLine);
-            this.finalizeMessage();
-          } else {
-            this.appendContentLine(contentLine);
-          }
+          // Meaningful tool output (errors like "OAuth token revoked") emitted
+          // as standalone finalized messages, bypassing streamStatusOnly.
+          // These errors often don't appear in the transcript.
+          const id = generateId();
+          const message: Message = {
+            id,
+            sessionId: this.config.sessionId,
+            sender: 'agent',
+            content: contentLine,
+            createdAt: now(),
+            state: 'sent',
+            stateChangedAt: now(),
+            isEditing: false,
+          };
+          this.events.onMessage?.(message);
         }
       } else if (boundary === 'user' || boundary === 'thinking') {
       } else {
@@ -328,9 +337,7 @@ export class OutputProcessor {
 
   private finalizeMessage(): void {
     if (this.currentMessageId !== null) {
-      // Final update with isEditing = false
       if (!this.config.streamStatusOnly) {
-        this.events.onMessageUpdate?.(this.currentMessageId, this.currentMessageContent, undefined);
         this.events.onMessageFinalized?.(this.currentMessageId);
       }
     }

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -25,6 +25,9 @@ export interface OutputEvents {
   /** Existing message updated (progressive output) */
   onMessageUpdate: (messageId: UUID, content: string, tool?: string) => void;
 
+  /** Message is finalized (no longer editing) */
+  onMessageFinalized: (messageId: UUID) => void;
+
   /** Question detected */
   onQuestion: (question: Question) => void;
 
@@ -232,16 +235,23 @@ export class OutputProcessor {
         }
         // Note: Even if filteredLine is empty (tool execution line filtered out),
         // currentMessageId is now set, so subsequent content lines will be appended.
-      } else if (boundary === 'user' || boundary === 'thinking' || boundary === 'tool_output') {
+      } else if (boundary === 'tool_output') {
+        const filteredLine = cleanAndFilterOutput(rawLine);
+        const contentLine = cleanMessageLine(filteredLine);
+        if (contentLine.trim().length > 0) {
+          if (this.currentMessageId === null) {
+            this.appendContentLine(contentLine);
+            this.finalizeMessage();
+          } else {
+            this.appendContentLine(contentLine);
+          }
+        }
+      } else if (boundary === 'user' || boundary === 'thinking') {
       } else {
         // Continuation of current message
         const filteredLine = cleanAndFilterOutput(rawLine);
         if (filteredLine.trim().length > 0 && this.currentMessageId !== null) {
-          const newContent = this.deduplicateContent(filteredLine);
-          if (newContent.length > 0) {
-            this.currentMessageContent += `\n${newContent}`;
-            this.emitMessageUpdate([]);
-          }
+          this.appendContentLine(filteredLine);
         }
       }
     }
@@ -255,6 +265,27 @@ export class OutputProcessor {
   private extractToolName(line: string): string | undefined {
     const match = line.match(/^(\w+)\(/);
     return match ? match[1] : undefined;
+  }
+
+  private appendContentLine(line: string): void {
+    if (line.trim().length === 0) {
+      return;
+    }
+
+    const newContent = this.deduplicateContent(line);
+    if (newContent.length === 0) {
+      return;
+    }
+
+    if (this.currentMessageId === null) {
+      this.currentMessageId = generateId();
+      this.currentMessageContent = newContent;
+      this.emitMessageUpdate([]);
+      return;
+    }
+
+    this.currentMessageContent += `\n${newContent}`;
+    this.emitMessageUpdate([]);
   }
 
   private emitMessageUpdate(_lines: readonly string[]): void {
@@ -300,6 +331,7 @@ export class OutputProcessor {
       // Final update with isEditing = false
       if (!this.config.streamStatusOnly) {
         this.events.onMessageUpdate?.(this.currentMessageId, this.currentMessageContent, undefined);
+        this.events.onMessageFinalized?.(this.currentMessageId);
       }
     }
 

--- a/packages/daemon/tests/ansi.test.ts
+++ b/packages/daemon/tests/ansi.test.ts
@@ -210,6 +210,11 @@ describe('filterTerminalUI()', () => {
     expect(filterTerminalUI(input)).toBe('Real content here');
   });
 
+  test('preserves meaningful tool output lines', () => {
+    const input = '  ⎿ OAuth token revoked · Please run /login';
+    expect(filterTerminalUI(input)).toBe(input);
+  });
+
   test('filters ANSI color code fragments', () => {
     const input = '39m\nReal content here\n90m';
     expect(filterTerminalUI(input)).toBe('Real content here');

--- a/packages/daemon/tests/output-processor.test.ts
+++ b/packages/daemon/tests/output-processor.test.ts
@@ -265,10 +265,27 @@ describe('OutputProcessor', () => {
       },
     );
 
-    processor.process('⎿ tool output here\n');
+    processor.process('⎿ Read 5 lines\n');
     processor.flush();
 
     expect(messages.length).toBe(0);
+  });
+
+  test('emits meaningful tool output lines as agent messages', () => {
+    const messages: Message[] = [];
+    const processor = new OutputProcessor(
+      { sessionId },
+      {
+        onMessage: (msg) => messages.push(msg),
+      },
+    );
+
+    processor.process('⎿ OAuth token revoked · Please run /login\n');
+    processor.flush();
+
+    expect(messages.length).toBe(1);
+    expect(messages[0]?.content).toContain('OAuth token revoked');
+    expect(messages[0]?.content).toContain('Please run /login');
   });
 
   test('deduplicates repeated content', () => {
@@ -341,11 +358,13 @@ describe('OutputProcessor', () => {
   test('finalizes message on new agent boundary', () => {
     const messages: Message[] = [];
     const updates: Array<{ id: string; content: string }> = [];
+    const finalized: string[] = [];
     const processor = new OutputProcessor(
       { sessionId },
       {
         onMessage: (msg) => messages.push(msg),
         onMessageUpdate: (id, content) => updates.push({ id, content }),
+        onMessageFinalized: (id) => finalized.push(id),
       },
     );
 
@@ -355,5 +374,6 @@ describe('OutputProcessor', () => {
 
     // Should have created at least one message
     expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(finalized.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
- route PTY parser message events back into MessageAPI so remote clients receive fallback structured output
- preserve meaningful `⎿ ...` tool-output lines like terminal-only auth failures while still filtering metadata-only tool lines
- send finalized structured updates so fallback PTY messages settle with `isEditing: false`

## Verification
- bun test packages/daemon/tests/output-processor.test.ts
- bun test packages/daemon/tests/ansi.test.ts
- bun run typecheck
- live wrapper session on localhost with a real prompt over WebSocket
- remote attach received `structured_agent_output` for `OAuth token revoked · Please run /login` and the final non-editing update

Closes #191