### PR TITLE
fix: multi-choice question options, Notification upgrade

### DIFF
--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -105,11 +105,11 @@ export class HookEventBridge {
   handlePermissionRequest(input: PermissionRequestHookInput): void {
     this.lastPermissionRequestAt = Date.now();
 
-    // Build a rich question from the tool_name and permission_suggestions.
-    // If permission_suggestions are provided, use them as numbered options;
-    // otherwise fall back to a Yes/No question with tool context.
+    // Build a rich question from the tool_name, tool_input, and permission_suggestions.
+    // Include tool input context (e.g., the command being run) in the prompt.
     const toolName = input.tool_name || 'unknown tool';
-    const promptText = `Allow ${toolName}?`;
+    const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
+    const promptText = inputSummary ? `Allow ${toolName}: ${inputSummary}` : `Allow ${toolName}?`;
 
     if (input.permission_suggestions && input.permission_suggestions.length >= 2) {
       const options: QuestionOption[] = input.permission_suggestions.map((suggestion, idx) => {
@@ -224,5 +224,49 @@ export class HookEventBridge {
       allowsFreeText: false,
       isAnswered: false,
     };
+  }
+
+  /** Extract a short summary from tool input for the question prompt. */
+  private summarizeToolInput(toolName: string, toolInput: Record<string, unknown>): string | null {
+    if (!toolInput || typeof toolInput !== 'object') return null;
+    const lower = toolName.toLowerCase();
+
+    const get = (key: string): unknown => toolInput[key];
+
+    // Bash: show the command
+    if (lower === 'bash' || lower === 'terminal') {
+      const cmd = get('command') ?? get('cmd');
+      if (typeof cmd === 'string') {
+        return cmd.length > 120 ? `${cmd.slice(0, 117)}...` : cmd;
+      }
+    }
+
+    // Read/Write/Edit: show the file path
+    if (lower === 'read' || lower === 'write' || lower === 'edit') {
+      const path = get('file_path') ?? get('path');
+      if (typeof path === 'string') return path;
+    }
+
+    // Glob/Grep: show the pattern
+    if (lower === 'glob' || lower === 'grep') {
+      const pattern = get('pattern') ?? get('glob');
+      if (typeof pattern === 'string') return pattern;
+    }
+
+    // WebFetch: show the URL
+    if (lower.includes('fetch') || lower.includes('web')) {
+      const url = get('url');
+      if (typeof url === 'string') return url;
+    }
+
+    // Generic: try common field names
+    for (const key of ['command', 'file_path', 'path', 'url', 'description']) {
+      const val = get(key);
+      if (typeof val === 'string' && val.length > 0) {
+        return val.length > 120 ? `${val.slice(0, 117)}...` : val;
+      }
+    }
+
+    return null;
   }
 }

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -35,6 +35,8 @@ export class HookEventBridge {
   private readonly events: HookBridgeEvents;
   /** Timestamp of last PermissionRequest, used to suppress duplicate Notification */
   private lastPermissionRequestAt = 0;
+  /** Whether last PermissionRequest had multi-choice options (not just Yes/No fallback) */
+  private lastPermissionHadOptions = false;
 
   constructor(sessionId: UUID, events: HookBridgeEvents) {
     this.sessionId = sessionId;
@@ -68,8 +70,10 @@ export class HookEventBridge {
 
   handleNotification(input: NotificationHookInput): void {
     if (input.notification_type === 'permission_prompt') {
-      // Suppress if PermissionRequest already handled this prompt (within 2s window)
-      if (Date.now() - this.lastPermissionRequestAt < 2000) {
+      // If PermissionRequest already fired with multi-choice options, suppress this duplicate.
+      // But if it only produced Yes/No (no permission_suggestions), let the Notification
+      // through because it may parse richer options from the full message text.
+      if (Date.now() - this.lastPermissionRequestAt < 2000 && this.lastPermissionHadOptions) {
         return;
       }
       const question = this.buildPermissionQuestion(input.message);
@@ -111,7 +115,12 @@ export class HookEventBridge {
     const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
     const promptText = inputSummary ? `Allow ${toolName}: ${inputSummary}` : `Allow ${toolName}?`;
 
+    console.log(
+      `[HookEventBridge] PermissionRequest: tool=${toolName}, suggestions=${JSON.stringify(input.permission_suggestions)}, inputKeys=${Object.keys(input.tool_input || {})}`,
+    );
+
     if (input.permission_suggestions && input.permission_suggestions.length >= 2) {
+      this.lastPermissionHadOptions = true;
       const options: QuestionOption[] = input.permission_suggestions.map((suggestion, idx) => {
         const lower = suggestion.toLowerCase();
         const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
@@ -133,6 +142,9 @@ export class HookEventBridge {
         isAnswered: false,
       });
     } else {
+      // No multi-choice suggestions; send Yes/No but allow Notification handler
+      // to upgrade with richer options if it arrives within the dedup window
+      this.lastPermissionHadOptions = false;
       this.events.onQuestion(this.buildPermissionQuestion(promptText));
     }
 

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -172,7 +172,8 @@ describe('HookEventBridge', () => {
 
     expect(statuses).toEqual([{ status: 'waiting' }]);
     expect(questions.length).toBe(1);
-    expect(questions[0]?.text).toBe('Allow Bash?');
+    // Prompt includes tool input context (the command)
+    expect(questions[0]?.text).toBe('Allow Bash: rm -rf /');
     expect(questions[0]?.options.length).toBe(2);
     expect(questions[0]?.options[0]?.isYes).toBe(true);
     expect(questions[0]?.options[1]?.isNo).toBe(true);

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -169,42 +169,29 @@ export function InputArea({
         <div className="border-b border-[var(--color-border)] px-4 py-3">
           <p className="mb-2 text-sm text-[var(--color-text-secondary)]">{question.prompt}</p>
           <div className="flex flex-wrap gap-2">
-            {question.type === 'yes_no' && (
-              <>
-                <QuickResponse
-                  label="Yes"
-                  onClick={() => handleQuickResponse('yes')}
-                  variant="primary"
-                />
-                <QuickResponse
-                  label="No"
-                  onClick={() => handleQuickResponse('no')}
-                  variant="danger"
-                />
-              </>
-            )}
-            {question.type === 'numbered' &&
-              question.options?.map((option, index) => (
-                <QuickResponse
-                  key={index}
-                  label={`${index + 1}. ${option}`}
-                  onClick={() => handleQuickResponse(String(index + 1))}
-                />
-              ))}
-            {question.type === 'permission' && (
-              <>
-                <QuickResponse
-                  label="Allow"
-                  onClick={() => handleQuickResponse('allow')}
-                  variant="primary"
-                />
-                <QuickResponse
-                  label="Deny"
-                  onClick={() => handleQuickResponse('deny')}
-                  variant="danger"
-                />
-              </>
-            )}
+            {question.structuredOptions && question.structuredOptions.length > 0
+              ? question.structuredOptions.map((opt, index) => (
+                  <QuickResponse
+                    key={index}
+                    label={opt.label}
+                    onClick={() => handleQuickResponse(opt.value)}
+                    variant={opt.isYes ? 'primary' : opt.isNo ? 'danger' : 'default'}
+                  />
+                ))
+              : question.type === 'yes_no' && (
+                  <>
+                    <QuickResponse
+                      label="Yes"
+                      onClick={() => handleQuickResponse('y')}
+                      variant="primary"
+                    />
+                    <QuickResponse
+                      label="No"
+                      onClick={() => handleQuickResponse('n')}
+                      variant="danger"
+                    />
+                  </>
+                )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

When PermissionRequest fires without permission_suggestions (common), the Notification handler was suppressed by the 2s dedup window, losing the richer multi-choice options parsed from the full message text.

Now: dedup only suppresses if PermissionRequest already produced multi-choice options. If it only sent Yes/No, the Notification handler can upgrade it with parsed options (e.g., "1) Yes 2) Yes, always 3) No").

Also adds diagnostic logging for PermissionRequest hook inputs to debug question content.

## Test plan
- [x] 1326 tests pass
- [x] TypeScript clean

Fixes #282