### PR TITLE
refactor(cli): extract 'remi code' subcommand into its own handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -543,25 +543,8 @@ if (cliSubcommand === 'keys') {
 // Handle 'code' subcommand: show or refresh the persistent connection code
 if (cliSubcommand === 'code') {
   const { CodeStore } = await import('./remote/code-store.ts');
-  const codeStore = new CodeStore();
-  if (cliCodeRefresh) {
-    const newCode = codeStore.refresh();
-    console.log(`New permanent connection code: ${newCode}`);
-    console.log('Restart the daemon for the new code to take effect.');
-  } else {
-    const code = codeStore.load();
-    if (code) {
-      console.log(`Permanent connection code: ${code}`);
-      console.log('Use --permanent-code flag when starting daemon to enable this code.');
-    } else {
-      const newCode = codeStore.refresh();
-      console.log(`Permanent connection code: ${newCode} (newly generated)`);
-      console.log('Use --permanent-code flag when starting daemon to enable this code.');
-    }
-  }
-  console.log('\nNote: By default, codes rotate on each reconnect. Use --permanent-code to');
-  console.log('persist a fixed code (requires Ed25519 authentication for relay connections).');
-  process.exit(0);
+  const { runCodeCommand } = await import('./cli/cmd-code.ts');
+  process.exit(runCodeCommand(new CodeStore(), { refresh: cliCodeRefresh }));
 }
 
 // Handle daemon lifecycle commands: start, stop, status, logs

--- a/packages/daemon/src/cli/cmd-code.ts
+++ b/packages/daemon/src/cli/cmd-code.ts
@@ -1,0 +1,51 @@
+/**
+ * Handler for `remi code [--refresh]` — prints the persistent connection code
+ * used for relay auth, optionally rotating it.
+ *
+ * Without `--refresh`: prints existing code, or generates one if none is set.
+ * With `--refresh`: always generates a new code and prompts the user to
+ * restart the daemon.
+ */
+
+export interface CodeCommandIO {
+  readonly out: (msg: string) => void;
+}
+
+const defaultIO: CodeCommandIO = {
+  out: (msg) => console.log(msg),
+};
+
+/** Minimal CodeStore interface the handler depends on. */
+export interface CodeStoreLike {
+  load(): string | null;
+  refresh(): string;
+}
+
+export interface CodeCommandOptions {
+  readonly refresh?: boolean;
+}
+
+export function runCodeCommand(
+  store: CodeStoreLike,
+  opts: CodeCommandOptions = {},
+  io: CodeCommandIO = defaultIO,
+): number {
+  if (opts.refresh) {
+    const newCode = store.refresh();
+    io.out(`New permanent connection code: ${newCode}`);
+    io.out('Restart the daemon for the new code to take effect.');
+  } else {
+    const code = store.load();
+    if (code) {
+      io.out(`Permanent connection code: ${code}`);
+      io.out('Use --permanent-code flag when starting daemon to enable this code.');
+    } else {
+      const newCode = store.refresh();
+      io.out(`Permanent connection code: ${newCode} (newly generated)`);
+      io.out('Use --permanent-code flag when starting daemon to enable this code.');
+    }
+  }
+  io.out('\nNote: By default, codes rotate on each reconnect. Use --permanent-code to');
+  io.out('persist a fixed code (requires Ed25519 authentication for relay connections).');
+  return 0;
+}

--- a/packages/daemon/tests/cli/cmd-code.test.ts
+++ b/packages/daemon/tests/cli/cmd-code.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { type CodeStoreLike, runCodeCommand } from '../../src/cli/cmd-code.ts';
+
+function makeIO() {
+  const out: string[] = [];
+  return { io: { out: (msg: string) => out.push(msg) }, out };
+}
+
+function makeStore(
+  initial: string | null,
+  refreshValue = 'NEWCODE-42',
+): CodeStoreLike & {
+  loadCalls: number;
+  refreshCalls: number;
+} {
+  let stored = initial;
+  const self = {
+    loadCalls: 0,
+    refreshCalls: 0,
+    load(): string | null {
+      self.loadCalls++;
+      return stored;
+    },
+    refresh(): string {
+      self.refreshCalls++;
+      stored = refreshValue;
+      return refreshValue;
+    },
+  };
+  return self;
+}
+
+describe('runCodeCommand', () => {
+  test('--refresh prints new code and restart hint, rotates the store', () => {
+    const store = makeStore('OLD', 'ROTATED-1');
+    const { io, out } = makeIO();
+    const code = runCodeCommand(store, { refresh: true }, io);
+    expect(code).toBe(0);
+    expect(store.loadCalls).toBe(0);
+    expect(store.refreshCalls).toBe(1);
+    expect(out[0]).toBe('New permanent connection code: ROTATED-1');
+    expect(out[1]).toBe('Restart the daemon for the new code to take effect.');
+    expect(out.some((m) => m.includes('By default, codes rotate on each reconnect'))).toBe(true);
+  });
+
+  test('default (no refresh) prints existing code if present', () => {
+    const store = makeStore('EXISTING-CODE');
+    const { io, out } = makeIO();
+    const code = runCodeCommand(store, {}, io);
+    expect(code).toBe(0);
+    expect(store.loadCalls).toBe(1);
+    expect(store.refreshCalls).toBe(0);
+    expect(out[0]).toBe('Permanent connection code: EXISTING-CODE');
+    expect(out[1]).toBe('Use --permanent-code flag when starting daemon to enable this code.');
+  });
+
+  test('default generates a new code when none exists and annotates it', () => {
+    const store = makeStore(null, 'NEW-AUTO');
+    const { io, out } = makeIO();
+    const code = runCodeCommand(store, {}, io);
+    expect(code).toBe(0);
+    expect(store.loadCalls).toBe(1);
+    expect(store.refreshCalls).toBe(1);
+    expect(out[0]).toBe('Permanent connection code: NEW-AUTO (newly generated)');
+    expect(out[1]).toBe('Use --permanent-code flag when starting daemon to enable this code.');
+  });
+
+  test('always appends the exact two-line informational footer', () => {
+    const store = makeStore('X');
+    const { io, out } = makeIO();
+    runCodeCommand(store, {}, io);
+    const footer = out.slice(-2);
+    // Character-for-character equivalence, including the leading \n on the
+    // first line — matches the original console.log('\nNote: ...') exactly.
+    expect(footer[0]).toBe(
+      '\nNote: By default, codes rotate on each reconnect. Use --permanent-code to',
+    );
+    expect(footer[1]).toBe(
+      'persist a fixed code (requires Ed25519 authentication for relay connections).',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 8** (see \`.context/cleanup-audit.md\`).

Extracts the inline \`code\` subcommand block out of cli.ts into \`packages/daemon/src/cli/cmd-code.ts\`.

### API

\`\`\`ts
runCodeCommand(store: CodeStoreLike, opts?, io?): number
\`\`\`

\`CodeStoreLike\` is a minimal structural interface (\`load\`, \`refresh\`) so tests can use a counter-backed fake without importing the real \`CodeStore\` (which reads/writes \`~/.remi/code-store\`).

### Behavior preserved

Three code paths, verified character-for-character against the old inline block:
- \`--refresh\` → rotates, prints \"New permanent connection code: X\" + \"Restart the daemon...\"
- default + existing code → prints \"Permanent connection code: X\" + flag hint
- default + missing code → auto-generates, prints \"Permanent connection code: X (newly generated)\" + flag hint
- Always appends the two-line \"Note: By default, codes rotate...\" footer

### Test coverage

4 characterization tests cover all three branches plus the footer invariant. The test store counts \`load\`/\`refresh\` calls so we can assert that \`--refresh\` never calls \`load\` and the default path only refreshes when load returned null.

### Running cli.ts tally after 8 cleanup PRs

| PR | cli.ts delta |
|----|--------------|
| #325-#331 | -265 |
| #332 (this) | -18 |
| **Total** | **-283** |

cli.ts: 3894 → ~3611

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/cmd-code.test.ts\` — 4/4 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 651/651 pass