### PR TITLE
fix(hooks): stop subagent events from hijacking main session lock

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -287,6 +287,7 @@ import {
 } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
+import { classifySessionEvent } from './hooks/session-lock-classifier.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
@@ -1811,6 +1812,17 @@ async function createNewSession(
     // Before SessionStart fires, we let events through (claudeSessionId is null).
     let claudeSessionId: string | null = null;
 
+    // Our PTY is the ground truth for "main interactive session". A hook event
+    // with a different session_id is NEVER our main:
+    //  - Subagent spawn (TaskCreate/TeamCreate) — different session_id, no own PTY
+    //  - Sibling daemon's Claude — different session_id, different PTY elsewhere
+    //  - Actual Claude restart in our PTY — only possible after our PTY exited
+    // So: while our PTY is running, treat any different session_id as foreign.
+    // Once our PTY exits, a new session_id represents a genuine new Claude.
+    // Flag set on explicit SessionEnd so we don't wait for PTY exit if Claude
+    // shut down cleanly.
+    let mainSessionEnded = false;
+
     // Extract transcript info from hook events. Most Claude Code hook events include
     // session_id and transcript_path. When present, the first event gives us the
     // transcript path, bypassing the slower mtime fallback.
@@ -1853,15 +1865,27 @@ async function createNewSession(
     }): void {
       if (!input.session_id) return;
 
-      // Detect Claude restart: a different Claude session ID means Claude exited
-      // and restarted in the same directory. Tear down old watcher and notify clients.
-      if (claudeSessionId && claudeSessionId !== input.session_id) {
-        log(`[Hooks] Claude restarted: ${claudeSessionId} -> ${input.session_id}`);
+      const classification = classifySessionEvent({
+        currentLock: claudeSessionId,
+        incomingSessionId: input.session_id,
+        mainPtyRunning: sessionRegistry.getSession(sessionId)?.pty.isRunning ?? false,
+        mainSessionEnded,
+      });
+
+      if (classification === 'foreign') {
+        // Subagent or sibling daemon event. Drop to avoid hijacking our lock.
+        return;
+      }
+      if (classification === 'restart') {
+        log(
+          `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
+        );
         teardownWatcher('claude_restarted', 'restart');
         claudeSessionId = null;
+        mainSessionEnded = false;
       }
-
-      if (claudeSessionId) return; // already initialized for this Claude session
+      // classification === 'match': either our tracked session or first-time lock.
+      if (claudeSessionId) return; // already initialized
       if (!input.transcript_path) return;
 
       if (hasSiblingInDir === null) {
@@ -2082,6 +2106,15 @@ async function createNewSession(
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
       handlers.onStop?.(input);
+    });
+    hookServer.on('SessionEnd', (input) => {
+      // Only mark our main as ended when the session_id matches what we locked.
+      // Foreign SessionEnds (subagents, siblings) must not unlock our tracking.
+      if (input.session_id && claudeSessionId && input.session_id === claudeSessionId) {
+        mainSessionEnded = true;
+      }
+      if (!filterBySession(input)) return;
+      handlers.onSessionEnd?.(input);
     });
 
     log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1874,6 +1874,10 @@ async function createNewSession(
 
       if (classification === 'foreign') {
         // Subagent or sibling daemon event. Drop to avoid hijacking our lock.
+        // Log for observability: if classifier misbehaves, we still see activity.
+        log(
+          `[Hooks] Dropped foreign ${input.hook_event_name ?? 'event'}: lock=${claudeSessionId?.slice(0, 8)} incoming=${input.session_id.slice(0, 8)}`,
+        );
         return;
       }
       if (classification === 'restart') {
@@ -1961,13 +1965,27 @@ async function createNewSession(
         }
         if (hasSiblingInDir) return;
 
-        // Detect Claude restart via onSessionInfo path
-        if (claudeSessionId && claudeSessionId !== hookClaudeSessionId) {
+        // Use the same classifier as initFromHookEvent so both paths share
+        // one rule for distinguishing foreign (subagent/sibling) from restart.
+        const classification = classifySessionEvent({
+          currentLock: claudeSessionId,
+          incomingSessionId: hookClaudeSessionId,
+          mainPtyRunning: sessionRegistry.getSession(sessionId)?.pty.isRunning ?? false,
+          mainSessionEnded,
+        });
+        if (classification === 'foreign') {
           log(
-            `[Hooks] Claude restarted (SessionInfo): ${claudeSessionId} -> ${hookClaudeSessionId}`,
+            `[Hooks] Dropped foreign SessionInfo: lock=${claudeSessionId?.slice(0, 8)} incoming=${hookClaudeSessionId.slice(0, 8)}`,
+          );
+          return;
+        }
+        if (classification === 'restart') {
+          log(
+            `[Hooks] Claude restart (SessionInfo, ended=${mainSessionEnded}): ${claudeSessionId} -> ${hookClaudeSessionId}`,
           );
           teardownWatcher('claude_restarted', 'restart-sessioninfo');
           claudeSessionId = null;
+          mainSessionEnded = false;
         }
 
         try {
@@ -2005,6 +2023,19 @@ async function createNewSession(
     // onSessionInfo doesn't fire (PreToolUse, etc.). For SessionStart, both paths
     // converge; guards prevent double-processing.
     hookServer.on('SessionStart', (input) => {
+      // SessionStart with an explicit main-transition source (/clear /compact
+      // /resume) is the authoritative signal that our main Claude took a new
+      // session_id while our PTY kept running. Pre-empt the classifier by
+      // treating the old session as ended, so the classifier sees a 'restart'
+      // and cleanly switches the lock.
+      if (input.source === 'clear' || input.source === 'compact' || input.source === 'resume') {
+        if (claudeSessionId && input.session_id && input.session_id !== claudeSessionId) {
+          log(
+            `[Hooks] Main lifecycle transition (${input.source}): ${claudeSessionId} -> ${input.session_id}`,
+          );
+          mainSessionEnded = true; // classifier will pick this up as 'restart'
+        }
+      }
       initFromHookEvent(input);
       handlers.onSessionStart?.(input);
     });

--- a/packages/daemon/src/hooks/session-lock-classifier.ts
+++ b/packages/daemon/src/hooks/session-lock-classifier.ts
@@ -1,0 +1,55 @@
+/**
+ * Classifies hook events by session_id relative to our tracked main session.
+ *
+ * Background: Claude Code subagents (spawned via TaskCreate/TeamCreate/Task)
+ * have DIFFERENT session_ids than their parent main session, but fire hooks to
+ * the SAME hook server (shared .claude/settings.local.json). A naive "different
+ * session_id == restart" rule hijacks our lock onto a subagent, breaking both
+ * filter and routing:
+ *   - Main's events get filtered out (session_id no longer matches)
+ *   - Subagent's events pass the filter → auto-approve may inject into main's PTY
+ *
+ * Ground truth: our PTY process IS the interactive main session. While our PTY
+ * is running and main has not explicitly ended, any different session_id must
+ * be a subagent or sibling-daemon event — foreign, drop it. If our PTY has
+ * exited or main emitted SessionEnd, a new session_id represents a genuine
+ * Claude restart.
+ */
+
+export type SessionEventClass = 'match' | 'foreign' | 'restart';
+
+export interface SessionClassificationInput {
+  /** Our currently-tracked main session_id, or null if unlocked. */
+  readonly currentLock: string | null;
+  /** The session_id from the incoming hook event. */
+  readonly incomingSessionId: string;
+  /** Whether our own PTY is still running (the main interactive session). */
+  readonly mainPtyRunning: boolean;
+  /** Whether main explicitly emitted SessionEnd for our lock. */
+  readonly mainSessionEnded: boolean;
+}
+
+/**
+ * Classify an incoming hook event relative to our tracked main session.
+ *
+ *   - match:   event is from our tracked main (normal processing)
+ *   - foreign: event is from a subagent or sibling daemon — drop it to
+ *              prevent hijacking our lock
+ *   - restart: our main is gone; treat the new session_id as a new main
+ */
+export function classifySessionEvent(input: SessionClassificationInput): SessionEventClass {
+  const { currentLock, incomingSessionId, mainPtyRunning, mainSessionEnded } = input;
+
+  // Unlocked: any event is a candidate for initialization. Caller handles the
+  // sibling-in-dir guard separately before locking.
+  if (currentLock === null) return 'match';
+
+  if (currentLock === incomingSessionId) return 'match';
+
+  // Different session_id. Our PTY is the ground truth for "main alive":
+  // while it's running and main hasn't explicitly ended, this is foreign.
+  if (mainPtyRunning && !mainSessionEnded) return 'foreign';
+
+  // PTY exited or SessionEnd fired → our main is gone → treat as restart.
+  return 'restart';
+}

--- a/packages/daemon/tests/hooks/session-lock-classifier.test.ts
+++ b/packages/daemon/tests/hooks/session-lock-classifier.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { classifySessionEvent } from '../../src/hooks/session-lock-classifier.ts';
+
+describe('classifySessionEvent', () => {
+  test('unlocked: any event is match (caller handles locking)', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: null,
+        incomingSessionId: 'any-id',
+        mainPtyRunning: true,
+        mainSessionEnded: false,
+      }),
+    ).toBe('match');
+  });
+
+  test('same session_id as lock: match', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: 'main-abc',
+        incomingSessionId: 'main-abc',
+        mainPtyRunning: true,
+        mainSessionEnded: false,
+      }),
+    ).toBe('match');
+  });
+
+  test('different session_id + PTY running + not ended: foreign (subagent/sibling)', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: 'main-abc',
+        incomingSessionId: 'subagent-xyz',
+        mainPtyRunning: true,
+        mainSessionEnded: false,
+      }),
+    ).toBe('foreign');
+  });
+
+  test('different session_id + PTY exited: restart', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: 'main-abc',
+        incomingSessionId: 'new-main-def',
+        mainPtyRunning: false,
+        mainSessionEnded: false,
+      }),
+    ).toBe('restart');
+  });
+
+  test('different session_id + main ended (PTY may still be alive): restart', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: 'main-abc',
+        incomingSessionId: 'new-main-def',
+        mainPtyRunning: true,
+        mainSessionEnded: true,
+      }),
+    ).toBe('restart');
+  });
+
+  test('different session_id + PTY exited + ended: restart', () => {
+    expect(
+      classifySessionEvent({
+        currentLock: 'main-abc',
+        incomingSessionId: 'new-main-def',
+        mainPtyRunning: false,
+        mainSessionEnded: true,
+      }),
+    ).toBe('restart');
+  });
+
+  test('realistic background team spawn: foreign', () => {
+    // User runs `remi --auto-approve` and the agent spawns background teams.
+    // Teams have different session_ids but fire hooks to the same server.
+    // Must NOT hijack our lock.
+    expect(
+      classifySessionEvent({
+        currentLock: 'user-main-1234',
+        incomingSessionId: 'team-agent-5678',
+        mainPtyRunning: true,
+        mainSessionEnded: false,
+      }),
+    ).toBe('foreign');
+  });
+
+  test('realistic Claude crash + user restarts: restart', () => {
+    // Claude in our PTY crashed without emitting SessionEnd. User kills remi
+    // and restarts. Our PTY is no longer running.
+    expect(
+      classifySessionEvent({
+        currentLock: 'dead-main-1111',
+        incomingSessionId: 'fresh-main-2222',
+        mainPtyRunning: false,
+        mainSessionEnded: false,
+      }),
+    ).toBe('restart');
+  });
+
+  test('realistic clean Claude exit then reopen: restart', () => {
+    // Clean exit → SessionEnd → user /resume → new session_id.
+    expect(
+      classifySessionEvent({
+        currentLock: 'old-main-1111',
+        incomingSessionId: 'resumed-main-2222',
+        mainPtyRunning: true,
+        mainSessionEnded: true,
+      }),
+    ).toBe('restart');
+  });
+});


### PR DESCRIPTION
Closes #319.

## Problem

In `cli.ts` \`initFromHookEvent()\`, any hook event with a different \`session_id\` than our tracked \`claudeSessionId\` was treated as a "Claude restart". Background subagents spawned via \`TaskCreate\`/\`TeamCreate\` have DIFFERENT session_ids but share \`.claude/settings.local.json\` with our hook server. Main's lock was getting hijacked to the subagent's id, which:

1. Made main's events fail \`filterBySession\` → dropped permission questions, no GPU spike
2. Made subagent's events pass the filter → auto-approve injected "1" into main's PTY (which was at its \`❯\` chat prompt, so the "1" became chat input)

## Root cause

\`\`\`ts
// OLD (broken):
if (claudeSessionId && claudeSessionId !== input.session_id) {
  log('Claude restarted'); // WRONG: could be subagent
  teardownWatcher();
  claudeSessionId = null;
}
\`\`\`

## Fix

Extracted into pure \`classifySessionEvent()\` function. Uses our PTY as ground truth for "main interactive session":

| Scenario | Classification | Action |
|----------|---------------|--------|
| Same session_id as lock | match | process |
| Different + PTY running + not ended | **foreign** | drop |
| Different + PTY exited OR SessionEnd | restart | accept |

Also wires a \`SessionEnd\` handler that sets \`mainSessionEnded\` flag only when event's session_id matches our lock (foreign SessionEnds don't unlock us).

## Tests

- 9 unit tests for \`classifySessionEvent\` covering all branches + realistic scenarios (background team spawn, Claude crash without SessionEnd, clean reopen with SessionEnd)
- 94 hook tests pass, 1569 overall

## Manual verification

Building locally and spinning up a session with \`TaskCreate\` subagents. Expected logs:

\`\`\`
[Hooks] Transcript from SessionStart: claude=<main-id> ...
# later subagent events arrive:
# no log (dropped as foreign) - good
\`\`\`

No \`❯ 1\` in chat anymore.

## Follow-up

If user wants a UI signal when a subagent asks something (so they know work is happening), that's a separate enhancement. Current fix is "stop the bug"; "add subagent visibility" is future work.