### PR TITLE
feat: local push notifications for question prompts

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import { SettingsPanel } from '@/components/settings';
 import { useConnectionManager, parseConnectionId } from '@/hooks';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
+import { notifyQuestion } from '@/lib/notifications';
 import type {
   AppSettings,
   ConnectionId,
@@ -167,6 +168,7 @@ function App() {
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
   const connectionsRef = useRef<readonly import('@/types').ConnectionState[]>([]);
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
+  const sessionsRef = useRef<UISession[]>([]);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -435,6 +437,12 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === questionSessionId ? { ...s, questionPending: true } : s)),
         );
+
+        // Send local notification if user isn't viewing this session
+        if (questionSessionId !== activeSessionIdRef.current || document.hidden) {
+          const sessionName = sessionsRef.current.find((s) => s.id === questionSessionId)?.name || 'Agent';
+          notifyQuestion(sessionName, q.text);
+        }
         break;
       }
 
@@ -693,6 +701,7 @@ function App() {
   // Keep refs in sync for use in handleMessage callbacks
   connectionsRef.current = connections;
   getSessionIdRef.current = getSessionId;
+  sessionsRef.current = sessions;
 
   // Derived connection status
   const hasAnyConnected = connections.some((c) => c.status === 'connected');

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -1,0 +1,95 @@
+/**
+ * Local notification utilities for Remi.
+ *
+ * Wraps @capacitor/local-notifications to send notifications when:
+ * - A question/permission prompt arrives from the agent
+ * - A session completes or errors
+ *
+ * Notifications are only sent when the app is in the background
+ * or the user is viewing a different session.
+ */
+
+import { LocalNotifications } from '@capacitor/local-notifications';
+import { isNative } from './platform';
+
+let permissionGranted = false;
+let notificationIdCounter = 1;
+
+/** Request notification permission. Call once on app startup. */
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (!isNative()) return false;
+  try {
+    const result = await LocalNotifications.requestPermissions();
+    permissionGranted = result.display === 'granted';
+    return permissionGranted;
+  } catch (err) {
+    console.warn('[Notifications] Permission request failed:', err);
+    return false;
+  }
+}
+
+/** Check if notifications are enabled (permission granted + user setting). */
+export function canNotify(): boolean {
+  return permissionGranted;
+}
+
+/** Send a notification for a question/permission prompt. */
+export async function notifyQuestion(sessionName: string, prompt: string): Promise<void> {
+  if (!permissionGranted) return;
+  try {
+    await LocalNotifications.schedule({
+      notifications: [
+        {
+          title: `${sessionName} needs input`,
+          body: prompt.length > 100 ? `${prompt.slice(0, 97)}...` : prompt,
+          id: notificationIdCounter++,
+          schedule: { at: new Date() },
+          sound: 'default',
+          actionTypeId: 'QUESTION',
+        },
+      ],
+    });
+  } catch (err) {
+    console.warn('[Notifications] Failed to schedule question notification:', err);
+  }
+}
+
+/** Send a notification for session completion. */
+export async function notifySessionComplete(sessionName: string): Promise<void> {
+  if (!permissionGranted) return;
+  try {
+    await LocalNotifications.schedule({
+      notifications: [
+        {
+          title: `${sessionName} finished`,
+          body: 'The agent has completed its work.',
+          id: notificationIdCounter++,
+          schedule: { at: new Date() },
+          sound: 'default',
+        },
+      ],
+    });
+  } catch (err) {
+    console.warn('[Notifications] Failed to schedule completion notification:', err);
+  }
+}
+
+/** Send a notification for a session error. */
+export async function notifySessionError(sessionName: string, error: string): Promise<void> {
+  if (!permissionGranted) return;
+  try {
+    await LocalNotifications.schedule({
+      notifications: [
+        {
+          title: `${sessionName} error`,
+          body: error.length > 100 ? `${error.slice(0, 97)}...` : error,
+          id: notificationIdCounter++,
+          schedule: { at: new Date() },
+          sound: 'default',
+        },
+      ],
+    });
+  } catch (err) {
+    console.warn('[Notifications] Failed to schedule error notification:', err);
+  }
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { requestNotificationPermission } from './lib/notifications';
 import { isNative } from './lib/platform';
 
 /** Initialize native platform features after React mount */
@@ -29,6 +30,9 @@ async function initNative(): Promise<void> {
       document.dispatchEvent(new CustomEvent('app-resume'));
     }
   });
+
+  // Request notification permission
+  await requestNotificationPermission();
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary

- Add `notifications.ts` utility wrapping `@capacitor/local-notifications`
- Request notification permission on app startup (iOS permission dialog)
- Send local notification when an agent question/permission prompt arrives and the user isn't viewing that session (or app is in background)
- Add `notifySessionComplete` and `notifySessionError` for future use

## Test plan

- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [x] Simulator: notification permission dialog appears on first launch
- [ ] Test: receive a question notification when app is backgrounded
- [ ] Test on physical device

Closes #51 (partially -- local notifications, not remote push)