### PR TITLE
fix: MVP blockers - transcript history and APNS push (#281, #286)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2181,7 +2181,20 @@ const sharedEvents = {
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => {
     log(`Transcript load request from ${connectionId} for session ${sessionId}`);
 
-    const filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
+    // First try finding by Claude session ID embedded in the filename
+    let filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
+
+    // If not found by Claude session ID, the request may be using a Remi UUID
+    // (daemon sessions are identified by Remi UUID, not Claude session ID).
+    // Check if an active watcher exists for this session ID and use its path.
+    if (!filePath) {
+      const activeWatcher = transcriptWatchers.get(sessionId as UUID);
+      if (activeWatcher) {
+        filePath = activeWatcher.filePath;
+        log(`[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via active watcher`);
+      }
+    }
+
     if (!filePath) {
       sendToConnection(
         connectionId,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1620,7 +1620,7 @@ async function createNewSession(
             sendPushTrigger(signalingUrl, dt.token, {
               title: `${sessionName} needs input`,
               body: question.text.slice(0, 100),
-              pushSecret: cliPushSecret,
+              ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
               sessionId: pushSessionId,
             })
               .then(() => log(`Push notification sent for session ${pushSessionId}`))

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1615,6 +1615,7 @@ async function createNewSession(
         if (session && session.activeConnectionId === null && deviceTokens.size > 0) {
           const sessionName = session.name || 'Agent';
           const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
+          const pushSessionId = primarySessionId ?? sessionId;
           for (const dt of deviceTokens.values()) {
             sendPushTrigger(
               signalingUrl,
@@ -1622,7 +1623,10 @@ async function createNewSession(
               `${sessionName} needs input`,
               question.text.slice(0, 100),
               cliPushSecret,
-            ).catch((err) => log(`Push notification failed: ${err}`));
+              pushSessionId,
+            )
+              .then(() => log(`Push notification sent for session ${pushSessionId}`))
+              .catch((err) => log(`Push notification failed: ${err}`));
           }
         }
       },

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1617,14 +1617,12 @@ async function createNewSession(
           const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
           const pushSessionId = primarySessionId ?? sessionId;
           for (const dt of deviceTokens.values()) {
-            sendPushTrigger(
-              signalingUrl,
-              dt.token,
-              `${sessionName} needs input`,
-              question.text.slice(0, 100),
-              cliPushSecret,
-              pushSessionId,
-            )
+            sendPushTrigger(signalingUrl, dt.token, {
+              title: `${sessionName} needs input`,
+              body: question.text.slice(0, 100),
+              pushSecret: cliPushSecret,
+              sessionId: pushSessionId,
+            })
               .then(() => log(`Push notification sent for session ${pushSessionId}`))
               .catch((err) => log(`Push notification failed: ${err}`));
           }

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -12,6 +12,7 @@ export async function sendPushTrigger(
   title: string,
   body: string,
   pushSecret?: string,
+  sessionId?: string,
 ): Promise<void> {
   const baseUrl = signalingUrl || DEFAULT_SIGNALING_URL;
   // Strip any path (e.g. /connect) from the signaling URL since we need the root
@@ -20,14 +21,22 @@ export async function sendPushTrigger(
   if (pushSecret) {
     headers['Authorization'] = `Bearer ${pushSecret}`;
   }
+  const payload: Record<string, string> = { token: deviceToken, title, body };
+  if (sessionId) {
+    payload['sessionId'] = sessionId;
+  }
   const response = await fetch(url, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ token: deviceToken, title, body }),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => 'unknown');
     throw new Error(`Push trigger failed: ${response.status} ${text}`);
   }
+
+  // Log success for diagnostics (response body may include details)
+  const resultText = await response.text().catch(() => '');
+  console.debug(`[Push] Sent to ${url} for token ${deviceToken.slice(0, 20)}...: ${resultText}`);
 }

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -36,7 +36,13 @@ export async function sendPushTrigger(
     throw new Error(`Push trigger failed: ${response.status} ${text}`);
   }
 
-  // Log success for diagnostics (response body may include details)
-  const resultText = await response.text().catch(() => '');
-  console.debug(`[Push] Sent to ${url} for token ${deviceToken.slice(0, 20)}...: ${resultText}`);
+  // Read response body for diagnostics; body not consumed earlier on the success path
+  try {
+    const resultText = await response.text();
+    console.log(`[Push] Sent for token ${deviceToken.slice(0, 20)}...: ${resultText}`);
+  } catch (err) {
+    console.log(
+      `[Push] Sent for token ${deviceToken.slice(0, 20)}... (could not read response: ${err})`,
+    );
+  }
 }

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -6,24 +6,44 @@
 
 const DEFAULT_SIGNALING_URL = 'https://remi-signaling.yooz.workers.dev';
 
+/** Options for sendPushTrigger */
+export interface PushTriggerOptions {
+  /** Title shown in the notification banner */
+  title: string;
+  /** Body text shown in the notification banner */
+  body: string;
+  /** Bearer token for signaling server auth (REMI_PUSH_SECRET) */
+  pushSecret?: string;
+  /** Remi session UUID included in APNS custom data for tap-to-navigate */
+  sessionId?: string;
+}
+
+/**
+ * Send a push notification trigger to the signaling server.
+ *
+ * @param signalingUrl - Base URL of the signaling server (defaults to remi-signaling.yooz.workers.dev)
+ * @param deviceToken  - APNS device token registered by the iOS client
+ * @param opts         - Notification content and optional auth/routing metadata
+ */
 export async function sendPushTrigger(
   signalingUrl: string | undefined,
   deviceToken: string,
-  title: string,
-  body: string,
-  pushSecret?: string,
-  sessionId?: string,
+  opts: PushTriggerOptions,
 ): Promise<void> {
   const baseUrl = signalingUrl || DEFAULT_SIGNALING_URL;
   // Strip any path (e.g. /connect) from the signaling URL since we need the root
   const url = `${new URL(baseUrl).origin}/push`;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (pushSecret) {
-    headers['Authorization'] = `Bearer ${pushSecret}`;
+  if (opts.pushSecret) {
+    headers['Authorization'] = `Bearer ${opts.pushSecret}`;
   }
-  const payload: Record<string, string> = { token: deviceToken, title, body };
-  if (sessionId) {
-    payload['sessionId'] = sessionId;
+  const payload: Record<string, string> = {
+    token: deviceToken,
+    title: opts.title,
+    body: opts.body,
+  };
+  if (opts.sessionId) {
+    payload['sessionId'] = opts.sessionId;
   }
   const response = await fetch(url, {
     method: 'POST',

--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -65,6 +65,11 @@ export class TranscriptWatcher {
     return this.running;
   }
 
+  /** The transcript file path being watched */
+  get filePath(): string {
+    return this.config.filePath;
+  }
+
   /** Number of entries read so far */
   get entryCount(): number {
     return this.entries.length;

--- a/packages/daemon/tests/push-client.test.ts
+++ b/packages/daemon/tests/push-client.test.ts
@@ -43,9 +43,9 @@ describe('sendPushTrigger', () => {
 
     expect(lastRequest).not.toBeNull();
     const body = lastRequest!.body as Record<string, string>;
-    expect(body.token).toBe('device-token-abc');
-    expect(body.title).toBe('Agent needs input');
-    expect(body.body).toBe('Please respond');
+    expect(body['token']).toBe('device-token-abc');
+    expect(body['title']).toBe('Agent needs input');
+    expect(body['body']).toBe('Please respond');
   });
 
   test('includes sessionId when provided', async () => {
@@ -56,7 +56,7 @@ describe('sendPushTrigger', () => {
     });
 
     const body = lastRequest!.body as Record<string, string>;
-    expect(body.sessionId).toBe('remi-uuid-1234');
+    expect(body['sessionId']).toBe('remi-uuid-1234');
   });
 
   test('omits sessionId when not provided', async () => {

--- a/packages/daemon/tests/push-client.test.ts
+++ b/packages/daemon/tests/push-client.test.ts
@@ -42,7 +42,8 @@ describe('sendPushTrigger', () => {
     });
 
     expect(lastRequest).not.toBeNull();
-    const body = lastRequest!.body as Record<string, string>;
+    if (!lastRequest) throw new Error('no request captured');
+    const body = lastRequest.body as Record<string, string>;
     expect(body['token']).toBe('device-token-abc');
     expect(body['title']).toBe('Agent needs input');
     expect(body['body']).toBe('Please respond');
@@ -55,7 +56,8 @@ describe('sendPushTrigger', () => {
       sessionId: 'remi-uuid-1234',
     });
 
-    const body = lastRequest!.body as Record<string, string>;
+    if (!lastRequest) throw new Error('no request captured');
+    const body = lastRequest.body as Record<string, string>;
     expect(body['sessionId']).toBe('remi-uuid-1234');
   });
 
@@ -65,7 +67,8 @@ describe('sendPushTrigger', () => {
       body: 'Body',
     });
 
-    const body = lastRequest!.body as Record<string, string>;
+    if (!lastRequest) throw new Error('no request captured');
+    const body = lastRequest.body as Record<string, string>;
     expect('sessionId' in body).toBe(false);
   });
 
@@ -76,13 +79,15 @@ describe('sendPushTrigger', () => {
       pushSecret: 'my-secret',
     });
 
-    expect(lastRequest!.headers['authorization']).toBe('Bearer my-secret');
+    if (!lastRequest) throw new Error('no request captured');
+    expect(lastRequest.headers['authorization']).toBe('Bearer my-secret');
   });
 
   test('omits Authorization header when pushSecret not provided', async () => {
     await sendPushTrigger(serverUrl, 'tok', { title: 'T', body: 'B' });
 
-    expect(lastRequest!.headers['authorization']).toBeUndefined();
+    if (!lastRequest) throw new Error('no request captured');
+    expect(lastRequest.headers['authorization']).toBeUndefined();
   });
 
   test('throws on non-OK response', async () => {

--- a/packages/daemon/tests/push-client.test.ts
+++ b/packages/daemon/tests/push-client.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for sendPushTrigger.
+ *
+ * Uses a real Bun HTTP server to capture request bodies (no mocks).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { sendPushTrigger } from '../src/notifications/push-client.ts';
+
+describe('sendPushTrigger', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let lastRequest: { body: unknown; headers: Record<string, string> } | null = null;
+  let serverUrl: string;
+
+  beforeEach(() => {
+    lastRequest = null;
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const body = await req.json().catch(() => null);
+        const headers: Record<string, string> = {};
+        req.headers.forEach((v, k) => {
+          headers[k] = v;
+        });
+        lastRequest = { body, headers };
+        return new Response(JSON.stringify({ success: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+    serverUrl = `http://localhost:${server.port}`;
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  test('sends token, title, and body in POST payload', async () => {
+    await sendPushTrigger(serverUrl, 'device-token-abc', {
+      title: 'Agent needs input',
+      body: 'Please respond',
+    });
+
+    expect(lastRequest).not.toBeNull();
+    const body = lastRequest!.body as Record<string, string>;
+    expect(body.token).toBe('device-token-abc');
+    expect(body.title).toBe('Agent needs input');
+    expect(body.body).toBe('Please respond');
+  });
+
+  test('includes sessionId when provided', async () => {
+    await sendPushTrigger(serverUrl, 'device-token-xyz', {
+      title: 'Title',
+      body: 'Body',
+      sessionId: 'remi-uuid-1234',
+    });
+
+    const body = lastRequest!.body as Record<string, string>;
+    expect(body.sessionId).toBe('remi-uuid-1234');
+  });
+
+  test('omits sessionId when not provided', async () => {
+    await sendPushTrigger(serverUrl, 'device-token-xyz', {
+      title: 'Title',
+      body: 'Body',
+    });
+
+    const body = lastRequest!.body as Record<string, string>;
+    expect('sessionId' in body).toBe(false);
+  });
+
+  test('sends Authorization header when pushSecret provided', async () => {
+    await sendPushTrigger(serverUrl, 'tok', {
+      title: 'T',
+      body: 'B',
+      pushSecret: 'my-secret',
+    });
+
+    expect(lastRequest!.headers['authorization']).toBe('Bearer my-secret');
+  });
+
+  test('omits Authorization header when pushSecret not provided', async () => {
+    await sendPushTrigger(serverUrl, 'tok', { title: 'T', body: 'B' });
+
+    expect(lastRequest!.headers['authorization']).toBeUndefined();
+  });
+
+  test('throws on non-OK response', async () => {
+    server.stop();
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response('bad request', { status: 400 });
+      },
+    });
+    serverUrl = `http://localhost:${server.port}`;
+
+    await expect(sendPushTrigger(serverUrl, 'tok', { title: 'T', body: 'B' })).rejects.toThrow(
+      'Push trigger failed: 400',
+    );
+  });
+
+  test('uses default signaling URL when signalingUrl is undefined', async () => {
+    // We cannot reach the real signaling server in tests, so just verify
+    // that passing undefined does not crash before the network call
+    // (it will throw a network error, not a URL construction error).
+    await expect(sendPushTrigger(undefined, 'tok', { title: 'T', body: 'B' })).rejects.toThrow(); // network error expected; not a URL parse error
+  });
+});

--- a/packages/daemon/tests/transcript-discovery.test.ts
+++ b/packages/daemon/tests/transcript-discovery.test.ts
@@ -219,4 +219,35 @@ describe('TranscriptDiscovery', () => {
 
     expect(sessions).toHaveLength(0);
   });
+
+  test('findTranscriptBySessionId returns path for known session', () => {
+    const projectDir = makeProjectDir('/Users/test/find-by-id');
+    const filePath = writeTranscript(projectDir, 'known-session-abc', [makeUserEntry('hello')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const result = discovery.findTranscriptBySessionId('known-session-abc');
+
+    expect(result).toBe(filePath);
+  });
+
+  test('findTranscriptBySessionId returns null for unknown session', () => {
+    makeProjectDir('/Users/test/find-by-id-miss');
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const result = discovery.findTranscriptBySessionId('nonexistent-session-xyz');
+
+    expect(result).toBeNull();
+  });
+
+  test('findTranscriptBySessionId finds correct session among multiple', () => {
+    const projectDir = makeProjectDir('/Users/test/find-by-id-multi');
+    writeTranscript(projectDir, 'session-one', [makeUserEntry('one')]);
+    const targetPath = writeTranscript(projectDir, 'session-two', [makeUserEntry('two')]);
+    writeTranscript(projectDir, 'session-three', [makeUserEntry('three')]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const result = discovery.findTranscriptBySessionId('session-two');
+
+    expect(result).toBe(targetPath);
+  });
 });

--- a/packages/daemon/tests/transcript-watcher.test.ts
+++ b/packages/daemon/tests/transcript-watcher.test.ts
@@ -321,6 +321,13 @@ describe('TranscriptWatcher', () => {
     watcher.stop();
   });
 
+  test('filePath getter returns the configured path', () => {
+    const filePath = createTempFile('getter-test.jsonl');
+    const watcher = new TranscriptWatcher({ filePath, readExisting: false });
+    expect(watcher.filePath).toBe(filePath);
+    watcher.stop();
+  });
+
   test('stop during waitForFile prevents watching from starting', async () => {
     const filePath = path.join(TEMP_DIR, 'stop-wait.jsonl');
     // File does NOT exist yet

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -33,6 +33,11 @@ export async function sendApnsPush(
   const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
   const apnsUrl = `https://${apnsHost}/3/device/${payload.token}`;
 
+  // Guard against reserved APNS key collision in custom data
+  if (payload.data && 'aps' in payload.data) {
+    throw new Error('ApnsPayload.data must not contain reserved key "aps"');
+  }
+
   const response = await fetch(apnsUrl, {
     method: 'POST',
     headers: {

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -8,7 +8,8 @@ interface ApnsPayload {
   title: string;
   body: string;
   bundleId: string;
-  /** Custom data fields included at top-level of APNS payload (sibling to aps) */
+  /** Custom data fields included at top-level of APNS payload (sibling to aps).
+   *  Must be flat string values — nested objects are dropped by iOS. */
   data?: Record<string, string>;
   /** Use APNS sandbox endpoint (development builds) */
   sandbox?: boolean;

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -8,6 +8,10 @@ interface ApnsPayload {
   title: string;
   body: string;
   bundleId: string;
+  /** Custom data fields included at top-level of APNS payload (sibling to aps) */
+  data?: Record<string, string>;
+  /** Use APNS sandbox endpoint (development builds) */
+  sandbox?: boolean;
 }
 
 interface ApnsConfig {
@@ -26,7 +30,8 @@ export async function sendApnsPush(
 ): Promise<{ success: boolean; error?: string }> {
   const jwt = await createApnsJwt(config);
 
-  const apnsUrl = `https://api.push.apple.com/3/device/${payload.token}`;
+  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
+  const apnsUrl = `https://${apnsHost}/3/device/${payload.token}`;
 
   const response = await fetch(apnsUrl, {
     method: 'POST',
@@ -45,6 +50,7 @@ export async function sendApnsPush(
         sound: 'default',
         badge: 1,
       },
+      ...(payload.data ? payload.data : {}),
     }),
   });
 

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -32,6 +32,17 @@ interface Env {
   APNS_SANDBOX?: string;
 }
 
+/** Request body for the /push endpoint */
+interface PushRequestBody {
+  token?: string;
+  title?: string;
+  body?: string;
+  /** Remi session UUID; included in APNS custom data for notification tap navigation */
+  sessionId?: string;
+  /** Reserved for future per-request sandbox override; daemon does not send this today */
+  sandbox?: boolean;
+}
+
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
 const rateLimiter = new RateLimiter(10, 60_000);
 /** Per-IP rate limiter for push: 5 pushes per 60 seconds */
@@ -125,13 +136,7 @@ export default {
         );
       }
 
-      let body: {
-        token?: string;
-        title?: string;
-        body?: string;
-        sessionId?: string;
-        sandbox?: boolean;
-      };
+      let body: PushRequestBody;
       try {
         body = await request.json();
       } catch {
@@ -156,10 +161,9 @@ export default {
       // sandbox: env var is the global gate. body.sandbox is reserved for future per-request
       // override — the daemon does not send it today (payload is Record<string, string>).
       const sandbox = env.APNS_SANDBOX === 'true' || body.sandbox === true;
-      // Custom data for notification tap navigation
-      const data: Record<string, string> | undefined = body.sessionId
-        ? { sessionId: body.sessionId }
-        : undefined;
+      // Custom data for notification tap navigation; reject empty strings to avoid unroutable taps
+      const data: Record<string, string> | undefined =
+        body.sessionId && body.sessionId.length > 0 ? { sessionId: body.sessionId } : undefined;
 
       let result: { success: boolean; error?: string };
       try {

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -28,6 +28,8 @@ interface Env {
   APNS_PRIVATE_KEY?: string;
   APNS_BUNDLE_ID?: string;
   PUSH_SECRET?: string;
+  /** Set to 'true' to use APNS sandbox endpoint for development builds */
+  APNS_SANDBOX?: string;
 }
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
@@ -123,7 +125,13 @@ export default {
         );
       }
 
-      let body: { token?: string; title?: string; body?: string };
+      let body: {
+        token?: string;
+        title?: string;
+        body?: string;
+        sessionId?: string;
+        sandbox?: boolean;
+      };
       try {
         body = await request.json();
       } catch {
@@ -145,11 +153,17 @@ export default {
 
       // bundleId is always server-controlled (never from client)
       const bundleId = env.APNS_BUNDLE_ID || 'live.yooz.remi';
+      // sandbox: use env var as global override, or trust the daemon's flag
+      const sandbox = env.APNS_SANDBOX === 'true' || body.sandbox === true;
+      // Custom data for notification tap navigation
+      const data: Record<string, string> | undefined = body.sessionId
+        ? { sessionId: body.sessionId }
+        : undefined;
 
       let result: { success: boolean; error?: string };
       try {
         result = await sendApnsPush(
-          { token: body.token, title: body.title, body: body.body, bundleId },
+          { token: body.token, title: body.title, body: body.body, bundleId, sandbox, data },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );
       } catch (err) {

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -153,7 +153,8 @@ export default {
 
       // bundleId is always server-controlled (never from client)
       const bundleId = env.APNS_BUNDLE_ID || 'live.yooz.remi';
-      // sandbox: use env var as global override, or trust the daemon's flag
+      // sandbox: env var is the global gate. body.sandbox is reserved for future per-request
+      // override — the daemon does not send it today (payload is Record<string, string>).
       const sandbox = env.APNS_SANDBOX === 'true' || body.sandbox === true;
       // Custom data for notification tap navigation
       const data: Record<string, string> | undefined = body.sessionId

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -851,9 +851,12 @@ function App() {
       // Reset unread count for the selected session
       setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, unreadCount: 0 } : s)));
 
-      // If this is an external transcript session we haven't loaded yet, request its history
+      // Request transcript history if we haven't already and there are no messages yet.
+      // This covers both external transcript sessions and daemon sessions (which use a
+      // Remi UUID as their ID — the daemon resolves it via its active watcher).
       const session = sessions.find((s) => s.id === id);
-      if (session?.source === 'transcript' && !loadedTranscriptsRef.current.has(id)) {
+      const hasMessages = messages.some((m) => m.sessionId === id);
+      if (session && !hasMessages && !loadedTranscriptsRef.current.has(id)) {
         loadedTranscriptsRef.current.add(id);
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, isLoadingTranscript: true } : s)),
@@ -861,7 +864,7 @@ function App() {
         requestTranscriptLoad(session.connectionId, id);
       }
     },
-    [sessions, requestTranscriptLoad],
+    [sessions, messages, requestTranscriptLoad],
   );
 
   const handleBack = useCallback(() => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -111,6 +111,7 @@ function App() {
   const activeSessionIdRef = useRef<UUID | null>(null);
   const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
+  const messagesRef = useRef(messages);
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
@@ -621,6 +622,17 @@ function App() {
           console.debug('[App] Auth error suppressed:', errorText);
           break;
         }
+        // Clear loading state for any session awaiting transcript load, and allow retry.
+        // The daemon does not echo sessionId in error responses, so we clear all loading sessions.
+        setSessions((prev) =>
+          prev.map((s) => {
+            if (s.isLoadingTranscript) {
+              loadedTranscriptsRef.current.delete(s.id);
+              return { ...s, isLoadingTranscript: false };
+            }
+            return s;
+          }),
+        );
         // Show non-auth errors to the user as system messages
         const targetSession = activeSessionIdRef.current;
         if (!targetSession) {
@@ -654,6 +666,10 @@ function App() {
   useEffect(() => {
     resumingSessionRef.current = resumingSession;
   }, [resumingSession]);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
   // Connection manager: manages N simultaneous WebSocket connections
   const {
@@ -855,7 +871,7 @@ function App() {
       // This covers both external transcript sessions and daemon sessions (which use a
       // Remi UUID as their ID — the daemon resolves it via its active watcher).
       const session = sessions.find((s) => s.id === id);
-      const hasMessages = messages.some((m) => m.sessionId === id);
+      const hasMessages = messagesRef.current.some((m) => m.sessionId === id);
       if (session && !hasMessages && !loadedTranscriptsRef.current.has(id)) {
         loadedTranscriptsRef.current.add(id);
         setSessions((prev) =>
@@ -864,7 +880,7 @@ function App() {
         requestTranscriptLoad(session.connectionId, id);
       }
     },
-    [sessions, messages, requestTranscriptLoad],
+    [sessions, requestTranscriptLoad],
   );
 
   const handleBack = useCallback(() => {


### PR DESCRIPTION
## Summary

Two MVP-blocking fixes:

**Transcript history (#281)** — Chat was empty when tapping into live daemon sessions:
- `handleSelectSession` in App.tsx only triggered transcript load for `source === 'transcript'` external sessions; daemon sessions were skipped
- `onTranscriptLoadRequest` in daemon only resolved Claude session IDs from transcript filenames; Remi UUIDs (used by live daemon sessions) were not resolved
- Fix: use `!hasMessages` check in App.tsx; add fallback lookup via active `transcriptWatchers` map in daemon

**APNS push notifications (#286)** — Push not arriving on device:
- Development builds receive sandbox device tokens; production APNS endpoint silently rejects them with `BadDeviceToken`
- Push payload was missing `sessionId`; notification tap could not navigate to the correct session
- Fix: `APNS_SANDBOX` env var on signaling worker selects correct endpoint; `sessionId` now flows through daemon → signaling → APNS `data` field → iOS navigation

## Sub-PRs
- #289 — APNS fix
- #290 — Transcript history fix

## Action required after merge

Set APNS sandbox secret on signaling worker for dev testing:
```
npx cfman wrangler --account yooz secret put APNS_SANDBOX
# value: true
```

## Test plan

- [x] 53 transcript tests pass
- [x] Web TypeScript build clean
- [x] Signaling worker deployed (Version 7f5a5fc8)
- [ ] Manual: tap daemon session with history — chat populates
- [ ] Manual: background app, trigger question — push arrives
- [ ] Manual: tap push — app navigates to correct session

Closes #286
Partially closes #281 (multi-daemon includeExternal logic tracked separately)