### PR TITLE
refactor(cli): extract 3 input sharedEvents handlers into handler module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -96,7 +96,6 @@ const cleanupStatusFile = (): void => statusWriter.cleanup();
 loadDotenvFile();
 
 import {
-  createBulletExpandResponse,
   createCreateSessionResponse,
   createDetachSessionAck,
   createError,
@@ -133,6 +132,7 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
+import { createInputHandlers } from './cli/handlers/input-events.ts';
 import { createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
@@ -1702,8 +1702,14 @@ const trivialHandlers = createTrivialHandlers({
   send: sendToConnection,
 });
 
+const inputHandlers = createInputHandlers({
+  sessionRegistry,
+  send: sendToConnection,
+});
+
 const sharedEvents = {
   ...trivialHandlers,
+  ...inputHandlers,
   onConnect: async (connectionId: UUID, metadata: AdapterMetadata) => {
     log(`Client connected: ${connectionId} (${metadata.adapterType})`);
 
@@ -1788,67 +1794,6 @@ const sharedEvents = {
     sessionRegistry.detachConnection(connectionId);
     registry.untrackConnection(connectionId);
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
-  },
-
-  onUserInput: async (connectionId: UUID, _sessionId: UUID, content: string, raw?: boolean) => {
-    log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
-
-    const session = sessionRegistry.getSessionForConnection(connectionId);
-    if (session) {
-      if (raw) {
-        // Raw terminal input from attach client: write directly without Enter
-        try {
-          session.pty.write(content);
-        } catch (err) {
-          log(`[PTY] raw write failed: ${errorToString(err)}`);
-        }
-      } else {
-        // Structured input from web/mobile client: append Enter
-        await session.pty.submitInput(content);
-      }
-    } else {
-      log(`No session found for connection ${connectionId}`);
-    }
-  },
-
-  onAnswer: async (connectionId: UUID, sessionId: UUID, _questionId: UUID, answer: string) => {
-    log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
-
-    // Prefer lookup by sessionId (from push-action answers) so reconnected clients
-    // can answer even before the connection is fully mapped in the registry.
-    const session =
-      sessionRegistry.getSession(sessionId) ??
-      sessionRegistry.getSessionForConnection(connectionId);
-    if (session) {
-      await session.pty.submitInput(answer);
-      sessionRegistry.updateQuestion(session.sessionId, null);
-    } else {
-      log(`No session found for connection ${connectionId} or session ${sessionId}`);
-    }
-  },
-
-  onBulletExpandRequest: (
-    connectionId: UUID,
-    sessionId: UUID,
-    bulletId: number,
-    requestId: UUID,
-  ) => {
-    const session = sessionRegistry.getSession(sessionId);
-    if (!session) {
-      sendToConnection(connectionId, createError('NOT_FOUND', `Session ${sessionId} not found`));
-      return;
-    }
-
-    const fullContent = session.messageApi.getFullBulletContent(bulletId);
-    if (fullContent === null) {
-      sendToConnection(
-        connectionId,
-        createError('CONTENT_EXPIRED', `Content for bullet ${bulletId} not found or expired`),
-      );
-      return;
-    }
-
-    sendToConnection(connectionId, createBulletExpandResponse(bulletId, fullContent, requestId));
   },
 
   onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -132,8 +132,8 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
-import { createInputHandlers } from './cli/handlers/input-events.ts';
-import { createTrivialHandlers } from './cli/handlers/trivial-events.ts';
+import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
+import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
@@ -1695,14 +1695,14 @@ const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean
   return registry.sendRaw(connectionId, message);
 };
 
-const trivialHandlers = createTrivialHandlers({
+const trivialHandlers: TrivialHandlers = createTrivialHandlers({
   deviceTokens,
   sessionStore,
   sessionRegistry,
   send: sendToConnection,
 });
 
-const inputHandlers = createInputHandlers({
+const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
   send: sendToConnection,
 });

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -1,12 +1,12 @@
 /**
  * sharedEvents handlers for client-to-PTY input flows:
- *   onUserInput       — terminal keystrokes (raw or line-buffered)
- *   onAnswer          — response to a pending Question
- *   onBulletExpandRequest — expand a truncated bullet from the MessageAPI
+ *   onUserInput, terminal keystrokes (raw or line-buffered)
+ *   onAnswer, response to a pending Question
+ *   onBulletExpandRequest, expand a truncated bullet from the MessageAPI
  *
  * All three look up a session from `sessionRegistry` and interact with its
  * PTY or MessageAPI. onBulletExpandRequest is the only one that writes back
- * to the caller, so `send` is only required when that handler is in use.
+ * to the caller, so `send` is only invoked by that handler.
  */
 
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
@@ -20,6 +20,8 @@ export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
   send: SendToConnection;
 }
+
+export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 export function createInputHandlers(deps: InputHandlerDeps) {
   const { sessionRegistry, send } = deps;

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -1,0 +1,102 @@
+/**
+ * sharedEvents handlers for client-to-PTY input flows:
+ *   onUserInput       — terminal keystrokes (raw or line-buffered)
+ *   onAnswer          — response to a pending Question
+ *   onBulletExpandRequest — expand a truncated bullet from the MessageAPI
+ *
+ * All three look up a session from `sessionRegistry` and interact with its
+ * PTY or MessageAPI. onBulletExpandRequest is the only one that writes back
+ * to the caller, so `send` is only required when that handler is in use.
+ */
+
+import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+
+import type { SessionRegistry } from '../../session/index.ts';
+import { log } from '../logger.ts';
+import type { SendToConnection } from './trivial-events.ts';
+
+export interface InputHandlerDeps {
+  sessionRegistry: SessionRegistry;
+  send: SendToConnection;
+}
+
+export function createInputHandlers(deps: InputHandlerDeps) {
+  const { sessionRegistry, send } = deps;
+
+  return {
+    onUserInput: async (
+      connectionId: UUID,
+      _sessionId: UUID,
+      content: string,
+      raw?: boolean,
+    ): Promise<void> => {
+      log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
+
+      const session = sessionRegistry.getSessionForConnection(connectionId);
+      if (!session) {
+        log(`No session found for connection ${connectionId}`);
+        return;
+      }
+
+      if (raw) {
+        // Raw terminal input from attach client: write directly without Enter
+        try {
+          session.pty.write(content);
+        } catch (err) {
+          log(`[PTY] raw write failed: ${errorToString(err)}`);
+        }
+        return;
+      }
+
+      // Structured input from web/mobile client: append Enter
+      await session.pty.submitInput(content);
+    },
+
+    onAnswer: async (
+      connectionId: UUID,
+      sessionId: UUID,
+      _questionId: UUID,
+      answer: string,
+    ): Promise<void> => {
+      log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
+
+      // Prefer lookup by sessionId (from push-action answers) so reconnected clients
+      // can answer even before the connection is fully mapped in the registry.
+      const session =
+        sessionRegistry.getSession(sessionId) ??
+        sessionRegistry.getSessionForConnection(connectionId);
+      if (!session) {
+        log(`No session found for connection ${connectionId} or session ${sessionId}`);
+        return;
+      }
+
+      await session.pty.submitInput(answer);
+      sessionRegistry.updateQuestion(session.sessionId, null);
+    },
+
+    onBulletExpandRequest: (
+      connectionId: UUID,
+      sessionId: UUID,
+      bulletId: number,
+      requestId: UUID,
+    ): void => {
+      const session = sessionRegistry.getSession(sessionId);
+      if (!session) {
+        send(connectionId, createError('NOT_FOUND', `Session ${sessionId} not found`));
+        return;
+      }
+
+      const fullContent = session.messageApi.getFullBulletContent(bulletId);
+      if (fullContent === null) {
+        send(
+          connectionId,
+          createError('CONTENT_EXPIRED', `Content for bullet ${bulletId} not found or expired`),
+        );
+        return;
+      }
+
+      send(connectionId, createBulletExpandResponse(bulletId, fullContent, requestId));
+    },
+  };
+}

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -31,6 +31,8 @@ export interface TrivialHandlerDeps {
   send: SendToConnection;
 }
 
+export type TrivialHandlers = ReturnType<typeof createTrivialHandlers>;
+
 export function createTrivialHandlers(deps: TrivialHandlerDeps) {
   const { deviceTokens, sessionStore, sessionRegistry, send } = deps;
 

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { createInputHandlers } from '../../../src/cli/handlers/input-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+
+/**
+ * Minimal PTY/MessageAPI fakes matching the pattern used in
+ * `tests/session-registry.test.ts` (registerSession needs both). Real
+ * PTYSession would spawn a shell; real MessageAPI would install callbacks.
+ * These fakes only cover the surface the handlers actually call.
+ */
+function fakePTY(capture: {
+  writes: string[];
+  submits: string[];
+  writeError?: Error;
+}): PTYSession {
+  return {
+    id: generateId(),
+    write: (content: string) => {
+      if (capture.writeError) throw capture.writeError;
+      capture.writes.push(content);
+    },
+    submitInput: async (content: string) => {
+      capture.submits.push(content);
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(bulletMap: Map<number, string | null>): MessageAPI {
+  return {
+    getFullBulletContent: (bulletId: number) => bulletMap.get(bulletId) ?? null,
+  } as unknown as MessageAPI;
+}
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const QID = 'ques0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+describe('createInputHandlers', () => {
+  let sessionRegistry: SessionRegistry;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+  let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
+
+  beforeEach(() => {
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    sendCalls = [];
+    send = (connectionId, message) => {
+      sendCalls.push({ connectionId, message });
+      return true;
+    };
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await sessionRegistry.shutdown();
+  });
+
+  describe('onUserInput', () => {
+    test('routes raw input to pty.write (no Enter appended)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
+
+      expect(ptyCapture.writes).toEqual(['\x1b[A']);
+      expect(ptyCapture.submits).toEqual([]);
+    });
+
+    test('routes structured input to pty.submitInput (appends Enter)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      await handlers.onUserInput(CID, sessionId, 'hello world', false);
+
+      expect(ptyCapture.submits).toEqual(['hello world']);
+      expect(ptyCapture.writes).toEqual([]);
+    });
+
+    test('logs and returns when no session is attached to the connection', async () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      const handlers = createInputHandlers({ sessionRegistry, send });
+
+      await handlers.onUserInput(CID, 's' as UUID, 'ignored', false);
+
+      expect(logs.some((m) => m.includes('No session found for connection'))).toBe(true);
+    });
+
+    test('swallows pty.write errors and logs them (raw path)', async () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        writeError: new Error('broken pipe'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      // Should not throw
+      await handlers.onUserInput(CID, sessionId, 'x', true);
+
+      expect(
+        logs.some((m) => m.includes('[PTY] raw write failed') && m.includes('broken pipe')),
+      ).toBe(true);
+    });
+  });
+
+  describe('onAnswer', () => {
+    test('submits answer via pty and clears the pending question', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'yes?',
+        options: [
+          { value: 'yes', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'no', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'yes');
+
+      expect(ptyCapture.submits).toEqual(['yes']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
+    });
+
+    test('falls back to connection lookup when sessionId is unknown', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      // Pass a bogus sessionId — handler should still find the session via connection
+      await handlers.onAnswer(CID, 'bogus0000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
+
+      expect(ptyCapture.submits).toEqual(['hello']);
+    });
+
+    test('logs when neither sessionId nor connectionId maps to a session', async () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      const handlers = createInputHandlers({ sessionRegistry, send });
+
+      await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
+
+      expect(logs.some((m) => m.includes('No session found'))).toBe(true);
+    });
+  });
+
+  describe('onBulletExpandRequest', () => {
+    test('sends NOT_FOUND when session is missing', () => {
+      const handlers = createInputHandlers({ sessionRegistry, send });
+
+      handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message;
+      expect(msg?.type).toBe('error');
+      expect((msg as { code?: string } | undefined)?.code).toBe('NOT_FOUND');
+    });
+
+    test('sends CONTENT_EXPIRED when the bullet is not in the MessageAPI cache', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY({ writes: [], submits: [] }),
+        fakeMessageAPI(new Map()),
+      );
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message;
+      expect(msg?.type).toBe('error');
+      expect((msg as { code?: string } | undefined)?.code).toBe('CONTENT_EXPIRED');
+    });
+
+    test('sends bullet_expand_response with full content when found', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY({ writes: [], submits: [] }),
+        fakeMessageAPI(new Map([[7, 'full expanded content']])),
+      );
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0]?.message.type).toBe('bullet_expand_response');
+    });
+  });
+});

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -8,10 +8,13 @@ import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 
 /**
- * Minimal PTY/MessageAPI fakes matching the pattern used in
- * `tests/session-registry.test.ts` (registerSession needs both). Real
- * PTYSession would spawn a shell; real MessageAPI would install callbacks.
- * These fakes only cover the surface the handlers actually call.
+ * Minimal PTY/MessageAPI fakes, loosely inspired by the cast-through-unknown
+ * pattern in `tests/session-registry.test.ts` (`createMockPTY` / `createMockMessageAPI`).
+ * Extended here to capture writes/submits so handlers can be asserted on
+ * observable behavior. Real PTYSession would spawn a shell; real MessageAPI
+ * would install callbacks. These fakes cover only the surface the handlers
+ * actually call: `write`, `submitInput`, `close` (called by
+ * `sessionRegistry.shutdown()` in `afterEach`), and `getFullBulletContent`.
  */
 function fakePTY(capture: {
   writes: string[];
@@ -103,7 +106,12 @@ describe('createInputHandlers', () => {
       configureLogger({ writeLog: (msg) => logs.push(msg) });
       const handlers = createInputHandlers({ sessionRegistry, send });
 
-      await handlers.onUserInput(CID, 's' as UUID, 'ignored', false);
+      await handlers.onUserInput(
+        CID,
+        'nosn0000-0000-0000-0000-000000000000' as UUID,
+        'ignored',
+        false,
+      );
 
       expect(logs.some((m) => m.includes('No session found for connection'))).toBe(true);
     });
@@ -173,12 +181,46 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
       sessionRegistry.attachConnection(sessionId, CID);
+      // Pre-seed a question so we can assert the fallback path clears it on
+      // the REAL session's id, not on the bogus arg it was handed.
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [
+          { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
 
       const handlers = createInputHandlers({ sessionRegistry, send });
-      // Pass a bogus sessionId — handler should still find the session via connection
-      await handlers.onAnswer(CID, 'bogus0000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
+      // Pass a bogus sessionId, handler should still find the session via connection
+      await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
       expect(ptyCapture.submits).toEqual(['hello']);
+      // Question must be cleared on the real session id, not the bogus one.
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
+    });
+
+    test('submits and leaves currentQuestion null when no question was pending', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // No updateQuestion call, currentQuestion stays null from registerSession.
+
+      const handlers = createInputHandlers({ sessionRegistry, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'hi');
+
+      expect(ptyCapture.submits).toEqual(['hi']);
+      // Push-action answers can arrive after a state resync, so a null clear
+      // on an already-null slot must remain safe and a no-op for the client.
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
     });
 
     test('logs when neither sessionId nor connectionId maps to a session', async () => {


### PR DESCRIPTION
## Summary
- Phase 3b of the cleanup wave: extracts `onUserInput`, `onAnswer`, and `onBulletExpandRequest`. All three look up a session from `SessionRegistry` and interact with its PTY or MessageAPI — same dep shape, no cross-handler state.
- `cli.ts`: **3014 → 2959 (−55)**.
- 1605/1605 tests pass (non-LLM suite).

## Changes
- **New `packages/daemon/src/cli/handlers/input-events.ts`**: `createInputHandlers({ sessionRegistry, send })` returns the three handlers. Reuses `SendToConnection` from `trivial-events.ts`.
- **`packages/daemon/src/cli.ts`**:
  - Imports `createInputHandlers`, builds `inputHandlers` alongside `trivialHandlers`, spreads both into `sharedEvents`.
  - Deletes the three inline handler bodies.
  - Drops `createBulletExpandResponse` from the `@remi/shared` import — only the extracted handler used it.
- **`packages/daemon/tests/cli/handlers/input-events.test.ts`**: 10 tests against a real `SessionRegistry` with the project's existing `fakePTY`/`fakeMessageAPI` pattern from `tests/session-registry.test.ts`. Covers:
  - raw vs. structured PTY input routing
  - PTY write-error swallowing (raw path)
  - question-clearing after answer
  - `sessionId` → connection-lookup fallback
  - `NOT_FOUND` for missing session, `CONTENT_EXPIRED` for missing bullet, success for bullet expansion

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/input-events.test.ts` — 10/10 pass
- [x] `bun test packages/daemon/tests/cli/` — 469/469 pass
- [x] Non-LLM full suite (`find ... -not -path '*/auto-approve/*' | xargs bun test`) — 1605/1605 pass in 19s. Auto-approve LLM tests skipped: this PR does not touch `packages/daemon/src/auto-approve/`.
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean