### PR TITLE
fix: send session_reset when Claude restarts in same directory

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -252,6 +252,7 @@ import {
   createResumeSessionResponse,
   createSessionHistoryResponse,
   createSessionListResponse,
+  createSessionReset,
   createStructuredAgentOutput,
   createTranscriptLoadComplete,
   generateId,
@@ -1781,8 +1782,24 @@ async function createNewSession(
       transcript_path?: string;
       hook_event_name?: string;
     }): void {
-      if (claudeSessionId) return;
-      if (!input.session_id || !input.transcript_path) return;
+      if (!input.session_id) return;
+
+      // Detect Claude restart: a different Claude session ID means Claude exited
+      // and restarted in the same directory. Tear down old watcher and notify clients.
+      if (claudeSessionId && claudeSessionId !== input.session_id) {
+        log(`[Hooks] Claude restarted: ${claudeSessionId} -> ${input.session_id}`);
+        const oldWatcher = transcriptWatchers.get(sessionId);
+        if (oldWatcher) {
+          oldWatcher.stop();
+          transcriptWatchers.delete(sessionId);
+        }
+        messageApi.reset();
+        sendAndRecord(createSessionReset(sessionId, 'claude_restarted'));
+        claudeSessionId = null;
+      }
+
+      if (claudeSessionId) return; // already initialized for this Claude session
+      if (!input.transcript_path) return;
 
       if (hasSiblingInDir === null) {
         hasSiblingInDir = liveSessionsRegistry
@@ -1843,6 +1860,21 @@ async function createNewSession(
             );
         }
         if (hasSiblingInDir) return;
+
+        // Detect Claude restart via onSessionInfo path
+        if (claudeSessionId && claudeSessionId !== hookClaudeSessionId) {
+          log(
+            `[Hooks] Claude restarted (SessionInfo): ${claudeSessionId} -> ${hookClaudeSessionId}`,
+          );
+          const oldWatcher = transcriptWatchers.get(sessionId);
+          if (oldWatcher) {
+            oldWatcher.stop();
+            transcriptWatchers.delete(sessionId);
+          }
+          messageApi.reset();
+          sendAndRecord(createSessionReset(sessionId, 'claude_restarted'));
+          claudeSessionId = null;
+        }
 
         try {
           claudeSessionId = hookClaudeSessionId;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -76,6 +76,7 @@ export type {
   DetachSessionMessage,
   DetachSessionAckMessage,
   RegisterDeviceTokenMessage,
+  SessionResetMessage,
 } from './protocol.ts';
 
 export {
@@ -120,6 +121,7 @@ export {
   createDetachSession,
   createDetachSessionAck,
   createRegisterDeviceToken,
+  createSessionReset,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -98,7 +98,8 @@ export type ProtocolMessage =
   | ResumeSessionResponseMessage
   | DetachSessionMessage
   | DetachSessionAckMessage
-  | RegisterDeviceTokenMessage;
+  | RegisterDeviceTokenMessage
+  | SessionResetMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -531,6 +532,17 @@ export interface RegisterDeviceTokenMessage {
   readonly platform: 'ios' | 'android';
 }
 
+/** Notification that a Claude session restarted within the same Remi session */
+export interface SessionResetMessage {
+  readonly type: 'session_reset';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session ID that was reset */
+  readonly sessionId: UUID;
+  /** Reason for the reset */
+  readonly reason: string;
+}
+
 /** A recent project directory aggregated from session history */
 export interface RecentDirectory {
   /** Absolute path */
@@ -639,6 +651,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'detach_session',
     'detach_session_ack',
     'register_device_token',
+    'session_reset',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1253,6 +1266,19 @@ export function createRegisterDeviceToken(
     timestamp: now(),
     token,
     platform,
+  };
+}
+
+/**
+ * Create a session reset notification (Claude restarted within the same Remi session).
+ */
+export function createSessionReset(sessionId: UUID, reason: string): SessionResetMessage {
+  return {
+    type: 'session_reset',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    reason,
   };
 }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -342,6 +342,21 @@ function App() {
         break;
       }
 
+      case 'session_reset': {
+        // Claude restarted in the same directory; clear old messages and questions
+        const resetSessionId = message.sessionId;
+        if (resetSessionId) {
+          setMessages((prev) => prev.filter((m) => m.sessionId !== resetSessionId));
+          setQuestions((prev) => {
+            if (!prev.has(resetSessionId)) return prev;
+            const next = new Map(prev);
+            next.delete(resetSessionId);
+            return next;
+          });
+        }
+        break;
+      }
+
       case 'question': {
         const q = message.question;
         // Dedup: skip if we already have this question (can arrive from multiple connections or hook+PTY)


### PR DESCRIPTION
## Summary

Fixes #310. When Claude Code exits and restarts in the same directory, the daemon now:

1. Detects the Claude session ID change (two detection points: initFromHookEvent + onSessionInfo)
2. Stops the old transcript watcher
3. Resets the message API
4. Sends `session_reset` protocol message to connected clients

Client receives `session_reset` and clears messages + pending questions for that session.

Previously the daemon reused the same Remi session UUID across Claude restarts, so the client never cleared old history.

## Changes

- `packages/shared/src/protocol.ts`: Added SessionResetMessage type + createSessionReset factory
- `packages/shared/src/index.ts`: Exported new type and factory
- `packages/daemon/src/cli.ts`: Detect Claude session ID change, send session_reset
- `packages/web/src/App.tsx`: Handle session_reset, clear messages and questions

## Test plan

- [x] TypeScript type check passes
- [x] All 1343 tests pass
- [ ] Start Claude session, send messages, exit Claude, restart Claude in same dir
- [ ] Verify chat clears on restart (session_reset received)
- [ ] Verify new transcript content loads after reset