### PR TITLE
refactor(cli): extract primarySessionId into session-state module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -854,8 +854,11 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
-// The primary session ID (in wrapper mode, this is the one running in the terminal)
-let primarySessionId: UUID | null = null;
+// The primary session ID (in wrapper mode, this is the one running in the terminal).
+// Stored in cli/session-state.ts so extracted handler modules can read it via
+// getPrimarySessionId() without closing over a cli.ts-local `let` that flips
+// after handler registration.
+import { getPrimarySessionId, setPrimarySessionId } from './cli/session-state.ts';
 // Ports being claimed by in-flight daemon spawn requests (prevents TOCTOU race)
 const spawningPorts = new Set<number>();
 
@@ -912,7 +915,7 @@ async function createNewSession(
   const sendAndRecord = (message: ProtocolMessage) => {
     // Always record under primarySessionId so replay works correctly.
     // The client only knows primarySessionId (from hello_ack).
-    const recordId = primarySessionId ?? sessionId;
+    const recordId = getPrimarySessionId() ?? sessionId;
     sendMessage(sessionId, message);
     sessionRegistry.recordOutgoingMessage(recordId, message);
   };
@@ -943,7 +946,7 @@ async function createNewSession(
       },
       onQuestion: (question) => {
         log(`Question detected: ${question.text.substring(0, 50)}...`);
-        const questionSessionId = primarySessionId ?? sessionId;
+        const questionSessionId = getPrimarySessionId() ?? sessionId;
         const msg: ProtocolMessage = {
           type: 'question',
           id: generateId(),
@@ -963,7 +966,7 @@ async function createNewSession(
           const session = sessionRegistry.getSession(sessionId);
           const sessionName = session?.name || 'Agent';
           const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
-          const pushSessionId = primarySessionId ?? sessionId;
+          const pushSessionId = getPrimarySessionId() ?? sessionId;
           const pushCategory = selectPushCategory(question.options);
           const pushOptions = question.options.map((o) => o.value);
           for (const dt of deviceTokens.values()) {
@@ -1700,16 +1703,17 @@ const sharedEvents = {
     updateRemiStatus({ connections: remiStatus.connections + 1 });
 
     const resumeSessionId = metadata.platformData?.['resumeSessionId'] as UUID | undefined;
+    const currentPrimary = getPrimarySessionId();
 
     // Unified connection flow: one session per daemon, both modes behave the same.
     // If a resumeSessionId is provided, validate it matches our session.
-    if (resumeSessionId && primarySessionId && resumeSessionId !== primarySessionId) {
-      log(`Resume ID mismatch: requested ${resumeSessionId}, daemon has ${primarySessionId}`);
+    if (resumeSessionId && currentPrimary && resumeSessionId !== currentPrimary) {
+      log(`Resume ID mismatch: requested ${resumeSessionId}, daemon has ${currentPrimary}`);
       sendToConnection(
         connectionId,
         createError(
           'SESSION_NOT_FOUND',
-          `Session ${resumeSessionId} not found on this daemon. Active session: ${primarySessionId}.`,
+          `Session ${resumeSessionId} not found on this daemon. Active session: ${currentPrimary}.`,
         ),
       );
       return;
@@ -1717,15 +1721,14 @@ const sharedEvents = {
 
     // Try to attach to the primary (only) session
     const isQueryMode = metadata.platformData?.['mode'] === 'query';
-    if (primarySessionId) {
+    if (currentPrimary) {
       // Only auto-attach if the client wants to attach (not a utility client like ls/kill)
       if (!isQueryMode) {
-        const targetSession = primarySessionId;
-        const result = sessionRegistry.attachConnection(targetSession, connectionId);
+        const result = sessionRegistry.attachConnection(currentPrimary, connectionId);
         if (result.success) {
           sendToConnection(
             connectionId,
-            createHelloAck('1.0.0', targetSession, {
+            createHelloAck('1.0.0', currentPrimary, {
               isResume: result.replayMessages.length > 0,
               replayCount: result.replayMessages.length,
               nextBulletId: result.nextBulletId,
@@ -1734,18 +1737,18 @@ const sharedEvents = {
           if (result.replayMessages.length > 0) {
             sendToConnection(
               connectionId,
-              createReplayBatch(targetSession, result.replayMessages, true),
+              createReplayBatch(currentPrimary, result.replayMessages, true),
             );
           }
           cancelOrphanTimeout();
-          log(`Attached connection ${connectionId} to session ${targetSession}`);
+          log(`Attached connection ${connectionId} to session ${currentPrimary}`);
           return;
         }
       }
 
       // Query mode or attach failed (session busy); send hello_ack without attach
       // so utility clients (ls, kill) can still send requests
-      sendToConnection(connectionId, createHelloAck('1.0.0', primarySessionId));
+      sendToConnection(connectionId, createHelloAck('1.0.0', currentPrimary));
       log(
         `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
       );
@@ -2511,8 +2514,9 @@ async function cleanup(): Promise<void> {
   cleanupStatusFile();
 
   // Remove from live sessions directory
-  if (primarySessionId) {
-    liveSessionsRegistry.unregister(primarySessionId);
+  const primary = getPrimarySessionId();
+  if (primary) {
+    liveSessionsRegistry.unregister(primary);
   }
 }
 
@@ -2579,7 +2583,7 @@ if (cliDaemonMode) {
   // Create the daemon's single session (one session per daemon)
   const workingDirectory = cliDir ? path.resolve(cliDir) : process.cwd();
   const sessionId = sessionRegistry.createSessionId();
-  primarySessionId = sessionId;
+  setPrimarySessionId(sessionId);
 
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
   installStatusLine(REMI_DIR);
@@ -2727,7 +2731,7 @@ if (cliDaemonMode) {
   installStatusLine(REMI_DIR);
   const workingDirectory = process.cwd();
   const sessionId = sessionRegistry.createSessionId();
-  primarySessionId = sessionId;
+  setPrimarySessionId(sessionId);
 
   updateRemiStatus({ wsPort: PORT, sessionId, sessionStatus: 'starting' });
 

--- a/packages/daemon/src/cli/session-state.ts
+++ b/packages/daemon/src/cli/session-state.ts
@@ -1,0 +1,27 @@
+/**
+ * Daemon-lifetime state container for mutable singletons read by extracted
+ * handler modules.
+ *
+ * Today this holds only the primary session ID: the (single) live session a
+ * daemon instance owns. The value is `null` until `createNewSession` creates
+ * it, and gets reassigned when wrapper and daemon-mode paths each finalize
+ * their session. Direct `let` exports would bind importers to the initial
+ * value, so callers read through `getPrimarySessionId()` instead.
+ */
+
+import type { UUID } from '@remi/shared';
+
+let primarySessionId: UUID | null = null;
+
+export function getPrimarySessionId(): UUID | null {
+  return primarySessionId;
+}
+
+export function setPrimarySessionId(id: UUID | null): void {
+  primarySessionId = id;
+}
+
+/** Test-only: reset module state between test cases. */
+export function __resetSessionStateForTests(): void {
+  primarySessionId = null;
+}

--- a/packages/daemon/tests/cli/session-state.test.ts
+++ b/packages/daemon/tests/cli/session-state.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
+import {
+  __resetSessionStateForTests,
+  getPrimarySessionId,
+  setPrimarySessionId,
+} from '../../src/cli/session-state.ts';
+
+describe('session-state', () => {
+  afterEach(() => {
+    __resetSessionStateForTests();
+  });
+
+  test('defaults to null', () => {
+    expect(getPrimarySessionId()).toBeNull();
+  });
+
+  test('setPrimarySessionId stores the id', () => {
+    const id = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+    setPrimarySessionId(id);
+    expect(getPrimarySessionId()).toBe(id);
+  });
+
+  test('setPrimarySessionId(null) clears it', () => {
+    setPrimarySessionId('deadbeef-0000-0000-0000-000000000000' as UUID);
+    setPrimarySessionId(null);
+    expect(getPrimarySessionId()).toBeNull();
+  });
+
+  test('later writes overwrite earlier values', () => {
+    const first = '11111111-1111-1111-1111-111111111111' as UUID;
+    const second = '22222222-2222-2222-2222-222222222222' as UUID;
+    setPrimarySessionId(first);
+    setPrimarySessionId(second);
+    expect(getPrimarySessionId()).toBe(second);
+  });
+
+  test('module state survives across getter calls (singleton)', () => {
+    const id = '33333333-3333-3333-3333-333333333333' as UUID;
+    setPrimarySessionId(id);
+    expect(getPrimarySessionId()).toBe(id);
+    expect(getPrimarySessionId()).toBe(id);
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 2 of the next cleanup wave: moves the mutable `primarySessionId` singleton out of `cli.ts` into a dedicated `cli/session-state.ts`.
- Why: `primarySessionId` is a `let` that gets reassigned after adapter/handler registration (wrapper mode sets it at the daemon startup path; daemon mode sets it in its own branch). When handlers move out of `cli.ts` in later PRs, they need to read the *current* value at call time — not a stale closure over `null` captured at registration. This PR gives them `getPrimarySessionId()` for that.
- 1746/1746 tests pass.

## Changes
- `packages/daemon/src/cli/session-state.ts`: new module, 27 lines. `getPrimarySessionId()` and `setPrimarySessionId(id)` over a module-local `let`. Pattern mirrors `cli/logger.ts` from #343.
- `packages/daemon/src/cli.ts`:
  - Removed `let primarySessionId: UUID | null = null;`
  - 5 read sites now call `getPrimarySessionId()` (sendAndRecord, onQuestion, onQuestion push block, cleanup, onConnect)
  - 2 write sites now call `setPrimarySessionId(sessionId)` (wrapper and daemon-mode session creation paths)
  - `onConnect`: collapsed three redundant reads into one local `currentPrimary` for readability; no behavior change.
  - Net +4 lines (3038 → 3042; setup cost of the import + comment).
- `packages/daemon/tests/cli/session-state.test.ts`: 5 tests (default, set, clear, overwrite, singleton persistence).

## Sequencing
Stacks on #343 (logger extraction). No handler extractions yet — those come in subsequent PRs, which will now be able to import both `log`/`logError` and `getPrimarySessionId` cleanly.

## Test plan
- [x] `bun test packages/daemon/tests/cli/session-state.test.ts` — 5/5 pass
- [x] `bun test packages/daemon/tests/cli/` — 454/454 pass
- [x] Full `bun test` — 1746/1746 pass
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean