### PR TITLE
refactor(cli): extract log-file session into its own module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -41,7 +41,6 @@ const DAEMON_STATUS_FILE = path.join(REMI_DIR, 'daemon-status.json');
 // Status file is per-port so multiple wrapper sessions don't overwrite each other.
 // The statusline script uses $REMI_PORT to read the correct file.
 let STATUS_FILE = path.join(REMI_DIR, 'status.json'); // Updated after PORT is resolved
-let logFd: number | null = null;
 
 // In wrapper mode, we save the real stdout file descriptor before overriding.
 // Raw PTY bytes are written directly via fs.writeSync to avoid decode/encode.
@@ -60,22 +59,6 @@ function selectPushCategory(options: readonly QuestionOption[]): string | undefi
 
 function ensureRemiDir(): void {
   fs.mkdirSync(REMI_DIR, { recursive: true });
-}
-
-function openLogFile(): number {
-  ensureRemiDir();
-  const fd = fs.openSync(LOG_FILE, 'a');
-  fs.writeSync(fd, `\n--- Remi session started at ${new Date().toISOString()} ---\n`);
-  return fd;
-}
-
-function writeToLog(msg: string): void {
-  if (logFd === null) return;
-  try {
-    fs.writeSync(logFd, `${msg}\n`);
-  } catch {
-    // Silently drop: in wrapper mode, terminal cleanliness is non-negotiable
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -195,6 +178,7 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
+import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
@@ -3213,20 +3197,8 @@ if (cliDaemonMode) {
   // (via fs.writeSync to stdout fd) can reach the actual terminal.
   ptyStdoutFd = 1; // stdout file descriptor
 
-  try {
-    logFd = openLogFile();
-  } catch (logErr) {
-    // Fall back to a temp file so diagnostics are not completely lost
-    try {
-      const tmpLog = path.join(os.tmpdir(), `remi-${process.pid}.log`);
-      logFd = fs.openSync(tmpLog, 'a');
-      fs.writeSync(logFd, `[remi] Primary log file failed: ${errorToString(logErr)}\n`);
-      fs.writeSync(2, `[remi] Logging to ${tmpLog} (primary log unavailable)\n`);
-    } catch {
-      // Last resort: write one message to stderr before it gets overridden
-      fs.writeSync(2, '[remi] WARNING: All logging disabled (cannot open any log file)\n');
-    }
-  }
+  ensureRemiDir();
+  startLogFileSession(LOG_FILE, { dir: os.tmpdir(), pid: process.pid });
 
   // Layer 1: Override console methods (catches Bun's native console path)
   const toLog = (...args: unknown[]) => writeToLog(args.map(String).join(' '));
@@ -3249,16 +3221,7 @@ if (cliDaemonMode) {
   process.stderr.write = streamToLog as typeof process.stderr.write;
 
   // Close log fd as the very last thing on process exit
-  process.on('exit', () => {
-    if (logFd !== null) {
-      try {
-        fs.closeSync(logFd);
-      } catch {
-        // ignore
-      }
-      logFd = null;
-    }
-  });
+  process.on('exit', endLogFileSession);
 
   // Install status line script (~/.remi/statusline.sh) and auto-configure Claude Code settings
   installStatusLine(REMI_DIR);

--- a/packages/daemon/src/cli/log-file.ts
+++ b/packages/daemon/src/cli/log-file.ts
@@ -1,0 +1,132 @@
+/**
+ * Low-level log-file session for wrapper mode.
+ *
+ * In wrapper mode, Remi overrides stdout/stderr to keep the Claude Code
+ * terminal clean. Diagnostics are redirected into `~/.remi/remi.log` via the
+ * functions in this module.
+ *
+ * Lifecycle:
+ *   1. `startLogFileSession(primary, fallback?)` - opens the primary log
+ *      file; on failure, attempts a fallback in the system tmp directory.
+ *   2. `writeToLog(msg)` - appends a line; silent no-op if the session never
+ *      opened. Errors are swallowed so a full disk never corrupts the PTY.
+ *   3. `endLogFileSession()` - closes the file descriptor. Safe to call
+ *      multiple times.
+ *
+ * The module owns a single global log fd, matching the single log-file-per-
+ * process assumption of wrapper mode.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+
+let logFd: number | null = null;
+
+/** Result of `startLogFileSession`. */
+export interface LogSessionResult {
+  /** The fd that's been opened; null if all attempts failed. */
+  readonly fd: number | null;
+  /** The path that was actually opened (primary or fallback). */
+  readonly path: string | null;
+  /** True when the fallback path was used because the primary failed. */
+  readonly usedFallback: boolean;
+  /** Error from the primary open, if any. */
+  readonly primaryError?: unknown;
+}
+
+/** Options for the fallback log file. Omit to disable fallback. */
+export interface FallbackLogOptions {
+  /** Directory for the fallback log file (e.g. `os.tmpdir()`). */
+  readonly dir: string;
+  /** PID suffix so parallel wrapper instances do not collide. */
+  readonly pid: number;
+}
+
+/**
+ * Open the log file, falling back to a tmp path if the primary open fails.
+ *
+ * On success writes a `--- Remi session started at ... ---` header to the
+ * opened fd. On fallback, first writes a note to the fallback log describing
+ * the primary failure, then writes a one-line warning to fd 2 so the user
+ * sees where diagnostics went before stderr is redirected elsewhere.
+ *
+ * Never throws. If both primary and fallback fail, the session fd is `null`
+ * and future `writeToLog` calls become no-ops.
+ */
+export function startLogFileSession(
+  primary: string,
+  fallback?: FallbackLogOptions,
+): LogSessionResult {
+  try {
+    fs.mkdirSync(path.dirname(primary), { recursive: true });
+    const fd = fs.openSync(primary, 'a');
+    fs.writeSync(fd, `\n--- Remi session started at ${new Date().toISOString()} ---\n`);
+    logFd = fd;
+    return { fd, path: primary, usedFallback: false };
+  } catch (primaryError) {
+    if (!fallback) {
+      logFd = null;
+      return { fd: null, path: null, usedFallback: false, primaryError };
+    }
+    try {
+      const tmpLog = path.join(fallback.dir, `remi-${fallback.pid}.log`);
+      const fd = fs.openSync(tmpLog, 'a');
+      fs.writeSync(fd, `[remi] Primary log file failed: ${errorToString(primaryError)}\n`);
+      // Best-effort notice on the real stderr before it gets redirected.
+      try {
+        fs.writeSync(2, `[remi] Logging to ${tmpLog} (primary log unavailable)\n`);
+      } catch {
+        // stderr may already be closed/redirected; swallow.
+      }
+      logFd = fd;
+      return { fd, path: tmpLog, usedFallback: true, primaryError };
+    } catch {
+      try {
+        fs.writeSync(2, '[remi] WARNING: All logging disabled (cannot open any log file)\n');
+      } catch {
+        // Nothing left to try.
+      }
+      logFd = null;
+      return { fd: null, path: null, usedFallback: true, primaryError };
+    }
+  }
+}
+
+/**
+ * Append a line to the currently-open log file.
+ * Silent no-op if no session has been started, or if the underlying write
+ * fails. In wrapper mode, terminal cleanliness is non-negotiable — never
+ * surface IO errors to the user's terminal.
+ */
+export function writeToLog(msg: string): void {
+  if (logFd === null) return;
+  try {
+    fs.writeSync(logFd, `${msg}\n`);
+  } catch {
+    // Silently drop.
+  }
+}
+
+/**
+ * Close the log file and reset internal state. Safe to call multiple times.
+ * Typical call site: `process.on('exit', endLogFileSession)`.
+ */
+export function endLogFileSession(): void {
+  if (logFd === null) return;
+  try {
+    fs.closeSync(logFd);
+  } catch {
+    // Already-closed fd or descriptor exhaustion — nothing to recover.
+  }
+  logFd = null;
+}
+
+/**
+ * Returns the current log fd, or null if no session is open.
+ * Exposed so callers that need to dup2 onto the log fd can do so without
+ * maintaining their own reference.
+ */
+export function getLogFd(): number | null {
+  return logFd;
+}

--- a/packages/daemon/tests/cli/log-file.test.ts
+++ b/packages/daemon/tests/cli/log-file.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  endLogFileSession,
+  getLogFd,
+  startLogFileSession,
+  writeToLog,
+} from '../../src/cli/log-file.ts';
+
+describe('log-file session', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-log-'));
+    // Tests share module state; make sure previous runs aren't leaking.
+    endLogFileSession();
+  });
+
+  afterEach(() => {
+    endLogFileSession();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('opens the primary log file and writes the session header', () => {
+    const primary = path.join(sandbox, 'remi.log');
+    const result = startLogFileSession(primary);
+    expect(result.fd).not.toBeNull();
+    expect(result.path).toBe(primary);
+    expect(result.usedFallback).toBe(false);
+    expect(fs.existsSync(primary)).toBe(true);
+    const content = fs.readFileSync(primary, 'utf-8');
+    expect(content).toMatch(/^\n--- Remi session started at /);
+  });
+
+  test('creates the primary log parent directory when absent', () => {
+    const primary = path.join(sandbox, 'nested', 'dir', 'remi.log');
+    const result = startLogFileSession(primary);
+    expect(result.usedFallback).toBe(false);
+    expect(fs.existsSync(primary)).toBe(true);
+  });
+
+  test('falls back to the fallback dir when primary parent cannot be created', () => {
+    // Put a regular file where the primary parent needs to be — mkdirSync will fail.
+    const blocker = path.join(sandbox, 'blocker');
+    fs.writeFileSync(blocker, 'not a directory');
+    const primary = path.join(blocker, 'nested', 'remi.log');
+    const result = startLogFileSession(primary, { dir: sandbox, pid: 99999 });
+    expect(result.usedFallback).toBe(true);
+    const expectedPath = path.join(sandbox, 'remi-99999.log');
+    expect(result.path).toBe(expectedPath);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    const content = fs.readFileSync(expectedPath, 'utf-8');
+    expect(content).toContain('[remi] Primary log file failed:');
+  });
+
+  test('returns null fd with no session if both primary and fallback fail', () => {
+    const blocker = path.join(sandbox, 'blocker');
+    fs.writeFileSync(blocker, 'not a dir');
+    const primary = path.join(blocker, 'nested', 'x.log');
+    const badFallbackDir = path.join(blocker, 'also-nested');
+    const result = startLogFileSession(primary, { dir: badFallbackDir, pid: 1 });
+    expect(result.fd).toBeNull();
+    expect(result.path).toBeNull();
+    expect(result.usedFallback).toBe(true);
+    expect(getLogFd()).toBeNull();
+  });
+
+  test('writeToLog appends lines with trailing newline', () => {
+    const primary = path.join(sandbox, 'remi.log');
+    startLogFileSession(primary);
+    writeToLog('hello');
+    writeToLog('world');
+    endLogFileSession();
+    const content = fs.readFileSync(primary, 'utf-8');
+    expect(content).toContain('\nhello\n');
+    expect(content).toContain('\nworld\n');
+  });
+
+  test('writeToLog is a silent no-op with no open session', () => {
+    expect(() => writeToLog('nothing')).not.toThrow();
+  });
+
+  test('endLogFileSession is idempotent', () => {
+    const primary = path.join(sandbox, 'remi.log');
+    startLogFileSession(primary);
+    endLogFileSession();
+    endLogFileSession();
+    expect(getLogFd()).toBeNull();
+  });
+
+  test('getLogFd returns the current fd or null', () => {
+    const primary = path.join(sandbox, 'remi.log');
+    expect(getLogFd()).toBeNull();
+    const result = startLogFileSession(primary);
+    expect(getLogFd()).toBe(result.fd);
+  });
+
+  test('startLogFileSession without fallback returns null fd on failure', () => {
+    const blocker = path.join(sandbox, 'blocker2');
+    fs.writeFileSync(blocker, 'not a dir');
+    const primary = path.join(blocker, 'x.log');
+    const result = startLogFileSession(primary);
+    expect(result.fd).toBeNull();
+    expect(result.usedFallback).toBe(false);
+    expect(result.primaryError).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 10** (see \`.context/cleanup-audit.md\`).

Moves the wrapper-mode log-file state + helpers out of cli.ts into \`packages/daemon/src/cli/log-file.ts\` with proper encapsulation.

### API

- **\`startLogFileSession(primary, fallback?)\`** — opens primary, falls back to a tmp path if primary fails, writes the session header, stores the fd inside the module. Always returns a \`LogSessionResult\` (never throws).
- **\`writeToLog(msg)\`** — no-op if no session is open; swallows IO errors (wrapper mode must never corrupt the PTY).
- **\`endLogFileSession()\`** — idempotent close, exit-handler safe.
- **\`getLogFd()\`** — for callers that need the raw fd.

### Impact on cli.ts

- Removes the mutable \`logFd\` state (moves inside the module)
- Deletes \`openLogFile()\` + \`writeToLog()\` function definitions
- Replaces the 15-line \"fallback open\" dance with a single \`startLogFileSession(...)\` call
- Replaces the 9-line on-exit close block with \`process.on('exit', endLogFileSession)\`
- **cli.ts drops 41 lines**

### Test coverage

9 characterization tests:
- Primary open writes the session header
- Primary parent directory is created on demand
- Fallback kicks in when primary parent can't be created; fallback log contains \"Primary log file failed:\" note
- Both-fail path returns \`null\` fd + leaves \`getLogFd()\` null
- \`writeToLog\` adds trailing newlines
- \`writeToLog\` is a silent no-op without an open session
- \`endLogFileSession\` is idempotent
- Primary failure without fallback returns null fd + \`primaryError\` set

### Running cli.ts tally after 10 cleanup PRs

| PR | Δ |
|----|---|
| #325–#334 | −314 |
| #335 (this) | −41 |
| **Total** | **−355** |

cli.ts: 3894 → ~3539 (−9.1%).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/log-file.test.ts\` — 9/9 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 676/676 pass