### PR TITLE
fix: filter tool output tree lines with checkmarks/crosses

### DIFF
--- a/packages/daemon/src/parser/ansi.ts
+++ b/packages/daemon/src/parser/ansi.ts
@@ -155,6 +155,10 @@ export function filterTerminalUI(text: string): string {
     // Tool output tree characters with status (filter status lines, keep content)
     /^[\s]*⎿[\s]*(Running|Waiting|No content)/i,
     /^[\s]*⎿[\s]*$/,
+    // Tool output tree with checkmarks/crosses (task completion indicators)
+    /^[\s]*⎿[\s]*[✔✓✗✕✘☑☒⬜]/,
+    // Standalone checkmark/cross lines (subtask results)
+    /^[\s]*[✔✓✗✕✘]\s+\w/,
     // Lines starting with + or * followed by status
     /^[+*]\s*(Honking|Misting)/i,
     // Date output from bash (standalone)

--- a/packages/daemon/tests/ansi.test.ts
+++ b/packages/daemon/tests/ansi.test.ts
@@ -210,6 +210,22 @@ describe('filterTerminalUI()', () => {
     expect(filterTerminalUI(input)).toBe('Real content here');
   });
 
+  test('filters tool output tree lines with checkmarks', () => {
+    const input =
+      '  ⎿  ✔ Technical landscape research (virtualization, emulation, open source)\nReal content';
+    expect(filterTerminalUI(input)).toBe('Real content');
+  });
+
+  test('filters standalone checkmark status lines', () => {
+    const input = '✔ Technical landscape research\nReal content';
+    expect(filterTerminalUI(input)).toBe('Real content');
+  });
+
+  test('filters tool output tree with cross marks', () => {
+    const input = '  ⎿  ✗ Failed to compile\nReal content';
+    expect(filterTerminalUI(input)).toBe('Real content');
+  });
+
   test('preserves meaningful tool output lines', () => {
     const input = '  ⎿ OAuth token revoked · Please run /login';
     expect(filterTerminalUI(input)).toBe(input);


### PR DESCRIPTION
## Summary

- Add filter patterns for tool output tree lines with check/cross marks (✔/✗) that were leaking through to the display
- Add pattern for standalone checkmark status lines
- Add tests for the new patterns

## Test plan

- [x] `bun test packages/daemon/tests/ansi.test.ts` passes (80 tests)
- [ ] Verify on iOS that progress lines like `⎿  ✔ Technical landscape...` no longer appear

Closes #209