### PR TITLE
fix: session connectivity, message filtering, and haptics

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -42,6 +42,8 @@ const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
  */
 const toolOutputPatterns = [
   /^\(No output\)$/,
+  /^Done\.?$/i,
+  /^OK\.?$/i,
   /^Added \d+ lines?/,
   /^Removed \d+ lines?/,
   /^Added \d+ lines?, removed \d+ lines?/,
@@ -50,6 +52,7 @@ const toolOutputPatterns = [
   /^Created \S+$/,
   /^Deleted \S+$/,
   /^Modified \S+$/,
+  /^Error editing file$/,
   /^\$ .+/, // Shell command echo ($ ls /path)
   /^\d+ files? (changed|modified|deleted|created)/,
   /^\[[\d/]+\]\s/, // Progress indicators like [0/1], [3/5]
@@ -59,7 +62,13 @@ const toolOutputPatterns = [
   /^\d+ (insertions?|deletions?)\(/, // git diff summary
   /^\d+ messages$/, // Session message count
   /^[a-f0-9]{7,40}$/, // Bare git commit hashes
-  /^feat:|^fix:|^chore:|^docs:|^refactor:|^test:/, // Commit message prefixes (tool output)
+  /^feat:|^fix:|^chore:|^docs:|^refactor:|^test:/, // Commit message prefixes
+  /^Sources?\//i, // Source file paths
+  /^Tests?\//i, // Test file paths
+  /^packages?\//i, // Package file paths
+  /^\[[\w\s]+\]$/, // Bare bracketed labels like [Kernel Boot], [HV Diagnostic]
+  /^vm_\w+::/i, // VM function calls
+  /^Error \w+ file$/i, // Tool errors like "Error editing file"
 ];
 
 function isToolOutputNoise(content: string): boolean {
@@ -148,6 +157,7 @@ function App() {
   const activeSessionIdRef = useRef<UUID | null>(null);
   const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
+  const connectionsRef = useRef<readonly import('@/types').ConnectionState[]>([]);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -429,6 +439,9 @@ function App() {
       }
 
       case 'session_list_response': {
+        // Look up the hello_ack session ID for this connection
+        const thisConn = connectionsRef.current.find((c) => c.connectionId === connectionId);
+        const helloAckSessionId = thisConn?.sessionId ?? null;
         // Map, filter, and sort DiscoverableSession[] to UISession[]
         const discovered: UISession[] = message.sessions
           .filter((ds: DiscoverableSession) => {
@@ -448,7 +461,7 @@ function App() {
             const showResume = isDead && !ds.canAttach && ds.canResume;
             // Check if this session is the one we're directly attached to via hello_ack
             const isActiveSession = ds.sessionId === activeSessionIdRef.current;
-            const isAttachedSession = !ds.canAttach && ds.status === 'active' && ds.source === 'daemon';
+            const isAttachedViaHelloAck = ds.sessionId === helloAckSessionId;
             return {
               id: ds.sessionId as UUID,
               name: ds.name || ds.projectPath.split('/').pop() || 'Session',
@@ -456,7 +469,7 @@ function App() {
               createdAt: ds.lastActivity,
               lastActiveAt: ds.lastActivity,
               status: mapSessionStatus(ds.status),
-              connectionStatus: (isActiveSession || isAttachedSession || ds.canAttach) ? ('connected' as const) : ('disconnected' as const),
+              connectionStatus: (isActiveSession || isAttachedViaHelloAck || ds.canAttach) ? ('connected' as const) : ('disconnected' as const),
               unreadCount: 0,
               cwd: ds.projectPath,
               preview: cleanPreview.slice(0, 100),
@@ -638,6 +651,9 @@ function App() {
     clientId: 'remi-web',
     clientVersion: '0.0.1',
   });
+
+  // Keep connections ref in sync for use in handleMessage callbacks
+  connectionsRef.current = connections;
 
   // Derived connection status
   const hasAnyConnected = connections.some((c) => c.status === 'connected');

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { UIQuestion } from '@/types';
+import { hapticImpact } from '@/lib/haptics';
 import { clsx } from 'clsx';
 import { Send, StopCircle } from 'lucide-react';
 import {
@@ -111,6 +112,7 @@ export function InputArea({
       sendingRef.current = true;
 
       // Send message
+      hapticImpact('light');
       onSend(trimmed);
 
       // Clear input
@@ -135,6 +137,7 @@ export function InputArea({
       return;
     }
 
+    hapticImpact('light');
     onSend(trimmed);
     setValue('');
 

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -149,6 +149,7 @@ function toConnectionState(mc: ManagedConnection): ConnectionState {
     needsPassphrase: mc.needsPassphrase,
     serverFingerprint: mc.serverFingerprint,
     error: mc.error?.message ?? null,
+    sessionId: mc.sessionId,
   };
 }
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -33,6 +33,8 @@ export interface ConnectionState {
   readonly needsPassphrase: boolean;
   readonly serverFingerprint: string | null;
   readonly error: string | null;
+  /** The session ID from hello_ack (the directly attached session) */
+  readonly sessionId: string | null;
 }
 
 /** Agent status as displayed in the UI */


### PR DESCRIPTION
## Summary

- Fix attached session not showing as 'connected': expose hello_ack sessionId in ConnectionState, use it to correctly identify the directly attached session in session_list_response merge
- Expand message filter patterns: "Done", "OK", bracketed labels, VM calls, file paths
- Add haptic feedback on message send (light impact)

## Test plan

- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [x] Simulator: attached session now shows "Type a message..." (enabled input)
- [x] Simulator: tool output noise significantly reduced in chat view

Follow-up to #208, #214, #215