### PR TITLE
feat: Phase 1 - transcript-only messages, PTY for status only

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,7 +11,7 @@ import { SettingsPanel } from '@/components/settings';
 import { useConnectionManager, parseConnectionId } from '@/hooks';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
-import { cleanPreviewText, isToolOutputNoise, stripProtocolTags } from '@/lib/message-filter';
+import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { notifyQuestion } from '@/lib/notifications';
 import type {
   AppSettings,
@@ -173,14 +173,11 @@ function App() {
         const { sessionId, entryUuid, role, content, isUpdate } = message;
         const structuredMsg = message.message;
 
-        // Filter out tool output noise from agent messages (not updates or user messages)
-        if (!isUpdate && role === 'assistant' && isToolOutputNoise(structuredMsg.content || content)) {
-          break;
-        }
-
-        // Skip user messages that are entirely protocol tags (empty after stripping)
+        // Skip empty messages and strip protocol tags from user messages
+        const rawContent = structuredMsg.content || content;
+        if (!rawContent || !rawContent.trim()) break;
         if (!isUpdate && role === 'user') {
-          const stripped = stripProtocolTags(structuredMsg.content || content);
+          const stripped = stripProtocolTags(rawContent);
           if (!stripped) break;
         }
 
@@ -267,70 +264,14 @@ function App() {
       }
 
       case 'structured_agent_output': {
-        // Handle structured message with bullets (from PTY stream)
+        // PTY stream: use ONLY for status updates, NOT for message content.
+        // All chat messages come from transcript_content (clean JSONL data).
         const structuredMsg = message.message;
-
-        // Filter out tool output noise from agent messages
-        if (structuredMsg.sender === 'agent' && isToolOutputNoise(structuredMsg.content)) {
-          break;
-        }
-
-        const uiBullets = toBullets(structuredMsg.bullets);
-
-        setMessages((prev) => {
-          // Same-type dedup by message ID (streaming updates)
-          const existingIndex = prev.findIndex((m) => m.id === structuredMsg.id);
-          if (existingIndex >= 0) {
-            return prev.map((m, i) =>
-              i === existingIndex
-                ? {
-                    ...m,
-                    content: structuredMsg.content,
-                    isEditing: structuredMsg.isEditing,
-                    tool: structuredMsg.tool,
-                    bullets: uiBullets,
-                    firstBulletId: structuredMsg.firstBulletId,
-                    lastBulletId: structuredMsg.lastBulletId,
-                  }
-                : m,
-            );
-          }
-
-          // Cross-type dedup via extracted pure function
-          const dedup = deduplicateMessage(prev, {
-            sessionId: structuredMsg.sessionId,
-            sender: structuredMsg.sender,
-            content: structuredMsg.content,
-            source: 'pty',
-          });
-          if (dedup.action === 'skip') {
-            return prev;
-          }
-
-          const uiMessage: UIMessage = {
-            id: structuredMsg.id,
-            sessionId: structuredMsg.sessionId,
-            connectionId,
-            sender: structuredMsg.sender,
-            content: structuredMsg.content,
-            timestamp: structuredMsg.createdAt,
-            state: structuredMsg.state,
-            isEditing: structuredMsg.isEditing,
-            tool: structuredMsg.tool,
-            source: 'pty',
-            bullets: uiBullets,
-            firstBulletId: structuredMsg.firstBulletId,
-            lastBulletId: structuredMsg.lastBulletId,
-          };
-          return [...prev, uiMessage];
-        });
-
         setSessions((prev) =>
-          updateSessionActivity(
-            prev,
-            structuredMsg.sessionId,
-            activeSessionIdRef.current,
-            structuredMsg.content,
+          prev.map((s) =>
+            s.id === structuredMsg.sessionId
+              ? { ...s, lastActiveAt: new Date().toISOString() }
+              : s,
           ),
         );
         break;


### PR DESCRIPTION
## Summary

Architectural shift: stop showing PTY stream content as chat messages. All chat messages now come exclusively from the JSONL transcript (clean structured data). The PTY stream is used only for session activity timestamps.

This eliminates the entire brute-force message filtering problem. No more pattern-by-pattern whack-a-mole. The transcript contains only structured ContentBlocks with no terminal chrome.

**+11 lines, -70 lines** -- deleting code is the fix.

## What changed

- `structured_agent_output` handler: removed all message creation logic (70 lines). Now only updates session lastActiveAt.
- `transcript_content` handler: removed `isToolOutputNoise` filter. Keep only empty-message check and user protocol tag stripping.
- Removed `isToolOutputNoise` import.

## Why this works

From cc-ref architecture research (.context/cc-architecture-reference.md):
- JSONL transcript has clean structured data (Text, ToolUse, ToolResult blocks)
- Terminal chrome (spinners, markers, "Added 3 lines") is ephemeral rendering, NOT in transcript
- JSONL writes are synchronous and immediate (few ms delay)
- Questions arrive via hook system, unaffected by this change

## Test plan

- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [ ] Verify on device: chat shows clean transcript messages only
- [ ] Verify: no more tool output noise in chat
- [ ] Verify: status indicator still works (thinking/executing/idle)
- [ ] Verify: questions still appear and can be answered

Closes #239