### PR TITLE
refactor(cli): extract daemon lifecycle subcommands into cmd-daemon

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -571,35 +571,21 @@ if (
   cliSubcommand === 'status' ||
   cliSubcommand === 'logs'
 ) {
-  const dm = await import('./cli/daemon-manager.ts');
-
-  if (cliSubcommand === 'start') {
-    // Only pass port if user explicitly set --port flag.
-    // Do NOT inherit REMI_PORT from env (it's set by wrapper sessions and
-    // would conflict). The daemon finds its own free port.
-    const explicitPort = cliPort;
-    const extraArgs: string[] = [];
-    if (cliBindHost) extraArgs.push('--bind', cliBindHost);
-    if (cliAuth === true) extraArgs.push('--auth');
-    if (cliAuth === false) extraArgs.push('--no-auth');
-    if (cliNoMdns) extraArgs.push('--no-mdns');
-    if (cliNoRelay) extraArgs.push('--no-relay');
-    if (cliNoTelegram) extraArgs.push('--no-telegram');
-    if (cliPermanentCode) extraArgs.push('--permanent-code');
-    if (cliSignalingUrl) extraArgs.push('--signaling-url', cliSignalingUrl);
-    if (cliPushSecret) extraArgs.push('--push-secret', cliPushSecret);
-    if (cliOrphanTimeout !== undefined)
-      extraArgs.push('--orphan-timeout', String(cliOrphanTimeout));
-    await dm.startDaemon({ port: explicitPort, extraArgs });
-  } else if (cliSubcommand === 'stop') {
-    dm.stopDaemon();
-  } else if (cliSubcommand === 'status') {
-    dm.showDaemonStatus();
-  } else {
-    dm.showDaemonLogs();
-  }
-
-  process.exit(0);
+  const { runDaemonLifecycleCommand } = await import('./cli/cmd-daemon.ts');
+  process.exit(
+    await runDaemonLifecycleCommand(cliSubcommand, {
+      ...(cliPort !== undefined && { port: cliPort }),
+      ...(cliBindHost !== undefined && { bindHost: cliBindHost }),
+      ...(cliAuth !== undefined && { auth: cliAuth }),
+      noMdns: cliNoMdns,
+      noRelay: cliNoRelay,
+      noTelegram: cliNoTelegram,
+      permanentCode: cliPermanentCode,
+      ...(cliSignalingUrl !== undefined && { signalingUrl: cliSignalingUrl }),
+      ...(cliPushSecret !== undefined && { pushSecret: cliPushSecret }),
+      ...(cliOrphanTimeout !== undefined && { orphanTimeout: cliOrphanTimeout }),
+    }),
+  );
 }
 
 // Live sessions registry: shared by subcommands and daemon/wrapper mode.

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -1,0 +1,82 @@
+/**
+ * Handler for the daemon lifecycle subcommands: `start`, `stop`, `status`, `logs`.
+ *
+ * These four all dispatch to functions in `daemon-manager.ts`; this module
+ * keeps the dispatch in one place and shapes the `start` option forwarding
+ * into a single options object so cli.ts can stay narrow.
+ */
+
+import * as dm from './daemon-manager.ts';
+
+/** Subset of CLI flags needed for the `start` path. */
+export interface StartDaemonOptions {
+  readonly port?: number;
+  readonly bindHost?: string;
+  readonly auth?: boolean;
+  readonly noMdns?: boolean;
+  readonly noRelay?: boolean;
+  readonly noTelegram?: boolean;
+  readonly permanentCode?: boolean;
+  readonly signalingUrl?: string;
+  readonly pushSecret?: string;
+  readonly orphanTimeout?: number;
+}
+
+/** Subcommands this handler owns. */
+export type DaemonSubcommand = 'start' | 'stop' | 'status' | 'logs';
+
+/**
+ * Build the `--flag value` list that `remi start` should forward to the
+ * spawned daemon process. Isolated so it can be unit-tested without
+ * exercising the full daemon-manager path.
+ */
+export function buildStartDaemonArgs(opts: StartDaemonOptions): string[] {
+  const extraArgs: string[] = [];
+  if (opts.bindHost) extraArgs.push('--bind', opts.bindHost);
+  if (opts.auth === true) extraArgs.push('--auth');
+  if (opts.auth === false) extraArgs.push('--no-auth');
+  if (opts.noMdns) extraArgs.push('--no-mdns');
+  if (opts.noRelay) extraArgs.push('--no-relay');
+  if (opts.noTelegram) extraArgs.push('--no-telegram');
+  if (opts.permanentCode) extraArgs.push('--permanent-code');
+  if (opts.signalingUrl) extraArgs.push('--signaling-url', opts.signalingUrl);
+  if (opts.pushSecret) extraArgs.push('--push-secret', opts.pushSecret);
+  if (opts.orphanTimeout !== undefined) {
+    extraArgs.push('--orphan-timeout', String(opts.orphanTimeout));
+  }
+  return extraArgs;
+}
+
+/**
+ * Run one of the daemon lifecycle subcommands.
+ * Always exits 0 — errors inside daemon-manager are handled there.
+ */
+export async function runDaemonLifecycleCommand(
+  sub: DaemonSubcommand,
+  opts: StartDaemonOptions = {},
+): Promise<number> {
+  if (sub === 'start') {
+    // Only pass port if user explicitly set --port flag.
+    // Do NOT inherit REMI_PORT from env (it's set by wrapper sessions and
+    // would conflict). The daemon finds its own free port.
+    await dm.startDaemon({ port: opts.port, extraArgs: buildStartDaemonArgs(opts) });
+    return 0;
+  }
+  if (sub === 'stop') {
+    dm.stopDaemon();
+    return 0;
+  }
+  if (sub === 'status') {
+    dm.showDaemonStatus();
+    return 0;
+  }
+  if (sub === 'logs') {
+    dm.showDaemonLogs();
+    return 0;
+  }
+  // Exhaustiveness check: if DaemonSubcommand gains a new value, this becomes
+  // a type error rather than silently routing to showDaemonLogs.
+  const _exhaustive: never = sub;
+  void _exhaustive;
+  return 0;
+}

--- a/packages/daemon/tests/cli/cmd-daemon.test.ts
+++ b/packages/daemon/tests/cli/cmd-daemon.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { buildStartDaemonArgs } from '../../src/cli/cmd-daemon.ts';
+
+describe('buildStartDaemonArgs', () => {
+  test('returns an empty list for an empty options object', () => {
+    expect(buildStartDaemonArgs({})).toEqual([]);
+  });
+
+  test('maps --bind when bindHost is provided', () => {
+    expect(buildStartDaemonArgs({ bindHost: '0.0.0.0' })).toEqual(['--bind', '0.0.0.0']);
+  });
+
+  test('distinguishes auth true from auth false from auth undefined', () => {
+    expect(buildStartDaemonArgs({ auth: true })).toEqual(['--auth']);
+    expect(buildStartDaemonArgs({ auth: false })).toEqual(['--no-auth']);
+    expect(buildStartDaemonArgs({})).toEqual([]);
+  });
+
+  test('adds the flag for each truthy boolean option', () => {
+    expect(
+      buildStartDaemonArgs({
+        noMdns: true,
+        noRelay: true,
+        noTelegram: true,
+        permanentCode: true,
+      }),
+    ).toEqual(['--no-mdns', '--no-relay', '--no-telegram', '--permanent-code']);
+  });
+
+  test('omits flags for falsy boolean options', () => {
+    expect(
+      buildStartDaemonArgs({
+        noMdns: false,
+        noRelay: false,
+        noTelegram: false,
+        permanentCode: false,
+      }),
+    ).toEqual([]);
+  });
+
+  test('maps signalingUrl and pushSecret', () => {
+    expect(
+      buildStartDaemonArgs({
+        signalingUrl: 'wss://example.test/connect',
+        pushSecret: 'shhh',
+      }),
+    ).toEqual(['--signaling-url', 'wss://example.test/connect', '--push-secret', 'shhh']);
+  });
+
+  test('stringifies orphanTimeout when present', () => {
+    expect(buildStartDaemonArgs({ orphanTimeout: 300 })).toEqual(['--orphan-timeout', '300']);
+  });
+
+  test('accepts orphanTimeout of 0 (distinct from undefined)', () => {
+    // `if (orphanTimeout !== undefined)` preserves the semantics of disabling
+    // the orphan timer via 0; an `if (orphanTimeout)` bug would silently drop it.
+    expect(buildStartDaemonArgs({ orphanTimeout: 0 })).toEqual(['--orphan-timeout', '0']);
+  });
+
+  test('emits flags in a stable order matching the old inline block', () => {
+    const args = buildStartDaemonArgs({
+      bindHost: '1.2.3.4',
+      auth: true,
+      noMdns: true,
+      noRelay: true,
+      noTelegram: true,
+      permanentCode: true,
+      signalingUrl: 'wss://x',
+      pushSecret: 's',
+      orphanTimeout: 60,
+    });
+    expect(args).toEqual([
+      '--bind',
+      '1.2.3.4',
+      '--auth',
+      '--no-mdns',
+      '--no-relay',
+      '--no-telegram',
+      '--permanent-code',
+      '--signaling-url',
+      'wss://x',
+      '--push-secret',
+      's',
+      '--orphan-timeout',
+      '60',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 7** (see \`.context/cleanup-audit.md\`).

Extracts the inline dispatch for \`remi start/stop/status/logs\` out of cli.ts into \`packages/daemon/src/cli/cmd-daemon.ts\`.

### Two exported functions

- **\`buildStartDaemonArgs(opts)\`** — pure builder for the \`--flag value\` list that gets forwarded to the spawned daemon process. Isolated so flag ordering and semantics (e.g. \`orphanTimeout = 0\` vs \`undefined\`) can be unit-tested without the daemon-manager path.
- **\`runDaemonLifecycleCommand(sub, opts)\`** — dispatches to \`daemon-manager.ts\` for start/stop/status/logs and returns an exit code.

### Test coverage

9 characterization tests for \`buildStartDaemonArgs\`:
- Empty options
- Auth tri-state (\`true\` → \`--auth\`, \`false\` → \`--no-auth\`, \`undefined\` → nothing)
- Each boolean flag family
- \`orphanTimeout = 0\` is emitted (guarded by \`!== undefined\`, not truthy check — catches a potential silent-drop bug)
- Stable flag ordering identical to the old inline block
- String flags: \`signalingUrl\`, \`pushSecret\`

### Impact

- \`cli.ts\` net −14 lines (29 → 15 at the call site)
- Subtlety: the cli.ts call site uses \`{ ...(value !== undefined && { key: value }) }\` spread pattern for TS \`exactOptionalPropertyTypes\` compatibility

### Running cli.ts tally after 7 cleanup PRs

| PR | cli.ts delta |
|----|--------------|
| #325 | -27 |
| #326 | -52 |
| #327 | -32 |
| #328 | -91 |
| #329 | -22 |
| #330 | -27 |
| #331 (this) | -14 |
| **Total** | **-265** |

cli.ts: 3894 → ~3629

## Guardrails

- No behavior change; stop/status/logs paths are single-call pass-throughs; start-path args order matches old block character-for-character
- \`bun run typecheck\` clean
- \`bunx biome check\` clean
- 647 tests pass (cli + hooks + shared)

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bunx biome check packages/daemon/src/cli.ts packages/daemon/src/cli/cmd-daemon.ts\`
- [x] \`bun test packages/daemon/tests/cli/cmd-daemon.test.ts\` — 9/9 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 647/647 pass