### PR TITLE
fix: iOS layout, message filtering, and session connectivity

### DIFF
--- a/packages/web/capacitor.config.ts
+++ b/packages/web/capacitor.config.ts
@@ -9,11 +9,11 @@ const config: CapacitorConfig = {
     allowNavigation: ['*'],
   },
   ios: {
-    // Use WKWebView configuration for better performance
     contentInset: 'automatic',
     preferredContentMode: 'mobile',
-    // Support dark mode
     overrideUserAgent: 'Remi/1.0 iOS',
+    backgroundColor: '#1a1d21',
+    scrollEnabled: false,
   },
   android: {
     // Use AndroidX WebView
@@ -27,7 +27,7 @@ const config: CapacitorConfig = {
       backgroundColor: '#1a1d21',
     },
     Keyboard: {
-      resize: 'body',
+      resize: 'none',
       scrollPadding: false,
     },
   },

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -47,15 +47,19 @@ const toolOutputPatterns = [
   /^Added \d+ lines?, removed \d+ lines?/,
   /^Read \d+ lines?/,
   /^Wrote \d+ lines?/,
-  /^Created \S+/,
-  /^Deleted \S+/,
-  /^Modified \S+/,
+  /^Created \S+$/,
+  /^Deleted \S+$/,
+  /^Modified \S+$/,
   /^\$ .+/, // Shell command echo ($ ls /path)
   /^\d+ files? (changed|modified|deleted|created)/,
   /^\[[\d/]+\]\s/, // Progress indicators like [0/1], [3/5]
+  /^\[\d+-[a-z]/, // Kernel/system log prefixes like [8-virtio-console...]
   /^To https:\/\/github\.com\//, // git push output
   /^\w+ \| \d+ [+-]+$/, // git diff stat lines
   /^\d+ (insertions?|deletions?)\(/, // git diff summary
+  /^\d+ messages$/, // Session message count
+  /^[a-f0-9]{7,40}$/, // Bare git commit hashes
+  /^feat:|^fix:|^chore:|^docs:|^refactor:|^test:/, // Commit message prefixes (tool output)
 ];
 
 function isToolOutputNoise(content: string): boolean {
@@ -297,6 +301,11 @@ function App() {
         // Handle structured message with bullets (from PTY stream)
         const structuredMsg = message.message;
 
+        // Filter out tool output noise from agent messages
+        if (structuredMsg.sender === 'agent' && isToolOutputNoise(structuredMsg.content)) {
+          break;
+        }
+
         const uiBullets = toBullets(structuredMsg.bullets);
 
         setMessages((prev) => {
@@ -437,8 +446,9 @@ function App() {
             // Only show resume for dead sessions (completed/orphaned), never for idle/active
             const isDead = ds.status !== 'active' && ds.status !== 'idle';
             const showResume = isDead && !ds.canAttach && ds.canResume;
-            // If this session is the one we're actively connected to, keep it connected
+            // Check if this session is the one we're directly attached to via hello_ack
             const isActiveSession = ds.sessionId === activeSessionIdRef.current;
+            const isAttachedSession = !ds.canAttach && ds.status === 'active' && ds.source === 'daemon';
             return {
               id: ds.sessionId as UUID,
               name: ds.name || ds.projectPath.split('/').pop() || 'Session',
@@ -446,7 +456,7 @@ function App() {
               createdAt: ds.lastActivity,
               lastActiveAt: ds.lastActivity,
               status: mapSessionStatus(ds.status),
-              connectionStatus: (isActiveSession || ds.canAttach) ? ('connected' as const) : ('disconnected' as const),
+              connectionStatus: (isActiveSession || isAttachedSession || ds.canAttach) ? ('connected' as const) : ('disconnected' as const),
               unreadCount: 0,
               cwd: ds.projectPath,
               preview: cleanPreview.slice(0, 100),
@@ -471,8 +481,7 @@ function App() {
           const attachedSession = prev.find(
             (s) =>
               s.connectionId === connectionId &&
-              s.connectionStatus === 'connected' &&
-              s.id === activeSessionIdRef.current,
+              s.connectionStatus === 'connected',
           );
           const discoveredIds = new Set(discovered.map((s) => s.id));
           // Start with sessions from other connections

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -14,6 +14,7 @@ async function initNative(): Promise<void> {
     window.matchMedia('(prefers-color-scheme: dark)').matches;
 
   await StatusBar.setStyle({ style: prefersDark ? Style.Dark : Style.Light });
+  await StatusBar.setOverlaysWebView({ overlay: true });
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary

- Fix iOS edge-to-edge layout: set WebView background color, enable StatusBar overlay, set keyboard resize to none
- Apply tool output noise filter to PTY stream path (was only on transcript path); add more filter patterns
- Fix attached session losing 'connected' status when session_list_response overwrites it
- Fix merge logic to find attached session without requiring activeSessionId

## Test plan

- [x] TypeScript compiles clean
- [x] Vite build succeeds  
- [x] Tested on iPhone 17 Pro simulator: session list shows all sessions, chat view filters noise, input enabled on attached session

Follow-up to #208, #214