### PR TITLE
refactor(cli): extract resolveDirectory + getRecentDirectories

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -117,7 +117,6 @@ import type {
   AgentStatus,
   ProtocolMessage,
   QuestionOption,
-  RecentDirectory,
   UUID,
   UnlockedIdentity,
 } from '@remi/shared';
@@ -194,32 +193,7 @@ function logError(...args: unknown[]): void {
 
 import { resolveShellPath } from './cli/shell-path.ts';
 
-// ---------------------------------------------------------------------------
-// Resolve directory helper
-// ---------------------------------------------------------------------------
-function resolveDirectory(
-  inputPath: string | null | undefined,
-): { resolved: string } | { error: string } {
-  if (!inputPath) {
-    return { resolved: process.cwd() };
-  }
-
-  let resolved = inputPath;
-  if (resolved.startsWith('~/')) {
-    resolved = path.join(os.homedir(), resolved.slice(2));
-  } else if (resolved === '~') {
-    resolved = os.homedir();
-  }
-  resolved = path.resolve(resolved);
-  if (!fs.existsSync(resolved)) {
-    return { error: `Directory not found: ${resolved}` };
-  }
-  const stat = fs.statSync(resolved);
-  if (!stat.isDirectory()) {
-    return { error: `Not a directory: ${resolved}` };
-  }
-  return { resolved };
-}
+import { resolveDirectory } from './cli/path-resolver.ts';
 
 // ---------------------------------------------------------------------------
 // Parse CLI arguments
@@ -1747,35 +1721,7 @@ const registry = new AdapterRegistry({
   },
 });
 
-function getRecentDirectories(store: SessionStore, limit: number): RecentDirectory[] {
-  const sessions = store.list();
-  const dirMap = new Map<string, { count: number; lastUsed: string }>();
-
-  for (const s of sessions) {
-    const dir = s.projectPath;
-    const existing = dirMap.get(dir);
-    if (existing) {
-      existing.count++;
-      if (s.startedAt > existing.lastUsed) {
-        existing.lastUsed = s.startedAt;
-      }
-    } else {
-      dirMap.set(dir, { count: 1, lastUsed: s.startedAt });
-    }
-  }
-
-  const entries = Array.from(dirMap.entries())
-    .map(([directory, { count, lastUsed }]) => ({
-      directory,
-      lastUsed,
-      sessionCount: count,
-      displayName: path.basename(directory),
-    }))
-    .sort((a, b) => (a.lastUsed > b.lastUsed ? -1 : 1))
-    .slice(0, limit);
-
-  return entries;
-}
+import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
   return registry.sendRaw(connectionId, message);

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -1,0 +1,36 @@
+/**
+ * Directory-path resolution for CLI flags like `--dir` and interactive
+ * `remi recent` picks. Handles `~` / `~/...` expansion, converts relative
+ * to absolute paths, and validates the result exists and is a directory.
+ *
+ * Returns a tagged result so the caller can distinguish success from a
+ * human-readable error without throwing.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type ResolveDirectoryResult = { resolved: string } | { error: string };
+
+export function resolveDirectory(inputPath: string | null | undefined): ResolveDirectoryResult {
+  if (!inputPath) {
+    return { resolved: process.cwd() };
+  }
+
+  let resolved = inputPath;
+  if (resolved.startsWith('~/')) {
+    resolved = path.join(os.homedir(), resolved.slice(2));
+  } else if (resolved === '~') {
+    resolved = os.homedir();
+  }
+  resolved = path.resolve(resolved);
+  if (!fs.existsSync(resolved)) {
+    return { error: `Directory not found: ${resolved}` };
+  }
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) {
+    return { error: `Not a directory: ${resolved}` };
+  }
+  return { resolved };
+}

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -7,6 +7,7 @@
  */
 
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
 import {
   createHello,
@@ -16,8 +17,41 @@ import {
   serialize,
 } from '@remi/shared';
 import type { ProtocolMessage, RecentDirectory } from '@remi/shared';
+import type { SessionStore } from '../session/session-store.ts';
 import { performAuthHandshake } from './auth-helper.ts';
 import { formatAge } from './ls-client.ts';
+
+/**
+ * Collect the N most-recent project directories from the SessionStore,
+ * with session counts and display names derived from the path basename.
+ */
+export function getRecentDirectories(store: SessionStore, limit: number): RecentDirectory[] {
+  const sessions = store.list();
+  const dirMap = new Map<string, { count: number; lastUsed: string }>();
+
+  for (const s of sessions) {
+    const dir = s.projectPath;
+    const existing = dirMap.get(dir);
+    if (existing) {
+      existing.count++;
+      if (s.startedAt > existing.lastUsed) {
+        existing.lastUsed = s.startedAt;
+      }
+    } else {
+      dirMap.set(dir, { count: 1, lastUsed: s.startedAt });
+    }
+  }
+
+  return Array.from(dirMap.entries())
+    .map(([directory, { count, lastUsed }]) => ({
+      directory,
+      lastUsed,
+      sessionCount: count,
+      displayName: path.basename(directory),
+    }))
+    .sort((a, b) => (a.lastUsed > b.lastUsed ? -1 : 1))
+    .slice(0, limit);
+}
 
 export interface RecentClientOptions {
   readonly host: string;

--- a/packages/daemon/tests/cli/get-recent-directories.test.ts
+++ b/packages/daemon/tests/cli/get-recent-directories.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { getRecentDirectories } from '../../src/cli/recent-client.ts';
+import type { SessionStore } from '../../src/session/session-store.ts';
+
+function makeStore(sessions: Array<{ projectPath: string; startedAt: string }>): SessionStore {
+  return { list: () => sessions } as unknown as SessionStore;
+}
+
+describe('getRecentDirectories', () => {
+  test('returns empty list when store has no sessions', () => {
+    expect(getRecentDirectories(makeStore([]), 20)).toEqual([]);
+  });
+
+  test('groups sessions by projectPath and counts them', () => {
+    const store = makeStore([
+      { projectPath: '/tmp/proj-a', startedAt: '2026-04-17T10:00:00Z' },
+      { projectPath: '/tmp/proj-a', startedAt: '2026-04-17T12:00:00Z' },
+      { projectPath: '/tmp/proj-b', startedAt: '2026-04-17T11:00:00Z' },
+    ]);
+    const result = getRecentDirectories(store, 20);
+    const byDir = new Map(result.map((r) => [r.directory, r]));
+    expect(byDir.get('/tmp/proj-a')?.sessionCount).toBe(2);
+    expect(byDir.get('/tmp/proj-b')?.sessionCount).toBe(1);
+  });
+
+  test('uses the most recent startedAt as lastUsed per directory', () => {
+    const store = makeStore([
+      { projectPath: '/tmp/proj', startedAt: '2026-04-17T10:00:00Z' },
+      { projectPath: '/tmp/proj', startedAt: '2026-04-17T14:00:00Z' },
+      { projectPath: '/tmp/proj', startedAt: '2026-04-17T12:00:00Z' },
+    ]);
+    const result = getRecentDirectories(store, 20);
+    expect(result[0]?.lastUsed).toBe('2026-04-17T14:00:00Z');
+  });
+
+  test('sorts by lastUsed descending', () => {
+    const store = makeStore([
+      { projectPath: '/tmp/old', startedAt: '2026-04-10T10:00:00Z' },
+      { projectPath: '/tmp/new', startedAt: '2026-04-17T10:00:00Z' },
+      { projectPath: '/tmp/mid', startedAt: '2026-04-15T10:00:00Z' },
+    ]);
+    const result = getRecentDirectories(store, 20);
+    expect(result.map((r) => r.directory)).toEqual(['/tmp/new', '/tmp/mid', '/tmp/old']);
+  });
+
+  test('enforces the limit argument', () => {
+    const store = makeStore(
+      Array.from({ length: 25 }, (_, i) => ({
+        projectPath: `/tmp/proj-${i}`,
+        startedAt: `2026-04-17T${String(i).padStart(2, '0')}:00:00Z`,
+      })),
+    );
+    expect(getRecentDirectories(store, 20).length).toBe(20);
+    expect(getRecentDirectories(store, 5).length).toBe(5);
+  });
+
+  test('derives displayName from the path basename', () => {
+    const store = makeStore([
+      { projectPath: '/Users/yahya/projects/remi', startedAt: '2026-04-17T00:00:00Z' },
+    ]);
+    const result = getRecentDirectories(store, 20);
+    expect(result[0]?.displayName).toBe('remi');
+  });
+});

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveDirectory } from '../../src/cli/path-resolver.ts';
+
+describe('resolveDirectory', () => {
+  let sandbox: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-resolve-'));
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('returns cwd when input is null / undefined / empty string', () => {
+    process.chdir(sandbox);
+    // On macOS, tmpdir paths are symlinked: /var/folders -> /private/var/folders.
+    // process.cwd() after chdir returns the realpath-resolved form.
+    const expectedCwd = process.cwd();
+    expect(resolveDirectory(null)).toEqual({ resolved: expectedCwd });
+    expect(resolveDirectory(undefined)).toEqual({ resolved: expectedCwd });
+    expect(resolveDirectory('')).toEqual({ resolved: expectedCwd });
+  });
+
+  test('expands `~/` to the home directory', () => {
+    const result = resolveDirectory('~/');
+    // Success branch: home expansion resolves to an existing directory.
+    expect(result).toHaveProperty('resolved');
+    if ('resolved' in result) {
+      expect(result.resolved).toBe(os.homedir());
+    }
+  });
+
+  test('expands `~` alone to the home directory', () => {
+    const result = resolveDirectory('~');
+    expect(result).toEqual({ resolved: os.homedir() });
+  });
+
+  test('resolves absolute paths as-is', () => {
+    expect(resolveDirectory(sandbox)).toEqual({ resolved: sandbox });
+  });
+
+  test('resolves relative paths against cwd', () => {
+    const child = fs.mkdtempSync(path.join(sandbox, 'child-'));
+    process.chdir(sandbox);
+    const result = resolveDirectory(path.basename(child));
+    // See previous test for the tmpdir symlink explanation.
+    const expected = path.resolve(path.basename(child));
+    expect(result).toEqual({ resolved: expected });
+  });
+
+  test('returns an error for non-existent paths', () => {
+    const result = resolveDirectory(path.join(sandbox, 'nope'));
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error).toStartWith('Directory not found: ');
+    }
+  });
+
+  test('returns an error when the path is a file (not a directory)', () => {
+    const file = path.join(sandbox, 'file.txt');
+    fs.writeFileSync(file, 'hello');
+    const result = resolveDirectory(file);
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error).toStartWith('Not a directory: ');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 16** (see \`.context/cleanup-audit.md\`).

Two small pure helpers move out of cli.ts:

1. **\`resolveDirectory\`** → new \`packages/daemon/src/cli/path-resolver.ts\`
   - ~/ and ~ expansion, relative→absolute, exists+is-directory validation
   - Returns a tagged union (\`{ resolved } | { error }\`); never throws

2. **\`getRecentDirectories\`** → \`packages/daemon/src/cli/recent-client.ts\`
   - Moves into the module where it logically belongs (next to \`renderRecentDirectories\` and the remote \`fetchRecentDirectories\`)
   - Three existing call sites in cli.ts now import it from the new home

### Test coverage (13 new tests)

**\`resolveDirectory\` (7):** null/undefined/empty → cwd, ~/ expansion, ~ alone, absolute, relative, missing path, file-not-directory

**\`getRecentDirectories\` (6):** empty store, grouping + counts, most-recent lastUsed per dir, descending sort, limit enforcement, basename displayName

### Impact

- cli.ts drops **56 lines**
- Running tally: cli.ts 3894 → ~3071, **−823 lines (−21.1%)** across 16 PRs
- 152 new characterization tests across the epic

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test packages/daemon/tests/cli/path-resolver.test.ts packages/daemon/tests/cli/get-recent-directories.test.ts\` — 13/13 pass
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/hooks packages/shared/tests\` — 747/747 pass