### PR TITLE
feat: app lifecycle handling and improved message filtering

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -735,6 +735,17 @@ function App() {
     }
   }, []);
 
+  // Refresh session lists when app resumes from background
+  useEffect(() => {
+    const handleResume = () => {
+      for (const id of connectedIds) {
+        requestSessionList(id, true);
+      }
+    };
+    document.addEventListener('app-resume', handleResume);
+    return () => document.removeEventListener('app-resume', handleResume);
+  }, [connectedIds, requestSessionList]);
+
   // Get active session
   const activeSession = sessions.find((s) => s.id === activeSessionId);
   const sessionMessages = messages.filter((m) => m.sessionId === activeSessionId);

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,3 +1,4 @@
+import { App as CapApp } from '@capacitor/app';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -15,6 +16,19 @@ async function initNative(): Promise<void> {
 
   await StatusBar.setStyle({ style: prefersDark ? Style.Dark : Style.Light });
   await StatusBar.setOverlaysWebView({ overlay: true });
+
+  // Handle hardware back button (Android) and app state changes
+  await CapApp.addListener('backButton', ({ canGoBack }) => {
+    if (canGoBack) {
+      window.history.back();
+    }
+  });
+
+  await CapApp.addListener('appStateChange', ({ isActive }) => {
+    if (isActive) {
+      document.dispatchEvent(new CustomEvent('app-resume'));
+    }
+  });
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary

- Wire up @capacitor/app for hardware back button and app state changes
- Refresh session lists when app resumes from background
- Expand message filter patterns (Done, OK, bracketed labels, VM calls, file paths)

## Test plan

- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [ ] Test app resume behavior on iOS
- [ ] Verify back button works on Android

Follow-up to #208