### PR TITLE
fix: replace stale fallback watcher when hooks provide correct transcript path

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1777,6 +1777,31 @@ async function createNewSession(
     // mtime fallback handle it. For single-daemon directories (the common case),
     // accept the first event immediately.
     let hasSiblingInDir: boolean | null = null; // Computed once, then cached
+
+    // Safely tear down an existing transcript watcher, reset messages, and notify
+    // clients. Handles errors from stop() and sendAndRecord() so they never prevent
+    // the new watcher from being created. Shared by initFromHookEvent and onSessionInfo.
+    function teardownWatcher(reason: string, label: string): void {
+      const watcher = transcriptWatchers.get(sessionId);
+      if (!watcher) return;
+      transcriptWatchers.delete(sessionId); // Remove from map FIRST to unblock new watcher
+      try {
+        watcher.stop();
+      } catch (stopErr) {
+        logError(
+          `[Hooks] Failed to stop watcher (${label}): ${stopErr instanceof Error ? stopErr.message : String(stopErr)}`,
+        );
+      }
+      messageApi.reset();
+      try {
+        sendAndRecord(createSessionReset(sessionId, reason));
+      } catch (sendErr) {
+        logError(
+          `[Hooks] Failed to send ${reason} for ${sessionId}: ${sendErr instanceof Error ? sendErr.message : String(sendErr)}`,
+        );
+      }
+    }
+
     function initFromHookEvent(input: {
       session_id?: string;
       transcript_path?: string;
@@ -1788,13 +1813,7 @@ async function createNewSession(
       // and restarted in the same directory. Tear down old watcher and notify clients.
       if (claudeSessionId && claudeSessionId !== input.session_id) {
         log(`[Hooks] Claude restarted: ${claudeSessionId} -> ${input.session_id}`);
-        const oldWatcher = transcriptWatchers.get(sessionId);
-        if (oldWatcher) {
-          oldWatcher.stop();
-          transcriptWatchers.delete(sessionId);
-        }
-        messageApi.reset();
-        sendAndRecord(createSessionReset(sessionId, 'claude_restarted'));
+        teardownWatcher('claude_restarted', 'restart');
         claudeSessionId = null;
       }
 
@@ -1832,14 +1851,14 @@ async function createNewSession(
         // If a fallback watcher claimed the slot with a different (stale) file,
         // replace it with the authoritative hook-provided path.
         const existingWatcher = transcriptWatchers.get(sessionId);
-        if (existingWatcher && existingWatcher.filePath !== input.transcript_path) {
+        if (
+          existingWatcher &&
+          path.resolve(existingWatcher.filePath) !== path.resolve(input.transcript_path)
+        ) {
           log(
             `[Hooks] Replacing stale watcher: ${existingWatcher.filePath} -> ${input.transcript_path}`,
           );
-          existingWatcher.stop();
-          transcriptWatchers.delete(sessionId);
-          messageApi.reset();
-          sendAndRecord(createSessionReset(sessionId, 'transcript_changed'));
+          teardownWatcher('transcript_changed', 'stale-replace');
         }
 
         if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
@@ -1879,13 +1898,7 @@ async function createNewSession(
           log(
             `[Hooks] Claude restarted (SessionInfo): ${claudeSessionId} -> ${hookClaudeSessionId}`,
           );
-          const oldWatcher = transcriptWatchers.get(sessionId);
-          if (oldWatcher) {
-            oldWatcher.stop();
-            transcriptWatchers.delete(sessionId);
-          }
-          messageApi.reset();
-          sendAndRecord(createSessionReset(sessionId, 'claude_restarted'));
+          teardownWatcher('claude_restarted', 'restart-sessioninfo');
           claudeSessionId = null;
         }
 
@@ -1897,14 +1910,14 @@ async function createNewSession(
           // If a fallback watcher claimed the slot with a different (stale) file,
           // replace it with the authoritative hook-provided path.
           const existingWatcher = transcriptWatchers.get(sessionId);
-          if (existingWatcher && existingWatcher.filePath !== transcriptPath) {
+          if (
+            existingWatcher &&
+            path.resolve(existingWatcher.filePath) !== path.resolve(transcriptPath)
+          ) {
             log(
               `[Hooks] Replacing stale watcher (SessionInfo): ${existingWatcher.filePath} -> ${transcriptPath}`,
             );
-            existingWatcher.stop();
-            transcriptWatchers.delete(sessionId);
-            messageApi.reset();
-            sendAndRecord(createSessionReset(sessionId, 'transcript_changed'));
+            teardownWatcher('transcript_changed', 'stale-replace-sessioninfo');
           }
 
           if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1829,6 +1829,19 @@ async function createNewSession(
           transcriptFallbackTimers.delete(sessionId);
         }
 
+        // If a fallback watcher claimed the slot with a different (stale) file,
+        // replace it with the authoritative hook-provided path.
+        const existingWatcher = transcriptWatchers.get(sessionId);
+        if (existingWatcher && existingWatcher.filePath !== input.transcript_path) {
+          log(
+            `[Hooks] Replacing stale watcher: ${existingWatcher.filePath} -> ${input.transcript_path}`,
+          );
+          existingWatcher.stop();
+          transcriptWatchers.delete(sessionId);
+          messageApi.reset();
+          sendAndRecord(createSessionReset(sessionId, 'transcript_changed'));
+        }
+
         if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
           startTranscriptWatcher(sessionId, input.transcript_path, messageApi, sendAndRecord);
         }
@@ -1880,6 +1893,19 @@ async function createNewSession(
           claudeSessionId = hookClaudeSessionId;
           log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
           sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+
+          // If a fallback watcher claimed the slot with a different (stale) file,
+          // replace it with the authoritative hook-provided path.
+          const existingWatcher = transcriptWatchers.get(sessionId);
+          if (existingWatcher && existingWatcher.filePath !== transcriptPath) {
+            log(
+              `[Hooks] Replacing stale watcher (SessionInfo): ${existingWatcher.filePath} -> ${transcriptPath}`,
+            );
+            existingWatcher.stop();
+            transcriptWatchers.delete(sessionId);
+            messageApi.reset();
+            sendAndRecord(createSessionReset(sessionId, 'transcript_changed'));
+          }
 
           if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
             startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
@@ -2128,8 +2154,8 @@ async function createNewSession(
   return ptySession;
 }
 
-/** Extract Claude session ID from transcript filename and persist it. */
-function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): void {
+/** Extract Claude session ID from transcript filename and persist it. Returns the extracted ID or null. */
+function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): string | null {
   // Transcript filenames are plain UUIDs (e.g. "abc123-def456.jsonl").
   // The underscore split is defensive in case a prefixed format is ever introduced.
   const basename = path.basename(transcriptPath, '.jsonl');
@@ -2138,7 +2164,9 @@ function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): void {
   if (candidateId && candidateId.length >= 8) {
     sessionStore.updateClaudeSessionId(sessionId, candidateId);
     log(`Claude session ID: ${candidateId}`);
+    return candidateId;
   }
+  return null;
 }
 
 /** Start watching a transcript file for a session. */


### PR DESCRIPTION
## Summary

Fixes #310. Root cause: race condition between mtime-fallback and hook-based transcript discovery.

**The race:**
1. Remi starts, spawns Claude PTY
2. At ~2s: fallback timer fires, finds OLD JSONL file (modified < 5 min ago), claims the watcher slot with `readExisting: true`, replays old conversation
3. At ~3s: Claude initializes, hooks fire with the NEW session_id and NEW transcript_path
4. `initFromHookEvent` checks `transcriptWatchers.has(sessionId)` -- already true (fallback claimed it). Skips.
5. Old watcher stays forever. New transcript never watched.

**Why PR #311's restart detection didn't help:**
- PR #311 detects when `claudeSessionId` changes from one value to another
- But the fallback path doesn't set the `claudeSessionId` closure variable (it's in the `if (hookServer)` scope)
- So when hooks arrive, `claudeSessionId` is still null; no "restart" detected; no watcher replacement

**The fix:**
In both `initFromHookEvent` and `onSessionInfo`, before creating a new watcher, check if an existing watcher points to a **different file path** than the hook provides. If so:
1. Stop the old watcher
2. Delete it from the map
3. Reset messageApi (clear old messages)
4. Send `session_reset` to clients
5. Let the new watcher be created normally

This is path-agnostic: if the hook says "transcript is at X" and the watcher is watching Y, replace it. Period. No timing, session ID, or ordering assumptions.

## Changes

- `packages/daemon/src/cli.ts`: Add stale watcher replacement in both hook paths
- `extractClaudeSessionId`: Returns extracted ID (signature change only; existing callers unaffected)

## Scenarios covered

| Scenario | Before | After |
|----------|--------|-------|
| Exit remi, restart in same dir | Old conversation shown | session_reset sent, new transcript loaded |
| `/clear` in Claude Code | Worked (PR #311) | Still works (claudeSessionId changes trigger PR #311 logic first) |
| Fallback wins race, hooks arrive later | Old file stuck forever | Hooks replace stale watcher |
| Hooks arrive first (no race) | Worked | Still works (no existing watcher to replace) |

## Test plan

- [x] TypeScript type check passes
- [x] All 1343 tests pass
- [ ] Manual: start remi, have a conversation, exit, restart remi in same dir -- verify new conversation shown
- [ ] Manual: start remi, run /clear in Claude -- verify history clears
- [ ] Manual: verify daemon logs show "Replacing stale watcher" when race occurs