### PR TITLE
fix: kill queries all daemons, ls shows per-session port

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -894,23 +894,41 @@ if (cliSubcommand === 'kill') {
     process.exit(1);
   }
   let resolvedPort = resolved.port;
+  let killTarget = resolved.targetId;
 
   const { runKillClient } = await import('./cli/kill-client.ts');
   try {
     // Resolve port by querying all local daemon ports (session may be on any daemon)
     if (!cliPort && resolved.host === 'localhost') {
-      const allPorts = liveSessionsRegistry.getLivePorts();
+      const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
+      let allPorts = liveSessionsRegistry.getLivePorts();
+
+      // Fallback: probe default port range when registry is empty (matches ls behavior)
+      if (allPorts.length === 0) {
+        const { getDefaultPortRange } = await import('./cli/ls-client.ts');
+        allPorts = getDefaultPortRange();
+      }
+
       if (allPorts.length > 0) {
-        const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
         const results = await queryMultiplePorts({
           host: 'localhost',
           ports: allPorts,
           timeoutMs: 5000,
           logLabel: 'kill',
         });
-        const match = resolveSession(results, resolved.targetId);
+
+        if (results.length === 0) {
+          console.error(
+            `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
+          );
+          process.exit(1);
+        }
+
+        const match = resolveSession(results, killTarget);
         if (match) {
           resolvedPort = match.port;
+          // Use session ID directly to avoid TOCTOU race
+          killTarget = match.session.sessionId;
         }
       }
     }
@@ -918,7 +936,7 @@ if (cliSubcommand === 'kill') {
     await runKillClient({
       host: resolved.host,
       port: resolvedPort,
-      target: resolved.targetId,
+      target: killTarget,
     });
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
@@ -941,14 +959,34 @@ if (cliSubcommand === 'detach') {
   }
 
   let resolvedPort = resolved.port;
+  let detachTarget = resolved.targetId;
 
-  // Resolve port from live registry if target matches a known local session
+  // Resolve port by querying all local daemon ports (session may be on any daemon)
   if (!cliPort && resolved.host === 'localhost') {
-    const liveMatch =
-      liveSessionsRegistry.findByName(resolved.targetId) ??
-      liveSessionsRegistry.findBySessionId(resolved.targetId);
-    if (liveMatch) {
-      resolvedPort = liveMatch.wsPort;
+    const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
+    let allPorts = liveSessionsRegistry.getLivePorts();
+    if (allPorts.length === 0) {
+      const { getDefaultPortRange } = await import('./cli/ls-client.ts');
+      allPorts = getDefaultPortRange();
+    }
+    if (allPorts.length > 0) {
+      const results = await queryMultiplePorts({
+        host: 'localhost',
+        ports: allPorts,
+        timeoutMs: 5000,
+        logLabel: 'detach',
+      });
+      if (results.length === 0) {
+        console.error(
+          `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
+        );
+        process.exit(1);
+      }
+      const match = resolveSession(results, detachTarget);
+      if (match) {
+        resolvedPort = match.port;
+        detachTarget = match.session.sessionId;
+      }
     }
   }
 
@@ -957,7 +995,7 @@ if (cliSubcommand === 'detach') {
     await runDetachClient({
       host: resolved.host,
       port: resolvedPort,
-      target: resolved.targetId,
+      target: detachTarget,
     });
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -895,26 +895,26 @@ if (cliSubcommand === 'kill') {
   }
   let resolvedPort = resolved.port;
 
-  // Resolve port by querying all local daemon ports (session may be on any daemon)
-  if (!cliPort && resolved.host === 'localhost') {
-    const allPorts = liveSessionsRegistry.getLivePorts();
-    if (allPorts.length > 0) {
-      const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
-      const results = await queryMultiplePorts({
-        host: 'localhost',
-        ports: allPorts,
-        timeoutMs: 5000,
-        logLabel: 'kill',
-      });
-      const match = resolveSession(results, resolved.targetId);
-      if (match) {
-        resolvedPort = match.port;
-      }
-    }
-  }
-
   const { runKillClient } = await import('./cli/kill-client.ts');
   try {
+    // Resolve port by querying all local daemon ports (session may be on any daemon)
+    if (!cliPort && resolved.host === 'localhost') {
+      const allPorts = liveSessionsRegistry.getLivePorts();
+      if (allPorts.length > 0) {
+        const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
+        const results = await queryMultiplePorts({
+          host: 'localhost',
+          ports: allPorts,
+          timeoutMs: 5000,
+          logLabel: 'kill',
+        });
+        const match = resolveSession(results, resolved.targetId);
+        if (match) {
+          resolvedPort = match.port;
+        }
+      }
+    }
+
     await runKillClient({
       host: resolved.host,
       port: resolvedPort,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -895,13 +895,21 @@ if (cliSubcommand === 'kill') {
   }
   let resolvedPort = resolved.port;
 
-  // Resolve port from live registry if target matches a known local session
+  // Resolve port by querying all local daemon ports (session may be on any daemon)
   if (!cliPort && resolved.host === 'localhost') {
-    const liveMatch =
-      liveSessionsRegistry.findByName(resolved.targetId) ??
-      liveSessionsRegistry.findBySessionId(resolved.targetId);
-    if (liveMatch) {
-      resolvedPort = liveMatch.wsPort;
+    const allPorts = liveSessionsRegistry.getLivePorts();
+    if (allPorts.length > 0) {
+      const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
+      const results = await queryMultiplePorts({
+        host: 'localhost',
+        ports: allPorts,
+        timeoutMs: 5000,
+        logLabel: 'kill',
+      });
+      const match = resolveSession(results, resolved.targetId);
+      if (match) {
+        resolvedPort = match.port;
+      }
     }
   }
 

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -107,7 +107,7 @@ export interface LsClientOptions {
 
 export async function runLsClient(opts: LsClientOptions): Promise<void> {
   const sessions = await fetchSessions(opts.host, opts.port, opts.timeout);
-  renderSessionList(sessions, opts.port);
+  renderSessionList(sessions.map((session) => ({ session, port: opts.port })));
 }
 
 // ---------------------------------------------------------------------------
@@ -151,7 +151,8 @@ export async function runHostLs(opts: HostLsOptions): Promise<void> {
 
   // Single port: render flat list (same as --host --port)
   if (results.length === 1) {
-    renderSessionList(allSessions, results[0]?.port);
+    const port = results[0]?.port ?? 0;
+    renderSessionList(allSessions.map((session) => ({ session, port })));
     return;
   }
 
@@ -543,36 +544,65 @@ function renderNetworkSessionList(results: DaemonSessions[]): void {
 // Rendering helpers
 // ---------------------------------------------------------------------------
 
-function renderSessionList(sessions: readonly DiscoverableSession[], port?: number): void {
-  if (sessions.length === 0) {
+export interface SessionWithPort {
+  readonly session: DiscoverableSession;
+  readonly port: number;
+}
+
+function renderSessionList(entries: readonly SessionWithPort[]): void {
+  if (entries.length === 0) {
     console.log('No active sessions. Start one with: remi [claude-args...]');
     return;
   }
 
-  if (port !== undefined) {
-    console.log(`Daemon port: ${port}`);
+  const uniquePorts = new Set(entries.map((e) => e.port));
+  const multiPort = uniquePorts.size > 1;
+
+  if (!multiPort) {
+    console.log(`Daemon port: ${entries[0]?.port}`);
   }
 
-  // Fixed columns: STATUS(12) + DURATION(10) + LAST ACTIVITY(16) = 38
-  const nameCol = Math.max(MIN_NAME_WIDTH, getTerminalWidth() - 38);
-  const header = `${'NAME'.padEnd(nameCol)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
-  console.log(header);
-  console.log('-'.repeat(header.length));
+  if (multiPort) {
+    // Fixed columns: PORT(8) + STATUS(12) + DURATION(10) + LAST ACTIVITY(16) = 46
+    const nameCol = Math.max(MIN_NAME_WIDTH, getTerminalWidth() - 46);
+    const header = `${'NAME'.padEnd(nameCol)}${'PORT'.padEnd(8)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+    console.log(header);
+    console.log('-'.repeat(header.length));
 
-  for (const s of sessions) {
-    const rawName = s.name ?? path.basename(s.projectPath);
-    const maxLen = nameCol - 2;
-    const name = rawName.length > maxLen ? `${rawName.slice(0, maxLen - 3)}...` : rawName;
-    const duration = formatDuration(s.createdAt);
-    const lastAct = formatAge(s.lastActivity);
-    const mark = s.canAttach ? ' *' : '';
+    for (const { session: s, port } of entries) {
+      const rawName = s.name ?? path.basename(s.projectPath);
+      const maxLen = nameCol - 2;
+      const name = rawName.length > maxLen ? `${rawName.slice(0, maxLen - 3)}...` : rawName;
+      const duration = formatDuration(s.createdAt);
+      const lastAct = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
 
-    console.log(
-      `${name.padEnd(nameCol)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
-    );
+      console.log(
+        `${name.padEnd(nameCol)}${String(port).padEnd(8)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+      );
+    }
+  } else {
+    // Fixed columns: STATUS(12) + DURATION(10) + LAST ACTIVITY(16) = 38
+    const nameCol = Math.max(MIN_NAME_WIDTH, getTerminalWidth() - 38);
+    const header = `${'NAME'.padEnd(nameCol)}${'STATUS'.padEnd(12)}${'DURATION'.padStart(10)}${'LAST ACTIVITY'.padStart(16)}`;
+    console.log(header);
+    console.log('-'.repeat(header.length));
+
+    for (const { session: s } of entries) {
+      const rawName = s.name ?? path.basename(s.projectPath);
+      const maxLen = nameCol - 2;
+      const name = rawName.length > maxLen ? `${rawName.slice(0, maxLen - 3)}...` : rawName;
+      const duration = formatDuration(s.createdAt);
+      const lastAct = formatAge(s.lastActivity);
+      const mark = s.canAttach ? ' *' : '';
+
+      console.log(
+        `${name.padEnd(nameCol)}${s.status.padEnd(12)}${duration.padStart(10)}${lastAct.padStart(16)}${mark}`,
+      );
+    }
   }
 
-  const attachable = sessions.filter((s) => s.canAttach);
+  const attachable = entries.filter((e) => e.session.canAttach);
   if (attachable.length > 0) {
     console.log('');
     console.log(
@@ -631,11 +661,11 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
       timeoutMs: timeout,
       logLabel: 'ls',
     });
-    const fallbackSessions = fallbackResults.flatMap((r) => r.sessions);
-    if (fallbackSessions.length > 0) {
-      const uniquePorts = new Set(fallbackResults.map((r) => r.port));
-      const sharedPort = uniquePorts.size === 1 ? fallbackResults[0]?.port : undefined;
-      renderSessionList(fallbackSessions, sharedPort);
+    const fallbackEntries = fallbackResults.flatMap((r) =>
+      r.sessions.map((session) => ({ session, port: r.port })),
+    );
+    if (fallbackEntries.length > 0) {
+      renderSessionList(fallbackEntries);
       return;
     }
     console.log('No active sessions. Start one with: remi [claude-args...]');
@@ -649,10 +679,10 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
     logLabel: 'ls',
   });
 
-  const allSessions: DiscoverableSession[] = results.flatMap((r) => r.sessions);
-  const uniquePorts = new Set(results.map((r) => r.port));
-  const sharedPort = uniquePorts.size === 1 ? results[0]?.port : undefined;
-  renderSessionList(allSessions, sharedPort);
+  const allEntries: SessionWithPort[] = results.flatMap((r) =>
+    r.sessions.map((session) => ({ session, port: r.port })),
+  );
+  renderSessionList(allEntries);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `remi ls` now shows a PORT column when sessions span multiple daemon ports. Previously, port info was hidden when `uniquePorts.size > 1` in `runMultiPortLs`, making it impossible to tell which daemon owns each session. When all sessions share one port, the existing "Daemon port: N" header is preserved.

- `remi kill` now queries ALL known daemon ports (via `liveSessionsRegistry.getLivePorts()` and `queryMultiplePorts`) to resolve the target session, then sends the kill to the correct port. Previously it only checked the registry for exact name/ID matches and fell back to the default port, failing to find sessions on other daemons.

## Changes

- `packages/daemon/src/cli/ls-client.ts`: Refactored `renderSessionList` to accept `SessionWithPort[]` instead of `(DiscoverableSession[], port?)`. When entries have multiple unique ports, renders a PORT column (same layout as `runHostLs`). Updated all 4 call sites.

- `packages/daemon/src/cli.ts`: Replaced the kill command's `findByName`/`findBySessionId` single-registry-entry lookup with multi-port querying via `queryMultiplePorts` + `resolveSession` from `session-resolver.ts`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (1355 tests)
- [x] `bunx biome check` passes on changed files
- [ ] Manual: run two daemons on different ports, verify `remi ls` shows PORT column
- [ ] Manual: run two daemons, verify `remi kill <session-on-other-daemon>` works