### PR TITLE
fix: cap replay batch at 200 most recent messages

### DIFF
--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -269,8 +269,13 @@ export class SessionRegistry {
     this.session.lastDisconnectedAt = null;
     this.session.explicitlyDetached = false;
 
-    // Get messages to replay (from after last delivered)
-    const replayMessages = this.session.messageHistory.slice(this.session.lastDeliveredIndex + 1);
+    // Get messages to replay (from after last delivered, capped at 200 most recent)
+    const MAX_REPLAY_MESSAGES = 200;
+    const undelivered = this.session.messageHistory.slice(this.session.lastDeliveredIndex + 1);
+    const replayMessages =
+      undelivered.length > MAX_REPLAY_MESSAGES
+        ? undelivered.slice(-MAX_REPLAY_MESSAGES)
+        : undelivered;
 
     // Mark all as delivered now
     this.session.lastDeliveredIndex = this.session.messageHistory.length - 1;


### PR DESCRIPTION
## Problem

Transcript has 3751 entries (26MB) for a single session. Sending all as one replay_batch overwhelms the WebSocket and causes the app to show only the last few messages.

## Fix

Cap the replay batch at 200 most recent messages. This provides sufficient history without overwhelming the connection.

## Test plan
- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [ ] Restart daemon, verify ~200 messages of history load in chat