### PR TITLE
feat: new session creation from app

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -504,9 +504,24 @@ function App() {
       }
 
       case 'create_session_response': {
-        // Log session creation failures. Success case currently unhandled.
-        if (!message.success) {
-          console.error(`Session creation rejected: ${message.error}`);
+        if (message.success && message.sessionId) {
+          // New session created; it will appear via hello_ack. Refresh session list.
+          for (const id of connectedIds) {
+            requestSessionList(id, connectedIds.size === 1);
+          }
+        } else {
+          console.error(`Session creation failed: ${message.error}`);
+          const errorMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            connectionId: '' as ConnectionId,
+            sender: 'system',
+            content: `Failed to create session: ${message.error || 'unknown error'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errorMsg]);
         }
         break;
       }
@@ -602,6 +617,7 @@ function App() {
     requestSessionList,
     requestTranscriptLoad,
     requestResumeSession,
+    requestNewSession,
     needsPassphrase,
     passphraseConnectionId,
     passphraseServerFingerprint,
@@ -963,6 +979,16 @@ function App() {
     [sessions, requestResumeSession, resumingSession],
   );
 
+  // Create new session on the first connected daemon
+  const handleNewSession = useCallback(
+    (directory?: string) => {
+      const conn = connections.find((c) => c.status === 'connected');
+      if (!conn) return;
+      requestNewSession(conn.connectionId, directory);
+    },
+    [connections, requestNewSession],
+  );
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -1038,6 +1064,7 @@ function App() {
       onAddConnection={() => setShowConnectModal(true)}
       onDisconnect={handleDisconnect}
       onDisconnectAll={handleDisconnectAll}
+      onNewSession={handleNewSession}
       onSettings={() => setShowSettings(true)}
     />
   );

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -9,7 +9,7 @@
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { ChevronDown, ChevronRight, Link2, Link2Off, Plus, RefreshCw, Settings } from 'lucide-react';
+import { ChevronDown, ChevronRight, Link2, Link2Off, MessageSquarePlus, Plus, RefreshCw, Settings } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
 
@@ -36,6 +36,7 @@ interface SessionListProps {
   readonly onAddConnection?: () => void;
   readonly onDisconnect: (connectionId: ConnectionId) => void;
   readonly onDisconnectAll: () => void;
+  readonly onNewSession?: (directory?: string) => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -51,6 +52,7 @@ export function SessionList({
   onAddConnection,
   onDisconnect,
   onDisconnectAll,
+  onNewSession,
   onSettings,
   className,
 }: SessionListProps) {
@@ -186,9 +188,28 @@ export function SessionList({
             ))}
 
             {activeSessions.length === 0 && (
-              <p className="px-3 py-6 text-center text-sm text-[var(--color-text-muted)]">
+              <p className="px-3 py-4 text-center text-sm text-[var(--color-text-muted)]">
                 No active sessions
               </p>
+            )}
+
+            {/* New Session button */}
+            {onNewSession && (
+              <button
+                onClick={() => {
+                  const dir = prompt('Project directory (leave empty for home):');
+                  onNewSession(dir || undefined);
+                }}
+                className={clsx(
+                  'flex w-full items-center gap-3 rounded-xl px-4 py-3 mt-1',
+                  'border border-dashed border-[var(--color-border)]',
+                  'text-sm text-[var(--color-text-secondary)]',
+                  'transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]',
+                )}
+              >
+                <MessageSquarePlus className="size-5" />
+                New Session
+              </button>
             )}
 
             {/* Recent sessions */}


### PR DESCRIPTION
## Summary

- "New Session" button in session list (dashed border with message icon)
- Prompts for project directory, creates session on connected daemon
- Handle create_session_response: refresh list on success, error message on failure
- Wire requestNewSession from useConnectionManager

## UX notes (for TestFlight polish)

- Currently uses browser prompt() for directory input - needs proper modal
- Should show recent directories dropdown from requestSessionHistory
- Directory input should have path autocomplete

## Test plan
- [x] TypeScript compiles clean
- [x] 1317 tests pass
- [x] Simulator: button renders correctly
- [ ] Test: create session and verify it appears

Closes #252