### PR TITLE
fix: resolve P0 regressions in multi-daemon messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,15 @@ android/
 *.apk
 *.aab
 
+# Context and MCP
+.context/
+.mcp.json
+.serena/
+
+# Xcode workspace user data
+**/project.xcworkspace/
+**/CapApp-SPM/
+
 # Temporary
 tmp/
 temp/

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -395,8 +395,11 @@ export class SessionRegistry {
    */
   recordOutgoingMessage(sessionId: UUID, message: ProtocolMessage): void {
     if (this.session === null) {
-      // Session not yet registered; buffer for later
+      // Session not yet registered; buffer for later (capped to prevent unbounded growth)
       this.preRegistrationBuffer.push(message);
+      if (this.preRegistrationBuffer.length > this.maxReplayHistory) {
+        this.preRegistrationBuffer = this.preRegistrationBuffer.slice(-this.maxReplayHistory);
+      }
       return;
     }
     if (this.session.sessionId !== sessionId) {

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -36,6 +36,8 @@ export class TranscriptMessageBridge {
   private readonly messageApi: MessageAPI;
   private readonly events: Partial<TranscriptMessageBridgeEvents>;
   private readonly processedEntryUuids: Set<string> = new Set();
+  /** Tracks the transcript file's own session ID to detect session boundaries */
+  private transcriptSessionId: string | null = null;
 
   constructor(
     config: TranscriptMessageBridgeConfig,
@@ -59,6 +61,20 @@ export class TranscriptMessageBridge {
   handleAssistantEntry(entry: AssistantEntry): void {
     if (this.processedEntryUuids.has(entry.uuid)) {
       return; // Already processed
+    }
+    // Track the transcript's own session ID to detect session boundaries.
+    // If the entry's sessionId changes from a previously seen one, a new
+    // Claude Code session started in the same directory; skip old entries.
+    if (
+      entry.sessionId &&
+      this.transcriptSessionId &&
+      entry.sessionId !== this.transcriptSessionId
+    ) {
+      this.processedEntryUuids.add(entry.uuid);
+      return;
+    }
+    if (entry.sessionId) {
+      this.transcriptSessionId = entry.sessionId;
     }
 
     const textContent = this.extractTextContent(entry.message.content);
@@ -127,6 +143,18 @@ export class TranscriptMessageBridge {
   handleUserEntry(entry: UserEntry): void {
     if (this.processedEntryUuids.has(entry.uuid)) {
       return; // Already processed
+    }
+    // Track the transcript's own session ID to detect session boundaries.
+    if (
+      entry.sessionId &&
+      this.transcriptSessionId &&
+      entry.sessionId !== this.transcriptSessionId
+    ) {
+      this.processedEntryUuids.add(entry.uuid);
+      return;
+    }
+    if (entry.sessionId) {
+      this.transcriptSessionId = entry.sessionId;
     }
 
     const content =

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -278,5 +278,6 @@ export class TranscriptMessageBridge {
    */
   reset(): void {
     this.processedEntryUuids.clear();
+    this.transcriptSessionId = null;
   }
 }

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -101,15 +101,16 @@ describe('SessionRegistry', () => {
       expect(result.error).toBe('Session not found');
     });
 
-    test('returns error if session already has connection', () => {
+    test('queues second connection when session already has one', () => {
       const sessionId = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, generateId());
 
       const result = registry.attachConnection(sessionId, generateId());
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Session already has active connection');
+      // Second connection is queued (read-only with replay) rather than rejected
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
     });
 
     test('getSessionForConnection works after attach', () => {
@@ -215,7 +216,7 @@ describe('SessionRegistry', () => {
       expect(pty.close).not.toHaveBeenCalled();
     });
 
-    test('resume returns replay messages', () => {
+    test('resume replays last 200 messages (not just undelivered)', () => {
       const sessionId = generateId();
       const connectionId1 = generateId();
       const connectionId2 = generateId();
@@ -234,13 +235,15 @@ describe('SessionRegistry', () => {
       const msg3: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
       registry.recordOutgoingMessage(sessionId, msg3);
 
-      // Resume
+      // Resume - now replays ALL messages (up to 200), not just undelivered
       const result = registry.attachConnection(sessionId, connectionId2);
 
       expect(result.success).toBe(true);
       expect(result.isResume).toBe(true);
-      expect(result.replayMessages.length).toBe(1);
-      expect(result.replayMessages[0]).toBe(msg3);
+      expect(result.replayMessages.length).toBe(3);
+      expect(result.replayMessages).toContain(msg1);
+      expect(result.replayMessages).toContain(msg2);
+      expect(result.replayMessages).toContain(msg3);
       expect(result.nextBulletId).toBe(6);
     });
   });
@@ -568,12 +571,13 @@ describe('SessionRegistry', () => {
       registry.registerSession(sessionId, '/tmp/test', createMockPTY(), createMockMessageAPI());
     });
 
-    test('queues connection when session is busy', () => {
+    test('queues connection when session is busy (with read-only replay)', () => {
       registry.attachConnection(sessionId, connA);
       const result = registry.attachConnection(sessionId, connB);
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Session already has active connection');
+      // Queued connections now succeed with read-only replay access
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
       expect(registry.waitingConnectionCount).toBe(1);
     });
 
@@ -698,10 +702,10 @@ describe('SessionRegistry', () => {
       expect(result.isResume).toBe(true);
     });
 
-    test('promoted connection receives undelivered replay messages', () => {
+    test('promoted connection receives all recent replay messages', () => {
       registry.attachConnection(sessionId, connA);
 
-      // Record messages, then detach A so they become undelivered
+      // Record messages while A is connected
       const msg1 = {
         type: 'session_update',
         id: generateId(),
@@ -715,10 +719,10 @@ describe('SessionRegistry', () => {
       registry.recordOutgoingMessage(sessionId, msg1);
       registry.recordOutgoingMessage(sessionId, msg2);
 
-      // Detach A, making messages orphaned
+      // Detach A
       registry.detachConnection(connA);
 
-      // Now record more messages while orphaned (no active connection)
+      // Record more messages while orphaned
       const msg3 = {
         type: 'session_update',
         id: generateId(),
@@ -726,11 +730,10 @@ describe('SessionRegistry', () => {
       } as ProtocolMessage;
       registry.recordOutgoingMessage(sessionId, msg3);
 
-      // B attaches manually (simulates what promotion would do)
+      // B attaches - now gets ALL recent messages (up to 200), not just undelivered
       const result = registry.attachConnection(sessionId, connB);
       expect(result.success).toBe(true);
-      // Only msg3 is undelivered (msg1 and msg2 were delivered to A)
-      expect(result.replayMessages.length).toBe(1);
+      expect(result.replayMessages.length).toBe(3);
     });
 
     test('onSessionResumed fires during promotion', () => {

--- a/packages/daemon/tests/transcript-message-bridge.test.ts
+++ b/packages/daemon/tests/transcript-message-bridge.test.ts
@@ -328,6 +328,68 @@ describe('TranscriptMessageBridge', () => {
     });
   });
 
+  describe('session boundary detection', () => {
+    test('accepts entries from a single session', () => {
+      const { bridge, transcriptMessages } = createBridge();
+      bridge.handleAssistantEntry(makeAssistantEntry({ sessionId: 'session-A' }));
+      bridge.handleUserEntry(makeUserEntry({ sessionId: 'session-A' }));
+      bridge.handleAssistantEntry(
+        makeAssistantEntry({ sessionId: 'session-A', uuid: generateId() }),
+      );
+
+      expect(transcriptMessages.length).toBe(3);
+    });
+
+    test('skips entries from a different session after first is established', () => {
+      const { bridge, transcriptMessages } = createBridge();
+      // First entry establishes session A
+      bridge.handleAssistantEntry(makeAssistantEntry({ sessionId: 'session-A' }));
+      expect(transcriptMessages.length).toBe(1);
+
+      // Entry from session B is skipped
+      bridge.handleAssistantEntry(
+        makeAssistantEntry({ sessionId: 'session-B', uuid: generateId() }),
+      );
+      expect(transcriptMessages.length).toBe(1);
+      expect(bridge.processedCount).toBe(2); // still marked as processed
+    });
+
+    test('entries without sessionId pass through regardless', () => {
+      const { bridge, transcriptMessages } = createBridge();
+      bridge.handleAssistantEntry(makeAssistantEntry({ sessionId: 'session-A' }));
+
+      // Entry with no sessionId passes through
+      const noSessionEntry = makeAssistantEntry({ uuid: generateId() });
+      // Remove sessionId by creating entry without it
+      const entryWithoutSession = { ...noSessionEntry, sessionId: undefined as unknown as string };
+      bridge.handleAssistantEntry(entryWithoutSession);
+      expect(transcriptMessages.length).toBe(2);
+    });
+
+    test('user entries respect session boundary', () => {
+      const { bridge, transcriptMessages } = createBridge();
+      bridge.handleUserEntry(makeUserEntry({ sessionId: 'session-A' }));
+      expect(transcriptMessages.length).toBe(1);
+
+      bridge.handleUserEntry(makeUserEntry({ sessionId: 'session-B', uuid: generateId() }));
+      expect(transcriptMessages.length).toBe(1); // skipped
+    });
+
+    test('reset clears session boundary state', () => {
+      const { bridge, transcriptMessages } = createBridge();
+      bridge.handleAssistantEntry(makeAssistantEntry({ sessionId: 'session-A' }));
+      expect(transcriptMessages.length).toBe(1);
+
+      bridge.reset();
+
+      // After reset, entries from a new session are accepted
+      bridge.handleAssistantEntry(
+        makeAssistantEntry({ sessionId: 'session-B', uuid: generateId() }),
+      );
+      expect(transcriptMessages.length).toBe(2);
+    });
+  });
+
   describe('event handling', () => {
     test('works without event handlers', () => {
       const messageApi = new MessageAPI({ sessionId: generateId() });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
   const [sessions, setSessions] = useState<UISession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
-  const [question, setQuestion] = useState<UIQuestion | null>(null);
+  const [questions, setQuestions] = useState<Map<UUID, UIQuestion>>(new Map());
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -114,6 +114,8 @@ function App() {
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
+  const requestSessionListRef = useRef<typeof requestSessionList>(null as unknown as typeof requestSessionList);
+  const connectionsRef = useRef<readonly { connectionId: ConnectionId; status: string }[]>([]);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -284,8 +286,13 @@ function App() {
           prev.map((s) => (s.id === sessionData.id ? { ...s, status: sessionData.status } : s)),
         );
         // If status moved from 'waiting' to something else, the question was answered elsewhere
-        if (sessionData.status !== 'waiting' && question?.sessionId === sessionData.id) {
-          setQuestion(null);
+        if (sessionData.status !== 'waiting') {
+          setQuestions((prev) => {
+            if (!prev.has(sessionData.id)) return prev;
+            const next = new Map(prev);
+            next.delete(sessionData.id);
+            return next;
+          });
         }
         break;
       }
@@ -334,7 +341,11 @@ function App() {
           structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
           timestamp: new Date().toISOString(),
         };
-        setQuestion(uiQuestion);
+        setQuestions((prev) => {
+          const next = new Map(prev);
+          next.set(questionSessionId, uiQuestion);
+          return next;
+        });
 
         // Mark session as having a pending question
         setSessions((prev) =>
@@ -523,8 +534,9 @@ function App() {
       case 'create_session_response': {
         if (message.success && message.sessionId) {
           // New session created; it will appear via hello_ack. Refresh session list.
-          for (const id of connectedIds) {
-            requestSessionList(id, connectedIds.size === 1);
+          const conns = connectionsRef.current.filter((c) => c.status === 'connected');
+          for (const conn of conns) {
+            requestSessionListRef.current(conn.connectionId, conns.length === 1);
           }
         } else {
           console.error(`Session creation failed: ${message.error}`);
@@ -591,12 +603,23 @@ function App() {
 
       case 'error': {
         const errorText = message.message ?? 'unknown';
-        // Suppress auth errors (handled by the connection manager silently)
+        // Suppress auth errors (handled by the connection manager)
         if (errorText.includes('Authentication required') || errorText.includes('AUTH_REQUIRED')) {
           console.debug('[App] Auth error suppressed:', errorText);
           break;
         }
-        console.error('Daemon error:', message);
+        // Show non-auth errors to the user as system messages
+        const errorMsg: UIMessage = {
+          id: message.id ?? generateId(),
+          sessionId: activeSessionIdRef.current ?? ('' as UUID),
+          connectionId: connectionId,
+          sender: 'system',
+          content: errorText,
+          timestamp: message.timestamp ?? new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, errorMsg]);
         break;
       }
 
@@ -643,6 +666,8 @@ function App() {
   // Keep refs in sync for use in handleMessage callbacks
   getSessionIdRef.current = getSessionId;
   sessionsRef.current = sessions;
+  requestSessionListRef.current = requestSessionList;
+  connectionsRef.current = connections;
 
   // Derived connection status
   const hasAnyConnected = connections.some((c) => c.status === 'connected');
@@ -682,9 +707,9 @@ function App() {
       });
       return changed ? next : prev;
     });
-    // Clear stale question if all connections are down
+    // Clear stale questions if all connections are down
     if (!hasAnyConnected && !isAnyConnecting) {
-      setQuestion(null);
+      setQuestions(new Map());
       setResumingSession(null);
     }
   }, [connections, hasAnyConnected, isAnyConnecting]);
@@ -768,7 +793,7 @@ function App() {
       })()
     : undefined;
   const sessionMessages = messages.filter((m) => m.sessionId === activeSessionId);
-  const sessionQuestion = question?.sessionId === activeSessionId ? question : null;
+  const sessionQuestion = activeSessionId ? (questions.get(activeSessionId) ?? null) : null;
 
   const handleSelectSession = useCallback(
     (id: UUID) => {
@@ -818,8 +843,19 @@ function App() {
         const sent = sendAnswer(connId, sessionQuestion.id, content);
         if (!sent) return; // Don't transition question UI if send failed
         // Mark question as answered (card shows collapsed state briefly)
-        setQuestion({ ...sessionQuestion, answeredWith: content });
-        setTimeout(() => setQuestion(null), 1500);
+        setQuestions((prev) => {
+          const next = new Map(prev);
+          next.set(activeSessionId, { ...sessionQuestion, answeredWith: content });
+          return next;
+        });
+        setTimeout(() => {
+          setQuestions((prev) => {
+            if (!prev.has(activeSessionId)) return prev;
+            const next = new Map(prev);
+            next.delete(activeSessionId);
+            return next;
+          });
+        }, 1500);
         // Clear question-pending on the session
         setSessions((prev) =>
           prev.map((s) => (s.id === activeSessionId ? { ...s, questionPending: false } : s)),
@@ -928,7 +964,7 @@ function App() {
     setSessions([]);
     setMessages([]);
     setActiveSessionId(null);
-    setQuestion(null);
+    setQuestions(new Map());
     try {
       localStorage.removeItem(LOCALSTORAGE_CONNECTIONS_KEY);
     } catch (err) { console.warn('[App] Failed to clear persisted connections:', err); }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
-  const requestSessionListRef = useRef<typeof requestSessionList>(null as unknown as typeof requestSessionList);
+  const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly { connectionId: ConnectionId; status: string }[]>([]);
 
   useEffect(() => {
@@ -534,9 +534,12 @@ function App() {
       case 'create_session_response': {
         if (message.success && message.sessionId) {
           // New session created; it will appear via hello_ack. Refresh session list.
-          const conns = connectionsRef.current.filter((c) => c.status === 'connected');
-          for (const conn of conns) {
-            requestSessionListRef.current(conn.connectionId, conns.length === 1);
+          const reqList = requestSessionListRef.current;
+          if (reqList) {
+            const conns = connectionsRef.current.filter((c) => c.status === 'connected');
+            for (const conn of conns) {
+              reqList(conn.connectionId, conns.length === 1);
+            }
           }
         } else {
           console.error(`Session creation failed: ${message.error}`);
@@ -609,9 +612,14 @@ function App() {
           break;
         }
         // Show non-auth errors to the user as system messages
+        const targetSession = activeSessionIdRef.current;
+        if (!targetSession) {
+          console.error('[App] Daemon error with no active session:', errorText);
+          break;
+        }
         const errorMsg: UIMessage = {
           id: message.id ?? generateId(),
-          sessionId: activeSessionIdRef.current ?? ('' as UUID),
+          sessionId: targetSession,
           connectionId: connectionId,
           sender: 'system',
           content: errorText,
@@ -841,7 +849,20 @@ function App() {
       // If there's an active question, send as answer
       if (sessionQuestion) {
         const sent = sendAnswer(connId, sessionQuestion.id, content);
-        if (!sent) return; // Don't transition question UI if send failed
+        if (!sent) {
+          const failMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionId,
+            connectionId: connId,
+            sender: 'system',
+            content: 'Failed to send answer: connection unavailable. Try again.',
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, failMsg]);
+          return;
+        }
         // Mark question as answered (card shows collapsed state briefly)
         setQuestions((prev) => {
           const next = new Map(prev);

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -380,9 +380,14 @@ export function useConnectionManager(
   const connectDirect = useCallback((url: string, directory?: string): ConnectionId => {
     const connectionId = parseConnectionId(url);
 
-    // If already connected to this host:port, disconnect first
+    // If already connected/connecting to this host:port, skip
     const existing = connectionsMapRef.current.get(connectionId);
     if (existing) {
+      const s = existing.status;
+      if (s === 'connected' || s === 'connecting' || s === 'authenticating' || s === 'reconnecting') {
+        return connectionId;
+      }
+      // Only tear down errored or disconnected connections
       stopPing(existing);
       existing.client.disconnect();
       connectionsMapRef.current.delete(connectionId);


### PR DESCRIPTION
## Summary

Fixes 4 critical regressions discovered in the PR #260 review (Epic #267).

- **#269**: Infinite auto-connect loop between daemons - `connectDirect` now skips if a healthy connection already exists instead of tearing it down
- **#270**: Questions lost in multi-stream - replaced single `question` state with per-session `Map<UUID, UIQuestion>`, fixed stale closure in `handleMessage` (empty `[]` deps capturing `null` question), added refs for `requestSessionList`/`connections` to fix stale closure in `create_session_response`
- **#264**: Stale transcript replay - `TranscriptMessageBridge` now tracks the transcript's own `sessionId` to detect session boundaries and skips entries from old sessions
- **#271**: Daemon errors invisible on mobile - restored user-facing error messages for non-auth errors (was `console.error` only, completely inaccessible on Capacitor/iOS)

Also:
- Capped `preRegistrationBuffer` to `maxReplayHistory` (was unbounded)
- Updated 4 session registry tests to match new replay semantics (queued connections get replay, resume sends last 200 messages)

## Test plan

- [x] 1317 tests pass, 0 failures
- [x] Biome lint clean
- [x] TypeScript compiles without errors
- [x] iOS simulator testing: auto-connect stable, questions display across sessions, no notification spam
- [x] Multi-daemon scenario: 3-4 daemons connected simultaneously without reconnection storm

Fixes #269, #270, #264, #271