### PR TITLE
Release: Session detach and Ctrl+Z handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.19",
+  "version": "0.4.20-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -66,6 +66,9 @@ export interface AdapterEvents {
   /** Session history request received */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 
+  /** Detach session request received (tmux-style) */
+  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;
 }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -149,6 +149,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onSessionHistoryRequest?.(connectionId, requestId, limit);
       },
 
+      onDetachSession: (connectionId, sessionId, requestId) => {
+        this.events.onDetachSession?.(connectionId, sessionId, requestId);
+      },
+
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.19'; // REMI_COMPILED_VERSION
+      return '0.4.20-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.19'; // REMI_COMPILED_VERSION
+    return '0.4.20-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -232,6 +232,7 @@ if (fs.existsSync(envPath)) {
 import {
   createBulletExpandResponse,
   createCreateSessionResponse,
+  createDetachSessionAck,
   createError,
   createHelloAck,
   createKillSessionResponse,
@@ -915,17 +916,41 @@ if (cliSubcommand === 'kill') {
   process.exit(0);
 }
 
-// Handle 'detach' subcommand: detach from a session
+// Handle 'detach' subcommand: detach from a session without killing it
 if (cliSubcommand === 'detach') {
-  // Without args: not meaningful from CLI (Ctrl+B d handles interactive detach)
-  // With name: informational only; there's no remote detach protocol yet
   if (!resolved.targetId) {
-    console.log('To detach from a session interactively, press Ctrl+B d.');
-    console.log('To detach a specific session by name: remi detach <session-name>');
-    console.log('(Remote detach is not yet implemented; use Ctrl+B d in the attached terminal.)');
-  } else {
-    console.log('Remote detach of named sessions is not yet implemented.');
-    console.log('To detach, press Ctrl+B d in the attached terminal.');
+    console.error('Usage: remi detach <session-name-or-id>');
+    console.error('  Detach from a session without killing it (tmux-style).');
+    console.error('  The session remains alive and can be re-attached with `remi attach`.');
+    console.error('  Examples: remi detach my-session');
+    console.error('            remi detach host:port/session-name');
+    console.error('  Tip: When attached interactively, press Ctrl+B d to detach.');
+    console.error('Run `remi ls` to see live sessions.');
+    process.exit(1);
+  }
+
+  let resolvedPort = resolved.port;
+
+  // Resolve port from live registry if target matches a known local session
+  if (!cliPort && resolved.host === 'localhost') {
+    const liveMatch =
+      liveSessionsRegistry.findByName(resolved.targetId) ??
+      liveSessionsRegistry.findBySessionId(resolved.targetId);
+    if (liveMatch) {
+      resolvedPort = liveMatch.wsPort;
+    }
+  }
+
+  const { runDetachClient } = await import('./cli/detach-client.ts');
+  try {
+    await runDetachClient({
+      host: resolved.host,
+      port: resolvedPort,
+      target: resolved.targetId,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
   }
   process.exit(0);
 }
@@ -1451,6 +1476,8 @@ const sessionRegistry = new SessionRegistry(
       const session = sessionRegistry.getSession(sessionId);
       if (session?.locallyOwned) {
         log(`Session detached: ${sessionId} (locally owned, no timeout)`);
+      } else if (session?.explicitlyDetached) {
+        log(`Session explicitly detached: ${sessionId} (no timeout, re-attachable)`);
       } else {
         log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
       }
@@ -1957,8 +1984,8 @@ function getRecentDirectories(store: SessionStore, limit: number): RecentDirecto
   return entries;
 }
 
-const sendToConnection = (connectionId: UUID, message: ProtocolMessage): void => {
-  registry.sendRaw(connectionId, message);
+const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
+  return registry.sendRaw(connectionId, message);
 };
 
 const sharedEvents = {
@@ -2280,6 +2307,44 @@ const sharedEvents = {
     } else {
       log(`Session killed: ${sessionName}`);
     }
+  },
+
+  onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID) => {
+    log(`Detach session request from ${connectionId} for session ${sessionId}`);
+
+    const session = sessionRegistry.getSession(sessionId);
+    if (!session) {
+      sendToConnection(
+        connectionId,
+        createDetachSessionAck(sessionId, false, `Session ${sessionId} not found`),
+      );
+      return;
+    }
+
+    const activeConnId = session.activeConnectionId;
+    if (activeConnId === null) {
+      sendToConnection(
+        connectionId,
+        createDetachSessionAck(sessionId, false, 'Session is already detached'),
+      );
+      return;
+    }
+
+    // Send ack to the requesting connection (may be the active client or
+    // a separate query-mode client like `remi detach <session>`)
+    const ackSent = sendToConnection(connectionId, createDetachSessionAck(sessionId, true));
+    if (!ackSent) {
+      log(`Warning: detach ack could not be delivered to ${connectionId}`);
+    }
+
+    // Detach the ACTIVE connection (not necessarily the requesting one)
+    sessionRegistry.detachConnection(activeConnId, true);
+    registry.untrackConnection(activeConnId);
+    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
+
+    log(
+      `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
+    );
   },
 
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2337,10 +2337,14 @@ const sharedEvents = {
       log(`Warning: detach ack could not be delivered to ${connectionId}`);
     }
 
-    // Detach the ACTIVE connection (not necessarily the requesting one)
+    // Detach the ACTIVE connection (not necessarily the requesting one).
+    // Only untrack/decrement here for third-party detach (connectionId !== activeConnId).
+    // For self-detach, onDisconnect will handle cleanup when the WebSocket closes.
     sessionRegistry.detachConnection(activeConnId, true);
-    registry.untrackConnection(activeConnId);
-    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
+    if (activeConnId !== connectionId) {
+      registry.untrackConnection(activeConnId);
+      updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
+    }
 
     log(
       `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1406,6 +1406,18 @@ const TELEGRAM_AUTHORIZED_CHAT_IDS = [...remiConfig.telegram.authorized_chat_ids
 const TELEGRAM_AUTHORIZED_USER_IDS = [...remiConfig.telegram.authorized_user_ids];
 
 // ---------------------------------------------------------------------------
+// SIGTSTP protection: the daemon must never suspend itself.
+// When Claude Code handles Ctrl+Z (which spawns a subshell inside its PTY),
+// the terminal may propagate SIGTSTP to the process group. Ignoring it here
+// keeps the daemon, WebSocket server, and all remote connections alive.
+// ---------------------------------------------------------------------------
+process.on('SIGTSTP', () => {
+  // Intentionally ignored. The PTY child handles Ctrl+Z on its own; the
+  // daemon process must remain running to serve remote clients.
+  writeToLog('[signal] SIGTSTP received and ignored (daemon must not suspend)');
+});
+
+// ---------------------------------------------------------------------------
 // Core components
 // ---------------------------------------------------------------------------
 const _ptyManager = new PTYManager();

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import {
+  createDetachSession,
   createHello,
   createPong,
   createTerminalResize,
@@ -42,6 +43,8 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let authInProgress = false;
   let receivedRawPty = false;
   let rawPtyTimer: ReturnType<typeof setTimeout> | null = null;
+  let detachPending = false;
+  let detachAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -57,6 +60,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   }
 
   function restoreTerminal(): void {
+    if (detachAckTimer) {
+      clearTimeout(detachAckTimer);
+      detachAckTimer = null;
+    }
     if (rawPtyTimer) {
       clearTimeout(rawPtyTimer);
       rawPtyTimer = null;
@@ -203,8 +210,20 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         // raw byte 0x02 and kitty keyboard protocol ESC[98;5u)
         detachScannerInstance = new DetachScanner({
           onDetach: () => {
-            process.stderr.write('[detached]\n');
-            finish({ exitCode: 0, reason: 'detached' });
+            // Notify daemon of explicit detach so it skips orphan timeout.
+            // Wait briefly for the ack to ensure the daemon processes the
+            // detach before we close the WebSocket connection.
+            if (attachedSessionId) {
+              sendMessage(createDetachSession(attachedSessionId));
+              detachPending = true;
+              detachAckTimer = setTimeout(() => {
+                process.stderr.write('[detached]\n');
+                finish({ exitCode: 0, reason: 'detached' });
+              }, 500);
+            } else {
+              process.stderr.write('[detached]\n');
+              finish({ exitCode: 0, reason: 'detached' });
+            }
           },
           onData: (data) => {
             sendInput(data.toString());
@@ -252,6 +271,17 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
 
       if (msg.type === 'ping') {
         sendMessage(createPong(msg.id));
+        return;
+      }
+
+      if (msg.type === 'detach_session_ack' && detachPending) {
+        // Daemon confirmed the explicit detach; finish immediately
+        if (detachAckTimer) {
+          clearTimeout(detachAckTimer);
+          detachAckTimer = null;
+        }
+        process.stderr.write('[detached]\n');
+        finish({ exitCode: 0, reason: 'detached' });
         return;
       }
 

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -1,0 +1,150 @@
+/**
+ * Detach Client - Sends a detach request to a running daemon to detach
+ * the active connection from a session without killing it (tmux-style).
+ *
+ * Connects via WebSocket, resolves the session by name or ID, and sends
+ * a detach_session message.
+ */
+
+import {
+  createDetachSession,
+  createHello,
+  createSessionListRequest,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
+import { performAuthHandshake } from './auth-helper.ts';
+import { resolveSession as sharedResolveSession } from './session-resolver.ts';
+
+export interface DetachClientOptions {
+  readonly host: string;
+  readonly port: number;
+  /** Session name or ID to detach */
+  readonly target: string;
+  readonly timeout?: number;
+}
+
+export async function runDetachClient(opts: DetachClientOptions): Promise<void> {
+  const { host, port, target, timeout = 5000 } = opts;
+  const url = `ws://${host}:${port}/ws`;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let authInProgress = false;
+    let sessions: DiscoverableSession[] | null = null;
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      ws.close();
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Timed out connecting to daemon at ${host}:${port}`));
+      }
+    }, timeout);
+
+    function done(err?: Error): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.close();
+      if (err) reject(err);
+      else resolve();
+    }
+
+    function sendHello(): void {
+      const clientId = generateId();
+      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+    }
+
+    function handleMessage(msg: ProtocolMessage): void {
+      if (msg.type === 'hello_ack') {
+        // Request session list first to resolve the name
+        ws.send(serialize(createSessionListRequest(false)));
+      } else if (msg.type === 'session_list_response') {
+        sessions = msg.sessions as DiscoverableSession[];
+        try {
+          const resolved = sharedResolveSession([{ host, port, sessions }], target);
+          if (!resolved) {
+            done(
+              new Error(
+                `No session found matching "${target}". Run \`remi ls\` to see live sessions.`,
+              ),
+            );
+            return;
+          }
+          // Send detach request
+          ws.send(serialize(createDetachSession(resolved.session.sessionId as UUID)));
+        } catch (err) {
+          done(err instanceof Error ? err : new Error(String(err)));
+        }
+      } else if (msg.type === 'detach_session_ack') {
+        if (msg.success) {
+          const session =
+            sessions?.find((s) => s.sessionId === target) ??
+            sessions?.find((s) => s.name === target) ??
+            sessions?.find((s) => s.name?.startsWith(target)) ??
+            sessions?.find((s) => s.sessionId.startsWith(target));
+          const displayName = session?.name ?? target;
+          console.log(`Detached from session: ${displayName}`);
+          console.log("Use 'remi attach' to reconnect.");
+          done();
+        } else {
+          done(new Error(`Failed to detach session: ${msg.error ?? 'unknown error'}`));
+        }
+      } else if (msg.type === 'error') {
+        if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
+        done(new Error(`Daemon error: ${msg.message}`));
+      }
+    }
+
+    ws.onopen = () => {
+      sendHello();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      const msg = deserialize(data);
+      if (!msg) {
+        console.error('Warning: received unparsable message from daemon');
+        return;
+      }
+
+      // Handle auth challenge if needed
+      if (msg.type === 'auth_challenge') {
+        authInProgress = true;
+        performAuthHandshake(ws, msg)
+          .then(() => {
+            authInProgress = false;
+            sendHello();
+          })
+          .catch((err) => {
+            done(err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
+      if (authInProgress) return;
+      handleMessage(msg);
+    };
+
+    ws.onerror = () => {
+      done(new Error(`WebSocket error connecting to daemon at ${host}:${port}`));
+    };
+
+    ws.onclose = () => {
+      if (!settled) {
+        done(new Error('Connection closed before detach completed'));
+      }
+    };
+  });
+}

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -9,6 +9,7 @@
 import {
   createDetachSession,
   createHello,
+  createPong,
   createSessionListRequest,
   deserialize,
   generateId,
@@ -101,6 +102,8 @@ export async function runDetachClient(opts: DetachClientOptions): Promise<void> 
         } else {
           done(new Error(`Failed to detach session: ${msg.error ?? 'unknown error'}`));
         }
+      } else if (msg.type === 'ping') {
+        ws.send(serialize(createPong(msg.id)));
       } else if (msg.type === 'error') {
         if (msg.code === 'AUTH_REQUIRED' && authInProgress) return;
         done(new Error(`Daemon error: ${msg.message}`));

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -216,13 +216,15 @@ const commandHelp: Record<Subcommand, string[]> = {
     entry('cat key.json | remi import-key', 'Import from stdin'),
   ],
   detach: [
-    'Detach from a session.',
+    'Detach from a session without killing it (tmux-style).',
+    'The session remains alive and can be re-attached with `remi attach`.',
     '',
     bold('Usage:'),
-    entry('remi detach', 'Detach from current session'),
-    entry('remi detach <name>', 'Detach a named session'),
+    entry('remi detach <name>', 'Detach the named session'),
+    entry('remi detach <host:port/name>', 'Detach a remote session'),
     '',
-    dim('  In practice, use Ctrl+B d to detach interactively.'),
+    dim('  When attached interactively, press Ctrl+B d to detach.'),
+    dim('  Detached sessions show as "detached" in `remi ls`.'),
   ],
 };
 

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -32,6 +32,7 @@ import type {
   AuthResponseMessage,
   BulletExpandRequestMessage,
   CreateSessionRequestMessage,
+  DetachSessionMessage,
   HelloMessage,
   KillSessionRequestMessage,
   PingMessage,
@@ -86,6 +87,9 @@ export interface ConnectionEvents {
 
   /** Session history request received */
   onSessionHistoryRequest: (requestId: UUID, limit: number | undefined) => void;
+
+  /** Detach session request received (tmux-style) */
+  onDetachSession: (sessionId: UUID, requestId: UUID) => void;
 
   /** Authentication succeeded */
   onAuthSuccess: (clientFingerprint: string) => void;
@@ -277,6 +281,9 @@ export class Connection {
       case 'session_history_request':
         this.handleSessionHistoryRequest(message);
         break;
+      case 'detach_session':
+        this.handleDetachSession(message);
+        break;
       case 'ping':
         this.handlePing(message);
         break;
@@ -454,6 +461,11 @@ export class Connection {
   private handleSessionHistoryRequest(message: SessionHistoryRequestMessage): void {
     this.sendAck(message.id, 'delivered');
     this.events.onSessionHistoryRequest?.(message.id, message.limit);
+  }
+
+  private handleDetachSession(message: DetachSessionMessage): void {
+    this.sendAck(message.id, 'delivered');
+    this.events.onDetachSession?.(message.sessionId, message.id);
   }
 
   private handleTerminalResize(message: TerminalResizeMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -80,6 +80,9 @@ export interface ServerEvents {
   /** Session history request from client */
   onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
 
+  /** Detach session request from client (tmux-style) */
+  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
+
   /** Error occurred */
   onError: (error: Error) => void;
 }
@@ -329,6 +332,10 @@ export class WebSocketServer {
 
       onSessionHistoryRequest: (requestId, limit) => {
         this.events.onSessionHistoryRequest?.(ws.data.connectionId, requestId, limit);
+      },
+
+      onDetachSession: (sessionId, requestId) => {
+        this.events.onDetachSession?.(ws.data.connectionId, sessionId, requestId);
       },
 
       onError: (error) => {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -103,6 +103,10 @@ export interface ManagedSession {
   /** Whether this session is owned by the local process (wrapper mode).
    * Locally-owned sessions are never killed by orphan timeout. */
   readonly locallyOwned: boolean;
+
+  /** Whether the last detach was an explicit user request (tmux-style).
+   * Explicitly detached sessions skip the orphan timeout entirely. */
+  explicitlyDetached: boolean;
 }
 
 /**
@@ -166,6 +170,7 @@ export class SessionRegistry {
       currentStatus: 'idle',
       currentQuestion: null,
       locallyOwned,
+      explicitlyDetached: false,
     };
 
     this.events.onSessionCreated?.(sessionId);
@@ -262,6 +267,7 @@ export class SessionRegistry {
     // Attach connection
     this.session.activeConnectionId = connectionId;
     this.session.lastDisconnectedAt = null;
+    this.session.explicitlyDetached = false;
 
     // Get messages to replay (from after last delivered)
     const replayMessages = this.session.messageHistory.slice(this.session.lastDeliveredIndex + 1);
@@ -288,8 +294,12 @@ export class SessionRegistry {
    * If there are waiting connections, the next one is auto-promoted.
    * Otherwise, non-locally-owned sessions become orphaned and start the timeout countdown.
    * Locally-owned sessions remain active without a timeout.
+   *
+   * When `explicit` is true (tmux-style detach), the orphan timeout is skipped
+   * regardless of whether the session is locally owned; the session remains
+   * discoverable and re-attachable indefinitely.
    */
-  detachConnection(connectionId: UUID): void {
+  detachConnection(connectionId: UUID, explicit = false): void {
     if (this.session === null || this.session.activeConnectionId !== connectionId) {
       // Also remove from waiting list if it was queued
       const waitIdx = this.waitingConnections.indexOf(connectionId);
@@ -328,10 +338,13 @@ export class SessionRegistry {
       }
     }
 
-    // Start orphan timeout (skip for locally-owned sessions; they stay alive
-    // until PTY exits, explicit kill, or daemon shutdown).
-    // orphanTimeoutMs === 0 disables automatic cleanup.
-    if (!this.session.locallyOwned && this.orphanTimeoutMs > 0) {
+    // Track explicit detach state for discovery status
+    this.session.explicitlyDetached = explicit;
+
+    // Start orphan timeout (skip for locally-owned sessions, explicit detaches,
+    // and when orphanTimeoutMs === 0).
+    // Explicitly detached sessions stay alive indefinitely like locally-owned ones.
+    if (!this.session.locallyOwned && !explicit && this.orphanTimeoutMs > 0) {
       this.session.orphanTimeoutId = setTimeout(() => {
         this.closeSession(sessionId, 'timeout');
       }, this.orphanTimeoutMs);
@@ -489,9 +502,13 @@ export class SessionRegistry {
     ];
   }
 
-  private getDiscoverableStatus(session: ManagedSession): 'active' | 'idle' | 'orphaned' {
+  private getDiscoverableStatus(
+    session: ManagedSession,
+  ): 'active' | 'idle' | 'orphaned' | 'detached' {
     if (session.activeConnectionId === null) {
-      return session.locallyOwned ? 'active' : 'orphaned';
+      if (session.locallyOwned) return 'active';
+      if (session.explicitlyDetached) return 'detached';
+      return 'orphaned';
     }
     if (session.currentStatus === 'idle') {
       return 'idle';

--- a/packages/daemon/tests/cli/detach-scanner.test.ts
+++ b/packages/daemon/tests/cli/detach-scanner.test.ts
@@ -129,4 +129,36 @@ describe('DetachScanner', () => {
     // After destroy, no timeout should fire
     expect(forwarded.length).toBe(0);
   });
+
+  test('Ctrl+Z byte (0x1a) passes through without interception', () => {
+    // Ctrl+Z sends 0x1a (SUB) to the PTY. The scanner must not intercept it;
+    // Claude Code handles Ctrl+Z internally (e.g. spawning a subshell).
+    const CTRL_Z = 0x1a;
+    scanner.write(Buffer.from([CTRL_Z]));
+    expect(detached).toBe(false);
+    const result = getForwarded();
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(CTRL_Z);
+  });
+
+  test('Ctrl+Z byte surrounded by normal data passes through', () => {
+    const CTRL_Z = 0x1a;
+    scanner.write(Buffer.from([0x61, 0x62, CTRL_Z, 0x63, 0x64])); // "ab" + Ctrl+Z + "cd"
+    expect(detached).toBe(false);
+    const result = getForwarded();
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(0x61); // 'a'
+    expect(result[2]).toBe(CTRL_Z);
+    expect(result[4]).toBe(0x64); // 'd'
+  });
+
+  test('Ctrl+Z does not interfere with Ctrl+B d detection', () => {
+    const CTRL_Z = 0x1a;
+    // Ctrl+Z followed by Ctrl+B d: Ctrl+Z should pass through, then detach
+    scanner.write(Buffer.from([CTRL_Z, CTRL_B, 0x64]));
+    expect(detached).toBe(true);
+    const result = getForwarded();
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(CTRL_Z);
+  });
 });

--- a/packages/daemon/tests/pty-sigtstp.test.ts
+++ b/packages/daemon/tests/pty-sigtstp.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for Ctrl+Z (SIGTSTP) handling in PTY sessions.
+ *
+ * Verifies that:
+ * 1. The \x1a byte (Ctrl+Z) can be written to the PTY without crashing
+ * 2. The PTY session stays alive after receiving \x1a
+ * 3. The daemon process ignores SIGTSTP
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { PTYSession } from '../src/pty/pty-session';
+
+describe('PTY SIGTSTP handling', () => {
+  let session: PTYSession;
+
+  afterEach(async () => {
+    try {
+      await session?.close(2000);
+    } catch {
+      // Session may have already exited
+    }
+  });
+
+  test('writing \\x1a to PTY does not crash the session', async () => {
+    // Spawn a simple shell that will receive the Ctrl+Z byte
+    session = new PTYSession(
+      { command: '/bin/cat', args: [] },
+      {
+        onError: (err) => {
+          // Log but don't fail -- we just want to verify no crash
+          console.error('[PTY error]', err.message);
+        },
+      },
+    );
+    await session.start();
+    expect(session.isRunning).toBe(true);
+
+    // Write Ctrl+Z byte to the PTY
+    session.write('\x1a');
+
+    // Small delay to let the PTY process the byte
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Session should still be running -- \x1a is just a byte in the PTY stream
+    expect(session.isRunning).toBe(true);
+  });
+
+  test('PTY session survives \\x1a followed by normal input', async () => {
+    let output = '';
+    session = new PTYSession(
+      { command: '/bin/sh', args: ['-c', 'cat'] },
+      {
+        onData: (data) => {
+          output += data;
+        },
+        onError: (err) => {
+          console.error('[PTY error]', err.message);
+        },
+      },
+    );
+    await session.start();
+    expect(session.isRunning).toBe(true);
+
+    // Send Ctrl+Z then normal text
+    session.write('\x1a');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    session.write('hello\r');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Session should still be alive
+    expect(session.isRunning).toBe(true);
+
+    // The output should contain "hello" (cat echoes input)
+    expect(output).toContain('hello');
+  });
+
+  test('daemon process ignores SIGTSTP without suspending', async () => {
+    // Register SIGTSTP handler (same as cli.ts does)
+    const received = new Promise<void>((resolve) => {
+      const handler = () => {
+        process.removeListener('SIGTSTP', handler);
+        resolve();
+      };
+      process.on('SIGTSTP', handler);
+    });
+
+    // Send SIGTSTP to ourselves -- should not suspend the process
+    process.kill(process.pid, 'SIGTSTP');
+
+    // Wait for the signal to be delivered (async on some platforms)
+    await received;
+
+    // If we reach here, the process was not suspended -- it handled the signal
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -436,6 +436,111 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('explicit detach (tmux-style)', () => {
+    test('explicit detach skips orphan timeout', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      // Wait well past the orphan timeout (100ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Session should still exist (not killed by timeout)
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(events.onSessionClosed).not.toHaveBeenCalled();
+    });
+
+    test('explicit detach sets explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      const session = registry.getSession(sessionId);
+      expect(session?.explicitlyDetached).toBe(true);
+    });
+
+    test('non-explicit detach does not set explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      const session = registry.getSession(sessionId);
+      expect(session?.explicitlyDetached).toBe(false);
+    });
+
+    test('reattach clears explicitlyDetached flag', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+      const conn2 = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1, true);
+
+      const beforeAttach = registry.getSession(sessionId);
+      expect(beforeAttach?.explicitlyDetached).toBe(true);
+
+      registry.attachConnection(sessionId, conn2);
+
+      const afterAttach = registry.getSession(sessionId);
+      expect(afterAttach?.explicitlyDetached).toBe(false);
+    });
+
+    test('explicitly detached session reports "detached" status in listSessions', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('detached');
+    });
+
+    test('non-explicit detach reports "orphaned" status', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, false);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('orphaned');
+    });
+
+    test('explicitly detached session is re-attachable', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1, true);
+
+      expect(registry.canResume(sessionId)).toBe(true);
+
+      const conn2 = generateId();
+      const result = registry.attachConnection(sessionId, conn2);
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
+    });
+  });
+
   describe('shutdown()', () => {
     test('closes the session', async () => {
       const pty = createMockPTY();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -72,6 +72,8 @@ export type {
   SessionHistoryResponseMessage,
   ResumeSessionRequestMessage,
   ResumeSessionResponseMessage,
+  DetachSessionMessage,
+  DetachSessionAckMessage,
 } from './protocol.ts';
 
 export {
@@ -112,6 +114,8 @@ export {
   createSessionHistoryResponse,
   createResumeSessionRequest,
   createResumeSessionResponse,
+  createDetachSession,
+  createDetachSessionAck,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -95,7 +95,9 @@ export type ProtocolMessage =
   | SessionHistoryRequestMessage
   | SessionHistoryResponseMessage
   | ResumeSessionRequestMessage
-  | ResumeSessionResponseMessage;
+  | ResumeSessionResponseMessage
+  | DetachSessionMessage
+  | DetachSessionAckMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -473,6 +475,28 @@ export interface KillSessionResponseMessage {
   readonly requestId: UUID;
 }
 
+/** Request to detach from a session without killing it (tmux-style) */
+export interface DetachSessionMessage {
+  readonly type: 'detach_session';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID to detach from */
+  readonly sessionId: UUID;
+}
+
+/** Acknowledgment that detach was processed; sent before the server closes the connection */
+export interface DetachSessionAckMessage {
+  readonly type: 'detach_session_ack';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Session ID that was detached */
+  readonly sessionId: UUID;
+  /** Whether the detach succeeded */
+  readonly success: boolean;
+  /** Error message if detach failed */
+  readonly error?: string;
+}
+
 /** A recent project directory aggregated from session history */
 export interface RecentDirectory {
   /** Absolute path */
@@ -578,6 +602,8 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'session_history_response',
     'resume_session_request',
     'resume_session_response',
+    'detach_session',
+    'detach_session_ack',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1128,6 +1154,36 @@ export function createResumeSessionResponse(
     success,
     requestId,
     ...(sessionId !== undefined && { sessionId }),
+    ...(error !== undefined && { error }),
+  };
+}
+
+/**
+ * Create a detach session request (tmux-style detach without killing).
+ */
+export function createDetachSession(sessionId: UUID): DetachSessionMessage {
+  return {
+    type: 'detach_session',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+  };
+}
+
+/**
+ * Create a detach session acknowledgment.
+ */
+export function createDetachSessionAck(
+  sessionId: UUID,
+  success: boolean,
+  error?: string,
+): DetachSessionAckMessage {
+  return {
+    type: 'detach_session_ack',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    success,
     ...(error !== undefined && { error }),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -239,8 +239,8 @@ export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error:
 /** How a session was discovered */
 export type SessionSource = 'daemon' | 'transcript';
 
-/** Session status for discovery. Daemon sessions use 'active'/'idle'/'orphaned'; transcript sessions use 'active'/'idle'/'completed'. */
-export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'completed';
+/** Session status for discovery. Daemon sessions use 'active'/'idle'/'orphaned'/'detached'; transcript sessions use 'active'/'idle'/'completed'. */
+export type DiscoverableSessionStatus = 'active' | 'idle' | 'orphaned' | 'detached' | 'completed';
 
 /**
  * A session visible through the discovery mechanism.

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -9,6 +9,8 @@ import {
   createAgentOutput,
   createBulletExpandRequest,
   createBulletExpandResponse,
+  createDetachSession,
+  createDetachSessionAck,
   createEdit,
   createError,
   createHello,
@@ -790,6 +792,53 @@ describe('Message factory functions', () => {
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
       expect(deserialized?.type).toBe('resume_session_response');
+    });
+  });
+
+  describe('createDetachSession()', () => {
+    test('creates detach request with session ID', () => {
+      const sessionId = generateId();
+      const msg = createDetachSession(sessionId);
+      expect(msg.type).toBe('detach_session');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.id).toBeDefined();
+      expect(msg.timestamp).toBeDefined();
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createDetachSession(generateId());
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('detach_session');
+    });
+  });
+
+  describe('createDetachSessionAck()', () => {
+    test('creates successful ack', () => {
+      const sessionId = generateId();
+      const msg = createDetachSessionAck(sessionId, true);
+      expect(msg.type).toBe('detach_session_ack');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.success).toBe(true);
+      expect(msg.error).toBeUndefined();
+    });
+
+    test('creates failed ack with error', () => {
+      const sessionId = generateId();
+      const msg = createDetachSessionAck(sessionId, false, 'Session not found');
+      expect(msg.type).toBe('detach_session_ack');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.success).toBe(false);
+      expect(msg.error).toBe('Session not found');
+    });
+
+    test('serializes and deserializes', () => {
+      const msg = createDetachSessionAck(generateId(), true);
+      const serialized = serialize(msg);
+      const deserialized = deserialize(serialized);
+      expect(deserialized).not.toBeNull();
+      expect(deserialized?.type).toBe('detach_session_ack');
     });
   });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -524,6 +524,11 @@ function App() {
           isEditing: false,
         };
         setMessages((prev) => [...prev, detachedMsg]);
+        // On successful detach, clear active session so the UI reflects
+        // the disconnected state. The WebSocket close will handle cleanup.
+        if (message.success) {
+          setActiveSessionId(null);
+        }
         break;
       }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -26,6 +26,7 @@ import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createBulletExpandRequest,
+  createDetachSession,
   createHello,
   createResumeSessionRequest,
   createSessionListRequest,
@@ -510,6 +511,22 @@ function App() {
         break;
       }
 
+      case 'detach_session_ack': {
+        const detachedMsg: UIMessage = {
+          id: generateId(),
+          sessionId: message.sessionId,
+          sender: 'system',
+          content: message.success
+            ? 'Session detached. Use "remi attach" or reconnect to resume.'
+            : `Failed to detach session: ${message.error ?? 'unknown error'}`,
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, detachedMsg]);
+        break;
+      }
+
       case 'error':
         console.error('Daemon error:', message);
         break;
@@ -561,6 +578,7 @@ function App() {
     connect,
     sendInput,
     sendAnswer,
+    sendMessage: wsSendMessage,
     requestBulletExpand,
     requestSessionList,
     requestTranscriptLoad,
@@ -651,6 +669,14 @@ function App() {
       return requestResumeSession(sessionId);
     },
     [connectionMode, relaySend, requestResumeSession],
+  );
+
+  const effectiveDetachSession = useCallback(
+    (sessionId: UUID): boolean => {
+      if (connectionMode === 'relay') return relaySend(createDetachSession(sessionId));
+      return wsSendMessage(createDetachSession(sessionId));
+    },
+    [connectionMode, relaySend, wsSendMessage],
   );
 
   // Close modal and store URL on successful connect
@@ -1060,6 +1086,23 @@ function App() {
     }
   }, [activeSessionId]);
 
+  const handleDetach = useCallback(() => {
+    if (!activeSessionId) return;
+    const sent = effectiveDetachSession(activeSessionId);
+    if (!sent) {
+      const errorMsg: UIMessage = {
+        id: generateId(),
+        sessionId: activeSessionId,
+        sender: 'system',
+        content: 'Cannot detach: not connected to daemon.',
+        timestamp: new Date().toISOString(),
+        state: 'delivered',
+        isEditing: false,
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    }
+  }, [activeSessionId, effectiveDetachSession]);
+
   const handleExportText = useCallback(() => {
     const text = sessionMessages
       .map((m) => `[${new Date(m.timestamp).toLocaleString()}] [${m.sender}] ${m.content}`)
@@ -1107,6 +1150,7 @@ function App() {
       onClearMessages={handleClearMessages}
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
+      onDetach={handleDetach}
     />
   ) : (
     <div className="flex h-full items-center justify-center text-[var(--color-text-muted)]">

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Layers,
   Loader2,
+  LogOut,
   MessageSquare,
   MoreVertical,
   Terminal,
@@ -37,6 +38,7 @@ interface ChatHeaderProps {
   readonly onCopyConversation?: () => void;
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
+  readonly onDetach?: () => void;
   readonly className?: string;
 }
 
@@ -112,12 +114,13 @@ export function ChatHeader({
   onCopyConversation,
   onClearMessages,
   onExportText,
+  onDetach,
   className,
 }: ChatHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const hasMenuActions = onCopyConversation || onClearMessages || onExportText;
+  const hasMenuActions = onCopyConversation || onClearMessages || onExportText || onDetach;
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -255,6 +258,21 @@ export function ChatHeader({
                   <FileText className="size-4 text-[var(--color-text-muted)]" />
                   Export as text
                 </button>
+              )}
+              {onDetach && (
+                <>
+                  <div className="my-1 h-px bg-[var(--color-border)]" />
+                  <button
+                    onClick={() => {
+                      onDetach();
+                      closeMenu();
+                    }}
+                    className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-warning)] transition-colors hover:bg-[var(--color-surface-light)]"
+                  >
+                    <LogOut className="size-4" />
+                    Detach session
+                  </button>
+                </>
               )}
               {onClearMessages && (
                 <>

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -32,6 +32,7 @@ interface ChatViewProps {
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
+  readonly onDetach?: () => void;
   readonly className?: string;
 }
 
@@ -51,6 +52,7 @@ export function ChatView({
   onClearMessages,
   onExportText,
   onBulletExpand,
+  onDetach,
   className,
 }: ChatViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
@@ -78,6 +80,7 @@ export function ChatView({
         onCopyConversation={onCopyConversation}
         onClearMessages={onClearMessages}
         onExportText={onExportText}
+        onDetach={onDetach}
       />
 
       <MessageList


### PR DESCRIPTION
## Summary

Merge develop into main for release. Contains two new features:

- **Session detach (#201, PR #205)**: tmux-style Ctrl+B d detach from sessions without killing them. Adds detach_session/detach_session_ack protocol messages, explicit detach in SessionRegistry (skips orphan timeout), CLI detach subcommand, web UI detach button, and re-attach support.
- **Ctrl+Z handling (#202, PR #204)**: Prevents daemon from suspending when Claude Code handles Ctrl+Z. Adds SIGTSTP handler to keep daemon, WebSocket server, and remote connections alive.

## Changes (20 files, +741/-31)

### Protocol (packages/shared)
- New `detach_session` and `detach_session_ack` message types
- `'detached'` added to `DiscoverableSessionStatus` union

### Daemon (packages/daemon)
- SessionRegistry: explicit detach flag, orphan timeout skip, "detached" status
- Connection/server/adapter: full message chain for detach_session
- New `detach-client.ts` for `remi detach` CLI subcommand
- Attach-client: Ctrl+B d sends detach protocol message, waits for ack
- SIGTSTP handler prevents daemon suspension on Ctrl+Z
- Version bump to 0.4.20-dev.1

### Web (packages/web)
- Detach button in ChatHeader dropdown
- Detach ack handling with user feedback (success and failure)

### Tests
- 5 protocol tests for detach message factories
- 7 session registry tests for explicit detach behavior
- 3 detach-scanner tests for \x1a passthrough
- 3 PTY SIGTSTP tests
- All 1308+ tests pass

## Test plan

- [x] All tests pass on develop
- [x] PR #204 CI passed and merged
- [x] PR #205 CI passed and merged
- [x] Both PRs underwent full review (code-reviewer, silent-failure-hunter, pr-test-analyzer)
- [x] Critical bug in detach handler found and fixed during review
- [x] Biome lint clean, TypeScript typecheck clean, web build succeeds