### PR TITLE
fix: session list UX, keyboard modal, question badge, notification dedup

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -114,6 +114,7 @@ function App() {
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
+  const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly { connectionId: ConnectionId; status: string }[]>([]);
 
@@ -352,8 +353,8 @@ function App() {
           prev.map((s) => (s.id === questionSessionId ? { ...s, questionPending: true } : s)),
         );
 
-        // Send local notification if user isn't viewing this session
-        if (questionSessionId !== activeSessionIdRef.current || document.hidden) {
+        // Send local notification if user isn't viewing this session (skip during replay)
+        if (!isReplayingRef.current && (questionSessionId !== activeSessionIdRef.current || document.hidden)) {
           const sessionName = sessionsRef.current.find((s) => s.id === questionSessionId)?.name || 'Agent';
           notifyQuestion(sessionName, q.text);
         }
@@ -361,11 +362,13 @@ function App() {
       }
 
       case 'replay_batch': {
-        // Replay batches can arrive immediately after hello_ack on first attach.
-        // Dispatch them directly so early history is not dropped before refs/effects settle.
+        // Replay batches arrive on connect/reconnect. Suppress notifications during replay
+        // to prevent spamming the user with old events.
+        isReplayingRef.current = true;
         for (const replayMsg of message.messages) {
           handleMessage(connectionId, replayMsg);
         }
+        isReplayingRef.current = false;
         break;
       }
 

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -305,8 +305,8 @@ export function ConnectModal({
   const canConnect = mode === 'local' ? host.trim().length > 0 : code.length === 9;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 safe-area-bottom">
-      <div className="w-full max-w-md rounded-t-2xl sm:rounded-2xl bg-[var(--color-surface)] shadow-xl border border-[var(--color-border)]">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-md max-h-[85vh] overflow-y-auto rounded-2xl bg-[var(--color-surface)] shadow-xl border border-[var(--color-border)]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
           <h2 className="text-lg font-semibold text-[var(--color-text)]">Connect</h2>

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -9,7 +9,7 @@ import { formatRelativeTime } from '@/lib/format-time';
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 import type { ConnectionId } from '@/types';
 import { clsx } from 'clsx';
-import { Link2Off, MessageCircleQuestion, RotateCcw } from 'lucide-react';
+import { Link2, Link2Off, MessageCircleQuestion, RotateCcw } from 'lucide-react';
 
 /** Strip hostname prefix and truncate branch for display.
  *  "yahyas-mcm:remi/develop" -> "remi/develop"
@@ -119,6 +119,27 @@ export function SessionCard({
             <Link2Off className="size-3.5" />
           </button>
         )}
+        {showResume && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onResume(session.id);
+            }}
+            disabled={isResuming}
+            className={clsx(
+              'shrink-0 rounded-full p-1 transition-colors',
+              isResuming
+                ? 'text-[var(--color-text-muted)] cursor-wait'
+                : 'text-[var(--color-primary)] hover:bg-[var(--color-primary)]/10',
+            )}
+            aria-label="Resume"
+          >
+            {isResuming
+              ? <RotateCcw className="size-3.5 animate-spin" />
+              : <Link2 className="size-3.5" />}
+          </button>
+        )}
       </div>
 
       {/* Preview line: status/preview + timestamp */}
@@ -143,26 +164,6 @@ export function SessionCard({
         <p className="mt-0.5 truncate pl-4.5 text-xs text-[var(--color-text-muted)]">{session.cwd}</p>
       )}
 
-      {/* Resume button for dead sessions */}
-      {showResume && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onResume(session.id);
-          }}
-          disabled={isResuming}
-          className={clsx(
-            'mt-2 ml-4.5 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
-            isResuming
-              ? 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)] cursor-wait'
-              : 'bg-[var(--color-primary)]/10 text-[var(--color-primary)] hover:bg-[var(--color-primary)]/20',
-          )}
-        >
-          <RotateCcw className={clsx('size-3', isResuming && 'animate-spin')} />
-          {isResuming ? 'Resuming...' : 'Resume'}
-        </button>
-      )}
     </button>
   );
 }

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -8,7 +8,7 @@
 import { formatRelativeTime } from '@/lib/format-time';
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 import { clsx } from 'clsx';
-import { RotateCcw } from 'lucide-react';
+import { MessageCircleQuestion, RotateCcw } from 'lucide-react';
 
 /** Strip hostname prefix and truncate branch for display.
  *  "yahyas-mcm:remi/develop" -> "remi/develop"
@@ -104,8 +104,15 @@ export function SessionCard({
           </div>
 
           {/* Preview or status */}
-          <p className="mt-0.5 truncate text-sm text-[var(--color-text-secondary)]">
-            {session.preview || getStatusText(session.status)}
+          <p className={clsx(
+            'mt-0.5 truncate text-sm',
+            session.questionPending
+              ? 'font-medium text-[var(--color-warning)]'
+              : 'text-[var(--color-text-secondary)]',
+          )}>
+            {session.questionPending
+              ? 'Needs your input'
+              : (session.preview || getStatusText(session.status))}
           </p>
 
           {/* CWD if available */}
@@ -135,12 +142,17 @@ export function SessionCard({
           )}
         </div>
 
-        {/* Unread badge */}
-        {session.unreadCount > 0 && (
-          <span className="flex size-5 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-medium text-white">
-            {session.unreadCount > 9 ? '9+' : session.unreadCount}
-          </span>
-        )}
+        {/* Question and unread badges */}
+        <div className="flex items-center gap-1.5">
+          {session.questionPending && (
+            <MessageCircleQuestion className="size-5 text-[var(--color-warning)]" />
+          )}
+          {session.unreadCount > 0 && (
+            <span className="flex size-5 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-medium text-white">
+              {session.unreadCount > 9 ? '9+' : session.unreadCount}
+            </span>
+          )}
+        </div>
       </div>
     </button>
   );

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -7,8 +7,9 @@
 // Status icons are rendered via StatusDot, not used directly
 import { formatRelativeTime } from '@/lib/format-time';
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
+import type { ConnectionId } from '@/types';
 import { clsx } from 'clsx';
-import { MessageCircleQuestion, RotateCcw } from 'lucide-react';
+import { Link2Off, MessageCircleQuestion, RotateCcw } from 'lucide-react';
 
 /** Strip hostname prefix and truncate branch for display.
  *  "yahyas-mcm:remi/develop" -> "remi/develop"
@@ -30,6 +31,7 @@ interface SessionCardProps {
   readonly isActive: boolean;
   readonly onClick: () => void;
   readonly onResume?: ((sessionId: string) => void) | undefined;
+  readonly onDisconnect?: ((connectionId: ConnectionId) => void) | undefined;
   readonly isResuming?: boolean;
 }
 
@@ -70,12 +72,15 @@ export function SessionCard({
   isActive,
   onClick,
   onResume,
+  onDisconnect,
   isResuming,
 }: SessionCardProps) {
   const showResume =
     onResume &&
     session.canResume &&
     session.connectionStatus === 'disconnected';
+
+  const isConnected = session.connectionStatus === 'connected';
 
   return (
     <button
@@ -86,74 +91,78 @@ export function SessionCard({
         isActive && 'bg-[var(--color-surface-light)] ring-1 ring-[var(--color-primary)]/30',
       )}
     >
-      <div className="flex items-start gap-3">
-        {/* Status indicator */}
-        <div className="mt-1.5">
-          <StatusDot connectionStatus={session.connectionStatus} agentStatus={session.status} />
-        </div>
-
-        {/* Session info */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="truncate font-medium text-[var(--color-text)]">
-              {formatSessionName(session.name || 'Claude Session')}
-            </h3>
-            <span className="shrink-0 text-xs text-[var(--color-text-muted)]">
-              {formatRelativeTime(session.lastActiveAt)}
-            </span>
-          </div>
-
-          {/* Preview or status */}
-          <p className={clsx(
-            'mt-0.5 truncate text-sm',
-            session.questionPending
-              ? 'font-medium text-[var(--color-warning)]'
-              : 'text-[var(--color-text-secondary)]',
-          )}>
-            {session.questionPending
-              ? 'Needs your input'
-              : (session.preview || getStatusText(session.status))}
-          </p>
-
-          {/* CWD if available */}
-          {session.cwd && (
-            <p className="mt-1 truncate text-xs text-[var(--color-text-muted)]">{session.cwd}</p>
-          )}
-
-          {/* Resume button for dead sessions */}
-          {showResume && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onResume(session.id);
-              }}
-              disabled={isResuming}
-              className={clsx(
-                'mt-2 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
-                isResuming
-                  ? 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)] cursor-wait'
-                  : 'bg-[var(--color-primary)]/10 text-[var(--color-primary)] hover:bg-[var(--color-primary)]/20',
-              )}
-            >
-              <RotateCcw className={clsx('size-3', isResuming && 'animate-spin')} />
-              {isResuming ? 'Resuming...' : 'Resume'}
-            </button>
-          )}
-        </div>
-
+      {/* Title line: status dot, name, disconnect */}
+      <div className="flex items-center gap-2">
+        <StatusDot connectionStatus={session.connectionStatus} agentStatus={session.status} />
+        <h3 className="flex-1 truncate font-medium text-[var(--color-text)]">
+          {formatSessionName(session.name || 'Claude Session')}
+        </h3>
         {/* Question and unread badges */}
-        <div className="flex items-center gap-1.5">
-          {session.questionPending && (
-            <MessageCircleQuestion className="size-5 text-[var(--color-warning)]" />
-          )}
-          {session.unreadCount > 0 && (
-            <span className="flex size-5 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-medium text-white">
-              {session.unreadCount > 9 ? '9+' : session.unreadCount}
-            </span>
-          )}
-        </div>
+        {session.questionPending && (
+          <MessageCircleQuestion className="size-4 shrink-0 text-[var(--color-warning)]" />
+        )}
+        {session.unreadCount > 0 && (
+          <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-medium text-white">
+            {session.unreadCount > 9 ? '9+' : session.unreadCount}
+          </span>
+        )}
+        {isConnected && onDisconnect && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDisconnect(session.connectionId);
+            }}
+            className="shrink-0 rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
+            aria-label="Disconnect"
+          >
+            <Link2Off className="size-3.5" />
+          </button>
+        )}
       </div>
+
+      {/* Preview line: status/preview + timestamp */}
+      <div className="mt-1 flex items-center gap-2 pl-4.5">
+        <p className={clsx(
+          'flex-1 truncate text-sm',
+          session.questionPending
+            ? 'font-medium text-[var(--color-warning)]'
+            : 'text-[var(--color-text-secondary)]',
+        )}>
+          {session.questionPending
+            ? 'Needs your input'
+            : (session.preview || getStatusText(session.status))}
+        </p>
+        <span className="shrink-0 text-xs text-[var(--color-text-muted)]">
+          {formatRelativeTime(session.lastActiveAt)}
+        </span>
+      </div>
+
+      {/* CWD if available */}
+      {session.cwd && (
+        <p className="mt-0.5 truncate pl-4.5 text-xs text-[var(--color-text-muted)]">{session.cwd}</p>
+      )}
+
+      {/* Resume button for dead sessions */}
+      {showResume && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onResume(session.id);
+          }}
+          disabled={isResuming}
+          className={clsx(
+            'mt-2 ml-4.5 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+            isResuming
+              ? 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)] cursor-wait'
+              : 'bg-[var(--color-primary)]/10 text-[var(--color-primary)] hover:bg-[var(--color-primary)]/20',
+          )}
+        >
+          <RotateCcw className={clsx('size-3', isResuming && 'animate-spin')} />
+          {isResuming ? 'Resuming...' : 'Resume'}
+        </button>
+      )}
     </button>
   );
 }

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -9,21 +9,9 @@
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { ChevronDown, ChevronRight, Link2, Link2Off, MessageSquarePlus, RefreshCw, Settings } from 'lucide-react';
+import { ChevronDown, ChevronRight, Link2, Link2Off, MessageSquarePlus, Settings } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
-
-function StatusDot({ status }: { readonly status: ConnectionState['status'] }) {
-  const colorClass =
-    status === 'connected'
-      ? 'bg-green-500'
-      : status === 'connecting' || status === 'authenticating' || status === 'reconnecting'
-        ? 'bg-yellow-500 animate-pulse'
-        : status === 'error'
-          ? 'bg-red-500'
-          : 'bg-gray-400';
-  return <span className={clsx('inline-block size-2 rounded-full', colorClass)} />;
-}
 
 interface SessionListProps {
   readonly sessions: readonly UISession[];
@@ -49,7 +37,7 @@ export function SessionList({
   onResumeSession,
   resumingSessionId,
   onConnect,
-  onDisconnect,
+  onDisconnect: _onDisconnect,
   onDisconnectAll,
   onNewSession,
   onSettings,
@@ -141,32 +129,6 @@ export function SessionList({
           </div>
         ) : (
           <div className="p-2 space-y-1">
-            {/* Per-connection status bars (only if multiple connections) */}
-            {connections.length > 1 && connections.map((conn) => (
-              <div key={conn.connectionId} className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-[var(--color-surface-light)]">
-                <StatusDot status={conn.status} />
-                <span className="flex-1 text-xs font-medium text-[var(--color-text-muted)] truncate">
-                  {conn.connectionId}
-                </span>
-                {conn.status === 'error' && onConnect && (
-                  <button
-                    onClick={onConnect}
-                    className="flex items-center gap-1 text-xs text-[var(--color-warning)]"
-                  >
-                    <RefreshCw className="size-3" /> Reconnect
-                  </button>
-                )}
-                {onDisconnect && (
-                  <button
-                    onClick={() => onDisconnect(conn.connectionId)}
-                    className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
-                  >
-                    Disconnect
-                  </button>
-                )}
-              </div>
-            ))}
-
             {/* Active sessions */}
             {activeSessions.map((session) => (
               <SessionCard

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -37,7 +37,7 @@ export function SessionList({
   onResumeSession,
   resumingSessionId,
   onConnect,
-  onDisconnect: _onDisconnect,
+  onDisconnect,
   onDisconnectAll,
   onNewSession,
   onSettings,
@@ -45,18 +45,13 @@ export function SessionList({
 }: SessionListProps) {
   const [showRecent, setShowRecent] = useState(false);
 
-  // Active = sessions that are actually running (thinking, executing, waiting, or recently active).
-  // Recent = idle/completed sessions (folded by default).
+  // Active = sessions owned by a running daemon (has a live port behind it).
+  // Recent = transcript-discovered sessions with no live daemon.
   const { activeSessions, recentSessions } = useMemo(() => {
     const active: UISession[] = [];
     const recent: UISession[] = [];
-    const RECENT_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
-    const now = Date.now();
     for (const session of sessions) {
-      const isLiveStatus = session.status === 'thinking' || session.status === 'executing' || session.status === 'waiting';
-      const isRecentlyActive = session.lastActiveAt && (now - new Date(session.lastActiveAt).getTime()) < RECENT_THRESHOLD_MS;
-      const isDaemonConnected = session.source === 'daemon' && session.connectionStatus === 'connected';
-      if (isLiveStatus || (isDaemonConnected && isRecentlyActive)) {
+      if (session.source === 'daemon') {
         active.push(session);
       } else {
         recent.push(session);
@@ -142,6 +137,7 @@ export function SessionList({
                 isActive={session.id === activeSessionId}
                 onClick={() => onSelectSession(session.id)}
                 onResume={onResumeSession}
+                onDisconnect={onDisconnect}
                 isResuming={resumingSessionId === session.id}
               />
             ))}

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -45,13 +45,18 @@ export function SessionList({
 }: SessionListProps) {
   const [showRecent, setShowRecent] = useState(false);
 
-  // Active = sessions from connected daemons (source 'daemon') or connected status.
-  // Recent = everything else (transcript discoveries, completed sessions).
+  // Active = sessions that are actually running (thinking, executing, waiting, or recently active).
+  // Recent = idle/completed sessions (folded by default).
   const { activeSessions, recentSessions } = useMemo(() => {
     const active: UISession[] = [];
     const recent: UISession[] = [];
+    const RECENT_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+    const now = Date.now();
     for (const session of sessions) {
-      if (session.source === 'daemon' || session.connectionStatus === 'connected') {
+      const isLiveStatus = session.status === 'thinking' || session.status === 'executing' || session.status === 'waiting';
+      const isRecentlyActive = session.lastActiveAt && (now - new Date(session.lastActiveAt).getTime()) < RECENT_THRESHOLD_MS;
+      const isDaemonConnected = session.source === 'daemon' && session.connectionStatus === 'connected';
+      if (isLiveStatus || (isDaemonConnected && isRecentlyActive)) {
         active.push(session);
       } else {
         recent.push(session);


### PR DESCRIPTION
## Summary

Fixes 4 P1 issues from the iOS App Polish Sprint (Epic #267).

- **#265**: Remove connection bars from session list. Sessions now display directly with StatusDot indicators on each card. Cleaner, less cluttered layout.
- **#263**: Add question indicator badge on session cards. Shows a `MessageCircleQuestion` icon and "Needs your input" text (in warning color) when `questionPending` is true.
- **#261**: Center Connect modal with `max-h-[85vh]` and `overflow-y-auto`. Keyboard no longer covers the Connect/Cancel buttons on iOS.
- **#262**: Suppress notifications during `replay_batch` processing. Uses `isReplayingRef` flag to prevent old replay events from triggering notification spam on connect/reconnect.

## Test plan

- [x] 1322 tests pass, 0 failures
- [x] TypeScript compiles clean
- [x] iOS simulator: connection bars removed, clean session list
- [x] iOS simulator: Connect modal buttons visible above keyboard
- [x] iOS simulator: no notification spam on connect
- [x] Installed on physical iPhone 15 Pro Max

Fixes #265, #263, #261, #262