### PR TITLE
refactor(cli): extract 'remi reload' subcommand into its own handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -193,6 +193,7 @@ import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
+import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
@@ -328,33 +329,7 @@ if (parsedArgs.subcommand === 'config') {
 
 // Handle 'reload' subcommand
 if (parsedArgs.subcommand === 'reload') {
-  const liveSessions = new SessionRegistryFile().listLive();
-  if (liveSessions.length === 0) {
-    console.error('No running daemons found.');
-    process.exit(1);
-  }
-  let reloaded = 0;
-  for (const entry of liveSessions) {
-    try {
-      process.kill(entry.pid, 'SIGUSR1');
-      console.log(`Sent reload signal to ${entry.name} (PID ${entry.pid}, port ${entry.wsPort})`);
-      reloaded++;
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ESRCH') {
-        console.error(`Process ${entry.pid} not found (stale session entry)`);
-      } else {
-        console.error(`Failed to signal PID ${entry.pid}: ${errorToString(err)}`);
-      }
-    }
-  }
-  if (reloaded > 0) {
-    console.log(`Reloaded ${reloaded} daemon(s).`);
-    process.exit(0);
-  } else {
-    console.error('Failed to reload any daemons (all session entries appear stale).');
-    process.exit(1);
-  }
+  process.exit(runReloadCommand());
 }
 
 // Destructure into existing variable names for zero downstream changes

--- a/packages/daemon/src/cli/cmd-reload.ts
+++ b/packages/daemon/src/cli/cmd-reload.ts
@@ -1,0 +1,72 @@
+/**
+ * Handler for `remi reload` — sends SIGUSR1 to every live daemon so it picks
+ * up an updated binary/config without dropping its PTY session.
+ *
+ * Exits 0 if at least one daemon was successfully signaled, 1 otherwise (no
+ * live daemons OR all signal attempts failed).
+ *
+ * Stale session entries (ESRCH) are reported but do not count as success.
+ */
+
+import { errorToString } from '@remi/shared';
+import { SessionRegistryFile } from '../session/session-registry-file.ts';
+
+export interface ReloadCommandIO {
+  readonly out: (msg: string) => void;
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: ReloadCommandIO = {
+  out: (msg) => console.log(msg),
+  err: (msg) => console.error(msg),
+};
+
+/** Dependencies the handler needs. Exposed for tests. */
+export interface ReloadCommandDeps {
+  /** Lists currently-live daemons. Defaults to the production SessionRegistryFile. */
+  readonly listLive?: () => ReadonlyArray<{
+    name: string;
+    pid: number;
+    wsPort: number;
+  }>;
+  /** Sends a signal to a pid. Defaults to `process.kill`. Must throw with
+   *  `code: 'ESRCH'` on NodeJS.ErrnoException when the pid is gone. */
+  readonly kill?: (pid: number, signal: NodeJS.Signals) => void;
+}
+
+export function runReloadCommand(
+  io: ReloadCommandIO = defaultIO,
+  deps: ReloadCommandDeps = {},
+): number {
+  const listLive = deps.listLive ?? (() => new SessionRegistryFile().listLive());
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+
+  const liveSessions = listLive();
+  if (liveSessions.length === 0) {
+    io.err('No running daemons found.');
+    return 1;
+  }
+
+  let reloaded = 0;
+  for (const entry of liveSessions) {
+    try {
+      kill(entry.pid, 'SIGUSR1');
+      io.out(`Sent reload signal to ${entry.name} (PID ${entry.pid}, port ${entry.wsPort})`);
+      reloaded++;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ESRCH') {
+        io.err(`Process ${entry.pid} not found (stale session entry)`);
+      } else {
+        io.err(`Failed to signal PID ${entry.pid}: ${errorToString(err)}`);
+      }
+    }
+  }
+
+  if (reloaded > 0) {
+    io.out(`Reloaded ${reloaded} daemon(s).`);
+    return 0;
+  }
+  io.err('Failed to reload any daemons (all session entries appear stale).');
+  return 1;
+}

--- a/packages/daemon/tests/cli/cmd-reload.test.ts
+++ b/packages/daemon/tests/cli/cmd-reload.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { runReloadCommand } from '../../src/cli/cmd-reload.ts';
+
+function makeIO() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    io: { out: (msg: string) => out.push(msg), err: (msg: string) => err.push(msg) },
+    out,
+    err,
+  };
+}
+
+function mkSession(name: string, pid: number, wsPort: number) {
+  return { name, pid, wsPort };
+}
+
+describe('runReloadCommand', () => {
+  test('exits 1 and logs an error when no daemons are running', () => {
+    const { io, out, err } = makeIO();
+    const code = runReloadCommand(io, { listLive: () => [], kill: () => {} });
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(err).toEqual(['No running daemons found.']);
+  });
+
+  test('signals every live daemon and reports success count', () => {
+    const killCalls: Array<[number, NodeJS.Signals]> = [];
+    const { io, out, err } = makeIO();
+    const code = runReloadCommand(io, {
+      listLive: () => [mkSession('alpha', 100, 18765), mkSession('beta', 101, 18766)],
+      kill: (pid, sig) => {
+        killCalls.push([pid, sig]);
+      },
+    });
+    expect(code).toBe(0);
+    expect(killCalls).toEqual([
+      [100, 'SIGUSR1'],
+      [101, 'SIGUSR1'],
+    ]);
+    expect(out.some((m) => m.includes('Reloaded 2 daemon(s).'))).toBe(true);
+    expect(err).toHaveLength(0);
+  });
+
+  test('handles ESRCH (stale pid) separately from other errors', () => {
+    const { io, out, err } = makeIO();
+    const kill = (pid: number) => {
+      if (pid === 100) {
+        const e = new Error('no such process') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        throw e;
+      }
+      // pid 101 succeeds
+    };
+    const code = runReloadCommand(io, {
+      listLive: () => [mkSession('stale', 100, 18765), mkSession('live', 101, 18766)],
+      kill,
+    });
+    expect(code).toBe(0); // at least one succeeded
+    expect(err).toEqual(['Process 100 not found (stale session entry)']);
+    expect(out.some((m) => m.includes('Sent reload signal to live'))).toBe(true);
+    expect(out.some((m) => m.includes('Reloaded 1 daemon(s).'))).toBe(true);
+  });
+
+  test('exits 1 when all daemons are stale', () => {
+    const { io, out, err } = makeIO();
+    const kill = () => {
+      const e = new Error('no such process') as NodeJS.ErrnoException;
+      e.code = 'ESRCH';
+      throw e;
+    };
+    const code = runReloadCommand(io, {
+      listLive: () => [mkSession('stale', 100, 18765)],
+      kill,
+    });
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(err.some((m) => m.includes('Failed to reload any daemons'))).toBe(true);
+  });
+
+  test('reports non-ESRCH errors with errorToString wrapping', () => {
+    const { io, out, err } = makeIO();
+    const kill = () => {
+      throw new Error('permission denied');
+    };
+    const code = runReloadCommand(io, {
+      listLive: () => [mkSession('locked', 100, 18765)],
+      kill,
+    });
+    expect(code).toBe(1);
+    expect(err.some((m) => m.includes('Failed to signal PID 100: permission denied'))).toBe(true);
+    expect(out).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 6** (see \`.context/cleanup-audit.md\`).

Follows the pattern from #329. Extracts the inline \`reload\` subcommand block out of cli.ts into \`packages/daemon/src/cli/cmd-reload.ts\`.

### API

\`\`\`ts
runReloadCommand(io?, deps?): number
\`\`\`

Both IO and deps are injectable:
- \`io\` — stdout/stderr captures
- \`deps.listLive\` defaults to \`SessionRegistryFile().listLive()\`
- \`deps.kill\` defaults to \`process.kill\`

This makes the handler fully testable without touching real live daemons or sending signals.

### Branch coverage

5 characterization tests cover every branch:
- No live daemons → exit 1
- All signaled successfully → exit 0 with count
- Mixed ESRCH (stale pid) + live → exit 0 for the live ones
- All ESRCH → exit 1 \"all stale\" message
- Non-ESRCH error → wrapped with \`errorToString\`

### Impact

- \`cli.ts\` drops **27 lines**
- New module: 75 lines
- 5 tests, 17 expect() calls

## Running cli.ts tally after 6 cleanup PRs

| PR | cli.ts delta |
|----|--------------|
| #325 | -27 |
| #326 | -52 |
| #327 | -32 |
| #328 | -91 |
| #329 | -22 |
| #330 (this) | -27 |
| **Total** | **-251** |

cli.ts: 3894 → ~3643

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/cmd-reload.test.ts\` — 5/5 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 638/638 pass