### PR TITLE
fix: same-dir session confusion and dedup (issue #285)

### DIFF
--- a/.context/ideas.md
+++ b/.context/ideas.md
@@ -97,11 +97,14 @@ Think of Remi as "WhatsApp for your terminal agent":
 **Concept:** Get notified when Claude asks a question, even with app closed
 **User Value:** Don't miss important decisions while away
 **Implementation:**
-- Daemon sends push via APNs/FCM
+- Daemon sends push via APNs (APNS bridge built in iOS Capacitor app)
+- Always-push on question (WS local notification removed)
+- Push-client in daemon sends to signaling server which forwards to device
 - Notification shows question text
-- Actionable buttons for Yes/No
-**Complexity:** High (requires push server)
-**Priority:** Nice-to-have (Phase 5)
+- Actionable lock-screen replies: future (#278)
+**Status:** Infrastructure built and wired. End-to-end test on physical device pending (#286).
+**Complexity:** High (done)
+**Priority:** MVP-blocking
 
 ### Feature: Code Diff Gallery
 **Concept:** Visual timeline of file changes during session

--- a/.context/message-routing-trace.md
+++ b/.context/message-routing-trace.md
@@ -1,0 +1,269 @@
+# Message Routing Trace: App -> Daemon -> PTY
+
+**Date:** 2026-03-29
+**Context:** Tracing the full path of user messages from mobile/web app to Claude Code PTY session.
+
+## Overview
+
+When a user sends a message from the Remi app, it must travel:
+```
+App (React) -> WebSocket -> Daemon -> Session Registry -> PTY -> Claude Code stdin
+```
+
+The critical gate is the **session registry lookup**: if the connection isn't properly attached to a session, the message is silently dropped.
+
+---
+
+## 1. Web/Mobile Client Side
+
+**Entry point:** `packages/web/src/components/InputArea.tsx`
+
+- User types message, `handleSend()` fires
+- Creates `UIMessage` with `state: 'sending'`
+- Calls `effectiveSendInput(activeSessionId, content)`
+- Creates protocol message via `createUserInput(sessionId, content)`
+
+**Message structure:**
+```typescript
+{
+  type: 'user_input',
+  id: UUID,            // unique message ID
+  timestamp: string,   // ISO
+  sessionId: UUID,     // target session
+  content: string,     // user text
+  raw: false           // web client sends structured, not raw bytes
+}
+```
+
+Sent via WebSocket using `clientRef.send()`.
+
+---
+
+## 2. Daemon Receives Message
+
+**Path:** `WebSocketServer` -> `Connection.handleMessage()` -> `Connection.handleUserInput()`
+
+1. WebSocket server deserializes the message
+2. `Connection` routes by `type` field in switch statement
+3. `handleUserInput()` checks connection state, sends ACK
+4. Fires `events.onUserInput(sessionId, content, raw)`
+
+**Adapter chain adds connectionId:**
+- `WebSocketServer` -> `WebSocketAdapter` -> `cli.ts`
+- Final call: `onUserInput(connectionId, sessionId, content, raw)`
+
+**Key files:**
+- `packages/daemon/src/server/connection.ts` (lines 380-395)
+- `packages/daemon/src/server/websocket-server.ts` (lines 294-295)
+- `packages/daemon/src/adapters/websocket-adapter.ts` (lines 112-113)
+
+---
+
+## 3. Session Registry Lookup (THE CRITICAL GATE)
+
+**File:** `packages/daemon/src/cli.ts` (lines 1955-1973)
+
+```typescript
+onUserInput: async (connectionId, _sessionId, content, raw) => {
+  const session = sessionRegistry.getSessionForConnection(connectionId);
+  if (session) {
+    if (raw) {
+      session.pty.write(content);      // Raw terminal input
+    } else {
+      await session.pty.submitInput(content);  // Structured input + Enter
+    }
+  } else {
+    log(`No session found for connection ${connectionId}`);  // SILENT DROP
+  }
+}
+```
+
+**SessionRegistry lookup** (`session-registry.ts` lines 199-204):
+```typescript
+getSessionForConnection(connectionId: UUID): ManagedSession | undefined {
+  if (this.session !== null &&
+      this.session.activeConnectionId === connectionId) {
+    return this.session;
+  }
+  return undefined;
+}
+```
+
+**Requirement:** `session.activeConnectionId === connectionId` must be true.
+
+---
+
+## 4. Connection Attachment: When the Mapping Gets Created
+
+This happens during the **hello handshake** in `cli.ts` `onConnect` handler (lines 1850-1944):
+
+```typescript
+// Only if NOT query mode:
+const isQueryMode = metadata.platformData?.['mode'] === 'query';
+if (!isQueryMode) {
+  const result = sessionRegistry.attachConnection(primarySessionId, connectionId);
+  if (result.success) {
+    sendToConnection(connectionId, createHelloAck(...));
+  }
+}
+```
+
+**SessionRegistry.attachConnection()** (lines 220-276):
+```typescript
+if (this.session.activeConnectionId !== null) {
+  return { success: false, error: 'Session already has active connection' };
+}
+// *** MAKE THE MAPPING ***
+this.session.activeConnectionId = connectionId;
+return { success: true, replayMessages: [...] };
+```
+
+**Mapping persists until:**
+1. `detachConnection(connectionId)` is called (on disconnect)
+2. Session is closed or orphan timeout expires
+
+---
+
+## 5. PTY Write: Final Destination
+
+**File:** `packages/daemon/src/pty-session.ts` (lines 189-202)
+
+```typescript
+async submitInput(text: string): Promise<void> {
+  if (this.state !== 'running' || !this.process?.terminal) {
+    throw new Error(`Cannot write to session in state: ${this.state}`);
+  }
+  this.process.terminal.write(text);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  this.process.terminal.write('\r');  // Send Enter
+}
+```
+
+Claude Code reads from stdin and processes the input.
+
+---
+
+## 6. Wrapper Mode vs Daemon Mode
+
+Both modes create PTY sessions. The difference is in behavior flags:
+
+| Property | Wrapper Mode | Daemon Mode |
+|----------|-------------|-------------|
+| `passThrough` | `true` (terminal-attached) | `false` (server-only) |
+| `locallyOwned` | `true` | `false` |
+| Orphan timeout | None (stays alive) | 5 minutes |
+| PTY output | Passes through to terminal | All access via WebSocket |
+| Session lifecycle | Lives with terminal | Kills if no connections |
+
+**Both modes DO have a PTY session** -- daemon mode creates it at `cli.ts` line 2722 via `createNewSession()`.
+
+---
+
+## 7. Answer vs User Input
+
+Both use the same connection lookup, different message types:
+
+| Type | Created by | Handler | Use case |
+|------|-----------|---------|----------|
+| `user_input` | `createUserInput()` | `handleUserInput()` | Free-form text |
+| `answer` | `createAnswer()` | `handleAnswer()` | Response to a question |
+
+Both ultimately call `sessionRegistry.getSessionForConnection(connectionId)` and then `session.pty.submitInput()`.
+
+---
+
+## 8. Failure Points (Where Messages Get Silently Dropped)
+
+### Failure 1: Connection Never Attached
+- Client sent `hello` in **query mode** -> `attachConnection()` never called
+- Client can send messages but they all hit "No session found"
+
+### Failure 2: Session Already Busy (Exclusive Lock)
+- Connection A is attached (`activeConnectionId = "A"`)
+- Connection B arrives, `attachConnection()` returns failure
+- B's messages all dropped; B gets `SESSION_BUSY` error on attach
+
+### Failure 3: Session Orphaned/Timeout (Daemon Mode Only)
+- Connection disconnects -> `detachConnection()` called
+- If `locallyOwned = false`, 5-minute orphan timer starts
+- Timer expires -> session closed -> all future messages dropped
+
+### Failure 4: Disconnect/Reconnect Race
+- Client disconnects briefly (network blip)
+- `detachConnection()` fires, clears `activeConnectionId`
+- Client reconnects with **new connectionId**
+- If reconnect hello + attach completes before next message, OK
+- If message arrives before re-attach, it's dropped
+
+### Failure 5: Standalone `remi start` Without PTY
+- When `remi start` is run, it spawns a **child process** (`spawn(..., { detached: true })`)
+- The child process runs `remi --daemon` which creates the PTY
+- The parent process exits immediately
+- If someone starts remi manually (e.g., `bun run ... start`), the foreground process has no PTY
+
+---
+
+## 9. Debugging
+
+### Key log line to search for:
+```
+No session found for connection [connectionId]
+```
+
+### Checklist when messages aren't arriving:
+1. Is the daemon running? (`ps aux | grep remi`)
+2. Is it in wrapper mode or daemon mode?
+3. Did the client receive `hello_ack` (not an error)?
+4. Was the client in query mode? (check `platformData.mode`)
+5. Is another client already attached? (exclusive lock)
+6. Has the session been orphaned? (daemon mode, 5-min timeout)
+7. Check daemon logs: `~/.remi/daemon.log`
+
+### No test coverage
+As of 2026-03-29, there are **no integration tests** covering the `user_input` -> session registry -> PTY write path. This is the most critical path in the product and needs test coverage (see issue #178 or equivalent).
+
+---
+
+## 10. Complete Flow Diagram
+
+```
+User taps Send in app
+       |
+       v
+createUserInput(sessionId, content)
+       |
+       v
+WebSocket.send(JSON.stringify(message))
+       |
+       v
+Daemon: WebSocketServer receives frame
+       |
+       v
+Connection.handleMessage() -> switch on type
+       |
+       v
+Connection.handleUserInput()
+  - Check state === 'connected'
+  - Send ACK (delivered) back to client
+  - Fire events.onUserInput(sessionId, content, raw)
+       |
+       v
+WebSocketAdapter bridges -> cli.ts sharedEvents.onUserInput
+       |
+       v
+cli.ts: sessionRegistry.getSessionForConnection(connectionId)
+       |
+       +--- FOUND (activeConnectionId matches) ---+
+       |                                           |
+       v                                           v
+  "No session found"                    session.pty.submitInput(content)
+  (message dropped,                           |
+   only logged)                               v
+                                    PTY.terminal.write(content + '\r')
+                                              |
+                                              v
+                                    Claude Code reads from stdin
+                                              |
+                                              v
+                                    Command executes
+```

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -33,62 +33,70 @@ Remote connectivity, relay, authentication, mDNS discovery, session persistence,
 | Parallel CI (spelling, lint, typecheck, test) | Done | PR #44 |
 | Pre-commit hook (lefthook + biome) | Done | PR #44 |
 
-### Phase 2: Session UX (NEXT)
-
-Make sessions feel like tmux, not like debugging infrastructure.
+### Phase 2: Session UX (PARTIAL)
 
 | Feature | Status | Issue |
 |---------|--------|-------|
-| Human-readable session names (`hostname/dir/branch`) | Todo | #45 |
-| Explicit `remi new` / `remi detach` / `remi kill` commands | Todo | #46 |
-| Session list shows name, status, duration, last activity | Todo | #47 |
+| Human-readable session names (`hostname/dir/branch`) | Done | #45 |
+| Explicit `remi new` / `remi detach` / `remi kill` commands | Partial | #46 |
+| Session list shows name, status, duration, last activity | Done (iOS) | #47 |
 | Orphan timeout configurable (`--timeout 30m`) | Todo | - |
 
-**Session Naming Convention:**
-Sessions should be named `hostname/directory/branch` instead of UUID hashes. For example:
-- `macbook/remi/main` - Remi project on macbook, main branch
-- `workstation/yooz-engine/feature-stt` - Engine project on workstation, feature branch
-- `macbook/remi/main:2` - Second session in the same context
+Session names display in iOS app as `dir/branch` (hostname stripped for brevity).
 
-The name is derived automatically from:
-- `os.hostname()` - machine name
-- Last component of the working directory
-- Current git branch or worktree name
-- Numeric suffix for duplicates
+### Phase 3: Chat Mode (PARTIAL)
 
-Users see these names in `remi ls`, `remi attach`, and the web client session list.
-
-### Phase 3: Chat Mode (NEXT)
-
-Transform the web client from a terminal mirror to a clean chat interface.
+iOS app ships a chat-style interface. Core pieces work; UX still rough.
 
 | Feature | Status | Issue |
 |---------|--------|-------|
-| Chat mode view (structured messages, no terminal rendering) | Todo | #48 |
-| Separate code blocks from conversation text | Todo | #48 |
+| Chat view (structured messages, no terminal rendering) | Done | #48 |
+| Tool chips (`Used Bash`, `$ cmd...`) | Done | - |
+| Question cards with tap-to-answer | Done (buggy) | #49 |
+| Session switcher | Done | #50 |
+| Push notifications infra (APNS bridge) | Built, untested | #286 |
+| Consistent history replay | In progress | #281 |
 | Collapsible tool-use sections | Todo | #48 |
-| Question cards with tap-to-answer | Todo | #49 |
-| Session switcher with unread badges | Todo | #50 |
-| Push notifications (Capacitor) | Todo | #51 |
+| Unread badges | Todo | #50 |
 
-**Chat mode design:**
-The daemon already sends structured `transcript_content` messages with role, content, and type information parsed from Claude's JSONL transcript. The web client currently renders everything through xterm.js (terminal emulator). Chat mode renders the same data as a messaging interface:
+**Known chat UX issues (blocking MVP):**
+- Chat history inconsistent: appears/disappears across reconnects
+- Zero-storage reconnect model not fully implemented (stream 200 msgs on connect, clear on disconnect)
+- Auth error messages leak into chat bubbles on localhost
+- Stale question cards don't clear after answer
+- Connection bars clutter header when all healthy
 
-- **Assistant messages** - Clean text with syntax-highlighted code blocks
-- **User messages** - What the user typed/approved
-- **Tool use** - Collapsible sections showing what Claude did (file reads, edits, commands)
-- **Questions** - Cards with the question text and response buttons (Yes/No/custom)
-- **Status** - Progress indicators (thinking, reading, writing)
-
-### Phase 4: Polish and Ship
+### Phase 4: iOS Polish Sprint (IN PROGRESS — Epic #267)
 
 | Feature | Status | Issue |
 |---------|--------|-------|
-| iOS app (Capacitor build + App Store) | Todo | - |
-| Android app (Capacitor build + Play Store) | Todo | - |
-| Homebrew formula | Todo | - |
-| Documentation site | Todo | - |
+| iOS Capacitor app (working build) | Done | - |
+| Auto-connect to all daemon ports | Done | - |
+| Hook system (25 events, PermissionRequest wired) | Done | - |
+| APNS push on question | Done | - |
+| APNS end-to-end test (physical device) | Todo | #286 |
+| Same-dir session confusion | In progress | #285 |
+| Auth prompt on localhost | Open | #257 |
+| Transcript history on daemon restart | Open | #280 |
+| Keyboard + scroll issues | Open | #226 |
+| Session disconnect/reconnect/resume | Open | #241 |
+| Android app | Future | - |
+| App Store submission | Future | - |
+| Homebrew formula | Future | - |
 | Voice interaction (STT/TTS via yooz-engine) | Future | - |
+
+### Phase 5: MVP Blockers (NEXT — must fix before calling it MVP)
+
+In priority order:
+
+1. **#285** Same-dir session confusion -- sessions sharing a project directory get crossed messages/questions
+2. **Chat consistency** -- zero-storage reconnect model; history reliable on every connect
+3. **#286** APNS end-to-end -- test push on physical device
+4. **#257** Auth on localhost -- suppress or auto-complete; new users shouldn't see auth prompts locally
+5. **#241** Session lifecycle -- working disconnect/reconnect/resume buttons
+6. **#238** Message display epic -- scope and ship Phase 1 of redesign
+
+**Not MVP:** #255 server-daemon arch, #153 remote spawn, #276 background location, voice, team features, session history search.
 
 ## Completed Work (Historical)
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,7 @@ android/
 *.aab
 
 # Context and MCP
-.context/
 .mcp.json
-.serena/
 
 # Xcode workspace user data
 **/project.xcworkspace/

--- a/.serena/memories/session_discovery_and_listing_mechanism.md
+++ b/.serena/memories/session_discovery_and_listing_mechanism.md
@@ -1,0 +1,349 @@
+# Remi Session Discovery and Listing Mechanism
+
+## Overview
+Remi implements a **single-daemon-per-web-session model** where:
+1. The web app connects to **one daemon at a time** via WebSocket
+2. That daemon can have **multiple sessions** (in daemon mode) or **one primary session** (in wrapper mode)
+3. Each daemon reports its own sessions via the `session_list_response` protocol message
+4. The CLI (`remi ls`, `remi attach`) supports discovery across multiple daemons, but the web app does not (yet)
+
+---
+
+## How `remi ls` Works (CLI)
+
+The CLI has three discovery paths:
+
+### 1. Local Multi-Port Discovery (Default)
+```bash
+remi ls
+```
+1. Reads live sessions registry at `~/.remi/live-sessions/`
+2. Queries each unique port in parallel
+3. Aggregates results
+4. Renders local format (no host column)
+
+**Function:** `runMultiPortLs()` in `packages/daemon/src/cli/ls-client.ts`
+
+### 2. Network-Wide Discovery
+```bash
+remi ls --network
+```
+1. Query all local ports (from registry)
+2. Run mDNS discovery for services named `_remi._tcp.local` (Bonjour)
+3. Run VPN discovery (Tailscale, WireGuard)
+4. Deduplicate hosts by IP
+5. Query all daemons on each host in parallel
+6. Render network format (includes host column, attach hints)
+
+**Functions:**
+- `runNetworkLs()` - orchestrator
+- `discoverDaemons()` (mdns-browser.ts) - mDNS discovery
+- `discoverVpnPeers()` (vpn-discovery.ts) - VPN peer discovery
+- `fetchSessions()` - WebSocket query to daemon
+
+### 3. Direct Host/Port Connection
+```bash
+remi ls --host 192.168.1.5 --port 18766
+```
+1. Single WebSocket connection to specified host:port
+2. Send `hello`, then `session_list_request`
+3. Render results (local format)
+
+**Functions:** `runLsClient()` -> `fetchSessions()`
+
+---
+
+## Protocol Messages for Session Listing
+
+### Request (Client to Daemon)
+```typescript
+interface SessionListRequestMessage {
+  type: 'session_list_request';
+  id: UUID;
+  timestamp: Timestamp;
+  includeExternal?: boolean;  // Include external transcript sessions
+}
+```
+
+**Created via:** `createSessionListRequest(includeExternal)`
+
+### Response (Daemon to Client)
+```typescript
+interface SessionListResponseMessage {
+  type: 'session_list_response';
+  id: UUID;
+  timestamp: Timestamp;
+  sessions: readonly DiscoverableSession[];  // Array of discoverable sessions
+  requestId: UUID;  // ID of the request this responds to
+}
+```
+
+**Created via:** `createSessionListResponse(sessions, requestId)`
+
+---
+
+## Session Discovery on Daemon Side
+
+### Handler Chain (cli.ts)
+```typescript
+onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => {
+  // 1. Get all daemon-managed sessions
+  const daemonSessions = sessionRegistry.listSessions();
+  
+  // 2. If requested, also discover external sessions from transcripts
+  let allSessions = [...daemonSessions];
+  if (includeExternal) {
+    const managedIds = new Set(sessionRegistry.getActiveSessionIds());
+    const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
+    allSessions = [...daemonSessions, ...externalSessions];
+  }
+  
+  // 3. Send response
+  sendToConnection(connectionId, createSessionListResponse(allSessions, requestId));
+}
+```
+
+### Event Flow
+1. Connection receives `session_list_request` message
+2. connection.ts calls `onSessionListRequest` handler
+3. websocket-server.ts bridges to adapter events
+4. cli.ts handles the event and queries:
+   - `sessionRegistry.listSessions()` - daemon-managed sessions
+   - `transcriptDiscovery.discoverSessions()` - transcript files
+
+---
+
+## DiscoverableSession Structure
+
+Each session returned has:
+```typescript
+interface DiscoverableSession {
+  sessionId: string;              // UUID (daemon) or Claude Code ID (transcript)
+  name?: string;                  // e.g., "hostname/project/branch"
+  projectPath: string;            // Working directory
+  status: 'active' | 'idle' | 'orphaned' | 'completed';
+  createdAt?: Timestamp;
+  lastActivity: Timestamp;        // Last message time
+  messageCount: number;
+  model?: string;                 // AI model (if known)
+  lastMessage?: string;           // Preview (truncated)
+  source: 'daemon' | 'transcript'; // Discovery source
+  canAttach: boolean;             // Can attach to session
+  canResume: boolean;             // Can resume via --resume
+}
+```
+
+---
+
+## Web App Session Listing
+
+### Current Architecture
+The web app displays sessions from a **single connected daemon**:
+
+1. **Connect Phase:**
+   - User provides daemon URL or connection code
+   - Web app connects WebSocket to `directUrl` or via signaling server
+   - Auth handshake (if daemon requires it)
+   - Send `hello` message
+
+2. **Session List Request:**
+   - Web app calls `requestSessionList(includeExternal)` from hook
+   - Hook sends `session_list_request` via WebSocket
+   - Daemon responds with `session_list_response`
+
+3. **UI Mapping:**
+   - `DiscoverableSession` → `UISession` mapping in App.tsx (lines 378-395)
+   - UISession includes:
+     ```typescript
+     interface UISession {
+       id: UUID;
+       name: string;
+       createdAt: Timestamp;
+       lastActiveAt: Timestamp;
+       status: AgentStatus;
+       connectionStatus: ConnectionStatus;
+       unreadCount: number;
+       cwd?: string;
+       preview?: string;
+       source?: 'daemon' | 'transcript';
+       isLoadingTranscript?: boolean;
+       questionPending?: boolean;
+       canResume?: boolean;
+     }
+     ```
+   - **Note:** `UISession` does NOT contain host/daemon information
+
+4. **SessionList Component:**
+   - Displays list of sessions from single daemon
+   - No multi-daemon display
+   - Comment says: "Displays the daemon's session (one session per daemon)"
+
+---
+
+## Host vs Daemon Concept
+
+### In CLI (`remi` command)
+- **Host:** Physical machine (IP address or hostname)
+- **Daemon:** Remi service running on a port on that host
+- **One host can have multiple daemons** (ports 18765-18774 in wrapper mode)
+- CLI discovers and queries all daemons on a host
+
+### In Web App (current)
+- **No host concept** - web app connects to single daemon
+- SessionList doesn't show which host/daemon sessions come from
+- Would need architecture change for multi-daemon web UI
+
+---
+
+## Port Allocation Strategy
+
+### Wrapper Mode (Default)
+- Auto-selects available port from range 18765-18774 (10 ports max)
+- Checks live sessions registry to avoid collisions
+- Checks PID liveness (cleans stale entries)
+- Retries up to 3 times on EADDRINUSE race
+
+### Daemon Mode (`--daemon`)
+- Uses explicit port or single fixed port
+- No auto-selection
+
+### Live Sessions Registry
+File-based registry at `~/.remi/live-sessions/<sessionId>.json`:
+```json
+{
+  "sessionId": "uuid",
+  "pid": 12345,
+  "wsPort": 18765,
+  "hookPort": 18865,
+  "projectPath": "/path/to/project",
+  "name": "project-name",
+  "startedAt": "2026-03-20T..."
+}
+```
+
+CLI reads this to discover all running daemons on localhost.
+
+---
+
+## Discovery Methods Comparison
+
+| Method | Scope | Web App Support | CLI Support |
+|--------|-------|-----------------|-------------|
+| Live Registry (`~/.remi/live-sessions/`) | Localhost only | No | Yes (default `remi ls`) |
+| Direct URL/Port | Single daemon | Yes (via connection modal) | Yes (`--host`, `--port`) |
+| mDNS (`_remi._tcp.local`) | LAN + VPN | No | Yes (`--network`) |
+| VPN Peers (Tailscale/WireGuard) | VPN network | No | Yes (`--network`) |
+
+---
+
+## Multi-Daemon Support
+
+### CLI: Full Multi-Daemon Support
+- `remi ls` queries all local daemons
+- `remi ls --network` discovers all daemons on network
+- `remi attach hostname:sessionid` resolves hostname via mDNS/VPN, queries all ports
+- `remi kill --network` discovers and queries remote daemons
+
+### Web App: No Multi-Daemon Support (Yet)
+- Connects to one daemon at a time
+- SessionList doesn't show daemon/host info
+- Would require:
+  1. Add `host` to UISession or new "DaemonInfo" concept
+  2. Support multiple concurrent WebSocket connections (one per daemon)
+  3. Aggregate sessions across daemons
+  4. Enhance SessionList UI to show daemon/host grouping
+  5. Update ConnectModal to support multi-daemon discovery
+
+---
+
+## Key Implementation Files
+
+### Discovery (CLI)
+- `packages/daemon/src/cli/ls-client.ts` - ls/network discovery
+- `packages/daemon/src/mdns/mdns-browser.ts` - mDNS discovery
+- `packages/daemon/src/mdns/vpn-discovery.ts` - Tailscale/WireGuard discovery
+- `packages/daemon/src/session/session-registry-file.ts` - Live registry
+
+### Protocol
+- `packages/shared/src/protocol.ts` - SessionListRequestMessage, SessionListResponseMessage
+- `packages/shared/src/types.ts` - DiscoverableSession
+
+### Daemon
+- `packages/daemon/src/server/connection.ts` - ConnectionEvents.onSessionListRequest
+- `packages/daemon/src/server/websocket-server.ts` - ServerEvents.onSessionListRequest
+- `packages/daemon/src/cli.ts` - sharedEvents.onSessionListRequest handler
+
+### Web App
+- `packages/web/src/hooks/useWebSocket.ts` - requestSessionList()
+- `packages/web/src/App.tsx` - session_list_response handler (lines 378-395)
+- `packages/web/src/components/session/SessionList.tsx` - UI display
+- `packages/web/src/types/index.ts` - UISession interface
+- `packages/web/src/lib/websocket-client.ts` - WebSocket transport
+
+---
+
+## Session Lifecycle (Related to Discovery)
+
+### Creation
+- Daemon: `sessionRegistry.registerSession(sessionId, pty, messageApi, locallyOwned)`
+- Wrapper: Auto-creates primary session on startup
+- CLI: `--create-session-request` message type
+
+### Discoverable State
+- Daemon sessions: `sessionRegistry.listSessions()` returns all registered sessions
+- Transcript sessions: `transcriptDiscovery.discoverSessions()` scans `~/.remi/sessions/` for `.jsonl` files
+
+### Orphan Timeout
+- Non-locally-owned sessions: 5 minutes after detach
+- Locally-owned sessions: Never timeout (wrapper mode primary session)
+- On timeout: `closeSession('timeout')` removes from registry
+
+### Session Resumption
+- `canResume: true` for non-locally-owned, completed sessions with transcript
+- Resume via `claude code --resume <sessionId>`
+- Connection exclusive: Only one client can attach at a time
+
+---
+
+## Error Handling in Discovery
+
+### Expected Errors (Dimmed in CLI Output)
+- ECONNREFUSED - daemon not running on port
+- ENOTFOUND - hostname resolution failed
+- Session already has active connection - multi-attach on exclusive session
+
+### Auth-Related
+- auth_challenge - daemon requires authentication
+- auth_result with error - identity rejected or invalid signature
+- Timeout: 10 seconds for auth handshake
+
+### Network-Related
+- mDNS discovery timeout: 3 seconds
+- VPN peer discovery timeout: 2 seconds per probe
+- Fetch timeout: 5000ms (ls), 3000ms (attach name resolution)
+
+---
+
+## Inconsistencies & Duplicate Logic
+
+1. **VPN Discovery:**
+   - Runs in both `runNetworkLs()` and `attach` command
+   - Different timeout configs (3000ms vs 2000ms)
+   - Same filtering logic duplicated
+
+2. **Port Resolution:**
+   - `runNetworkLs()`: Uses `liveSessionsRegistry.getLivePorts()`
+   - `attach`: Manual loop, different error handling
+
+3. **Session Querying:**
+   - `runNetworkLs()`: Filters local, queries all
+   - `attach`: Manual port loop, different error messages
+   - `runLsClient()`: Single port, simple flow
+
+4. **Error Classification:**
+   - `runNetworkLs()`: Dims "expected" errors with ANSI codes
+   - `attach`: No dimming, different messages
+
+5. **Name vs ID Resolution:**
+   - `attach`: Inline multi-fallback stages
+   - `kill`: Similar but separate implementation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,29 @@ feature/*   Short-lived branches off develop
 - **Hotfixes**: branch off `main`, PR to both `main` and `develop`
 - Never push directly to `main` or `develop`
 
+## Local Binary Installation
+
+The local `remi` binary is symlinked into PATH:
+
+```bash
+sudo ln -sf /Users/yahya/Documents/git/yooz/remi/dist/remi /opt/homebrew/bin/remi
+```
+
+**NOT Homebrew-managed** — it is a manual symlink pointing directly to `dist/remi`.
+After any build, the symlink picks up the new binary automatically; no reinstall needed.
+
+```bash
+# Build and verify
+bun run build:binary
+remi --version   # should reflect new version immediately
+```
+
+For PR/branch test builds, use `set` to assign a recognizable version:
+```bash
+./scripts/bump-version.sh set 0.4.23-p292.1
+bun run build:binary   # dist/remi updated; /opt/homebrew/bin/remi picks it up
+```
+
 ## Releasing
 
 **Always use the bump-version script for releases.** Never manually edit version numbers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.23-p292.1",
+  "version": "0.4.23-p292.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.22",
+  "version": "0.4.23-p292.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.23-p292.2",
+  "version": "0.4.23-p292.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.23-p292.3",
+  "version": "0.4.23-p292.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.4.23-p292.4",
+  "version": "0.4.23-p292.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1429,7 +1429,8 @@ STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
 
 const MAX_BULLET_LENGTH = cliMaxBulletLength ?? remiConfig.display.max_bullet_length;
 const TELEGRAM_TOKEN = remiConfig.telegram.bot_token || undefined;
-const TELEGRAM_ENABLED = !cliNoTelegram && remiConfig.telegram.enabled && !!TELEGRAM_TOKEN;
+// Telegram disabled: low priority; multi-daemon 409 conflicts not worth solving now.
+const TELEGRAM_ENABLED = false;
 const TELEGRAM_AUTHORIZED_CHAT_IDS = [...remiConfig.telegram.authorized_chat_ids];
 const TELEGRAM_AUTHORIZED_USER_IDS = [...remiConfig.telegram.authorized_user_ids];
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.22'; // REMI_COMPILED_VERSION
+      return '0.4.23-p292.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.22'; // REMI_COMPILED_VERSION
+    return '0.4.23-p292.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.23-p292.2'; // REMI_COMPILED_VERSION
+      return '0.4.23-p292.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.23-p292.2'; // REMI_COMPILED_VERSION
+    return '0.4.23-p292.3'; // REMI_COMPILED_VERSION
   }
 })();
 
@@ -1861,23 +1861,15 @@ async function createNewSession(
       transcriptFallbackTimers.delete(sessionId);
       return;
     }
-    // Look for a transcript file created AFTER this daemon started (birthtimeMs check avoids
-    // picking up a sibling daemon's already-active file). Fall back to a 5-minute mtime
-    // window only when no other daemon is serving the same directory (handles restarts).
+    // Look for a transcript file that is actively being written to.
+    // Accept any transcript modified after daemon startup or within 5 minutes
+    // (handles daemon restarts and session resumption).
     const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
     const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
     if (transcriptPath) {
       try {
         const stat = fs.statSync(transcriptPath);
-        const createdAfterStart = stat.birthtimeMs >= startupTime;
-        const siblingInSameDir = liveSessionsRegistry
-          .listLive()
-          .some(
-            (e) =>
-              e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
-          );
-        const isRecentStale = !siblingInSameDir && Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-        if (createdAfterStart || isRecentStale) {
+        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
           clearInterval(fallbackInterval);
           transcriptFallbackTimers.delete(sessionId);
           log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
@@ -1896,18 +1888,9 @@ async function createNewSession(
       if (transcriptPath) {
         try {
           const stat = fs.statSync(transcriptPath);
-          const createdAfterStart = stat.birthtimeMs >= startupTime;
-          const siblingInSameDir = liveSessionsRegistry
-            .listLive()
-            .some(
-              (e) =>
-                e.projectPath === workingDirectory &&
-                e.sessionId !== sessionId &&
-                e.wsPort !== PORT,
-            );
-          const isRecentStale =
-            !siblingInSameDir && Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-          if (createdAfterStart || isRecentStale) {
+          const isRecent =
+            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
+          if (isRecent) {
             log('[Hooks] Transcript fallback: found recent transcript on final check.');
             startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
             extractClaudeSessionId(transcriptPath, sessionId);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -3171,16 +3171,39 @@ if (cliDaemonMode) {
 
     // Watch for new daemons registering in live-sessions and push updates to clients.
     // This lets clients auto-connect when a sibling session starts in the same directory.
+    let liveWatchDebounce: ReturnType<typeof setTimeout> | null = null;
     try {
       liveSessionsWatcher = fs.watch(
         liveSessionsRegistry.dirPath,
         { persistent: false },
         (_event) => {
-          const newPorts = liveSessionsRegistry.getLivePorts().filter((p) => p !== PORT);
-          if (newPorts.length === 0) return;
-          const daemonSessions = sessionRegistry.listSessions();
-          const msg = createSessionListResponse(daemonSessions, generateId() as UUID, newPorts);
-          registry.broadcast(msg);
+          // Debounce: macOS FSEvents fires multiple events per rename (tmp → final).
+          if (liveWatchDebounce) clearTimeout(liveWatchDebounce);
+          liveWatchDebounce = setTimeout(() => {
+            liveWatchDebounce = null;
+            try {
+              const newPorts = liveSessionsRegistry.getLivePorts().filter((p) => p !== PORT);
+              if (newPorts.length === 0) return;
+              // Include external sessions so the broadcast doesn't wipe transcript sessions
+              // that are already visible on the client (session_list_response replaces all
+              // sessions for this connection).
+              const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
+              for (const remiId of [...managedIds]) {
+                const stored = sessionStore.findByRemiSessionId(remiId as UUID);
+                if (stored?.claudeSessionId) managedIds.add(stored.claudeSessionId);
+              }
+              const allSessions = [
+                ...sessionRegistry.listSessions(),
+                ...transcriptDiscovery.discoverSessions(managedIds),
+              ];
+              const msg = createSessionListResponse(allSessions, generateId() as UUID, newPorts);
+              registry.broadcast(msg);
+            } catch (err) {
+              log(
+                `[LiveSessions] Error pushing session update: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }, 300);
         },
       );
     } catch (err) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1429,7 +1429,7 @@ STATUS_FILE = path.join(REMI_DIR, `status-${PORT}.json`);
 
 const MAX_BULLET_LENGTH = cliMaxBulletLength ?? remiConfig.display.max_bullet_length;
 const TELEGRAM_TOKEN = remiConfig.telegram.bot_token || undefined;
-// Telegram disabled: low priority; multi-daemon 409 conflicts not worth solving now.
+// Telegram disabled: multi-daemon 409 conflicts (issue #285). Re-enable when addressed.
 const TELEGRAM_ENABLED = false;
 const TELEGRAM_AUTHORIZED_CHAT_IDS = [...remiConfig.telegram.authorized_chat_ids];
 const TELEGRAM_AUTHORIZED_USER_IDS = [...remiConfig.telegram.authorized_user_ids];
@@ -1536,6 +1536,7 @@ let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = nul
 
 // Watcher for live-sessions directory (pushes session list updates on new daemon startup)
 let liveSessionsWatcher: import('node:fs').FSWatcher | null = null;
+let liveWatchDebounce: ReturnType<typeof setTimeout> | null = null;
 
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
@@ -1692,16 +1693,16 @@ async function createNewSession(
     // Before SessionStart fires, we let events through (claudeSessionId is null).
     let claudeSessionId: string | null = null;
 
-    // Extract transcript info from hook events. Every Claude Code hook event carries
-    // session_id + transcript_path, so even if SessionStart doesn't fire, any event
-    // gives us the transcript path.
+    // Extract transcript info from hook events. Most Claude Code hook events include
+    // session_id and transcript_path. When present, the first event gives us the
+    // transcript path, bypassing the slower mtime fallback.
     //
     // GUARD: When sibling daemons serve the same directory, all Claudes POST to all
     // hook URLs (shared settings.local.json). So a sibling's event may arrive before
     // our own Claude fires. In that case, skip hook-based discovery and let the
     // mtime fallback handle it. For single-daemon directories (the common case),
     // accept the first event immediately.
-    let hasSiblingInDir = false; // Cached on first check; used to suppress cross-talk
+    let hasSiblingInDir: boolean | null = null; // Computed once, then cached
     function initFromHookEvent(input: {
       session_id?: string;
       transcript_path?: string;
@@ -1710,33 +1711,42 @@ async function createNewSession(
       if (claudeSessionId) return;
       if (!input.session_id || !input.transcript_path) return;
 
-      hasSiblingInDir = liveSessionsRegistry
-        .listLive()
-        .some(
-          (e) =>
-            e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
-        );
+      if (hasSiblingInDir === null) {
+        hasSiblingInDir = liveSessionsRegistry
+          .listLive()
+          .some(
+            (e) =>
+              e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
+          );
+      }
 
       if (hasSiblingInDir) {
         // Cannot trust which Claude sent this event — defer to fallback
         return;
       }
 
-      claudeSessionId = input.session_id;
-      log(
-        `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
-      );
-      sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+      try {
+        claudeSessionId = input.session_id;
+        log(
+          `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
+        );
+        sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
 
-      // Cancel the fallback timer since we have the exact path
-      const fallbackTimer = transcriptFallbackTimers.get(sessionId);
-      if (fallbackTimer) {
-        clearInterval(fallbackTimer);
-        transcriptFallbackTimers.delete(sessionId);
-      }
+        // Cancel the fallback timer since we have the exact path
+        const fallbackTimer = transcriptFallbackTimers.get(sessionId);
+        if (fallbackTimer) {
+          clearInterval(fallbackTimer);
+          transcriptFallbackTimers.delete(sessionId);
+        }
 
-      if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
-        startTranscriptWatcher(sessionId, input.transcript_path, messageApi, sendAndRecord);
+        if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
+          startTranscriptWatcher(sessionId, input.transcript_path, messageApi, sendAndRecord);
+        }
+      } catch (err) {
+        logError(
+          `[Hooks] initFromHookEvent failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        claudeSessionId = null; // Reset so fallback can take over
       }
     }
 
@@ -1748,6 +1758,19 @@ async function createNewSession(
         messageApi.handleQuestion(question);
       },
       onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
+        // Guard: skip if sibling daemons share this directory (event may be from sibling's Claude)
+        if (hasSiblingInDir === null) {
+          hasSiblingInDir = liveSessionsRegistry
+            .listLive()
+            .some(
+              (e) =>
+                e.projectPath === workingDirectory &&
+                e.sessionId !== sessionId &&
+                e.wsPort !== PORT,
+            );
+        }
+        if (hasSiblingInDir) return;
+
         claudeSessionId = hookClaudeSessionId;
         log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
         sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
@@ -1760,6 +1783,9 @@ async function createNewSession(
     });
 
     const handlers = hookBridge.hookHandlers();
+    // initFromHookEvent runs before the bridge handler: it covers events where
+    // onSessionInfo doesn't fire (PreToolUse, etc.). For SessionStart, both paths
+    // converge; guards prevent double-processing.
     hookServer.on('SessionStart', (input) => {
       initFromHookEvent(input);
       handlers.onSessionStart?.(input);
@@ -1909,9 +1935,9 @@ async function createNewSession(
     exitCode: null,
   });
 
-  // Transcript watcher: started by SessionStart hook (provides path directly).
-  // Safety net: if hook doesn't fire, poll for a NEW transcript file.
-  // Claude creates its transcript file after startup, so we must wait for it.
+  // Transcript watcher: normally started by hook event (provides path directly).
+  // When sibling daemons serve the same directory, hook events are skipped and
+  // this fallback becomes the primary discovery path.
   const startupTime = Date.now();
   const fallbackInterval = setInterval(() => {
     if (transcriptWatchers.has(sessionId)) {
@@ -1991,7 +2017,8 @@ async function createNewSession(
 
 /** Extract Claude session ID from transcript filename and persist it. */
 function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): void {
-  // Filenames are either "uuid.jsonl" or "prefix_uuid.jsonl" — last segment is always the ID
+  // Transcript filenames are plain UUIDs (e.g. "abc123-def456.jsonl").
+  // The underscore split is defensive in case a prefixed format is ever introduced.
   const basename = path.basename(transcriptPath, '.jsonl');
   const parts = basename.split('_');
   const candidateId = parts[parts.length - 1];
@@ -2892,6 +2919,10 @@ async function cleanup(): Promise<void> {
     clearInterval(timer);
   }
   transcriptFallbackTimers.clear();
+  if (liveWatchDebounce) {
+    clearTimeout(liveWatchDebounce);
+    liveWatchDebounce = null;
+  }
   if (liveSessionsWatcher) {
     liveSessionsWatcher.close();
     liveSessionsWatcher = null;
@@ -3240,7 +3271,6 @@ if (cliDaemonMode) {
 
     // Watch for new daemons registering in live-sessions and push updates to clients.
     // This lets clients auto-connect when a sibling session starts in the same directory.
-    let liveWatchDebounce: ReturnType<typeof setTimeout> | null = null;
     try {
       liveSessionsWatcher = fs.watch(
         liveSessionsRegistry.dirPath,
@@ -3268,7 +3298,7 @@ if (cliDaemonMode) {
               const msg = createSessionListResponse(allSessions, generateId() as UUID, newPorts);
               registry.broadcast(msg);
             } catch (err) {
-              log(
+              logError(
                 `[LiveSessions] Error pushing session update: ${err instanceof Error ? err.message : String(err)}`,
               );
             }
@@ -3276,7 +3306,7 @@ if (cliDaemonMode) {
         },
       );
     } catch (err) {
-      log(
+      logError(
         `[LiveSessions] Could not watch live-sessions dir: ${err instanceof Error ? err.message : String(err)}`,
       );
     }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1431,6 +1431,9 @@ const MAX_BULLET_LENGTH = cliMaxBulletLength ?? remiConfig.display.max_bullet_le
 const TELEGRAM_TOKEN = remiConfig.telegram.bot_token || undefined;
 // Telegram disabled: multi-daemon 409 conflicts (issue #285). Re-enable when addressed.
 const TELEGRAM_ENABLED = false;
+if (TELEGRAM_TOKEN) {
+  console.warn('[Telegram] Telegram notifications are currently disabled (multi-daemon conflict)');
+}
 const TELEGRAM_AUTHORIZED_CHAT_IDS = [...remiConfig.telegram.authorized_chat_ids];
 const TELEGRAM_AUTHORIZED_USER_IDS = [...remiConfig.telegram.authorized_user_ids];
 
@@ -1771,13 +1774,19 @@ async function createNewSession(
         }
         if (hasSiblingInDir) return;
 
-        claudeSessionId = hookClaudeSessionId;
-        log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
-        sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+        try {
+          claudeSessionId = hookClaudeSessionId;
+          log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
+          sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
 
-        // Start transcript watcher immediately using the path from the hook
-        if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
-          startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
+          if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
+            startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
+          }
+        } catch (err) {
+          logError(
+            `[Hooks] onSessionInfo failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          claudeSessionId = null;
         }
       },
     });
@@ -1975,8 +1984,10 @@ async function createNewSession(
           extractClaudeSessionId(transcriptPath, sessionId);
           return;
         }
-      } catch {
-        /* stat failed, retry */
+      } catch (err) {
+        log(
+          `[Hooks] Fallback stat failed for ${transcriptPath}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
     // Give up after 30 seconds

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1533,6 +1533,9 @@ let hookConfigManager: HookConfigManager | null = null;
 // mDNS publisher (initialized when daemon is network-accessible)
 let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = null;
 
+// Watcher for live-sessions directory (pushes session list updates on new daemon startup)
+let liveSessionsWatcher: import('node:fs').FSWatcher | null = null;
+
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
 ): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
@@ -2166,7 +2169,14 @@ const sharedEvents = {
     let allSessions = [...daemonSessions];
 
     if (includeExternal) {
-      const managedIds = new Set(sessionRegistry.getActiveSessionIds());
+      const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
+      // Also exclude by Claude session ID (JSONL filename UUID — different namespace from remi IDs)
+      for (const remiId of [...managedIds]) {
+        const stored = sessionStore.findByRemiSessionId(remiId as UUID);
+        if (stored?.claudeSessionId) {
+          managedIds.add(stored.claudeSessionId);
+        }
+      }
       const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
       allSessions = [...daemonSessions, ...externalSessions];
     }
@@ -2813,6 +2823,10 @@ async function cleanup(): Promise<void> {
     clearInterval(timer);
   }
   transcriptFallbackTimers.clear();
+  if (liveSessionsWatcher) {
+    liveSessionsWatcher.close();
+    liveSessionsWatcher = null;
+  }
   await registry.stopAll();
   await sessionRegistry.shutdown();
   cleanupStatusFile();
@@ -3154,6 +3168,26 @@ if (cliDaemonMode) {
       name: path.basename(workingDirectory),
       startedAt: new Date().toISOString(),
     });
+
+    // Watch for new daemons registering in live-sessions and push updates to clients.
+    // This lets clients auto-connect when a sibling session starts in the same directory.
+    try {
+      liveSessionsWatcher = fs.watch(
+        liveSessionsRegistry.dirPath,
+        { persistent: false },
+        (_event) => {
+          const newPorts = liveSessionsRegistry.getLivePorts().filter((p) => p !== PORT);
+          if (newPorts.length === 0) return;
+          const daemonSessions = sessionRegistry.listSessions();
+          const msg = createSessionListResponse(daemonSessions, generateId() as UUID, newPorts);
+          registry.broadcast(msg);
+        },
+      );
+    } catch (err) {
+      log(
+        `[LiveSessions] Could not watch live-sessions dir: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   // Create and start the primary PTY session

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.23-p292.4'; // REMI_COMPILED_VERSION
+      return '0.4.23-p292.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.23-p292.4'; // REMI_COMPILED_VERSION
+    return '0.4.23-p292.5'; // REMI_COMPILED_VERSION
   }
 })();
 
@@ -1692,9 +1692,15 @@ async function createNewSession(
     // Before SessionStart fires, we let events through (claudeSessionId is null).
     let claudeSessionId: string | null = null;
 
-    // Extract transcript info from the FIRST hook event received. Every Claude Code
-    // hook event carries session_id + transcript_path, so even if SessionStart doesn't
-    // fire, PreToolUse/PostToolUse (which fire constantly) give us the transcript path.
+    // Extract transcript info from hook events. Every Claude Code hook event carries
+    // session_id + transcript_path, so even if SessionStart doesn't fire, any event
+    // gives us the transcript path.
+    //
+    // GUARD: When sibling daemons serve the same directory, all Claudes POST to all
+    // hook URLs (shared settings.local.json). So a sibling's event may arrive before
+    // our own Claude fires. In that case, skip hook-based discovery and let the
+    // mtime fallback handle it. For single-daemon directories (the common case),
+    // accept the first event immediately.
     function initFromHookEvent(input: {
       session_id?: string;
       transcript_path?: string;
@@ -1702,6 +1708,21 @@ async function createNewSession(
     }): void {
       if (claudeSessionId) return;
       if (!input.session_id || !input.transcript_path) return;
+
+      const hasSibling = liveSessionsRegistry
+        .listLive()
+        .some(
+          (e) =>
+            e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
+        );
+
+      if (hasSibling) {
+        // Cannot trust which Claude sent this event — defer to fallback
+        log(
+          `[Hooks] Sibling in same dir, deferring transcript to fallback (candidate: ${input.session_id})`,
+        );
+        return;
+      }
 
       claudeSessionId = input.session_id;
       log(
@@ -1899,10 +1920,19 @@ async function createNewSession(
       return;
     }
     // Look for a transcript file that is actively being written to.
-    // Accept any transcript modified after daemon startup or within 5 minutes
-    // (handles daemon restarts and session resumption).
+    // When sibling daemons serve the same directory, exclude transcripts they've
+    // already claimed (by claudeSessionId in sessions.json) to avoid double-watching.
     const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
-    const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
+    const siblingClaudeIds = new Set<string>();
+    for (const entry of sessionStore.list()) {
+      if (entry.remiSessionId !== sessionId && entry.claudeSessionId && !entry.exitedAt) {
+        siblingClaudeIds.add(entry.claudeSessionId);
+      }
+    }
+    const transcriptPath =
+      siblingClaudeIds.size > 0
+        ? transcriptDiscovery.findLatestTranscriptExcluding(workingDirectory, siblingClaudeIds)
+        : transcriptDiscovery.findLatestTranscript(workingDirectory);
     if (transcriptPath) {
       try {
         const stat = fs.statSync(transcriptPath);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.23-p292.1'; // REMI_COMPILED_VERSION
+      return '0.4.23-p292.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.23-p292.1'; // REMI_COMPILED_VERSION
+    return '0.4.23-p292.2'; // REMI_COMPILED_VERSION
   }
 })();
 
@@ -1861,15 +1861,23 @@ async function createNewSession(
       transcriptFallbackTimers.delete(sessionId);
       return;
     }
-    // Look for a transcript file that is actively being written to.
-    // Accept any transcript modified within the last 5 minutes (handles daemon
-    // restarts where the session was already running before startup).
+    // Look for a transcript file created AFTER this daemon started (birthtimeMs check avoids
+    // picking up a sibling daemon's already-active file). Fall back to a 5-minute mtime
+    // window only when no other daemon is serving the same directory (handles restarts).
     const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
     const transcriptPath = transcriptDiscovery.findLatestTranscript(workingDirectory);
     if (transcriptPath) {
       try {
         const stat = fs.statSync(transcriptPath);
-        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
+        const createdAfterStart = stat.birthtimeMs >= startupTime;
+        const siblingInSameDir = liveSessionsRegistry
+          .listLive()
+          .some(
+            (e) =>
+              e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
+          );
+        const isRecentStale = !siblingInSameDir && Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
+        if (createdAfterStart || isRecentStale) {
           clearInterval(fallbackInterval);
           transcriptFallbackTimers.delete(sessionId);
           log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
@@ -1888,9 +1896,18 @@ async function createNewSession(
       if (transcriptPath) {
         try {
           const stat = fs.statSync(transcriptPath);
-          const isRecent =
-            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-          if (isRecent) {
+          const createdAfterStart = stat.birthtimeMs >= startupTime;
+          const siblingInSameDir = liveSessionsRegistry
+            .listLive()
+            .some(
+              (e) =>
+                e.projectPath === workingDirectory &&
+                e.sessionId !== sessionId &&
+                e.wsPort !== PORT,
+            );
+          const isRecentStale =
+            !siblingInSameDir && Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
+          if (createdAfterStart || isRecentStale) {
             log('[Hooks] Transcript fallback: found recent transcript on final check.');
             startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
             extractClaudeSessionId(transcriptPath, sessionId);
@@ -1919,17 +1936,13 @@ async function createNewSession(
 
 /** Extract Claude session ID from transcript filename and persist it. */
 function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): void {
-  // Transcript filenames look like: <encoded-path>_<timestamp>_<claude-session-id>.jsonl
+  // Filenames are either "uuid.jsonl" or "prefix_uuid.jsonl" — last segment is always the ID
   const basename = path.basename(transcriptPath, '.jsonl');
   const parts = basename.split('_');
-  // The Claude session ID is typically the last segment
-  if (parts.length >= 2) {
-    const candidateId = parts[parts.length - 1];
-    // Claude session IDs are UUIDs or similar identifiers
-    if (candidateId && candidateId.length >= 8) {
-      sessionStore.updateClaudeSessionId(sessionId, candidateId);
-      log(`Claude session ID: ${candidateId}`);
-    }
+  const candidateId = parts[parts.length - 1];
+  if (candidateId && candidateId.length >= 8) {
+    sessionStore.updateClaudeSessionId(sessionId, candidateId);
+    log(`Claude session ID: ${candidateId}`);
   }
 }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1701,6 +1701,7 @@ async function createNewSession(
     // our own Claude fires. In that case, skip hook-based discovery and let the
     // mtime fallback handle it. For single-daemon directories (the common case),
     // accept the first event immediately.
+    let hasSiblingInDir = false; // Cached on first check; used to suppress cross-talk
     function initFromHookEvent(input: {
       session_id?: string;
       transcript_path?: string;
@@ -1709,18 +1710,15 @@ async function createNewSession(
       if (claudeSessionId) return;
       if (!input.session_id || !input.transcript_path) return;
 
-      const hasSibling = liveSessionsRegistry
+      hasSiblingInDir = liveSessionsRegistry
         .listLive()
         .some(
           (e) =>
             e.projectPath === workingDirectory && e.sessionId !== sessionId && e.wsPort !== PORT,
         );
 
-      if (hasSibling) {
+      if (hasSiblingInDir) {
         // Cannot trust which Claude sent this event — defer to fallback
-        log(
-          `[Hooks] Sibling in same dir, deferring transcript to fallback (candidate: ${input.session_id})`,
-        );
         return;
       }
 
@@ -1766,29 +1764,36 @@ async function createNewSession(
       initFromHookEvent(input);
       handlers.onSessionStart?.(input);
     });
+    // Filter: accept events only from our own Claude. Before claudeSessionId is known,
+    // block events when siblings exist (they could be from sibling's Claude).
+    const filterBySession = (input: { session_id?: string }): boolean => {
+      if (claudeSessionId) return input.session_id === claudeSessionId;
+      return !hasSiblingInDir; // No sibling → events can only be ours
+    };
+
     hookServer.on('PreToolUse', (input) => {
       initFromHookEvent(input);
-      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      if (!filterBySession(input)) return;
       handlers.onPreToolUse?.(input);
     });
     hookServer.on('PostToolUse', (input) => {
       initFromHookEvent(input);
-      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      if (!filterBySession(input)) return;
       handlers.onPostToolUse?.(input);
     });
     hookServer.on('Notification', (input) => {
       initFromHookEvent(input);
-      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      if (!filterBySession(input)) return;
       handlers.onNotification?.(input);
     });
     hookServer.on('PermissionRequest', (input) => {
       initFromHookEvent(input);
-      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      if (!filterBySession(input)) return;
       handlers.onPermissionRequest?.(input);
     });
     hookServer.on('Stop', (input) => {
       initFromHookEvent(input);
-      if (claudeSessionId && input.session_id !== claudeSessionId) return;
+      if (!filterBySession(input)) return;
       handlers.onStop?.(input);
     });
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.4.23-p292.3'; // REMI_COMPILED_VERSION
+      return '0.4.23-p292.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.4.23-p292.3'; // REMI_COMPILED_VERSION
+    return '0.4.23-p292.4'; // REMI_COMPILED_VERSION
   }
 })();
 
@@ -1692,6 +1692,35 @@ async function createNewSession(
     // Before SessionStart fires, we let events through (claudeSessionId is null).
     let claudeSessionId: string | null = null;
 
+    // Extract transcript info from the FIRST hook event received. Every Claude Code
+    // hook event carries session_id + transcript_path, so even if SessionStart doesn't
+    // fire, PreToolUse/PostToolUse (which fire constantly) give us the transcript path.
+    function initFromHookEvent(input: {
+      session_id?: string;
+      transcript_path?: string;
+      hook_event_name?: string;
+    }): void {
+      if (claudeSessionId) return;
+      if (!input.session_id || !input.transcript_path) return;
+
+      claudeSessionId = input.session_id;
+      log(
+        `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
+      );
+      sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+
+      // Cancel the fallback timer since we have the exact path
+      const fallbackTimer = transcriptFallbackTimers.get(sessionId);
+      if (fallbackTimer) {
+        clearInterval(fallbackTimer);
+        transcriptFallbackTimers.delete(sessionId);
+      }
+
+      if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
+        startTranscriptWatcher(sessionId, input.transcript_path, messageApi, sendAndRecord);
+      }
+    }
+
     const hookBridge = new HookEventBridge(sessionId, {
       onStatusChange: (status: AgentStatus, context?: string) => {
         messageApi.handleStatusChange(status, context);
@@ -1712,24 +1741,32 @@ async function createNewSession(
     });
 
     const handlers = hookBridge.hookHandlers();
-    hookServer.on('SessionStart', (input) => handlers.onSessionStart?.(input));
+    hookServer.on('SessionStart', (input) => {
+      initFromHookEvent(input);
+      handlers.onSessionStart?.(input);
+    });
     hookServer.on('PreToolUse', (input) => {
+      initFromHookEvent(input);
       if (claudeSessionId && input.session_id !== claudeSessionId) return;
       handlers.onPreToolUse?.(input);
     });
     hookServer.on('PostToolUse', (input) => {
+      initFromHookEvent(input);
       if (claudeSessionId && input.session_id !== claudeSessionId) return;
       handlers.onPostToolUse?.(input);
     });
     hookServer.on('Notification', (input) => {
+      initFromHookEvent(input);
       if (claudeSessionId && input.session_id !== claudeSessionId) return;
       handlers.onNotification?.(input);
     });
     hookServer.on('PermissionRequest', (input) => {
+      initFromHookEvent(input);
       if (claudeSessionId && input.session_id !== claudeSessionId) return;
       handlers.onPermissionRequest?.(input);
     });
     hookServer.on('Stop', (input) => {
+      initFromHookEvent(input);
       if (claudeSessionId && input.session_id !== claudeSessionId) return;
       handlers.onStop?.(input);
     });

--- a/packages/daemon/src/pty/pty-session.ts
+++ b/packages/daemon/src/pty/pty-session.ts
@@ -108,6 +108,11 @@ export class PTYSession {
     return this.state === 'running';
   }
 
+  /** Get child process PID (null if not started) */
+  get childPid(): number | null {
+    return this.process?.pid ?? null;
+  }
+
   /** Get exit code (null if not exited or killed by signal) */
   get processExitCode(): number | null {
     return this.exitCode;

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -54,6 +54,11 @@ export class SessionRegistryFile {
     this.dir = dir ?? LIVE_SESSIONS_DIR;
   }
 
+  /** Path to the live-sessions directory. */
+  get dirPath(): string {
+    return this.dir;
+  }
+
   /** Ensure the live-sessions directory exists. */
   private ensureDir(): void {
     if (!fs.existsSync(this.dir)) {

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -127,6 +127,26 @@ export class TranscriptDiscovery {
   }
 
   /**
+   * Find the most recent transcript for a project, skipping specific session IDs.
+   * Used when sibling daemons in the same directory have already claimed transcripts.
+   */
+  findLatestTranscriptExcluding(projectPath: string, excludeIds: Set<string>): string | null {
+    const transcriptDir = this.getProjectTranscriptDir(projectPath);
+    if (!fs.existsSync(transcriptDir)) return null;
+
+    const files = this.listJsonlFiles(transcriptDir);
+    if (files.length === 0) return null;
+
+    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+    for (const file of files) {
+      if (!excludeIds.has(file.sessionId)) {
+        return file.filePath;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Find a transcript file path by its session ID (the UUID filename without .jsonl).
    * Returns the file path if found, null otherwise.
    */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -97,6 +97,19 @@ function updateSessionActivity(
   );
 }
 
+/** Append " (2)", " (3)", etc. to sessions that share the same display name.
+ *  The input array should already be sorted in priority order; the first session
+ *  with a given name keeps the bare name, subsequent ones are numbered. */
+function disambiguateSessions(sessions: UISession[]): UISession[] {
+  const counts = new Map<string, number>();
+  return sessions.map((s) => {
+    const base = s.name;
+    const n = (counts.get(base) ?? 0) + 1;
+    counts.set(base, n);
+    return n === 1 ? s : { ...s, name: `${base} (${n})` };
+  });
+}
+
 function App() {
   const [sessions, setSessions] = useState<UISession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
@@ -420,16 +433,10 @@ function App() {
               canResume: showResume,
             };
           })
-          // Filter out transcript sessions that duplicate a daemon session
-          // from the SAME connection (same cwd, keep daemon version)
+          // Dedup: same session ID from daemon + transcript → keep daemon version.
+          // Different session IDs in the same cwd are kept (parallel/sequential sessions).
           .reduce<UISession[]>((acc, s) => {
-            if (!s.cwd) {
-              acc.push(s);
-              return acc;
-            }
-            const existingIdx = acc.findIndex(
-              (other) => other.cwd === s.cwd && other.connectionId === s.connectionId,
-            );
+            const existingIdx = acc.findIndex((other) => other.id === s.id);
             if (existingIdx === -1) {
               acc.push(s);
               return acc;
@@ -476,33 +483,28 @@ function App() {
               }
             }
           }
-          // Cross-connection dedup: when two connections report the same
-          // project (same cwd), keep the daemon-sourced version (it routes
-          // to the correct daemon). Drop the transcript-sourced duplicate.
+          // Cross-connection dedup: same session ID from multiple connections →
+          // keep daemon-sourced version. Different IDs in same cwd → keep both.
           const deduped = result.reduce<UISession[]>((acc, s) => {
-            if (!s.cwd) {
-              acc.push(s);
-              return acc;
-            }
-            const dupIdx = acc.findIndex((other) => other.cwd === s.cwd);
+            const dupIdx = acc.findIndex((other) => other.id === s.id);
             if (dupIdx === -1) {
               acc.push(s);
               return acc;
             }
             const existing = acc[dupIdx];
-            // Prefer daemon over transcript source
             if (s.source === 'daemon' && existing.source !== 'daemon') {
               acc[dupIdx] = s;
             }
             return acc;
           }, []);
           // Sort: live first, then by last activity
-          return deduped.sort((a, b) => {
+          const sorted = deduped.sort((a, b) => {
             const aLive = a.connectionStatus === 'connected' ? 0 : 1;
             const bLive = b.connectionStatus === 'connected' ? 0 : 1;
             if (aLive !== bLive) return aLive - bLive;
             return new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime();
           });
+          return disambiguateSessions(sorted);
         });
 
         // Auto-connect to other daemon ports on the same machine.


### PR DESCRIPTION
## Summary

Five layered fixes for sessions in the same working directory being confused or dropped (issue #285).

- **Exclude set namespace mismatch (daemon)**: `onSessionListRequest` excluded by remi UUID, but JSONL filenames use Claude's UUID. Fixed `extractClaudeSessionId` to handle plain `uuid.jsonl` filenames (was broken: `parts.length >= 2` always false).
- **Hook-based transcript discovery**: Every hook event carries `transcript_path`. `initFromHookEvent` extracts the path from the first event (typically PreToolUse), bypassing the unreliable mtime fallback. Sibling guard skips this when multiple daemons serve the same directory.
- **Fallback excludes sibling-claimed transcripts**: `findLatestTranscriptExcluding` skips JSONL files whose session IDs are already claimed by other active daemons in `sessions.json`.
- **Client dedup by session ID**: Both `reduce` passes now match by `id` instead of `cwd`, so different sessions in the same directory coexist.
- **Name disambiguation**: `disambiguateSessions()` appends ` (2)`, ` (3)` to colliding display names.

## Changes

### `packages/daemon/src/cli.ts`
- Fix `extractClaudeSessionId`: handles plain `uuid.jsonl` filenames (was broken for all sessions)
- Add `initFromHookEvent`: extracts transcript path from any hook event, with sibling guard
- Fallback uses `findLatestTranscriptExcluding` to skip sibling-claimed transcripts
- `onSessionListRequest`: adds Claude session IDs to exclude set
- Watches `~/.remi/live-sessions/` for new daemon registrations
- Disable Telegram (`TELEGRAM_ENABLED = false`) to prevent multi-daemon 409 conflicts

### `packages/daemon/src/pty/pty-session.ts`
- Add `childPid` getter exposing Claude child process PID

### `packages/daemon/src/transcript/transcript-discovery.ts`
- Add `findLatestTranscriptExcluding(projectPath, excludeIds)` method

### `packages/daemon/src/session/session-registry-file.ts`
- Add `dirPath` getter for live-sessions directory path

### `packages/web/src/App.tsx`
- `disambiguateSessions()` helper: appends ` (2)`, ` (3)` to colliding names
- Dedup by session `id` instead of `cwd`

## Test plan

- [x] `bun test` -- 1345 pass, 0 fail
- [x] `bun run typecheck` -- clean
- [x] `biome check` -- clean
- [x] Manual: two claude sessions in same dir both appear with distinct names
- [x] Manual: each session shows its own transcript (not sibling's)
- [x] Manual: messages routed to correct session
- [x] Manual: eventformer session (different dir) works independently