### PR TITLE
refactor(cli): extract 'remi kill' + shared resolve-local-session helper

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -547,64 +547,13 @@ if (cliSubcommand === 'recent') {
 
 // Handle 'kill' subcommand: kill a session by name or ID
 if (cliSubcommand === 'kill') {
-  if (!resolved.targetId) {
-    console.error('Usage: remi kill <session-name-or-id>');
-    console.error('  Examples: remi kill my-session');
-    console.error('            remi kill host:port/session-name');
-    console.error('            remi kill my-session --host 192.168.1.1');
-    console.error('Run `remi ls` to see live sessions.');
-    process.exit(1);
-  }
-  let resolvedPort = resolved.port;
-  let killTarget = resolved.targetId;
-
-  const { runKillClient } = await import('./cli/kill-client.ts');
-  try {
-    // Resolve port by querying all local daemon ports (session may be on any daemon)
-    if (!cliPort && resolved.host === 'localhost') {
-      const { queryMultiplePorts, resolveSession } = await import('./cli/session-resolver.ts');
-      let allPorts = liveSessionsRegistry.getLivePorts();
-
-      // Fallback: probe default port range when registry is empty (matches ls behavior)
-      if (allPorts.length === 0) {
-        const { getDefaultPortRange } = await import('./cli/ls-client.ts');
-        allPorts = getDefaultPortRange();
-      }
-
-      if (allPorts.length > 0) {
-        const results = await queryMultiplePorts({
-          host: 'localhost',
-          ports: allPorts,
-          timeoutMs: 5000,
-          logLabel: 'kill',
-        });
-
-        if (results.length === 0) {
-          console.error(
-            `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
-          );
-          process.exit(1);
-        }
-
-        const match = resolveSession(results, killTarget);
-        if (match) {
-          resolvedPort = match.port;
-          // Use session ID directly to avoid TOCTOU race
-          killTarget = match.session.sessionId;
-        }
-      }
-    }
-
-    await runKillClient({
-      host: resolved.host,
-      port: resolvedPort,
-      target: killTarget,
-    });
-  } catch (err) {
-    console.error(errorToString(err));
-    process.exit(1);
-  }
-  process.exit(0);
+  const { runKillCommand } = await import('./cli/cmd-kill.ts');
+  process.exit(
+    await runKillCommand(resolved, {
+      getLivePorts: () => liveSessionsRegistry.getLivePorts(),
+      explicitPort: cliPort,
+    }),
+  );
 }
 
 // Handle 'detach' subcommand: detach from a session without killing it

--- a/packages/daemon/src/cli/cmd-detach.ts
+++ b/packages/daemon/src/cli/cmd-detach.ts
@@ -2,12 +2,12 @@
  * Handler for `remi detach <session>` — detach from a session without
  * killing it (tmux-style). The session remains alive and can be re-attached.
  *
- * Complex branch: if the caller gave us a session name on localhost without
- * an explicit port, we probe every known local daemon to find which one
- * owns the session.
+ * Localhost + no explicit port: uses the shared resolveLocalSession helper
+ * to probe known daemons and map the target name/id to a specific port.
  */
 
 import { errorToString } from '@remi/shared';
+import { resolveLocalSession } from './resolve-local-session.ts';
 import type { PortQueryResult, ResolvedSession } from './session-resolver.ts';
 import type { ResolvedTarget } from './target-resolver.ts';
 
@@ -51,10 +51,6 @@ const defaultLoader = async (): Promise<DetachCommandHelpers> => {
   };
 };
 
-/**
- * Print the detach-subcommand usage to stderr. Lifted verbatim from the old
- * inline block so behavior is identical.
- */
 function printUsage(err: (msg: string) => void): void {
   err('Usage: remi detach <session-name-or-id>');
   err('  Detach from a session without killing it (tmux-style).');
@@ -81,32 +77,27 @@ export async function runDetachCommand(
 
   const helpers = await loadHelpers();
 
-  // If the user asked for a localhost target without an explicit port,
-  // probe every known local daemon port to find the session.
   if (deps.explicitPort === undefined && target.host === 'localhost') {
-    let allPorts = deps.getLivePorts();
-    if (allPorts.length === 0) {
-      allPorts = helpers.getDefaultPortRange();
+    const resolution = await resolveLocalSession(
+      { target: detachTarget, logLabel: 'detach' },
+      {
+        getLivePorts: deps.getLivePorts,
+        queryMultiplePorts: helpers.queryMultiplePorts,
+        resolveSession: helpers.resolveSession,
+        getDefaultPortRange: helpers.getDefaultPortRange,
+      },
+    );
+    if (resolution.status === 'no-daemons') {
+      io.err(
+        `Cannot reach any remi daemon (tried ${resolution.probedCount} port(s)). Is a daemon running?`,
+      );
+      return 1;
     }
-    if (allPorts.length > 0) {
-      const results = await helpers.queryMultiplePorts({
-        host: 'localhost',
-        ports: allPorts,
-        timeoutMs: 5000,
-        logLabel: 'detach',
-      });
-      if (results.length === 0) {
-        io.err(
-          `Cannot reach any remi daemon (tried ${allPorts.length} port(s)). Is a daemon running?`,
-        );
-        return 1;
-      }
-      const match = helpers.resolveSession(results, detachTarget);
-      if (match) {
-        resolvedPort = match.port;
-        detachTarget = match.session.sessionId;
-      }
+    if (resolution.status === 'resolved') {
+      resolvedPort = resolution.port;
+      detachTarget = resolution.target;
     }
+    // 'no-ports' and 'unresolved' both fall through to the original target.
   }
 
   try {

--- a/packages/daemon/src/cli/cmd-kill.ts
+++ b/packages/daemon/src/cli/cmd-kill.ts
@@ -1,0 +1,107 @@
+/**
+ * Handler for `remi kill <session>` — terminate a session.
+ *
+ * Localhost + no explicit port: uses the shared resolveLocalSession helper
+ * to probe known daemons and map the target name/id to a specific port.
+ */
+
+import { errorToString } from '@remi/shared';
+import { resolveLocalSession } from './resolve-local-session.ts';
+import type { PortQueryResult, ResolvedSession } from './session-resolver.ts';
+import type { ResolvedTarget } from './target-resolver.ts';
+
+export interface KillCommandIO {
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: KillCommandIO = { err: (msg) => console.error(msg) };
+
+export interface KillCommandDeps {
+  readonly getLivePorts: () => number[];
+  readonly explicitPort: number | undefined;
+}
+
+export interface KillCommandHelpers {
+  queryMultiplePorts: (args: {
+    host: string;
+    ports: number[];
+    timeoutMs: number;
+    logLabel: string;
+  }) => Promise<readonly PortQueryResult[]>;
+  resolveSession: (results: readonly PortQueryResult[], target: string) => ResolvedSession | null;
+  getDefaultPortRange: () => number[];
+  runKillClient: (args: { host: string; port: number; target: string }) => Promise<void>;
+}
+
+const defaultLoader = async (): Promise<KillCommandHelpers> => {
+  const [sessionResolver, lsClient, killClient] = await Promise.all([
+    import('./session-resolver.ts'),
+    import('./ls-client.ts'),
+    import('./kill-client.ts'),
+  ]);
+  return {
+    queryMultiplePorts: sessionResolver.queryMultiplePorts,
+    resolveSession: sessionResolver.resolveSession,
+    getDefaultPortRange: lsClient.getDefaultPortRange,
+    runKillClient: killClient.runKillClient,
+  };
+};
+
+function printUsage(err: (msg: string) => void): void {
+  err('Usage: remi kill <session-name-or-id>');
+  err('  Examples: remi kill my-session');
+  err('            remi kill host:port/session-name');
+  err('            remi kill my-session --host 192.168.1.1');
+  err('Run `remi ls` to see live sessions.');
+}
+
+export async function runKillCommand(
+  target: ResolvedTarget,
+  deps: KillCommandDeps,
+  io: KillCommandIO = defaultIO,
+  loadHelpers: () => Promise<KillCommandHelpers> = defaultLoader,
+): Promise<number> {
+  if (!target.targetId) {
+    printUsage(io.err);
+    return 1;
+  }
+
+  let resolvedPort = target.port;
+  let killTarget = target.targetId;
+
+  const helpers = await loadHelpers();
+
+  try {
+    if (deps.explicitPort === undefined && target.host === 'localhost') {
+      const resolution = await resolveLocalSession(
+        { target: killTarget, logLabel: 'kill' },
+        {
+          getLivePorts: deps.getLivePorts,
+          queryMultiplePorts: helpers.queryMultiplePorts,
+          resolveSession: helpers.resolveSession,
+          getDefaultPortRange: helpers.getDefaultPortRange,
+        },
+      );
+      if (resolution.status === 'no-daemons') {
+        io.err(
+          `Cannot reach any remi daemon (tried ${resolution.probedCount} port(s)). Is a daemon running?`,
+        );
+        return 1;
+      }
+      if (resolution.status === 'resolved') {
+        resolvedPort = resolution.port;
+        killTarget = resolution.target;
+      }
+    }
+
+    await helpers.runKillClient({
+      host: target.host,
+      port: resolvedPort,
+      target: killTarget,
+    });
+    return 0;
+  } catch (err) {
+    io.err(errorToString(err));
+    return 1;
+  }
+}

--- a/packages/daemon/src/cli/resolve-local-session.ts
+++ b/packages/daemon/src/cli/resolve-local-session.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared helper for `remi kill` and `remi detach`: given a session name (or
+ * id) on localhost without an explicit port, probe every known local daemon
+ * port to find which one owns the session.
+ *
+ * Returns one of:
+ *   - `{ status: 'resolved', port, target }` — found a session; use these.
+ *   - `{ status: 'no-ports' }` — neither the live registry nor the default
+ *     port range had any ports to probe; caller should fall through to the
+ *     original target.
+ *   - `{ status: 'no-daemons', probedCount }` — probed ports but no daemons
+ *     responded; caller should print the "Cannot reach any" error and exit 1.
+ *   - `{ status: 'unresolved' }` — daemons responded but no session matched
+ *     the target; caller should fall through to the original target.
+ */
+
+import type { PortQueryResult, ResolvedSession } from './session-resolver.ts';
+
+export type LocalSessionResolution =
+  | { readonly status: 'resolved'; readonly port: number; readonly target: string }
+  | { readonly status: 'no-ports' }
+  | { readonly status: 'no-daemons'; readonly probedCount: number }
+  | { readonly status: 'unresolved' };
+
+export interface ResolveLocalSessionDeps {
+  readonly getLivePorts: () => number[];
+  readonly queryMultiplePorts: (args: {
+    host: string;
+    ports: number[];
+    timeoutMs: number;
+    logLabel: string;
+  }) => Promise<readonly PortQueryResult[]>;
+  readonly resolveSession: (
+    results: readonly PortQueryResult[],
+    target: string,
+  ) => ResolvedSession | null;
+  readonly getDefaultPortRange: () => number[];
+}
+
+export interface ResolveLocalSessionArgs {
+  readonly target: string;
+  /** Label for query-multi-port log output (e.g. 'kill', 'detach'). */
+  readonly logLabel: string;
+  /** How long to wait for each port query. Default 5000 ms. */
+  readonly timeoutMs?: number;
+}
+
+export async function resolveLocalSession(
+  args: ResolveLocalSessionArgs,
+  deps: ResolveLocalSessionDeps,
+): Promise<LocalSessionResolution> {
+  let allPorts = deps.getLivePorts();
+
+  // Fallback: probe default port range when registry is empty (matches ls behavior).
+  if (allPorts.length === 0) {
+    allPorts = deps.getDefaultPortRange();
+  }
+
+  if (allPorts.length === 0) {
+    return { status: 'no-ports' };
+  }
+
+  const results = await deps.queryMultiplePorts({
+    host: 'localhost',
+    ports: allPorts,
+    timeoutMs: args.timeoutMs ?? 5000,
+    logLabel: args.logLabel,
+  });
+
+  if (results.length === 0) {
+    return { status: 'no-daemons', probedCount: allPorts.length };
+  }
+
+  const match = deps.resolveSession(results, args.target);
+  if (match) {
+    // Use session ID directly to avoid TOCTOU race
+    return { status: 'resolved', port: match.port, target: match.session.sessionId };
+  }
+
+  return { status: 'unresolved' };
+}

--- a/packages/daemon/tests/cli/cmd-kill.test.ts
+++ b/packages/daemon/tests/cli/cmd-kill.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+import { type DiscoverableSession, type UUID, now } from '@remi/shared';
+import { type KillCommandHelpers, runKillCommand } from '../../src/cli/cmd-kill.ts';
+import type { PortQueryResult } from '../../src/cli/session-resolver.ts';
+import type { ResolvedTarget } from '../../src/cli/target-resolver.ts';
+
+function makeSession(overrides: Partial<DiscoverableSession> = {}): DiscoverableSession {
+  return {
+    sessionId: 'SES-DEFAULT' as UUID,
+    projectPath: '/tmp/fake',
+    status: 'active',
+    lastActivity: now(),
+    messageCount: 0,
+    source: 'daemon',
+    canAttach: true,
+    canResume: false,
+    ...overrides,
+  };
+}
+
+function makeIO() {
+  const err: string[] = [];
+  return { io: { err: (m: string) => err.push(m) }, err };
+}
+
+function mkTarget(overrides: Partial<ResolvedTarget> = {}): ResolvedTarget {
+  return { host: 'localhost', port: 18765, targetId: 'my-session', ...overrides };
+}
+
+type Call =
+  | { fn: 'queryMultiplePorts'; args: { ports: number[]; host: string } }
+  | { fn: 'resolveSession'; args: { target: string } }
+  | { fn: 'getDefaultPortRange' }
+  | { fn: 'runKillClient'; args: { host: string; port: number; target: string } };
+
+interface HelpersOptions {
+  readonly livePorts?: number[];
+  readonly queryResults?: readonly PortQueryResult[];
+  readonly resolvedSession?: { port: number; sessionId: UUID; name?: string } | null;
+  readonly defaultPortRange?: number[];
+  readonly throwOnKill?: boolean;
+}
+
+function makeHelpersAndDeps(opts: HelpersOptions = {}) {
+  const calls: Call[] = [];
+  const helpers: KillCommandHelpers = {
+    queryMultiplePorts: async (args) => {
+      calls.push({ fn: 'queryMultiplePorts', args: { ports: [...args.ports], host: args.host } });
+      return opts.queryResults ?? [];
+    },
+    resolveSession: (_results, target) => {
+      calls.push({ fn: 'resolveSession', args: { target } });
+      if (!opts.resolvedSession) return null;
+      const fake = makeSession({
+        sessionId: opts.resolvedSession.sessionId,
+        name: opts.resolvedSession.name ?? 'resolved',
+      });
+      return { session: fake, port: opts.resolvedSession.port, host: 'localhost' };
+    },
+    getDefaultPortRange: () => {
+      calls.push({ fn: 'getDefaultPortRange' });
+      return opts.defaultPortRange ?? [18765, 18766];
+    },
+    runKillClient: async (args) => {
+      calls.push({ fn: 'runKillClient', args });
+      if (opts.throwOnKill) throw new Error('kill failed');
+    },
+  };
+  const deps = {
+    getLivePorts: () => opts.livePorts ?? [],
+    explicitPort: undefined as number | undefined,
+  };
+  return { helpers, deps, calls };
+}
+
+describe('runKillCommand', () => {
+  test('prints usage and returns 1 when target id is missing', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const code = await runKillCommand(
+      mkTarget({ targetId: undefined }),
+      deps,
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(err[0]).toBe('Usage: remi kill <session-name-or-id>');
+    expect(err.some((m) => m.includes('Run `remi ls` to see live sessions.'))).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('explicit port skips multi-port resolution', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const deps2 = { ...deps, explicitPort: 18800 };
+    const code = await runKillCommand(mkTarget({ port: 18800 }), deps2, io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls.map((c) => c.fn)).toEqual(['runKillClient']);
+  });
+
+  test('non-localhost skips multi-port resolution even without explicit port', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps();
+    const code = await runKillCommand(
+      mkTarget({ host: 'remote.example', port: 18900 }),
+      deps,
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(calls).toEqual([
+      { fn: 'runKillClient', args: { host: 'remote.example', port: 18900, target: 'my-session' } },
+    ]);
+  });
+
+  test('localhost resolution maps to session id and port', async () => {
+    const { io } = makeIO();
+    const { helpers, deps, calls } = makeHelpersAndDeps({
+      livePorts: [18765, 18766],
+      queryResults: [{ port: 18766, host: 'localhost', sessions: [] }],
+      resolvedSession: { port: 18766, sessionId: 'SES-KILL-ME' as UUID, name: 'my-session' },
+    });
+    const code = await runKillCommand(mkTarget(), deps, io, async () => helpers);
+    expect(code).toBe(0);
+    expect(calls[calls.length - 1]).toEqual({
+      fn: 'runKillClient',
+      args: { host: 'localhost', port: 18766, target: 'SES-KILL-ME' },
+    });
+  });
+
+  test('"Cannot reach any" when query returns zero results', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps } = makeHelpersAndDeps({
+      livePorts: [18765, 18766, 18767],
+      queryResults: [],
+    });
+    const code = await runKillCommand(mkTarget(), deps, io, async () => helpers);
+    expect(code).toBe(1);
+    expect(err[0]).toBe('Cannot reach any remi daemon (tried 3 port(s)). Is a daemon running?');
+  });
+
+  test('kill errors are caught, printed to stderr, exit 1', async () => {
+    const { io, err } = makeIO();
+    const { helpers, deps } = makeHelpersAndDeps({
+      livePorts: [18765],
+      queryResults: [],
+      throwOnKill: true,
+    });
+    const deps2 = { ...deps, explicitPort: 18800 };
+    const code = await runKillCommand(mkTarget({ port: 18800 }), deps2, io, async () => helpers);
+    expect(code).toBe(1);
+    expect(err).toEqual(['kill failed']);
+  });
+});

--- a/packages/daemon/tests/cli/resolve-local-session.test.ts
+++ b/packages/daemon/tests/cli/resolve-local-session.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { type UUID, now } from '@remi/shared';
+import {
+  type LocalSessionResolution,
+  resolveLocalSession,
+} from '../../src/cli/resolve-local-session.ts';
+import type { PortQueryResult } from '../../src/cli/session-resolver.ts';
+
+function fakeSession(sessionId: UUID, name: string) {
+  return {
+    sessionId,
+    name,
+    projectPath: '/tmp/fake',
+    status: 'active' as const,
+    lastActivity: now(),
+    messageCount: 0,
+    source: 'daemon' as const,
+    canAttach: true,
+    canResume: false,
+  };
+}
+
+interface DepsOptions {
+  readonly livePorts?: number[];
+  readonly defaultPortRange?: number[];
+  readonly queryResults?: readonly PortQueryResult[];
+  readonly resolvedMatch?: { port: number; sessionId: UUID; name: string } | null;
+}
+
+function makeDeps(opts: DepsOptions = {}) {
+  const calls: Array<{ fn: string; args?: unknown }> = [];
+  return {
+    calls,
+    deps: {
+      getLivePorts: () => {
+        calls.push({ fn: 'getLivePorts' });
+        return opts.livePorts ?? [];
+      },
+      getDefaultPortRange: () => {
+        calls.push({ fn: 'getDefaultPortRange' });
+        return opts.defaultPortRange ?? [18765, 18766];
+      },
+      queryMultiplePorts: async (args: unknown) => {
+        calls.push({ fn: 'queryMultiplePorts', args });
+        return opts.queryResults ?? [];
+      },
+      resolveSession: (_results: unknown, target: string) => {
+        calls.push({ fn: 'resolveSession', args: { target } });
+        if (!opts.resolvedMatch) return null;
+        return {
+          session: fakeSession(opts.resolvedMatch.sessionId, opts.resolvedMatch.name),
+          port: opts.resolvedMatch.port,
+          host: 'localhost',
+        };
+      },
+    },
+  };
+}
+
+describe('resolveLocalSession', () => {
+  test('returns no-ports when registry and default range are both empty', async () => {
+    const { deps, calls } = makeDeps({ livePorts: [], defaultPortRange: [] });
+    const result = await resolveLocalSession({ target: 'abc', logLabel: 'kill' }, deps);
+    expect(result).toEqual({ status: 'no-ports' });
+    expect(calls.map((c) => c.fn)).toEqual(['getLivePorts', 'getDefaultPortRange']);
+  });
+
+  test('uses live ports first, skips default fallback when available', async () => {
+    const { deps, calls } = makeDeps({
+      livePorts: [18765, 18766],
+      queryResults: [],
+    });
+    const result = await resolveLocalSession({ target: 'abc', logLabel: 'kill' }, deps);
+    expect((result as LocalSessionResolution).status).toBe('no-daemons');
+    expect(calls.map((c) => c.fn)).toEqual(['getLivePorts', 'queryMultiplePorts']);
+  });
+
+  test('falls back to default port range when registry is empty', async () => {
+    const { deps, calls } = makeDeps({
+      livePorts: [],
+      defaultPortRange: [18765, 18766, 18767],
+      queryResults: [],
+    });
+    await resolveLocalSession({ target: 'abc', logLabel: 'kill' }, deps);
+    expect(calls.map((c) => c.fn)).toEqual([
+      'getLivePorts',
+      'getDefaultPortRange',
+      'queryMultiplePorts',
+    ]);
+    expect((calls[2]?.args as { ports: number[] }).ports).toEqual([18765, 18766, 18767]);
+  });
+
+  test('returns no-daemons when query returns zero results, with probed count', async () => {
+    const { deps } = makeDeps({
+      livePorts: [18765, 18766, 18767],
+      queryResults: [],
+    });
+    const result = await resolveLocalSession({ target: 'abc', logLabel: 'kill' }, deps);
+    expect(result).toEqual({ status: 'no-daemons', probedCount: 3 });
+  });
+
+  test('returns resolved when resolveSession finds a match, with session id not name', async () => {
+    const fake: PortQueryResult = {
+      port: 18766,
+      host: 'localhost',
+      sessions: [fakeSession('SES-REAL-123' as UUID, 'my-session')],
+    };
+    const { deps } = makeDeps({
+      livePorts: [18765, 18766],
+      queryResults: [fake],
+      resolvedMatch: { port: 18766, sessionId: 'SES-REAL-123' as UUID, name: 'my-session' },
+    });
+    const result = await resolveLocalSession({ target: 'my-session', logLabel: 'kill' }, deps);
+    expect(result).toEqual({
+      status: 'resolved',
+      port: 18766,
+      // Use session ID directly to avoid TOCTOU race
+      target: 'SES-REAL-123',
+    });
+  });
+
+  test('returns unresolved when query yields daemons but no session matches', async () => {
+    const fake: PortQueryResult = {
+      port: 18765,
+      host: 'localhost',
+      sessions: [fakeSession('SES-OTHER' as UUID, 'other-session')],
+    };
+    const { deps } = makeDeps({
+      livePorts: [18765],
+      queryResults: [fake],
+      resolvedMatch: null,
+    });
+    const result = await resolveLocalSession({ target: 'missing', logLabel: 'detach' }, deps);
+    expect(result).toEqual({ status: 'unresolved' });
+  });
+
+  test('forwards logLabel and timeoutMs to queryMultiplePorts', async () => {
+    const { deps, calls } = makeDeps({
+      livePorts: [18765],
+      queryResults: [],
+    });
+    await resolveLocalSession({ target: 'abc', logLabel: 'detach', timeoutMs: 2500 }, deps);
+    const queryCall = calls.find((c) => c.fn === 'queryMultiplePorts');
+    expect((queryCall?.args as { logLabel: string; timeoutMs: number }).logLabel).toBe('detach');
+    expect((queryCall?.args as { logLabel: string; timeoutMs: number }).timeoutMs).toBe(2500);
+  });
+
+  test('defaults timeout to 5000 ms', async () => {
+    const { deps, calls } = makeDeps({
+      livePorts: [18765],
+      queryResults: [],
+    });
+    await resolveLocalSession({ target: 'abc', logLabel: 'kill' }, deps);
+    const queryCall = calls.find((c) => c.fn === 'queryMultiplePorts');
+    expect((queryCall?.args as { timeoutMs: number }).timeoutMs).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 14** (see \`.context/cleanup-audit.md\`).

Three changes in a single PR (logical unit):

1. **New shared helper** \`packages/daemon/src/cli/resolve-local-session.ts\` — owns the multi-port probe + resolveSession dance used by both \`kill\` and \`detach\`. Returns a \`LocalSessionResolution\` discriminated union:
   \`\`\`ts
   type LocalSessionResolution =
     | { status: 'resolved'; port; target }
     | { status: 'no-ports' }
     | { status: 'no-daemons'; probedCount }
     | { status: 'unresolved' };
   \`\`\`

2. **Refactor cmd-detach.ts** to use the helper. No behavior change.

3. **New cmd-kill.ts** using the same helper, wired into cli.ts. Replaces the 60-line inline \`kill\` block.

### Behavior preserved

- 5-line usage message on missing targetId → exit 1
- explicit-port / non-localhost skip-resolution
- \"Cannot reach any remi daemon (tried N port(s)). Is a daemon running?\" on empty query (carried by \`probedCount\`)
- Exit 0 on success, 1 on kill-client throw

### Test coverage

- **8 tests** for \`resolveLocalSession\`: all four resolution statuses, logLabel + timeoutMs forwarding, default timeout
- **6 tests** for \`runKillCommand\`: usage, explicit port, non-localhost, localhost resolution, no-daemons, kill error
- Existing **9 cmd-detach tests** still pass after the refactor (no regression)

### Impact

- cli.ts drops **60 lines** (the biggest single cut of the epic)
- cmd-detach.ts net −5 lines from the dedup
- Running tally: cli.ts 3894 → ~3375 (**−519 lines, −13.3%**)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/resolve-local-session.test.ts\` — 8/8 pass
- [x] \`bun test packages/daemon/tests/cli/cmd-kill.test.ts\` — 6/6 pass
- [x] \`bun test packages/daemon/tests/cli/cmd-detach.test.ts\` — 9/9 pass (regression)
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 715/715 pass