### PR TITLE
refactor(cli): extract 'remi recent' subcommand into cmd-recent handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -533,29 +533,16 @@ if (cliSubcommand === 'ls') {
 
 // Handle 'recent' subcommand: browse recent project directories
 if (cliSubcommand === 'recent') {
-  const explicitPort =
-    cliPort ?? (process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined);
-
-  if (cliHost || explicitPort) {
-    // Remote mode: query a daemon via WebSocket
-    const { runRecentClient } = await import('./cli/recent-client.ts');
-    try {
-      await runRecentClient({
-        host: cliHost ?? 'localhost',
-        port: explicitPort ?? DEFAULT_BASE_PORT,
-      });
-    } catch (err) {
-      console.error(errorToString(err));
-      process.exit(1);
-    }
-  } else {
-    // Local mode: read SessionStore directly
-    const store = new SessionStore();
-    const { renderRecentDirectories } = await import('./cli/recent-client.ts');
-    const directories = getRecentDirectories(store, 20);
-    renderRecentDirectories(directories);
-  }
-  process.exit(0);
+  const { runRecentCommand } = await import('./cli/cmd-recent.ts');
+  process.exit(
+    await runRecentCommand(
+      {
+        ...(cliPort !== undefined && { port: cliPort }),
+        ...(cliHost !== undefined && { host: cliHost }),
+      },
+      () => getRecentDirectories(new SessionStore(), 20),
+    ),
+  );
 }
 
 // Handle 'kill' subcommand: kill a session by name or ID

--- a/packages/daemon/src/cli/cmd-recent.ts
+++ b/packages/daemon/src/cli/cmd-recent.ts
@@ -1,0 +1,71 @@
+/**
+ * Handler for `remi recent` — browse recent project directories.
+ *
+ * Two branches:
+ *   - Remote: `--host <h>` or `--port <p>` (or `REMI_PORT` env) queries a
+ *     running daemon over WebSocket.
+ *   - Local: reads the persisted `SessionStore` directly.
+ */
+
+import { errorToString } from '@remi/shared';
+import type { RecentDirectory } from '@remi/shared';
+import { DEFAULT_BASE_PORT } from '../session/session-registry-file.ts';
+
+export interface RecentCommandIO {
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: RecentCommandIO = { err: (msg) => console.error(msg) };
+
+export interface RecentCommandOptions {
+  readonly port?: number;
+  readonly host?: string;
+}
+
+/** Injectable helpers so tests avoid the real WebSocket / SessionStore. */
+export interface RecentCommandHelpers {
+  runRecentClient: (args: { host: string; port: number }) => Promise<void>;
+  renderRecentDirectories: (dirs: readonly RecentDirectory[]) => void;
+  listLocalDirectories: () => RecentDirectory[];
+}
+
+const defaultLoader = async (
+  listLocalDirectories: () => RecentDirectory[],
+): Promise<RecentCommandHelpers> => {
+  const mod = await import('./recent-client.ts');
+  return {
+    runRecentClient: mod.runRecentClient,
+    renderRecentDirectories: mod.renderRecentDirectories,
+    listLocalDirectories,
+  };
+};
+
+export async function runRecentCommand(
+  opts: RecentCommandOptions,
+  listLocalDirectories: () => RecentDirectory[],
+  io: RecentCommandIO = defaultIO,
+  loadHelpers: (
+    listLocal: () => RecentDirectory[],
+  ) => Promise<RecentCommandHelpers> = defaultLoader,
+): Promise<number> {
+  const envPort = process.env['REMI_PORT'] ? Number.parseInt(process.env['REMI_PORT']) : undefined;
+  const explicitPort = opts.port ?? envPort;
+  const helpers = await loadHelpers(listLocalDirectories);
+
+  if (opts.host || explicitPort) {
+    // Remote mode
+    try {
+      await helpers.runRecentClient({
+        host: opts.host ?? 'localhost',
+        port: explicitPort ?? DEFAULT_BASE_PORT,
+      });
+      return 0;
+    } catch (err) {
+      io.err(errorToString(err));
+      return 1;
+    }
+  }
+  // Local mode
+  helpers.renderRecentDirectories(helpers.listLocalDirectories());
+  return 0;
+}

--- a/packages/daemon/tests/cli/cmd-recent.test.ts
+++ b/packages/daemon/tests/cli/cmd-recent.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { RecentDirectory } from '@remi/shared';
+import { type RecentCommandHelpers, runRecentCommand } from '../../src/cli/cmd-recent.ts';
+
+function makeIO() {
+  const err: string[] = [];
+  return { io: { err: (m: string) => err.push(m) }, err };
+}
+
+type Call =
+  | { fn: 'runRecentClient'; args: { host: string; port: number } }
+  | { fn: 'renderRecentDirectories'; args: readonly RecentDirectory[] }
+  | { fn: 'listLocalDirectories' };
+
+function makeHelpers(throwOnRemote = false): {
+  helpers: RecentCommandHelpers;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const sampleDir: RecentDirectory = {
+    directory: '/tmp/project',
+    displayName: 'project',
+    lastUsed: '2026-04-17T00:00:00.000Z',
+    sessionCount: 3,
+  };
+  const helpers: RecentCommandHelpers = {
+    runRecentClient: async (args) => {
+      calls.push({ fn: 'runRecentClient', args });
+      if (throwOnRemote) throw new Error('remote unreachable');
+    },
+    renderRecentDirectories: (dirs) => {
+      calls.push({ fn: 'renderRecentDirectories', args: dirs });
+    },
+    listLocalDirectories: () => {
+      calls.push({ fn: 'listLocalDirectories' });
+      return [sampleDir];
+    },
+  };
+  return { helpers, calls };
+}
+
+describe('runRecentCommand', () => {
+  let savedPort: string | undefined;
+
+  beforeEach(() => {
+    savedPort = process.env['REMI_PORT'];
+    // biome-ignore lint/performance/noDelete: restoring unset env var requires removal.
+    delete process.env['REMI_PORT'];
+  });
+
+  afterEach(() => {
+    if (savedPort === undefined) {
+      // biome-ignore lint/performance/noDelete: same reason.
+      delete process.env['REMI_PORT'];
+    } else {
+      process.env['REMI_PORT'] = savedPort;
+    }
+  });
+
+  test('default (no port/host) routes to local mode', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    const code = await runRecentCommand(
+      {},
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    // Calls listLocalDirectories (via helper) then renderRecentDirectories.
+    expect(calls.map((c) => c.fn)).toEqual(['listLocalDirectories', 'renderRecentDirectories']);
+  });
+
+  test('explicit port routes to remote mode on localhost', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    const code = await runRecentCommand(
+      { port: 18800 },
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(calls).toEqual([{ fn: 'runRecentClient', args: { host: 'localhost', port: 18800 } }]);
+  });
+
+  test('--host routes to remote mode on default port', async () => {
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runRecentCommand(
+      { host: 'remote.example' },
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(calls).toEqual([
+      { fn: 'runRecentClient', args: { host: 'remote.example', port: 18765 } },
+    ]);
+  });
+
+  test('REMI_PORT env triggers remote mode when no --host', async () => {
+    process.env['REMI_PORT'] = '19000';
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runRecentCommand(
+      {},
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(calls).toEqual([{ fn: 'runRecentClient', args: { host: 'localhost', port: 19000 } }]);
+  });
+
+  test('--port overrides REMI_PORT', async () => {
+    process.env['REMI_PORT'] = '19000';
+    const { io } = makeIO();
+    const { helpers, calls } = makeHelpers();
+    await runRecentCommand(
+      { port: 18888 },
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(calls).toEqual([{ fn: 'runRecentClient', args: { host: 'localhost', port: 18888 } }]);
+  });
+
+  test('remote-mode errors are caught, stderr written, exit 1, no local fallback', async () => {
+    const { io, err } = makeIO();
+    const { helpers, calls } = makeHelpers(true);
+    const code = await runRecentCommand(
+      { port: 18800 },
+      () => [],
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(err).toEqual(['remote unreachable']);
+    // Must not fall back to local rendering on remote failure.
+    expect(calls.map((c) => c.fn)).toEqual(['runRecentClient']);
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 12** (see \`.context/cleanup-audit.md\`).

Extracts the two-branch 'recent' subcommand dispatch out of cli.ts into \`packages/daemon/src/cli/cmd-recent.ts\`.

### Branches preserved

| Condition | Behavior |
|-----------|----------|
| \`--host\` or \`--port\` (or \`REMI_PORT\` env) | \`runRecentClient\` queries daemon remotely |
| Default | Reads \`SessionStore\` directly + \`renderRecentDirectories\` |

### Intentional API

\`\`\`ts
runRecentCommand(
  opts,
  listLocalDirectories: () => RecentDirectory[],
  io?,
  loadHelpers?,
): Promise<number>
\`\`\`

\`listLocalDirectories\` is passed as an explicit argument — the existing \`getRecentDirectories\` helper in cli.ts has two other callers, so extracting it would widen this PR. Keeping it factored out as a callback matches the cleanup pattern (shallow-DI, no state entanglement).

### Test coverage

6 characterization tests:
1. Default → listLocalDirectories + renderRecentDirectories in order
2. Explicit port → runRecentClient on localhost
3. \`--host\` without port → runRecentClient with DEFAULT_BASE_PORT
4. \`REMI_PORT\` env triggers remote mode
5. \`--port\` overrides \`REMI_PORT\`
6. Remote errors caught, printed to stderr, exit 1

### Impact

- cli.ts drops **13 lines**
- New module: 70 lines
- Running tally: cli.ts 3894 → ~3483 (−411 lines, **−10.6%**)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/cmd-recent.test.ts\` — 6/6 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 692/692 pass