### PR TITLE
fix: patch missing npm dep before upgrade in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,11 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Verify npm OIDC support
+      - name: Upgrade npm for OIDC support
         run: |
+          npm install -g promise-retry
+          npm install -g npm@latest
           echo "npm version: $(npm --version)"
-          echo "node version: $(node --version)"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
Node 22.22.2's bundled npm is missing `promise-retry`, preventing `npm install -g npm@latest` from running in the publish-npm job. Install the missing dep first as a workaround.

Fixes the v0.4.17 and v0.4.18 publish failures.