### PR TITLE
fix: forward push category to foreground local notifications

### DIFF
--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -182,6 +182,11 @@ export default {
         });
       }
       const category = body.category && body.category.length > 0 ? body.category : undefined;
+      // Mirror category into custom data so foreground handlers can read it
+      // without digging into the aps dict (Capacitor exposes data, not aps).
+      if (category) {
+        data['category'] = category;
+      }
 
       let result: { success: boolean; error?: string };
       try {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,7 +12,7 @@ import { parseConnectionId, useConnectionManager } from '@/hooks';
 import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
-import { setSoundEnabled } from '@/lib/notifications';
+import { setSoundEnabled, setSuppressForegroundPush } from '@/lib/notifications';
 import type {
   AppSettings,
   ConnectionId,
@@ -781,6 +781,12 @@ function App() {
     }
     prevConnectedIdsRef.current = connectedIds;
   }, [connectedIds, requestSessionList]);
+
+  // Suppress foreground push-to-local notification banners when at least one
+  // WebSocket connection is live (the question already shows in the chat UI).
+  useEffect(() => {
+    setSuppressForegroundPush(connectedIds.size > 0);
+  }, [connectedIds]);
 
   // Auto-connect from localStorage on mount (run once)
   const connectDirectRef = useRef(connectDirect);

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -48,48 +48,10 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
     console.warn('[Notifications] Local permission request failed:', err);
   }
 
-  // Register local notification action types. These mirror the UNNotificationCategory
-  // objects in AppDelegate.swift so that local notifications (including foreground
-  // re-creations of push notifications) show the same action buttons.
-  try {
-    await LocalNotifications.registerActionTypes({
-      types: [
-        {
-          id: 'REMI_YN',
-          actions: [
-            { id: 'OPT_0', title: 'Yes' },
-            { id: 'OPT_1', title: 'No', destructive: true },
-          ],
-        },
-        {
-          id: 'REMI_YNA',
-          actions: [
-            { id: 'OPT_0', title: 'Yes' },
-            { id: 'OPT_1', title: 'Yes, always' },
-            { id: 'OPT_2', title: 'No', destructive: true },
-          ],
-        },
-        {
-          id: 'REMI_MULTI',
-          actions: [
-            { id: 'OPT_0', title: 'Option 1' },
-            { id: 'OPT_1', title: 'Option 2' },
-            { id: 'OPT_2', title: 'Option 3' },
-            { id: 'OPT_3', title: 'Option 4' },
-          ],
-        },
-        {
-          id: 'QUESTION',
-          actions: [
-            { id: 'OPT_0', title: 'Yes' },
-            { id: 'OPT_1', title: 'No', destructive: true },
-          ],
-        },
-      ],
-    });
-  } catch (err) {
-    console.warn('[Notifications] Failed to register action types:', err);
-  }
+  // NOTE: Notification action types (REMI_YN, REMI_YNA, REMI_MULTI) are registered
+  // natively in AppDelegate.swift with .authenticationRequired. Do NOT call
+  // LocalNotifications.registerActionTypes() here; it uses setNotificationCategories
+  // which is a replace-all operation and would strip the native auth requirement.
 
   // Register for push notifications (APNS token)
   try {

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -45,6 +45,49 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
     console.warn('[Notifications] Local permission request failed:', err);
   }
 
+  // Register local notification action types. These mirror the UNNotificationCategory
+  // objects in AppDelegate.swift so that local notifications (including foreground
+  // re-creations of push notifications) show the same action buttons.
+  try {
+    await LocalNotifications.registerActionTypes({
+      types: [
+        {
+          id: 'REMI_YN',
+          actions: [
+            { id: 'OPT_0', title: 'Yes' },
+            { id: 'OPT_1', title: 'No', destructive: true },
+          ],
+        },
+        {
+          id: 'REMI_YNA',
+          actions: [
+            { id: 'OPT_0', title: 'Yes' },
+            { id: 'OPT_1', title: 'Yes, always' },
+            { id: 'OPT_2', title: 'No', destructive: true },
+          ],
+        },
+        {
+          id: 'REMI_MULTI',
+          actions: [
+            { id: 'OPT_0', title: 'Option 1' },
+            { id: 'OPT_1', title: 'Option 2' },
+            { id: 'OPT_2', title: 'Option 3' },
+            { id: 'OPT_3', title: 'Option 4' },
+          ],
+        },
+        {
+          id: 'QUESTION',
+          actions: [
+            { id: 'OPT_0', title: 'Yes' },
+            { id: 'OPT_1', title: 'No', destructive: true },
+          ],
+        },
+      ],
+    });
+  } catch (err) {
+    console.warn('[Notifications] Failed to register action types:', err);
+  }
+
   // Register for push notifications (APNS token)
   try {
     const pushResult = await PushNotifications.requestPermissions();
@@ -63,22 +106,36 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
       console.warn('[Notifications] Push registration failed:', err.error);
     });
 
-    // Handle incoming push notifications (when app is in foreground)
+    // Handle incoming push notifications (when app is in foreground).
+    // Re-create as a local notification, forwarding the APNS category and
+    // custom data so that action buttons appear and work correctly.
     await PushNotifications.addListener('pushNotificationReceived', (notification) => {
-      // Show as local notification since the app is in foreground
-      if (localPermissionGranted) {
-        LocalNotifications.schedule({
-          notifications: [
-            {
-              title: notification.title ?? 'Remi',
-              body: notification.body ?? 'Your agent needs attention',
-              id: nextNotificationId(),
-              schedule: { at: new Date() },
-              ...(soundEnabled ? { sound: 'default' } : {}),
-            },
-          ],
-        }).catch((err) => console.warn('[Notifications] Failed to show push as local:', err));
+      if (!localPermissionGranted) return;
+      const data = (notification.data ?? {}) as Record<string, string>;
+
+      // Determine actionTypeId: prefer the explicit category field mirrored
+      // into custom data by the signaling server; fall back to counting opt_N keys.
+      let actionTypeId: string | undefined = data['category'];
+      if (!actionTypeId) {
+        const optCount = Object.keys(data).filter((k) => k.startsWith('opt_')).length;
+        if (optCount === 2) actionTypeId = 'REMI_YN';
+        else if (optCount === 3) actionTypeId = 'REMI_YNA';
+        else if (optCount === 4) actionTypeId = 'REMI_MULTI';
       }
+
+      LocalNotifications.schedule({
+        notifications: [
+          {
+            title: notification.title ?? 'Remi',
+            body: notification.body ?? 'Your agent needs attention',
+            id: nextNotificationId(),
+            schedule: { at: new Date() },
+            ...(soundEnabled ? { sound: 'default' } : {}),
+            ...(actionTypeId ? { actionTypeId } : {}),
+            extra: data,
+          },
+        ],
+      }).catch((err) => console.warn('[Notifications] Failed to show push as local:', err));
     });
 
     // Handle notification action tap (action buttons or plain tap)
@@ -111,6 +168,39 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
     });
   } catch (err) {
     console.warn('[Notifications] Push registration setup failed:', err);
+  }
+
+  // Handle action button taps on local notifications (including foreground
+  // re-creations of push notifications). Mirrors the push action handler above.
+  try {
+    await LocalNotifications.addListener('localNotificationActionPerformed', (action) => {
+      const data = (action.notification.extra ?? {}) as Record<string, string>;
+      const actionId: string = action.actionId ?? '';
+      console.debug('[Notifications] Local notification action:', actionId, data);
+
+      if (actionId.startsWith('OPT_')) {
+        const optKey = actionId.toLowerCase();
+        const answerValue = data[optKey];
+        if (answerValue !== undefined && data['sessionId'] && data['questionId']) {
+          document.dispatchEvent(
+            new CustomEvent('push-notification-answer', {
+              detail: {
+                sessionId: data['sessionId'],
+                questionId: data['questionId'],
+                answer: answerValue,
+              },
+            }),
+          );
+        } else {
+          console.warn('[Notifications] Local action tap missing data:', { optKey, data });
+        }
+      } else {
+        // Default tap (notification body)
+        document.dispatchEvent(new CustomEvent('push-notification-tap', { detail: data }));
+      }
+    });
+  } catch (err) {
+    console.warn('[Notifications] Local action listener setup failed:', err);
   }
 
   return localPermissionGranted;

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -18,6 +18,9 @@ import { isNative } from './platform';
 
 let localPermissionGranted = false;
 let soundEnabled = true;
+/** When true, foreground push notifications are suppressed (the question is
+ *  already visible in the chat UI via the WebSocket connection). */
+let suppressForegroundPush = false;
 /** Use timestamp-based IDs to avoid collisions across app restarts */
 function nextNotificationId(): number {
   return (Date.now() % 2_000_000_000) + Math.floor(Math.random() * 1000);
@@ -109,8 +112,10 @@ export async function initNotifications(onToken?: TokenCallback): Promise<boolea
     // Handle incoming push notifications (when app is in foreground).
     // Re-create as a local notification, forwarding the APNS category and
     // custom data so that action buttons appear and work correctly.
+    // When the app is connected via WebSocket, the question already appears
+    // in the chat UI, so skip the duplicate banner.
     await PushNotifications.addListener('pushNotificationReceived', (notification) => {
-      if (!localPermissionGranted) return;
+      if (!localPermissionGranted || suppressForegroundPush) return;
       const data = (notification.data ?? {}) as Record<string, string>;
 
       // Determine actionTypeId: prefer the explicit category field mirrored
@@ -214,6 +219,12 @@ export function getDeviceToken(): string | null {
 /** Set whether notification sounds are enabled (controls local notification sound field) */
 export function setSoundEnabled(enabled: boolean): void {
   soundEnabled = enabled;
+}
+
+/** Suppress foreground push-to-local re-creation when the app is actively
+ *  connected via WebSocket (the question already shows in the chat UI). */
+export function setSuppressForegroundPush(suppress: boolean): void {
+  suppressForegroundPush = suppress;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Register local notification action types (REMI_YN, REMI_YNA, REMI_MULTI, QUESTION) via `LocalNotifications.registerActionTypes()` to mirror the `UNNotificationCategory` objects in `AppDelegate.swift`. Without this, local notifications never showed action buttons regardless of `actionTypeId`.
- Fix the foreground `pushNotificationReceived` handler to forward the APNS category and custom data (`sessionId`, `questionId`, `opt_N` values) when re-creating as a local notification. Previously this created a plain notification without `actionTypeId` or `extra`.
- Add `localNotificationActionPerformed` listener so tapping action buttons on local notifications dispatches the `push-notification-answer` CustomEvent (same as the push handler).
- Mirror the category into APNS custom data in the signaling server so the foreground handler can read it from `notification.data.category` directly (Capacitor exposes custom data, not the aps dict).
- Suppress foreground push-to-local re-creation when at least one WebSocket connection is live, since the question already appears in the chat UI.
- Redeployed signaling Cloudflare Worker to pick up the category forwarding from PR #299.

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] Lint passes (`biome check`)
- [x] All 1355 tests pass
- [x] Signaling server deployed (version a614d465)
- [ ] Send push notification to iOS app in foreground with no WS connection; verify action buttons appear on the local notification banner
- [ ] Tap an action button on the foreground local notification; verify answer is sent back to the daemon
- [ ] Send push notification to iOS app in background; verify action buttons still work
- [ ] Verify that when connected via WebSocket, foreground push does NOT create a duplicate banner
- [ ] Verify Apple Watch notification mirrors action buttons