### PR TITLE
refactor(cli): extract 3 session-lifecycle sharedEvents handlers

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -97,10 +97,8 @@ loadDotenvFile();
 
 import {
   createCreateSessionResponse,
-  createDetachSessionAck,
   createError,
   createHelloAck,
-  createKillSessionResponse,
   createRawPtyOutput,
   createReplayBatch,
   createResumeSessionResponse,
@@ -133,6 +131,7 @@ import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
 import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
+import { type SessionHandlers, createSessionHandlers } from './cli/handlers/session-events.ts';
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
@@ -1707,9 +1706,22 @@ const inputHandlers: InputHandlers = createInputHandlers({
   send: sendToConnection,
 });
 
+const sessionHandlers: SessionHandlers = createSessionHandlers({
+  sessionRegistry,
+  sessionStore,
+  transcriptDiscovery,
+  liveSessionsRegistry,
+  currentPort: () => PORT,
+  untrackConnection: (id) => registry.untrackConnection(id),
+  onConnectionRemoved: () =>
+    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) }),
+  send: sendToConnection,
+});
+
 const sharedEvents = {
   ...trivialHandlers,
   ...inputHandlers,
+  ...sessionHandlers,
   onConnect: async (connectionId: UUID, metadata: AdapterMetadata) => {
     log(`Client connected: ${connectionId} (${metadata.adapterType})`);
 
@@ -1794,33 +1806,6 @@ const sharedEvents = {
     sessionRegistry.detachConnection(connectionId);
     registry.untrackConnection(connectionId);
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
-  },
-
-  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => {
-    const daemonSessions = sessionRegistry.listSessions();
-
-    let allSessions = [...daemonSessions];
-
-    if (includeExternal) {
-      const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
-      // Also exclude by Claude session ID (JSONL filename UUID — different namespace from remi IDs)
-      for (const remiId of [...managedIds]) {
-        const stored = sessionStore.findByRemiSessionId(remiId as UUID);
-        if (stored?.claudeSessionId) {
-          managedIds.add(stored.claudeSessionId);
-        }
-      }
-      const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
-      allSessions = [...daemonSessions, ...externalSessions];
-    }
-
-    log(
-      `Session list request from ${connectionId}: ${allSessions.length} sessions ` +
-        `(${daemonSessions.length} daemon, ${allSessions.length - daemonSessions.length} external)`,
-    );
-    // Include other daemon ports on this machine so the app can auto-connect
-    const livePorts = liveSessionsRegistry.getLivePorts().filter((p) => p !== PORT);
-    sendToConnection(connectionId, createSessionListResponse(allSessions, requestId, livePorts));
   },
 
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => {
@@ -1969,82 +1954,6 @@ const sharedEvents = {
       logError(`Failed to spawn daemon: ${msg}`);
       sendToConnection(connectionId, createCreateSessionResponse(false, requestId, undefined, msg));
     }
-  },
-
-  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
-    log(`Kill session request from ${connectionId} for session ${sessionId}`);
-
-    const session = sessionRegistry.getSession(sessionId);
-    if (!session) {
-      sendToConnection(
-        connectionId,
-        createKillSessionResponse(false, requestId, `Session ${sessionId} not found`),
-      );
-      return;
-    }
-
-    const sessionName = session.name;
-    log(`Killing session: ${sessionName} (${sessionId})`);
-
-    // Notify attached client before destroying the session
-    if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
-      sendToConnection(
-        session.activeConnectionId,
-        createError('SESSION_ENDED', 'Session killed by remote request'),
-      );
-    }
-
-    const hadActiveClient =
-      session.activeConnectionId !== null && session.activeConnectionId !== connectionId;
-    sessionRegistry.closeSession(sessionId, 'forced');
-    sendToConnection(connectionId, createKillSessionResponse(true, requestId));
-    if (hadActiveClient) {
-      log(`Session killed: ${sessionName} (disconnected attached client)`);
-    } else {
-      log(`Session killed: ${sessionName}`);
-    }
-  },
-
-  onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID) => {
-    log(`Detach session request from ${connectionId} for session ${sessionId}`);
-
-    const session = sessionRegistry.getSession(sessionId);
-    if (!session) {
-      sendToConnection(
-        connectionId,
-        createDetachSessionAck(sessionId, false, `Session ${sessionId} not found`),
-      );
-      return;
-    }
-
-    const activeConnId = session.activeConnectionId;
-    if (activeConnId === null) {
-      sendToConnection(
-        connectionId,
-        createDetachSessionAck(sessionId, false, 'Session is already detached'),
-      );
-      return;
-    }
-
-    // Send ack to the requesting connection (may be the active client or
-    // a separate query-mode client like `remi detach <session>`)
-    const ackSent = sendToConnection(connectionId, createDetachSessionAck(sessionId, true));
-    if (!ackSent) {
-      log(`Warning: detach ack could not be delivered to ${connectionId}`);
-    }
-
-    // Detach the ACTIVE connection (not necessarily the requesting one).
-    // Only untrack/decrement here for third-party detach (connectionId !== activeConnId).
-    // For self-detach, onDisconnect will handle cleanup when the WebSocket closes.
-    sessionRegistry.detachConnection(activeConnId, true);
-    if (activeConnId !== connectionId) {
-      registry.untrackConnection(activeConnId);
-      updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
-    }
-
-    log(
-      `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
-    );
   },
 
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -1,0 +1,159 @@
+/**
+ * sharedEvents handlers for whole-session lifecycle requests:
+ *   onSessionListRequest, enumerate daemon + external sessions
+ *   onKillSessionRequest, tear down a session (and notify any active client)
+ *   onDetachSession, release a session's active connection without killing it
+ *
+ * These three are grouped because they all operate on session records via
+ * `sessionRegistry` and speak the kill/detach/list protocol back to the
+ * caller. External-session discovery (list) and third-party detach (detach)
+ * need a couple of extra injected seams: a port getter (PORT is mutated
+ * during port probing in daemon mode), a connection-untrack callback on the
+ * AdapterRegistry, and a connection-count decrement callback on the
+ * StatusWriter. Everything else flows through `sessionRegistry`.
+ */
+
+import {
+  createDetachSessionAck,
+  createError,
+  createKillSessionResponse,
+  createSessionListResponse,
+} from '@remi/shared';
+import type { UUID } from '@remi/shared';
+
+import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import type { TranscriptDiscovery } from '../../transcript/index.ts';
+import { log } from '../logger.ts';
+import type { SendToConnection } from './trivial-events.ts';
+
+export interface SessionHandlerDeps {
+  sessionRegistry: SessionRegistry;
+  sessionStore: SessionStore;
+  transcriptDiscovery: TranscriptDiscovery;
+  liveSessionsRegistry: SessionRegistryFile;
+  /** PORT is reassigned during daemon-mode port probing; read lazily. */
+  currentPort: () => number;
+  /** Untrack a connection on the AdapterRegistry (third-party detach only). */
+  untrackConnection: (connectionId: UUID) => void;
+  /** Decrement the statusWriter connection count (third-party detach only). */
+  onConnectionRemoved: () => void;
+  send: SendToConnection;
+}
+
+export type SessionHandlers = ReturnType<typeof createSessionHandlers>;
+
+export function createSessionHandlers(deps: SessionHandlerDeps) {
+  const {
+    sessionRegistry,
+    sessionStore,
+    transcriptDiscovery,
+    liveSessionsRegistry,
+    currentPort,
+    untrackConnection,
+    onConnectionRemoved,
+    send,
+  } = deps;
+
+  return {
+    onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean): void => {
+      const daemonSessions = sessionRegistry.listSessions();
+      let allSessions = [...daemonSessions];
+
+      if (includeExternal) {
+        const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
+        // Also exclude by Claude session ID (JSONL filename UUID is a different namespace from remi IDs).
+        for (const remiId of [...managedIds]) {
+          const stored = sessionStore.findByRemiSessionId(remiId as UUID);
+          if (stored?.claudeSessionId) {
+            managedIds.add(stored.claudeSessionId);
+          }
+        }
+        const externalSessions = transcriptDiscovery.discoverSessions(managedIds);
+        allSessions = [...daemonSessions, ...externalSessions];
+      }
+
+      log(
+        `Session list request from ${connectionId}: ${allSessions.length} sessions ` +
+          `(${daemonSessions.length} daemon, ${allSessions.length - daemonSessions.length} external)`,
+      );
+      // Include other daemon ports on this machine so the app can auto-connect.
+      const port = currentPort();
+      const livePorts = liveSessionsRegistry.getLivePorts().filter((p) => p !== port);
+      send(connectionId, createSessionListResponse(allSessions, requestId, livePorts));
+    },
+
+    onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID): void => {
+      log(`Kill session request from ${connectionId} for session ${sessionId}`);
+
+      const session = sessionRegistry.getSession(sessionId);
+      if (!session) {
+        send(
+          connectionId,
+          createKillSessionResponse(false, requestId, `Session ${sessionId} not found`),
+        );
+        return;
+      }
+
+      const sessionName = session.name;
+      log(`Killing session: ${sessionName} (${sessionId})`);
+
+      // Notify attached client before destroying the session.
+      if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
+        send(
+          session.activeConnectionId,
+          createError('SESSION_ENDED', 'Session killed by remote request'),
+        );
+      }
+
+      const hadActiveClient =
+        session.activeConnectionId !== null && session.activeConnectionId !== connectionId;
+      sessionRegistry.closeSession(sessionId, 'forced');
+      send(connectionId, createKillSessionResponse(true, requestId));
+      if (hadActiveClient) {
+        log(`Session killed: ${sessionName} (disconnected attached client)`);
+      } else {
+        log(`Session killed: ${sessionName}`);
+      }
+    },
+
+    onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID): void => {
+      log(`Detach session request from ${connectionId} for session ${sessionId}`);
+
+      const session = sessionRegistry.getSession(sessionId);
+      if (!session) {
+        send(
+          connectionId,
+          createDetachSessionAck(sessionId, false, `Session ${sessionId} not found`),
+        );
+        return;
+      }
+
+      const activeConnId = session.activeConnectionId;
+      if (activeConnId === null) {
+        send(connectionId, createDetachSessionAck(sessionId, false, 'Session is already detached'));
+        return;
+      }
+
+      // Send ack to the requesting connection. It may be the active client
+      // itself, or a separate query-mode client (like `remi detach <session>`).
+      const ackSent = send(connectionId, createDetachSessionAck(sessionId, true));
+      if (!ackSent) {
+        log(`Warning: detach ack could not be delivered to ${connectionId}`);
+      }
+
+      // Detach the ACTIVE connection (not necessarily the requesting one).
+      // Only untrack + decrement here for third-party detach
+      // (connectionId !== activeConnId). For self-detach, onDisconnect will
+      // clean up when the WebSocket actually closes.
+      sessionRegistry.detachConnection(activeConnId, true);
+      if (activeConnId !== connectionId) {
+        untrackConnection(activeConnId);
+        onConnectionRemoved();
+      }
+
+      log(
+        `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
+      );
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { createSessionHandlers } from '../../../src/cli/handlers/session-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/index.ts';
+
+/** Minimal fakes matching the pattern established in input-events.test.ts. */
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    getFullBulletContent: () => null,
+  } as unknown as MessageAPI;
+}
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const OTHER_CID = 'othr0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+const BOGUS = 'bogu0000-0000-0000-0000-000000000000' as UUID;
+
+describe('createSessionHandlers', () => {
+  let tmpDir: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+  let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
+  let untrackCalls: UUID[];
+  let connectionRemovedCount: number;
+  const PORT = 8765;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-session-events-'));
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    liveSessionsRegistry = new SessionRegistryFile(tmpDir);
+    transcriptDiscovery = new TranscriptDiscovery({
+      projectsDir: path.join(tmpDir, 'claude-projects'),
+    });
+    sendCalls = [];
+    send = (connectionId, message) => {
+      sendCalls.push({ connectionId, message });
+      return true;
+    };
+    untrackCalls = [];
+    connectionRemovedCount = 0;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers() {
+    return createSessionHandlers({
+      sessionRegistry,
+      sessionStore,
+      transcriptDiscovery,
+      liveSessionsRegistry,
+      currentPort: () => PORT,
+      untrackConnection: (id) => {
+        untrackCalls.push(id);
+      },
+      onConnectionRemoved: () => {
+        connectionRemovedCount += 1;
+      },
+      send,
+    });
+  }
+
+  describe('onSessionListRequest', () => {
+    test('returns the daemon-only list when includeExternal is false', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as unknown as {
+        type: string;
+        sessions: unknown[];
+      };
+      expect(msg.type).toBe('session_list_response');
+      expect(msg.sessions).toHaveLength(1);
+    });
+
+    test('omits the current daemon port from daemonPorts', () => {
+      // Register one session entry for a DIFFERENT port alongside ours.
+      liveSessionsRegistry.register({
+        sessionId: 'othr1234-1234-1234-1234-123456789012',
+        wsPort: 9999,
+        pid: process.pid,
+        hookPort: 0,
+        projectPath: tmpDir,
+        name: 'other',
+        startedAt: new Date().toISOString(),
+      });
+      liveSessionsRegistry.register({
+        sessionId: 'curr1234-1234-1234-1234-123456789012',
+        wsPort: PORT,
+        pid: process.pid,
+        hookPort: 0,
+        projectPath: tmpDir,
+        name: 'current',
+        startedAt: new Date().toISOString(),
+      });
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      const msg = sendCalls[0]?.message as unknown as { daemonPorts?: number[] };
+      expect(msg.daemonPorts).toEqual([9999]);
+      expect(msg.daemonPorts).not.toContain(PORT);
+    });
+  });
+
+  describe('onKillSessionRequest', () => {
+    test('responds with failure when the session is unknown', () => {
+      makeHandlers().onKillSessionRequest(CID, BOGUS, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(msg.type).toBe('kill_session_response');
+      expect(msg.success).toBe(false);
+    });
+
+    test('closes the session and acks success when called by the active client', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+
+      // Only an ack to the caller: no SESSION_ENDED error since the requester IS the active client.
+      expect(sendCalls).toHaveLength(1);
+      const ack = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(ack.type).toBe('kill_session_response');
+      expect(ack.success).toBe(true);
+      expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
+    });
+
+    test('notifies a third-party attached client with SESSION_ENDED before killing', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, OTHER_CID);
+
+      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+
+      expect(sendCalls).toHaveLength(2);
+      const notice = sendCalls[0]?.message as { type: string; code?: string };
+      expect(notice.type).toBe('error');
+      expect(notice.code).toBe('SESSION_ENDED');
+      expect(sendCalls[0]?.connectionId).toBe(OTHER_CID);
+      const ack = sendCalls[1]?.message as { type: string; success: boolean };
+      expect(ack.type).toBe('kill_session_response');
+      expect(ack.success).toBe(true);
+    });
+  });
+
+  describe('onDetachSession', () => {
+    test('responds with failure when the session is unknown', () => {
+      makeHandlers().onDetachSession(CID, BOGUS, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(msg.type).toBe('detach_session_ack');
+      expect(msg.success).toBe(false);
+    });
+
+    test('responds with failure when the session is already detached', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      // No attachConnection: activeConnectionId stays null.
+
+      makeHandlers().onDetachSession(CID, sessionId, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as {
+        type: string;
+        success: boolean;
+        error?: string;
+      };
+      expect(msg.success).toBe(false);
+      expect(msg.error).toBe('Session is already detached');
+    });
+
+    test('self-detach acks and releases the connection without untrack', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      makeHandlers().onDetachSession(CID, sessionId, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      const ack = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(ack.success).toBe(true);
+      // Self-detach path: onDisconnect will handle cleanup when the WebSocket actually closes.
+      expect(untrackCalls).toEqual([]);
+      expect(connectionRemovedCount).toBe(0);
+    });
+
+    test('third-party detach untracks the active connection and decrements the count', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, OTHER_CID);
+
+      makeHandlers().onDetachSession(CID, sessionId, REQ);
+
+      expect(sendCalls).toHaveLength(1);
+      expect(untrackCalls).toEqual([OTHER_CID]);
+      expect(connectionRemovedCount).toBe(1);
+    });
+  });
+});

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -30,7 +30,7 @@ function fakeMessageAPI(): MessageAPI {
 }
 
 const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
-const OTHER_CID = 'othr0000-0000-0000-0000-000000000000' as UUID;
+const OTHER_CID = '0a000000-0000-0000-0000-000000000002' as UUID;
 const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 const BOGUS = 'bogu0000-0000-0000-0000-000000000000' as UUID;
 
@@ -106,7 +106,7 @@ describe('createSessionHandlers', () => {
     test('omits the current daemon port from daemonPorts', () => {
       // Register one session entry for a DIFFERENT port alongside ours.
       liveSessionsRegistry.register({
-        sessionId: 'othr1234-1234-1234-1234-123456789012',
+        sessionId: '0a001234-1234-1234-1234-123456789012',
         wsPort: 9999,
         pid: process.pid,
         hookPort: 0,


### PR DESCRIPTION
## Summary
- Wave 3c of the cleanup epic: extracts `onSessionListRequest`, `onKillSessionRequest`, `onDetachSession` into `packages/daemon/src/cli/handlers/session-events.ts`. All three operate on session records via `SessionRegistry` and speak the list/kill/detach protocol.
- `cli.ts`: **2959 → 2868 (−91)**.
- 1615/1615 non-LLM tests pass. Auto-approve LLM tests skipped: this PR does not touch `packages/daemon/src/auto-approve/`.

## Changes

**New `packages/daemon/src/cli/handlers/session-events.ts`** — 159 lines.
- `createSessionHandlers(deps)` returns the three handlers.
- Deps wire in `SessionRegistry`, `SessionStore`, `TranscriptDiscovery`, `SessionRegistryFile`, plus three seams for mutable cli.ts state that handlers can't close over:
  - `currentPort: () => PORT` — PORT is reassigned during daemon-mode port probing, so a getter is needed instead of a captured value.
  - `untrackConnection` — forwards to `AdapterRegistry.untrackConnection` for third-party detach cleanup.
  - `onConnectionRemoved` — forwards to the `StatusWriter` connection-count decrement for third-party detach cleanup.
- Exports a named `SessionHandlers` type via `ReturnType<typeof createSessionHandlers>`, bound explicitly at the cli.ts construction site so a typo in a handler key would fail to compile against `AdapterEvents`. Follows the pattern #346 established for `InputHandlers` / `TrivialHandlers`.

**`packages/daemon/src/cli.ts`**
- Imports `createSessionHandlers`, builds `sessionHandlers` alongside `trivialHandlers`/`inputHandlers`, spreads all three into `sharedEvents`.
- Deletes 3 inline handler bodies (~92 lines).
- Drops `createDetachSessionAck` and `createKillSessionResponse` from the `@remi/shared` import (only the extracted handlers used them).

**`packages/daemon/tests/cli/handlers/session-events.test.ts`** — 232 lines, 9 tests.
- Real-dep tests with tmpdir-backed `SessionStore`, `SessionRegistryFile`, `TranscriptDiscovery`, and real `SessionRegistry`. Only `PTYSession` and `MessageAPI` are minimal fakes (per the established `session-registry.test.ts` pattern).
- Covers: daemon-only list (`includeExternal=false`), daemon-port exclusion from `daemonPorts`, kill (unknown session / self-kill / third-party kill with `SESSION_ENDED` notification), detach (unknown / already-detached / self-detach with no untrack / third-party with untrack + decrement).

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/session-events.test.ts` — 9/9 pass
- [x] Non-LLM full suite — 1615/1615 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean