### PR TITLE
fix(hooks): filter subagent/team events by agent_id

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2046,29 +2046,52 @@ async function createNewSession(
       return !hasSiblingInDir; // No sibling → events can only be ours
     };
 
+    // Subagent/team-member events carry `agent_id` (confirmed via
+    // REMI_HOOK_DEBUG capture 2026-04-16). They share main's session_id and
+    // transcript, so session-id filtering cannot distinguish them. Drop these
+    // at the hook layer so status updates, auto-approve, question emission,
+    // and PTY injection all stay scoped to the main interactive session.
+    const isSubagentEvent = (input: { agent_id?: string }): boolean =>
+      typeof input.agent_id === 'string' && input.agent_id.length > 0;
+
     hookServer.on('PreToolUse', (input) => {
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
+      if (isSubagentEvent(input)) return;
       handlers.onPreToolUse?.(input);
     });
     hookServer.on('PostToolUse', (input) => {
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
+      if (isSubagentEvent(input)) return;
       handlers.onPostToolUse?.(input);
     });
     hookServer.on('Notification', (input) => {
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
+      // Subagent notifications must not bubble up to the user (phantom prompts).
+      if (isSubagentEvent(input)) {
+        log(`[Hooks] Dropped subagent Notification: agent=${input.agent_id?.slice(0, 8)}`);
+        return;
+      }
       handlers.onNotification?.(input);
     });
     hookServer.on('PermissionRequest', (input) => {
       initFromHookEvent(input);
       if (!filterBySession(input)) return;
 
-      // Subagent context: user can't answer while a Task is running (main agent
-      // is blocked waiting for subagent). During this window we must NEVER
-      // escalate to user — either auto-approve decides, or we default-deny
-      // rather than hang the subagent.
+      // Subagent PermissionRequest: Claude Code sets `agent_id` on events
+      // originating from Task/Agent-spawned subagents or team members. Those
+      // events share the main session_id and transcript but are handled
+      // internally by Claude Code — they MUST NOT be injected into our main PTY.
+      if (isSubagentEvent(input)) {
+        log(
+          `[Hooks] Dropped subagent PermissionRequest: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
+        );
+        return;
+      }
+
+      // Legacy nested-Task context (kept as secondary safety net).
       const inSubagent = hookBridge.isInSubagentContext();
       const sessionTag = sessionId.slice(0, 8);
 

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -13,6 +13,16 @@ export interface HookCommonInput {
   cwd: string;
   permission_mode: string;
   hook_event_name: HookEventName;
+  /** Set ONLY on events originating from a subagent (background Task/Agent).
+   *  Main-agent events have this absent. Confirmed via REMI_HOOK_DEBUG capture
+   *  2026-04-16: subagent PermissionRequest/PreToolUse/PostToolUse/SubagentStart
+   *  /SubagentStop carry agent_id, main events do not. This is the reliable
+   *  discriminator to prevent subagent PermissionRequests from being mis-routed
+   *  through auto-approve into main's PTY. */
+  agent_id?: string;
+  /** Subagent type identifier (e.g. "general-purpose", "feature-dev:code-architect").
+   *  Only present when agent_id is set. */
+  agent_type?: string;
 }
 
 // --- Original 5 events ---

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -17,7 +17,7 @@ export interface HookCommonInput {
    *  Main-agent events have this absent. Confirmed via REMI_HOOK_DEBUG capture
    *  2026-04-16: subagent PermissionRequest/PreToolUse/PostToolUse/SubagentStart
    *  /SubagentStop carry agent_id, main events do not. This is the reliable
-   *  discriminator to prevent subagent PermissionRequests from being mis-routed
+   *  discriminator to prevent subagent PermissionRequests from being misrouted
    *  through auto-approve into main's PTY. */
   agent_id?: string;
   /** Subagent type identifier (e.g. "general-purpose", "feature-dev:code-architect").

--- a/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
@@ -113,6 +113,62 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
     expect(questions).toHaveLength(1);
   });
 
+  test('agent_id present: subagent PermissionRequest does not emit user question', async () => {
+    // Verified via REMI_HOOK_DEBUG 2026-04-16: Task/Agent subagents and team
+    // members tag their hook events with `agent_id`. Main events don't.
+    // This test models the cli.ts hook-server-level filter: bridge handler is
+    // not called for agent-tagged events.
+    const questions: Question[] = [];
+    const bridge = new HookEventBridge('session-1' as UUID, {
+      onStatusChange: () => {},
+      onQuestion: (q) => questions.push(q),
+      onSessionInfo: () => {},
+    });
+    server = new HookServer({ port: 0 });
+    const h = bridge.hookHandlers();
+    // Simulate cli.ts: skip dispatch when agent_id is set.
+    server.on('PermissionRequest', (input) => {
+      if (typeof input.agent_id === 'string' && input.agent_id.length > 0) return;
+      h.onPermissionRequest?.(input);
+    });
+    server.start();
+    const url = `http://127.0.0.1:${server.port}/hooks`;
+
+    // Subagent PermissionRequest with agent_id set (as captured from real payload)
+    expect(
+      await post(url, {
+        hook_event_name: 'PermissionRequest',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Bash',
+        tool_input: { command: 'nmap --version' },
+        agent_id: 'a26be54375f029520',
+        agent_type: 'general-purpose',
+      }),
+    ).toBe(200);
+
+    // Must NOT emit a user-visible question
+    expect(questions).toHaveLength(0);
+
+    // Main PermissionRequest (no agent_id) still passes through
+    expect(
+      await post(url, {
+        hook_event_name: 'PermissionRequest',
+        session_id: 'session-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Bash',
+        tool_input: { command: 'dig example.com' },
+      }),
+    ).toBe(200);
+
+    expect(questions).toHaveLength(1);
+    expect(questions[0]?.text).toContain('dig example.com');
+  });
+
   test('PreToolUse without tool_use_id degrades gracefully (no context)', async () => {
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},


### PR DESCRIPTION
Closes #316 properly.

## Background

PR #318 attempted to fix #316 by tracking nested \`Task\`/\`Agent\` tool calls. That approach only works for SYNCHRONOUS subagent spawns. Background subagents (\`TaskCreate\`) and team members (\`TeamCreate\`+\`Agent\`) fire asynchronously — no Pre/PostToolUse wrapping. The tracker never caught them, so subagent PermissionRequests still reached the user as phantom phone notifications AND auto-approve still injected "1" into main's PTY (appearing as \`❯ 1\` in chat).

## Empirical evidence (this session, REMI_HOOK_DEBUG=1)

Captured raw hook payloads to \`~/.remi/hook-diag.jsonl\`, compared main vs subagent/team events:

\`\`\`
Main Bash PermissionRequest:
  keys: [session_id, transcript_path, cwd, permission_mode,
         hook_event_name, tool_name, tool_input, permission_suggestions]

Subagent (Task) Bash PermissionRequest:
  keys: [... same ..., agent_id, agent_type]
        agent_id: "a26be54375f029520"
        agent_type: "general-purpose"

Team member Bash PermissionRequest (via TeamCreate + Agent):
  keys: [... same ..., agent_id, agent_type]
        agent_id: "a9da4625e0d19b961"
        agent_type: "probe-member"
\`\`\`

**Discriminator:** \`agent_id\` present → subagent/team event. Absent → main. Same session_id and transcript for all; session-based filtering alone cannot separate them.

## Fix

One-line filter in hook-server listeners:

\`\`\`ts
const isSubagentEvent = (input) =>
  typeof input.agent_id === 'string' && input.agent_id.length > 0;

hookServer.on('PermissionRequest', (input) => {
  initFromHookEvent(input);
  if (!filterBySession(input)) return;
  if (isSubagentEvent(input)) { log('Dropped subagent ...'); return; }
  // ... auto-approve + bridge dispatch
});
\`\`\`

Same check on \`PreToolUse\`, \`PostToolUse\`, \`Notification\`, \`PermissionRequest\`. Single gate covers:

- PTY injection (no more \`❯ 1\` in chat from subagent activity)
- UI question WebSocket message
- APNS push to phone (no phantom notifications)
- Status updates (main status stays accurate)

Type: added optional \`agent_id?: string\` and \`agent_type?: string\` to \`HookCommonInput\`.

## Follow-up

The Task/Agent tool-nesting tracker from #318 remains as a secondary safety net (still useful for the synchronous Task case where main IS blocked). Both mechanisms complement; \`agent_id\` is authoritative when present.

## Tests

- New HTTP-to-bridge integration test: subagent PermissionRequest (with \`agent_id\`) does NOT emit a user-visible question; main still does.
- 95 hook tests pass.

## Test plan

- [x] Typecheck + Biome clean
- [x] 95 hook tests pass
- [x] Empirical capture from real Task-subagent and real team-member sessions confirmed discriminator
- [ ] Live test with new binary: spawn background team + Task subagent, confirm no \`❯ 1\` in chat and no phone push