### PR TITLE
refactor(cli): extract statusline installer into its own module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -167,56 +167,6 @@ function cleanupStatusFile(): void {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Status line script (embedded, written to ~/.remi/statusline.sh)
-// Requires 'jq' to be installed on the host system.
-// ---------------------------------------------------------------------------
-const STATUSLINE_SCRIPT = `#!/bin/bash
-input=$(cat)
-REMI=""
-# REMI_PORT is set by remi when spawning Claude; status file is per-port
-REMI_STATUS_FILE="${REMI_DIR}/status-\$REMI_PORT.json"
-if [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
-  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // ""] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
-  if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
-    CLIENT_INFO="no clients"
-    [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
-    REMI="remi :\$REMI_PORT \${S_REPO}:\${S_BRANCH} | \${CLIENT_INFO} | \${S_STATUS}"
-  fi
-fi
-IFS=\$'\\t' read -r C_PCT C_MODEL < <(echo "$input" | jq -r '[(.context_window.used_percentage // 0 | floor), (.model.display_name // "?")] | @tsv' 2>/dev/null)
-echo "\${REMI:+\$REMI | }[\${C_MODEL:-?}] \${C_PCT:-0}% context"
-`;
-
-function installStatusLine(): void {
-  try {
-    ensureRemiDir();
-    const scriptPath = path.join(REMI_DIR, 'statusline.sh');
-    fs.writeFileSync(scriptPath, STATUSLINE_SCRIPT, { mode: 0o755 });
-
-    // Auto-configure Claude Code settings if no statusLine key exists in
-    // ~/.claude/settings.json. Preserves all other settings but rewrites the file.
-    const claudeSettingsFile = path.join(os.homedir(), '.claude', 'settings.json');
-    let settings: Record<string, unknown> = {};
-    if (fs.existsSync(claudeSettingsFile)) {
-      try {
-        settings = JSON.parse(fs.readFileSync(claudeSettingsFile, 'utf-8'));
-      } catch {
-        console.error(`[warn] Claude settings file is corrupted: ${claudeSettingsFile}`);
-        return;
-      }
-    }
-    if (!settings['statusLine']) {
-      fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
-      settings['statusLine'] = { type: 'command', command: scriptPath };
-      fs.writeFileSync(claudeSettingsFile, `${JSON.stringify(settings, null, 2)}\n`);
-    }
-  } catch (err) {
-    // console.error works in both wrapper and daemon mode
-    console.error(`[warn] Failed to install status line: ${err}`);
-  }
-}
-
 // Load .env file if present
 const envPath = path.join(process.cwd(), '.env');
 if (fs.existsSync(envPath)) {
@@ -279,6 +229,7 @@ import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
+import { installStatusLine } from './cli/statusline-installer.ts';
 import {
   CONFIG_PATH,
   applyEnvOverrides,
@@ -3378,7 +3329,7 @@ if (cliDaemonMode) {
   primarySessionId = sessionId;
 
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
-  installStatusLine();
+  installStatusLine(REMI_DIR);
 
   // Start hook server for Claude Code event detection (port 0 = OS-assigned)
   try {
@@ -3541,7 +3492,7 @@ if (cliDaemonMode) {
   });
 
   // Install status line script (~/.remi/statusline.sh) and auto-configure Claude Code settings
-  installStatusLine();
+  installStatusLine(REMI_DIR);
   const workingDirectory = process.cwd();
   const sessionId = sessionRegistry.createSessionId();
   primarySessionId = sessionId;

--- a/packages/daemon/src/cli/statusline-installer.ts
+++ b/packages/daemon/src/cli/statusline-installer.ts
@@ -1,0 +1,85 @@
+/**
+ * Install the Claude Code statusline integration.
+ *
+ * Writes a bash script to `~/.remi/statusline.sh` that the Claude Code
+ * `statusLine` hook invokes on every prompt. The script reads the per-port
+ * `~/.remi/status-$REMI_PORT.json` file and formats a compact status string.
+ *
+ * Auto-wires itself into `~/.claude/settings.json` only if no `statusLine`
+ * key exists, preserving any user customization.
+ *
+ * Extracted from cli.ts as part of the cleanup epic (see
+ * `.context/cleanup-audit.md`). Pure with respect to module state — the only
+ * input is the Remi home directory.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+
+/**
+ * Build the statusline shell script. Takes `remiDir` as input so the script
+ * references the correct status-file location.
+ *
+ * The generated script requires `jq` on the host system.
+ */
+export function buildStatuslineScript(remiDir: string): string {
+  return `#!/bin/bash
+input=$(cat)
+REMI=""
+# REMI_PORT is set by remi when spawning Claude; status file is per-port
+REMI_STATUS_FILE="${remiDir}/status-\$REMI_PORT.json"
+if [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
+  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // ""] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
+  if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
+    CLIENT_INFO="no clients"
+    [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
+    REMI="remi :\$REMI_PORT \${S_REPO}:\${S_BRANCH} | \${CLIENT_INFO} | \${S_STATUS}"
+  fi
+fi
+IFS=\$'\\t' read -r C_PCT C_MODEL < <(echo "$input" | jq -r '[(.context_window.used_percentage // 0 | floor), (.model.display_name // "?")] | @tsv' 2>/dev/null)
+echo "\${REMI:+\$REMI | }[\${C_MODEL:-?}] \${C_PCT:-0}% context"
+`;
+}
+
+/**
+ * Install the statusline: write the script to `remiDir/statusline.sh` and
+ * register it in `claudeSettingsPath` (defaults to `~/.claude/settings.json`)
+ * if no `statusLine` key is set.
+ *
+ * Never throws — any failure is logged and swallowed. The statusline is a
+ * convenience feature; if installation fails, Remi still functions.
+ *
+ * `claudeSettingsPath` is exposed for tests that need to run against an
+ * isolated settings file. Production callers omit it.
+ */
+export function installStatusLine(
+  remiDir: string,
+  claudeSettingsPath: string = path.join(os.homedir(), '.claude', 'settings.json'),
+): void {
+  try {
+    fs.mkdirSync(remiDir, { recursive: true });
+    const scriptPath = path.join(remiDir, 'statusline.sh');
+    fs.writeFileSync(scriptPath, buildStatuslineScript(remiDir), { mode: 0o755 });
+
+    // Auto-configure Claude Code settings if no statusLine key exists.
+    // Preserves all other settings but rewrites the file.
+    let settings: Record<string, unknown> = {};
+    if (fs.existsSync(claudeSettingsPath)) {
+      try {
+        settings = JSON.parse(fs.readFileSync(claudeSettingsPath, 'utf-8'));
+      } catch {
+        console.error(`[warn] Claude settings file is corrupted: ${claudeSettingsPath}`);
+        return;
+      }
+    }
+    if (!settings['statusLine']) {
+      fs.mkdirSync(path.dirname(claudeSettingsPath), { recursive: true });
+      settings['statusLine'] = { type: 'command', command: scriptPath };
+      fs.writeFileSync(claudeSettingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+    }
+  } catch (err) {
+    console.error(`[warn] Failed to install status line: ${errorToString(err)}`);
+  }
+}

--- a/packages/daemon/tests/cli/statusline-installer.test.ts
+++ b/packages/daemon/tests/cli/statusline-installer.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { buildStatuslineScript, installStatusLine } from '../../src/cli/statusline-installer.ts';
+
+describe('buildStatuslineScript', () => {
+  test('interpolates the remi directory into REMI_STATUS_FILE', () => {
+    const script = buildStatuslineScript('/tmp/fake-remi');
+    expect(script).toContain('REMI_STATUS_FILE="/tmp/fake-remi/status-$REMI_PORT.json"');
+  });
+
+  test('starts with bash shebang', () => {
+    expect(buildStatuslineScript('/x')).toStartWith('#!/bin/bash\n');
+  });
+
+  test('emits the final echo line for context percentage and model', () => {
+    const script = buildStatuslineScript('/x');
+    expect(script).toContain('% context');
+    expect(script).toContain('used_percentage');
+  });
+});
+
+describe('installStatusLine', () => {
+  let tmpRemi: string;
+  let sandbox: string;
+  let settingsPath: string;
+
+  beforeEach(() => {
+    tmpRemi = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-statusline-'));
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-sandbox-'));
+    settingsPath = path.join(sandbox, '.claude', 'settings.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRemi, { recursive: true, force: true });
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('writes statusline.sh into the target directory with exec mode', () => {
+    installStatusLine(tmpRemi, settingsPath);
+    const scriptPath = path.join(tmpRemi, 'statusline.sh');
+    expect(fs.existsSync(scriptPath)).toBe(true);
+    const stat = fs.statSync(scriptPath);
+    expect((stat.mode & 0o777).toString(8)).toBe('755');
+  });
+
+  test('installs statusLine key in the settings file when missing', () => {
+    installStatusLine(tmpRemi, settingsPath);
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(settings.statusLine).toEqual({
+      type: 'command',
+      command: path.join(tmpRemi, 'statusline.sh'),
+    });
+  });
+
+  test('preserves existing statusLine key if already set', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ statusLine: { type: 'command', command: '/custom/path' } }),
+    );
+    installStatusLine(tmpRemi, settingsPath);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(settings.statusLine.command).toBe('/custom/path');
+  });
+
+  test('does not clobber unrelated settings keys', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ foo: 'bar', env: { X: '1' } }));
+    installStatusLine(tmpRemi, settingsPath);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(settings.foo).toBe('bar');
+    expect(settings.env).toEqual({ X: '1' });
+    expect(settings.statusLine).toBeDefined();
+  });
+
+  test('does not throw when the settings file is corrupted JSON', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{not valid json');
+    expect(() => installStatusLine(tmpRemi, settingsPath)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 2** (see `.context/cleanup-audit.md`).

Extracts the 45-line `STATUSLINE_SCRIPT` constant + `installStatusLine()` function out of cli.ts into a focused module: `packages/daemon/src/cli/statusline-installer.ts`.

### API changes

- `buildStatuslineScript(remiDir)` — builds the shell script with the remi-dir path injected. Previously relied on cli.ts module-scoped `REMI_DIR`; now an explicit argument.
- `installStatusLine(remiDir, claudeSettingsPath?)` — second parameter defaults to `~/.claude/settings.json`. Exposed primarily so tests can run in a sandbox (`os.homedir()` ignores `$HOME` overrides on macOS, so a direct path is the only safe way to isolate tests).

### Impact

- `cli.ts`: **-52 lines** of embedded shell script + JSON merge boilerplate
- New module: 85 lines, cleanly scoped
- Net +120 lines (the test file: 8 characterization tests across script interpolation, exec mode, new install, preserve existing, don't clobber unrelated keys, corrupt JSON tolerance).

## Guardrails honored

- No behavior change
- Test suite passes: 606 tests across cli + hooks + shared
- Daemon binary builds and boots (`./dist/remi --version`)
- Biome + typecheck clean

## Test plan

- [x] `bun run typecheck`
- [x] `bunx biome check packages/daemon/src/cli.ts packages/daemon/src/cli/statusline-installer.ts`
- [x] `bun test packages/daemon/tests/cli/statusline-installer.test.ts` — 8/8 pass
- [x] `bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests` — 606/606 pass
- [x] `bun run build:binary && ./dist/remi --version`

## Follow-up

PR 3 (next in the epic) — extract `detectGitInfo()` and the Remi status file management from cli.ts. Those three helpers (detectGitInfo, RemiStatus, updateRemiStatus/writeStatus/cleanupStatusFile) form a cohesive unit with less state entanglement than the log/logFd pair.