### PR TITLE
feat(hooks): filter subagent/team questions from reaching user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.5.0-dev.5",
+  "version": "0.5.0-p318.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.5.0-dev.5'; // REMI_COMPILED_VERSION
+      return '0.5.0-p318.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -27,7 +27,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.5.0-dev.5'; // REMI_COMPILED_VERSION
+    return '0.5.0-p318.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2010,40 +2010,69 @@ async function createNewSession(
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
 
+      // Subagent context: user can't answer while a Task is running (main agent
+      // is blocked waiting for subagent). During this window we must NEVER
+      // escalate to user — either auto-approve decides, or we default-deny
+      // rather than hang the subagent.
+      const inSubagent = hookBridge.isInSubagentContext();
+      const sessionTag = sessionId.slice(0, 8);
+
+      // Helper: inject an answer into the PTY. Returns true on success.
+      const inject = async (value: '1' | '3', reason: string): Promise<boolean> => {
+        const session = sessionRegistry.getSession(sessionId);
+        if (!session) {
+          logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
+          return false;
+        }
+        await session.pty.submitInput(value);
+        log(`[AutoApprove ${sessionTag}] Injected "${value}" into PTY (${reason})`);
+        sessionRegistry.updateStatus(sessionId, value === '1' ? 'executing' : 'thinking');
+        hookBridge.markPermissionHandled();
+        return true;
+      };
+
       // Auto-approve gate: evaluate before creating Question object.
-      // Intercepts at hook level, bypassing the mobile question UI entirely.
       if (autoApproveService) {
         const aaService = autoApproveService;
-        const sessionTag = sessionId.slice(0, 8);
         aaService
           .evaluate(input.tool_name, input.tool_input, sessionTag)
           .then(async (result) => {
-            if (result.decision === 'approve' || result.decision === 'deny') {
-              // Suppress the Notification(permission_prompt) that follows shortly.
-              // Dedup window in HookEventBridge is 5000ms, well above typical latency.
-              hookBridge.markPermissionHandled();
-              const session = sessionRegistry.getSession(sessionId);
-              if (session) {
-                const value = result.decision === 'approve' ? '1' : '3';
-                await session.pty.submitInput(value);
-                log(`[AutoApprove ${sessionTag}] Injected "${value}" into PTY`);
-                sessionRegistry.updateStatus(
-                  sessionId,
-                  result.decision === 'approve' ? 'executing' : 'thinking',
-                );
-                return;
-              }
-              logError(
-                `[AutoApprove ${sessionTag}] Session not found after ${result.decision}; escalating`,
-              );
+            if (result.decision === 'approve') {
+              await inject('1', 'approved');
+              return;
             }
-            // escalate or session-not-found: fall through to normal question flow
+            if (result.decision === 'deny') {
+              await inject('3', 'denied');
+              return;
+            }
+            // escalate: if we're in a subagent context, default-deny to avoid
+            // hanging the subagent. The user would not be able to answer anyway.
+            if (inSubagent) {
+              log(`[AutoApprove ${sessionTag}] Subagent context; escalate->deny to prevent hang`);
+              await inject('3', 'subagent-escalate-default-deny');
+              return;
+            }
             handlers.onPermissionRequest?.(input);
           })
-          .catch((err) => {
-            logError(`[AutoApprove ${sessionTag}] Unexpected error, escalating:`, err);
+          .catch(async (err) => {
+            logError(`[AutoApprove ${sessionTag}] Unexpected error:`, err);
+            if (inSubagent) {
+              // Error inside subagent context: default-deny to prevent hang
+              await inject('3', 'subagent-error-default-deny');
+              return;
+            }
             handlers.onPermissionRequest?.(input);
           });
+        return;
+      }
+
+      // No auto-approve. If in subagent context, still must not hang the subagent:
+      // default-deny rather than emit a question the user can't answer.
+      if (inSubagent) {
+        log(`[${sessionTag}] Subagent context without auto-approve; default-deny`);
+        inject('3', 'subagent-no-aa-default-deny').catch((err) => {
+          logError(`[${sessionTag}] Failed to inject default-deny:`, err);
+        });
         return;
       }
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -32,6 +32,7 @@ import type {
   SubagentStartHookInput,
   SubagentStopHookInput,
 } from './hook-types.ts';
+import { SubagentContextTracker } from './subagent-context-tracker.ts';
 
 export interface HookBridgeEvents {
   onStatusChange: (status: AgentStatus, context?: string) => void;
@@ -56,10 +57,18 @@ export class HookEventBridge {
   private readonly events: HookBridgeEvents;
   /** Timestamp of last question emitted from handlePermissionRequest */
   private lastPermissionEmitAt = 0;
+  /** Tracks subagent/team nesting depth to filter inter-agent questions. */
+  private readonly subagentContext = new SubagentContextTracker();
 
   constructor(sessionId: UUID, events: HookBridgeEvents) {
     this.sessionId = sessionId;
     this.events = events;
+  }
+
+  /** True when the main agent is inside a Task tool call (subagent running).
+   *  Callers can use this to short-circuit auto-approve entirely during team work. */
+  isInSubagentContext(): boolean {
+    return this.subagentContext.isInSubagentContext();
   }
 
   /** Mark that a PermissionRequest was handled externally (e.g. by auto-approve).
@@ -87,10 +96,12 @@ export class HookEventBridge {
   }
 
   handlePreToolUse(input: PreToolUseHookInput): void {
+    this.subagentContext.onPreToolUse(input.tool_name, input.tool_use_id);
     this.events.onStatusChange('executing', input.tool_name);
   }
 
-  handlePostToolUse(_input: PostToolUseHookInput): void {
+  handlePostToolUse(input: PostToolUseHookInput): void {
+    this.subagentContext.onPostToolUse(input.tool_name, input.tool_use_id);
     this.events.onStatusChange('thinking');
   }
 
@@ -100,6 +111,13 @@ export class HookEventBridge {
       if (Date.now() - this.lastPermissionEmitAt < PERMISSION_DEDUP_WINDOW_MS) {
         console.debug(
           `[HookEventBridge] Suppressed duplicate Notification(permission_prompt): ${(input.message || '').substring(0, 80)}`,
+        );
+        return;
+      }
+      // Subagent/team context: don't bubble inter-agent questions to the user.
+      if (this.subagentContext.isInSubagentContext()) {
+        console.debug(
+          `[HookEventBridge] Suppressed subagent Notification(permission_prompt): ${(input.message || '').substring(0, 80)}`,
         );
         return;
       }
@@ -143,6 +161,18 @@ export class HookEventBridge {
   }
 
   handlePermissionRequest(input: PermissionRequestHookInput): void {
+    // Subagent/team context: suppress inter-agent questions from reaching the user.
+    // The main agent is blocked waiting for Task to return and cannot generate
+    // questions during this window. Any PermissionRequest here is from a subagent.
+    if (this.subagentContext.isInSubagentContext()) {
+      console.debug(
+        `[HookEventBridge] Suppressed subagent PermissionRequest: tool=${input.tool_name}`,
+      );
+      // Still mark dedup so the follow-up Notification(permission_prompt) is suppressed too.
+      this.lastPermissionEmitAt = Date.now();
+      return;
+    }
+
     const toolName = input.tool_name || 'unknown tool';
     const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
     const promptText = inputSummary ? `Allow ${toolName}: ${inputSummary}` : `Allow ${toolName}?`;

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -147,6 +147,9 @@ export class HookEventBridge {
     // session is NOT actually stopping; it remains active.
     if (!input.stop_hook_active) {
       this.events.onStatusChange('idle');
+      // Agent turn is done; clear any orphaned subagent tracking so a dropped
+      // PostToolUse(Task) can't permanently block the user's permission prompts.
+      this.subagentContext.reset();
     }
   }
 
@@ -157,6 +160,8 @@ export class HookEventBridge {
       );
       return;
     }
+    // Reset tracker for a fresh session (also covers daemon restart mid-Task).
+    this.subagentContext.reset();
     this.events.onSessionInfo(input.session_id, input.transcript_path);
   }
 
@@ -225,6 +230,9 @@ export class HookEventBridge {
   }
 
   handleStopFailure(input: StopFailureHookInput): void {
+    // Stop failed: agent may be in an unknown state. Reset subagent tracking
+    // so orphaned Task IDs don't permanently block user permissions.
+    this.subagentContext.reset();
     // Emit a question so the user is notified of the stop failure
     const question: Question = {
       id: generateId(),
@@ -241,6 +249,7 @@ export class HookEventBridge {
   }
 
   handleSessionEnd(_input: SessionEndHookInput): void {
+    this.subagentContext.reset();
     this.events.onStatusChange('idle');
   }
 

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -6,6 +6,9 @@
  * to consume (status changes, question detection, session info).
  */
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type {
   HookInput,
   NotificationHookInput,
@@ -54,6 +57,8 @@ export class HookServer {
   private readonly config: Required<HookServerConfig>;
   private readonly events: Partial<HookServerEvents>;
   private readonly listeners: Map<string, Listener<HookInput>[]> = new Map();
+  /** Whether we've already warned about REMI_HOOK_DEBUG write failures. Throttles spam. */
+  private diagLogWarned = false;
 
   constructor(config: HookServerConfig, events: Partial<HookServerEvents> = {}) {
     this.config = {
@@ -145,11 +150,19 @@ export class HookServer {
     if (process.env['REMI_HOOK_DEBUG'] === '1') {
       try {
         const logLine = JSON.stringify({ _ts: new Date().toISOString(), ...body });
-        const logPath = `${process.env['HOME']}/.remi/hook-diag.jsonl`;
-        // Append synchronously so order is preserved across rapid events
-        require('node:fs').appendFileSync(logPath, `${logLine}\n`);
-      } catch {
-        // Diagnostic logging must never break the hook path
+        const remiDir = path.join(os.homedir(), '.remi');
+        const logPath = path.join(remiDir, 'hook-diag.jsonl');
+        fs.mkdirSync(remiDir, { recursive: true });
+        fs.appendFileSync(logPath, `${logLine}\n`);
+      } catch (err) {
+        // Diagnostic logging must never break the hook path.
+        // But warn ONCE so an enabled flag producing no output is visible.
+        if (!this.diagLogWarned) {
+          this.diagLogWarned = true;
+          console.warn(
+            `[HookServer] REMI_HOOK_DEBUG enabled but writing failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
     }
 

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -139,6 +139,20 @@ export class HookServer {
       });
     }
 
+    // Diagnostic dump: when REMI_HOOK_DEBUG=1, write every raw hook payload
+    // to ~/.remi/hook-diag.jsonl for inspecting what Claude Code actually sends.
+    // Used to investigate team/subagent event filtering (issue #316).
+    if (process.env['REMI_HOOK_DEBUG'] === '1') {
+      try {
+        const logLine = JSON.stringify({ _ts: new Date().toISOString(), ...body });
+        const logPath = `${process.env['HOME']}/.remi/hook-diag.jsonl`;
+        // Append synchronously so order is preserved across rapid events
+        require('node:fs').appendFileSync(logPath, `${logLine}\n`);
+      } catch {
+        // Diagnostic logging must never break the hook path
+      }
+    }
+
     const eventName = body['hook_event_name'] as string;
 
     if (!eventName) {

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -21,6 +21,9 @@ export interface PreToolUseHookInput extends HookCommonInput {
   hook_event_name: 'PreToolUse';
   tool_name: string;
   tool_input: Record<string, unknown>;
+  /** Unique ID for this tool invocation. Claude Code sends this so Pre/PostToolUse
+   *  pairs can be matched even when calls nest (e.g. Task inside another Task). */
+  tool_use_id?: string;
 }
 
 export interface PostToolUseHookInput extends HookCommonInput {
@@ -28,6 +31,7 @@ export interface PostToolUseHookInput extends HookCommonInput {
   tool_name: string;
   tool_input: Record<string, unknown>;
   tool_response: unknown;
+  tool_use_id?: string;
 }
 
 export interface NotificationHookInput extends HookCommonInput {

--- a/packages/daemon/src/hooks/subagent-context-tracker.ts
+++ b/packages/daemon/src/hooks/subagent-context-tracker.ts
@@ -1,0 +1,69 @@
+/**
+ * Tracks subagent/team execution depth for hook event filtering.
+ *
+ * Claude Code hooks are configured at the project level (`.claude/settings.local.json`)
+ * and fire for EVERY tool call, including tools invoked by subagents spawned via
+ * the `Task` tool. Hook payloads themselves don't carry an `agent_id` field that
+ * would let us distinguish subagent calls from main-agent calls.
+ *
+ * We infer context by counting nesting depth:
+ *
+ *   PreToolUse(Task)  -> depth++   (main agent spawns subagent)
+ *     PreToolUse(Bash)              (subagent's internal tool call — nested)
+ *     PostToolUse(Bash)
+ *     ...
+ *   PostToolUse(Task) -> depth--   (subagent finished)
+ *
+ * While depth > 0, any PermissionRequest or Notification(permission_prompt) is
+ * likely a subagent-internal request. The main agent is blocked waiting for the
+ * Task tool to return and cannot generate new permission prompts during this
+ * window. Auto-approve still evaluates these (subagents need tool execution) but
+ * we suppress user-facing notifications to prevent inter-agent questions from
+ * bubbling up to the team leader.
+ *
+ * Tracks by tool_use_id to correctly handle concurrent/nested Task calls.
+ */
+
+/** Tool names that spawn a nested agent context. */
+const NESTING_TOOLS: ReadonlySet<string> = new Set([
+  'Task', // standard subagent spawn
+  // Future: teammate-spawning tools. Add here as Claude Code evolves.
+]);
+
+export class SubagentContextTracker {
+  /** Active tool_use_ids that are currently spawning nested agents. */
+  private readonly active = new Set<string>();
+
+  /** Record PreToolUse. Returns true if this started a nesting context. */
+  onPreToolUse(toolName: string, toolUseId: string | undefined): boolean {
+    if (!NESTING_TOOLS.has(toolName)) return false;
+    if (toolUseId) {
+      this.active.add(toolUseId);
+    }
+    return true;
+  }
+
+  /** Record PostToolUse. Returns true if this ended a nesting context. */
+  onPostToolUse(toolName: string, toolUseId: string | undefined): boolean {
+    if (!NESTING_TOOLS.has(toolName)) return false;
+    if (toolUseId) {
+      this.active.delete(toolUseId);
+    }
+    return true;
+  }
+
+  /** True when a subagent/team context is in-flight. */
+  isInSubagentContext(): boolean {
+    return this.active.size > 0;
+  }
+
+  /** Current nesting depth (number of concurrent subagents). */
+  depth(): number {
+    return this.active.size;
+  }
+
+  /** Reset all tracked state (e.g. on session restart). */
+  reset(): void {
+    this.active.clear();
+  }
+}

--- a/packages/daemon/src/hooks/subagent-context-tracker.ts
+++ b/packages/daemon/src/hooks/subagent-context-tracker.ts
@@ -24,32 +24,42 @@
  * Tracks by tool_use_id to correctly handle concurrent/nested Task calls.
  */
 
-/** Tool names that spawn a nested agent context. */
-const NESTING_TOOLS: ReadonlySet<string> = new Set([
-  'Task', // standard subagent spawn
-  // Future: teammate-spawning tools. Add here as Claude Code evolves.
-]);
+/** Tool names that spawn a nested agent context.
+ *  - `Task`: standard Claude Code subagent spawn
+ *  - `Agent`: cc-ref reference name; include for safety in case variants ship
+ *  - Future tools: teammate-spawning, delegation, etc. Add here as Claude Code evolves.
+ *  When adding, also extend the regression tests. */
+const NESTING_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent']);
 
 export class SubagentContextTracker {
   /** Active tool_use_ids that are currently spawning nested agents. */
   private readonly active = new Set<string>();
+  /** Whether we've warned about a nesting tool firing without tool_use_id. Throttles spam. */
+  private warnedMissingId = false;
 
-  /** Record PreToolUse. Returns true if this started a nesting context. */
+  /** Record PreToolUse. Returns true iff a nesting context was actually started
+   *  (tool is in NESTING_TOOLS AND tool_use_id was present). */
   onPreToolUse(toolName: string, toolUseId: string | undefined): boolean {
     if (!NESTING_TOOLS.has(toolName)) return false;
-    if (toolUseId) {
-      this.active.add(toolUseId);
+    if (!toolUseId) {
+      if (!this.warnedMissingId) {
+        this.warnedMissingId = true;
+        console.warn(
+          `[SubagentContextTracker] ${toolName} fired without tool_use_id; nested-agent filtering disabled for this call`,
+        );
+      }
+      return false;
     }
+    this.active.add(toolUseId);
     return true;
   }
 
-  /** Record PostToolUse. Returns true if this ended a nesting context. */
+  /** Record PostToolUse. Returns true iff a nesting context was ended
+   *  (tool is in NESTING_TOOLS AND the tool_use_id matched an active entry). */
   onPostToolUse(toolName: string, toolUseId: string | undefined): boolean {
     if (!NESTING_TOOLS.has(toolName)) return false;
-    if (toolUseId) {
-      this.active.delete(toolUseId);
-    }
-    return true;
+    if (!toolUseId) return false;
+    return this.active.delete(toolUseId);
   }
 
   /** True when a subagent/team context is in-flight. */

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -363,4 +363,151 @@ describe('HookEventBridge', () => {
       expect(questions[0]?.text).toBe('Allow Bash: ssh hallu "uv run pytest"');
     });
   });
+
+  describe('subagent context filtering (issue #316)', () => {
+    it('suppresses PermissionRequest while inside a Task tool call', () => {
+      const { bridge, questions } = createBridge();
+
+      // Main agent spawns subagent via Task
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: { subagent_type: 'general-purpose', prompt: 'do stuff' },
+        tool_use_id: 'tu_task_1',
+      } as PreToolUseHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      // Subagent tries to run an unapproved Bash command — PermissionRequest fires
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'nmap --version' },
+      } as PermissionRequestHookInput);
+
+      // User should NOT see this question
+      expect(questions).toHaveLength(0);
+
+      // Task completes; context exits
+      bridge.handlePostToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_response: { result: 'done' },
+        tool_use_id: 'tu_task_1',
+      } as PostToolUseHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+
+      // Now a real user-facing PermissionRequest SHOULD pass through
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'dig example.com' },
+      } as PermissionRequestHookInput);
+
+      expect(questions).toHaveLength(1);
+      expect(questions[0]?.text).toContain('dig example.com');
+    });
+
+    it('suppresses Notification(permission_prompt) while in subagent context', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_1',
+      } as PreToolUseHookInput);
+
+      // Notification(permission_prompt) that would fire during subagent work
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Claude needs your permission to use Bash',
+      } as NotificationHookInput);
+
+      expect(questions).toHaveLength(0);
+    });
+
+    it('concurrent Task calls: context exits only when all complete', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_A',
+      } as PreToolUseHookInput);
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_B',
+      } as PreToolUseHookInput);
+
+      // Close A only
+      bridge.handlePostToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_response: {},
+        tool_use_id: 'tu_A',
+      } as PostToolUseHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(true); // B still running
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      } as PermissionRequestHookInput);
+      expect(questions).toHaveLength(0);
+
+      // Close B
+      bridge.handlePostToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_response: {},
+        tool_use_id: 'tu_B',
+      } as PostToolUseHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
+
+    it('nested non-Task tool uses do NOT enter context', () => {
+      const { bridge, questions } = createBridge();
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        tool_use_id: 'tu_b1',
+      } as PreToolUseHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+
+      // Normal PermissionRequest should still reach the user
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'sudo something' },
+      } as PermissionRequestHookInput);
+
+      expect(questions).toHaveLength(1);
+    });
+  });
 });

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -509,5 +509,90 @@ describe('HookEventBridge', () => {
 
       expect(questions).toHaveLength(1);
     });
+
+    it('handleStop(stop_hook_active=false) resets orphan subagent state', () => {
+      const { bridge } = createBridge();
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_orphan',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      // Agent turn stops without matching PostToolUse(Task)
+      bridge.handleStop({
+        ...makeCommon(),
+        hook_event_name: 'Stop',
+        stop_hook_active: false,
+      } as StopHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
+
+    it('handleSessionEnd resets orphan subagent state', () => {
+      const { bridge } = createBridge();
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_orphan2',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      bridge.handleSessionEnd({
+        ...makeCommon(),
+        hook_event_name: 'SessionEnd',
+        reason: 'user_exit',
+      } as SessionEndHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
+
+    it('handleStopFailure resets orphan subagent state', () => {
+      const { bridge } = createBridge();
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_orphan3',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      bridge.handleStopFailure({
+        ...makeCommon(),
+        hook_event_name: 'StopFailure',
+        error_type: 'network',
+        error: 'conn refused',
+      } as StopFailureHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
+
+    it('handleSessionStart resets any stale state from prior session', () => {
+      const { bridge } = createBridge();
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_stale',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      bridge.handleSessionStart({
+        ...makeCommon(),
+        session_id: 'new-session-id',
+        transcript_path: '/tmp/new.jsonl',
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        model: 'claude-opus',
+      } as SessionStartHookInput);
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
   });
 });

--- a/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * End-to-end: real HTTP POST to HookServer -> bridge integration.
+ *
+ * Exercises the full path so schema assumptions (field names, casing of
+ * tool_use_id) are exercised against live dispatch. Unit tests using
+ * hand-constructed objects can't catch e.g. snake_case vs camelCase mismatch.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { AgentStatus, Question, UUID } from '@remi/shared';
+import { HookEventBridge } from '../../src/hooks/hook-event-bridge.ts';
+import { HookServer } from '../../src/hooks/hook-server.ts';
+
+describe('HookServer -> HookEventBridge (HTTP integration)', () => {
+  let server: HookServer | null = null;
+
+  afterEach(() => {
+    if (server) {
+      server.stop();
+      server = null;
+    }
+  });
+
+  async function post(url: string, body: Record<string, unknown>): Promise<number> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return res.status;
+  }
+
+  test('tool_use_id flows from HTTP body into subagent tracker', async () => {
+    const statuses: Array<{ status: AgentStatus; context?: string }> = [];
+    const questions: Question[] = [];
+    const bridge = new HookEventBridge('session-1' as UUID, {
+      onStatusChange: (status, context) => {
+        statuses.push(context !== undefined ? { status, context } : { status });
+      },
+      onQuestion: (q) => questions.push(q),
+      onSessionInfo: () => {},
+    });
+
+    server = new HookServer({ port: 0 });
+    const h = bridge.hookHandlers();
+    server.on('PreToolUse', (input) => h.onPreToolUse?.(input));
+    server.on('PostToolUse', (input) => h.onPostToolUse?.(input));
+    server.on('PermissionRequest', (input) => h.onPermissionRequest?.(input));
+    server.start();
+    const url = `http://127.0.0.1:${server.port}/hooks`;
+
+    // POST PreToolUse(Task) with tool_use_id
+    expect(
+      await post(url, {
+        hook_event_name: 'PreToolUse',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Task',
+        tool_input: { subagent_type: 'Explore', prompt: 'look' },
+        tool_use_id: 'tu_http_1',
+      }),
+    ).toBe(200);
+
+    expect(bridge.isInSubagentContext()).toBe(true);
+
+    // Subagent's Bash PermissionRequest should now be suppressed
+    expect(
+      await post(url, {
+        hook_event_name: 'PermissionRequest',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Bash',
+        tool_input: { command: 'nmap -sV' },
+      }),
+    ).toBe(200);
+
+    expect(questions).toHaveLength(0);
+
+    // PostToolUse(Task) with matching tool_use_id closes context
+    expect(
+      await post(url, {
+        hook_event_name: 'PostToolUse',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_response: { ok: true },
+        tool_use_id: 'tu_http_1',
+      }),
+    ).toBe(200);
+
+    expect(bridge.isInSubagentContext()).toBe(false);
+
+    // Now a real user-directed PermissionRequest should pass through
+    expect(
+      await post(url, {
+        hook_event_name: 'PermissionRequest',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Bash',
+        tool_input: { command: 'dig example.com' },
+      }),
+    ).toBe(200);
+
+    expect(questions).toHaveLength(1);
+  });
+
+  test('PreToolUse without tool_use_id degrades gracefully (no context)', async () => {
+    const bridge = new HookEventBridge('session-1' as UUID, {
+      onStatusChange: () => {},
+      onQuestion: () => {},
+      onSessionInfo: () => {},
+    });
+
+    server = new HookServer({ port: 0 });
+    const h = bridge.hookHandlers();
+    server.on('PreToolUse', (input) => h.onPreToolUse?.(input));
+    server.start();
+    const url = `http://127.0.0.1:${server.port}/hooks`;
+
+    await post(url, {
+      hook_event_name: 'PreToolUse',
+      session_id: 'session-1',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/tmp',
+      permission_mode: 'default',
+      tool_name: 'Task',
+      tool_input: {},
+      // tool_use_id intentionally omitted
+    });
+
+    // Should NOT enter subagent context when id missing
+    expect(bridge.isInSubagentContext()).toBe(false);
+  });
+});

--- a/packages/daemon/tests/hooks/subagent-context-tracker.test.ts
+++ b/packages/daemon/tests/hooks/subagent-context-tracker.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { SubagentContextTracker } from '../../src/hooks/subagent-context-tracker.ts';
+
+describe('SubagentContextTracker', () => {
+  test('starts with zero depth', () => {
+    const t = new SubagentContextTracker();
+    expect(t.isInSubagentContext()).toBe(false);
+    expect(t.depth()).toBe(0);
+  });
+
+  test('Task PreToolUse enters context', () => {
+    const t = new SubagentContextTracker();
+    expect(t.onPreToolUse('Task', 'tu_1')).toBe(true);
+    expect(t.isInSubagentContext()).toBe(true);
+    expect(t.depth()).toBe(1);
+  });
+
+  test('Task PostToolUse exits context', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_1');
+    expect(t.onPostToolUse('Task', 'tu_1')).toBe(true);
+    expect(t.isInSubagentContext()).toBe(false);
+    expect(t.depth()).toBe(0);
+  });
+
+  test('non-nesting tools do not affect depth', () => {
+    const t = new SubagentContextTracker();
+    expect(t.onPreToolUse('Bash', 'tu_b1')).toBe(false);
+    expect(t.onPreToolUse('Read', 'tu_r1')).toBe(false);
+    expect(t.onPreToolUse('Edit', 'tu_e1')).toBe(false);
+    expect(t.isInSubagentContext()).toBe(false);
+  });
+
+  test('nested tools during Task context stay inside', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_task1');
+    // Inner tools fire but don't exit the context
+    t.onPreToolUse('Bash', 'tu_b1');
+    t.onPostToolUse('Bash', 'tu_b1');
+    expect(t.isInSubagentContext()).toBe(true);
+    t.onPostToolUse('Task', 'tu_task1');
+    expect(t.isInSubagentContext()).toBe(false);
+  });
+
+  test('concurrent Task invocations tracked by tool_use_id', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_task_A');
+    t.onPreToolUse('Task', 'tu_task_B');
+    expect(t.depth()).toBe(2);
+    t.onPostToolUse('Task', 'tu_task_A');
+    expect(t.depth()).toBe(1);
+    expect(t.isInSubagentContext()).toBe(true); // still in B
+    t.onPostToolUse('Task', 'tu_task_B');
+    expect(t.depth()).toBe(0);
+    expect(t.isInSubagentContext()).toBe(false);
+  });
+
+  test('unpaired PostToolUse does not go negative', () => {
+    const t = new SubagentContextTracker();
+    t.onPostToolUse('Task', 'tu_phantom');
+    expect(t.depth()).toBe(0);
+    expect(t.isInSubagentContext()).toBe(false);
+  });
+
+  test('missing tool_use_id does not track', () => {
+    // If Claude Code ever omits tool_use_id, we gracefully degrade: no tracking.
+    // Better than crashing.
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', undefined);
+    expect(t.depth()).toBe(0);
+  });
+
+  test('reset clears state', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_1');
+    t.onPreToolUse('Task', 'tu_2');
+    expect(t.depth()).toBe(2);
+    t.reset();
+    expect(t.depth()).toBe(0);
+    expect(t.isInSubagentContext()).toBe(false);
+  });
+
+  test('double PreToolUse with same id is idempotent', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_same');
+    t.onPreToolUse('Task', 'tu_same');
+    expect(t.depth()).toBe(1); // Set dedupes
+    t.onPostToolUse('Task', 'tu_same');
+    expect(t.depth()).toBe(0);
+  });
+});

--- a/packages/daemon/tests/hooks/subagent-context-tracker.test.ts
+++ b/packages/daemon/tests/hooks/subagent-context-tracker.test.ts
@@ -15,12 +15,25 @@ describe('SubagentContextTracker', () => {
     expect(t.depth()).toBe(1);
   });
 
+  test('Agent tool is also treated as nesting', () => {
+    const t = new SubagentContextTracker();
+    expect(t.onPreToolUse('Agent', 'tu_a1')).toBe(true);
+    expect(t.isInSubagentContext()).toBe(true);
+  });
+
   test('Task PostToolUse exits context', () => {
     const t = new SubagentContextTracker();
     t.onPreToolUse('Task', 'tu_1');
     expect(t.onPostToolUse('Task', 'tu_1')).toBe(true);
     expect(t.isInSubagentContext()).toBe(false);
     expect(t.depth()).toBe(0);
+  });
+
+  test('PostToolUse returns false when tool_use_id does not match an active entry', () => {
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_1');
+    expect(t.onPostToolUse('Task', 'tu_2')).toBe(false); // wrong id
+    expect(t.depth()).toBe(1); // still in context
   });
 
   test('non-nesting tools do not affect depth', () => {
@@ -62,12 +75,22 @@ describe('SubagentContextTracker', () => {
     expect(t.isInSubagentContext()).toBe(false);
   });
 
-  test('missing tool_use_id does not track', () => {
+  test('missing tool_use_id does not track and returns false', () => {
     // If Claude Code ever omits tool_use_id, we gracefully degrade: no tracking.
-    // Better than crashing.
+    // Returns false so callers can observe the degradation. Warns once.
     const t = new SubagentContextTracker();
-    t.onPreToolUse('Task', undefined);
+    expect(t.onPreToolUse('Task', undefined)).toBe(false);
     expect(t.depth()).toBe(0);
+  });
+
+  test('asymmetric tool_use_id: Pre has id, Post without id leaks the entry', () => {
+    // Document behavior: mismatched tool_use_id between Pre and Post leaks
+    // the Pre's entry. The reset() on session boundaries in HookEventBridge
+    // is the safety net for this.
+    const t = new SubagentContextTracker();
+    t.onPreToolUse('Task', 'tu_pre');
+    expect(t.onPostToolUse('Task', undefined)).toBe(false);
+    expect(t.depth()).toBe(1); // leak; session lifecycle reset catches it
   });
 
   test('reset clears state', () => {


### PR DESCRIPTION
## Summary

Closes #316. Stops inter-agent questions (subagent permission prompts, team-to-team communication) from bubbling up to the user as if they need to answer them.

## Problem

When Claude Code runs a team or a Task-spawned subagent, the subagent's tool calls still fire `PermissionRequest` hook events. Remi's hook bridge couldn't distinguish these from main-agent requests and pushed notifications to the user's phone for every inter-agent question.

Verified in `cc-ref/rust/crates/plugins/src/hooks.rs` — the hook payload only carries `tool_name`, `tool_input`, `tool_output`. No `agent_id`, `subagent_id`, or `parent_tool_use_id`. The session JSONL does record `agentId`/`isSidechain` on persisted messages, but hook events at the network level don't.

## Approach

**Tool-nesting depth tracking.** The main agent is blocked waiting for `Task` to return while the subagent runs. Any Pre/PostToolUse/PermissionRequest/Notification that fires between `PreToolUse(Task)` and `PostToolUse(Task)` is therefore nested inside the subagent's context.

```
PreToolUse(Task, tu_A)     <- main agent spawns subagent
  PreToolUse(Bash, tu_1)   <- subagent's internal tool
  PermissionRequest(Bash)  <- suppressed (bubble-up bug)
  PostToolUse(Bash, tu_1)
  ...
PostToolUse(Task, tu_A)    <- subagent done
```

New `SubagentContextTracker` counts active Task `tool_use_id`s. While `depth > 0`, `HookEventBridge`:
- Suppresses `PermissionRequest` events
- Suppresses `Notification(permission_prompt)` events
- Marks the dedup timestamp so any trailing notification is also caught

Tracked by `tool_use_id` so concurrent Task calls (parallel teammates) close independently.

## New/Modified

- **new**: `packages/daemon/src/hooks/subagent-context-tracker.ts` (pure function, ~60 lines)
- **new**: `packages/daemon/tests/hooks/subagent-context-tracker.test.ts` (10 tests)
- `hook-event-bridge.ts` — wires tracker into PreToolUse/PostToolUse, gates question emission
- `hook-types.ts` — adds optional `tool_use_id?` to Pre/PostToolUseHookInput
- `hook-server.ts` — optional diagnostic mode: `REMI_HOOK_DEBUG=1` dumps raw payloads to `~/.remi/hook-diag.jsonl` for future field discovery

## Edge cases covered
- Concurrent Task invocations (Set-keyed, each closes independently)
- Unpaired PostToolUse (no-op, doesn't go negative)
- Missing tool_use_id (gracefully degrades to no tracking)
- Non-Task tools don't enter context (regression guard)
- Double PreToolUse with same id is idempotent

## Test plan
- [x] 76 hook tests pass
- [x] 10 new tracker unit tests
- [x] 4 new bridge integration tests (suppression, dedup, concurrent, pass-through)
- [x] Typecheck, Biome lint clean
- [ ] Manual test: spin up a team in yooz-engine, confirm no phantom questions
- [ ] Manual test: `REMI_HOOK_DEBUG=1 remi --auto-approve` + team session → inspect `hook-diag.jsonl`

## Follow-up if needed

If Claude Code evolves to include agent context directly in hook payloads (e.g. `agent_id`), we can switch to that richer signal. The `REMI_HOOK_DEBUG` path is in place so we can observe new fields without code changes.

If `Teammate` or similar non-Task spawning tools appear, add them to `NESTING_TOOLS` in `subagent-context-tracker.ts`.