### PR TITLE
refactor(cli): encapsulate RemiStatus writer into its own class

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -65,76 +65,33 @@ function ensureRemiDir(): void {
 // Status file for status line integration
 // Guard: only writes in wrapper mode (wrapperMode is set during arg parsing)
 // ---------------------------------------------------------------------------
-type RemiSessionStatus = AgentStatus | 'starting';
-
-interface RemiStatus {
-  pid: number;
-  connections: number;
-  sessionStatus: RemiSessionStatus;
-  adapters: string[];
-  wsPort: number;
-  sessionId: UUID | null;
-  repo: string;
-  branch: string;
-}
-
 import { detectGitInfo, loadDotenvFile } from './cli/startup-env.ts';
+import { type RemiStatus, StatusWriter } from './cli/status-writer.ts';
 
 const gitInfo = detectGitInfo();
 
-const remiStatus: RemiStatus = {
-  pid: process.pid,
-  connections: 0,
-  sessionStatus: 'starting',
-  adapters: [],
-  wsPort: 0,
-  sessionId: null,
-  repo: gitInfo.repo,
-  branch: gitInfo.branch,
-};
+const statusWriter = new StatusWriter(
+  {
+    pid: process.pid,
+    connections: 0,
+    sessionStatus: 'starting',
+    adapters: [],
+    wsPort: 0,
+    sessionId: null,
+    repo: gitInfo.repo,
+    branch: gitInfo.branch,
+  },
+  {
+    getTargetFile: () => (cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE),
+    isEnabled: () => wrapperMode || cliDaemonMode,
+    writeLog: writeToLog,
+  },
+);
 
-let statusWriteErrorLogged = false;
-let statusWriteTimer: ReturnType<typeof setTimeout> | null = null;
-
-function updateRemiStatus(patch: Partial<RemiStatus>): void {
-  Object.assign(remiStatus, patch);
-  scheduleStatusWrite();
-}
-
-function scheduleStatusWrite(): void {
-  if (statusWriteTimer) return;
-  statusWriteTimer = setTimeout(() => {
-    statusWriteTimer = null;
-    writeStatus();
-  }, 300);
-}
-
-function writeStatus(): void {
-  if (!wrapperMode && !cliDaemonMode) return;
-  // Daemon mode writes to daemon-status.json; wrapper writes to status.json
-  const targetFile = cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE;
-  // Atomic write: write to temp file then rename to avoid readers seeing partial JSON
-  const tmpFile = `${targetFile}.tmp`;
-  try {
-    fs.writeFileSync(tmpFile, JSON.stringify(remiStatus));
-    fs.renameSync(tmpFile, targetFile);
-    statusWriteErrorLogged = false;
-  } catch (err) {
-    if (!statusWriteErrorLogged) {
-      writeToLog(`[error] Failed to write status file: ${err}`);
-      statusWriteErrorLogged = true;
-    }
-  }
-}
-
-function cleanupStatusFile(): void {
-  const targetFile = cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE;
-  try {
-    fs.unlinkSync(targetFile);
-  } catch {
-    // File may not exist during cleanup
-  }
-}
+/** Thin back-compat aliases so existing cli.ts call sites keep working. */
+const remiStatus: Readonly<RemiStatus> = statusWriter.state;
+const updateRemiStatus = (patch: Partial<RemiStatus>): void => statusWriter.update(patch);
+const cleanupStatusFile = (): void => statusWriter.cleanup();
 
 loadDotenvFile();
 

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -1,0 +1,117 @@
+/**
+ * Debounced writer for the per-session status file that the Claude Code
+ * statusline script reads on every prompt.
+ *
+ * Encapsulates three concerns that used to live as free-functions in cli.ts:
+ *
+ *   1. Mutable in-memory status object (`RemiStatus`).
+ *   2. 300 ms debounce — many updates in quick succession (e.g. during a
+ *      tool call) collapse into a single disk write.
+ *   3. Atomic write-then-rename so readers never see partial JSON.
+ *
+ * The writer is enabled only when the caller says so (via `isEnabled`). The
+ * target path is resolved lazily each write via `getTargetFile` so the
+ * STATUS_FILE rename at port-resolution time still picks up correctly.
+ *
+ * Errors during write are logged exactly once via `writeToLog` so a
+ * persistently-failing disk never floods the log.
+ */
+
+import * as fs from 'node:fs';
+import type { AgentStatus, UUID } from '@remi/shared';
+
+export type RemiSessionStatus = AgentStatus | 'starting';
+
+export interface RemiStatus {
+  pid: number;
+  connections: number;
+  sessionStatus: RemiSessionStatus;
+  adapters: string[];
+  wsPort: number;
+  sessionId: UUID | null;
+  repo: string;
+  branch: string;
+}
+
+export interface StatusWriterDeps {
+  /** Returns the path to write to. Called on every flush so caller can swap files at runtime. */
+  readonly getTargetFile: () => string;
+  /** Guard — return false to skip writes (e.g. not in wrapper/daemon mode). */
+  readonly isEnabled: () => boolean;
+  /** Logger for write errors; called at most once per consecutive failure streak. */
+  readonly writeLog: (msg: string) => void;
+  /** Debounce window in ms. Default 300. Tests override to 0. */
+  readonly debounceMs?: number;
+}
+
+export class StatusWriter {
+  private readonly status: RemiStatus;
+  private readonly deps: Required<StatusWriterDeps>;
+  private errorLogged = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(initial: RemiStatus, deps: StatusWriterDeps) {
+    this.status = { ...initial };
+    this.deps = {
+      ...deps,
+      debounceMs: deps.debounceMs ?? 300,
+    };
+  }
+
+  /** Read-only snapshot of the current status. */
+  get state(): Readonly<RemiStatus> {
+    return this.status;
+  }
+
+  /** Apply a partial patch and schedule a debounced flush. */
+  update(patch: Partial<RemiStatus>): void {
+    Object.assign(this.status, patch);
+    this.schedule();
+  }
+
+  /** Immediately write to disk (skips the debounce). Used on graceful shutdown. */
+  flush(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.write();
+  }
+
+  /** Remove the status file. Typical caller is the shutdown handler. */
+  cleanup(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    try {
+      fs.unlinkSync(this.deps.getTargetFile());
+    } catch {
+      // File may not exist during cleanup
+    }
+  }
+
+  private schedule(): void {
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.write();
+    }, this.deps.debounceMs);
+  }
+
+  private write(): void {
+    if (!this.deps.isEnabled()) return;
+    const targetFile = this.deps.getTargetFile();
+    const tmpFile = `${targetFile}.tmp`;
+    try {
+      fs.writeFileSync(tmpFile, JSON.stringify(this.status));
+      fs.renameSync(tmpFile, targetFile);
+      this.errorLogged = false;
+    } catch (err) {
+      if (!this.errorLogged) {
+        this.deps.writeLog(`[error] Failed to write status file: ${err}`);
+        this.errorLogged = true;
+      }
+    }
+  }
+}

--- a/packages/daemon/tests/cli/status-writer.test.ts
+++ b/packages/daemon/tests/cli/status-writer.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { type RemiStatus, StatusWriter } from '../../src/cli/status-writer.ts';
+
+function baseStatus(overrides: Partial<RemiStatus> = {}): RemiStatus {
+  return {
+    pid: 12345,
+    connections: 0,
+    sessionStatus: 'starting',
+    adapters: [],
+    wsPort: 0,
+    sessionId: null,
+    repo: 'remi',
+    branch: 'develop',
+    ...overrides,
+  };
+}
+
+describe('StatusWriter', () => {
+  let sandbox: string;
+  let target: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-status-'));
+    target = path.join(sandbox, 'status.json');
+    logs = [];
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('flush writes JSON atomically at the current target path', () => {
+    const writer = new StatusWriter(baseStatus({ connections: 3, adapters: ['ws'] }), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: (m) => logs.push(m),
+      debounceMs: 0,
+    });
+    writer.flush();
+    const content = JSON.parse(fs.readFileSync(target, 'utf-8'));
+    expect(content.connections).toBe(3);
+    expect(content.adapters).toEqual(['ws']);
+  });
+
+  test('update merges the patch into state', () => {
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 0,
+    });
+    writer.update({ connections: 1, sessionStatus: 'executing' });
+    expect(writer.state.connections).toBe(1);
+    expect(writer.state.sessionStatus).toBe('executing');
+    // Unrelated fields preserved.
+    expect(writer.state.pid).toBe(12345);
+  });
+
+  test('state reflects updates across multiple patches', () => {
+    const writer = new StatusWriter(baseStatus({ adapters: ['ws'] }), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 0,
+    });
+    writer.update({ adapters: [...writer.state.adapters, 'tg'] });
+    writer.update({ connections: 5 });
+    expect(writer.state.adapters).toEqual(['ws', 'tg']);
+    expect(writer.state.connections).toBe(5);
+  });
+
+  test('write is a no-op when isEnabled returns false', () => {
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => target,
+      isEnabled: () => false,
+      writeLog: () => {},
+      debounceMs: 0,
+    });
+    writer.flush();
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  test('debounce collapses bursts into a single write', async () => {
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 20,
+    });
+    writer.update({ connections: 1 });
+    writer.update({ connections: 2 });
+    writer.update({ connections: 3 });
+    // Not written yet
+    expect(fs.existsSync(target)).toBe(false);
+    await new Promise((r) => setTimeout(r, 40));
+    const content = JSON.parse(fs.readFileSync(target, 'utf-8'));
+    expect(content.connections).toBe(3);
+  });
+
+  test('getTargetFile is called on every flush so the path can change at runtime', () => {
+    let current = path.join(sandbox, 'first.json');
+    const writer = new StatusWriter(baseStatus({ connections: 1 }), {
+      getTargetFile: () => current,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 0,
+    });
+    writer.flush();
+    expect(fs.existsSync(current)).toBe(true);
+    current = path.join(sandbox, 'second.json');
+    writer.update({ connections: 2 });
+    writer.flush();
+    expect(fs.existsSync(current)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(current, 'utf-8'));
+    expect(content.connections).toBe(2);
+  });
+
+  test('write errors are logged at most once per failure streak', () => {
+    // Point target to a path whose parent is a regular file — writes will fail.
+    const blocker = path.join(sandbox, 'blocker');
+    fs.writeFileSync(blocker, 'not a dir');
+    const bad = path.join(blocker, 'nested', 'status.json');
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => bad,
+      isEnabled: () => true,
+      writeLog: (m) => logs.push(m),
+      debounceMs: 0,
+    });
+    writer.flush();
+    writer.flush();
+    writer.flush();
+    expect(logs.length).toBe(1);
+    expect(logs[0]).toMatch(/^\[error\] Failed to write status file/);
+  });
+
+  test('a successful write after an error resets the error-logged flag', () => {
+    // Start with a bad path, then swap to a good one.
+    let targetRef = path.join(sandbox, 'bad-parent', 'status.json');
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => targetRef,
+      isEnabled: () => true,
+      writeLog: (m) => logs.push(m),
+      debounceMs: 0,
+    });
+    fs.writeFileSync(path.join(sandbox, 'bad-parent'), 'blocker');
+    writer.flush();
+    expect(logs.length).toBe(1);
+    // Restore target to a writable location and flush again
+    targetRef = path.join(sandbox, 'good.json');
+    writer.flush();
+    expect(fs.existsSync(targetRef)).toBe(true);
+    // Now force another failure to prove the flag was reset.
+    targetRef = path.join(sandbox, 'bad-parent', 'other.json');
+    writer.flush();
+    expect(logs.length).toBe(2);
+  });
+
+  test('cleanup removes the target file and cancels pending debounce', async () => {
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 30,
+    });
+    fs.writeFileSync(target, 'pre-existing');
+    writer.update({ connections: 99 }); // schedules a write
+    writer.cleanup();
+    expect(fs.existsSync(target)).toBe(false);
+    // Wait past the debounce window to confirm no delayed write recreates the file.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  test('cleanup is a no-op when the target file does not exist', () => {
+    const writer = new StatusWriter(baseStatus(), {
+      getTargetFile: () => target,
+      isEnabled: () => true,
+      writeLog: () => {},
+      debounceMs: 0,
+    });
+    expect(() => writer.cleanup()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 11** (see \`.context/cleanup-audit.md\`).

This one is structurally bigger than the subcommand extractions — it encapsulates cli.ts's mutable status state + debounced atomic writer into a cohesive class.

### What moves

- \`RemiStatus\` interface → \`packages/daemon/src/cli/status-writer.ts\`
- \`remiStatus\` object + \`statusWriteErrorLogged\` + \`statusWriteTimer\` (mutable state) → instance fields
- \`updateRemiStatus\`, \`scheduleStatusWrite\`, \`writeStatus\`, \`cleanupStatusFile\` → \`StatusWriter\` methods

### Public surface

\`\`\`ts
class StatusWriter {
  constructor(initial: RemiStatus, deps: StatusWriterDeps);
  get state: Readonly<RemiStatus>;
  update(patch: Partial<RemiStatus>): void;
  flush(): void;              // bypasses debounce; for shutdown
  cleanup(): void;             // unlinks file + cancels pending debounce
}
\`\`\`

Dependencies are explicit:
- \`getTargetFile()\` — called every flush so STATUS_FILE can still change at runtime
- \`isEnabled()\` — guard for wrapper/daemon modes
- \`writeLog(msg)\` — error sink
- \`debounceMs\` — default 300 ms

### Zero-breakage bridge

cli.ts keeps three thin wrappers:

\`\`\`ts
const remiStatus: Readonly<RemiStatus> = statusWriter.state;
const updateRemiStatus = (patch) => statusWriter.update(patch);
const cleanupStatusFile = () => statusWriter.cleanup();
\`\`\`

Existing 20+ call sites compile unchanged.

### Test coverage

10 characterization tests:
- flush writes JSON atomically at the current target
- update merges patches into state; unrelated fields preserved
- state persists across patches
- \`isEnabled()=false\` skips writes
- 300 ms debounce collapses bursts into a single write
- \`getTargetFile\` called every flush (runtime path swap)
- Write errors logged **at most once** per failure streak
- Success resets the error-logged flag
- cleanup removes the file AND cancels any pending debounced write
- cleanup is a no-op on missing file

### Impact

cli.ts: 3539 → ~3496 (**−43 lines**).

### Running tally after 11 PRs

| PR | Δ |
|----|---|
| #325–#335 | −355 |
| #336 (this) | −43 |
| **Total** | **−398** |

cli.ts: 3894 → ~3496 (−10.2%).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/status-writer.test.ts\` — 10/10 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 686/686 pass