### PR TITLE
refactor(cli): extract detectGitInfo and .env loader into startup-env module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -95,21 +95,7 @@ interface RemiStatus {
   branch: string;
 }
 
-function detectGitInfo(): { repo: string; branch: string } {
-  try {
-    const cwd = process.cwd();
-    const repo = path.basename(cwd);
-    const headFile = path.join(cwd, '.git', 'HEAD');
-    if (fs.existsSync(headFile)) {
-      const head = fs.readFileSync(headFile, 'utf-8').trim();
-      const branch = head.startsWith('ref: refs/heads/') ? head.slice(16) : head.slice(0, 8);
-      return { repo, branch };
-    }
-    return { repo, branch: '?' };
-  } catch {
-    return { repo: path.basename(process.cwd()), branch: '?' };
-  }
-}
+import { detectGitInfo, loadDotenvFile } from './cli/startup-env.ts';
 
 const gitInfo = detectGitInfo();
 
@@ -167,29 +153,7 @@ function cleanupStatusFile(): void {
   }
 }
 
-// Load .env file if present
-const envPath = path.join(process.cwd(), '.env');
-if (fs.existsSync(envPath)) {
-  const envContent = fs.readFileSync(envPath, 'utf-8');
-  for (const line of envContent.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIndex = trimmed.indexOf('=');
-    if (eqIndex > 0) {
-      const key = trimmed.slice(0, eqIndex).trim();
-      let value = trimmed.slice(eqIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-      if (!process.env[key]) {
-        process.env[key] = value;
-      }
-    }
-  }
-}
+loadDotenvFile();
 
 import {
   createBulletExpandResponse,

--- a/packages/daemon/src/cli/startup-env.ts
+++ b/packages/daemon/src/cli/startup-env.ts
@@ -1,0 +1,85 @@
+/**
+ * Startup environment helpers: git context detection and .env file loading.
+ *
+ * Extracted from cli.ts to shrink the main CLI module and isolate small,
+ * independently-testable units.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Current working directory's git context — short form used in status line. */
+export interface GitInfo {
+  repo: string;
+  branch: string;
+}
+
+/**
+ * Detect the project name and branch from the current working directory.
+ *
+ * Avoids shelling out to `git` — reads `.git/HEAD` directly so it works in
+ * minimal environments (compiled binary, LaunchAgent) without a git CLI.
+ *
+ * Falls back to directory basename and `'?'` branch on any IO or parse error.
+ */
+export function detectGitInfo(cwd: string = process.cwd()): GitInfo {
+  try {
+    const repo = path.basename(cwd);
+    const headFile = path.join(cwd, '.git', 'HEAD');
+    if (fs.existsSync(headFile)) {
+      const head = fs.readFileSync(headFile, 'utf-8').trim();
+      const branch = head.startsWith('ref: refs/heads/') ? head.slice(16) : head.slice(0, 8);
+      return { repo, branch };
+    }
+    return { repo, branch: '?' };
+  } catch {
+    return { repo: path.basename(cwd), branch: '?' };
+  }
+}
+
+/**
+ * Parse a single `.env`-style line.
+ * Returns `null` for blank lines, comments, or malformed entries.
+ *
+ * Supports:
+ *   - KEY=value
+ *   - KEY="quoted value"
+ *   - KEY='quoted value'
+ *   - leading/trailing whitespace
+ *   - `#` comments (anywhere the line starts, after trim)
+ *
+ * Does NOT support: escape sequences, multiline values, variable expansion.
+ */
+export function parseEnvLine(line: string): { key: string; value: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  const eqIndex = trimmed.indexOf('=');
+  if (eqIndex <= 0) return null;
+  const key = trimmed.slice(0, eqIndex).trim();
+  let value = trimmed.slice(eqIndex + 1).trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return { key, value };
+}
+
+/**
+ * Load a `.env` file into `process.env`, respecting already-set variables
+ * (existing values win). Silently returns if the file does not exist.
+ *
+ * `envPath` defaults to `./.env` — matches the prior cli.ts behavior.
+ */
+export function loadDotenvFile(envPath: string = path.join(process.cwd(), '.env')): void {
+  if (!fs.existsSync(envPath)) return;
+  const envContent = fs.readFileSync(envPath, 'utf-8');
+  for (const line of envContent.split('\n')) {
+    const parsed = parseEnvLine(line);
+    if (!parsed) continue;
+    if (!process.env[parsed.key]) {
+      process.env[parsed.key] = parsed.value;
+    }
+  }
+}

--- a/packages/daemon/tests/cli/startup-env.test.ts
+++ b/packages/daemon/tests/cli/startup-env.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { detectGitInfo, loadDotenvFile, parseEnvLine } from '../../src/cli/startup-env.ts';
+
+describe('detectGitInfo', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-gitinfo-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('returns basename + ? when .git is absent', () => {
+    const info = detectGitInfo(sandbox);
+    expect(info.repo).toBe(path.basename(sandbox));
+    expect(info.branch).toBe('?');
+  });
+
+  test('parses a ref-style HEAD file', () => {
+    fs.mkdirSync(path.join(sandbox, '.git'));
+    fs.writeFileSync(path.join(sandbox, '.git', 'HEAD'), 'ref: refs/heads/feature/x\n');
+    const info = detectGitInfo(sandbox);
+    expect(info.branch).toBe('feature/x');
+  });
+
+  test('shortens a detached-HEAD commit sha to 8 chars', () => {
+    fs.mkdirSync(path.join(sandbox, '.git'));
+    fs.writeFileSync(
+      path.join(sandbox, '.git', 'HEAD'),
+      'abcdef1234567890abcdef1234567890abcdef12',
+    );
+    const info = detectGitInfo(sandbox);
+    expect(info.branch).toBe('abcdef12');
+  });
+
+  test('does not throw on inaccessible HEAD file', () => {
+    // Create .git as a file, not directory — stats lookup on HEAD should fail
+    fs.writeFileSync(path.join(sandbox, '.git'), 'gitdir: /nowhere');
+    const info = detectGitInfo(sandbox);
+    expect(info.repo).toBe(path.basename(sandbox));
+    expect(info.branch).toBe('?');
+  });
+});
+
+describe('parseEnvLine', () => {
+  test('parses KEY=value', () => {
+    expect(parseEnvLine('FOO=bar')).toEqual({ key: 'FOO', value: 'bar' });
+  });
+
+  test('strips double quotes', () => {
+    expect(parseEnvLine('FOO="bar baz"')).toEqual({ key: 'FOO', value: 'bar baz' });
+  });
+
+  test('strips single quotes', () => {
+    expect(parseEnvLine("FOO='bar baz'")).toEqual({ key: 'FOO', value: 'bar baz' });
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(parseEnvLine('  FOO = bar  ')).toEqual({ key: 'FOO', value: 'bar' });
+  });
+
+  test('returns null for blank lines', () => {
+    expect(parseEnvLine('')).toBeNull();
+    expect(parseEnvLine('   ')).toBeNull();
+  });
+
+  test('returns null for comment lines', () => {
+    expect(parseEnvLine('# a comment')).toBeNull();
+    expect(parseEnvLine('   # indented comment')).toBeNull();
+  });
+
+  test('returns null when = is missing', () => {
+    expect(parseEnvLine('NOEQUALS')).toBeNull();
+  });
+
+  test('returns null when key is empty', () => {
+    expect(parseEnvLine('=value')).toBeNull();
+  });
+
+  test('allows empty value', () => {
+    expect(parseEnvLine('FOO=')).toEqual({ key: 'FOO', value: '' });
+  });
+
+  test('preserves = inside the value', () => {
+    expect(parseEnvLine('URL=https://example.com/?a=1&b=2')).toEqual({
+      key: 'URL',
+      value: 'https://example.com/?a=1&b=2',
+    });
+  });
+});
+
+describe('loadDotenvFile', () => {
+  let sandbox: string;
+  const testKeys = ['REMI_TEST_FOO', 'REMI_TEST_BAR', 'REMI_TEST_EXISTING'];
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-dotenv-'));
+    for (const k of testKeys) delete process.env[k];
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+    for (const k of testKeys) delete process.env[k];
+  });
+
+  test('sets vars from the file into process.env', () => {
+    const envPath = path.join(sandbox, '.env');
+    fs.writeFileSync(envPath, 'REMI_TEST_FOO=hello\nREMI_TEST_BAR="world"\n');
+    loadDotenvFile(envPath);
+    expect(process.env['REMI_TEST_FOO']).toBe('hello');
+    expect(process.env['REMI_TEST_BAR']).toBe('world');
+  });
+
+  test('does not override already-set variables', () => {
+    process.env['REMI_TEST_EXISTING'] = 'existing';
+    const envPath = path.join(sandbox, '.env');
+    fs.writeFileSync(envPath, 'REMI_TEST_EXISTING=from-dotenv\n');
+    loadDotenvFile(envPath);
+    expect(process.env['REMI_TEST_EXISTING']).toBe('existing');
+  });
+
+  test('is a no-op when the file is missing', () => {
+    const envPath = path.join(sandbox, 'nonexistent.env');
+    expect(() => loadDotenvFile(envPath)).not.toThrow();
+  });
+
+  test('skips comments and blank lines', () => {
+    const envPath = path.join(sandbox, '.env');
+    fs.writeFileSync(envPath, '# leading comment\n\nREMI_TEST_FOO=val\n   # indented comment\n');
+    loadDotenvFile(envPath);
+    expect(process.env['REMI_TEST_FOO']).toBe('val');
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 3** (see \`.context/cleanup-audit.md\`).

Extracts two independent startup helpers out of cli.ts into a focused module: \`packages/daemon/src/cli/startup-env.ts\`.

### Moved out of cli.ts

- **\`detectGitInfo(cwd?)\`** - reads \`.git/HEAD\` directly (no git CLI) to derive \`{ repo, branch }\` for the status line. Now takes \`cwd\` as a parameter (defaulting to \`process.cwd()\`) so tests can isolate to a temp directory.
- **\`loadDotenvFile(envPath?)\`** - processes a \`.env\` file into \`process.env\` with \"existing value wins\" semantics. Silently returns when missing.
- **\`parseEnvLine(line)\`** - exported so tests can cover parser edge cases without filesystem setup.

### Impact

- \`cli.ts\` drops **32 lines** of inline parsing
- New module: 81 lines, well documented
- 18 new characterization tests covering: git ref parsing, detached HEAD, bad \`.git\` layouts, comments, blank lines, quoted values, \`=\` inside values, missing/empty keys, missing file tolerance, already-set variables preserved

## Guardrails honored

- No behavior change
- \`bun run typecheck\` clean
- \`bunx biome check\` clean
- 624 tests pass across cli + hooks + shared

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bunx biome check packages/daemon/src/cli.ts packages/daemon/src/cli/startup-env.ts\`
- [x] \`bun test packages/daemon/tests/cli/startup-env.test.ts\` - 18/18 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` - 624/624 pass
- [x] Daemon binary compiles (\`bun run build:binary\`)

## Follow-up

PR 4 (next in the epic) - candidate: extract the \`RemiStatus\` state/writer block (detectGitInfo's main consumer). The status-file helpers (\`writeStatus\`, \`scheduleStatusWrite\`, \`cleanupStatusFile\`) form a cohesive unit but touch \`wrapperMode\`/\`cliDaemonMode\` module state - likely needs a small class with those as constructor args.