### PR TITLE
refactor(cli): extract 'remi ls' subcommand into cmd-ls handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -577,48 +577,17 @@ const liveSessionsRegistry = new SessionRegistryFile();
 
 // Handle 'ls' subcommand: query live sessions from running daemon(s)
 if (cliSubcommand === 'ls') {
-  const explicitPort =
-    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined);
-  if (cliNetwork) {
-    const { runNetworkLs } = await import('./cli/ls-client.ts');
-    try {
-      await runNetworkLs({
-        localPort: explicitPort ?? DEFAULT_BASE_PORT,
-        localPorts: liveSessionsRegistry.getLivePorts(),
-      });
-    } catch (err) {
-      console.error(errorToString(err));
-      process.exit(1);
-    }
-  } else if (explicitPort) {
-    // Explicit port: query single daemon on given (or default) host
-    const { runLsClient } = await import('./cli/ls-client.ts');
-    try {
-      await runLsClient({ host: cliHost ?? 'localhost', port: explicitPort });
-    } catch (err) {
-      console.error(errorToString(err));
-      process.exit(1);
-    }
-  } else if (cliHost) {
-    // Host without port: probe the standard port range on that host
-    const { runHostLs, getDefaultPortRange } = await import('./cli/ls-client.ts');
-    try {
-      await runHostLs({ host: cliHost, ports: getDefaultPortRange() });
-    } catch (err) {
-      console.error(errorToString(err));
-      process.exit(1);
-    }
-  } else {
-    // No explicit port: discover all local remi sessions via live registry
-    const { runMultiPortLs } = await import('./cli/ls-client.ts');
-    try {
-      await runMultiPortLs({ registry: liveSessionsRegistry });
-    } catch (err) {
-      console.error(errorToString(err));
-      process.exit(1);
-    }
-  }
-  process.exit(0);
+  const { runLsCommand } = await import('./cli/cmd-ls.ts');
+  process.exit(
+    await runLsCommand(
+      {
+        ...(cliPort !== undefined && { port: cliPort }),
+        ...(cliHost !== undefined && { host: cliHost }),
+        network: cliNetwork,
+      },
+      liveSessionsRegistry,
+    ),
+  );
 }
 
 // Handle 'recent' subcommand: browse recent project directories

--- a/packages/daemon/src/cli/cmd-ls.ts
+++ b/packages/daemon/src/cli/cmd-ls.ts
@@ -1,0 +1,75 @@
+/**
+ * Handler for `remi ls` — list live sessions with four branches:
+ *
+ *   1. `--network` → scan the LAN via mDNS for remi daemons
+ *   2. Explicit port (or REMI_PORT) → query a single daemon (optionally on --host)
+ *   3. `--host` without port → probe the standard port range on that host
+ *   4. Default → discover all local sessions via the live registry
+ *
+ * The four `ls-client` helpers stay in their current module; this handler
+ * decides which to call based on the CLI flag combination and uniformly maps
+ * thrown errors to `console.error` + exit code 1.
+ */
+
+import { errorToString } from '@remi/shared';
+import { DEFAULT_BASE_PORT, type SessionRegistryFile } from '../session/session-registry-file.ts';
+
+export interface LsCommandIO {
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: LsCommandIO = { err: (msg) => console.error(msg) };
+
+export interface LsCommandOptions {
+  readonly port?: number;
+  readonly host?: string;
+  readonly network?: boolean;
+}
+
+/** Injectable ls-client helpers; the default loader lazy-imports the real ones. */
+export interface LsClientHelpers {
+  runNetworkLs: (args: { localPort: number; localPorts: number[] }) => Promise<void>;
+  runLsClient: (args: { host: string; port: number }) => Promise<void>;
+  runHostLs: (args: { host: string; ports: number[] }) => Promise<void>;
+  getDefaultPortRange: () => number[];
+  runMultiPortLs: (args: { registry: SessionRegistryFile }) => Promise<void>;
+}
+
+const defaultLoader = async (): Promise<LsClientHelpers> => import('./ls-client.ts');
+
+export async function runLsCommand(
+  opts: LsCommandOptions,
+  registry: SessionRegistryFile,
+  io: LsCommandIO = defaultIO,
+  loadHelpers: () => Promise<LsClientHelpers> = defaultLoader,
+): Promise<number> {
+  const envPort = process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined;
+  const explicitPort = opts.port ?? envPort;
+  const helpers = await loadHelpers();
+
+  try {
+    if (opts.network) {
+      await helpers.runNetworkLs({
+        localPort: explicitPort ?? DEFAULT_BASE_PORT,
+        localPorts: registry.getLivePorts(),
+      });
+      return 0;
+    }
+    if (explicitPort) {
+      // Explicit port: query single daemon on given (or default) host
+      await helpers.runLsClient({ host: opts.host ?? 'localhost', port: explicitPort });
+      return 0;
+    }
+    if (opts.host) {
+      // Host without port: probe the standard port range on that host
+      await helpers.runHostLs({ host: opts.host, ports: helpers.getDefaultPortRange() });
+      return 0;
+    }
+    // No explicit port: discover all local remi sessions via live registry
+    await helpers.runMultiPortLs({ registry });
+    return 0;
+  } catch (err) {
+    io.err(errorToString(err));
+    return 1;
+  }
+}

--- a/packages/daemon/tests/cli/cmd-ls.test.ts
+++ b/packages/daemon/tests/cli/cmd-ls.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { type LsClientHelpers, runLsCommand } from '../../src/cli/cmd-ls.ts';
+import type { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
+
+type Call = {
+  fn: 'runNetworkLs' | 'runLsClient' | 'runHostLs' | 'runMultiPortLs' | 'getDefaultPortRange';
+  args: unknown;
+};
+
+function makeIO() {
+  const err: string[] = [];
+  return { io: { err: (m: string) => err.push(m) }, err };
+}
+
+function makeRegistry(livePorts: number[] = [18765, 18766]): SessionRegistryFile {
+  return { getLivePorts: () => livePorts } as unknown as SessionRegistryFile;
+}
+
+function makeHelpers(opts?: { throwOn?: keyof LsClientHelpers }): {
+  helpers: LsClientHelpers;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const record = (fn: Call['fn'], throwOnMatch: boolean) => async (args: unknown) => {
+    calls.push({ fn, args });
+    if (throwOnMatch) throw new Error(`${fn} failed`);
+  };
+  const helpers: LsClientHelpers = {
+    runNetworkLs: record('runNetworkLs', opts?.throwOn === 'runNetworkLs'),
+    runLsClient: record('runLsClient', opts?.throwOn === 'runLsClient'),
+    runHostLs: record('runHostLs', opts?.throwOn === 'runHostLs'),
+    runMultiPortLs: record('runMultiPortLs', opts?.throwOn === 'runMultiPortLs'),
+    getDefaultPortRange: () => {
+      calls.push({ fn: 'getDefaultPortRange', args: undefined });
+      return [18765, 18766, 18767];
+    },
+  };
+  return { helpers, calls };
+}
+
+describe('runLsCommand', () => {
+  let savedPort: string | undefined;
+
+  beforeEach(() => {
+    savedPort = process.env['REMI_PORT'];
+    // biome-ignore lint/performance/noDelete: tests must remove the env var, not undefined-stringify.
+    delete process.env['REMI_PORT'];
+  });
+
+  afterEach(() => {
+    if (savedPort === undefined) {
+      // biome-ignore lint/performance/noDelete: same reason.
+      delete process.env['REMI_PORT'];
+    } else {
+      process.env['REMI_PORT'] = savedPort;
+    }
+  });
+
+  test('--network routes to runNetworkLs with live ports', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    const code = await runLsCommand(
+      { network: true },
+      makeRegistry([18765, 18766]),
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(calls[0]?.fn).toBe('runNetworkLs');
+    expect((calls[0]?.args as { localPorts: number[] }).localPorts).toEqual([18765, 18766]);
+  });
+
+  test('explicit port routes to runLsClient on localhost', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    const code = await runLsCommand({ port: 18800 }, makeRegistry(), io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls[0]).toEqual({
+      fn: 'runLsClient',
+      args: { host: 'localhost', port: 18800 },
+    });
+  });
+
+  test('explicit port + host routes to runLsClient on that host', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runLsCommand(
+      { port: 18800, host: 'remote.example' },
+      makeRegistry(),
+      io,
+      async () => helpers,
+    );
+    expect(calls[0]).toEqual({
+      fn: 'runLsClient',
+      args: { host: 'remote.example', port: 18800 },
+    });
+  });
+
+  test('host without port routes to runHostLs with default port range', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runLsCommand({ host: 'remote.example' }, makeRegistry(), io, async () => helpers);
+    expect(calls.map((c) => c.fn)).toEqual(['getDefaultPortRange', 'runHostLs']);
+    expect(calls[1]).toEqual({
+      fn: 'runHostLs',
+      args: { host: 'remote.example', ports: [18765, 18766, 18767] },
+    });
+  });
+
+  test('no port, no host, no network routes to runMultiPortLs with registry', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    const registry = makeRegistry([18765]);
+    await runLsCommand({}, registry, io, async () => helpers);
+    expect(calls[0]?.fn).toBe('runMultiPortLs');
+    expect((calls[0]?.args as { registry: SessionRegistryFile }).registry).toBe(registry);
+  });
+
+  test('REMI_PORT env acts as explicit port when --port is absent', async () => {
+    process.env['REMI_PORT'] = '19000';
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runLsCommand({}, makeRegistry(), io, async () => helpers);
+    expect(calls[0]).toEqual({
+      fn: 'runLsClient',
+      args: { host: 'localhost', port: 19000 },
+    });
+  });
+
+  test('--port overrides REMI_PORT', async () => {
+    process.env['REMI_PORT'] = '19000';
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runLsCommand({ port: 18888 }, makeRegistry(), io, async () => helpers);
+    expect((calls[0]?.args as { port: number }).port).toBe(18888);
+  });
+
+  test('errors are caught, printed to stderr, and exit 1', async () => {
+    const { io, err } = makeIO();
+    const { helpers } = makeHelpers({ throwOn: 'runMultiPortLs' });
+    const code = await runLsCommand({}, makeRegistry(), io, async () => helpers);
+    expect(code).toBe(1);
+    expect(err).toEqual(['runMultiPortLs failed']);
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 9** (see \`.context/cleanup-audit.md\`).

Extracts the four-branch 'ls' subcommand dispatch out of cli.ts into \`packages/daemon/src/cli/cmd-ls.ts\`.

### Branches preserved

| Condition | Helper called |
|-----------|---------------|
| \`--network\` | \`runNetworkLs\` with live ports from registry |
| Explicit port (or \`REMI_PORT\` env) | \`runLsClient\` on \`localhost\` or \`--host\` |
| \`--host\` without port | \`runHostLs\` with default port range |
| Default | \`runMultiPortLs\` with full live registry |

### Intentional API: injectable helpers

\`\`\`ts
runLsCommand(
  opts: LsCommandOptions,
  registry: SessionRegistryFile,
  io?: LsCommandIO,
  loadHelpers?: () => Promise<LsClientHelpers>,
): Promise<number>
\`\`\`

\`loadHelpers\` defaults to a dynamic import of \`ls-client.ts\` — matches the existing lazy-load pattern. For tests, a recording stub is passed so branch selection can be asserted without real daemon I/O.

### Test coverage

8 characterization tests:
1. \`--network\` routes to runNetworkLs
2. Explicit port → runLsClient on localhost
3. Explicit port + host → runLsClient on that host
4. Host without port → runHostLs with default range
5. Default → runMultiPortLs with registry
6. \`REMI_PORT\` env acts as explicit port when flag absent
7. \`--port\` overrides \`REMI_PORT\`
8. Thrown errors caught, stderr + exit 1

### Impact

- cli.ts drops **31 lines** (44 inline → 13 at call site)
- New module: 74 lines
- Running tally after 9 cleanup PRs: cli.ts 3894 → ~3580, −314 lines (−8.1%)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/cmd-ls.test.ts\` — 8/8 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 667/667 pass