### PR TITLE
refactor(cli): extract onConnect + onDisconnect into connection-events handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -117,12 +117,7 @@ import type {
   UnlockedIdentity,
 } from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
-import {
-  type AdapterMetadata,
-  AdapterRegistry,
-  TelegramAdapter,
-  WebSocketAdapter,
-} from './adapters/index.ts';
+import { AdapterRegistry, TelegramAdapter, WebSocketAdapter } from './adapters/index.ts';
 import { MessageAPI } from './api/index.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
@@ -130,6 +125,10 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
+import {
+  type ConnectionHandlers,
+  createConnectionHandlers,
+} from './cli/handlers/connection-events.ts';
 import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
 import { type SessionHandlers, createSessionHandlers } from './cli/handlers/session-events.ts';
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
@@ -1718,96 +1717,23 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
   send: sendToConnection,
 });
 
+const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
+  sessionRegistry,
+  deviceTokens,
+  trackConnection: (id, adapterType) => registry.trackConnection(id, adapterType),
+  untrackConnection: (id) => registry.untrackConnection(id),
+  onConnectionAdded: () => updateRemiStatus({ connections: remiStatus.connections + 1 }),
+  onConnectionRemoved: () =>
+    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) }),
+  cancelOrphanTimeout,
+  send: sendToConnection,
+});
+
 const sharedEvents = {
   ...trivialHandlers,
   ...inputHandlers,
   ...sessionHandlers,
-  onConnect: async (connectionId: UUID, metadata: AdapterMetadata) => {
-    log(`Client connected: ${connectionId} (${metadata.adapterType})`);
-
-    registry.trackConnection(connectionId, metadata.adapterType);
-    updateRemiStatus({ connections: remiStatus.connections + 1 });
-
-    const resumeSessionId = metadata.platformData?.['resumeSessionId'] as UUID | undefined;
-    const currentPrimary = getPrimarySessionId();
-
-    // Unified connection flow: one session per daemon, both modes behave the same.
-    // If a resumeSessionId is provided, validate it matches our session.
-    if (resumeSessionId && currentPrimary && resumeSessionId !== currentPrimary) {
-      log(`Resume ID mismatch: requested ${resumeSessionId}, daemon has ${currentPrimary}`);
-      sendToConnection(
-        connectionId,
-        createError(
-          'SESSION_NOT_FOUND',
-          `Session ${resumeSessionId} not found on this daemon. Active session: ${currentPrimary}.`,
-        ),
-      );
-      return;
-    }
-
-    // Try to attach to the primary (only) session
-    const isQueryMode = metadata.platformData?.['mode'] === 'query';
-    if (currentPrimary) {
-      // Only auto-attach if the client wants to attach (not a utility client like ls/kill)
-      if (!isQueryMode) {
-        const result = sessionRegistry.attachConnection(currentPrimary, connectionId);
-        if (result.success) {
-          sendToConnection(
-            connectionId,
-            createHelloAck('1.0.0', currentPrimary, {
-              isResume: result.replayMessages.length > 0,
-              replayCount: result.replayMessages.length,
-              nextBulletId: result.nextBulletId,
-            }),
-          );
-          if (result.replayMessages.length > 0) {
-            sendToConnection(
-              connectionId,
-              createReplayBatch(currentPrimary, result.replayMessages, true),
-            );
-          }
-          cancelOrphanTimeout();
-          log(`Attached connection ${connectionId} to session ${currentPrimary}`);
-          return;
-        }
-      }
-
-      // Query mode or attach failed (session busy); send hello_ack without attach
-      // so utility clients (ls, kill) can still send requests
-      sendToConnection(connectionId, createHelloAck('1.0.0', currentPrimary));
-      log(
-        `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
-      );
-      return;
-    }
-
-    // No session available
-    sendToConnection(connectionId, createError('NO_SESSION', 'No active session available'));
-  },
-
-  onDisconnect: async (connectionId: UUID, reason: string) => {
-    log(`Client disconnected: ${connectionId}`);
-    log(`   Reason: ${reason}`);
-
-    // Remove device tokens registered by this connection so push
-    // notifications stop after explicit disconnect. The client
-    // re-registers on reconnect, so this is safe.
-    for (const [key, dt] of deviceTokens) {
-      if (dt.connectionId === connectionId) {
-        deviceTokens.delete(key);
-        log(`Device token unregistered (disconnect): ${key.slice(0, 20)}...`);
-      }
-    }
-
-    // Explicitly remove from waiting queue, then detach if active.
-    // detachConnection also handles waiting removal, but this ensures
-    // cleanup even if detachConnection's early-return path changes.
-    sessionRegistry.removeWaitingConnection(connectionId);
-    sessionRegistry.detachConnection(connectionId);
-    registry.untrackConnection(connectionId);
-    updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) });
-  },
-
+  ...connectionHandlers,
   onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => {
     log(`Transcript load request from ${connectionId} for session ${sessionId}`);
 

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -1,0 +1,138 @@
+/**
+ * sharedEvents handlers for connection lifecycle:
+ *   onConnect    - tracks a new connection, sends helloAck (optionally with
+ *                  replay), and auto-attaches to the primary session unless
+ *                  the client declared query mode
+ *   onDisconnect - cleans up device tokens, detaches from the session
+ *                  registry, untracks on the AdapterRegistry, and decrements
+ *                  the StatusWriter connection count
+ *
+ * The two handlers share the same "who owns a connection" machinery so they
+ * live in one module, with a single dep bundle, to keep the wiring in cli.ts
+ * consistent.
+ */
+
+import { createError, createHelloAck, createReplayBatch } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+
+import type { AdapterMetadata } from '../../adapters/index.ts';
+import type { SessionRegistry } from '../../session/index.ts';
+import { log } from '../logger.ts';
+import { getPrimarySessionId } from '../session-state.ts';
+import type { DeviceTokenEntry, SendToConnection } from './trivial-events.ts';
+
+export interface ConnectionHandlerDeps {
+  sessionRegistry: SessionRegistry;
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  /** Forward to AdapterRegistry.trackConnection. */
+  trackConnection: (connectionId: UUID, adapterType: string) => void;
+  /** Forward to AdapterRegistry.untrackConnection. */
+  untrackConnection: (connectionId: UUID) => void;
+  /** Increment StatusWriter connection count. */
+  onConnectionAdded: () => void;
+  /** Decrement StatusWriter connection count. */
+  onConnectionRemoved: () => void;
+  /** Cancel the SIGHUP orphan-shutdown timer after a remote client attaches. */
+  cancelOrphanTimeout: () => void;
+  send: SendToConnection;
+}
+
+export type ConnectionHandlers = ReturnType<typeof createConnectionHandlers>;
+
+export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
+  const {
+    sessionRegistry,
+    deviceTokens,
+    trackConnection,
+    untrackConnection,
+    onConnectionAdded,
+    onConnectionRemoved,
+    cancelOrphanTimeout,
+    send,
+  } = deps;
+
+  return {
+    onConnect: async (connectionId: UUID, metadata: AdapterMetadata): Promise<void> => {
+      log(`Client connected: ${connectionId} (${metadata.adapterType})`);
+
+      trackConnection(connectionId, metadata.adapterType);
+      onConnectionAdded();
+
+      const resumeSessionId = metadata.platformData?.['resumeSessionId'] as UUID | undefined;
+      const currentPrimary = getPrimarySessionId();
+
+      // Unified connection flow: one session per daemon, both modes behave the same.
+      // If a resumeSessionId is provided, validate it matches our session.
+      if (resumeSessionId && currentPrimary && resumeSessionId !== currentPrimary) {
+        log(`Resume ID mismatch: requested ${resumeSessionId}, daemon has ${currentPrimary}`);
+        send(
+          connectionId,
+          createError(
+            'SESSION_NOT_FOUND',
+            `Session ${resumeSessionId} not found on this daemon. Active session: ${currentPrimary}.`,
+          ),
+        );
+        return;
+      }
+
+      // Try to attach to the primary (only) session.
+      const isQueryMode = metadata.platformData?.['mode'] === 'query';
+      if (currentPrimary) {
+        // Only auto-attach if the client wants to attach, not a utility client like ls/kill.
+        if (!isQueryMode) {
+          const result = sessionRegistry.attachConnection(currentPrimary, connectionId);
+          if (result.success) {
+            send(
+              connectionId,
+              createHelloAck('1.0.0', currentPrimary, {
+                isResume: result.replayMessages.length > 0,
+                replayCount: result.replayMessages.length,
+                nextBulletId: result.nextBulletId,
+              }),
+            );
+            if (result.replayMessages.length > 0) {
+              send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
+            }
+            cancelOrphanTimeout();
+            log(`Attached connection ${connectionId} to session ${currentPrimary}`);
+            return;
+          }
+        }
+
+        // Query mode or attach failed (session busy); send hello_ack without
+        // attach so utility clients (ls, kill) can still send requests.
+        send(connectionId, createHelloAck('1.0.0', currentPrimary));
+        log(
+          `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
+        );
+        return;
+      }
+
+      // No session available.
+      send(connectionId, createError('NO_SESSION', 'No active session available'));
+    },
+
+    onDisconnect: async (connectionId: UUID, reason: string): Promise<void> => {
+      log(`Client disconnected: ${connectionId}`);
+      log(`   Reason: ${reason}`);
+
+      // Remove device tokens registered by this connection so push
+      // notifications stop after explicit disconnect. The client
+      // re-registers on reconnect, so this is safe.
+      for (const [key, dt] of deviceTokens) {
+        if (dt.connectionId === connectionId) {
+          deviceTokens.delete(key);
+          log(`Device token unregistered (disconnect): ${key.slice(0, 20)}...`);
+        }
+      }
+
+      // Explicitly remove from the waiting queue, then detach if active.
+      // detachConnection also handles waiting removal, but this ensures
+      // cleanup even if detachConnection's early-return path changes.
+      sessionRegistry.removeWaitingConnection(connectionId);
+      sessionRegistry.detachConnection(connectionId);
+      untrackConnection(connectionId);
+      onConnectionRemoved();
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { createConnectionHandlers } from '../../../src/cli/handlers/connection-events.ts';
+import type { DeviceTokenEntry } from '../../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import {
+  __resetSessionStateForTests,
+  setPrimarySessionId,
+} from '../../../src/cli/session-state.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+
+/** Minimal fakes matching the pattern in session-registry.test.ts (casts through unknown). */
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    getFullBulletContent: () => null,
+  } as unknown as MessageAPI;
+}
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+
+describe('createConnectionHandlers', () => {
+  let sessionRegistry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+  let trackedConnections: Array<{ id: UUID; type: string }>;
+  let untrackedConnections: UUID[];
+  let connectionAddedCount: number;
+  let connectionRemovedCount: number;
+  let cancelOrphanCalls: number;
+
+  function send(connectionId: UUID, message: ProtocolMessage): boolean {
+    sendCalls.push({ connectionId, message });
+    return true;
+  }
+
+  beforeEach(() => {
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    deviceTokens = new Map();
+    sendCalls = [];
+    trackedConnections = [];
+    untrackedConnections = [];
+    connectionAddedCount = 0;
+    connectionRemovedCount = 0;
+    cancelOrphanCalls = 0;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    __resetSessionStateForTests();
+    await sessionRegistry.shutdown();
+  });
+
+  function makeHandlers() {
+    return createConnectionHandlers({
+      sessionRegistry,
+      deviceTokens,
+      trackConnection: (id, type) => {
+        trackedConnections.push({ id, type });
+      },
+      untrackConnection: (id) => {
+        untrackedConnections.push(id);
+      },
+      onConnectionAdded: () => {
+        connectionAddedCount += 1;
+      },
+      onConnectionRemoved: () => {
+        connectionRemovedCount += 1;
+      },
+      cancelOrphanTimeout: () => {
+        cancelOrphanCalls += 1;
+      },
+      send,
+    });
+  }
+
+  describe('onConnect', () => {
+    test('tracks connection and sends NO_SESSION when no primary session exists', async () => {
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: {},
+      });
+
+      expect(trackedConnections).toEqual([{ id: CID, type: 'websocket' }]);
+      expect(connectionAddedCount).toBe(1);
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; code?: string };
+      expect(msg.type).toBe('error');
+      expect(msg.code).toBe('NO_SESSION');
+    });
+
+    test('auto-attaches and sends helloAck when a primary session exists (non-query)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: {},
+      });
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string };
+      expect(msg.type).toBe('hello_ack');
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(cancelOrphanCalls).toBe(1);
+    });
+
+    test('query-mode clients get a helloAck without attaching', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { mode: 'query' },
+      });
+
+      expect(sendCalls).toHaveLength(1);
+      expect((sendCalls[0]?.message as { type: string }).type).toBe('hello_ack');
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+      expect(cancelOrphanCalls).toBe(0);
+    });
+
+    test('rejects with SESSION_NOT_FOUND when resumeSessionId does not match primary', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: {
+          resumeSessionId: 'mism0000-0000-0000-0000-000000000000' as UUID,
+        },
+      });
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; code?: string };
+      expect(msg.type).toBe('error');
+      expect(msg.code).toBe('SESSION_NOT_FOUND');
+      // Attach should NOT have happened.
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+    });
+  });
+
+  describe('onDisconnect', () => {
+    test('detaches from registry and decrements connection count', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      await makeHandlers().onDisconnect(CID, 'client closed');
+
+      expect(untrackedConnections).toEqual([CID]);
+      expect(connectionRemovedCount).toBe(1);
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+    });
+
+    test('purges device tokens belonging to the disconnecting connection only', async () => {
+      deviceTokens.set('mine-token', {
+        token: 'mine-token',
+        platform: 'ios',
+        registeredAt: Date.now(),
+        connectionId: CID,
+      });
+      deviceTokens.set('keep-token', {
+        token: 'keep-token',
+        platform: 'ios',
+        registeredAt: Date.now(),
+        connectionId: '0a000000-0000-0000-0000-000000000042' as UUID,
+      });
+
+      await makeHandlers().onDisconnect(CID, 'client closed');
+
+      expect(deviceTokens.has('mine-token')).toBe(false);
+      expect(deviceTokens.has('keep-token')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wave 3d of the cleanup epic: extracts `onConnect` and `onDisconnect`. Both share the connection-ownership machinery (adapter-registry tracking, StatusWriter connection count, session-registry attach/detach, device-token cleanup), so grouping them into one module keeps cli.ts wiring consistent.
- `cli.ts`: **2868 → 2794 (−74)**.
- 1621/1621 non-LLM tests pass. Auto-approve LLM tests skipped: this PR does not touch `packages/daemon/src/auto-approve/`.

## Changes

**New `packages/daemon/src/cli/handlers/connection-events.ts`** — 138 lines.
- `createConnectionHandlers(deps)` returns `onConnect` + `onDisconnect`.
- Dep bundle:
  - `sessionRegistry`, `deviceTokens` — shared state both handlers mutate.
  - `trackConnection` / `untrackConnection` — forward to `AdapterRegistry`.
  - `onConnectionAdded` / `onConnectionRemoved` — forward to `StatusWriter` increment/decrement.
  - `cancelOrphanTimeout` — the cli.ts SIGHUP shutdown-timer cancel, called after a successful attach so the daemon doesn't shut down with a live client.
  - `send` — forward to `sendToConnection`.
- Reads `getPrimarySessionId()` directly from `cli/session-state.ts` (no closure over the cli.ts-local `let`).
- Exports a named `ConnectionHandlers` type via `ReturnType<typeof createConnectionHandlers>`, bound explicitly at the cli.ts construction site so a typo in a handler key would fail to compile against `AdapterEvents` (follows #346/#347 pattern).

**`packages/daemon/src/cli.ts`**
- Imports `createConnectionHandlers`, builds `connectionHandlers` alongside the other handler bundles, spreads all four into `sharedEvents`.
- Deletes the two inline handler bodies (92 lines).

**`packages/daemon/tests/cli/handlers/connection-events.test.ts`** — 191 lines, 6 tests with real `SessionRegistry`.
- `onConnect`: no-session NO_SESSION, auto-attach + orphan-cancel, query-mode hello_ack without attach, resume-mismatch SESSION_NOT_FOUND.
- `onDisconnect`: detach + decrement, device-token purge only for the disconnecting connection.

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/connection-events.test.ts` — 6/6 pass
- [x] Non-LLM full suite — 1621/1621 pass in 21s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `typos` on touched files — clean