### PR TITLE
fix: auto-switch session on restart at same port

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -194,6 +194,25 @@ function App() {
           ];
         });
         localStorage.setItem(LOCALSTORAGE_SESSION_KEY, message.sessionId);
+
+        // Auto-switch to new session when same connection restarts
+        const oldActive = activeSessionIdRef.current;
+        if (oldActive !== message.sessionId) {
+          const oldSession = sessionsRef.current.find((s) => s.id === oldActive);
+          const shouldSwitch = !oldActive || oldSession?.connectionId === connectionId;
+          if (shouldSwitch) {
+            setActiveSessionId(message.sessionId);
+            if (oldActive) {
+              setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
+              setQuestions((prev) => {
+                if (!prev.has(oldActive)) return prev;
+                const next = new Map(prev);
+                next.delete(oldActive);
+                return next;
+              });
+            }
+          }
+        }
         break;
       }
 


### PR DESCRIPTION
## Summary

- When Claude Code exits and restarts in the same directory (same port), the daemon sends a new `hello_ack` with a new session UUID. Previously the client's `activeSessionId` was never updated, so old history remained visible and new messages were filtered out.
- The `hello_ack` handler now checks if the old active session belonged to the same connection. If so, it switches `activeSessionId` to the new session and clears the old session's messages and pending questions.

## Test plan

- [x] TypeScript type check passes (`bunx tsc --noEmit` in packages/web)
- [x] All 1355 tests pass (`bun test`)
- [ ] Manual test: connect to a daemon, see messages, kill Claude Code, restart in same directory -- client should show fresh empty session, not old history
- [ ] Verify that connecting to a different daemon while viewing one session does NOT auto-switch