### PR TITLE
refactor(cli): extract resolveShellPath into shell-path module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -255,96 +255,7 @@ function logError(...args: unknown[]): void {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Shell PATH resolution (for LaunchAgent/systemd where PATH is minimal)
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the user's full PATH from their login shell.
- * LaunchAgents and systemd services inherit a minimal PATH that doesn't
- * include user-installed tools (e.g. ~/.local/bin, Homebrew, ~/.bun/bin).
- *
- * Strategy:
- * 1. Run both login shell (`zsh -l`) and interactive login shell (`zsh -l -i`)
- * 2. Merge all discovered entries (login shell may have .zprofile paths,
- *    interactive may have .zshrc paths like Homebrew or nvm)
- * 3. Merge well-known tool directories as a final fallback
- * 4. Verify `claude` is findable; warn if not
- */
-function resolveShellPath(): void {
-  const shell = process.env['SHELL'] || '/bin/zsh';
-  const currentEntries = (process.env['PATH'] || '').split(':').filter(Boolean);
-  const allEntries = new Set(currentEntries);
-
-  // Run both shells and merge all discovered PATH entries.
-  // Login shell sources .zprofile; interactive login shell also sources .zshrc.
-  const attempts: Array<{ flags: string[]; label: string }> = [
-    { flags: ['-l', '-c', 'echo $PATH'], label: 'login' },
-    { flags: ['-l', '-i', '-c', 'echo $PATH'], label: 'interactive login' },
-  ];
-
-  let anyShellSucceeded = false;
-  for (const { flags, label } of attempts) {
-    try {
-      const result = Bun.spawnSync([shell, ...flags], {
-        env: process.env,
-        timeout: 5000,
-      });
-      if (result.exitCode !== 0) {
-        const stderr = result.stderr?.toString().trim() || '(no stderr)';
-        log(`[PATH] ${label} shell exited with code ${result.exitCode}: ${stderr}`);
-        continue;
-      }
-      const shellPath = result.stdout?.toString().trim();
-      if (!shellPath) {
-        log(`[PATH] ${label} shell returned empty PATH`);
-        continue;
-      }
-
-      anyShellSucceeded = true;
-      for (const entry of shellPath.split(':')) {
-        if (entry) allEntries.add(entry);
-      }
-    } catch (err) {
-      logError(`[PATH] ${label} shell failed: ${errorToString(err)}`);
-    }
-  }
-
-  // Fallback: merge well-known directories if no shell succeeded
-  if (!anyShellSucceeded) {
-    const home = os.homedir();
-    const wellKnownDirs = [
-      '/opt/homebrew/bin',
-      '/opt/homebrew/sbin',
-      `${home}/.bun/bin`,
-      `${home}/.local/bin`,
-      '/usr/local/bin',
-    ];
-    for (const d of wellKnownDirs) {
-      if (!allEntries.has(d) && fs.existsSync(d)) allEntries.add(d);
-    }
-    log('[PATH] Shell resolution failed, merged well-known directories');
-  }
-
-  const merged = [...allEntries].join(':');
-  if (merged !== (process.env['PATH'] || '')) {
-    process.env['PATH'] = merged;
-    log(`[PATH] Resolved ${allEntries.size} entries (was ${currentEntries.length})`);
-  }
-
-  // Verify claude is findable after PATH resolution
-  try {
-    const which = Bun.spawnSync(['which', 'claude'], { env: process.env, timeout: 2000 });
-    if (which.exitCode !== 0) {
-      logError(
-        '[PATH] WARNING: "claude" not found in PATH after resolution. ' +
-          'Session creation will fail. Ensure claude is installed and in PATH.',
-      );
-    }
-  } catch {
-    // which command itself failed; non-fatal
-  }
-}
+import { resolveShellPath } from './cli/shell-path.ts';
 
 // ---------------------------------------------------------------------------
 // Resolve directory helper
@@ -3235,7 +3146,7 @@ async function cleanup(): Promise<void> {
 // In wrapper mode the terminal provides the PATH, but resolveShellPath
 // merges (never drops existing entries) so it's safe to call, and ensures
 // remote session creation works even after the terminal is detached (SIGHUP).
-resolveShellPath();
+resolveShellPath({ log, error: logError });
 
 if (cliDaemonMode) {
   console.log('Starting Remi daemon...');

--- a/packages/daemon/src/cli/shell-path.ts
+++ b/packages/daemon/src/cli/shell-path.ts
@@ -1,0 +1,107 @@
+/**
+ * Shell PATH resolution for environments where the inherited PATH is minimal
+ * (LaunchAgents, systemd user services, Xcode schemes). Extracted from cli.ts.
+ *
+ * Strategy:
+ * 1. Run both login shell (`zsh -l`) and interactive login shell (`zsh -l -i`)
+ *    to pick up .zprofile AND .zshrc additions (Homebrew, nvm, ~/.bun/bin).
+ * 2. Merge all discovered PATH entries with the inherited entries.
+ * 3. Fall back to well-known Homebrew / user-bin directories if no shell run
+ *    succeeded.
+ * 4. Verify `claude` is findable after resolution; warn if not.
+ *
+ * `resolveShellPath` mutates `process.env.PATH` in place — same behavior as
+ * the original inline version.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { errorToString } from '@remi/shared';
+
+/** Logger shape the resolver needs. Accepts anything compatible with console.log. */
+export interface ShellPathLogger {
+  log: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+/**
+ * Resolve the user's full PATH by probing their login shell and merging
+ * well-known directories. Mutates `process.env.PATH`.
+ *
+ * Never throws — shell spawn failures and missing `which` are logged but
+ * swallowed; PATH resolution is best-effort.
+ */
+export function resolveShellPath(logger: ShellPathLogger): void {
+  const shell = process.env['SHELL'] || '/bin/zsh';
+  const currentEntries = (process.env['PATH'] || '').split(':').filter(Boolean);
+  const allEntries = new Set(currentEntries);
+
+  // Run both shells and merge all discovered PATH entries.
+  // Login shell sources .zprofile; interactive login shell also sources .zshrc.
+  const attempts: Array<{ flags: string[]; label: string }> = [
+    { flags: ['-l', '-c', 'echo $PATH'], label: 'login' },
+    { flags: ['-l', '-i', '-c', 'echo $PATH'], label: 'interactive login' },
+  ];
+
+  let anyShellSucceeded = false;
+  for (const { flags, label } of attempts) {
+    try {
+      const result = Bun.spawnSync([shell, ...flags], {
+        env: process.env,
+        timeout: 5000,
+      });
+      if (result.exitCode !== 0) {
+        const stderr = result.stderr?.toString().trim() || '(no stderr)';
+        logger.log(`[PATH] ${label} shell exited with code ${result.exitCode}: ${stderr}`);
+        continue;
+      }
+      const shellPath = result.stdout?.toString().trim();
+      if (!shellPath) {
+        logger.log(`[PATH] ${label} shell returned empty PATH`);
+        continue;
+      }
+
+      anyShellSucceeded = true;
+      for (const entry of shellPath.split(':')) {
+        if (entry) allEntries.add(entry);
+      }
+    } catch (err) {
+      logger.error(`[PATH] ${label} shell failed: ${errorToString(err)}`);
+    }
+  }
+
+  // Fallback: merge well-known directories if no shell succeeded
+  if (!anyShellSucceeded) {
+    const home = os.homedir();
+    const wellKnownDirs = [
+      '/opt/homebrew/bin',
+      '/opt/homebrew/sbin',
+      `${home}/.bun/bin`,
+      `${home}/.local/bin`,
+      '/usr/local/bin',
+    ];
+    for (const d of wellKnownDirs) {
+      if (!allEntries.has(d) && fs.existsSync(d)) allEntries.add(d);
+    }
+    logger.log('[PATH] Shell resolution failed, merged well-known directories');
+  }
+
+  const merged = [...allEntries].join(':');
+  if (merged !== (process.env['PATH'] || '')) {
+    process.env['PATH'] = merged;
+    logger.log(`[PATH] Resolved ${allEntries.size} entries (was ${currentEntries.length})`);
+  }
+
+  // Verify claude is findable after PATH resolution
+  try {
+    const which = Bun.spawnSync(['which', 'claude'], { env: process.env, timeout: 2000 });
+    if (which.exitCode !== 0) {
+      logger.error(
+        '[PATH] WARNING: "claude" not found in PATH after resolution. ' +
+          'Session creation will fail. Ensure claude is installed and in PATH.',
+      );
+    }
+  } catch {
+    // which command itself failed; non-fatal
+  }
+}

--- a/packages/daemon/tests/cli/shell-path.test.ts
+++ b/packages/daemon/tests/cli/shell-path.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { resolveShellPath } from '../../src/cli/shell-path.ts';
+
+describe('resolveShellPath', () => {
+  let logCalls: string[];
+  let errorCalls: string[];
+  let savedPath: string | undefined;
+  let savedShell: string | undefined;
+
+  const logger = {
+    log: (msg: string) => logCalls.push(msg),
+    error: (msg: string) => errorCalls.push(msg),
+  };
+
+  beforeEach(() => {
+    logCalls = [];
+    errorCalls = [];
+    savedPath = process.env['PATH'];
+    savedShell = process.env['SHELL'];
+  });
+
+  afterEach(() => {
+    if (savedPath === undefined) {
+      // biome-ignore lint/performance/noDelete: restoring an unset env var requires true removal, not undefined-stringification.
+      delete process.env['PATH'];
+    } else {
+      process.env['PATH'] = savedPath;
+    }
+    if (savedShell === undefined) {
+      // biome-ignore lint/performance/noDelete: same reason as above.
+      delete process.env['SHELL'];
+    } else {
+      process.env['SHELL'] = savedShell;
+    }
+  });
+
+  test('adds shell-provided PATH entries into process.env.PATH', () => {
+    process.env['PATH'] = '/usr/bin';
+    process.env['SHELL'] = '/bin/zsh';
+    resolveShellPath(logger);
+    const entries = (process.env['PATH'] ?? '').split(':');
+    expect(entries).toContain('/usr/bin');
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('does not duplicate entries that are already in PATH', () => {
+    process.env['PATH'] = '/usr/bin:/bin';
+    process.env['SHELL'] = '/bin/zsh';
+    resolveShellPath(logger);
+    const entries = (process.env['PATH'] ?? '').split(':');
+    const counts = new Map<string, number>();
+    for (const e of entries) counts.set(e, (counts.get(e) ?? 0) + 1);
+    for (const [_k, n] of counts) expect(n).toBe(1);
+  });
+
+  test('logs resolved-entries message when PATH changes', () => {
+    // Use an intentionally-minimal PATH so the shell will add at least one new entry
+    process.env['PATH'] = '/nonexistent-base';
+    process.env['SHELL'] = '/bin/zsh';
+    resolveShellPath(logger);
+    expect(logCalls.some((msg) => msg.startsWith('[PATH] Resolved'))).toBe(true);
+  });
+
+  test('falls back to well-known dirs when SHELL is invalid', () => {
+    process.env['PATH'] = '/tmp-only-path';
+    process.env['SHELL'] = '/nonexistent/shell';
+    resolveShellPath(logger);
+    // The fallback branch must log "Shell resolution failed, merged well-known directories"
+    // — anchor this specific log line so the branch stays covered after future refactors.
+    expect(logCalls.some((msg) => msg.includes('Shell resolution failed'))).toBe(true);
+  });
+
+  test('never throws', () => {
+    process.env['SHELL'] = '/bin/zsh';
+    expect(() => resolveShellPath(logger)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 4** (see \`.context/cleanup-audit.md\`).

Extracts the 73-line \`resolveShellPath()\` function out of cli.ts into a focused module: \`packages/daemon/src/cli/shell-path.ts\`.

### API change (intentional)

\`resolveShellPath\` now takes an explicit logger dependency:

\`\`\`ts
interface ShellPathLogger {
  log: (msg: string) => void;
  error: (msg: string) => void;
}

function resolveShellPath(logger: ShellPathLogger): void;
\`\`\`

Previously it closed over cli.ts module-scope \`log\`/\`logError\` helpers (which in turn depend on \`wrapperMode\` state). Injecting the logger decouples the module from cli.ts wrapper state and lets tests capture logs cleanly.

Call site updated to \`resolveShellPath({ log, error: logError })\` — semantically identical.

### Behavior preserved

- Same login + interactive-login zsh probe order
- Same well-known directories fallback (/opt/homebrew/bin, ~/.bun/bin, etc.)
- Same \`which claude\` post-resolution verification
- Still mutates \`process.env.PATH\` in place
- Still never throws (shell spawn failures and missing \`which\` swallowed)

### Impact

- \`cli.ts\` drops **91 lines**
- New module: 107 lines
- 5 characterization tests added

## Guardrails honored

- No behavior change beyond the explicit-logger API
- \`bun run typecheck\` clean
- \`bunx biome check\` clean
- 629 tests pass across cli + hooks + shared

## Running cli.ts tally

After four cleanup PRs:
- PR #325: -27 LOC (errorToString consolidation)
- PR #326: -52 LOC (statusline-installer)
- PR #327: -32 LOC (startup-env)
- PR #328 (this): -91 LOC (shell-path)
- Net cli.ts reduction: ~202 lines (down from 3894 to ~3690)

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bunx biome check packages/daemon/src/cli.ts packages/daemon/src/cli/shell-path.ts\`
- [x] \`bun test packages/daemon/tests/cli/shell-path.test.ts\` — 5/5 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 629/629 pass