### PR TITLE
fix: wire iOS APNS native bridge (issue #286)

### DIFF
--- a/packages/web/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/web/ios/App/App.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9DQ459HAZB;

--- a/packages/web/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/web/ios/App/App.xcodeproj/project.pbxproj
@@ -271,7 +271,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
-				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9DQ459HAZB;
@@ -295,6 +294,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9DQ459HAZB;

--- a/packages/web/ios/App/App/App.entitlements
+++ b/packages/web/ios/App/App/App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -24,6 +24,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        NotificationCenter.default.post(
+            name: .capacitorDidRegisterForRemoteNotifications,
+            object: deviceToken
+        )
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NotificationCenter.default.post(
+            name: .capacitorDidFailToRegisterForRemoteNotifications,
+            object: error
+        )
+    }
+
     // Keep WebSocket alive when app enters background.
     // iOS grants ~30 seconds of background execution time.
     // During this window, the WebSocket stays connected and can


### PR DESCRIPTION
## Summary

- Wire `didRegisterForRemoteNotificationsWithDeviceToken` and `didFailToRegisterForRemoteNotifications` delegates in `AppDelegate.swift` so the Capacitor push-notifications plugin receives the device token
- Add `App.entitlements` with `aps-environment = development` so Xcode can sign with a push-capable provisioning profile
- Set `CODE_SIGN_ENTITLEMENTS` in both Debug and Release build configs (fix duplicate entry in Debug, add missing entry in Release)

## Test plan

- [ ] Build and install on physical device from Xcode (requires explicit provisioning profile with Push Notifications capability)
- [ ] Open app and accept notification permission prompt
- [ ] Verify device token is logged / received by daemon's APNS push client
- [ ] Trigger a question in a Claude Code session and confirm push notification arrives on device when app is backgrounded

## Notes

The wildcard provisioning profile does not support push notifications. Xcode must automatically create an explicit profile for `live.yooz.remi` with the Push Notifications capability when building from Xcode.app with an Apple ID signed in (`-allowProvisioningUpdates`). Running `xcodebuild` from a headless terminal without keychain access will fail provisioning.

Closes #286