### PR TITLE
fix: keyboard scroll to bottom and status output filtering

### DIFF
--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -95,6 +95,7 @@ export function ChatView({
         onRetry={onRetry}
         onBulletExpand={onBulletExpand}
         viewMode={viewMode}
+        keyboardVisible={keyboardVisible}
       />
 
       {/* Question card in chat mode */}

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -20,6 +20,7 @@ interface MessageListProps {
   readonly onRetry?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
   readonly viewMode?: ViewMode;
+  readonly keyboardVisible?: boolean;
   readonly className?: string;
 }
 
@@ -121,6 +122,7 @@ export function MessageList({
   onRetry,
   onBulletExpand,
   viewMode = 'compact',
+  keyboardVisible = false,
   className,
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -152,6 +154,15 @@ export function MessageList({
     shouldAutoScrollRef.current = true;
     setShowJumpButton(false);
   }, []);
+
+  // Scroll to bottom when keyboard opens
+  useEffect(() => {
+    if (keyboardVisible) {
+      requestAnimationFrame(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      });
+    }
+  }, [keyboardVisible]);
 
   // Show typing indicator when agent is thinking/executing
   const showTyping = agentStatus === 'thinking' || agentStatus === 'executing';

--- a/packages/web/src/lib/message-filter.ts
+++ b/packages/web/src/lib/message-filter.ts
@@ -50,6 +50,16 @@ const toolOutputPatterns = [
   /^\/Users\/\S+$/i, // Bare absolute file paths
   /^[a-z_]+_t$/i, // C/Swift type names like operating_modes_t
   /^Let me fix:?$/i, // Short tool action phrases
+  /^\w+ing\.{3}$/i, // Thinking status words ("Thinking...", "Compiling...")
+  /^\w+ing…$/i, // Same with ellipsis char
+  /^Set model to\b/i, // Model switch notifications
+  /^\[[\w\s.-]+\]\s*$/i, // Bracketed status like [task-name]
+  /^Billed\b/i, // Billing info
+  /^↓\s*\d/i, // Token count indicators (↓ 310 tokens)
+  /^·\s/i, // Middle dot bullet points (Claude Code status)
+  /^\d+%\s*conte?x?t?/i, // Context percentage (85% context)
+  /^Using\s/i, // "Using model X" status
+  /^Switching\s/i, // "Switching to..." status
 ];
 
 /** Patterns for content that contains XML/protocol tags that should be stripped */


### PR DESCRIPTION
## Summary
- Scroll message list to bottom when keyboard opens (passes keyboardVisible to MessageList)
- Filter thinking status words, model switch, billing, token counts, context percentage, bracketed status

Closes #226 (partially)