### PR TITLE
feat: chat experience MVP - session list, disconnect, question options

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -293,16 +293,20 @@ function App() {
           break;
         }
         lastQuestionIdRef.current = q.id;
-        // Map daemon Question to UIQuestion
+        // Map daemon Question to UIQuestion.
+        // Use yes_no ONLY for exactly 2 options with clear yes+no.
+        // Use multi_option for 3+ options (even if they include yes/no).
+        // Use numbered for options without yes/no semantics.
         let questionType: UIQuestion['type'] = 'free_text';
         if (q.options.length > 0) {
-          const hasYesNo = q.options.some((o) => o.isYes || o.isNo);
-          if (hasYesNo) {
-            // Check for multi-option (yes/no plus extra options like all/quit)
-            const extraOptions = q.options.filter((o) => !o.isYes && !o.isNo);
-            questionType = extraOptions.length > 0 ? 'multi_option' : 'yes_no';
+          if (q.options.length === 2) {
+            const hasYes = q.options.some((o) => o.isYes);
+            const hasNo = q.options.some((o) => o.isNo);
+            questionType = hasYes && hasNo ? 'yes_no' : 'multi_option';
           } else {
-            questionType = 'numbered';
+            // 3+ options: always show all of them
+            const hasYesNo = q.options.some((o) => o.isYes || o.isNo);
+            questionType = hasYesNo ? 'multi_option' : 'numbered';
           }
         }
 
@@ -891,6 +895,20 @@ function App() {
     } catch (err) { console.warn('[App] Failed to update persisted connections:', err); }
   }, [disconnectConnection]);
 
+  // Disconnect ALL connections and clear everything (back to connect screen)
+  const handleDisconnectAll = useCallback(() => {
+    for (const conn of connections) {
+      disconnectConnection(conn.connectionId);
+    }
+    setSessions([]);
+    setMessages([]);
+    setActiveSessionId(null);
+    setQuestion(null);
+    try {
+      localStorage.removeItem(LOCALSTORAGE_CONNECTIONS_KEY);
+    } catch (err) { console.warn('[App] Failed to clear persisted connections:', err); }
+  }, [connections, disconnectConnection]);
+
   const handleBulletExpand = useCallback(
     (bulletId: number) => {
       if (!activeSessionId) return;
@@ -1025,6 +1043,7 @@ function App() {
       onConnect={() => setShowConnectModal(true)}
       onAddConnection={() => setShowConnectModal(true)}
       onDisconnect={handleDisconnect}
+      onDisconnectAll={handleDisconnectAll}
       onSettings={() => setShowSettings(true)}
     />
   );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -594,6 +594,7 @@ function App() {
     connections,
     connectDirect,
     disconnect: disconnectConnection,
+    disconnectAll,
     sendInput,
     sendAnswer,
     sendMessage: cmSendMessage,
@@ -897,9 +898,7 @@ function App() {
 
   // Disconnect ALL connections and clear everything (back to connect screen)
   const handleDisconnectAll = useCallback(() => {
-    for (const conn of connections) {
-      disconnectConnection(conn.connectionId);
-    }
+    disconnectAll();
     setSessions([]);
     setMessages([]);
     setActiveSessionId(null);
@@ -907,7 +906,7 @@ function App() {
     try {
       localStorage.removeItem(LOCALSTORAGE_CONNECTIONS_KEY);
     } catch (err) { console.warn('[App] Failed to clear persisted connections:', err); }
-  }, [connections, disconnectConnection]);
+  }, [disconnectAll]);
 
   const handleBulletExpand = useCallback(
     (bulletId: number) => {
@@ -1015,11 +1014,7 @@ function App() {
     ? errorConnection.error ?? `Connection error: ${errorConnection.connectionId}`
     : null;
 
-  // Derive connectedHost from the first connected connection (for SessionList display)
-  const firstConnected = connections.find((c) => c.status === 'connected');
-  const connectedHost = firstConnected
-    ? firstConnected.connectionId.replace(/:\d+$/, '')
-    : null;
+
 
   // Compute effective status for ConnectModal: show the latest connection's status
   const effectiveStatus = (() => {
@@ -1036,7 +1031,6 @@ function App() {
       sessions={sessions}
       activeSessionId={activeSessionId}
       connections={connections}
-      connectedHost={connectedHost}
       onSelectSession={handleSelectSession}
       onResumeSession={hasAnyConnected ? handleResumeSession : undefined}
       resumingSessionId={resumingSession}

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -1,15 +1,16 @@
 /**
  * SessionList component.
  *
- * Displays sessions grouped by daemon connection when multiple connections
- * are active. Shows a flat list for single connections.
+ * Shows active sessions (from connected daemons) at the top.
+ * "Show recent" expander reveals historical/transcript sessions below.
+ * Each connection has a disconnect button. Reconnect shown when dropped.
  */
 
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { Link2, Plus, Settings } from 'lucide-react';
-import { useMemo } from 'react';
+import { ChevronDown, ChevronRight, Link2, Plus, RefreshCw, Settings, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
 
 /** Status dot for connection state */
@@ -45,7 +46,6 @@ export function SessionList({
   sessions,
   activeSessionId,
   connections = [],
-  connectedHost,
   onSelectSession,
   onResumeSession,
   resumingSessionId,
@@ -55,36 +55,31 @@ export function SessionList({
   onSettings,
   className,
 }: SessionListProps) {
-  const isMultiConnection = connections.length > 1;
+  const [showRecent, setShowRecent] = useState(false);
 
-  // Group sessions by connectionId, ensuring ALL connections appear
-  const grouped = useMemo(() => {
-    if (!isMultiConnection) return null;
-    const groups = new Map<ConnectionId, UISession[]>();
-    // Initialize with all connections so empty ones still show headers
-    for (const conn of connections) {
-      groups.set(conn.connectionId, []);
-    }
+  // Split sessions into active (from daemon, connected) and recent (transcript/disconnected)
+  const { activeSessions, recentSessions } = useMemo(() => {
+    const active: UISession[] = [];
+    const recent: UISession[] = [];
     for (const session of sessions) {
-      const key = session.connectionId;
-      const group = groups.get(key) ?? [];
-      group.push(session);
-      groups.set(key, group);
+      if (session.source === 'daemon' || session.connectionStatus === 'connected') {
+        active.push(session);
+      } else {
+        recent.push(session);
+      }
     }
-    return groups;
-  }, [sessions, connections, isMultiConnection]);
+    return { activeSessions: active, recentSessions: recent };
+  }, [sessions]);
+
+  const hasConnections = connections.length > 0;
 
   return (
     <div className={clsx('flex h-full flex-col bg-[var(--color-surface)]', className)}>
+      {/* Header */}
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
-        <h1 className="text-lg font-semibold text-[var(--color-text)]">
-          Remi
-          {!isMultiConnection && connectedHost ? (
-            <span className="font-normal text-[var(--color-text-muted)]"> on {connectedHost}</span>
-          ) : null}
-        </h1>
+        <h1 className="text-lg font-semibold text-[var(--color-text)]">Remi</h1>
         <div className="flex items-center gap-1">
-          {connections.length > 0 && (onAddConnection || onConnect) && (
+          {hasConnections && (onAddConnection || onConnect) && (
             <button
               onClick={onAddConnection ?? onConnect}
               className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
@@ -93,7 +88,7 @@ export function SessionList({
               <Plus className="size-5" />
             </button>
           )}
-          {connections.length === 0 && onConnect && (
+          {!hasConnections && onConnect && (
             <button
               onClick={onConnect}
               className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
@@ -114,8 +109,10 @@ export function SessionList({
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-2 safe-area-bottom">
-        {sessions.length === 0 ? (
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto safe-area-bottom">
+        {/* No connections state */}
+        {!hasConnections && (
           <div className="flex h-full flex-col items-center justify-center px-4 text-center">
             <div className="mb-4 rounded-full bg-[var(--color-surface-light)] p-4">
               <Link2 className="size-8 text-[var(--color-text-muted)]" />
@@ -134,29 +131,74 @@ export function SessionList({
               </button>
             )}
           </div>
-        ) : isMultiConnection && grouped ? (
-          // Multi-connection: grouped by daemon
-          <div className="space-y-3">
-            {Array.from(grouped.entries()).map(([connId, groupSessions]) => {
-              const conn = connections.find((c) => c.connectionId === connId);
-              return (
-                <div key={connId}>
-                  <div className="flex items-center gap-2 px-3 py-1.5">
-                    <StatusDot status={conn?.status ?? 'disconnected'} />
-                    <span className="text-xs font-medium text-[var(--color-text-muted)]">
-                      {connId}
-                    </span>
-                    {onDisconnect && conn && (
-                      <button
-                        onClick={() => onDisconnect(conn.connectionId)}
-                        className="ml-auto text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
-                      >
-                        Disconnect
-                      </button>
-                    )}
-                  </div>
+        )}
+
+        {/* Connected state */}
+        {hasConnections && (
+          <div className="p-2">
+            {/* Connection headers with disconnect */}
+            {connections.map((conn) => (
+              <div key={conn.connectionId} className="mb-1 flex items-center gap-2 px-2 py-1">
+                <StatusDot status={conn.status} />
+                <span className="text-xs font-medium text-[var(--color-text-muted)]">
+                  {conn.connectionId}
+                </span>
+                {conn.status === 'error' && onConnect && (
+                  <button
+                    onClick={onConnect}
+                    className="ml-auto flex items-center gap-1 text-xs text-[var(--color-warning)]"
+                  >
+                    <RefreshCw className="size-3" />
+                    Reconnect
+                  </button>
+                )}
+                {onDisconnect && conn.status !== 'error' && (
+                  <button
+                    onClick={() => onDisconnect(conn.connectionId)}
+                    className="ml-auto flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
+                  >
+                    <X className="size-3" />
+                    Disconnect
+                  </button>
+                )}
+              </div>
+            ))}
+
+            {/* Active sessions */}
+            {activeSessions.length > 0 && (
+              <div className="space-y-1">
+                {activeSessions.map((session) => (
+                  <SessionCard
+                    key={session.id}
+                    session={session}
+                    isActive={session.id === activeSessionId}
+                    onClick={() => onSelectSession(session.id)}
+                    onResume={onResumeSession}
+                    isResuming={resumingSessionId === session.id}
+                  />
+                ))}
+              </div>
+            )}
+
+            {activeSessions.length === 0 && (
+              <p className="px-3 py-4 text-center text-sm text-[var(--color-text-muted)]">
+                No active sessions on connected daemons
+              </p>
+            )}
+
+            {/* Recent sessions expander */}
+            {recentSessions.length > 0 && (
+              <div className="mt-3 border-t border-[var(--color-border)] pt-2">
+                <button
+                  onClick={() => setShowRecent(!showRecent)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
+                >
+                  {showRecent ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+                  Recent sessions ({recentSessions.length})
+                </button>
+                {showRecent && (
                   <div className="space-y-1">
-                    {groupSessions.map((session) => (
+                    {recentSessions.map((session) => (
                       <SessionCard
                         key={session.id}
                         session={session}
@@ -167,23 +209,9 @@ export function SessionList({
                       />
                     ))}
                   </div>
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          // Single connection: flat list
-          <div className="space-y-1">
-            {sessions.map((session) => (
-              <SessionCard
-                key={session.id}
-                session={session}
-                isActive={session.id === activeSessionId}
-                onClick={() => onSelectSession(session.id)}
-                onResume={onResumeSession}
-                isResuming={resumingSessionId === session.id}
-              />
-            ))}
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -29,14 +29,13 @@ interface SessionListProps {
   readonly sessions: readonly UISession[];
   readonly activeSessionId: UUID | null;
   readonly connections?: readonly ConnectionState[];
-  readonly connectedHost?: string | null;
   readonly onSelectSession: (id: UUID) => void;
   readonly onResumeSession?: ((sessionId: string) => void) | undefined;
   readonly resumingSessionId?: string | null;
-  readonly onConnect?: () => void;
+  readonly onConnect: () => void;
   readonly onAddConnection?: () => void;
-  readonly onDisconnect?: (connectionId: ConnectionId) => void;
-  readonly onDisconnectAll?: () => void;
+  readonly onDisconnect: (connectionId: ConnectionId) => void;
+  readonly onDisconnectAll: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -155,15 +154,15 @@ export function SessionList({
                 <span className="flex-1 text-xs font-medium text-[var(--color-text-muted)] truncate">
                   {conn.connectionId}
                 </span>
-                {conn.status === 'error' && (
+                {conn.status === 'error' && onConnect && (
                   <button
                     onClick={onConnect}
                     className="flex items-center gap-1 text-xs text-[var(--color-warning)]"
                   >
-                    <RefreshCw className="size-3" /> Retry
+                    <RefreshCw className="size-3" /> Reconnect
                   </button>
                 )}
-                {conn.status !== 'error' && onDisconnect && (
+                {onDisconnect && (
                   <button
                     onClick={() => onDisconnect(conn.connectionId)}
                     className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -1,19 +1,18 @@
 /**
  * SessionList component.
  *
- * Shows active sessions (from connected daemons) at the top.
- * "Show recent" expander reveals historical/transcript sessions below.
- * Each connection has a disconnect button. Reconnect shown when dropped.
+ * Active sessions from connected daemons shown at top.
+ * "Recent" expander for historical sessions below.
+ * Connection controls: connect, disconnect per machine, disconnect all.
  */
 
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { ChevronDown, ChevronRight, Link2, Link2Off, Plus, RefreshCw, Settings, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Link2, Link2Off, Plus, RefreshCw, Settings } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
 
-/** Status dot for connection state */
 function StatusDot({ status }: { readonly status: ConnectionState['status'] }) {
   const colorClass =
     status === 'connected'
@@ -23,7 +22,6 @@ function StatusDot({ status }: { readonly status: ConnectionState['status'] }) {
         : status === 'error'
           ? 'bg-red-500'
           : 'bg-gray-400';
-
   return <span className={clsx('inline-block size-2 rounded-full', colorClass)} />;
 }
 
@@ -59,7 +57,6 @@ export function SessionList({
 }: SessionListProps) {
   const [showRecent, setShowRecent] = useState(false);
 
-  // Split sessions into active (from daemon, connected) and recent (transcript/disconnected)
   const { activeSessions, recentSessions } = useMemo(() => {
     const active: UISession[] = [];
     const recent: UISession[] = [];
@@ -74,45 +71,49 @@ export function SessionList({
   }, [sessions]);
 
   const hasConnections = connections.length > 0;
+  // Derive display name from first connection (hostname without port)
+  const hostLabel = hasConnections
+    ? connections[0].connectionId.replace(/:\d+$/, '')
+    : null;
 
   return (
     <div className={clsx('flex h-full flex-col bg-[var(--color-surface)]', className)}>
       {/* Header */}
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
-        <h1 className="text-lg font-semibold text-[var(--color-text)]">Remi</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold text-[var(--color-text)]">Remi</h1>
+          {hostLabel && (
+            <span className="text-sm text-[var(--color-text-muted)]">
+              on {hostLabel}
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-1">
-          {/* Connect (chain) or Disconnect (broken chain) */}
           {hasConnections ? (
             <>
-              {(onAddConnection || onConnect) && (
-                <button
-                  onClick={onAddConnection ?? onConnect}
-                  className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-                  aria-label="Add connection"
-                >
-                  <Plus className="size-5" />
-                </button>
-              )}
-              {onDisconnectAll && (
-                <button
-                  onClick={onDisconnectAll}
-                  className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-error)]"
-                  aria-label="Disconnect all"
-                >
-                  <Link2Off className="size-5" />
-                </button>
-              )}
+              <button
+                onClick={onAddConnection ?? onConnect}
+                className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+                aria-label="Add connection"
+              >
+                <Plus className="size-5" />
+              </button>
+              <button
+                onClick={onDisconnectAll}
+                className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-error)]"
+                aria-label="Disconnect all"
+              >
+                <Link2Off className="size-5" />
+              </button>
             </>
           ) : (
-            onConnect && (
-              <button
-                onClick={onConnect}
-                className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-                aria-label="Connect to daemon"
-              >
-                <Link2 className="size-5" />
-              </button>
-            )
+            <button
+              onClick={onConnect}
+              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+              aria-label="Connect"
+            >
+              <Link2 className="size-5" />
+            </button>
           )}
           {onSettings && (
             <button
@@ -128,53 +129,45 @@ export function SessionList({
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto safe-area-bottom">
-        {/* No connections state */}
-        {!hasConnections && (
-          <div className="flex h-full flex-col items-center justify-center px-4 text-center">
+        {!hasConnections ? (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center">
             <div className="mb-4 rounded-full bg-[var(--color-surface-light)] p-4">
               <Link2 className="size-8 text-[var(--color-text-muted)]" />
             </div>
-            <h2 className="mb-1 font-medium text-[var(--color-text)]">No Active Sessions</h2>
-            <p className="mb-4 text-sm text-[var(--color-text-secondary)]">
-              Connect to a host to discover Claude sessions
+            <h2 className="mb-1 font-medium text-[var(--color-text)]">Connect to your machine</h2>
+            <p className="mb-5 text-sm text-[var(--color-text-secondary)]">
+              Enter your hostname or IP to see active Claude sessions
             </p>
-            {onConnect && (
-              <button
-                onClick={onConnect}
-                className="flex items-center gap-2 rounded-full bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-dark)]"
-              >
-                <Link2 className="size-4" />
-                Connect
-              </button>
-            )}
+            <button
+              onClick={onConnect}
+              className="flex items-center gap-2 rounded-full bg-[var(--color-primary)] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-dark)]"
+            >
+              <Link2 className="size-4" />
+              Connect
+            </button>
           </div>
-        )}
-
-        {/* Connected state */}
-        {hasConnections && (
-          <div className="p-2">
-            {/* Connection headers with disconnect */}
-            {connections.map((conn) => (
-              <div key={conn.connectionId} className="mb-1 flex items-center gap-2 px-2 py-1">
+        ) : (
+          <div className="p-2 space-y-1">
+            {/* Per-connection status bars (only if multiple connections) */}
+            {connections.length > 1 && connections.map((conn) => (
+              <div key={conn.connectionId} className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-[var(--color-surface-light)]">
                 <StatusDot status={conn.status} />
-                <span className="text-xs font-medium text-[var(--color-text-muted)]">
+                <span className="flex-1 text-xs font-medium text-[var(--color-text-muted)] truncate">
                   {conn.connectionId}
                 </span>
-                {conn.status === 'error' && onConnect && (
+                {conn.status === 'error' && (
                   <button
                     onClick={onConnect}
-                    className="ml-auto flex items-center gap-1 text-xs text-[var(--color-warning)]"
+                    className="flex items-center gap-1 text-xs text-[var(--color-warning)]"
                   >
-                    <RefreshCw className="size-3" />
-                    Reconnect
+                    <RefreshCw className="size-3" /> Retry
                   </button>
                 )}
-                {onDisconnect && conn.status !== 'error' && (
+                {conn.status !== 'error' && onDisconnect && (
                   <button
                     onClick={() => onDisconnect(conn.connectionId)}
-                    className="ml-auto flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
+                    className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
                   >
-                    <X className="size-3" />
                     Disconnect
                   </button>
                 )}
@@ -182,36 +175,32 @@ export function SessionList({
             ))}
 
             {/* Active sessions */}
-            {activeSessions.length > 0 && (
-              <div className="space-y-1">
-                {activeSessions.map((session) => (
-                  <SessionCard
-                    key={session.id}
-                    session={session}
-                    isActive={session.id === activeSessionId}
-                    onClick={() => onSelectSession(session.id)}
-                    onResume={onResumeSession}
-                    isResuming={resumingSessionId === session.id}
-                  />
-                ))}
-              </div>
-            )}
+            {activeSessions.map((session) => (
+              <SessionCard
+                key={session.id}
+                session={session}
+                isActive={session.id === activeSessionId}
+                onClick={() => onSelectSession(session.id)}
+                onResume={onResumeSession}
+                isResuming={resumingSessionId === session.id}
+              />
+            ))}
 
             {activeSessions.length === 0 && (
-              <p className="px-3 py-4 text-center text-sm text-[var(--color-text-muted)]">
-                No active sessions on connected daemons
+              <p className="px-3 py-6 text-center text-sm text-[var(--color-text-muted)]">
+                No active sessions
               </p>
             )}
 
-            {/* Recent sessions expander */}
+            {/* Recent sessions */}
             {recentSessions.length > 0 && (
-              <div className="mt-3 border-t border-[var(--color-border)] pt-2">
+              <div className="mt-2 pt-2 border-t border-[var(--color-border)]">
                 <button
                   onClick={() => setShowRecent(!showRecent)}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-[var(--color-text-muted)]"
                 >
-                  {showRecent ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
-                  Recent sessions ({recentSessions.length})
+                  {showRecent ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+                  Recent ({recentSessions.length})
                 </button>
                 {showRecent && (
                   <div className="space-y-1">

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -9,7 +9,7 @@
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { ChevronDown, ChevronRight, Link2, Plus, RefreshCw, Settings, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Link2, Link2Off, Plus, RefreshCw, Settings, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
 
@@ -38,6 +38,7 @@ interface SessionListProps {
   readonly onConnect?: () => void;
   readonly onAddConnection?: () => void;
   readonly onDisconnect?: (connectionId: ConnectionId) => void;
+  readonly onDisconnectAll?: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -52,6 +53,7 @@ export function SessionList({
   onConnect,
   onAddConnection,
   onDisconnect,
+  onDisconnectAll,
   onSettings,
   className,
 }: SessionListProps) {
@@ -79,23 +81,38 @@ export function SessionList({
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
         <h1 className="text-lg font-semibold text-[var(--color-text)]">Remi</h1>
         <div className="flex items-center gap-1">
-          {hasConnections && (onAddConnection || onConnect) && (
-            <button
-              onClick={onAddConnection ?? onConnect}
-              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-              aria-label="Add connection"
-            >
-              <Plus className="size-5" />
-            </button>
-          )}
-          {!hasConnections && onConnect && (
-            <button
-              onClick={onConnect}
-              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-              aria-label="Connect to daemon"
-            >
-              <Link2 className="size-5" />
-            </button>
+          {/* Connect (chain) or Disconnect (broken chain) */}
+          {hasConnections ? (
+            <>
+              {(onAddConnection || onConnect) && (
+                <button
+                  onClick={onAddConnection ?? onConnect}
+                  className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+                  aria-label="Add connection"
+                >
+                  <Plus className="size-5" />
+                </button>
+              )}
+              {onDisconnectAll && (
+                <button
+                  onClick={onDisconnectAll}
+                  className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-error)]"
+                  aria-label="Disconnect all"
+                >
+                  <Link2Off className="size-5" />
+                </button>
+              )}
+            </>
+          ) : (
+            onConnect && (
+              <button
+                onClick={onConnect}
+                className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+                aria-label="Connect to daemon"
+              >
+                <Link2 className="size-5" />
+              </button>
+            )
           )}
           {onSettings && (
             <button


### PR DESCRIPTION
## Summary

Session list redesign:
- Active sessions first, "Recent (N)" expander hidden by default
- "Remi on hostname" header
- Disconnect All (broken chain) clears everything, back to connect screen
- Per-connection disconnect for multi-connection mode
- Reconnect button on errored connections

Question options:
- 3+ options always show as multi_option (Yes/Yes always/No)
- Only exactly 2 yes+no options use yes_no type

Disconnect All handler clears sessions, messages, activeSessionId, localStorage.

## Test plan
- [x] TypeScript compiles clean
- [x] Simulator: session list shows active/recent split
- [x] Simulator: disconnect all goes to connect screen
- [x] Simulator: chat view shows messages with tool chips
- [ ] Physical device test

Addresses #227, #235, #241