### PR TITLE
refactor(cli): extract onTranscriptLoadRequest into transcript-events handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -97,7 +97,6 @@ loadDotenvFile();
 
 import {
   createCreateSessionResponse,
-  createError,
   createHelloAck,
   createRawPtyOutput,
   createReplayBatch,
@@ -105,7 +104,6 @@ import {
   createSessionListResponse,
   createSessionReset,
   createStructuredAgentOutput,
-  createTranscriptLoadComplete,
   generateId,
   now,
 } from '@remi/shared';
@@ -131,6 +129,10 @@ import {
 } from './cli/handlers/connection-events.ts';
 import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
 import { type SessionHandlers, createSessionHandlers } from './cli/handlers/session-events.ts';
+import {
+  type TranscriptHandlers,
+  createTranscriptHandlers,
+} from './cli/handlers/transcript-events.ts';
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
@@ -1717,6 +1719,12 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
   send: sendToConnection,
 });
 
+const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
+  transcriptDiscovery,
+  transcriptWatchers,
+  send: sendToConnection,
+});
+
 const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
   sessionRegistry,
   deviceTokens,
@@ -1734,82 +1742,7 @@ const sharedEvents = {
   ...inputHandlers,
   ...sessionHandlers,
   ...connectionHandlers,
-  onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => {
-    log(`Transcript load request from ${connectionId} for session ${sessionId}`);
-
-    // First try finding by Claude session ID embedded in the filename
-    let filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
-
-    // If not found by Claude session ID, the request may be using a Remi UUID
-    // (daemon sessions are identified by Remi UUID, not Claude session ID).
-    // Check if an active watcher exists for this session ID and use its path.
-    if (!filePath) {
-      const activeWatcher = transcriptWatchers.get(sessionId as UUID);
-      if (activeWatcher) {
-        filePath = activeWatcher.filePath;
-        log(`[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via active watcher`);
-      }
-    }
-
-    if (!filePath) {
-      sendToConnection(
-        connectionId,
-        createError('NOT_FOUND', `Transcript for session ${sessionId} not found`),
-      );
-      return;
-    }
-
-    // Create a temporary MessageAPI and bridge to read the transcript
-    const messageApi = new MessageAPI({ sessionId: sessionId as UUID });
-    let messageCount = 0;
-
-    const bridge = new TranscriptMessageBridge({ sessionId: sessionId as UUID }, messageApi, {
-      onTranscriptContent: (message) => {
-        messageCount++;
-        sendToConnection(connectionId, message);
-      },
-    });
-
-    const watcher = new TranscriptWatcher(
-      {
-        filePath,
-        readExisting: true,
-        pollIntervalMs: 0, // We only want to read existing, not watch
-      },
-      {
-        onAssistantMessage: (entry: AssistantEntry) => {
-          bridge.handleAssistantEntry(entry);
-        },
-        onUserMessage: (entry) => {
-          bridge.handleUserEntry(entry);
-        },
-        onError: (error) => {
-          logError(`[TranscriptLoad] Error reading ${sessionId}:`, error.message);
-        },
-      },
-    );
-
-    // Read the transcript file, then send completion
-    watcher
-      .start()
-      .then(() => {
-        // Stop the watcher immediately since we only needed to read existing entries
-        watcher.stop();
-        log(`Transcript load complete for ${sessionId}: ${messageCount} messages`);
-        sendToConnection(
-          connectionId,
-          createTranscriptLoadComplete(sessionId, messageCount, requestId),
-        );
-      })
-      .catch((error) => {
-        logError(`[TranscriptLoad] Failed to read ${sessionId}:`, error);
-        sendToConnection(
-          connectionId,
-          createError('LOAD_FAILED', `Failed to load transcript: ${error.message}`),
-        );
-      });
-  },
-
+  ...transcriptHandlers,
   onCreateSessionRequest: async (
     connectionId: UUID,
     directory: string | undefined,

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -1,0 +1,112 @@
+/**
+ * sharedEvents handler for one-shot transcript reads:
+ *   onTranscriptLoadRequest, read an entire Claude Code JSONL transcript
+ *     once (no long-lived watch), stream each message back to the caller,
+ *     then send a transcript_load_complete envelope.
+ *
+ * Separate from the live streaming watchers that createNewSession sets up:
+ * this handler serves clients asking for the *history* of an arbitrary
+ * session (daemon-owned or external) by its UUID. If the UUID is a Remi
+ * session ID, the handler falls back to the live watcher's file path so
+ * callers don't need to know which naming scheme the session uses.
+ */
+
+import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+
+import { MessageAPI } from '../../api/message-api.ts';
+import type {
+  TranscriptDiscovery,
+  TranscriptWatcher as TranscriptWatcherType,
+} from '../../transcript/index.ts';
+import { TranscriptMessageBridge, TranscriptWatcher } from '../../transcript/index.ts';
+import type { AssistantEntry } from '../../transcript/index.ts';
+import { log, logError } from '../logger.ts';
+import type { SendToConnection } from './trivial-events.ts';
+
+export interface TranscriptHandlerDeps {
+  transcriptDiscovery: TranscriptDiscovery;
+  /** Live watchers keyed by Remi session ID (for Remi-UUID fallback resolution). */
+  transcriptWatchers: Map<UUID, TranscriptWatcherType>;
+  send: SendToConnection;
+}
+
+export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
+
+export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
+  const { transcriptDiscovery, transcriptWatchers, send } = deps;
+
+  return {
+    onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
+      log(`Transcript load request from ${connectionId} for session ${sessionId}`);
+
+      // First try finding by Claude session ID embedded in the filename.
+      let filePath = transcriptDiscovery.findTranscriptBySessionId(sessionId);
+
+      // If not found by Claude session ID, the request may be using a Remi UUID.
+      // Daemon sessions are identified by Remi UUID, not Claude session ID.
+      // Check if an active watcher exists for this session ID and use its path.
+      if (!filePath) {
+        const activeWatcher = transcriptWatchers.get(sessionId as UUID);
+        if (activeWatcher) {
+          filePath = activeWatcher.filePath;
+          log(`[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via active watcher`);
+        }
+      }
+
+      if (!filePath) {
+        send(
+          connectionId,
+          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`),
+        );
+        return;
+      }
+
+      // Build a temporary MessageAPI + bridge to parse each entry and stream it.
+      const messageApi = new MessageAPI({ sessionId: sessionId as UUID });
+      let messageCount = 0;
+
+      const bridge = new TranscriptMessageBridge({ sessionId: sessionId as UUID }, messageApi, {
+        onTranscriptContent: (message) => {
+          messageCount++;
+          send(connectionId, message);
+        },
+      });
+
+      const watcher = new TranscriptWatcher(
+        {
+          filePath,
+          readExisting: true,
+          pollIntervalMs: 0, // One-shot read, not a live watch.
+        },
+        {
+          onAssistantMessage: (entry: AssistantEntry) => {
+            bridge.handleAssistantEntry(entry);
+          },
+          onUserMessage: (entry) => {
+            bridge.handleUserEntry(entry);
+          },
+          onError: (error) => {
+            logError(`[TranscriptLoad] Error reading ${sessionId}:`, error.message);
+          },
+        },
+      );
+
+      watcher
+        .start()
+        .then(() => {
+          // Stop immediately since we only wanted existing entries.
+          watcher.stop();
+          log(`Transcript load complete for ${sessionId}: ${messageCount} messages`);
+          send(connectionId, createTranscriptLoadComplete(sessionId, messageCount, requestId));
+        })
+        .catch((error: Error) => {
+          logError(`[TranscriptLoad] Failed to read ${sessionId}:`, error);
+          send(
+            connectionId,
+            createError('LOAD_FAILED', `Failed to load transcript: ${errorToString(error)}`),
+          );
+        });
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
+import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+/**
+ * Wait until the async transcript-read pipeline has published its final
+ * envelope. The handler kicks off `watcher.start()` (promise) and fans out
+ * send() calls from within a .then() block, so tests need to let the
+ * microtask queue drain. A small polling loop keeps the test resilient to
+ * the exact number of microtask turns the pipeline needs.
+ */
+async function waitForMessages(
+  sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>,
+  predicate: (calls: typeof sendCalls) => boolean,
+  maxMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate(sendCalls)) {
+    if (Date.now() - start > maxMs) {
+      throw new Error(
+        `waitForMessages timed out after ${maxMs}ms. sendCalls=${JSON.stringify(
+          sendCalls.map((c) => c.message.type),
+        )}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('createTranscriptHandlers', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+
+  function send(connectionId: UUID, message: ProtocolMessage): boolean {
+    sendCalls.push({ connectionId, message });
+    return true;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-transcript-events-'));
+    projectsDir = path.join(tmpDir, 'claude-projects');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+    transcriptWatchers = new Map();
+    sendCalls = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers() {
+    return createTranscriptHandlers({ transcriptDiscovery, transcriptWatchers, send });
+  }
+
+  function writeTranscript(claudeSessionId: string, entries: object[]): string {
+    const projectDir = path.join(projectsDir, '-Users-test-project');
+    fs.mkdirSync(projectDir, { recursive: true });
+    const filePath = path.join(projectDir, `${claudeSessionId}.jsonl`);
+    fs.writeFileSync(filePath, entries.map((e) => JSON.stringify(e)).join('\n'));
+    return filePath;
+  }
+
+  test('sends NOT_FOUND when the session id has no transcript and no active watcher', async () => {
+    makeHandlers().onTranscriptLoadRequest(CID, 'bogus0-0000-0000-0000-000000000000', REQ);
+
+    // Synchronous early-return path; no microtasks needed.
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; code?: string };
+    expect(msg.type).toBe('error');
+    expect(msg.code).toBe('NOT_FOUND');
+  });
+
+  test('reads a transcript by Claude session id and sends a completion envelope', async () => {
+    const claudeSessionId = '11111111-1111-1111-1111-111111111111';
+    writeTranscript(claudeSessionId, [
+      {
+        type: 'user',
+        uuid: 'u1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'hello' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: {
+          id: 'msg_1',
+          role: 'assistant',
+          model: 'claude',
+          content: [{ type: 'text', text: 'hi there' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      },
+    ]);
+
+    makeHandlers().onTranscriptLoadRequest(CID, claudeSessionId, REQ);
+
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+
+    const complete = sendCalls.find((c) => c.message.type === 'transcript_load_complete');
+    expect(complete).toBeDefined();
+    // Requesting connection matches the ack receiver.
+    expect(complete?.connectionId).toBe(CID);
+  });
+
+  test('falls back to the active watcher when the id is a Remi UUID', async () => {
+    // Write a file whose filename is a Claude UUID, then register a live
+    // watcher keyed by a DIFFERENT (Remi) UUID but pointing at the same file.
+    const claudeSessionId = '22222222-2222-2222-2222-222222222222';
+    const filePath = writeTranscript(claudeSessionId, [
+      {
+        type: 'user',
+        uuid: 'u1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'hi' },
+      },
+    ]);
+
+    const remiUuid = '33333333-3333-3333-3333-333333333333' as UUID;
+    const watcher = new TranscriptWatcher(
+      { filePath, readExisting: false, pollIntervalMs: 0 },
+      { onAssistantMessage: () => {}, onUserMessage: () => {} },
+    );
+    transcriptWatchers.set(remiUuid, watcher);
+
+    try {
+      makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+      await waitForMessages(sendCalls, (calls) =>
+        calls.some((c) => c.message.type === 'transcript_load_complete'),
+      );
+
+      // If fallback failed, we'd have received a NOT_FOUND instead.
+      expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+        false,
+      );
+    } finally {
+      watcher.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wave 4 of the cleanup epic: extracts the one-shot transcript read handler. Self-contained — two inputs (`transcriptDiscovery` for Claude-id lookup, `transcriptWatchers` Map for Remi-UUID fallback) plus `send`.
- `cli.ts`: **2794 → 2727 (−67)**.
- 1624/1624 non-LLM tests pass.

## Changes
- **New `packages/daemon/src/cli/handlers/transcript-events.ts`** (112 lines). Keeps existing behavior exactly:
  1. find by Claude session ID embedded in filename,
  2. else fall back to the live watcher's `filePath` if the UUID is a Remi ID,
  3. NOT_FOUND if neither resolves;
  then spin up a temporary `MessageAPI` + `TranscriptMessageBridge` + one-shot `TranscriptWatcher`, stream each parsed message back, stop the watcher, and send `transcript_load_complete`.
- Exports `TranscriptHandlers` via `ReturnType<typeof ...>`, bound at the cli.ts construction site. Matches the pattern from #346/#347/#348.
- **`packages/daemon/src/cli.ts`**: imports + builds `transcriptHandlers` alongside the other bundles, spreads into `sharedEvents`. Deletes the inline body (~75 lines). Drops `createTranscriptLoadComplete` from the `@remi/shared` import (only the extracted handler used it).
- **Tests** (166 lines, 3 real-fs tests with tmpdir-backed Claude projects dir):
  - NOT_FOUND for unknown session id with no active watcher.
  - Claude-id happy path: writes a hand-built JSONL (user + assistant entries), awaits the async `transcript_load_complete` envelope.
  - Remi-UUID fallback: registers a live watcher under a different UUID pointing at the same file and confirms the handler does not return NOT_FOUND.

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/transcript-events.test.ts` — 3/3 pass
- [x] Non-LLM full suite — 1624/1624 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `typos` on touched dirs — clean