### PR TITLE
refactor(cli): extract 'remi detach' subcommand into cmd-detach handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -609,61 +609,13 @@ if (cliSubcommand === 'kill') {
 
 // Handle 'detach' subcommand: detach from a session without killing it
 if (cliSubcommand === 'detach') {
-  if (!resolved.targetId) {
-    console.error('Usage: remi detach <session-name-or-id>');
-    console.error('  Detach from a session without killing it (tmux-style).');
-    console.error('  The session remains alive and can be re-attached with `remi attach`.');
-    console.error('  Examples: remi detach my-session');
-    console.error('            remi detach host:port/session-name');
-    console.error('  Tip: When attached interactively, press Ctrl+B d to detach.');
-    console.error('Run `remi ls` to see live sessions.');
-    process.exit(1);
-  }
-
-  let resolvedPort = resolved.port;
-  let detachTarget = resolved.targetId;
-
-  // Resolve port by querying all local daemon ports (session may be on any daemon)
-  if (!cliPort && resolved.host === 'localhost') {
-    const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
-    let allPorts = liveSessionsRegistry.getLivePorts();
-    if (allPorts.length === 0) {
-      const { getDefaultPortRange } = await import('./cli/ls-client.ts');
-      allPorts = getDefaultPortRange();
-    }
-    if (allPorts.length > 0) {
-      const results = await queryMultiplePorts({
-        host: 'localhost',
-        ports: allPorts,
-        timeoutMs: 5000,
-        logLabel: 'detach',
-      });
-      if (results.length === 0) {
-        console.error(
-          `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
-        );
-        process.exit(1);
-      }
-      const match = resolveSession(results, detachTarget);
-      if (match) {
-        resolvedPort = match.port;
-        detachTarget = match.session.sessionId;
-      }
-    }
-  }
-
-  const { runDetachClient } = await import('./cli/detach-client.ts');
-  try {
-    await runDetachClient({
-      host: resolved.host,
-      port: resolvedPort,
-      target: detachTarget,
-    });
-  } catch (err) {
-    console.error(errorToString(err));
-    process.exit(1);
-  }
-  process.exit(0);
+  const { runDetachCommand } = await import('./cli/cmd-detach.ts');
+  process.exit(
+    await runDetachCommand(resolved, {
+      getLivePorts: () => liveSessionsRegistry.getLivePorts(),
+      explicitPort: cliPort,
+    }),
+  );
 }
 
 // Handle 'attach' subcommand: attach terminal to an orphaned session

--- a/packages/daemon/src/cli/cmd-detach.ts
+++ b/packages/daemon/src/cli/cmd-detach.ts
@@ -1,0 +1,123 @@
+/**
+ * Handler for `remi detach <session>` — detach from a session without
+ * killing it (tmux-style). The session remains alive and can be re-attached.
+ *
+ * Complex branch: if the caller gave us a session name on localhost without
+ * an explicit port, we probe every known local daemon to find which one
+ * owns the session.
+ */
+
+import { errorToString } from '@remi/shared';
+import type { PortQueryResult, ResolvedSession } from './session-resolver.ts';
+import type { ResolvedTarget } from './target-resolver.ts';
+
+export interface DetachCommandIO {
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: DetachCommandIO = { err: (msg) => console.error(msg) };
+
+export interface DetachCommandDeps {
+  /** Caller-side live-port list (usually `liveSessionsRegistry.getLivePorts()`). */
+  readonly getLivePorts: () => number[];
+  /** Explicit --port flag value; used to skip the multi-port resolution step. */
+  readonly explicitPort: number | undefined;
+}
+
+/** Injectable helpers; defaults load production modules dynamically. */
+export interface DetachCommandHelpers {
+  queryMultiplePorts: (args: {
+    host: string;
+    ports: number[];
+    timeoutMs: number;
+    logLabel: string;
+  }) => Promise<readonly PortQueryResult[]>;
+  resolveSession: (results: readonly PortQueryResult[], target: string) => ResolvedSession | null;
+  getDefaultPortRange: () => number[];
+  runDetachClient: (args: { host: string; port: number; target: string }) => Promise<void>;
+}
+
+const defaultLoader = async (): Promise<DetachCommandHelpers> => {
+  const [sessionResolver, lsClient, detachClient] = await Promise.all([
+    import('./session-resolver.ts'),
+    import('./ls-client.ts'),
+    import('./detach-client.ts'),
+  ]);
+  return {
+    queryMultiplePorts: sessionResolver.queryMultiplePorts,
+    resolveSession: sessionResolver.resolveSession,
+    getDefaultPortRange: lsClient.getDefaultPortRange,
+    runDetachClient: detachClient.runDetachClient,
+  };
+};
+
+/**
+ * Print the detach-subcommand usage to stderr. Lifted verbatim from the old
+ * inline block so behavior is identical.
+ */
+function printUsage(err: (msg: string) => void): void {
+  err('Usage: remi detach <session-name-or-id>');
+  err('  Detach from a session without killing it (tmux-style).');
+  err('  The session remains alive and can be re-attached with `remi attach`.');
+  err('  Examples: remi detach my-session');
+  err('            remi detach host:port/session-name');
+  err('  Tip: When attached interactively, press Ctrl+B d to detach.');
+  err('Run `remi ls` to see live sessions.');
+}
+
+export async function runDetachCommand(
+  target: ResolvedTarget,
+  deps: DetachCommandDeps,
+  io: DetachCommandIO = defaultIO,
+  loadHelpers: () => Promise<DetachCommandHelpers> = defaultLoader,
+): Promise<number> {
+  if (!target.targetId) {
+    printUsage(io.err);
+    return 1;
+  }
+
+  let resolvedPort = target.port;
+  let detachTarget = target.targetId;
+
+  const helpers = await loadHelpers();
+
+  // If the user asked for a localhost target without an explicit port,
+  // probe every known local daemon port to find the session.
+  if (deps.explicitPort === undefined && target.host === 'localhost') {
+    let allPorts = deps.getLivePorts();
+    if (allPorts.length === 0) {
+      allPorts = helpers.getDefaultPortRange();
+    }
+    if (allPorts.length > 0) {
+      const results = await helpers.queryMultiplePorts({
+        host: 'localhost',
+        ports: allPorts,
+        timeoutMs: 5000,
+        logLabel: 'detach',
+      });
+      if (results.length === 0) {
+        io.err(
+          `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
+        );
+        return 1;
+      }
+      const match = helpers.resolveSession(results, detachTarget);
+      if (match) {
+        resolvedPort = match.port;
+        detachTarget = match.session.sessionId;
+      }
+    }
+  }
+
+  try {
+    await helpers.runDetachClient({
+      host: target.host,
+      port: resolvedPort,
+      target: detachTarget,
+    });
+    return 0;
+  } catch (err) {
+    io.err(errorToString(err));
+    return 1;
+  }
+}

--- a/packages/daemon/tests/cli/cmd-detach.test.ts
+++ b/packages/daemon/tests/cli/cmd-detach.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'bun:test';
+import { type DiscoverableSession, type UUID, now } from '@remi/shared';
+import { type DetachCommandHelpers, runDetachCommand } from '../../src/cli/cmd-detach.ts';
+import type { PortQueryResult } from '../../src/cli/session-resolver.ts';
+import type { ResolvedTarget } from '../../src/cli/target-resolver.ts';
+
+function makeSession(overrides: Partial<DiscoverableSession> = {}): DiscoverableSession {
+  return {
+    sessionId: 'SES-DEFAULT' as UUID,
+    projectPath: '/tmp/fake',
+    status: 'active',
+    lastActivity: now(),
+    messageCount: 0,
+    source: 'daemon',
+    canAttach: true,
+    canResume: false,
+    ...overrides,
+  };
+}
+
+function makeIO() {
+  const err: string[] = [];
+  return { io: { err: (m: string) => err.push(m) }, err };
+}
+
+function mkTarget(overrides: Partial<ResolvedTarget> = {}): ResolvedTarget {
+  return { host: 'localhost', port: 18765, targetId: 'my-session', ...overrides };
+}
+
+type Call =
+  | { fn: 'queryMultiplePorts'; args: { ports: number[]; host: string } }
+  | { fn: 'resolveSession'; args: { target: string; resultCount: number } }
+  | { fn: 'getDefaultPortRange' }
+  | { fn: 'runDetachClient'; args: { host: string; port: number; target: string } };
+
+interface HelpersOptions {
+  readonly livePorts?: number[];
+  readonly queryResults?: readonly PortQueryResult[];
+  readonly resolvedSession?: {
+    port: number;
+    sessionId: UUID;
+    name?: string;
+  } | null;
+  readonly defaultPortRange?: number[];
+  readonly throwOnDetach?: boolean;
+}
+
+function makeHelpersAndDeps(opts: HelpersOptions = {}) {
+  const calls: Call[] = [];
+  const helpers: DetachCommandHelpers = {
+    queryMultiplePorts: async (args) => {
+      calls.push({ fn: 'queryMultiplePorts', args: { ports: [...args.ports], host: args.host } });
+      return opts.queryResults ?? [];
+    },
+    resolveSession: (results, target) => {
+      calls.push({ fn: 'resolveSession', args: { target, resultCount: results.length } });
+      if (!opts.resolvedSession) return null;
+      const fake = makeSession({
+        sessionId: opts.resolvedSession.sessionId,
+        name: opts.resolvedSession.name ?? 'resolved',
+      });
+      return { session: fake, port: opts.resolvedSession.port, host: 'localhost' };
+    },
+    getDefaultPortRange: () => {
+      calls.push({ fn: 'getDefaultPortRange' });
+      return opts.defaultPortRange ?? [18765, 18766];
+    },
+    runDetachClient: async (args) => {
+      calls.push({ fn: 'runDetachClient', args });
+      if (opts.throwOnDetach) throw new Error('detach failed');
+    },
+  };
+  const deps = {
+    getLivePorts: () => opts.livePorts ?? [],
+    explicitPort: undefined as number | undefined,
+  };
+  return { helpers, deps, calls };
+}
+
+describe('runDetachCommand', () => {
+  test('prints usage and returns 1 when target id is missing', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const code = await runDetachCommand(
+      mkTarget({ targetId: undefined }),
+      deps,
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(err[0]).toBe('Usage: remi detach <session-name-or-id>');
+    expect(err.some((m) => m.includes('Run `remi ls` to see live sessions.'))).toBe(true);
+    expect(calls).toHaveLength(0); // no helpers called when usage fails
+  });
+
+  test('explicit port skips multi-port resolution', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const deps2 = { ...deps, explicitPort: 18800 };
+    const code = await runDetachCommand(mkTarget({ port: 18800 }), deps2, io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls.map((c) => c.fn)).toEqual(['runDetachClient']);
+    expect(calls[0]).toEqual({
+      fn: 'runDetachClient',
+      args: { host: 'localhost', port: 18800, target: 'my-session' },
+    });
+  });
+
+  test('non-localhost skips multi-port resolution even without explicit port', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const code = await runDetachCommand(
+      mkTarget({ host: 'remote.example', port: 18900 }),
+      deps,
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(calls.map((c) => c.fn)).toEqual(['runDetachClient']);
+    expect(calls[0]).toEqual({
+      fn: 'runDetachClient',
+      args: { host: 'remote.example', port: 18900, target: 'my-session' },
+    });
+  });
+
+  test('uses live registry ports first for localhost multi-port resolution', async () => {
+    const { io } = makeIO();
+    const fakeSession = makeSession({
+      sessionId: 'SES-ABC-123' as UUID,
+      name: 'my-session',
+    });
+    const { helpers, deps, calls } = makeHelpersAndDeps({
+      livePorts: [18765, 18766],
+      queryResults: [{ port: 18766, host: 'localhost', sessions: [fakeSession] }],
+      resolvedSession: { port: 18766, sessionId: 'SES-ABC-123' as UUID, name: 'my-session' },
+    });
+    const code = await runDetachCommand(mkTarget(), deps, io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls.map((c) => c.fn)).toEqual([
+      'queryMultiplePorts',
+      'resolveSession',
+      'runDetachClient',
+    ]);
+    const detach = calls[2];
+    expect(detach).toEqual({
+      fn: 'runDetachClient',
+      args: { host: 'localhost', port: 18766, target: 'SES-ABC-123' },
+    });
+  });
+
+  test('falls back to getDefaultPortRange when registry is empty', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps({
+      livePorts: [],
+      defaultPortRange: [18765, 18766, 18767],
+      queryResults: [],
+    });
+    const code = await runDetachCommand(mkTarget(), deps, io, async () => helpers);
+    // Empty queryResults -> "cannot reach any" error -> exit 1
+    expect(code).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['getDefaultPortRange', 'queryMultiplePorts']);
+    const query = calls[1];
+    expect((query as { args: { ports: number[] } }).args.ports).toEqual([18765, 18766, 18767]);
+  });
+
+  test('prints "Cannot reach any" when query returns zero results', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps } = makeHelpersAndDeps({
+      livePorts: [18765, 18766],
+      queryResults: [],
+    });
+    const code = await runDetachCommand(mkTarget(), deps, io, async () => helpers);
+    expect(code).toBe(1);
+    expect(err[0]).toBe('Cannot reach any remi daemon (tried 2 port(s)). Is a daemon running?');
+  });
+
+  test('if no live ports and no default range, skip multi-port and fall through', async () => {
+    // Both registry and defaults empty -> skip the block, go straight to detach.
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps({
+      livePorts: [],
+      defaultPortRange: [],
+    });
+    const code = await runDetachCommand(mkTarget(), deps, io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls.map((c) => c.fn)).toEqual(['getDefaultPortRange', 'runDetachClient']);
+  });
+
+  test('detach errors are caught, printed to stderr, exit 1', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps } = makeHelpersAndDeps({
+      livePorts: [18765],
+      queryResults: [],
+      throwOnDetach: true,
+    });
+    const deps2 = { ...deps, explicitPort: 18800 };
+    const code = await runDetachCommand(mkTarget({ port: 18800 }), deps2, io, async () => helpers);
+    expect(code).toBe(1);
+    expect(err).toEqual(['detach failed']);
+  });
+
+  test('unresolved session in query results still attempts detach on original port', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps({
+      livePorts: [18765, 18766],
+      queryResults: [{ port: 18765, host: 'localhost', sessions: [] }],
+      resolvedSession: null, // resolveSession returns null (session not found)
+    });
+    const code = await runDetachCommand(mkTarget(), deps, io, async () => helpers);
+    // Falls through to detach with the original target (from ResolvedTarget)
+    expect(code).toBe(0);
+    const detach = calls[calls.length - 1];
+    expect(detach).toEqual({
+      fn: 'runDetachClient',
+      args: { host: 'localhost', port: 18765, target: 'my-session' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 13** (see \`.context/cleanup-audit.md\`).

Extracts the 57-line \`detach\` subcommand block out of cli.ts into \`packages/daemon/src/cli/cmd-detach.ts\`. Biggest single cli.ts cut of the epic (−48 lines).

### Behavior preserved verbatim

1. Missing target id → 7-line usage to stderr, exit 1
2. Explicit port OR non-localhost host → skip multi-port resolution
3. Localhost + no explicit port → probe live ports (fall back to \`getDefaultPortRange\`) via \`queryMultiplePorts\` + \`resolveSession\`
4. \`runDetachClient\`; throw → stderr + exit 1

### API

\`\`\`ts
runDetachCommand(
  target: ResolvedTarget,
  deps: { getLivePorts; explicitPort },
  io?,
  loadHelpers?,
): Promise<number>
\`\`\`

All four helpers injectable via \`loadHelpers\`; default implementation \`Promise.all()\`s the three dynamic imports (\`session-resolver\`, \`ls-client\`, \`detach-client\`).

### Noted duplication

The multi-port resolve dance is a duplicate of logic in the \`kill\` subcommand. Next PR will factor it out so both share a \`resolveLocalSessionPort\` helper.

### Test coverage

9 characterization tests:
1. Missing target id → usage, no helpers called
2. Explicit port skips resolution
3. Non-localhost skips resolution
4. Live-registry ports used first
5. Falls back to getDefaultPortRange on empty registry
6. \"Cannot reach any\" error when query returns zero results
7. Both-empty (registry + defaults) skips multi-port
8. \`runDetachClient\` error caught and printed
9. Unresolved session still attempts detach on original port

### Impact

- cli.ts: **−48 lines**
- New module: 130 lines
- Running tally: cli.ts 3894 → ~3435, **−459 lines (−11.8%)**

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/cmd-detach.test.ts\` — 9/9 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 701/701 pass