### PR TITLE
feat: lock-screen and Apple Watch notification action buttons

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -31,7 +31,7 @@ export interface AdapterEvents {
   onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
 
   /** Answer to question received */
-  onAnswer: (connectionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -770,7 +770,7 @@ export class TelegramAdapter implements ConnectionAdapter {
     }
 
     // Notify daemon of answer
-    this.events.onAnswer?.(session.connectionId, questionId, answer);
+    this.events.onAnswer?.(session.connectionId, session.sessionId, questionId, answer);
 
     // Acknowledge the callback
     await ctx.answerCallbackQuery('Sent!');

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -113,8 +113,8 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onUserInput?.(connectionId, sessionId, content, raw);
       },
 
-      onAnswer: (connectionId, questionId, answer) => {
-        this.events.onAnswer?.(connectionId, questionId, answer);
+      onAnswer: (connectionId, sessionId, questionId, answer) => {
+        this.events.onAnswer?.(connectionId, sessionId, questionId, answer);
       },
 
       onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -46,6 +46,17 @@ let logFd: number | null = null;
 // Raw PTY bytes are written directly via fs.writeSync to avoid decode/encode.
 let ptyStdoutFd: number | null = null;
 
+/**
+ * Select the APNS notification category based on the number of question options.
+ * iOS will render action buttons matching the category; watchOS mirrors them automatically.
+ */
+function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
+  if (options.length === 2) return 'REMI_YN';
+  if (options.length === 3) return 'REMI_YNA';
+  if (options.length === 4) return 'REMI_MULTI';
+  return undefined;
+}
+
 function ensureRemiDir(): void {
   fs.mkdirSync(REMI_DIR, { recursive: true });
 }
@@ -249,6 +260,7 @@ import {
 import type {
   AgentStatus,
   ProtocolMessage,
+  QuestionOption,
   RecentDirectory,
   UUID,
   UnlockedIdentity,
@@ -1624,12 +1636,17 @@ async function createNewSession(
           const sessionName = session?.name || 'Agent';
           const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
           const pushSessionId = primarySessionId ?? sessionId;
+          const pushCategory = selectPushCategory(question.options);
+          const pushOptions = question.options.map((o) => o.value);
           for (const dt of deviceTokens.values()) {
             sendPushTrigger(signalingUrl, dt.token, {
               title: `${sessionName} needs input`,
               body: question.text.slice(0, 100),
               ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
               sessionId: pushSessionId,
+              questionId: question.id,
+              ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+              ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
             })
               .then(() => log(`Push notification sent for session ${pushSessionId}`))
               .catch((err) => log(`Push notification failed: ${err}`));
@@ -2234,15 +2251,19 @@ const sharedEvents = {
     }
   },
 
-  onAnswer: async (connectionId: UUID, _questionId: UUID, answer: string) => {
-    log(`Answer from ${connectionId}: ${answer}`);
+  onAnswer: async (connectionId: UUID, sessionId: UUID, _questionId: UUID, answer: string) => {
+    log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
 
-    const session = sessionRegistry.getSessionForConnection(connectionId);
+    // Prefer lookup by sessionId (from push-action answers) so reconnected clients
+    // can answer even before the connection is fully mapped in the registry.
+    const session =
+      sessionRegistry.getSession(sessionId) ??
+      sessionRegistry.getSessionForConnection(connectionId);
     if (session) {
       await session.pty.submitInput(answer);
       sessionRegistry.updateQuestion(session.sessionId, null);
     } else {
-      log(`No session found for connection ${connectionId}`);
+      log(`No session found for connection ${connectionId} or session ${sessionId}`);
     }
   },
 

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -16,6 +16,12 @@ export interface PushTriggerOptions {
   pushSecret?: string;
   /** Remi session UUID included in APNS custom data for tap-to-navigate */
   sessionId?: string;
+  /** Question UUID so the client can send the right answer back */
+  questionId?: string;
+  /** APNS notification category ('REMI_YN' | 'REMI_YNA' | 'REMI_MULTI') for action buttons */
+  category?: string;
+  /** Answer values for action buttons: opt_0, opt_1, ... */
+  options?: string[];
 }
 
 /**
@@ -39,13 +45,22 @@ export async function sendPushTrigger(
   if (opts.pushSecret) {
     headers['Authorization'] = `Bearer ${opts.pushSecret}`;
   }
-  const payload: Record<string, string> = {
+  const payload: Record<string, unknown> = {
     token: deviceToken,
     title: opts.title,
     body: opts.body,
   };
   if (opts.sessionId) {
     payload['sessionId'] = opts.sessionId;
+  }
+  if (opts.questionId) {
+    payload['questionId'] = opts.questionId;
+  }
+  if (opts.category) {
+    payload['category'] = opts.category;
+  }
+  if (opts.options && opts.options.length > 0) {
+    payload['options'] = opts.options;
   }
   const response = await fetch(url, {
     method: 'POST',

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -258,7 +258,12 @@ export class RelayAdapter implements ConnectionAdapter {
           console.warn('Invalid answer payload: missing questionId or answer');
           return;
         }
-        this.events.onAnswer?.(connectionId, msg['questionId'], msg['answer']);
+        this.events.onAnswer?.(
+          connectionId,
+          typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '',
+          msg['questionId'],
+          msg['answer'],
+        );
         break;
       case 'session_list_request':
         if (typeof msg['id'] !== 'string') {

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -63,7 +63,7 @@ export interface ConnectionEvents {
   onUserInput: (sessionId: UUID, content: string, raw?: boolean) => void;
 
   /** Answer to question received */
-  onAnswer: (questionId: UUID, answer: string) => void;
+  onAnswer: (sessionId: UUID, questionId: UUID, answer: string) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (sessionId: UUID, bulletId: number, requestId: UUID) => void;
@@ -418,7 +418,7 @@ export class Connection {
     this.sendAck(message.id, 'delivered');
 
     // Notify
-    this.events.onAnswer?.(message.questionId, message.answer);
+    this.events.onAnswer?.(message.sessionId, message.questionId, message.answer);
   }
 
   private handleBulletExpandRequest(message: BulletExpandRequestMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -45,7 +45,7 @@ export interface ServerEvents {
   onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
 
   /** Answer from client */
-  onAnswer: (connectionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
 
   /** Bullet expand request from client */
   onBulletExpandRequest: (
@@ -301,8 +301,8 @@ export class WebSocketServer {
         this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw);
       },
 
-      onAnswer: (questionId, answer) => {
-        this.events.onAnswer?.(ws.data.connectionId, questionId, answer);
+      onAnswer: (sessionId, questionId, answer) => {
+        this.events.onAnswer?.(ws.data.connectionId, sessionId, questionId, answer);
       },
 
       onBulletExpandRequest: (sessionId, bulletId, requestId) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -94,6 +94,7 @@ export {
   createPong,
   createError,
   createQuestion,
+  createAnswer,
   createSessionUpdate,
   createReplayBatch,
   createBulletExpandRequest,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -197,6 +197,7 @@ export interface AnswerMessage {
   readonly type: 'answer';
   readonly id: UUID;
   readonly timestamp: Timestamp;
+  readonly sessionId: UUID;
   readonly questionId: UUID;
   readonly answer: string;
 }
@@ -816,6 +817,20 @@ export function createQuestion(question: Question, sessionId?: UUID): QuestionMe
     timestamp: now(),
     question,
     ...(sessionId !== undefined && { sessionId }),
+  };
+}
+
+/**
+ * Create an answer message for a question.
+ */
+export function createAnswer(sessionId: UUID, questionId: UUID, answer: string): AnswerMessage {
+  return {
+    type: 'answer',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    questionId,
+    answer,
   };
 }
 

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -13,6 +13,8 @@ interface ApnsPayload {
   data?: Record<string, string>;
   /** Use APNS sandbox endpoint (development builds) */
   sandbox?: boolean;
+  /** UNNotificationCategory identifier for action buttons (lock screen / Watch) */
+  category?: string;
 }
 
 interface ApnsConfig {
@@ -55,6 +57,7 @@ export async function sendApnsPush(
         },
         sound: 'default',
         badge: 1,
+        ...(payload.category ? { category: payload.category } : {}),
       },
       ...(payload.data ? payload.data : {}),
     }),

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -39,6 +39,12 @@ interface PushRequestBody {
   body?: string;
   /** Remi session UUID; included in APNS custom data for notification tap navigation */
   sessionId?: string;
+  /** Question UUID so the client can send the right answer back */
+  questionId?: string;
+  /** APNS notification category identifier for action buttons */
+  category?: string;
+  /** Answer values for action buttons: mapped to opt_0, opt_1, ... in APNS data */
+  options?: string[];
   /** Reserved for future per-request sandbox override; daemon does not send this today */
   sandbox?: boolean;
 }
@@ -161,14 +167,34 @@ export default {
       // sandbox: env var is the global gate. body.sandbox is reserved for future per-request
       // override — the daemon does not send it today (payload is Record<string, string>).
       const sandbox = env.APNS_SANDBOX === 'true' || body.sandbox === true;
-      // Custom data for notification tap navigation; reject empty strings to avoid unroutable taps
-      const data: Record<string, string> | undefined =
-        body.sessionId && body.sessionId.length > 0 ? { sessionId: body.sessionId } : undefined;
+      // Build custom data for notification payload (sibling to aps).
+      // Include sessionId, questionId, and per-option answer values (opt_0, opt_1, ...).
+      const data: Record<string, string> = {};
+      if (body.sessionId && body.sessionId.length > 0) {
+        data['sessionId'] = body.sessionId;
+      }
+      if (body.questionId && body.questionId.length > 0) {
+        data['questionId'] = body.questionId;
+      }
+      if (Array.isArray(body.options)) {
+        body.options.forEach((val, idx) => {
+          data[`opt_${idx}`] = String(val);
+        });
+      }
+      const category = body.category && body.category.length > 0 ? body.category : undefined;
 
       let result: { success: boolean; error?: string };
       try {
         result = await sendApnsPush(
-          { token: body.token, title: body.title, body: body.body, bundleId, sandbox, data },
+          {
+            token: body.token,
+            title: body.title,
+            body: body.body,
+            bundleId,
+            sandbox,
+            data: Object.keys(data).length > 0 ? data : undefined,
+            category,
+          },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );
       } catch (err) {

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Capacitor
+import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,7 +14,53 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.rootViewController = vc
         window.makeKeyAndVisible()
         self.window = window
+        registerNotificationCategories()
         return true
+    }
+
+    /// Register UNNotificationCategory objects for lock-screen / Apple Watch action buttons.
+    /// Capacitor owns UNUserNotificationCenter.delegate; do NOT override it here.
+    private func registerNotificationCategories() {
+        let auth: UNNotificationActionOptions = [.authenticationRequired]
+        let dest: UNNotificationActionOptions = [.authenticationRequired, .destructive]
+
+        // Two-option: Yes / No
+        let yn = UNNotificationCategory(
+            identifier: "REMI_YN",
+            actions: [
+                UNNotificationAction(identifier: "OPT_0", title: "Yes", options: auth),
+                UNNotificationAction(identifier: "OPT_1", title: "No",  options: dest),
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        // Three-option: Yes / Yes, always / No
+        let yna = UNNotificationCategory(
+            identifier: "REMI_YNA",
+            actions: [
+                UNNotificationAction(identifier: "OPT_0", title: "Yes",         options: auth),
+                UNNotificationAction(identifier: "OPT_1", title: "Yes, always", options: auth),
+                UNNotificationAction(identifier: "OPT_2", title: "No",          options: dest),
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        // Four-option: generic multi-choice (titles overridden at runtime by action data)
+        let multi = UNNotificationCategory(
+            identifier: "REMI_MULTI",
+            actions: [
+                UNNotificationAction(identifier: "OPT_0", title: "Option 1", options: auth),
+                UNNotificationAction(identifier: "OPT_1", title: "Option 2", options: auth),
+                UNNotificationAction(identifier: "OPT_2", title: "Option 3", options: auth),
+                UNNotificationAction(identifier: "OPT_3", title: "Option 4", options: auth),
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        UNUserNotificationCenter.current().setNotificationCategories([yn, yna, multi])
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,9 +23,11 @@ import type {
   UISession,
 } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
+import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
+  createAnswer,
   createDetachSession,
   createRegisterDeviceToken,
   generateId,
@@ -823,6 +825,101 @@ function App() {
     return () => document.removeEventListener('push-notification-tap', handleNotificationTap);
   }, []);
 
+  // Stable refs for push-answer handler (avoids stale closures; connectDirectRef already declared above)
+  const pushAnswerSendRef = useRef(cmSendMessage);
+  useEffect(() => {
+    pushAnswerSendRef.current = cmSendMessage;
+  }, [cmSendMessage]);
+
+  // Handle push notification action button taps (lock screen / Apple Watch)
+  useEffect(() => {
+    const handlePushAnswer = async (e: Event) => {
+      const { sessionId, questionId, answer } = (
+        e as CustomEvent<{ sessionId: string; questionId: string; answer: string }>
+      ).detail;
+      if (!sessionId || !questionId || !answer) return;
+
+      // Find the session in our session list to get its connectionId
+      const session = sessionsRef.current.find((s) => s.id === sessionId);
+      const connectionId = session?.connectionId;
+
+      // Check if the connection is already live
+      const conn = connectionId
+        ? connectionsRef.current.find((c) => c.connectionId === connectionId)
+        : undefined;
+      const isConnected = conn?.status === 'connected';
+
+      if (isConnected && connectionId) {
+        // Already connected — send immediately
+        pushAnswerSendRef.current(
+          connectionId,
+          createAnswer(sessionId as UUID, questionId as UUID, answer),
+        );
+        return;
+      }
+
+      // Not connected; try to reconnect using the stored URL
+      const connUrl = (conn as { url?: string } | undefined)?.url;
+      if (!connUrl) {
+        // No URL available — notify user that answer could not be delivered
+        LocalNotifications.schedule({
+          notifications: [
+            {
+              title: 'Answer not delivered',
+              body: 'Open Remi to respond to the question.',
+              id: (Date.now() % 2_000_000_000) + Math.floor(Math.random() * 1000),
+              schedule: { at: new Date() },
+            },
+          ],
+        }).catch(() => undefined);
+        return;
+      }
+
+      // Attempt reconnect with 10s timeout
+      const targetConnId = connectDirectRef.current(connUrl);
+      const ANSWER_TIMEOUT_MS = 10_000;
+      const deadline = Date.now() + ANSWER_TIMEOUT_MS;
+      const delivered = await new Promise<boolean>((resolve) => {
+        const check = setInterval(() => {
+          const live = connectionsRef.current.find((c) => c.connectionId === targetConnId);
+          if (live?.status === 'connected') {
+            clearInterval(check);
+            const sent = pushAnswerSendRef.current(
+              targetConnId,
+              createAnswer(sessionId as UUID, questionId as UUID, answer),
+            );
+            resolve(sent);
+          } else if (Date.now() >= deadline) {
+            clearInterval(check);
+            resolve(false);
+          }
+        }, 250);
+      });
+
+      if (!delivered) {
+        LocalNotifications.schedule({
+          notifications: [
+            {
+              title: 'Answer not delivered',
+              body: 'Open Remi to respond to the question.',
+              id: (Date.now() % 2_000_000_000) + Math.floor(Math.random() * 1000),
+              schedule: { at: new Date() },
+            },
+          ],
+        }).catch(() => undefined);
+      }
+    };
+
+    const listener = (e: Event) => {
+      handlePushAnswer(e).catch((err) =>
+        console.error('[App] push-notification-answer handler error:', err),
+      );
+    };
+    document.addEventListener('push-notification-answer', listener);
+    return () => document.removeEventListener('push-notification-answer', listener);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Send device token to daemons: on new token or new connection
   const deviceTokenRef = useRef<string | null>(null);
   const tokenSentToRef = useRef<Set<ConnectionId>>(new Set());
@@ -921,7 +1018,7 @@ function App() {
 
       // If there's an active question, send as answer
       if (sessionQuestion) {
-        const sent = sendAnswer(connId, sessionQuestion.id, content);
+        const sent = sendAnswer(connId, activeSessionId, sessionQuestion.id, content);
         if (!sent) {
           const failMsg: UIMessage = {
             id: generateId(),

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -20,6 +20,7 @@ import type { UnlockedIdentity } from '@remi/shared';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
+  createAnswer,
   createBulletExpandRequest,
   createCreateSessionRequest,
   createHello,
@@ -29,8 +30,6 @@ import {
   createSessionListRequest,
   createTranscriptLoadRequest,
   createUserInput,
-  generateId,
-  now,
 } from '@remi/shared/protocol.ts';
 import type { UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -87,7 +86,12 @@ export interface UseConnectionManagerReturn {
   /** Send user input routed to the correct connection */
   sendInput: (connectionId: ConnectionId, sessionId: UUID, content: string) => boolean;
   /** Send answer to a question via the correct connection */
-  sendAnswer: (connectionId: ConnectionId, questionId: UUID, answer: string) => boolean;
+  sendAnswer: (
+    connectionId: ConnectionId,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+  ) => boolean;
   /** Send a raw protocol message to a specific connection */
   sendMessage: (connectionId: ConnectionId, message: ProtocolMessage) => boolean;
   /** Request bullet expand via a specific connection */
@@ -528,15 +532,8 @@ export function useConnectionManager(
   );
 
   const sendAnswer = useCallback(
-    (connectionId: ConnectionId, questionId: UUID, answer: string): boolean => {
-      const msg: ProtocolMessage = {
-        type: 'answer',
-        id: generateId(),
-        timestamp: now(),
-        questionId,
-        answer,
-      };
-      return sendToConnection(connectionId, msg);
+    (connectionId: ConnectionId, sessionId: UUID, questionId: UUID, answer: string): boolean => {
+      return sendToConnection(connectionId, createAnswer(sessionId, questionId, answer));
     },
     [sendToConnection],
   );

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -18,6 +18,7 @@ import type { UnlockedIdentity } from '@remi/shared';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
+  createAnswer,
   createBulletExpandRequest,
   createCreateSessionRequest,
   createHello,
@@ -27,8 +28,6 @@ import {
   createSessionListRequest,
   createTranscriptLoadRequest,
   createUserInput,
-  generateId,
-  now,
 } from '@remi/shared/protocol.ts';
 import type { UUID } from '@remi/shared/types.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -46,7 +45,7 @@ export interface UseWebSocketReturn {
   /** Send user input */
   sendInput: (sessionId: UUID, content: string) => boolean;
   /** Send an answer to a question */
-  sendAnswer: (questionId: UUID, answer: string) => boolean;
+  sendAnswer: (sessionId: UUID, questionId: UUID, answer: string) => boolean;
   /** Send raw message */
   sendMessage: (message: ProtocolMessage) => boolean;
   /** Request full content for a truncated bullet */
@@ -408,16 +407,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   }, []);
 
   // Send answer to a question
-  const sendAnswer = useCallback((questionId: UUID, answer: string): boolean => {
+  const sendAnswer = useCallback((sessionId: UUID, questionId: UUID, answer: string): boolean => {
     if (!clientRef.current) return false;
-    const msg: ProtocolMessage = {
-      type: 'answer',
-      id: generateId(),
-      timestamp: now(),
-      questionId,
-      answer,
-    };
-    return clientRef.current.send(msg);
+    return clientRef.current.send(createAnswer(sessionId, questionId, answer));
   }, []);
 
   // Send raw message

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -81,13 +81,33 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
       }
     });
 
-    // Handle notification tap (when user taps a push notification to open the app)
+    // Handle notification action tap (action buttons or plain tap)
     await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
-      const data = action.notification.data;
-      console.debug('[Notifications] Push notification tapped:', data);
-      // Dispatch a custom event so App.tsx can navigate to the relevant session
-      const event = new CustomEvent('push-notification-tap', { detail: data });
-      document.dispatchEvent(event);
+      const data = action.notification.data as Record<string, string>;
+      const actionId: string = action.actionIdentifier ?? '';
+      console.debug('[Notifications] Push notification action:', actionId, data);
+
+      if (actionId.startsWith('OPT_')) {
+        // Lock-screen / Apple Watch action button tapped
+        const optKey = actionId.toLowerCase(); // 'opt_0', 'opt_1', etc.
+        const answerValue = data[optKey];
+        if (answerValue !== undefined && data['sessionId'] && data['questionId']) {
+          document.dispatchEvent(
+            new CustomEvent('push-notification-answer', {
+              detail: {
+                sessionId: data['sessionId'],
+                questionId: data['questionId'],
+                answer: answerValue,
+              },
+            }),
+          );
+        } else {
+          console.warn('[Notifications] Action tap missing data:', { optKey, data });
+        }
+      } else {
+        // Default tap (notification body) — navigate to session
+        document.dispatchEvent(new CustomEvent('push-notification-tap', { detail: data }));
+      }
     });
   } catch (err) {
     console.warn('[Notifications] Push registration setup failed:', err);


### PR DESCRIPTION
## Summary

- Add APNS notification categories (`REMI_YN`, `REMI_YNA`, `REMI_MULTI`) so permission questions can be answered from the iOS lock screen or Apple Watch without opening the app
- Thread `sessionId` through the `AnswerMessage` protocol so push-woken reconnects can route answers to the correct session
- Deploy updated signaling worker that passes `category` into `aps` body and `opt_N` values into APNS custom data

## Changes

**Shared protocol (`packages/shared`)**
- Added `sessionId` field to `AnswerMessage` interface
- Added `createAnswer(sessionId, questionId, answer)` factory function
- Exported `createAnswer` from index

**Daemon (`packages/daemon`)**
- `AnswerMessage.sessionId` threaded through: `Connection` -> `WebSocketServer` -> `ConnectionAdapter` -> `WebSocketAdapter` -> `cli.ts`
- `onAnswer` handler in `cli.ts` now looks up session by `sessionId` first (enables push-woken reconnects), falls back to `connectionId`
- `selectPushCategory()` helper: 2 options -> `REMI_YN`, 3 -> `REMI_YNA`, 4 -> `REMI_MULTI`, else undefined
- Push trigger call includes `questionId`, `category`, and `opt_N` option values

**Signaling worker (`packages/signaling`)**
- `PushRequestBody` extended with `questionId`, `category`, `options`
- `ApnsPayload` extended with `category`
- APNS `category` placed inside `aps` JSON body (correct per Apple spec)
- `questionId` and `opt_0..N` added to APNS custom data dict
- Worker deployed to `remi-signaling.yooz.workers.dev`

**iOS native (`packages/web/ios`)**
- `AppDelegate.swift` registers three `UNNotificationCategory` objects on launch
- Capacitor owns `UNUserNotificationCenter.delegate`; not overridden
- Apple Watch mirrors lock-screen action buttons automatically (zero native Watch code)

**Web app (`packages/web`)**
- `notifications.ts`: `pushNotificationActionPerformed` listener distinguishes `OPT_*` action taps from plain taps; dispatches `push-notification-answer` custom event
- `App.tsx`: new `push-notification-answer` handler reconnects if needed (10s timeout), then sends `createAnswer` message; schedules "Answer not delivered" local notification on timeout
- `useConnectionManager.ts` + `useWebSocket.ts`: `sendAnswer` updated to include `sessionId`

## Test plan

- [x] `bun test` passes (1355 tests, 0 failures)
- [x] Web TypeScript typecheck clean (`tsc --noEmit --skipLibCheck`)
- [x] Biome lint/format clean on changed files
- [x] Signaling worker deployed successfully
- [ ] iOS: trigger a permission question, verify action buttons appear on lock screen
- [ ] iOS: tap "Yes" on lock screen, verify answer reaches daemon PTY
- [ ] Apple Watch: verify same action buttons appear on Watch notification
- [ ] Verify notification body tap still navigates to session
- [ ] Disconnect daemon, tap action button, verify "Answer not delivered" local notification fires after ~10s