### PR TITLE
refactor(cli): extract onCreateSessionRequest into create-session-events handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -96,7 +96,6 @@ const cleanupStatusFile = (): void => statusWriter.cleanup();
 loadDotenvFile();
 
 import {
-  createCreateSessionResponse,
   createHelloAck,
   createRawPtyOutput,
   createReplayBatch,
@@ -127,6 +126,10 @@ import {
   type ConnectionHandlers,
   createConnectionHandlers,
 } from './cli/handlers/connection-events.ts';
+import {
+  type CreateSessionHandlers,
+  createCreateSessionHandlers,
+} from './cli/handlers/create-session-events.ts';
 import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
 import { type SessionHandlers, createSessionHandlers } from './cli/handlers/session-events.ts';
 import {
@@ -1725,6 +1728,25 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   send: sendToConnection,
 });
 
+const createSessionHandlers_: CreateSessionHandlers = createCreateSessionHandlers({
+  liveSessionsRegistry,
+  spawningPorts,
+  basePort: remiConfig.daemon.base_port,
+  portRange: remiConfig.daemon.port_range,
+  // Lazy: bindHost is declared after sharedEvents is wired up, so compute
+  // the inherited-args array on each spawn rather than capturing it here.
+  inheritedArgs: () => {
+    const args: string[] = [];
+    if (cliAuth === true) args.push('--auth');
+    if (cliAuth === false) args.push('--no-auth');
+    if (cliNoRelay) args.push('--no-relay');
+    if (cliNoMdns) args.push('--no-mdns');
+    if (bindHost !== '0.0.0.0') args.push('--bind', bindHost);
+    return args;
+  },
+  send: sendToConnection,
+});
+
 const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
   sessionRegistry,
   deviceTokens,
@@ -1743,78 +1765,7 @@ const sharedEvents = {
   ...sessionHandlers,
   ...connectionHandlers,
   ...transcriptHandlers,
-  onCreateSessionRequest: async (
-    connectionId: UUID,
-    directory: string | undefined,
-    requestId: UUID,
-  ) => {
-    // One session per daemon. Spawn a new daemon process for the new session.
-    log(`Create session request from ${connectionId}, spawning new daemon`);
-
-    try {
-      const { spawnRemiDaemon } = await import('./cli/daemon-manager.ts');
-      const { findAvailableTcpPort } = await import('./session/port-utils.ts');
-
-      // Include in-flight spawn ports to prevent TOCTOU race on concurrent requests
-      const liveUsed = new Set([
-        ...liveSessionsRegistry.listLive().map((e) => e.wsPort),
-        ...spawningPorts,
-      ]);
-      const freePort = await findAvailableTcpPort(
-        remiConfig.daemon.base_port,
-        remiConfig.daemon.port_range,
-        liveUsed,
-      );
-      if (freePort === null) {
-        const rangeEnd = remiConfig.daemon.base_port + remiConfig.daemon.port_range - 1;
-        sendToConnection(
-          connectionId,
-          createCreateSessionResponse(
-            false,
-            requestId,
-            undefined,
-            `All ports in range ${remiConfig.daemon.base_port}-${rangeEnd} are in use.`,
-          ),
-        );
-        return;
-      }
-
-      // Forward parent's flags so spawned daemon has matching config
-      const inheritedArgs: string[] = [];
-      if (cliAuth === true) inheritedArgs.push('--auth');
-      if (cliAuth === false) inheritedArgs.push('--no-auth');
-      if (cliNoRelay) inheritedArgs.push('--no-relay');
-      if (cliNoMdns) inheritedArgs.push('--no-mdns');
-      if (bindHost !== '0.0.0.0') inheritedArgs.push('--bind', bindHost);
-
-      log(`Spawning new daemon on port ${freePort} for directory ${directory || '(cwd)'}`);
-      spawningPorts.add(freePort);
-      try {
-        const result = await spawnRemiDaemon(freePort, directory, inheritedArgs);
-
-        sendToConnection(
-          connectionId,
-          createCreateSessionResponse(
-            true,
-            requestId,
-            result.sessionId as UUID,
-            undefined,
-            result.port,
-          ),
-        );
-        log(
-          `New daemon spawned: port=${result.port}, session=${result.sessionId}, pid=${result.pid}`,
-        );
-      } finally {
-        spawningPorts.delete(freePort);
-      }
-    } catch (err) {
-      const msg = errorToString(err);
-      logError(`Failed to spawn daemon: ${msg}`);
-      sendToConnection(connectionId, createCreateSessionResponse(false, requestId, undefined, msg));
-    }
-  },
-
+  ...createSessionHandlers_,
   onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {
     log(`Resume session request from ${connectionId} for session ${targetSessionId}`);
 

--- a/packages/daemon/src/cli/handlers/create-session-events.ts
+++ b/packages/daemon/src/cli/handlers/create-session-events.ts
@@ -1,0 +1,123 @@
+/**
+ * sharedEvents handler for spawning a new daemon:
+ *   onCreateSessionRequest, find a free port, spawn a child remi daemon
+ *     with the parent's flags, and acknowledge with its session id + port.
+ *
+ * One session per daemon is a hard invariant, so "create session" always
+ * means "spawn a new daemon process". The in-flight `spawningPorts` set
+ * is shared with the parent cli.ts (written by this handler, read by the
+ * daemon-mode startup path) to prevent a TOCTOU race where two concurrent
+ * create requests race for the same free port.
+ */
+
+import { createCreateSessionResponse, errorToString } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+
+import type { SessionRegistryFile } from '../../session/index.ts';
+import { findAvailableTcpPort as defaultFindAvailableTcpPort } from '../../session/port-utils.ts';
+import { spawnRemiDaemon as defaultSpawnRemiDaemon } from '../daemon-manager.ts';
+import { log, logError } from '../logger.ts';
+import type { SendToConnection } from './trivial-events.ts';
+
+export interface SpawnResult {
+  readonly sessionId: string;
+  readonly port: number;
+  readonly pid: number;
+}
+
+export interface CreateSessionHandlerDeps {
+  liveSessionsRegistry: SessionRegistryFile;
+  /** In-flight spawn ports; shared with cli.ts daemon-mode startup. */
+  spawningPorts: Set<number>;
+  /** Range start for port probing (from remiConfig.daemon.base_port). */
+  basePort: number;
+  portRange: number;
+  /**
+   * CLI flags inherited by the spawned child so it has matching config.
+   * Getter so the caller can populate the array after handler construction
+   * (bindHost in cli.ts is declared after sharedEvents is wired up).
+   */
+  inheritedArgs: () => readonly string[];
+  send: SendToConnection;
+  /** Injectable for tests; defaults to the real port probe. */
+  findAvailableTcpPort?: typeof defaultFindAvailableTcpPort;
+  /** Injectable for tests; defaults to the real daemon spawner. */
+  spawnDaemon?: (
+    port: number,
+    directory: string | undefined,
+    extraArgs: string[],
+  ) => Promise<SpawnResult>;
+}
+
+export type CreateSessionHandlers = ReturnType<typeof createCreateSessionHandlers>;
+
+export function createCreateSessionHandlers(deps: CreateSessionHandlerDeps) {
+  const {
+    liveSessionsRegistry,
+    spawningPorts,
+    basePort,
+    portRange,
+    inheritedArgs,
+    send,
+    findAvailableTcpPort = defaultFindAvailableTcpPort,
+    spawnDaemon = defaultSpawnRemiDaemon,
+  } = deps;
+
+  return {
+    onCreateSessionRequest: async (
+      connectionId: UUID,
+      directory: string | undefined,
+      requestId: UUID,
+    ): Promise<void> => {
+      log(`Create session request from ${connectionId}, spawning new daemon`);
+
+      try {
+        // Include in-flight spawn ports to prevent a TOCTOU race on
+        // concurrent create requests.
+        const liveUsed = new Set([
+          ...liveSessionsRegistry.listLive().map((e) => e.wsPort),
+          ...spawningPorts,
+        ]);
+        const freePort = await findAvailableTcpPort(basePort, portRange, liveUsed);
+        if (freePort === null) {
+          const rangeEnd = basePort + portRange - 1;
+          send(
+            connectionId,
+            createCreateSessionResponse(
+              false,
+              requestId,
+              undefined,
+              `All ports in range ${basePort}-${rangeEnd} are in use.`,
+            ),
+          );
+          return;
+        }
+
+        log(`Spawning new daemon on port ${freePort} for directory ${directory || '(cwd)'}`);
+        spawningPorts.add(freePort);
+        try {
+          const result = await spawnDaemon(freePort, directory, [...inheritedArgs()]);
+          send(
+            connectionId,
+            createCreateSessionResponse(
+              true,
+              requestId,
+              result.sessionId as UUID,
+              undefined,
+              result.port,
+            ),
+          );
+          log(
+            `New daemon spawned: port=${result.port}, session=${result.sessionId}, pid=${result.pid}`,
+          );
+        } finally {
+          spawningPorts.delete(freePort);
+        }
+      } catch (err) {
+        const msg = errorToString(err);
+        logError(`Failed to spawn daemon: ${msg}`);
+        send(connectionId, createCreateSessionResponse(false, requestId, undefined, msg));
+      }
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/create-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/create-session-events.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import {
+  type SpawnResult,
+  createCreateSessionHandlers,
+} from '../../../src/cli/handlers/create-session-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+describe('createCreateSessionHandlers', () => {
+  let tmpDir: string;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let spawningPorts: Set<number>;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+
+  function send(connectionId: UUID, message: ProtocolMessage): boolean {
+    sendCalls.push({ connectionId, message });
+    return true;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-create-session-'));
+    liveSessionsRegistry = new SessionRegistryFile(tmpDir);
+    spawningPorts = new Set();
+    sendCalls = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('responds with failure when no free port is available', async () => {
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 3,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async () => null,
+      spawnDaemon: async () => {
+        throw new Error('spawnDaemon should not be called when no free port');
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.type).toBe('create_session_response');
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('20000-20002');
+    expect(spawningPorts.size).toBe(0);
+  });
+
+  test('spawns a daemon and returns session info on success', async () => {
+    const spawnHistory: Array<{
+      port: number;
+      directory: string | undefined;
+      extraArgs: string[];
+    }> = [];
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => ['--auth', '--bind', '0.0.0.0'],
+      send,
+      findAvailableTcpPort: async () => 20005,
+      spawnDaemon: async (port, directory, extraArgs) => {
+        spawnHistory.push({ port, directory, extraArgs });
+        return {
+          sessionId: '55555555-5555-5555-5555-555555555555',
+          port,
+          pid: 99999,
+        } satisfies SpawnResult;
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, '/tmp/project', REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as unknown as {
+      type: string;
+      success: boolean;
+      sessionId?: string;
+      port?: number;
+    };
+    expect(msg.type).toBe('create_session_response');
+    expect(msg.success).toBe(true);
+    expect(msg.sessionId).toBe('55555555-5555-5555-5555-555555555555');
+    expect(msg.port).toBe(20005);
+    expect(spawnHistory).toEqual([
+      {
+        port: 20005,
+        directory: '/tmp/project',
+        extraArgs: ['--auth', '--bind', '0.0.0.0'],
+      },
+    ]);
+    // Spawn port should be released from the in-flight set.
+    expect(spawningPorts.has(20005)).toBe(false);
+  });
+
+  test('reserves the port during spawn then releases it', async () => {
+    let sawReservedDuringSpawn = false;
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async () => 20006,
+      spawnDaemon: async (port) => {
+        // Observed during the spawn: port must be in the set.
+        sawReservedDuringSpawn = spawningPorts.has(port);
+        return { sessionId: 's', port, pid: 1 };
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+
+    expect(sawReservedDuringSpawn).toBe(true);
+    expect(spawningPorts.has(20006)).toBe(false);
+  });
+
+  test('releases the reservation even if spawn throws, responds with failure', async () => {
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async () => 20007,
+      spawnDaemon: async () => {
+        throw new Error('daemon crashed during spawn');
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.type).toBe('create_session_response');
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('daemon crashed during spawn');
+    // Critical: the try/finally around spawningPorts.add/delete MUST run even
+    // on throw, or concurrent create requests would skip this port forever.
+    expect(spawningPorts.has(20007)).toBe(false);
+  });
+
+  test('feeds live registry ports + in-flight spawns into findAvailableTcpPort to prevent TOCTOU', async () => {
+    // Pre-register a live session so listLive returns a non-empty set.
+    liveSessionsRegistry.register({
+      sessionId: '0a001234-1234-1234-1234-123456789012',
+      wsPort: 20001,
+      pid: process.pid,
+      hookPort: 0,
+      projectPath: tmpDir,
+      name: 'sibling',
+      startedAt: new Date().toISOString(),
+    });
+    spawningPorts.add(20002);
+
+    let usedPortsSeen: number[] = [];
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async (_base, _range, used) => {
+        usedPortsSeen = [...(used ?? new Set<number>())].sort((a, b) => a - b);
+        return 20009;
+      },
+      spawnDaemon: async (port) => ({ sessionId: 's', port, pid: 1 }),
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+
+    // Both the live-registry port and the in-flight spawn port must be in the
+    // usedPorts set passed to the port probe.
+    expect(usedPortsSeen).toContain(20001);
+    expect(usedPortsSeen).toContain(20002);
+  });
+});


### PR DESCRIPTION
## Summary
- Wave 5 of the cleanup epic: extracts the daemon-spawn handler. One session per daemon is an invariant, so create always means spawn.
- `cli.ts`: **2727 → 2678 (−49)**.
- 1629/1629 non-LLM tests pass.

## Changes

**New `packages/daemon/src/cli/handlers/create-session-events.ts`** (123 lines)
- Explicit dep bundle:
  - `liveSessionsRegistry` + `spawningPorts`: the TOCTOU-prevention set pair.
  - `basePort` / `portRange`: resolved from `remiConfig.daemon`.
  - `inheritedArgs: () => readonly string[]` — getter rather than value, because `bindHost` in cli.ts is declared after `sharedEvents`; reads `bindHost`/`cliAuth`/etc lazily at spawn time.
  - `findAvailableTcpPort` + `spawnDaemon`: both injectable with real-impl defaults. Tests substitute fast synchronous fakes instead of actually probing ports or spawning daemons.
  - `send`: forward to `sendToConnection`.
- Exports `CreateSessionHandlers` via `ReturnType<>`, bound at cli.ts construction site (matches #346/#347/#348/#349 pattern).

**`packages/daemon/src/cli.ts`**
- Imports + wires `createSessionHandlers_` (name-suffixed to avoid collision with `sessionHandlers` from #347) into `sharedEvents`.
- Deletes the inline body (~70 lines).
- Drops `createCreateSessionResponse` from the `@remi/shared` import.

**`packages/daemon/tests/cli/handlers/create-session-events.test.ts`** (196 lines, 5 deps-injected tests)
- Port-exhausted path: returns failure with the range rendered in the error.
- Happy path: spawn called with the inherited args; response carries `sessionId` + `port`; port released from in-flight set.
- Reservation observed during spawn (validates try/finally correctness).
- **Reservation released even when spawn throws** — critical: without this, a crashing spawn would blackhole the port forever for concurrent requests.
- TOCTOU coverage: live-registry ports and in-flight spawns both feed into the `usedPorts` set passed to `findAvailableTcpPort`.

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/create-session-events.test.ts` — 5/5 pass
- [x] Non-LLM full suite — 1629/1629 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `typos` on touched dirs — clean