### PR TITLE
feat: Phase 2 - content blocks in transcript messages

### DIFF
--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -9,7 +9,7 @@
  * - Phase 2 (Transcript): Clean content delivery via this bridge
  */
 
-import type { Message, TranscriptContentMessage, UUID } from '@remi/shared';
+import type { Message, TranscriptContentBlock, TranscriptContentMessage, UUID } from '@remi/shared';
 import { createTranscriptContent, generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { AssistantEntry, ContentBlock, UserEntry } from './types.ts';
@@ -65,8 +65,11 @@ export class TranscriptMessageBridge {
     const tools = this.extractToolNames(entry.message.content);
     const hadThinking = this.hasThinkingBlocks(entry.message.content);
 
-    // Skip entries with no text content (pure tool invocations, thinking-only, etc.)
-    if (!textContent) {
+    // Skip entries with no text AND no tool blocks (thinking-only entries)
+    const contentBlocks_check = entry.message.content.filter(
+      (b: ContentBlock) => b.type === 'text' || b.type === 'tool_use' || b.type === 'tool_result',
+    );
+    if (!textContent && contentBlocks_check.length === 0) {
       this.processedEntryUuids.add(entry.uuid);
       return;
     }
@@ -91,6 +94,9 @@ export class TranscriptMessageBridge {
     // Only mark as processed after successful structuring
     this.processedEntryUuids.add(entry.uuid);
 
+    // Convert raw content blocks for client rendering
+    const contentBlocks = this.toContentBlocks(entry.message.content);
+
     // Emit the transcript content message
     const transcriptMessage = createTranscriptContent(
       this.sessionId,
@@ -104,6 +110,7 @@ export class TranscriptMessageBridge {
         ...(entry.message.model != null && { model: entry.message.model }),
         ...(hadThinking && { hadThinking }),
         ...(entry.message.usage != null && { usage: entry.message.usage }),
+        contentBlocks,
       },
     );
 
@@ -186,6 +193,51 @@ export class TranscriptMessageBridge {
    */
   private hasThinkingBlocks(blocks: readonly ContentBlock[]): boolean {
     return blocks.some((block) => block.type === 'thinking');
+  }
+
+  /**
+   * Convert raw content blocks to protocol format for the web client.
+   * Includes text, tool_use, and tool_result blocks. Skips thinking blocks.
+   * Truncates tool output to prevent oversized messages.
+   */
+  private toContentBlocks(blocks: readonly ContentBlock[]): TranscriptContentBlock[] {
+    const MAX_TOOL_OUTPUT = 500;
+    return blocks
+      .filter((b) => b.type !== 'thinking')
+      .map((block): TranscriptContentBlock | null => {
+        if (block.type === 'text') {
+          return { type: 'text', text: block.text };
+        }
+        if (block.type === 'tool_use') {
+          return {
+            type: 'tool_use',
+            toolUseId: block.id,
+            toolName: block.name,
+            toolInput:
+              typeof block.input === 'string'
+                ? block.input.slice(0, MAX_TOOL_OUTPUT)
+                : JSON.stringify(block.input).slice(0, MAX_TOOL_OUTPUT),
+          };
+        }
+        if (block.type === 'tool_result') {
+          const output =
+            typeof block.content === 'string'
+              ? block.content
+              : Array.isArray(block.content)
+                ? block.content
+                    .filter((c) => c.type === 'text')
+                    .map((c) => (c as { text: string }).text)
+                    .join('\n')
+                : '';
+          return {
+            type: 'tool_result',
+            toolUseId: block.tool_use_id,
+            toolOutput: output.slice(0, MAX_TOOL_OUTPUT),
+          };
+        }
+        return null;
+      })
+      .filter((b): b is TranscriptContentBlock => b !== null);
   }
 
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -55,6 +55,7 @@ export type {
   SessionListRequestMessage,
   SessionListResponseMessage,
   TranscriptContentMessage,
+  TranscriptContentBlock,
   TranscriptLoadRequestMessage,
   TranscriptLoadCompleteMessage,
   TranscriptUsage,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -319,6 +319,25 @@ export interface TranscriptContentMessage {
   readonly message: StructuredMessage;
   /** Whether this updates a previously sent entry */
   readonly isUpdate: boolean;
+  /** Raw content blocks from the transcript entry (Text, ToolUse, ToolResult) */
+  readonly contentBlocks?: readonly TranscriptContentBlock[];
+}
+
+/** A content block from the Claude Code transcript */
+export interface TranscriptContentBlock {
+  readonly type: 'text' | 'tool_use' | 'tool_result';
+  /** Text content (for type=text) */
+  readonly text?: string;
+  /** Tool use ID (for type=tool_use) */
+  readonly toolUseId?: string;
+  /** Tool name (for type=tool_use or tool_result) */
+  readonly toolName?: string;
+  /** Tool input as JSON string (for type=tool_use) */
+  readonly toolInput?: string;
+  /** Tool output (for type=tool_result, truncated) */
+  readonly toolOutput?: string;
+  /** Whether tool execution failed (for type=tool_result) */
+  readonly isError?: boolean;
 }
 
 /** Request to load transcript history for an external session */
@@ -918,6 +937,7 @@ export function createTranscriptContent(
     model?: string;
     hadThinking?: boolean;
     usage?: TranscriptUsage;
+    contentBlocks?: readonly TranscriptContentBlock[];
   },
 ): TranscriptContentMessage {
   return {
@@ -934,6 +954,8 @@ export function createTranscriptContent(
     ...(options?.model != null && options.model !== '' && { model: options.model }),
     ...(options?.hadThinking != null && { hadThinking: options.hadThinking }),
     ...(options?.usage != null && { usage: options.usage }),
+    ...(options?.contentBlocks != null &&
+      options.contentBlocks.length > 0 && { contentBlocks: options.contentBlocks }),
   };
 }
 


### PR DESCRIPTION
## Summary

Protocol and daemon changes for Phase 2 content block rendering:

- Add TranscriptContentBlock type (text, tool_use, tool_result variants)
- Daemon TranscriptMessageBridge converts raw blocks and includes them in transcript_content messages
- Tool invocation entries (no text, only tool_use blocks) are now emitted instead of skipped
- Tool output truncated to 500 chars to prevent oversized messages

The web app can now use message.contentBlocks to render each block type appropriately. Web rendering components are next.

## Test plan
- [x] TypeScript compiles clean (all packages)
- [x] 1317 tests pass
- [ ] Web app: verify contentBlocks arrive in transcript_content messages
- [ ] Web app: render tool chips (Phase 2 web PR)

Closes #240 (protocol/daemon side)