### PR TITLE
fix: remove npm@latest upgrade that breaks on GHA runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for OIDC support
+      - name: Verify npm OIDC support
         run: |
-          npm install -g npm@latest
           echo "npm version: $(npm --version)"
+          echo "node version: $(node --version)"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Remove the `npm install -g npm@latest` step from the release workflow
- Node 22 ships with npm 10.x which already has OIDC/provenance support
- The upgrade step was failing with `MODULE_NOT_FOUND` for `promise-retry` due to a corrupted npm dependency tree on GitHub Actions runners

## Root Cause
The `publish-npm` job in `release.yml` runs `npm install -g npm@latest` to upgrade npm for OIDC support. On the current GHA runner (Node 22.22.2), this command fails because npm's own dependency (`promise-retry`) is missing from the installed npm tree. This is a known runner environment issue.

## Fix
Since Node 22's bundled npm 10.x already supports OIDC provenance (available since npm 9.5.0), the upgrade step is unnecessary. Replaced with a version verification step.