### PR TITLE
refactor(cli): extract log/logError into cli/logger module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -83,7 +83,7 @@ const statusWriter = new StatusWriter(
   },
   {
     getTargetFile: () => (cliDaemonMode ? DAEMON_STATUS_FILE : STATUS_FILE),
-    isEnabled: () => wrapperMode || cliDaemonMode,
+    isEnabled: () => isWrapperMode() || cliDaemonMode,
     writeLog: writeToLog,
   },
 );
@@ -162,7 +162,10 @@ import type { AssistantEntry } from './transcript/index.ts';
 // ---------------------------------------------------------------------------
 // Logging: In wrapper mode, all daemon logs go to ~/.remi/remi.log
 // ---------------------------------------------------------------------------
-let wrapperMode = true; // Default to wrapper mode
+import { configureLogger, isWrapperMode, log, logError, setWrapperMode } from './cli/logger.ts';
+
+configureLogger({ writeLog: writeToLog });
+
 let wrapperDetached = false; // Set when local terminal is detached (SIGHUP or Ctrl+B d)
 let sighupTimeoutId: ReturnType<typeof setTimeout> | null = null; // Orphan shutdown timer after SIGHUP
 
@@ -172,22 +175,6 @@ function cancelOrphanTimeout(): void {
     clearTimeout(sighupTimeoutId);
     sighupTimeoutId = null;
     log('[SIGHUP] Orphan timeout cancelled: remote client attached');
-  }
-}
-
-function log(...args: unknown[]): void {
-  if (wrapperMode) {
-    writeToLog(args.map(String).join(' '));
-  } else {
-    console.log(...args);
-  }
-}
-
-function logError(...args: unknown[]): void {
-  if (wrapperMode) {
-    writeToLog(`[error] ${args.map(String).join(' ')}`);
-  } else {
-    console.error(...args);
   }
 }
 
@@ -282,7 +269,7 @@ const cliOrphanTimeout = parsedArgs.orphanTimeout;
 const claudeArgs = [...parsedArgs.claudeArgs];
 
 if (cliDaemonMode) {
-  wrapperMode = false;
+  setWrapperMode(false);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli/logger.ts
+++ b/packages/daemon/src/cli/logger.ts
@@ -1,0 +1,62 @@
+/**
+ * Unified logging facade for the daemon CLI.
+ *
+ * In wrapper mode (terminal attached) messages go to the shared log file so
+ * they don't clobber Claude's TUI. In daemon-mode (--daemon) they go to the
+ * standard console streams because launchd/systemd capture those.
+ *
+ * The wrapper flag defaults to true; arg parsing in cli.ts flips it to false
+ * via `setWrapperMode(false)` when --daemon is set.
+ */
+
+type LogWriter = (msg: string) => void;
+
+let wrapperMode = true;
+let writer: LogWriter = () => {};
+let consoleLog: (...args: unknown[]) => void = console.log.bind(console);
+let consoleError: (...args: unknown[]) => void = console.error.bind(console);
+
+export interface LoggerConfig {
+  writeLog: LogWriter;
+  consoleLog?: (...args: unknown[]) => void;
+  consoleError?: (...args: unknown[]) => void;
+}
+
+/** Inject the file writer (production wires this to writeToLog). */
+export function configureLogger(config: LoggerConfig): void {
+  writer = config.writeLog;
+  if (config.consoleLog) consoleLog = config.consoleLog;
+  if (config.consoleError) consoleError = config.consoleError;
+}
+
+export function setWrapperMode(value: boolean): void {
+  wrapperMode = value;
+}
+
+export function isWrapperMode(): boolean {
+  return wrapperMode;
+}
+
+export function log(...args: unknown[]): void {
+  if (wrapperMode) {
+    writer(args.map(String).join(' '));
+  } else {
+    consoleLog(...args);
+  }
+}
+
+export function logError(...args: unknown[]): void {
+  if (wrapperMode) {
+    writer(`[error] ${args.map(String).join(' ')}`);
+  } else {
+    consoleError(...args);
+  }
+}
+
+/** Test-only: reset module state between test cases. */
+export function __resetLoggerForTests(): void {
+  wrapperMode = true;
+  writer = () => {};
+  consoleLog = console.log.bind(console);
+  consoleError = console.error.bind(console);
+}

--- a/packages/daemon/tests/cli/logger.test.ts
+++ b/packages/daemon/tests/cli/logger.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  __resetLoggerForTests,
+  configureLogger,
+  isWrapperMode,
+  log,
+  logError,
+  setWrapperMode,
+} from '../../src/cli/logger.ts';
+
+describe('logger', () => {
+  afterEach(() => {
+    __resetLoggerForTests();
+  });
+
+  test('defaults to wrapper mode', () => {
+    expect(isWrapperMode()).toBe(true);
+  });
+
+  test('setWrapperMode toggles state', () => {
+    setWrapperMode(false);
+    expect(isWrapperMode()).toBe(false);
+    setWrapperMode(true);
+    expect(isWrapperMode()).toBe(true);
+  });
+
+  test('log writes to injected writer in wrapper mode', () => {
+    const captured: string[] = [];
+    configureLogger({ writeLog: (msg) => captured.push(msg) });
+    log('hello', 'world', 42);
+    expect(captured).toEqual(['hello world 42']);
+  });
+
+  test('logError prefixes [error] in wrapper mode', () => {
+    const captured: string[] = [];
+    configureLogger({ writeLog: (msg) => captured.push(msg) });
+    logError('something', 'failed');
+    expect(captured).toEqual(['[error] something failed']);
+  });
+
+  test('log routes to console when not wrapper mode', () => {
+    const logCalls: unknown[][] = [];
+    const errCalls: unknown[][] = [];
+    configureLogger({
+      writeLog: () => {
+        throw new Error('writer should not be called when wrapperMode=false');
+      },
+      consoleLog: (...args) => logCalls.push(args),
+      consoleError: (...args) => errCalls.push(args),
+    });
+    setWrapperMode(false);
+
+    log('a', 'b');
+    logError('boom');
+
+    expect(logCalls).toEqual([['a', 'b']]);
+    expect(errCalls).toEqual([['boom']]);
+  });
+
+  test('stringifies non-string args in wrapper mode', () => {
+    const captured: string[] = [];
+    configureLogger({ writeLog: (msg) => captured.push(msg) });
+    log({ a: 1 }, null, undefined, 3.14);
+    expect(captured[0]).toBe('[object Object] null undefined 3.14');
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 1 of the next cleanup wave: extract the wrapper-mode logger out of `cli.ts` so future handler extractions don't have to pass `log` through every signature or reach back into `cli.ts` for it.
- New `packages/daemon/src/cli/logger.ts` exposes `log`, `logError`, `setWrapperMode`, `isWrapperMode`, and `configureLogger`. The writer is injected once from `cli.ts` (wired to `writeToLog`); tests swap it for a capture array.
- 179 existing call sites (`log(...)`, `logError(...)`) work unchanged — they now resolve to module-scoped functions instead of local closures.

## Why this first
Advisor flagged log extraction as the cheapest unblock: doing it *after* the sharedEvents handlers would force every extracted handler to either accept `log` as a constructor dependency or get refactored twice.

## Changes
- `packages/daemon/src/cli/logger.ts`: new module, DI-friendly, 62 lines.
- `packages/daemon/src/cli.ts`: deleted inline `wrapperMode` flag, `log`, and `logError` (~20 lines). Added import + one-line `configureLogger({ writeLog: writeToLog })` wiring. `statusWriter.isEnabled` and `--daemon` flip now call `isWrapperMode()` / `setWrapperMode(false)`. Net −13 lines (3051 → 3038).
- `packages/daemon/tests/cli/logger.test.ts`: 6 tests covering wrapper vs. console routing, `[error]` prefix, arg stringification, and `setWrapperMode` toggle.

## Test plan
- [x] `bun test packages/daemon/tests/cli/logger.test.ts` — 6/6 pass
- [x] `bun test packages/daemon/tests/cli/` — 443/443 pass (no regression)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] Full `bun test` — 1740/1741 pass; the single fail is a pre-existing flake in `port-utils.test.ts::isPortAvailable returns false for an occupied port` (unrelated, passes in isolation)