### PR TITLE
feat: Add tmux-style session detach (issue #201)

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -66,6 +66,9 @@ export interface AdapterEvents {
   /** Session history request received */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 
+  /** Detach session request received (tmux-style) */
+  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -149,6 +149,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onSessionHistoryRequest?.(connectionId, requestId, limit);
       },
 
+      onDetachSession: (connectionId, sessionId, requestId) => {
+        this.events.onDetachSession?.(connectionId, sessionId, requestId);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1972,8 +1972,8 @@ function getRecentDirectories(store: SessionStore, limit: number): RecentDirecto
   return entries;
 }
 
-const sendToConnection = (connectionId: UUID, message: ProtocolMessage): void => {
-  registry.sendRaw(connectionId, message);
+const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
+  return registry.sendRaw(connectionId, message);
 };
 
 const sharedEvents = {
@@ -2309,15 +2309,30 @@ const sharedEvents = {
       return;
     }
 
-    // Send ack before detaching (the connection may close after detach)
-    sendToConnection(connectionId, createDetachSessionAck(sessionId, true));
+    const activeConnId = session.activeConnectionId;
+    if (activeConnId === null) {
+      sendToConnection(
+        connectionId,
+        createDetachSessionAck(sessionId, false, 'Session is already detached'),
+      );
+      return;
+    }
 
-    // Perform explicit detach (skips orphan timeout)
-    sessionRegistry.detachConnection(connectionId, true);
-    registry.untrackConnection(connectionId);
+    // Send ack to the requesting connection (may be the active client or
+    // a separate query-mode client like `remi detach <session>`)
+    const ackSent = sendToConnection(connectionId, createDetachSessionAck(sessionId, true));
+    if (!ackSent) {
+      log(`Warning: detach ack could not be delivered to ${connectionId}`);
+    }
+
+    // Detach the ACTIVE connection (not necessarily the requesting one)
+    sessionRegistry.detachConnection(activeConnId, true);
+    registry.untrackConnection(activeConnId);
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
 
-    log(`Session explicitly detached: ${session.name} (no timeout, re-attachable)`);
+    log(
+      `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
+    );
   },
 
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -232,6 +232,7 @@ if (fs.existsSync(envPath)) {
 import {
   createBulletExpandResponse,
   createCreateSessionResponse,
+  createDetachSessionAck,
   createError,
   createHelloAck,
   createKillSessionResponse,
@@ -915,17 +916,41 @@ if (cliSubcommand === 'kill') {
   process.exit(0);
 }
 
-// Handle 'detach' subcommand: detach from a session
+// Handle 'detach' subcommand: detach from a session without killing it
 if (cliSubcommand === 'detach') {
-  // Without args: not meaningful from CLI (Ctrl+B d handles interactive detach)
-  // With name: informational only; there's no remote detach protocol yet
   if (!resolved.targetId) {
-    console.log('To detach from a session interactively, press Ctrl+B d.');
-    console.log('To detach a specific session by name: remi detach <session-name>');
-    console.log('(Remote detach is not yet implemented; use Ctrl+B d in the attached terminal.)');
-  } else {
-    console.log('Remote detach of named sessions is not yet implemented.');
-    console.log('To detach, press Ctrl+B d in the attached terminal.');
+    console.error('Usage: remi detach <session-name-or-id>');
+    console.error('  Detach from a session without killing it (tmux-style).');
+    console.error('  The session remains alive and can be re-attached with `remi attach`.');
+    console.error('  Examples: remi detach my-session');
+    console.error('            remi detach host:port/session-name');
+    console.error('  Tip: When attached interactively, press Ctrl+B d to detach.');
+    console.error('Run `remi ls` to see live sessions.');
+    process.exit(1);
+  }
+
+  let resolvedPort = resolved.port;
+
+  // Resolve port from live registry if target matches a known local session
+  if (!cliPort && resolved.host === 'localhost') {
+    const liveMatch =
+      liveSessionsRegistry.findByName(resolved.targetId) ??
+      liveSessionsRegistry.findBySessionId(resolved.targetId);
+    if (liveMatch) {
+      resolvedPort = liveMatch.wsPort;
+    }
+  }
+
+  const { runDetachClient } = await import('./cli/detach-client.ts');
+  try {
+    await runDetachClient({
+      host: resolved.host,
+      port: resolvedPort,
+      target: resolved.targetId,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
   }
   process.exit(0);
 }
@@ -1439,6 +1464,8 @@ const sessionRegistry = new SessionRegistry(
       const session = sessionRegistry.getSession(sessionId);
       if (session?.locallyOwned) {
         log(`Session detached: ${sessionId} (locally owned, no timeout)`);
+      } else if (session?.explicitlyDetached) {
+        log(`Session explicitly detached: ${sessionId} (no timeout, re-attachable)`);
       } else {
         log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
       }
@@ -2268,6 +2295,29 @@ const sharedEvents = {
     } else {
       log(`Session killed: ${sessionName}`);
     }
+  },
+
+  onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID) => {
+    log(`Detach session request from ${connectionId} for session ${sessionId}`);
+
+    const session = sessionRegistry.getSession(sessionId);
+    if (!session) {
+      sendToConnection(
+        connectionId,
+        createDetachSessionAck(sessionId, false, `Session ${sessionId} not found`),
+      );
+      return;
+    }
+
+    // Send ack before detaching (the connection may close after detach)
+    sendToConnection(connectionId, createDetachSessionAck(sessionId, true));
+
+    // Perform explicit detach (skips orphan timeout)
+    sessionRegistry.detachConnection(connectionId, true);
+    registry.untrackConnection(connectionId);
+    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
+
+    log(`Session explicitly detached: ${session.name} (no timeout, re-attachable)`);
   },
 
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import {
+  createDetachSession,
   createHello,
   createPong,
   createTerminalResize,
@@ -203,6 +204,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         // raw byte 0x02 and kitty keyboard protocol ESC[98;5u)
         detachScannerInstance = new DetachScanner({
           onDetach: () => {
+            // Notify daemon of explicit detach so it skips orphan timeout
+            if (attachedSessionId) {
+              sendMessage(createDetachSession(attachedSessionId));
+            }
             process.stderr.write('[detached]\n');
             finish({ exitCode: 0, reason: 'detached' });
           },

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -43,6 +43,8 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let authInProgress = false;
   let receivedRawPty = false;
   let rawPtyTimer: ReturnType<typeof setTimeout> | null = null;
+  let detachPending = false;
+  let detachAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -58,6 +60,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   }
 
   function restoreTerminal(): void {
+    if (detachAckTimer) {
+      clearTimeout(detachAckTimer);
+      detachAckTimer = null;
+    }
     if (rawPtyTimer) {
       clearTimeout(rawPtyTimer);
       rawPtyTimer = null;
@@ -204,12 +210,20 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         // raw byte 0x02 and kitty keyboard protocol ESC[98;5u)
         detachScannerInstance = new DetachScanner({
           onDetach: () => {
-            // Notify daemon of explicit detach so it skips orphan timeout
+            // Notify daemon of explicit detach so it skips orphan timeout.
+            // Wait briefly for the ack to ensure the daemon processes the
+            // detach before we close the WebSocket connection.
             if (attachedSessionId) {
               sendMessage(createDetachSession(attachedSessionId));
+              detachPending = true;
+              detachAckTimer = setTimeout(() => {
+                process.stderr.write('[detached]\n');
+                finish({ exitCode: 0, reason: 'detached' });
+              }, 500);
+            } else {
+              process.stderr.write('[detached]\n');
+              finish({ exitCode: 0, reason: 'detached' });
             }
-            process.stderr.write('[detached]\n');
-            finish({ exitCode: 0, reason: 'detached' });
           },
           onData: (data) => {
             sendInput(data.toString());
@@ -257,6 +271,17 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
 
       if (msg.type === 'ping') {
         sendMessage(createPong(msg.id));
+        return;
+      }
+
+      if (msg.type === 'detach_session_ack' && detachPending) {
+        // Daemon confirmed the explicit detach; finish immediately
+        if (detachAckTimer) {
+          clearTimeout(detachAckTimer);
+          detachAckTimer = null;
+        }
+        process.stderr.write('[detached]\n');
+        finish({ exitCode: 0, reason: 'detached' });
         return;
       }
 

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -1,0 +1,149 @@
+/**
+ * Detach Client - Sends a detach request to a running daemon to detach
+ * the active connection from a session without killing it (tmux-style).
+ *
+ * Connects via WebSocket, resolves the session by name or ID, and sends
+ * a detach_session message.
+ */
+
+import {
+  createDetachSession,
+  createHello,
+  createSessionListRequest,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
+import { resolveSession as sharedResolveSession } from './session-resolver.ts';
+
+export interface DetachClientOptions {
+  readonly host: string;
+  readonly port: number;
+  /** Session name or ID to detach */
+  readonly target: string;
+  readonly timeout?: number;
+}
+
+export async function runDetachClient(opts: DetachClientOptions): Promise<void> {
+  const { host, port, target, timeout = 5000 } = opts;
+  const url = `ws://${host}:${port}/ws`;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let authInProgress = false;
+    let sessions: DiscoverableSession[] | null = null;
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      ws.close();
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Timed out connecting to daemon at ${host}:${port}`));
+      }
+    }, timeout);
+
+    function done(err?: Error): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.close();
+      if (err) reject(err);
+      else resolve();
+    }
+
+    function sendHello(): void {
+      const clientId = generateId();
+      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+    }
+
+    function handleMessage(msg: ProtocolMessage): void {
+      if (msg.type === 'hello_ack') {
+        // Request session list first to resolve the name
+        ws.send(serialize(createSessionListRequest(false)));
+      } else if (msg.type === 'session_list_response') {
+        sessions = msg.sessions as DiscoverableSession[];
+        try {
+          const resolved = sharedResolveSession([{ host, port, sessions }], target);
+          if (!resolved) {
+            done(
+              new Error(
+                `No session found matching "${target}". Run \`remi ls\` to see live sessions.`,
+              ),
+            );
+            return;
+          }
+          // Send detach request
+          ws.send(serialize(createDetachSession(resolved.session.sessionId as UUID)));
+        } catch (err) {
+          done(err instanceof Error ? err : new Error(String(err)));
+        }
+      } else if (msg.type === 'detach_session_ack') {
+        if (msg.success) {
+          const session =
+            sessions?.find((s) => s.sessionId === target) ??
+            sessions?.find((s) => s.name === target) ??
+            sessions?.find((s) => s.name?.startsWith(target)) ??
+            sessions?.find((s) => s.sessionId.startsWith(target));
+          const displayName = session?.name ?? target;
+          console.log(`Detached from session: ${displayName}`);
+          console.log("Use 'remi attach' to reconnect.");
+          done();
+        } else {
+          done(new Error(`Failed to detach session: ${msg.error ?? 'unknown error'}`));
+        }
+      } else if (msg.type === 'error') {
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        done(new Error(`Daemon error: ${msg.message}`));
+      }
+    }
+
+    ws.onopen = () => {
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) {
+        console.error('Warning: received unparsable message from daemon');
+        return;
+      }
+
+      // Handle auth challenge if needed
+      if (msg.type === 'auth_challenge') {
+        authInProgress = true;
+        performAuthHandshake(ws, msg)
+          .then(() => {
+            authInProgress = false;
+            sendHello();
+          })
+          .catch((err) => {
+            done(err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
+      if (authInProgress) return;
+      handleMessage(msg);
+    };
+
+    ws.onerror = () => {
+      done(new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    };
+
+    ws.onclose = () => {
+      if (!settled) {
+        done(new Error('Connection closed before detach completed'));
+      }
+    };
+  });
+}

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -38,8 +38,9 @@ export async function runDetachClient(opts: DetachClientOptions): Promise<void> 
 
     try {
       ws = new WebSocket(url);
-    } catch {
-      reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));
       return;
     }
 

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -216,13 +216,15 @@ const commandHelp: Record<Subcommand, string[]> = {
     entry('cat key.json | remi import-key', 'Import from stdin'),
   ],
   detach: [
-    'Detach from a session.',
+    'Detach from a session without killing it (tmux-style).',
+    'The session remains alive and can be re-attached with `remi attach`.',
     '',
     bold('Usage:'),
-    entry('remi detach', 'Detach from current session'),
-    entry('remi detach <name>', 'Detach a named session'),
+    entry('remi detach <name>', 'Detach the named session'),
+    entry('remi detach <host:port/name>', 'Detach a remote session'),
     '',
-    dim('  In practice, use Ctrl+B d to detach interactively.'),
+    dim('  When attached interactively, press Ctrl+B d to detach.'),
+    dim('  Detached sessions show as "detached" in `remi ls`.'),
   ],
 };
 

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -32,6 +32,7 @@ import type {
   AuthResponseMessage,
   BulletExpandRequestMessage,
   CreateSessionRequestMessage,
+  DetachSessionMessage,
   HelloMessage,
   KillSessionRequestMessage,
   PingMessage,
@@ -86,6 +87,9 @@ export interface ConnectionEvents {
 
   /** Session history request received */
   onSessionHistoryRequest: (requestId: UUID, limit: number | undefined) => void;
+
+  /** Detach session request received (tmux-style) */
+  onDetachSession: (sessionId: UUID, requestId: UUID) => void;
 
   /** Authentication succeeded */
   onAuthSuccess: (clientFingerprint: string) => void;
@@ -277,6 +281,9 @@ export class Connection {
       case 'session_history_request':
         this.handleSessionHistoryRequest(message);
         break;
+      case 'detach_session':
+        this.handleDetachSession(message);
+        break;
       case 'ping':
         this.handlePing(message);
         break;
@@ -454,6 +461,11 @@ export class Connection {
   private handleSessionHistoryRequest(message: SessionHistoryRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onSessionHistoryRequest?.(message.id, message.limit);
+  }
+
+  private handleDetachSession(message: DetachSessionMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onDetachSession?.(message.sessionId, message.id);
   }
 
   private handleTerminalResize(message: TerminalResizeMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -80,6 +80,9 @@ export interface ServerEvents {
   /** Session history request from client */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 
+  /** Detach session request from client (tmux-style) */
+  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -329,6 +332,10 @@ export class WebSocketServer {
 
       onSessionHistoryRequest: (requestId, limit) => {
         this.events.onSessionHistoryRequest?.(ws.data.connectionId, requestId, limit);
+      },
+
+      onDetachSession: (sessionId, requestId) => {
+        this.events.onDetachSession?.(ws.data.connectionId, sessionId, requestId);
       },
 
       onError: (error) => {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -103,6 +103,10 @@ export interface ManagedSession {
   /** Whether this session is owned by the local process (wrapper mode).
    * Locally-owned sessions are never killed by orphan timeout. */
   readonly locallyOwned: boolean;
+
+  /** Whether the last detach was an explicit user request (tmux-style).
+   * Explicitly detached sessions skip the orphan timeout entirely. */
+  explicitlyDetached: boolean;
 }
 
 /**
@@ -166,6 +170,7 @@ export class SessionRegistry {
       currentStatus: 'idle',
       currentQuestion: null,
       locallyOwned,
+      explicitlyDetached: false,
     };
 
     this.events.onSessionCreated?.(sessionId);
@@ -262,6 +267,7 @@ export class SessionRegistry {
     // Attach connection
     this.session.activeConnectionId = connectionId;
     this.session.lastDisconnectedAt = null;
+    this.session.explicitlyDetached = false;
 
     // Get messages to replay (from after last delivered)
     const replayMessages = this.session.messageHistory.slice(this.session.lastDeliveredIndex + 1);
@@ -288,8 +294,12 @@ export class SessionRegistry {
    * If there are waiting connections, the next one is auto-promoted.
    * Otherwise, non-locally-owned sessions become orphaned and start the timeout countdown.
    * Locally-owned sessions remain active without a timeout.
+   *
+   * When `explicit` is true (tmux-style detach), the orphan timeout is skipped
+   * regardless of whether the session is locally owned; the session remains
+   * discoverable and re-attachable indefinitely.
    */
-  detachConnection(connectionId: UUID): void {
+  detachConnection(connectionId: UUID, explicit = false): void {
     if (this.session === null || this.session.activeConnectionId !== connectionId) {
       // Also remove from waiting list if it was queued
       const waitIdx = this.waitingConnections.indexOf(connectionId);
@@ -328,10 +338,13 @@ export class SessionRegistry {
       }
     }
 
-    // Start orphan timeout (skip for locally-owned sessions; they stay alive
-    // until PTY exits, explicit kill, or daemon shutdown).
-    // orphanTimeoutMs === 0 disables automatic cleanup.
-    if (!this.session.locallyOwned && this.orphanTimeoutMs > 0) {
+    // Track explicit detach state for discovery status
+    this.session.explicitlyDetached = explicit;
+
+    // Start orphan timeout (skip for locally-owned sessions, explicit detaches,
+    // and when orphanTimeoutMs === 0).
+    // Explicitly detached sessions stay alive indefinitely like locally-owned ones.
+    if (!this.session.locallyOwned && !explicit && this.orphanTimeoutMs > 0) {
       this.session.orphanTimeoutId = setTimeout(() => {
         this.closeSession(sessionId, 'timeout');
       }, this.orphanTimeoutMs);
@@ -489,9 +502,13 @@ export class SessionRegistry {
     ];
   }
 
-  private getDiscoverableStatus(session: ManagedSession): 'active' | 'idle' | 'orphaned' {
+  private getDiscoverableStatus(
+    session: ManagedSession,
+  ): 'active' | 'idle' | 'orphaned' | 'detached' {
     if (session.activeConnectionId === null) {
-      return session.locallyOwned ? 'active' : 'orphaned';
+      if (session.locallyOwned) return 'active';
+      if (session.explicitlyDetached) return 'detached';
+      return 'orphaned';
     }
     if (session.currentStatus === 'idle') {
       return 'idle';

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -436,6 +436,111 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('explicit detach (tmux-style)', () => {
+    test('explicit detach skips orphan timeout', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      // Wait well past the orphan timeout (100ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Session should still exist (not killed by timeout)
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(events.onSessionClosed).not.toHaveBeenCalled();
+    });
+
+    test('explicit detach sets explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      const session = registry.getSession(sessionId);
+      expect(session?.explicitlyDetached).toBe(true);
+    });
+
+    test('non-explicit detach does not set explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      const session = registry.getSession(sessionId);
+      expect(session?.explicitlyDetached).toBe(false);
+    });
+
+    test('reattach clears explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+      const conn2 = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1, true);
+
+      const beforeAttach = registry.getSession(sessionId);
+      expect(beforeAttach?.explicitlyDetached).toBe(true);
+
+      registry.attachConnection(sessionId, conn2);
+
+      const afterAttach = registry.getSession(sessionId);
+      expect(afterAttach?.explicitlyDetached).toBe(false);
+    });
+
+    test('explicitly detached session reports "detached" status in listSessions', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('detached');
+    });
+
+    test('non-explicit detach reports "orphaned" status', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, false);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('orphaned');
+    });
+
+    test('explicitly detached session is re-attachable', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1, true);
+
+      expect(registry.canResume(sessionId)).toBe(true);
+
+      const conn2 = generateId();
+      const result = registry.attachConnection(sessionId, conn2);
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
+    });
+  });
+
   describe('shutdown()', () => {
     test('closes the session', async () => {
       const pty = createMockPTY();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -72,6 +72,8 @@ export type {
   SessionHistoryResponseMessage,
   ResumeSessionRequestMessage,
   ResumeSessionResponseMessage,
+  DetachSessionMessage,
+  DetachSessionAckMessage,
 } from './protocol.ts';
 
 export {
@@ -112,6 +114,8 @@ export {
   createSessionHistoryResponse,
   createResumeSessionRequest,
   createResumeSessionResponse,
+  createDetachSession,
+  createDetachSessionAck,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -95,7 +95,9 @@ export type ProtocolMessage =
   | SessionHistoryRequestMessage
   | SessionHistoryResponseMessage
   | ResumeSessionRequestMessage
-  | ResumeSessionResponseMessage;
+  | ResumeSessionResponseMessage
+  | DetachSessionMessage
+  | DetachSessionAckMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -473,6 +475,28 @@ export interface KillSessionResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Request to detach from a session without killing it (tmux-style) */
+export interface DetachSessionMessage {
+  readonly type: 'detach_session';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID to detach from */
+  readonly sessionId: UUID;
+}
+
+/** Acknowledgment that detach was processed; sent before the server closes the connection */
+export interface DetachSessionAckMessage {
+  readonly type: 'detach_session_ack';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID that was detached */
+  readonly sessionId: UUID;
+  /** Whether the detach succeeded */
+  readonly success: boolean;
+  /** Error message if detach failed */
+  readonly error?: string;
+}
+
 /** A recent project directory aggregated from session history */
 export interface RecentDirectory {
   /** Absolute path */
@@ -578,6 +602,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'session_history_response',
     'resume_session_request',
     'resume_session_response',
+    'detach_session',
+    'detach_session_ack',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1128,6 +1154,36 @@ export function createResumeSessionResponse(
     success,
     requestId,
     ...(sessionId !== undefined && { sessionId }),
+    ...(error !== undefined && { error }),
+  };
+}
+
+/**
+ * Create a detach session request (tmux-style detach without killing).
+ */
+export function createDetachSession(sessionId: UUID): DetachSessionMessage {
+  return {
+    type: 'detach_session',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+  };
+}
+
+/**
+ * Create a detach session acknowledgment.
+ */
+export function createDetachSessionAck(
+  sessionId: UUID,
+  success: boolean,
+  error?: string,
+): DetachSessionAckMessage {
+  return {
+    type: 'detach_session_ack',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    success,
     ...(error !== undefined && { error }),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -239,8 +239,8 @@ export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error:
 /** How a session was discovered */
 export type SessionSource = 'daemon' | 'transcript';
 
-/** Session status for discovery. Daemon sessions use 'active'/'idle'/'orphaned'; transcript sessions use 'active'/'idle'/'completed'. */
-export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'completed';
+/** Session status for discovery. Daemon sessions use 'active'/'idle'/'orphaned'/'detached'; transcript sessions use 'active'/'idle'/'completed'. */
+export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'detached' | 'completed';
 
 /**
  * A session visible through the discovery mechanism.

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -9,6 +9,8 @@ import {
   createAgentOutput,
   createBulletExpandRequest,
   createBulletExpandResponse,
+  createDetachSession,
+  createDetachSessionAck,
   createEdit,
   createError,
   createHello,
@@ -790,6 +792,53 @@ describe('Message factory functions', () => {
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
       expect(deserialized?.type).toBe('resume_session_response');
+    });
+  });
+
+  describe('createDetachSession()', () => {
+    test('creates detach request with session ID', () => {
+      const sessionId = generateId();
+      const msg = createDetachSession(sessionId);
+      expect(msg.type).toBe('detach_session');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.id).toBeDefined();
+      expect(msg.timestamp).toBeDefined();
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createDetachSession(generateId());
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('detach_session');
+    });
+  });
+
+  describe('createDetachSessionAck()', () => {
+    test('creates successful ack', () => {
+      const sessionId = generateId();
+      const msg = createDetachSessionAck(sessionId, true);
+      expect(msg.type).toBe('detach_session_ack');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.success).toBe(true);
+      expect(msg.error).toBeUndefined();
+    });
+
+    test('creates failed ack with error', () => {
+      const sessionId = generateId();
+      const msg = createDetachSessionAck(sessionId, false, 'Session not found');
+      expect(msg.type).toBe('detach_session_ack');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.success).toBe(false);
+      expect(msg.error).toBe('Session not found');
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createDetachSessionAck(generateId(), true);
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('detach_session_ack');
     });
   });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -26,6 +26,7 @@ import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
+  createDetachSession,
   createHello,
   createResumeSessionRequest,
   createSessionListRequest,
@@ -510,6 +511,24 @@ function App() {
         break;
       }
 
+      case 'detach_session_ack': {
+        if (message.success) {
+          const detachedMsg: UIMessage = {
+            id: generateId(),
+            sessionId: message.sessionId,
+            sender: 'system',
+            content: 'Session detached. Use "remi attach" or reconnect to resume.',
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, detachedMsg]);
+        } else {
+          console.error(`Failed to detach: ${message.error}`);
+        }
+        break;
+      }
+
       case 'error':
         console.error('Daemon error:', message);
         break;
@@ -561,6 +580,7 @@ function App() {
     connect,
     sendInput,
     sendAnswer,
+    sendMessage: wsSendMessage,
     requestBulletExpand,
     requestSessionList,
     requestTranscriptLoad,
@@ -651,6 +671,14 @@ function App() {
       return requestResumeSession(sessionId);
     },
     [connectionMode, relaySend, requestResumeSession],
+  );
+
+  const effectiveDetachSession = useCallback(
+    (sessionId: UUID): boolean => {
+      if (connectionMode === 'relay') return relaySend(createDetachSession(sessionId));
+      return wsSendMessage(createDetachSession(sessionId));
+    },
+    [connectionMode, relaySend, wsSendMessage],
   );
 
   // Close modal and store URL on successful connect
@@ -1060,6 +1088,11 @@ function App() {
     }
   }, [activeSessionId]);
 
+  const handleDetach = useCallback(() => {
+    if (!activeSessionId) return;
+    effectiveDetachSession(activeSessionId);
+  }, [activeSessionId, effectiveDetachSession]);
+
   const handleExportText = useCallback(() => {
     const text = sessionMessages
       .map((m) => `[${new Date(m.timestamp).toLocaleString()}] [${m.sender}] ${m.content}`)
@@ -1107,6 +1140,7 @@ function App() {
       onClearMessages={handleClearMessages}
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
+      onDetach={handleDetach}
     />
   ) : (
     <div className="flex h-full items-center justify-center text-[var(--color-text-muted)]">

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -512,20 +512,18 @@ function App() {
       }
 
       case 'detach_session_ack': {
-        if (message.success) {
-          const detachedMsg: UIMessage = {
-            id: generateId(),
-            sessionId: message.sessionId,
-            sender: 'system',
-            content: 'Session detached. Use "remi attach" or reconnect to resume.',
-            timestamp: new Date().toISOString(),
-            state: 'delivered',
-            isEditing: false,
-          };
-          setMessages((prev) => [...prev, detachedMsg]);
-        } else {
-          console.error(`Failed to detach: ${message.error}`);
-        }
+        const detachedMsg: UIMessage = {
+          id: generateId(),
+          sessionId: message.sessionId,
+          sender: 'system',
+          content: message.success
+            ? 'Session detached. Use "remi attach" or reconnect to resume.'
+            : `Failed to detach session: ${message.error ?? 'unknown error'}`,
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, detachedMsg]);
         break;
       }
 
@@ -1090,7 +1088,19 @@ function App() {
 
   const handleDetach = useCallback(() => {
     if (!activeSessionId) return;
-    effectiveDetachSession(activeSessionId);
+    const sent = effectiveDetachSession(activeSessionId);
+    if (!sent) {
+      const errorMsg: UIMessage = {
+        id: generateId(),
+        sessionId: activeSessionId,
+        sender: 'system',
+        content: 'Cannot detach: not connected to daemon.',
+        timestamp: new Date().toISOString(),
+        state: 'delivered',
+        isEditing: false,
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    }
   }, [activeSessionId, effectiveDetachSession]);
 
   const handleExportText = useCallback(() => {

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Layers,
   Loader2,
+  LogOut,
   MessageSquare,
   MoreVertical,
   Terminal,
@@ -37,6 +38,7 @@ interface ChatHeaderProps {
   readonly onCopyConversation?: () => void;
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
+  readonly onDetach?: () => void;
   readonly className?: string;
 }
 
@@ -112,12 +114,13 @@ export function ChatHeader({
   onCopyConversation,
   onClearMessages,
   onExportText,
+  onDetach,
   className,
 }: ChatHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const hasMenuActions = onCopyConversation || onClearMessages || onExportText;
+  const hasMenuActions = onCopyConversation || onClearMessages || onExportText || onDetach;
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -255,6 +258,21 @@ export function ChatHeader({
                   <FileText className="size-4 text-[var(--color-text-muted)]" />
                   Export as text
                 </button>
+              )}
+              {onDetach && (
+                <>
+                  <div className="my-1 h-px bg-[var(--color-border)]" />
+                  <button
+                    onClick={() => {
+                      onDetach();
+                      closeMenu();
+                    }}
+                    className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-warning)] transition-colors hover:bg-[var(--color-surface-light)]"
+                  >
+                    <LogOut className="size-4" />
+                    Detach session
+                  </button>
+                </>
               )}
               {onClearMessages && (
                 <>

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -32,6 +32,7 @@ interface ChatViewProps {
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
+  readonly onDetach?: () => void;
   readonly className?: string;
 }
 
@@ -51,6 +52,7 @@ export function ChatView({
   onClearMessages,
   onExportText,
   onBulletExpand,
+  onDetach,
   className,
 }: ChatViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
@@ -78,6 +80,7 @@ export function ChatView({
         onCopyConversation={onCopyConversation}
         onClearMessages={onClearMessages}
         onExportText={onExportText}
+        onDetach={onDetach}
       />
 
       <MessageList


### PR DESCRIPTION
## Summary

Closes #201

Adds the ability to detach from a Remi session without killing it, similar to tmux's Ctrl+B d. After detaching, the session remains alive and re-attachable via `remi attach`.

## Changes

### Protocol (packages/shared)
- New `detach_session` and `detach_session_ack` message types
- Added `'detached'` to `DiscoverableSessionStatus` union

### Daemon (packages/daemon)
- `SessionRegistry`: explicit detach flag skips orphan timeout, session stays alive indefinitely
- `Connection`: handles `detach_session` message, emits event
- Full server/adapter bridging chain for the new message
- New `detach-client.ts` CLI client for `remi detach` subcommand
- `attach-client.ts`: Ctrl+B d now sends `detach_session` protocol message
- `remi ls` shows detached sessions with "detached" status

### Web (packages/web)
- Detach button in ChatHeader dropdown menu (LogOut icon)
- Sends `detach_session` message, handles ack, closes connection

### Tests
- 5 protocol tests for factory functions and validation
- 7 session registry tests for explicit detach behavior (timeout skip, flag lifecycle, status, re-attach)
- All 1308 tests pass, 0 failures

## Test plan

- [x] All 1308 tests pass
- [x] New protocol tests verify message creation and validation
- [x] New session registry tests verify explicit detach skips timeout, session re-attachable
- [x] Biome lint clean
- [x] TypeScript typecheck clean
- [x] Web build succeeds