### PR TITLE
test: cover replay on first attach

### DIFF
--- a/tests/e2e/helpers/daemon.ts
+++ b/tests/e2e/helpers/daemon.ts
@@ -1,7 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import type { Page } from '@playwright/test';
 
 export const DAEMON1_PORT = 19765;
 export const DAEMON2_PORT = 19766;
+
+const DAEMON_CONTAINERS: Record<number, string> = {
+  [DAEMON1_PORT]: 'remi-test-daemon1',
+  [DAEMON2_PORT]: 'remi-test-daemon2',
+};
+
+const DAEMON_PROJECTS: Record<number, string> = {
+  [DAEMON1_PORT]: '/projects/sample-app',
+  [DAEMON2_PORT]: '/projects/api-server',
+};
+
+/**
+ * Seed a daemon with replayable history before the browser attaches.
+ * Writes a fresh Claude transcript entry into the daemon container and waits
+ * for the fallback transcript watcher to ingest it.
+ */
+export async function seedReplayableHistory(
+  port: number = DAEMON1_PORT,
+  prompt = `remi-replay-${Date.now()}`,
+): Promise<string> {
+  const container = DAEMON_CONTAINERS[port];
+  const projectPath = DAEMON_PROJECTS[port];
+
+  if (!container || !projectPath) {
+    throw new Error(`No E2E daemon mapping configured for port ${port}`);
+  }
+
+  const transcriptDir = `/root/.claude/projects/${projectPath.replace(/\//g, '-')}`;
+  const transcriptFile = `${transcriptDir}/e2e_${Date.now()}_${randomUUID()}.jsonl`;
+  const entry = JSON.stringify({
+    type: 'user',
+    uuid: randomUUID(),
+    parentUuid: null,
+    sessionId: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd: projectPath,
+    version: 'e2e',
+    message: {
+      role: 'user',
+      content: prompt,
+    },
+  });
+
+  const script = [
+    `mkdir -p ${JSON.stringify(transcriptDir)}`,
+    `cat > ${JSON.stringify(transcriptFile)} <<'EOF'`,
+    entry,
+    'EOF',
+  ].join('\n');
+
+  execFileSync('docker', ['exec', container, 'sh', '-lc', script], {
+    stdio: 'pipe',
+  });
+
+  // The daemon polls for fresh transcripts every 2s when hooks are unavailable.
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  return prompt;
+}
 
 /**
  * Connect to a Remi daemon via the web UI's ConnectModal.
@@ -12,7 +72,7 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
   await page.click('[aria-label="Connect to daemon"]');
 
   // Wait for modal to appear
-  await page.waitForSelector('text=Connect to Daemon');
+  await page.getByRole('heading', { name: 'Connect' }).waitFor();
 
   // Clear the host input and point it at the requested daemon.
   const hostInput = page.locator('input[placeholder="localhost"]');
@@ -31,7 +91,8 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
   // Wait for the modal to close (auto-closes on first connection)
   // or wait for "Connected!" and close manually (when switching daemons)
   const modalClosed = await page
-    .waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 })
+    .getByRole('heading', { name: 'Connect' })
+    .waitFor({ state: 'hidden', timeout: 3_000 })
     .then(() => true)
     .catch(() => false);
 
@@ -39,7 +100,9 @@ export async function connectToDaemon(page: Page, port: number = DAEMON1_PORT): 
     // Modal still open; should show "Connected" status
     await page.waitForSelector('text=Connected', { timeout: 5_000 });
     await page.locator('[aria-label="Close"]').first().click();
-    await page.waitForSelector('text=Connect to Daemon', { state: 'hidden', timeout: 3_000 });
+    await page
+      .getByRole('heading', { name: 'Connect' })
+      .waitFor({ state: 'hidden', timeout: 3_000 });
   }
 }
 

--- a/tests/e2e/specs/connect.e2e.ts
+++ b/tests/e2e/specs/connect.e2e.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { DAEMON1_PORT, connectToDaemon, waitForSessionList } from '../helpers/daemon';
+import {
+  DAEMON1_PORT,
+  connectToDaemon,
+  seedReplayableHistory,
+  waitForSessionList,
+} from '../helpers/daemon';
 
 test.describe('Connection flow', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,14 +16,14 @@ test.describe('Connection flow', () => {
 
   test('app loads with empty state', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'No Sessions' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'No Active Sessions' })).toBeVisible();
     await expect(page.locator('[aria-label="Connect to daemon"]')).toBeVisible();
   });
 
   test('connect modal opens on click', async ({ page }) => {
     await page.goto('/');
     await page.click('[aria-label="Connect to daemon"]');
-    await expect(page.locator('text=Connect to Daemon')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Connect' })).toBeVisible();
     // Direct tab should be active by default
     await expect(page.locator('input[placeholder="localhost"]')).toBeVisible();
   });
@@ -26,11 +31,11 @@ test.describe('Connection flow', () => {
   test('connect modal can be closed', async ({ page }) => {
     await page.goto('/');
     await page.click('[aria-label="Connect to daemon"]');
-    await expect(page.locator('text=Connect to Daemon')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Connect' })).toBeVisible();
 
     // Click close button
     await page.click('[aria-label="Close"]');
-    await expect(page.locator('text=Connect to Daemon')).toBeHidden();
+    await expect(page.getByRole('heading', { name: 'Connect' })).toBeHidden();
   });
 
   test('direct connection to daemon succeeds', async ({ page }) => {
@@ -53,6 +58,18 @@ test.describe('Connection flow', () => {
     await waitForSessionList(page);
   });
 
+  test('first attach replays existing history immediately', async ({ page }) => {
+    await page.goto('/');
+
+    const replayPrompt = await seedReplayableHistory(DAEMON1_PORT);
+
+    await connectToDaemon(page, DAEMON1_PORT);
+    await waitForSessionList(page);
+
+    await expect(page.getByText(replayPrompt, { exact: false })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Waiting for agent output')).toHaveCount(0);
+  });
+
   test('invalid URL shows connection failure', async ({ page }) => {
     await page.goto('/');
     await page.click('[aria-label="Connect to daemon"]');
@@ -65,6 +82,6 @@ test.describe('Connection flow', () => {
     await connectButton.click();
 
     // Modal should remain open (connection failed)
-    await expect(page.locator('text=Connect to Daemon')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('heading', { name: 'Connect' })).toBeVisible({ timeout: 5_000 });
   });
 });


### PR DESCRIPTION
## Summary
- Seed replayable daemon history by writing a fresh transcript entry into the E2E daemon container before the browser attaches
- Add a first-attach browser regression that verifies the seeded history renders immediately instead of staying on "Waiting for agent output"
- Update stale connect-modal assertions to the current host-based Connect flow and current empty-state copy

## Verification
- bun run typecheck
- bunx playwright test --config tests/e2e/playwright.config.ts tests/e2e/specs/connect.e2e.ts tests/e2e/specs/session-list.e2e.ts

## Context
- Replaces #197 (auto-closed when base branch was merged)
- Regression test for the fix in #193

Closes #192