### PR TITLE
fix: APNS push notifications end-to-end (#286)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1615,6 +1615,7 @@ async function createNewSession(
         if (session && session.activeConnectionId === null && deviceTokens.size > 0) {
           const sessionName = session.name || 'Agent';
           const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
+          const pushSessionId = primarySessionId ?? sessionId;
           for (const dt of deviceTokens.values()) {
             sendPushTrigger(
               signalingUrl,
@@ -1622,7 +1623,10 @@ async function createNewSession(
               `${sessionName} needs input`,
               question.text.slice(0, 100),
               cliPushSecret,
-            ).catch((err) => log(`Push notification failed: ${err}`));
+              pushSessionId,
+            )
+              .then(() => log(`Push notification sent for session ${pushSessionId}`))
+              .catch((err) => log(`Push notification failed: ${err}`));
           }
         }
       },

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -12,6 +12,7 @@ export async function sendPushTrigger(
   title: string,
   body: string,
   pushSecret?: string,
+  sessionId?: string,
 ): Promise<void> {
   const baseUrl = signalingUrl || DEFAULT_SIGNALING_URL;
   // Strip any path (e.g. /connect) from the signaling URL since we need the root
@@ -20,14 +21,22 @@ export async function sendPushTrigger(
   if (pushSecret) {
     headers['Authorization'] = `Bearer ${pushSecret}`;
   }
+  const payload: Record<string, string> = { token: deviceToken, title, body };
+  if (sessionId) {
+    payload['sessionId'] = sessionId;
+  }
   const response = await fetch(url, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ token: deviceToken, title, body }),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => 'unknown');
     throw new Error(`Push trigger failed: ${response.status} ${text}`);
   }
+
+  // Log success for diagnostics (response body may include details)
+  const resultText = await response.text().catch(() => '');
+  console.debug(`[Push] Sent to ${url} for token ${deviceToken.slice(0, 20)}...: ${resultText}`);
 }

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -8,6 +8,10 @@ interface ApnsPayload {
   title: string;
   body: string;
   bundleId: string;
+  /** Custom data fields included at top-level of APNS payload (sibling to aps) */
+  data?: Record<string, string>;
+  /** Use APNS sandbox endpoint (development builds) */
+  sandbox?: boolean;
 }
 
 interface ApnsConfig {
@@ -26,7 +30,8 @@ export async function sendApnsPush(
 ): Promise<{ success: boolean; error?: string }> {
   const jwt = await createApnsJwt(config);
 
-  const apnsUrl = `https://api.push.apple.com/3/device/${payload.token}`;
+  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
+  const apnsUrl = `https://${apnsHost}/3/device/${payload.token}`;
 
   const response = await fetch(apnsUrl, {
     method: 'POST',
@@ -45,6 +50,7 @@ export async function sendApnsPush(
         sound: 'default',
         badge: 1,
       },
+      ...(payload.data ? payload.data : {}),
     }),
   });
 

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -28,6 +28,8 @@ interface Env {
   APNS_PRIVATE_KEY?: string;
   APNS_BUNDLE_ID?: string;
   PUSH_SECRET?: string;
+  /** Set to 'true' to use APNS sandbox endpoint for development builds */
+  APNS_SANDBOX?: string;
 }
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
@@ -123,7 +125,13 @@ export default {
         );
       }
 
-      let body: { token?: string; title?: string; body?: string };
+      let body: {
+        token?: string;
+        title?: string;
+        body?: string;
+        sessionId?: string;
+        sandbox?: boolean;
+      };
       try {
         body = await request.json();
       } catch {
@@ -145,11 +153,17 @@ export default {
 
       // bundleId is always server-controlled (never from client)
       const bundleId = env.APNS_BUNDLE_ID || 'live.yooz.remi';
+      // sandbox: use env var as global override, or trust the daemon's flag
+      const sandbox = env.APNS_SANDBOX === 'true' || body.sandbox === true;
+      // Custom data for notification tap navigation
+      const data: Record<string, string> | undefined = body.sessionId
+        ? { sessionId: body.sessionId }
+        : undefined;
 
       let result: { success: boolean; error?: string };
       try {
         result = await sendApnsPush(
-          { token: body.token, title: body.title, body: body.body, bundleId },
+          { token: body.token, title: body.title, body: body.body, bundleId, sandbox, data },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );
       } catch (err) {


### PR DESCRIPTION
## Summary

- Fix APNS sandbox vs production endpoint: development builds get sandbox device tokens that the production APNS endpoint (`api.push.apple.com`) rejects with BadDeviceToken. Added `sandbox` flag to `ApnsPayload` and `APNS_SANDBOX` env var to the worker so the correct endpoint is selected.
- Fix missing sessionId in push payload: the notification tap handler in `App.tsx` reads `data.sessionId` to navigate, but the daemon was not passing it. Now `sendPushTrigger` accepts `sessionId`, includes it in the POST body, the signaling worker embeds it in the APNS custom data field, and iOS delivers it in `action.notification.data`.
- Add diagnostic logging: push attempts now log success (`.then`) alongside existing error logging (`.catch`) so failures are visible in daemon logs.

## Files changed

- `packages/signaling/src/apns.ts`: add `sandbox` and `data` fields to `ApnsPayload`; select APNS host based on sandbox flag; spread custom data at top level of APNS payload body (sibling to `aps`)
- `packages/signaling/src/index.ts`: add `APNS_SANDBOX` to `Env`; parse `sessionId` and `sandbox` from request body; pass them through to `sendApnsPush`
- `packages/daemon/src/notifications/push-client.ts`: add `sessionId` param; include it in POST body; log success response
- `packages/daemon/src/cli.ts`: pass `primarySessionId` to `sendPushTrigger`; add `.then()` success log

## Deployment

The signaling worker has been deployed to `https://remi-signaling.yooz.workers.dev`.

**To enable sandbox mode for dev builds**, set the `APNS_SANDBOX` secret on the worker:
```
npx cfman wrangler --account yooz-labs secret put APNS_SANDBOX
# value: true
```
This can be removed once the app ships to production (or per-token detection can be added later).

## Test plan

- [x] `bun test` from root: 1243 pass, 11 fail (pre-existing mDNS/bonjour-service failures, unrelated)
- [x] `cd packages/daemon && bun run typecheck`: clean
- [x] `cd packages/web && bun run build`: clean
- [x] Signaling worker deployed successfully
- [ ] Manual: install dev build on device, background app, trigger a Claude Code question, verify push arrives and tapping it navigates to the correct session