### PR TITLE
fix: transcript history reliability (#281)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2181,7 +2181,20 @@ const sharedEvents = {
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => {
     log(`Transcript load request from ${connectionId} for session ${sessionId}`);
 
-    const filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
+    // First try finding by Claude session ID embedded in the filename
+    let filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
+
+    // If not found by Claude session ID, the request may be using a Remi UUID
+    // (daemon sessions are identified by Remi UUID, not Claude session ID).
+    // Check if an active watcher exists for this session ID and use its path.
+    if (!filePath) {
+      const activeWatcher = transcriptWatchers.get(sessionId as UUID);
+      if (activeWatcher) {
+        filePath = activeWatcher.filePath;
+        log(`[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via active watcher`);
+      }
+    }
+
     if (!filePath) {
       sendToConnection(
         connectionId,

--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -65,6 +65,11 @@ export class TranscriptWatcher {
     return this.running;
   }
 
+  /** The transcript file path being watched */
+  get filePath(): string {
+    return this.config.filePath;
+  }
+
   /** Number of entries read so far */
   get entryCount(): number {
     return this.entries.length;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -851,9 +851,12 @@ function App() {
       // Reset unread count for the selected session
       setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, unreadCount: 0 } : s)));
 
-      // If this is an external transcript session we haven't loaded yet, request its history
+      // Request transcript history if we haven't already and there are no messages yet.
+      // This covers both external transcript sessions and daemon sessions (which use a
+      // Remi UUID as their ID — the daemon resolves it via its active watcher).
       const session = sessions.find((s) => s.id === id);
-      if (session?.source === 'transcript' && !loadedTranscriptsRef.current.has(id)) {
+      const hasMessages = messages.some((m) => m.sessionId === id);
+      if (session && !hasMessages && !loadedTranscriptsRef.current.has(id)) {
         loadedTranscriptsRef.current.add(id);
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
@@ -861,7 +864,7 @@ function App() {
         requestTranscriptLoad(session.connectionId, id);
       }
     },
-    [sessions, requestTranscriptLoad],
+    [sessions, messages, requestTranscriptLoad],
   );
 
   const handleBack = useCallback(() => {


### PR DESCRIPTION
## Summary

- Fix `onTranscriptLoadRequest` failing for daemon sessions: the handler only resolved session IDs via Claude session ID (embedded in transcript filename). Daemon sessions use Remi UUIDs. Now falls back to checking active `transcriptWatchers` map by Remi UUID.
- Fix `handleSelectSession` in App.tsx: previously only requested transcript history for `source === 'transcript'` external sessions. Daemon sessions (live, attached via PTY) also need history loaded on select when empty. Now triggers for any session with no messages yet.
- Add `filePath` getter to `TranscriptWatcher` (required for the daemon fix).

## Root cause

When tapping a live daemon session (not a transcript-discovered external session), `handleSelectSession` skipped the transcript load request entirely due to `source === 'transcript'` guard. Even if the request was sent, the daemon's `onTranscriptLoadRequest` handler would fail to find the transcript path because it only searched by Claude session ID, not by Remi UUID.

The combined effect: empty chat on every daemon session select.

## Test plan

- [x] 53 transcript unit tests pass
- [x] Web build clean (TypeScript)
- [ ] Manual: tap a live daemon session that is "Thinking..." — chat history should populate
- [ ] Manual: restart daemon, reconnect, tap session — history should load from disk

## Related
- Closes #281 (partial — addresses daemon restart and live session history; multi-daemon includeExternal logic is a separate follow-up)