### PR TITLE
fix: shorten branch name truncation in session cards

### DIFF
--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -20,8 +20,8 @@ function formatSessionName(name: string): string {
   let display = name.replace(/^[^:]+:/, '');
   // Truncate branch part if too long (keep folder, limit branch to 10 chars)
   const slashIdx = display.indexOf('/');
-  if (slashIdx >= 0 && display.length > slashIdx + 10) {
-    display = `${display.slice(0, slashIdx + 10)}...`;
+  if (slashIdx >= 0 && display.length > slashIdx + 11) {
+    display = `${display.slice(0, slashIdx + 11)}...`;
   }
   return display || name;
 }

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -13,15 +13,15 @@ import { Link2, Link2Off, MessageCircleQuestion, RotateCcw } from 'lucide-react'
 
 /** Strip hostname prefix and truncate branch for display.
  *  "yahyas-mcm:remi/develop" -> "remi/develop"
- *  "remi/very-long-branch-name-here" -> "remi/very-long-br..."
+ *  "remi/very-long-branch-name-here" -> "remi/very-long..."
  */
 function formatSessionName(name: string): string {
   // Strip hostname: prefix (everything before the first colon that's followed by non-digit)
   let display = name.replace(/^[^:]+:/, '');
-  // Truncate branch part if too long (keep folder, limit branch to 15 chars)
+  // Truncate branch part if too long (keep folder, limit branch to 10 chars)
   const slashIdx = display.indexOf('/');
-  if (slashIdx >= 0 && display.length > slashIdx + 16) {
-    display = `${display.slice(0, slashIdx + 16)}...`;
+  if (slashIdx >= 0 && display.length > slashIdx + 10) {
+    display = `${display.slice(0, slashIdx + 10)}...`;
   }
   return display || name;
 }


### PR DESCRIPTION
## Summary
- Reduce branch name truncation from 16 to 10 characters after the directory slash in `formatSessionName`
- Improves readability on mobile screens where long branch names caused ugly wrapping
- Example: `remi/285-bug-multiple-sessions-in-same-dir...` now becomes `remi/285-bug-mu...`

## Test plan
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] Web build succeeds (`cd packages/web && bun run build`)
- [ ] Visual verification on mobile/narrow viewport that session cards display cleanly