### PR TITLE
fix: cache APNS JWT to avoid TooManyProviderTokenUpdates (429)

### DIFF
--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -68,11 +68,24 @@ export async function sendApnsPush(
   return { success: false, error: `APNS ${response.status}: ${errorBody}` };
 }
 
+/** Cache APNS JWTs per keyId: Apple rate-limits token updates to once per 20 min. */
+const jwtCache = new Map<string, { jwt: string; iat: number }>();
+/** Reuse a cached JWT if it is younger than 50 minutes (3000 s). */
+const JWT_MAX_AGE_S = 3000;
+
 /**
  * Create a JWT for APNS authentication.
  * Uses ES256 algorithm with the p8 private key.
+ * The JWT is cached per keyId and reused until it is 50 minutes old to avoid
+ * APNS TooManyProviderTokenUpdates (429) errors.
  */
 async function createApnsJwt(config: ApnsConfig): Promise<string> {
+  const nowS = Math.floor(Date.now() / 1000);
+  const cached = jwtCache.get(config.keyId);
+  if (cached && nowS - cached.iat < JWT_MAX_AGE_S) {
+    return cached.jwt;
+  }
+
   const header = {
     alg: 'ES256',
     kid: config.keyId,
@@ -80,7 +93,7 @@ async function createApnsJwt(config: ApnsConfig): Promise<string> {
 
   const payload = {
     iss: config.teamId,
-    iat: Math.floor(Date.now() / 1000),
+    iat: nowS,
   };
 
   const encodedHeader = base64UrlEncode(JSON.stringify(header));
@@ -107,7 +120,9 @@ async function createApnsJwt(config: ApnsConfig): Promise<string> {
   // WebCrypto SubtleCrypto returns ECDSA signature in raw r||s format (IEEE P1363) — no conversion needed
   const encodedSignature = base64UrlEncode(new Uint8Array(signature));
 
-  return `${signingInput}.${encodedSignature}`;
+  const jwt = `${signingInput}.${encodedSignature}`;
+  jwtCache.set(config.keyId, { jwt, iat: nowS });
+  return jwt;
 }
 
 function base64UrlEncode(input: string | Uint8Array): string {


### PR DESCRIPTION
## Summary

- APNS push was failing with `TooManyProviderTokenUpdates` (429) under load
- Each push request generated a fresh JWT with a new `iat`, causing Apple to rate-limit
- Apple's limit: no more than one provider token update per 20 minutes per key
- Fix: cache JWT at module level in the signaling worker, keyed by `keyId`
- Reuse cached JWT if it is < 50 minutes old; regenerate otherwise

## Root cause

`createApnsJwt()` was called on every `sendApnsPush` invocation. With Claude Code
questions arriving frequently (permission prompts), the key was being refreshed many
times per minute, triggering Apple's 429 rate limit.

## Verification

Daemon log confirmed the pattern:
```
Push notification failed: Error: Push trigger failed: 502 {"success":false,"error":"APNS 429: {\"reason\":\"TooManyProviderTokenUpdates\"}"}
```

## Deployment

Worker deployed: Version d08fd1fe (deployed before PR)

## Test plan

- [x] `bun test packages/signaling/tests/` — 49 pass
- [x] `bun run typecheck` — clean
- [x] Signaling worker deployed to `https://remi-signaling.yooz.workers.dev`
- [ ] Manual: background app, trigger multiple questions in quick succession, verify pushes arrive without 429 errors in daemon log