### PR TITLE
refactor(cli): extract 4 trivial sharedEvents handlers into handler module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -105,7 +105,6 @@ import {
   createRawPtyOutput,
   createReplayBatch,
   createResumeSessionResponse,
-  createSessionHistoryResponse,
   createSessionListResponse,
   createSessionReset,
   createStructuredAgentOutput,
@@ -134,6 +133,7 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
+import { createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
@@ -1695,7 +1695,15 @@ const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean
   return registry.sendRaw(connectionId, message);
 };
 
+const trivialHandlers = createTrivialHandlers({
+  deviceTokens,
+  sessionStore,
+  sessionRegistry,
+  send: sendToConnection,
+});
+
 const sharedEvents = {
+  ...trivialHandlers,
   onConnect: async (connectionId: UUID, metadata: AdapterMetadata) => {
     log(`Client connected: ${connectionId} (${metadata.adapterType})`);
 
@@ -2094,11 +2102,6 @@ const sharedEvents = {
     );
   },
 
-  onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string) => {
-    log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
-    deviceTokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
-  },
-
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {
     log(`Resume session request from ${connectionId} for session ${targetSessionId}`);
 
@@ -2265,37 +2268,6 @@ const sharedEvents = {
       sessionRegistry.closeSession(newSessionId, 'forced');
       sendToConnection(connectionId, createResumeSessionResponse(false, requestId, undefined, msg));
     }
-  },
-
-  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {
-    log(`Session history request from ${connectionId}, limit: ${limit ?? 'default'}`);
-    try {
-      const clampedLimit = Math.max(1, limit ?? 20);
-      const directories = getRecentDirectories(sessionStore, clampedLimit);
-      sendToConnection(connectionId, createSessionHistoryResponse(directories, requestId));
-    } catch (err) {
-      log(`Failed to get recent directories: ${err instanceof Error ? err.message : err}`);
-      sendToConnection(connectionId, createSessionHistoryResponse([], requestId));
-    }
-  },
-
-  onTerminalResize: (connectionId: UUID, cols: number, rows: number) => {
-    const session = sessionRegistry.getSessionForConnection(connectionId);
-    if (session) {
-      try {
-        session.pty.resize({ cols, rows });
-      } catch (err) {
-        log(
-          `Failed to resize PTY for connection ${connectionId}: ${err instanceof Error ? err.message : err}`,
-        );
-      }
-    } else {
-      log(`Terminal resize ignored: no session for connection ${connectionId}`);
-    }
-  },
-
-  onError: (connectionId: UUID, error: Error) => {
-    logError(`Error from ${connectionId}:`, error);
   },
 };
 

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -1,0 +1,76 @@
+/**
+ * Small, self-contained sharedEvents handlers that operate on isolated pieces
+ * of daemon state. Each handler has a single input/output surface and no
+ * cross-handler coupling, which is why they extract cleanly as a group.
+ *
+ * Larger or state-entangled handlers (onConnect, onAnswer, onResumeSessionRequest,
+ * createNewSession orchestration) live separately and will move out in their own
+ * PRs.
+ */
+
+import { createSessionHistoryResponse, errorToString } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import { log, logError } from '../logger.ts';
+import { getRecentDirectories } from '../recent-client.ts';
+
+export interface DeviceTokenEntry {
+  token: string;
+  platform: string;
+  registeredAt: number;
+  connectionId: UUID;
+}
+
+export type SendToConnection = (connectionId: UUID, message: ProtocolMessage) => boolean;
+
+export interface TrivialHandlerDeps {
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  sessionStore: SessionStore;
+  sessionRegistry: SessionRegistry;
+  send: SendToConnection;
+}
+
+export function createTrivialHandlers(deps: TrivialHandlerDeps) {
+  const { deviceTokens, sessionStore, sessionRegistry, send } = deps;
+
+  return {
+    onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string): void => {
+      log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
+      deviceTokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
+    },
+
+    onSessionHistoryRequest: (
+      connectionId: UUID,
+      requestId: UUID,
+      limit: number | undefined,
+    ): void => {
+      log(`Session history request from ${connectionId}, limit: ${limit ?? 'default'}`);
+      try {
+        const clampedLimit = Math.max(1, limit ?? 20);
+        const directories = getRecentDirectories(sessionStore, clampedLimit);
+        send(connectionId, createSessionHistoryResponse(directories, requestId));
+      } catch (err) {
+        log(`Failed to get recent directories: ${errorToString(err)}`);
+        send(connectionId, createSessionHistoryResponse([], requestId));
+      }
+    },
+
+    onTerminalResize: (connectionId: UUID, cols: number, rows: number): void => {
+      const session = sessionRegistry.getSessionForConnection(connectionId);
+      if (!session) {
+        log(`Terminal resize ignored: no session for connection ${connectionId}`);
+        return;
+      }
+      try {
+        session.pty.resize({ cols, rows });
+      } catch (err) {
+        log(`Failed to resize PTY for connection ${connectionId}: ${errorToString(err)}`);
+      }
+    },
+
+    onError: (connectionId: UUID, error: Error): void => {
+      logError(`Error from ${connectionId}:`, error);
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import {
+  type DeviceTokenEntry,
+  createTrivialHandlers,
+} from '../../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+interface SendCapture {
+  calls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+}
+
+function makeSend(): {
+  send: (connectionId: UUID, message: ProtocolMessage) => boolean;
+  captured: SendCapture;
+} {
+  const captured: SendCapture = { calls: [] };
+  return {
+    send: (connectionId, message) => {
+      captured.calls.push({ connectionId, message });
+      return true;
+    },
+    captured,
+  };
+}
+
+describe('createTrivialHandlers', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let sessionRegistry: SessionRegistry;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-trivial-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    sessionRegistry = new SessionRegistry({ maxReplayHistory: 10 });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('onRegisterDeviceToken stores the token in the shared map', () => {
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({
+      deviceTokens,
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'ios-device-token-abc', 'ios');
+
+    expect(deviceTokens.size).toBe(1);
+    const entry = deviceTokens.get('ios-device-token-abc');
+    expect(entry).toBeDefined();
+    expect(entry?.platform).toBe('ios');
+    expect(entry?.connectionId).toBe(CID);
+    expect(typeof entry?.registeredAt).toBe('number');
+  });
+
+  test('onTerminalResize logs and returns when no session is attached', () => {
+    const logs: string[] = [];
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({
+      deviceTokens: new Map(),
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: (msg) => logs.push(msg) });
+
+    // Real SessionRegistry, no connections -> getSessionForConnection returns undefined
+    handlers.onTerminalResize(CID, 80, 24);
+
+    expect(logs.some((m) => m.includes('Terminal resize ignored'))).toBe(true);
+  });
+
+  test('onError writes [error]-prefixed log in wrapper mode', () => {
+    const logs: string[] = [];
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({
+      deviceTokens: new Map(),
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: (msg) => logs.push(msg) });
+
+    handlers.onError(CID, new Error('boom'));
+
+    expect(logs.some((m) => m.startsWith('[error]') && m.includes('boom'))).toBe(true);
+  });
+
+  test('onSessionHistoryRequest sends session_history_response with real SessionStore', () => {
+    const { send, captured } = makeSend();
+    const handlers = createTrivialHandlers({
+      deviceTokens: new Map(),
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onSessionHistoryRequest(CID, REQ, 5);
+
+    expect(captured.calls).toHaveLength(1);
+    expect(captured.calls[0]?.message.type).toBe('session_history_response');
+    expect(captured.calls[0]?.connectionId).toBe(CID);
+  });
+
+  test('onSessionHistoryRequest clamps limit to a minimum of 1', () => {
+    const { send, captured } = makeSend();
+    const handlers = createTrivialHandlers({
+      deviceTokens: new Map(),
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onSessionHistoryRequest(CID, REQ, 0);
+    handlers.onSessionHistoryRequest(CID, REQ, -5);
+
+    expect(captured.calls).toHaveLength(2);
+    // Empty history, but both should respond (not throw) with a response envelope.
+    expect(captured.calls.every((c) => c.message.type === 'session_history_response')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 3 of the next cleanup wave: first `sharedEvents` extraction. Proves the factory/DI pattern on the smallest self-contained handlers so the bigger ones (onConnect, onAnswer, onResumeSessionRequest, onCreateSessionRequest, onTranscriptLoadRequest) can follow the same shape.
- `cli.ts`: **3042 → 3014 (−28)**.
- 1751/1751 tests pass.

## Changes

**New module: `packages/daemon/src/cli/handlers/trivial-events.ts`**
- `createTrivialHandlers(deps)` returns `onRegisterDeviceToken`, `onSessionHistoryRequest`, `onTerminalResize`, `onError`.
- Deps are explicit: `{ deviceTokens, sessionStore, sessionRegistry, send }`. Handlers close over those and read `log`/`logError` from `cli/logger.ts` directly (no per-handler log injection).
- Exports `DeviceTokenEntry` and `SendToConnection` types for reuse by future handler modules.

**`packages/daemon/src/cli.ts`**
- Imports `createTrivialHandlers`, constructs `trivialHandlers` where `sharedEvents` is declared (deps are in scope there), and spreads into the literal.
- Deletes the four inline handler bodies.
- Drops `createSessionHistoryResponse` from the `@remi/shared` import — only the extracted handler used it.

**Tests: `packages/daemon/tests/cli/handlers/trivial-events.test.ts`**
- 5 tests using real `SessionStore` (tmpdir-backed) and real `SessionRegistry`. No stubs of production surfaces — the NO MOCKS policy is respected; only test-owned primitives (a `Map`, a capture-array `send` closure) are constructed.
- Covers: token registration into the shared map, resize no-op path when no connection is attached, `[error]`-prefixed logging, history-response wiring, and negative-limit clamping.

## Why this ordering
Advisor flagged these as the cheapest first cut because:
1. Each touches exactly one piece of state (the `deviceTokens` map, the `sessionStore`, the connection map, or just the logger).
2. None of them write back to daemon-lifetime singletons, so no getter/setter plumbing is needed beyond what Phase 2 already provides.
3. Extracting them validates that `log`/`logError` resolve correctly from the shared module when called from a sibling `cli/handlers/*` file.

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/trivial-events.test.ts` — 5/5 pass
- [x] `bun test packages/daemon/tests/cli/` — 459/459 pass
- [x] Full `bun test` — 1751/1751 pass
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — no new findings on touched files (pre-existing unrelated warnings remain)