### PR TITLE
fix: use option label directly instead of hardcoded Yes/No

### DIFF
--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -33,13 +33,8 @@ function resolveAnswerLabel(question: UIQuestion, answer: string): string {
   return answer;
 }
 
-/** Get a friendly label for common option values */
+/** Get display label for an option. Uses the label from the daemon directly. */
 function getOptionDisplayLabel(option: UIQuestionOption): string {
-  const lower = option.value.toLowerCase();
-  if (option.isYes) return 'Yes';
-  if (option.isNo) return 'No';
-  if (lower === 'a' || lower === 'all') return 'All';
-  if (lower === 'q' || lower === 'quit') return 'Quit';
   return option.label;
 }
 


### PR DESCRIPTION
## Summary

Fixes #303. `getOptionDisplayLabel()` was returning hardcoded "Yes" for all options with `isYes: true`, causing both "Yes" and "Yes, always" to render as "Yes" in the multi-option card.

Fix: use `option.label` directly from the daemon, which already has the correct display text.

## Test plan

- [x] TypeScript type check passes
- [x] All 1343 tests pass
- [ ] Verify "Yes, always" shows correctly in multi-option question card