### PR TITLE
fix: allow kill/attach/detach by port number

### DIFF
--- a/packages/daemon/src/cli/session-resolver.ts
+++ b/packages/daemon/src/cli/session-resolver.ts
@@ -178,6 +178,22 @@ export function resolveSession(
     return { session: match.session, port: match.port, host: match.host };
   }
 
+  // 0. Port number match: if input is all digits, match by port
+  if (/^\d+$/.test(nameOrId)) {
+    const port = Number.parseInt(nameOrId, 10);
+    const byPort = entries.filter((e) => e.port === port);
+    if (byPort.length === 1) return toResult(byPort);
+    if (byPort.length > 1) {
+      throw new AmbiguousSessionError(
+        nameOrId,
+        byPort.map((e) => ({
+          name: e.session.name ?? e.session.sessionId.slice(0, 8),
+          port: e.port,
+        })),
+      );
+    }
+  }
+
   // 1. Exact name match
   const exactName = entries.filter((e) => e.session.name === nameOrId);
   const exactNameResult = toResult(exactName);


### PR DESCRIPTION
## Summary

Adds port-number matching to `resolveSession()`. Users can now:

```bash
remi kill 18767
remi attach 18766
remi detach 18768
```

Previously only session names, IDs, and `host:port/session-name` format worked. A bare port number was treated as a session name and never matched.

## Test plan

- [x] TypeScript type check passes
- [x] All 1343 tests pass
- [ ] `remi kill 18767` kills the session on that port
- [ ] `remi attach 18766` attaches to the session on that port