### PR TITLE
feat: multi-daemon simultaneous connections

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -95,7 +95,6 @@ function updateSessionActivity(
 }
 
 function App() {
-  // State
   const [sessions, setSessions] = useState<UISession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
@@ -106,12 +105,10 @@ function App() {
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
 
-  // Refs for stable callbacks
   const activeSessionIdRef = useRef<UUID | null>(null);
   const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
 
-  // Apply theme and font size on settings change
   useEffect(() => {
     applyTheme(settings.theme);
 
@@ -128,12 +125,13 @@ function App() {
     setSettings(newSettings);
   }, []);
 
-  // Multi-daemon message handler: connectionId identifies which daemon sent the message
+  // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
   const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
-        // One session per daemon; the sessionId identifies the daemon's single session.
+        // The attached session from this daemon. Additional sessions may arrive via session_list_response.
         if (!message.sessionId) {
+          console.warn('[App] Received hello_ack without sessionId from connection:', connectionId);
           break;
         }
         setSessions((prev) => {
@@ -419,8 +417,10 @@ function App() {
             return new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime();
           });
 
+        // Multi-daemon merge: keep sessions from other connections, preserve attached session
+        // for this connection if not in discovered list, add all newly discovered sessions,
+        // sort live-first then by recency.
         setSessions((prev) => {
-          // Multi-daemon merge: keep sessions from OTHER connections, replace only THIS connection's sessions
           const otherConnSessions = prev.filter((s) => s.connectionId !== connectionId);
           // Keep the attached session for this connection (from hello_ack)
           const attachedSession = prev.find(
@@ -449,7 +449,7 @@ function App() {
       }
 
       case 'session_history_response': {
-        // Session history received; currently unused (one session per daemon)
+        // Session history response received; not yet integrated into the UI
         break;
       }
 
@@ -481,7 +481,7 @@ function App() {
       }
 
       case 'create_session_response': {
-        // One session per daemon; session creation is rejected.
+        // Log session creation failures. Success case currently unhandled.
         if (!message.success) {
           console.error(`Session creation rejected: ${message.error}`);
         }
@@ -534,9 +534,23 @@ function App() {
         break;
       }
 
-      case 'error':
+      case 'error': {
         console.error('Daemon error:', message);
+        const errorSessionId = activeSessionIdRef.current;
+        if (errorSessionId) {
+          const errMsg: UIMessage = {
+            id: generateId(),
+            sessionId: errorSessionId,
+            sender: 'system',
+            content: `Daemon error: ${message.message ?? 'unknown'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errMsg]);
+        }
         break;
+      }
     }
   }, []);
 
@@ -596,7 +610,6 @@ function App() {
     setSessions((prev) => {
       let changed = false;
       const next = prev.map((s) => {
-        if (!s.connectionId) return s;
         const connStatus = connMap.get(s.connectionId);
         if ((connStatus === 'disconnected' || connStatus === 'error') && s.connectionStatus !== 'disconnected') {
           changed = true;
@@ -657,7 +670,6 @@ function App() {
   const sessionMessages = messages.filter((m) => m.sessionId === activeSessionId);
   const sessionQuestion = question?.sessionId === activeSessionId ? question : null;
 
-  // Handlers
   const handleSelectSession = useCallback(
     (id: UUID) => {
       setActiveSessionId(id);
@@ -673,9 +685,7 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
         );
-        if (session.connectionId) {
-          requestTranscriptLoad(session.connectionId, id);
-        }
+        requestTranscriptLoad(session.connectionId, id);
       }
     },
     [sessions, requestTranscriptLoad],
@@ -689,11 +699,24 @@ function App() {
     (content: string) => {
       if (!activeSessionId) return;
       const connId = getActiveConnectionId();
-      if (!connId) return;
+      if (!connId) {
+        const systemMsg: UIMessage = {
+          id: generateId(),
+          sessionId: activeSessionId,
+          sender: 'system',
+          content: 'Cannot send: not connected to daemon',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, systemMsg]);
+        return;
+      }
 
       // If there's an active question, send as answer
       if (sessionQuestion) {
-        sendAnswer(connId, sessionQuestion.id, content);
+        const sent = sendAnswer(connId, sessionQuestion.id, content);
+        if (!sent) return; // Don't transition question UI if send failed
         // Mark question as answered (card shows collapsed state briefly)
         setQuestion({ ...sessionQuestion, answeredWith: content });
         setTimeout(() => setQuestion(null), 1500);
@@ -735,6 +758,20 @@ function App() {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
         );
+      } else {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'delivered' as const } : m)),
+        );
+        const errorMsg: UIMessage = {
+          id: generateId(),
+          sessionId: activeSessionId,
+          sender: 'system',
+          content: 'Failed to send message: connection unavailable',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, errorMsg]);
       }
     },
     [activeSessionId, getActiveConnectionId, sendInput, sendAnswer, sessionQuestion],
@@ -767,8 +804,8 @@ function App() {
           urls.push(url);
         }
         localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(urls));
-      } catch {
-        // Ignore localStorage errors
+      } catch (err) {
+        console.warn('[App] Failed to persist connection URL:', err);
       }
     },
     [connectDirect],
@@ -784,7 +821,7 @@ function App() {
       const urls: string[] = stored ? JSON.parse(stored) : [];
       const filtered = urls.filter((u) => parseConnectionId(u) !== connectionId);
       localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(filtered));
-    } catch { /* ignore parse errors */ }
+    } catch (err) { console.warn('[App] Failed to update persisted connections:', err); }
   }, [disconnectConnection]);
 
   const handleBulletExpand = useCallback(
@@ -807,6 +844,17 @@ function App() {
       const connId = getActiveConnectionId();
       if (connId) {
         requestBulletExpand(connId, activeSessionId, bulletId);
+      } else {
+        // Revert expanding state since we can't reach the daemon
+        setMessages((prev) =>
+          prev.map((msg) => {
+            if (!msg.bullets) return msg;
+            const updatedBullets = msg.bullets.map((b) =>
+              b.bulletId === bulletId ? { ...b, isExpanding: false } : b,
+            );
+            return { ...msg, bullets: updatedBullets };
+          }),
+        );
       }
     },
     [activeSessionId, getActiveConnectionId, requestBulletExpand],
@@ -818,7 +866,10 @@ function App() {
       // Find the connection that owns this session
       const session = sessions.find((s) => s.id === sessionId);
       const connId = session?.connectionId;
-      if (!connId) return;
+      if (!connId) {
+        console.warn('[App] Cannot resume session: no connection for session', sessionId);
+        return;
+      }
       setResumingSession(sessionId);
       const sent = requestResumeSession(connId, sessionId);
       if (!sent) {
@@ -875,7 +926,9 @@ function App() {
 
   // Derive error from the most recently errored connection (if any)
   const errorConnection = connections.find((c) => c.status === 'error');
-  const error: string | null = errorConnection ? `Connection error: ${errorConnection.connectionId}` : null;
+  const error: string | null = errorConnection
+    ? errorConnection.error ?? `Connection error: ${errorConnection.connectionId}`
+    : null;
 
   // Derive connectedHost from the first connected connection (for SessionList display)
   const firstConnected = connections.find((c) => c.status === 'connected');

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,12 +8,12 @@ import { ChatView } from '@/components/chat';
 import { AppLayout } from '@/components/layout';
 import { ConnectModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
-import { useWebSocket } from '@/hooks';
+import { useConnectionManager, parseConnectionId } from '@/hooks';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
-import { checkKnownHost, trustHost } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import type {
   AppSettings,
+  ConnectionId,
   UIBullet,
   UIMessage,
   UIQuestion,
@@ -22,23 +22,15 @@ import type {
 } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
-import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
-  createBulletExpandRequest,
   createDetachSession,
-  createHello,
-  createResumeSessionRequest,
-  createSessionListRequest,
-  createTranscriptLoadRequest,
-  createUserInput,
   generateId,
-  now,
 } from '@remi/shared/protocol.ts';
 import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-const LOCALSTORAGE_URL_KEY = 'remi-last-url';
+const LOCALSTORAGE_CONNECTIONS_KEY = 'remi-connections';
 const LOCALSTORAGE_SESSION_KEY = 'remi-last-session';
 const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
 
@@ -109,18 +101,15 @@ function App() {
   const [messages, setMessages] = useState<UIMessage[]>([]);
   const [question, setQuestion] = useState<UIQuestion | null>(null);
   const [showConnectModal, setShowConnectModal] = useState(false);
-  const [connectedHost, setConnectedHost] = useState<string | null>(null);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [unlockedIdentity, setUnlockedIdentity] = useState<UnlockedIdentity | null>(null);
 
   // Refs for stable callbacks
-  const handleMessageRef = useRef<((message: ProtocolMessage) => void) | undefined>(undefined);
   const activeSessionIdRef = useRef<UUID | null>(null);
   const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
-  const unlockedIdentityRef = useRef<UnlockedIdentity | null>(null);
 
   // Apply theme and font size on settings change
   useEffect(() => {
@@ -139,8 +128,8 @@ function App() {
     setSettings(newSettings);
   }, []);
 
-  // WebSocket connection
-  const handleMessage = useCallback((message: ProtocolMessage) => {
+  // Multi-daemon message handler: connectionId identifies which daemon sent the message
+  const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
     switch (message.type) {
       case 'hello_ack': {
         // One session per daemon; the sessionId identifies the daemon's single session.
@@ -151,7 +140,9 @@ function App() {
           const exists = prev.some((s) => s.id === message.sessionId);
           if (exists) {
             return prev.map((s) =>
-              s.id === message.sessionId ? { ...s, connectionStatus: 'connected' } : s,
+              s.id === message.sessionId
+                ? { ...s, connectionStatus: 'connected', connectionId }
+                : s,
             );
           }
           if (message.isResume) return prev;
@@ -164,6 +155,7 @@ function App() {
               lastActiveAt: new Date().toISOString(),
               status: 'idle',
               connectionStatus: 'connected',
+              connectionId,
               unreadCount: 0,
               preview: 'Connected',
             } satisfies UISession,
@@ -226,6 +218,7 @@ function App() {
           const uiMessage: UIMessage = {
             id: structuredMsg.id,
             sessionId,
+            connectionId,
             sender: newSender,
             content: resolvedContent,
             timestamp: structuredMsg.createdAt || message.timestamp,
@@ -296,6 +289,7 @@ function App() {
           const uiMessage: UIMessage = {
             id: structuredMsg.id,
             sessionId: structuredMsg.sessionId,
+            connectionId,
             sender: structuredMsg.sender,
             content: structuredMsg.content,
             timestamp: structuredMsg.createdAt,
@@ -377,7 +371,7 @@ function App() {
         // Replay batches can arrive immediately after hello_ack on first attach.
         // Dispatch them directly so early history is not dropped before refs/effects settle.
         for (const replayMsg of message.messages) {
-          handleMessage(replayMsg);
+          handleMessage(connectionId, replayMsg);
         }
         break;
       }
@@ -405,6 +399,7 @@ function App() {
             return {
               id: ds.sessionId as UUID,
               name: ds.name || ds.projectPath.split('/').pop() || 'Session',
+              connectionId,
               createdAt: ds.lastActivity,
               lastActiveAt: ds.lastActivity,
               status: mapSessionStatus(ds.status),
@@ -425,16 +420,23 @@ function App() {
           });
 
         setSessions((prev) => {
-          // Keep only the currently attached session (from hello_ack), replace everything else
-          // with the freshly discovered sessions from the daemon
+          // Multi-daemon merge: keep sessions from OTHER connections, replace only THIS connection's sessions
+          const otherConnSessions = prev.filter((s) => s.connectionId !== connectionId);
+          // Keep the attached session for this connection (from hello_ack)
           const attachedSession = prev.find(
-            (s) => s.connectionStatus === 'connected' && s.id === activeSessionIdRef.current,
+            (s) =>
+              s.connectionId === connectionId &&
+              s.connectionStatus === 'connected' &&
+              s.id === activeSessionIdRef.current,
           );
           const discoveredIds = new Set(discovered.map((s) => s.id));
-          // Start with attached session (if not already in discovered list)
-          const result = attachedSession && !discoveredIds.has(attachedSession.id)
-            ? [attachedSession, ...discovered]
-            : [...discovered];
+          // Start with sessions from other connections
+          const result = [...otherConnSessions];
+          // Add attached session if not already in discovered list
+          if (attachedSession && !discoveredIds.has(attachedSession.id)) {
+            result.push(attachedSession);
+          }
+          result.push(...discovered);
           // Sort: live first, then by last activity
           return result.sort((a, b) => {
             const aLive = a.connectionStatus === 'connected' ? 0 : 1;
@@ -538,9 +540,6 @@ function App() {
     }
   }, []);
 
-  // Keep the latest message handler available synchronously for relay callbacks.
-  handleMessageRef.current = handleMessage;
-
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId]);
@@ -549,207 +548,97 @@ function App() {
     resumingSessionRef.current = resumingSession;
   }, [resumingSession]);
 
-  useEffect(() => {
-    unlockedIdentityRef.current = unlockedIdentity;
-  }, [unlockedIdentity]);
-
-  // Restore session ID from localStorage for reconnect after page reload (read once)
-  const [storedSessionId] = useState<UUID | null>(
-    () => localStorage.getItem(LOCALSTORAGE_SESSION_KEY) as UUID | null,
-  );
-
-  const signalingClientRef = useRef<import('@/lib/signaling-client').WebSignalingClient | null>(
-    null,
-  );
-  const pendingRelayChallengeRef = useRef<{
-    challenge: string;
-    serverPublicKey: string;
-    serverFingerprint: string;
-  } | null>(null);
-  const [connectionMode, setConnectionMode] = useState<'direct' | 'relay'>('direct');
-  const [relayStatus, setRelayStatus] = useState<'disconnected' | 'connecting' | 'connected'>(
-    'disconnected',
-  );
-  const [relayError, setRelayError] = useState<Error | null>(null);
-
-  /** Set error (works for both direct and relay modes) */
-  const setError = useCallback((err: Error) => {
-    setRelayError(err);
-  }, []);
-
+  // Connection manager: manages N simultaneous WebSocket connections
   const {
-    status: connectionStatus,
-    error: wsError,
-    connect,
+    connections,
+    connectDirect,
+    disconnect: disconnectConnection,
     sendInput,
     sendAnswer,
-    sendMessage: wsSendMessage,
+    sendMessage: cmSendMessage,
     requestBulletExpand,
     requestSessionList,
     requestTranscriptLoad,
     requestResumeSession,
     needsPassphrase,
-    serverFingerprint,
+    passphraseConnectionId,
+    passphraseServerFingerprint,
     provideIdentity,
-  } = useWebSocket({
+  } = useConnectionManager({
     onMessage: handleMessage,
-    initialResumeSessionId: storedSessionId ?? undefined,
     unlockedIdentity,
+    clientId: 'remi-web',
+    clientVersion: '0.0.1',
   });
 
-  const error = (connectionMode === 'relay' ? relayError?.message : wsError?.message) ?? null;
-
-  // Effective connection status: use relay status when in relay mode
-  const effectiveStatus = connectionMode === 'relay' ? relayStatus : connectionStatus;
-
-  // Relay-aware send: dispatches through signaling client when in relay mode
-  const relaySend = useCallback(
-    (message: ProtocolMessage): boolean => {
-      if (connectionMode === 'relay') {
-        if (signalingClientRef.current?.isConnected) {
-          signalingClientRef.current.sendMessage(message);
-          return true;
-        }
-        console.warn(`Relay send dropped (not connected): ${message.type}`);
-        return false;
-      }
-      return false;
-    },
-    [connectionMode],
+  // Derived connection status
+  const hasAnyConnected = connections.some((c) => c.status === 'connected');
+  const isAnyConnecting = connections.some(
+    (c) => c.status === 'connecting' || c.status === 'authenticating',
   );
 
-  // Relay-aware wrappers for send functions
-  const effectiveSendInput = useCallback(
-    (sessionId: UUID, content: string): boolean => {
-      if (connectionMode === 'relay') return relaySend(createUserInput(sessionId, content));
-      return sendInput(sessionId, content);
-    },
-    [connectionMode, relaySend, sendInput],
-  );
+  // Resolve connectionId for the active session
+  const getActiveConnectionId = useCallback((): ConnectionId | undefined => {
+    const session = sessions.find((s) => s.id === activeSessionId);
+    return session?.connectionId;
+  }, [sessions, activeSessionId]);
 
-  const effectiveSendAnswer = useCallback(
-    (questionId: UUID, answer: string): boolean => {
-      if (connectionMode === 'relay') {
-        return relaySend({
-          type: 'answer',
-          id: generateId(),
-          timestamp: now(),
-          questionId,
-          answer,
-        });
-      }
-      return sendAnswer(questionId, answer);
-    },
-    [connectionMode, relaySend, sendAnswer],
-  );
-
-  const effectiveRequestBulletExpand = useCallback(
-    (sessionId: UUID, bulletId: number): boolean => {
-      if (connectionMode === 'relay')
-        return relaySend(createBulletExpandRequest(sessionId, bulletId));
-      return requestBulletExpand(sessionId, bulletId);
-    },
-    [connectionMode, relaySend, requestBulletExpand],
-  );
-
-  const effectiveRequestSessionList = useCallback(
-    (includeExternal?: boolean): boolean => {
-      if (connectionMode === 'relay') return relaySend(createSessionListRequest(includeExternal));
-      return requestSessionList(includeExternal);
-    },
-    [connectionMode, relaySend, requestSessionList],
-  );
-
-  const effectiveRequestTranscriptLoad = useCallback(
-    (sessionId: string): boolean => {
-      if (connectionMode === 'relay') return relaySend(createTranscriptLoadRequest(sessionId));
-      return requestTranscriptLoad(sessionId);
-    },
-    [connectionMode, relaySend, requestTranscriptLoad],
-  );
-
-  const effectiveRequestResumeSession = useCallback(
-    (sessionId: string): boolean => {
-      if (connectionMode === 'relay') return relaySend(createResumeSessionRequest(sessionId));
-      return requestResumeSession(sessionId);
-    },
-    [connectionMode, relaySend, requestResumeSession],
-  );
-
-  const effectiveDetachSession = useCallback(
-    (sessionId: UUID): boolean => {
-      if (connectionMode === 'relay') return relaySend(createDetachSession(sessionId));
-      return wsSendMessage(createDetachSession(sessionId));
-    },
-    [connectionMode, relaySend, wsSendMessage],
-  );
-
-  // Close modal and store URL on successful connect
+  // Close modal on successful connect
   useEffect(() => {
-    if (connectionStatus === 'connected') {
+    if (hasAnyConnected) {
       setShowConnectModal(false);
     }
-  }, [connectionStatus]);
+  }, [hasAnyConnected]);
 
-  // Update session connectionStatus on disconnect/reconnecting
-  // Clear stale question on disconnect
+  // Update session connectionStatus when connections change
   useEffect(() => {
-    if (effectiveStatus === 'disconnected' || effectiveStatus === 'reconnecting') {
-      setSessions((prev) =>
-        prev.map((s) =>
-          s.connectionStatus === 'connected'
-            ? { ...s, connectionStatus: 'disconnected' as const, questionPending: false }
-            : s,
-        ),
-      );
+    const connMap = new Map(connections.map((c) => [c.connectionId, c.status]));
+    setSessions((prev) =>
+      prev.map((s) => {
+        if (!s.connectionId) return s;
+        const connStatus = connMap.get(s.connectionId);
+        if (connStatus === 'disconnected' || connStatus === 'error') {
+          return { ...s, connectionStatus: 'disconnected' as const, questionPending: false };
+        }
+        if (connStatus === 'connected' && s.connectionStatus === 'disconnected') {
+          return { ...s, connectionStatus: 'connected' as const };
+        }
+        return s;
+      }),
+    );
+    // Clear stale question if all connections are down
+    if (!hasAnyConnected && !isAnyConnecting) {
       setQuestion(null);
       setResumingSession(null);
-    } else if (effectiveStatus === 'connected') {
-      // Restore connected status for active session
-      if (activeSessionId) {
-        setSessions((prev) =>
-          prev.map((s) =>
-            s.id === activeSessionId ? { ...s, connectionStatus: 'connected' as const } : s,
-          ),
-        );
+    }
+  }, [connections, hasAnyConnected, isAnyConnecting]);
+
+  // Request session list from all connected daemons
+  useEffect(() => {
+    for (const conn of connections) {
+      if (conn.status === 'connected') {
+        requestSessionList(conn.connectionId, false);
       }
     }
-  }, [effectiveStatus, activeSessionId]);
-
-  // Request session list after direct connection
-  // Use includeExternal=false so only sessions owned by THIS daemon are listed.
-  // External transcript sessions belong to other daemons and cannot receive
-  // input from this connection.
-  useEffect(() => {
-    if (connectionStatus === 'connected') {
-      effectiveRequestSessionList(false);
-    }
-  }, [connectionStatus, effectiveRequestSessionList]);
-
-  // Request session list after relay connection (hello_ack received)
-  useEffect(() => {
-    if (connectionMode === 'relay' && relayStatus === 'connected' && activeSessionId) {
-      effectiveRequestSessionList(false);
-    }
-  }, [connectionMode, relayStatus, activeSessionId, effectiveRequestSessionList]);
+  }, [connections, requestSessionList]);
 
   // Auto-connect from localStorage on mount (run once)
-  const connectRef = useRef(connect);
+  const connectDirectRef = useRef(connectDirect);
   useEffect(() => {
-    connectRef.current = connect;
-  }, [connect]);
+    connectDirectRef.current = connectDirect;
+  }, [connectDirect]);
 
   useEffect(() => {
-    const storedUrl = localStorage.getItem(LOCALSTORAGE_URL_KEY);
-    if (storedUrl) {
-      // Extract hostname for display
-      try {
-        const parsed = new URL(storedUrl);
-        setConnectedHost(parsed.hostname);
-      } catch (err) {
-        console.warn('[App] Failed to parse stored URL for hostname display:', err);
+    try {
+      const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
+      if (stored) {
+        const urls: string[] = JSON.parse(stored);
+        for (const url of urls) {
+          connectDirectRef.current(url);
+        }
       }
-      connectRef.current(storedUrl);
+    } catch (err) {
+      console.warn('[App] Failed to restore connections from localStorage:', err);
     }
   }, []);
 
@@ -774,10 +663,12 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
         );
-        effectiveRequestTranscriptLoad(id);
+        if (session.connectionId) {
+          requestTranscriptLoad(session.connectionId, id);
+        }
       }
     },
-    [sessions, effectiveRequestTranscriptLoad],
+    [sessions, requestTranscriptLoad],
   );
 
   const handleBack = useCallback(() => {
@@ -787,10 +678,12 @@ function App() {
   const handleSend = useCallback(
     (content: string) => {
       if (!activeSessionId) return;
+      const connId = getActiveConnectionId();
+      if (!connId) return;
 
       // If there's an active question, send as answer
       if (sessionQuestion) {
-        effectiveSendAnswer(sessionQuestion.id, content);
+        sendAnswer(connId, sessionQuestion.id, content);
         // Mark question as answered (card shows collapsed state briefly)
         setQuestion({ ...sessionQuestion, answeredWith: content });
         setTimeout(() => setQuestion(null), 1500);
@@ -827,14 +720,14 @@ function App() {
 
       setMessages((prev) => [...prev, newMessage]);
 
-      const success = effectiveSendInput(activeSessionId, content);
+      const success = sendInput(connId, activeSessionId, content);
       if (success) {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
         );
       }
     },
-    [activeSessionId, effectiveSendInput, effectiveSendAnswer, sessionQuestion],
+    [activeSessionId, getActiveConnectionId, sendInput, sendAnswer, sessionQuestion],
   );
 
   const handlePassphraseSubmit = useCallback(
@@ -842,205 +735,38 @@ function App() {
       try {
         const identity = await unlockStoredIdentity(passphrase);
         setUnlockedIdentity(identity);
-        provideIdentity(identity);
+        if (passphraseConnectionId) {
+          provideIdentity(passphraseConnectionId, identity);
+        }
       } catch (err) {
         console.error('Failed to unlock identity:', err);
         throw err;
       }
     },
-    [provideIdentity],
+    [provideIdentity, passphraseConnectionId],
   );
 
   const handleConnectDirect = useCallback(
     (url: string, directory?: string) => {
-      setConnectionMode('direct');
-      // Extract hostname from ws:// URL for display
-      let newHost: string | null = null;
+      connectDirect(url, directory);
+      // Persist connected URLs
       try {
-        const parsed = new URL(url);
-        newHost = parsed.hostname;
-      } catch (err) {
-        console.warn('[App] Failed to parse URL for hostname display:', err);
+        const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
+        const urls: string[] = stored ? JSON.parse(stored) : [];
+        if (!urls.includes(url)) {
+          urls.push(url);
+        }
+        localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(urls));
+      } catch {
+        // Ignore localStorage errors
       }
-      // Clear sessions when switching to a different host
-      if (newHost && newHost !== connectedHost) {
-        setSessions([]);
-        setMessages([]);
-        setActiveSessionId(null);
-        setQuestion(null);
-      }
-      setConnectedHost(newHost);
-      // Close any existing relay connection
-      if (signalingClientRef.current) {
-        signalingClientRef.current.close();
-        signalingClientRef.current = null;
-        setRelayStatus('disconnected');
-      }
-      localStorage.setItem(LOCALSTORAGE_URL_KEY, url);
-      connect(url, directory);
     },
-    [connect],
+    [connectDirect],
   );
 
-  // Clean up signaling client on unmount
-  useEffect(() => {
-    return () => {
-      signalingClientRef.current?.close();
-    };
-  }, []);
-
-  const handleConnectCode = useCallback((code: string) => {
-    // Dynamic import to avoid bundling when not used
-    import('@/lib/signaling-client')
-      .then(({ WebSignalingClient }) => {
-        // Close existing signaling connection if any
-        if (signalingClientRef.current) {
-          signalingClientRef.current.close();
-        }
-
-        setConnectionMode('relay');
-        setRelayStatus('connecting');
-        setRelayError(null);
-        pendingRelayChallengeRef.current = null;
-
-        const signalingUrl = 'wss://remi-signaling.yooz.workers.dev/connect';
-        const client = new WebSignalingClient({
-          onStateChange: (state) => {
-            if (state === 'connected') {
-              setRelayStatus('connected');
-              setShowConnectModal(false);
-              // Send hello via relay with resumeSessionId if reconnecting
-              // (harmless if auth is required; daemon drops it and sends
-              // auth_challenge first, then hello_ack after auth completes)
-              const resumeId = activeSessionIdRef.current ?? undefined;
-              client.sendMessage(createHello(generateId(), '0.1.0', undefined, resumeId));
-            } else if (state === 'connecting' || state === 'joined') {
-              setRelayStatus('connecting');
-            } else if (state === 'disconnected' || state === 'error') {
-              setRelayStatus('disconnected');
-            }
-          },
-          onMessage: (message) => {
-            if (!message || typeof message !== 'object' || !('type' in message)) return;
-            const msg = message as ProtocolMessage;
-
-            // Handle auth_challenge: TOFU check, sign, and respond
-            if (msg.type === 'auth_challenge') {
-              const identity = unlockedIdentityRef.current;
-              if (!identity) {
-                setError(
-                  new Error(
-                    'This daemon requires authentication. Unlock your identity first (Settings > Identity).',
-                  ),
-                );
-                setRelayStatus('disconnected');
-                client.close();
-                return;
-              }
-
-              // TOFU: check known hosts for relay server
-              const relayUrl = `relay:${msg.serverFingerprint}`;
-              const tofuResult = checkKnownHost(relayUrl, msg.serverFingerprint);
-              if (tofuResult === 'mismatch') {
-                setError(
-                  new Error(
-                    'Server fingerprint changed. This could indicate a MITM attack. Connection rejected.',
-                  ),
-                );
-                setRelayStatus('disconnected');
-                client.close();
-                return;
-              }
-
-              // Store challenge data for mutual auth verification in auth_result
-              pendingRelayChallengeRef.current = {
-                challenge: msg.challenge,
-                serverPublicKey: msg.serverPublicKey,
-                serverFingerprint: msg.serverFingerprint,
-              };
-
-              (async () => {
-                try {
-                  const challengeData = fromBase64(msg.challenge);
-                  const signature = await sign(identity.privateKey, challengeData);
-                  client.sendMessage(
-                    createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint),
-                  );
-                } catch (err) {
-                  const detail = err instanceof Error ? err.message : String(err);
-                  setError(new Error(`Relay authentication failed: ${detail}`));
-                  setRelayStatus('disconnected');
-                  client.close();
-                }
-              })();
-              return;
-            }
-
-            // Handle auth_result: verify mutual auth, TOFU trust, then send hello
-            if (msg.type === 'auth_result') {
-              if (!msg.success) {
-                setError(new Error(`Relay auth rejected: ${msg.error ?? 'unknown'}`));
-                setRelayStatus('disconnected');
-                client.close();
-                return;
-              }
-
-              const pending = pendingRelayChallengeRef.current;
-              if (!msg.serverSignature || !pending) {
-                setError(new Error('Server did not provide mutual authentication signature'));
-                setRelayStatus('disconnected');
-                client.close();
-                return;
-              }
-
-              // Verify server signature for mutual auth
-              (async () => {
-                try {
-                  const serverPubKey = await importPublicKey(fromBase64(pending.serverPublicKey));
-                  const challengeData = fromBase64(pending.challenge);
-                  const valid = await verify(serverPubKey, challengeData, msg.serverSignature!);
-                  if (!valid) {
-                    setError(new Error('Server signature verification failed'));
-                    setRelayStatus('disconnected');
-                    client.close();
-                    return;
-                  }
-
-                  // TOFU: trust server on first use
-                  const relayUrl = `relay:${pending.serverFingerprint}`;
-                  trustHost(relayUrl, pending.serverFingerprint, pending.serverPublicKey);
-                  pendingRelayChallengeRef.current = null;
-
-                  // Auth succeeded; now send hello so the daemon creates our session
-                  const resumeId = activeSessionIdRef.current ?? undefined;
-                  client.sendMessage(createHello(generateId(), '0.1.0', undefined, resumeId));
-                } catch (err) {
-                  const detail = err instanceof Error ? err.message : String(err);
-                  setError(new Error(`Server verification failed: ${detail}`));
-                  setRelayStatus('disconnected');
-                  client.close();
-                }
-              })();
-              return;
-            }
-
-            // Forward all other messages to the existing handler
-            handleMessageRef.current?.(msg);
-          },
-          onError: (errCode, errMsg) => {
-            console.error(`Signaling error [${errCode}]: ${errMsg}`);
-            setError(new Error(`Connection failed: ${errMsg}`));
-          },
-        });
-
-        signalingClientRef.current = client;
-        client.connect(signalingUrl, code);
-      })
-      .catch((err) => {
-        console.error('Failed to load signaling client:', err);
-        setRelayStatus('disconnected');
-        setConnectionMode('direct');
-      });
+  // Stub for relay connection code (to be extended later with connection manager relay support)
+  const handleConnectCode = useCallback((_code: string) => {
+    console.warn('[App] Relay connections not yet supported in multi-daemon mode');
   }, []);
 
   const handleBulletExpand = useCallback(
@@ -1060,21 +786,28 @@ function App() {
         }),
       );
 
-      effectiveRequestBulletExpand(activeSessionId, bulletId);
+      const connId = getActiveConnectionId();
+      if (connId) {
+        requestBulletExpand(connId, activeSessionId, bulletId);
+      }
     },
-    [activeSessionId, effectiveRequestBulletExpand],
+    [activeSessionId, getActiveConnectionId, requestBulletExpand],
   );
 
   const handleResumeSession = useCallback(
     (sessionId: string) => {
       if (resumingSession) return;
+      // Find the connection that owns this session
+      const session = sessions.find((s) => s.id === sessionId);
+      const connId = session?.connectionId;
+      if (!connId) return;
       setResumingSession(sessionId);
-      const sent = effectiveRequestResumeSession(sessionId);
+      const sent = requestResumeSession(connId, sessionId);
       if (!sent) {
         setResumingSession(null);
       }
     },
-    [effectiveRequestResumeSession, resumingSession],
+    [sessions, requestResumeSession, resumingSession],
   );
 
   // Menu actions
@@ -1093,7 +826,8 @@ function App() {
 
   const handleDetach = useCallback(() => {
     if (!activeSessionId) return;
-    const sent = effectiveDetachSession(activeSessionId);
+    const connId = getActiveConnectionId();
+    const sent = connId ? cmSendMessage(connId, createDetachSession(activeSessionId)) : false;
     if (!sent) {
       const errorMsg: UIMessage = {
         id: generateId(),
@@ -1106,7 +840,7 @@ function App() {
       };
       setMessages((prev) => [...prev, errorMsg]);
     }
-  }, [activeSessionId, effectiveDetachSession]);
+  }, [activeSessionId, getActiveConnectionId, cmSendMessage]);
 
   const handleExportText = useCallback(() => {
     const text = sessionMessages
@@ -1121,16 +855,38 @@ function App() {
     URL.revokeObjectURL(url);
   }, [sessionMessages, activeSessionId]);
 
+  // Derive error from the most recently errored connection (if any)
+  const errorConnection = connections.find((c) => c.status === 'error');
+  const error: string | null = errorConnection ? `Connection error: ${errorConnection.connectionId}` : null;
+
+  // Derive connectedHost from the first connected connection (for SessionList display)
+  const firstConnected = connections.find((c) => c.status === 'connected');
+  const connectedHost = firstConnected
+    ? parseConnectionId(firstConnected.url).split(':')[0]
+    : null;
+
+  // Compute effective status for ConnectModal: show the latest connection's status
+  const effectiveStatus = (() => {
+    if (hasAnyConnected) return 'connected' as const;
+    if (isAnyConnecting) return 'connecting' as const;
+    if (connections.some((c) => c.status === 'reconnecting')) return 'reconnecting' as const;
+    if (connections.some((c) => c.status === 'error')) return 'error' as const;
+    return 'disconnected' as const;
+  })();
+
   // Sidebar content
   const sidebar = (
     <SessionList
       sessions={sessions}
       activeSessionId={activeSessionId}
+      connections={connections}
       connectedHost={connectedHost}
       onSelectSession={handleSelectSession}
-      onResumeSession={effectiveStatus === 'connected' ? handleResumeSession : undefined}
+      onResumeSession={hasAnyConnected ? handleResumeSession : undefined}
       resumingSessionId={resumingSession}
       onConnect={() => setShowConnectModal(true)}
+      onAddConnection={() => setShowConnectModal(true)}
+      onDisconnect={disconnectConnection}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -1183,7 +939,7 @@ function App() {
         error={error}
         needsPassphrase={needsPassphrase}
         hasIdentity={hasIdentity()}
-        serverFingerprint={serverFingerprint}
+        serverFingerprint={passphraseServerFingerprint}
         onPassphraseSubmit={handlePassphraseSubmit}
       />
     </>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -28,7 +28,7 @@ import {
   generateId,
 } from '@remi/shared/protocol.ts';
 import type { Bullet, DiscoverableSession, UUID } from '@remi/shared/types.ts';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const LOCALSTORAGE_CONNECTIONS_KEY = 'remi-connections';
 const LOCALSTORAGE_SESSION_KEY = 'remi-last-session';
@@ -593,19 +593,23 @@ function App() {
   // Update session connectionStatus when connections change
   useEffect(() => {
     const connMap = new Map(connections.map((c) => [c.connectionId, c.status]));
-    setSessions((prev) =>
-      prev.map((s) => {
+    setSessions((prev) => {
+      let changed = false;
+      const next = prev.map((s) => {
         if (!s.connectionId) return s;
         const connStatus = connMap.get(s.connectionId);
-        if (connStatus === 'disconnected' || connStatus === 'error') {
+        if ((connStatus === 'disconnected' || connStatus === 'error') && s.connectionStatus !== 'disconnected') {
+          changed = true;
           return { ...s, connectionStatus: 'disconnected' as const, questionPending: false };
         }
         if (connStatus === 'connected' && s.connectionStatus === 'disconnected') {
+          changed = true;
           return { ...s, connectionStatus: 'connected' as const };
         }
         return s;
-      }),
-    );
+      });
+      return changed ? next : prev;
+    });
     // Clear stale question if all connections are down
     if (!hasAnyConnected && !isAnyConnecting) {
       setQuestion(null);
@@ -613,14 +617,20 @@ function App() {
     }
   }, [connections, hasAnyConnected, isAnyConnecting]);
 
-  // Request session list from all connected daemons
+  // Request session list when a connection transitions to 'connected'
+  const prevConnectedIdsRef = useRef<Set<ConnectionId>>(new Set());
+  const connectedIds = useMemo(
+    () => new Set(connections.filter((c) => c.status === 'connected').map((c) => c.connectionId)),
+    [connections],
+  );
   useEffect(() => {
-    for (const conn of connections) {
-      if (conn.status === 'connected') {
-        requestSessionList(conn.connectionId, false);
+    for (const id of connectedIds) {
+      if (!prevConnectedIdsRef.current.has(id)) {
+        requestSessionList(id, false);
       }
     }
-  }, [connections, requestSessionList]);
+    prevConnectedIdsRef.current = connectedIds;
+  }, [connectedIds, requestSessionList]);
 
   // Auto-connect from localStorage on mount (run once)
   const connectDirectRef = useRef(connectDirect);
@@ -764,10 +774,18 @@ function App() {
     [connectDirect],
   );
 
-  // Stub for relay connection code (to be extended later with connection manager relay support)
-  const handleConnectCode = useCallback((_code: string) => {
-    console.warn('[App] Relay connections not yet supported in multi-daemon mode');
-  }, []);
+  // Relay connections not yet ported to multi-daemon mode (handler hidden from ConnectModal)
+
+  // Disconnect a connection and remove from persisted localStorage
+  const handleDisconnect = useCallback((connectionId: ConnectionId) => {
+    disconnectConnection(connectionId);
+    try {
+      const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
+      const urls: string[] = stored ? JSON.parse(stored) : [];
+      const filtered = urls.filter((u) => parseConnectionId(u) !== connectionId);
+      localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(filtered));
+    } catch { /* ignore parse errors */ }
+  }, [disconnectConnection]);
 
   const handleBulletExpand = useCallback(
     (bulletId: number) => {
@@ -862,7 +880,7 @@ function App() {
   // Derive connectedHost from the first connected connection (for SessionList display)
   const firstConnected = connections.find((c) => c.status === 'connected');
   const connectedHost = firstConnected
-    ? parseConnectionId(firstConnected.url).split(':')[0]
+    ? firstConnected.connectionId.replace(/:\d+$/, '')
     : null;
 
   // Compute effective status for ConnectModal: show the latest connection's status
@@ -886,7 +904,7 @@ function App() {
       resumingSessionId={resumingSession}
       onConnect={() => setShowConnectModal(true)}
       onAddConnection={() => setShowConnectModal(true)}
-      onDisconnect={disconnectConnection}
+      onDisconnect={handleDisconnect}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -934,7 +952,6 @@ function App() {
         isOpen={showConnectModal || needsPassphrase}
         onClose={() => setShowConnectModal(false)}
         onConnectDirect={handleConnectDirect}
-        onConnectCode={handleConnectCode}
         connectionStatus={effectiveStatus}
         error={error}
         needsPassphrase={needsPassphrase}

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -23,7 +23,7 @@ interface ConnectModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly onConnectDirect: (url: string, directory?: string) => void;
-  readonly onConnectCode: (code: string) => void;
+  readonly onConnectCode?: (code: string) => void;
   readonly connectionStatus: ConnectionStatus;
   readonly error?: string | null;
   readonly needsPassphrase?: boolean;
@@ -290,7 +290,7 @@ export function ConnectModal({
       const wsUrl = buildWsUrl(host);
       localStorage.setItem(LOCALSTORAGE_HOST_KEY, host.trim());
       onConnectDirect(wsUrl);
-    } else {
+    } else if (onConnectCode) {
       onConnectCode(code);
     }
   };
@@ -335,18 +335,20 @@ export function ConnectModal({
               <Monitor className="size-4" />
               Host
             </button>
-            <button
-              onClick={() => setMode('remote')}
-              className={clsx(
-                'flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-colors',
-                mode === 'remote'
-                  ? 'bg-[var(--color-primary)] text-white'
-                  : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text)]',
-              )}
-            >
-              <Globe className="size-4" />
-              Code
-            </button>
+            {onConnectCode && (
+              <button
+                onClick={() => setMode('remote')}
+                className={clsx(
+                  'flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-colors',
+                  mode === 'remote'
+                    ? 'bg-[var(--color-primary)] text-white'
+                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text)]',
+                )}
+              >
+                <Globe className="size-4" />
+                Code
+              </button>
+            )}
           </div>
 
           {/* Host connection */}

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -1,23 +1,42 @@
 /**
  * SessionList component.
  *
- * Displays the daemon's session (one session per daemon).
+ * Displays sessions grouped by daemon connection when multiple connections
+ * are active. Shows a flat list for single connections.
  */
 
-import type { UISession } from '@/types';
+import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { Link2, Settings } from 'lucide-react';
+import { Link2, Plus, Settings } from 'lucide-react';
+import { useMemo } from 'react';
 import { SessionCard } from './SessionCard';
+
+/** Status dot for connection state */
+function StatusDot({ status }: { readonly status: ConnectionState['status'] }) {
+  const colorClass =
+    status === 'connected'
+      ? 'bg-green-500'
+      : status === 'connecting' || status === 'authenticating' || status === 'reconnecting'
+        ? 'bg-yellow-500 animate-pulse'
+        : status === 'error'
+          ? 'bg-red-500'
+          : 'bg-gray-400';
+
+  return <span className={clsx('inline-block size-2 rounded-full', colorClass)} />;
+}
 
 interface SessionListProps {
   readonly sessions: readonly UISession[];
   readonly activeSessionId: UUID | null;
+  readonly connections?: readonly ConnectionState[];
   readonly connectedHost?: string | null;
   readonly onSelectSession: (id: UUID) => void;
   readonly onResumeSession?: ((sessionId: string) => void) | undefined;
   readonly resumingSessionId?: string | null;
   readonly onConnect?: () => void;
+  readonly onAddConnection?: () => void;
+  readonly onDisconnect?: (connectionId: ConnectionId) => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -25,23 +44,54 @@ interface SessionListProps {
 export function SessionList({
   sessions,
   activeSessionId,
+  connections = [],
   connectedHost,
   onSelectSession,
   onResumeSession,
   resumingSessionId,
   onConnect,
+  onAddConnection,
+  onDisconnect,
   onSettings,
   className,
 }: SessionListProps) {
+  const isMultiConnection = connections.length > 1;
+
+  // Group sessions by connectionId
+  const grouped = useMemo(() => {
+    if (!isMultiConnection) return null;
+    const groups = new Map<ConnectionId | 'unknown', UISession[]>();
+    for (const session of sessions) {
+      const key = session.connectionId ?? 'unknown';
+      const group = groups.get(key) ?? [];
+      group.push(session);
+      groups.set(key, group);
+    }
+    return groups;
+  }, [sessions, isMultiConnection]);
+
   return (
     <div className={clsx('flex h-full flex-col bg-[var(--color-surface)]', className)}>
       {/* Header */}
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
         <h1 className="text-lg font-semibold text-[var(--color-text)]">
-          Remi{connectedHost ? <span className="font-normal text-[var(--color-text-muted)]"> on {connectedHost}</span> : ''}
+          Remi
+          {!isMultiConnection && connectedHost ? (
+            <span className="font-normal text-[var(--color-text-muted)]"> on {connectedHost}</span>
+          ) : null}
         </h1>
         <div className="flex items-center gap-1">
-          {onConnect && (
+          {/* "+" button to add another connection */}
+          {connections.length > 0 && (onAddConnection || onConnect) && (
+            <button
+              onClick={onAddConnection ?? onConnect}
+              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+              aria-label="Add connection"
+            >
+              <Plus className="size-5" />
+            </button>
+          )}
+          {connections.length === 0 && onConnect && (
             <button
               onClick={onConnect}
               className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
@@ -83,7 +133,45 @@ export function SessionList({
               </button>
             )}
           </div>
+        ) : isMultiConnection && grouped ? (
+          // Multi-connection: grouped by daemon
+          <div className="space-y-3">
+            {Array.from(grouped.entries()).map(([connId, groupSessions]) => {
+              const conn = connections.find((c) => c.connectionId === connId);
+              return (
+                <div key={connId}>
+                  <div className="flex items-center gap-2 px-3 py-1.5">
+                    <StatusDot status={conn?.status ?? 'disconnected'} />
+                    <span className="text-xs font-medium text-[var(--color-text-muted)]">
+                      {connId === 'unknown' ? 'Unknown' : connId}
+                    </span>
+                    {onDisconnect && conn && (
+                      <button
+                        onClick={() => onDisconnect(conn.connectionId)}
+                        className="ml-auto text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
+                      >
+                        Disconnect
+                      </button>
+                    )}
+                  </div>
+                  <div className="space-y-1">
+                    {groupSessions.map((session) => (
+                      <SessionCard
+                        key={session.id}
+                        session={session}
+                        isActive={session.id === activeSessionId}
+                        onClick={() => onSelectSession(session.id)}
+                        onResume={onResumeSession}
+                        isResuming={resumingSessionId === session.id}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         ) : (
+          // Single connection: flat list
           <div className="space-y-1">
             {sessions.map((session) => (
               <SessionCard

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -60,9 +60,9 @@ export function SessionList({
   // Group sessions by connectionId
   const grouped = useMemo(() => {
     if (!isMultiConnection) return null;
-    const groups = new Map<ConnectionId | 'unknown', UISession[]>();
+    const groups = new Map<ConnectionId, UISession[]>();
     for (const session of sessions) {
-      const key = session.connectionId ?? 'unknown';
+      const key = session.connectionId;
       const group = groups.get(key) ?? [];
       group.push(session);
       groups.set(key, group);
@@ -72,7 +72,6 @@ export function SessionList({
 
   return (
     <div className={clsx('flex h-full flex-col bg-[var(--color-surface)]', className)}>
-      {/* Header */}
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
         <h1 className="text-lg font-semibold text-[var(--color-text)]">
           Remi
@@ -81,7 +80,6 @@ export function SessionList({
           ) : null}
         </h1>
         <div className="flex items-center gap-1">
-          {/* "+" button to add another connection */}
           {connections.length > 0 && (onAddConnection || onConnect) && (
             <button
               onClick={onAddConnection ?? onConnect}
@@ -112,7 +110,6 @@ export function SessionList({
         </div>
       </header>
 
-      {/* Session list */}
       <div className="flex-1 overflow-y-auto p-2 safe-area-bottom">
         {sessions.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-4 text-center">
@@ -143,7 +140,7 @@ export function SessionList({
                   <div className="flex items-center gap-2 px-3 py-1.5">
                     <StatusDot status={conn?.status ?? 'disconnected'} />
                     <span className="text-xs font-medium text-[var(--color-text-muted)]">
-                      {connId === 'unknown' ? 'Unknown' : connId}
+                      {connId}
                     </span>
                     {onDisconnect && conn && (
                       <button

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -3,5 +3,11 @@
  */
 
 export { useWebSocket, type UseWebSocketReturn, type UseWebSocketOptions } from './useWebSocket';
+export {
+  useConnectionManager,
+  parseConnectionId,
+  type UseConnectionManagerReturn,
+  type UseConnectionManagerOptions,
+} from './useConnectionManager';
 export { usePlatform } from './usePlatform';
 export { useKeyboard } from './useKeyboard';

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -1,0 +1,568 @@
+/**
+ * Multi-daemon connection manager hook.
+ *
+ * Manages N simultaneous WebSocket connections to different daemons.
+ * Each connection has its own auth state, session, and message routing.
+ * WebSocketClient instances are created per connection and stored in a Map.
+ */
+
+import {
+  checkKnownHost,
+  ensureIdentity,
+  isIdentityEncrypted,
+  trustHost,
+  unlockStoredIdentity,
+} from '@/lib/identity-client';
+import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
+import type { ConnectionId, ConnectionState, ConnectionStatus } from '@/types';
+import type { UnlockedIdentity } from '@remi/shared';
+import {
+  createAuthResponse,
+  fromBase64,
+  importPublicKey,
+  sign,
+  verify,
+} from '@remi/shared';
+import type { ProtocolMessage } from '@remi/shared/protocol.ts';
+import {
+  createBulletExpandRequest,
+  createCreateSessionRequest,
+  createHello,
+  createPing,
+  createResumeSessionRequest,
+  createSessionHistoryRequest,
+  createSessionListRequest,
+  createTranscriptLoadRequest,
+  createUserInput,
+  generateId,
+  now,
+} from '@remi/shared/protocol.ts';
+import type { UUID } from '@remi/shared/types.ts';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Internal per-connection state */
+interface ManagedConnection {
+  client: WebSocketClient;
+  connectionId: ConnectionId;
+  url: string;
+  mode: 'direct' | 'relay';
+  status: ConnectionStatus;
+  error: Error | null;
+  sessionId: UUID | null;
+  helloSent: boolean;
+  pendingChallenge: {
+    challenge: string;
+    serverPublicKey: string;
+    serverFingerprint: string;
+  } | null;
+  needsPassphrase: boolean;
+  serverFingerprint: string | null;
+  directory?: string;
+  pingInterval?: ReturnType<typeof setInterval>;
+}
+
+/** Hook options */
+export interface UseConnectionManagerOptions {
+  /** Message handler: receives connectionId and the protocol message */
+  onMessage?: (connectionId: ConnectionId, message: ProtocolMessage) => void;
+  /** Pre-unlocked identity (shared across all connections) */
+  unlockedIdentity?: UnlockedIdentity | null;
+  /** Client ID for identification */
+  clientId?: string;
+  /** Client version */
+  clientVersion?: string;
+}
+
+/** Hook return value */
+export interface UseConnectionManagerReturn {
+  /** All active connections (reactive) */
+  connections: readonly ConnectionState[];
+  /** Add a new direct connection. Returns connectionId. */
+  connectDirect: (url: string, directory?: string) => ConnectionId;
+  /** Disconnect a specific connection */
+  disconnect: (connectionId: ConnectionId) => void;
+  /** Disconnect all connections */
+  disconnectAll: () => void;
+  /** Send user input routed to the correct connection */
+  sendInput: (connectionId: ConnectionId, sessionId: UUID, content: string) => boolean;
+  /** Send answer to a question via the correct connection */
+  sendAnswer: (connectionId: ConnectionId, questionId: UUID, answer: string) => boolean;
+  /** Send a raw protocol message to a specific connection */
+  sendMessage: (connectionId: ConnectionId, message: ProtocolMessage) => boolean;
+  /** Request bullet expand via a specific connection */
+  requestBulletExpand: (connectionId: ConnectionId, sessionId: UUID, bulletId: number) => boolean;
+  /** Request session list from a specific connection */
+  requestSessionList: (connectionId: ConnectionId, includeExternal?: boolean) => boolean;
+  /** Request transcript load via a specific connection */
+  requestTranscriptLoad: (connectionId: ConnectionId, sessionId: string) => boolean;
+  /** Request new session via a specific connection */
+  requestNewSession: (connectionId: ConnectionId, directory?: string) => boolean;
+  /** Request resume session via a specific connection */
+  requestResumeSession: (connectionId: ConnectionId, sessionId: string) => boolean;
+  /** Request session history via a specific connection */
+  requestSessionHistory: (connectionId: ConnectionId, limit?: number) => boolean;
+  /** Provide unlocked identity for a connection needing passphrase */
+  provideIdentity: (connectionId: ConnectionId, identity: UnlockedIdentity) => void;
+  /** Whether any connection needs a passphrase */
+  needsPassphrase: boolean;
+  /** The connectionId that needs a passphrase (if any) */
+  passphraseConnectionId: ConnectionId | null;
+  /** Server fingerprint for the connection needing passphrase */
+  passphraseServerFingerprint: string | null;
+}
+
+/** Derive connectionId from a WebSocket URL */
+export function parseConnectionId(url: string): ConnectionId {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname || 'localhost';
+    const port = parsed.port || '18765';
+    return `${host}:${port}`;
+  } catch {
+    return url;
+  }
+}
+
+/** Sign an auth challenge with the given identity */
+async function signChallenge(
+  identity: UnlockedIdentity,
+  challenge: string,
+): Promise<ProtocolMessage> {
+  const challengeData = fromBase64(challenge);
+  const signature = await sign(identity.privateKey, challengeData);
+  return createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);
+}
+
+/** Derive ConnectionState from ManagedConnection (for React state) */
+function toConnectionState(mc: ManagedConnection): ConnectionState {
+  return {
+    connectionId: mc.connectionId,
+    url: mc.url,
+    status: mc.status,
+    mode: mc.mode,
+    needsPassphrase: mc.needsPassphrase,
+    serverFingerprint: mc.serverFingerprint,
+  };
+}
+
+export function useConnectionManager(
+  options: UseConnectionManagerOptions = {},
+): UseConnectionManagerReturn {
+  const {
+    onMessage,
+    unlockedIdentity,
+    clientId = 'remi-web',
+    clientVersion = '0.0.1',
+  } = options;
+
+  const connectionsMapRef = useRef<Map<ConnectionId, ManagedConnection>>(new Map());
+  const [connectionsState, setConnectionsState] = useState<readonly ConnectionState[]>([]);
+  const onMessageRef = useRef(onMessage);
+  const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
+
+  // Keep refs current
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
+
+  useEffect(() => {
+    if (unlockedIdentity) {
+      identityRef.current = unlockedIdentity;
+    }
+  }, [unlockedIdentity]);
+
+  /** Re-derive React state from the Map */
+  const syncState = useCallback(() => {
+    const states = Array.from(connectionsMapRef.current.values()).map(toConnectionState);
+    setConnectionsState(states);
+  }, []);
+
+  /** Get a managed connection by ID */
+  const getMc = useCallback((connectionId: ConnectionId): ManagedConnection | undefined => {
+    return connectionsMapRef.current.get(connectionId);
+  }, []);
+
+  /** Send hello to a specific connection's client */
+  const sendHello = useCallback((mc: ManagedConnection) => {
+    if (mc.helloSent) return;
+    mc.helloSent = true;
+    const resumeId = mc.sessionId ?? undefined;
+    mc.client.send(createHello(clientId, clientVersion, mc.directory, resumeId));
+  }, [clientId, clientVersion]);
+
+  /** Handle auth_challenge for a specific connection */
+  const handleAuthChallenge = useCallback(async (
+    mc: ManagedConnection,
+    challenge: string,
+    srvFingerprint: string,
+    srvPublicKey: string,
+  ) => {
+    mc.serverFingerprint = srvFingerprint;
+
+    // TOFU: check known hosts
+    const tofuResult = checkKnownHost(mc.url, srvFingerprint);
+    if (tofuResult === 'mismatch') {
+      mc.error = new Error(
+        `Server fingerprint changed for ${mc.url}. ` +
+        'This could indicate a MITM attack. Connection rejected.',
+      );
+      mc.client.disconnect();
+      syncState();
+      return;
+    }
+
+    mc.pendingChallenge = { challenge, serverPublicKey: srvPublicKey, serverFingerprint: srvFingerprint };
+
+    let identity = identityRef.current;
+    if (!identity) {
+      try {
+        await ensureIdentity();
+        if (!isIdentityEncrypted()) {
+          identity = await unlockStoredIdentity();
+          identityRef.current = identity;
+        } else {
+          mc.needsPassphrase = true;
+          syncState();
+          return;
+        }
+      } catch (err) {
+        mc.error = new Error(`Identity setup failed: ${err instanceof Error ? err.message : String(err)}`);
+        mc.client.disconnect();
+        syncState();
+        return;
+      }
+    }
+
+    try {
+      const response = await signChallenge(identity, challenge);
+      mc.client.send(response);
+    } catch (err) {
+      mc.error = new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`);
+      mc.client.disconnect();
+      syncState();
+    }
+  }, [syncState]);
+
+  /** Handle auth_result for a specific connection */
+  const handleAuthResult = useCallback(async (
+    mc: ManagedConnection,
+    success: boolean,
+    authError: string | undefined,
+    srvSignature: string | undefined,
+  ) => {
+    if (!success) {
+      mc.error = new Error(`Authentication failed: ${authError ?? 'unknown error'}`);
+      mc.client.disconnect();
+      syncState();
+      return;
+    }
+
+    if (!srvSignature || !mc.pendingChallenge) {
+      mc.error = new Error('Server did not provide mutual authentication signature');
+      mc.client.disconnect();
+      syncState();
+      return;
+    }
+
+    try {
+      const serverPubKey = await importPublicKey(
+        fromBase64(mc.pendingChallenge.serverPublicKey),
+      );
+      const challengeData = fromBase64(mc.pendingChallenge.challenge);
+      const valid = await verify(serverPubKey, challengeData, srvSignature);
+      if (!valid) {
+        mc.error = new Error('Server signature verification failed');
+        mc.client.disconnect();
+        syncState();
+        return;
+      }
+    } catch (err) {
+      mc.error = new Error(
+        `Server verification error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      mc.client.disconnect();
+      syncState();
+      return;
+    }
+
+    // TOFU: trust on first use
+    const pending = mc.pendingChallenge;
+    trustHost(mc.url, pending.serverFingerprint, pending.serverPublicKey);
+
+    mc.pendingChallenge = null;
+    mc.needsPassphrase = false;
+
+    // Auth passed; re-send hello
+    mc.helloSent = false;
+    mc.client.setConnected();
+    sendHello(mc);
+    syncState();
+  }, [sendHello, syncState]);
+
+  /** Create message handler for a specific connectionId */
+  const createMessageHandler = useCallback((connectionId: ConnectionId) => {
+    return (message: ProtocolMessage) => {
+      const mc = connectionsMapRef.current.get(connectionId);
+      if (!mc) return;
+
+      // Intercept auth messages
+      if (message.type === 'auth_challenge') {
+        handleAuthChallenge(
+          mc,
+          message.challenge,
+          message.serverFingerprint,
+          message.serverPublicKey,
+        ).catch((err) => {
+          mc.error = err instanceof Error ? err : new Error(String(err));
+          mc.client.disconnect();
+          syncState();
+        });
+        return;
+      }
+
+      if (message.type === 'auth_result') {
+        handleAuthResult(
+          mc,
+          message.success,
+          message.error,
+          message.serverSignature,
+        ).catch((err) => {
+          mc.error = err instanceof Error ? err : new Error(String(err));
+          mc.client.disconnect();
+          syncState();
+        });
+        return;
+      }
+
+      // Track session ID from hello_ack
+      if (message.type === 'hello_ack') {
+        mc.sessionId = message.sessionId;
+        if (mc.client && !mc.client.isConnected) {
+          mc.client.setConnected();
+        }
+        syncState();
+      }
+
+      // Forward to app handler with connectionId context
+      onMessageRef.current?.(connectionId, message);
+    };
+  }, [handleAuthChallenge, handleAuthResult, syncState]);
+
+  /** Start ping keep-alive for a connection */
+  const startPing = useCallback((mc: ManagedConnection) => {
+    if (mc.pingInterval) clearInterval(mc.pingInterval);
+    mc.pingInterval = setInterval(() => {
+      mc.client.send(createPing());
+    }, 30000);
+  }, []);
+
+  /** Stop ping keep-alive for a connection */
+  const stopPing = useCallback((mc: ManagedConnection) => {
+    if (mc.pingInterval) {
+      clearInterval(mc.pingInterval);
+      mc.pingInterval = undefined;
+    }
+  }, []);
+
+  // Connect to a daemon (direct WebSocket)
+  const connectDirect = useCallback((url: string, directory?: string): ConnectionId => {
+    const connectionId = parseConnectionId(url);
+
+    // If already connected to this host:port, disconnect first
+    const existing = connectionsMapRef.current.get(connectionId);
+    if (existing) {
+      stopPing(existing);
+      existing.client.disconnect();
+      connectionsMapRef.current.delete(connectionId);
+    }
+
+    const mc: ManagedConnection = {
+      client: null as unknown as WebSocketClient, // set below
+      connectionId,
+      url,
+      mode: 'direct',
+      status: 'disconnected',
+      error: null,
+      sessionId: null,
+      helloSent: false,
+      pendingChallenge: null,
+      needsPassphrase: false,
+      serverFingerprint: null,
+      directory,
+    };
+
+    const config: WebSocketClientConfig = {
+      url,
+      autoReconnect: true,
+    };
+
+    const messageHandler = createMessageHandler(connectionId);
+
+    const client = new WebSocketClient(config, {
+      onStatusChange: (newStatus) => {
+        mc.status = newStatus;
+
+        if (newStatus === 'authenticating') {
+          sendHello(mc);
+        }
+
+        if (newStatus === 'connected') {
+          startPing(mc);
+        }
+
+        if (newStatus === 'disconnected') {
+          mc.sessionId = null;
+          mc.helloSent = false;
+          stopPing(mc);
+        }
+
+        syncState();
+      },
+      onMessage: messageHandler,
+      onError: (err) => {
+        console.error(`[ConnectionManager] Error on ${connectionId}:`, err);
+        mc.error = err;
+        syncState();
+      },
+    });
+
+    mc.client = client;
+    connectionsMapRef.current.set(connectionId, mc);
+    client.connect();
+    syncState();
+
+    return connectionId;
+  }, [createMessageHandler, sendHello, startPing, stopPing, syncState]);
+
+  // Disconnect a specific connection
+  const disconnect = useCallback((connectionId: ConnectionId) => {
+    const mc = connectionsMapRef.current.get(connectionId);
+    if (!mc) return;
+    stopPing(mc);
+    mc.client.disconnect();
+    connectionsMapRef.current.delete(connectionId);
+    syncState();
+  }, [stopPing, syncState]);
+
+  // Disconnect all
+  const disconnectAll = useCallback(() => {
+    for (const mc of connectionsMapRef.current.values()) {
+      stopPing(mc);
+      mc.client.disconnect();
+    }
+    connectionsMapRef.current.clear();
+    syncState();
+  }, [stopPing, syncState]);
+
+  // --- Send methods: route through the correct connection's client ---
+
+  const sendToConnection = useCallback((connectionId: ConnectionId, message: ProtocolMessage): boolean => {
+    const mc = getMc(connectionId);
+    if (!mc) return false;
+    return mc.client.send(message);
+  }, [getMc]);
+
+  const sendInput = useCallback((connectionId: ConnectionId, sessionId: UUID, content: string): boolean => {
+    return sendToConnection(connectionId, createUserInput(sessionId, content));
+  }, [sendToConnection]);
+
+  const sendAnswer = useCallback((connectionId: ConnectionId, questionId: UUID, answer: string): boolean => {
+    const msg: ProtocolMessage = {
+      type: 'answer',
+      id: generateId(),
+      timestamp: now(),
+      questionId,
+      answer,
+    };
+    return sendToConnection(connectionId, msg);
+  }, [sendToConnection]);
+
+  const sendMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage): boolean => {
+    return sendToConnection(connectionId, message);
+  }, [sendToConnection]);
+
+  const requestBulletExpand = useCallback(
+    (connectionId: ConnectionId, sessionId: UUID, bulletId: number): boolean => {
+      return sendToConnection(connectionId, createBulletExpandRequest(sessionId, bulletId));
+    },
+    [sendToConnection],
+  );
+
+  const requestSessionList = useCallback((connectionId: ConnectionId, includeExternal?: boolean): boolean => {
+    return sendToConnection(connectionId, createSessionListRequest(includeExternal));
+  }, [sendToConnection]);
+
+  const requestTranscriptLoad = useCallback((connectionId: ConnectionId, sessionId: string): boolean => {
+    return sendToConnection(connectionId, createTranscriptLoadRequest(sessionId));
+  }, [sendToConnection]);
+
+  const requestNewSession = useCallback((connectionId: ConnectionId, directory?: string): boolean => {
+    return sendToConnection(connectionId, createCreateSessionRequest(directory));
+  }, [sendToConnection]);
+
+  const requestResumeSession = useCallback((connectionId: ConnectionId, sessionId: string): boolean => {
+    return sendToConnection(connectionId, createResumeSessionRequest(sessionId));
+  }, [sendToConnection]);
+
+  const requestSessionHistory = useCallback((connectionId: ConnectionId, limit?: number): boolean => {
+    return sendToConnection(connectionId, createSessionHistoryRequest(limit));
+  }, [sendToConnection]);
+
+  // Provide identity for a connection waiting on passphrase
+  const provideIdentity = useCallback((connectionId: ConnectionId, identity: UnlockedIdentity) => {
+    identityRef.current = identity;
+
+    const mc = getMc(connectionId);
+    if (!mc || !mc.pendingChallenge) return;
+
+    mc.needsPassphrase = false;
+    syncState();
+
+    signChallenge(identity, mc.pendingChallenge.challenge)
+      .then((response) => mc.client.send(response))
+      .catch((err) => {
+        mc.error = new Error(`Auth failed: ${err instanceof Error ? err.message : String(err)}`);
+        mc.client.disconnect();
+        syncState();
+      });
+  }, [getMc, syncState]);
+
+  // Derived: passphrase state
+  const passphraseConnection = Array.from(connectionsMapRef.current.values()).find(
+    (mc) => mc.needsPassphrase,
+  );
+  const needsPassphrase = passphraseConnection != null;
+  const passphraseConnectionId = passphraseConnection?.connectionId ?? null;
+  const passphraseServerFingerprint = passphraseConnection?.serverFingerprint ?? null;
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      for (const mc of connectionsMapRef.current.values()) {
+        if (mc.pingInterval) clearInterval(mc.pingInterval);
+        mc.client.disconnect();
+      }
+      connectionsMapRef.current.clear();
+    };
+  }, []);
+
+  return {
+    connections: connectionsState,
+    connectDirect,
+    disconnect,
+    disconnectAll,
+    sendInput,
+    sendAnswer,
+    sendMessage,
+    requestBulletExpand,
+    requestSessionList,
+    requestTranscriptLoad,
+    requestNewSession,
+    requestResumeSession,
+    requestSessionHistory,
+    provideIdentity,
+    needsPassphrase,
+    passphraseConnectionId,
+    passphraseServerFingerprint,
+  };
+}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -4,6 +4,7 @@
  * Manages N simultaneous WebSocket connections to different daemons.
  * Each connection has its own auth state, session, and message routing.
  * WebSocketClient instances are created per connection and stored in a Map.
+ * Connections are keyed by host:port; connecting to the same endpoint replaces any existing connection.
  */
 
 import {
@@ -39,6 +40,10 @@ import {
 } from '@remi/shared/protocol.ts';
 import type { UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+function makeConnectionId(raw: string): ConnectionId {
+  return raw as ConnectionId;
+}
 
 /** Internal per-connection state */
 interface ManagedConnection {
@@ -111,15 +116,16 @@ export interface UseConnectionManagerReturn {
   passphraseServerFingerprint: string | null;
 }
 
-/** Derive connectionId from a WebSocket URL */
+/** Derive connectionId (host:port) from a WebSocket URL. Falls back to port 18765 if not specified. */
 export function parseConnectionId(url: string): ConnectionId {
   try {
     const parsed = new URL(url);
     const host = parsed.hostname || 'localhost';
     const port = parsed.port || '18765';
-    return `${host}:${port}`;
-  } catch {
-    return url;
+    return makeConnectionId(`${host}:${port}`);
+  } catch (err) {
+    console.warn(`[ConnectionManager] Failed to parse URL "${url}":`, err);
+    return makeConnectionId(url);
   }
 }
 
@@ -142,6 +148,7 @@ function toConnectionState(mc: ManagedConnection): ConnectionState {
     mode: mc.mode,
     needsPassphrase: mc.needsPassphrase,
     serverFingerprint: mc.serverFingerprint,
+    error: mc.error?.message ?? null,
   };
 }
 
@@ -160,7 +167,6 @@ export function useConnectionManager(
   const onMessageRef = useRef(onMessage);
   const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
 
-  // Keep refs current
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
@@ -292,7 +298,7 @@ export function useConnectionManager(
     mc.pendingChallenge = null;
     mc.needsPassphrase = false;
 
-    // Auth passed; re-send hello
+    // Auth complete; reset helloSent flag so sendHello dispatches the authenticated hello
     mc.helloSent = false;
     mc.client.setConnected();
     sendHello(mc);
@@ -303,7 +309,10 @@ export function useConnectionManager(
   const createMessageHandler = useCallback((connectionId: ConnectionId) => {
     return (message: ProtocolMessage) => {
       const mc = connectionsMapRef.current.get(connectionId);
-      if (!mc) return;
+      if (!mc) {
+        console.debug(`[ConnectionManager] Dropping message for disconnected connection "${connectionId}":`, message.type);
+        return;
+      }
 
       // Intercept auth messages
       if (message.type === 'auth_challenge') {
@@ -377,7 +386,10 @@ export function useConnectionManager(
     }
 
     const mc: ManagedConnection = {
-      client: null as unknown as WebSocketClient, // set below
+      // client is initialized after this object because WebSocketClient callbacks
+      // reference mc. The client is assigned on the next line after new WebSocketClient().
+      // No callbacks fire synchronously during construction, so this is safe.
+      client: null as unknown as WebSocketClient,
       connectionId,
       url,
       mode: 'direct',
@@ -454,11 +466,12 @@ export function useConnectionManager(
     syncState();
   }, [stopPing, syncState]);
 
-  // --- Send methods: route through the correct connection's client ---
-
   const sendToConnection = useCallback((connectionId: ConnectionId, message: ProtocolMessage): boolean => {
     const mc = getMc(connectionId);
-    if (!mc) return false;
+    if (!mc) {
+      console.warn(`[ConnectionManager] Cannot send ${message.type}: connection "${connectionId}" not found`);
+      return false;
+    }
     return mc.client.send(message);
   }, [getMc]);
 
@@ -513,7 +526,14 @@ export function useConnectionManager(
     identityRef.current = identity;
 
     const mc = getMc(connectionId);
-    if (!mc || !mc.pendingChallenge) return;
+    if (!mc) {
+      console.warn(`[ConnectionManager] Cannot provide identity: connection "${connectionId}" not found`);
+      return;
+    }
+    if (!mc.pendingChallenge) {
+      console.warn(`[ConnectionManager] No pending auth challenge for "${connectionId}"`);
+      return;
+    }
 
     mc.needsPassphrase = false;
     syncState();

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -527,10 +527,8 @@ export function useConnectionManager(
       });
   }, [getMc, syncState]);
 
-  // Derived: passphrase state
-  const passphraseConnection = Array.from(connectionsMapRef.current.values()).find(
-    (mc) => mc.needsPassphrase,
-  );
+  // Derived: passphrase state (from React state, not mutable ref)
+  const passphraseConnection = connectionsState.find((c) => c.needsPassphrase);
   const needsPassphrase = passphraseConnection != null;
   const passphraseConnectionId = passphraseConnection?.connectionId ?? null;
   const passphraseServerFingerprint = passphraseConnection?.serverFingerprint ?? null;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -21,6 +21,19 @@ export type ConnectionStatus =
   | 'reconnecting'
   | 'error';
 
+/** Unique identifier for a daemon connection (e.g. "localhost:18765" or "relay:abc123") */
+export type ConnectionId = string;
+
+/** Per-connection state tracked by the connection manager */
+export interface ConnectionState {
+  readonly connectionId: ConnectionId;
+  readonly url: string;
+  readonly status: ConnectionStatus;
+  readonly mode: 'direct' | 'relay';
+  readonly needsPassphrase: boolean;
+  readonly serverFingerprint: string | null;
+}
+
 /** Agent status as displayed in the UI */
 export type AgentStatus = 'idle' | 'thinking' | 'executing' | 'waiting';
 
@@ -50,6 +63,8 @@ export interface UIBullet {
 export interface UIMessage {
   readonly id: UUID;
   readonly sessionId: UUID;
+  /** Which daemon connection this message arrived from */
+  readonly connectionId?: ConnectionId;
   readonly sender: MessageSender;
   readonly content: string;
   readonly timestamp: Timestamp;
@@ -77,6 +92,8 @@ export interface UIMessage {
 export interface UISession {
   readonly id: UUID;
   readonly name: string;
+  /** Which daemon connection this session belongs to */
+  readonly connectionId?: ConnectionId;
   readonly createdAt: Timestamp;
   readonly lastActiveAt: Timestamp;
   readonly status: AgentStatus;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -21,8 +21,8 @@ export type ConnectionStatus =
   | 'reconnecting'
   | 'error';
 
-/** Unique identifier for a daemon connection (e.g. "localhost:18765" or "relay:abc123") */
-export type ConnectionId = string;
+/** Unique identifier for a daemon connection (e.g. "localhost:18765") */
+export type ConnectionId = string & { readonly __brand: 'ConnectionId' };
 
 /** Per-connection state tracked by the connection manager */
 export interface ConnectionState {
@@ -32,6 +32,7 @@ export interface ConnectionState {
   readonly mode: 'direct' | 'relay';
   readonly needsPassphrase: boolean;
   readonly serverFingerprint: string | null;
+  readonly error: string | null;
 }
 
 /** Agent status as displayed in the UI */
@@ -93,7 +94,7 @@ export interface UISession {
   readonly id: UUID;
   readonly name: string;
   /** Which daemon connection this session belongs to */
-  readonly connectionId?: ConnectionId;
+  readonly connectionId: ConnectionId;
   readonly createdAt: Timestamp;
   readonly lastActiveAt: Timestamp;
   readonly status: AgentStatus;


### PR DESCRIPTION
## Summary

- Add `useConnectionManager` hook managing N concurrent WebSocket connections to different daemon ports
- Refactor App.tsx from single-connection `useWebSocket` to multi-connection architecture
- Each connection has independent auth, session tracking, ping keep-alive, and reconnection
- Session list merges sessions from all connected daemons with connection grouping
- Messages and input routed to the correct daemon based on the active session's `connectionId`
- "+" button in SessionList to add new connections, per-connection disconnect support
- Add `ConnectionId`, `ConnectionState` types; extend `UISession` and `UIMessage` with `connectionId`

## Files changed

- `types/index.ts` - Add ConnectionId, ConnectionState, extend UISession/UIMessage
- `hooks/useConnectionManager.ts` - **New**: multi-connection management hook
- `hooks/index.ts` - Export new hook
- `App.tsx` - Major refactor: swap hook, update message routing, session merging
- `components/session/SessionList.tsx` - Connection grouping, "+" button, disconnect

**Untouched**: `websocket-client.ts`, `signaling-client.ts`, `identity-client.ts`

## Test plan

- [x] TypeScript compiles clean
- [x] Vite build succeeds (456KB bundle)
- [x] All 1317 tests pass
- [x] Biome lint clean
- [ ] Manual: connect to one daemon, verify sessions load
- [ ] Manual: add second daemon via "+", verify both sessions appear grouped
- [ ] Manual: switch between sessions, verify input routes correctly
- [ ] Manual: disconnect one daemon, verify only its sessions show disconnected
- [ ] Test on iOS device

Closes #208