### PR TITLE
refactor(cli): consolidate 5 key-management subcommand dispatches into cmd-keys

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -414,45 +414,23 @@ WantedBy=default.target`;
   process.exit(0);
 }
 
-// Handle key management subcommands
-if (cliSubcommand === 'keygen') {
-  const { runKeygen } = await import('./cli/keygen.ts');
-  await runKeygen({
-    passphrase: process.env['REMI_PASSPHRASE'],
-    usePassphrase: cliUsePassphrase,
-    decrypt: cliDecrypt,
-    encrypt: cliEncrypt,
-    force: cliForce,
-  });
-  process.exit(0);
-}
-
-if (cliSubcommand === 'export-key') {
-  const { runKeyExport } = await import('./cli/key-export.ts');
-  runKeyExport({ publicOnly: cliPublicOnly });
-  process.exit(0);
-}
-
-if (cliSubcommand === 'import-key') {
-  const { runKeyImport } = await import('./cli/key-import.ts');
-  await runKeyImport({ file: cliSubcommandArg, force: cliForce });
-  process.exit(0);
-}
-
-if (cliSubcommand === 'authorize') {
-  const { runAuthorize } = await import('./cli/authorize.ts');
-  await runAuthorize({
-    input: cliSubcommandArg,
-    label: cliLabel,
-    remove: cliRemoveFingerprint,
-  });
-  process.exit(0);
-}
-
-if (cliSubcommand === 'keys') {
-  const { runListKeys } = await import('./cli/authorize.ts');
-  runListKeys();
-  process.exit(0);
+// Handle key management subcommands (keygen, export-key, import-key, authorize, keys)
+{
+  const { isKeysSubcommand, runKeysCommand } = await import('./cli/cmd-keys.ts');
+  if (isKeysSubcommand(cliSubcommand)) {
+    process.exit(
+      await runKeysCommand(cliSubcommand, {
+        ...(cliSubcommandArg !== undefined && { subcommandArg: cliSubcommandArg }),
+        ...(cliUsePassphrase !== undefined && { usePassphrase: cliUsePassphrase }),
+        ...(cliDecrypt !== undefined && { decrypt: cliDecrypt }),
+        ...(cliEncrypt !== undefined && { encrypt: cliEncrypt }),
+        ...(cliForce !== undefined && { force: cliForce }),
+        ...(cliPublicOnly !== undefined && { publicOnly: cliPublicOnly }),
+        ...(cliLabel !== undefined && { label: cliLabel }),
+        ...(cliRemoveFingerprint !== undefined && { removeFingerprint: cliRemoveFingerprint }),
+      }),
+    );
+  }
 }
 
 // Handle 'code' subcommand: show or refresh the persistent connection code

--- a/packages/daemon/src/cli/cmd-keys.ts
+++ b/packages/daemon/src/cli/cmd-keys.ts
@@ -1,0 +1,80 @@
+/**
+ * Dispatcher for the five key-management subcommands:
+ *   `remi keygen`
+ *   `remi export-key`
+ *   `remi import-key <file>`
+ *   `remi authorize <key-or-fingerprint>`
+ *   `remi keys`
+ *
+ * Each target has its own standalone module (`./keygen.ts`, `./key-export.ts`,
+ * `./key-import.ts`, `./authorize.ts`); this dispatcher decides which to load
+ * based on the subcommand string and shapes the flags into the options the
+ * target expects.
+ */
+
+export type KeysSubcommand = 'keygen' | 'export-key' | 'import-key' | 'authorize' | 'keys';
+
+export function isKeysSubcommand(value: unknown): value is KeysSubcommand {
+  return (
+    value === 'keygen' ||
+    value === 'export-key' ||
+    value === 'import-key' ||
+    value === 'authorize' ||
+    value === 'keys'
+  );
+}
+
+export interface KeysCommandFlags {
+  readonly subcommandArg?: string;
+  readonly usePassphrase?: boolean;
+  readonly decrypt?: boolean;
+  readonly encrypt?: boolean;
+  readonly force?: boolean;
+  readonly publicOnly?: boolean;
+  readonly label?: string;
+  readonly removeFingerprint?: string;
+}
+
+export async function runKeysCommand(
+  sub: KeysSubcommand,
+  flags: KeysCommandFlags,
+): Promise<number> {
+  if (sub === 'keygen') {
+    const { runKeygen } = await import('./keygen.ts');
+    const passphrase = process.env['REMI_PASSPHRASE'];
+    await runKeygen({
+      ...(passphrase !== undefined && { passphrase }),
+      ...(flags.usePassphrase !== undefined && { usePassphrase: flags.usePassphrase }),
+      ...(flags.decrypt !== undefined && { decrypt: flags.decrypt }),
+      ...(flags.encrypt !== undefined && { encrypt: flags.encrypt }),
+      ...(flags.force !== undefined && { force: flags.force }),
+    });
+    return 0;
+  }
+  if (sub === 'export-key') {
+    const { runKeyExport } = await import('./key-export.ts');
+    runKeyExport({ ...(flags.publicOnly !== undefined && { publicOnly: flags.publicOnly }) });
+    return 0;
+  }
+  if (sub === 'import-key') {
+    const { runKeyImport } = await import('./key-import.ts');
+    await runKeyImport({
+      ...(flags.subcommandArg !== undefined && { file: flags.subcommandArg }),
+      ...(flags.force !== undefined && { force: flags.force }),
+    });
+    return 0;
+  }
+  if (sub === 'authorize') {
+    const { runAuthorize } = await import('./authorize.ts');
+    await runAuthorize({
+      ...(flags.subcommandArg !== undefined && { input: flags.subcommandArg }),
+      ...(flags.label !== undefined && { label: flags.label }),
+      ...(flags.removeFingerprint !== undefined && { remove: flags.removeFingerprint }),
+    });
+    return 0;
+  }
+  // 'keys'
+  const { runListKeys } = await import('./authorize.ts');
+  runListKeys();
+  return 0;
+}

--- a/packages/daemon/tests/cli/cmd-keys.test.ts
+++ b/packages/daemon/tests/cli/cmd-keys.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { isKeysSubcommand } from '../../src/cli/cmd-keys.ts';
+
+describe('isKeysSubcommand', () => {
+  test('returns true for every supported key subcommand', () => {
+    expect(isKeysSubcommand('keygen')).toBe(true);
+    expect(isKeysSubcommand('export-key')).toBe(true);
+    expect(isKeysSubcommand('import-key')).toBe(true);
+    expect(isKeysSubcommand('authorize')).toBe(true);
+    expect(isKeysSubcommand('keys')).toBe(true);
+  });
+
+  test('returns false for unrelated subcommands', () => {
+    expect(isKeysSubcommand('attach')).toBe(false);
+    expect(isKeysSubcommand('kill')).toBe(false);
+    expect(isKeysSubcommand('config')).toBe(false);
+    expect(isKeysSubcommand('ls')).toBe(false);
+  });
+
+  test('returns false for non-string inputs', () => {
+    expect(isKeysSubcommand(undefined)).toBe(false);
+    expect(isKeysSubcommand(null)).toBe(false);
+    expect(isKeysSubcommand(42)).toBe(false);
+    expect(isKeysSubcommand({})).toBe(false);
+    expect(isKeysSubcommand([])).toBe(false);
+  });
+
+  test('is case-sensitive', () => {
+    expect(isKeysSubcommand('Keygen')).toBe(false);
+    expect(isKeysSubcommand('KEYGEN')).toBe(false);
+    expect(isKeysSubcommand('Export-Key')).toBe(false);
+  });
+
+  test('narrows the type for the caller', () => {
+    const x: unknown = 'keygen';
+    if (isKeysSubcommand(x)) {
+      // TS should accept x as KeysSubcommand here
+      const sub: 'keygen' | 'export-key' | 'import-key' | 'authorize' | 'keys' = x;
+      expect(sub).toBe('keygen');
+    } else {
+      expect.unreachable();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Codebase Cleanup Epic **PR 17** (see \`.context/cleanup-audit.md\`).

The 5 inline dispatches for \`keygen\`, \`export-key\`, \`import-key\`, \`authorize\`, \`keys\` each repeated the same 5–7 line pattern. Consolidates into a single \`runKeysCommand(sub, flags): number\` dispatcher.

### Design

- \`isKeysSubcommand(value)\` — exported type guard narrows \`cliSubcommand\` to one of the 5 names
- \`runKeysCommand(sub, flags)\` — loads the relevant standalone module (\`keygen.ts\`, \`key-export.ts\`, \`key-import.ts\`, \`authorize.ts\`) and shapes the flags into the target's concrete options (respecting \`exactOptionalPropertyTypes\`)

The standalone modules themselves are untouched. This PR only rearranges the dispatch.

### Test coverage

5 tests for \`isKeysSubcommand\`:
- All 5 recognized names return true
- Unrelated subcommands return false
- Non-string inputs (undefined/null/number/object) return false
- Case-sensitive
- Type narrowing works for callers

### Impact

- cli.ts drops **22 lines**
- Running tally: cli.ts 3894 → ~3049, **−845 lines (−21.7%)** across 17 PRs
- 157 new characterization tests total