### PR TITLE
refactor(cli): extract onResumeSessionRequest into resume-session-events handler

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -99,7 +99,6 @@ import {
   createHelloAck,
   createRawPtyOutput,
   createReplayBatch,
-  createResumeSessionResponse,
   createSessionListResponse,
   createSessionReset,
   createStructuredAgentOutput,
@@ -131,6 +130,10 @@ import {
   createCreateSessionHandlers,
 } from './cli/handlers/create-session-events.ts';
 import { type InputHandlers, createInputHandlers } from './cli/handlers/input-events.ts';
+import {
+  type ResumeSessionHandlers,
+  createResumeSessionHandlers,
+} from './cli/handlers/resume-session-events.ts';
 import { type SessionHandlers, createSessionHandlers } from './cli/handlers/session-events.ts';
 import {
   type TranscriptHandlers,
@@ -1728,6 +1731,14 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   send: sendToConnection,
 });
 
+const resumeSessionHandlers: ResumeSessionHandlers = createResumeSessionHandlers({
+  sessionRegistry,
+  sessionStore,
+  transcriptDiscovery,
+  createNewSession,
+  send: sendToConnection,
+});
+
 const createSessionHandlers_: CreateSessionHandlers = createCreateSessionHandlers({
   liveSessionsRegistry,
   spawningPorts,
@@ -1766,173 +1777,7 @@ const sharedEvents = {
   ...connectionHandlers,
   ...transcriptHandlers,
   ...createSessionHandlers_,
-  onResumeSessionRequest: async (connectionId: UUID, targetSessionId: string, requestId: UUID) => {
-    log(`Resume session request from ${connectionId} for session ${targetSessionId}`);
-
-    // If the target matches our active session, try to attach
-    const existingSession = sessionRegistry.getSession(targetSessionId as UUID);
-    if (existingSession) {
-      const result = sessionRegistry.attachConnection(targetSessionId as UUID, connectionId);
-      if (result.success) {
-        sendToConnection(
-          connectionId,
-          createResumeSessionResponse(true, requestId, targetSessionId as UUID),
-        );
-        sendToConnection(
-          connectionId,
-          createHelloAck('1.0.0', targetSessionId as UUID, {
-            isResume: true,
-            replayCount: result.replayMessages.length,
-            nextBulletId: result.nextBulletId,
-          }),
-        );
-        if (result.replayMessages.length > 0) {
-          sendToConnection(
-            connectionId,
-            createReplayBatch(targetSessionId as UUID, result.replayMessages, true),
-          );
-        }
-        log(`Session ${targetSessionId} still alive; attached connection`);
-        return;
-      }
-      sendToConnection(
-        connectionId,
-        createResumeSessionResponse(false, requestId, undefined, result.error),
-      );
-      return;
-    }
-
-    // Session not alive in registry. One session per daemon, so we cannot
-    // spawn a new session if one already exists.
-    if (sessionRegistry.activeSession !== null) {
-      sendToConnection(
-        connectionId,
-        createResumeSessionResponse(
-          false,
-          requestId,
-          undefined,
-          "This daemon already has an active session. Use 'remi new' to start a new daemon for resume.",
-        ),
-      );
-      return;
-    }
-
-    // No active session; attempt transcript-based resume by spawning a new PTY.
-    let claudeSessionId: string | null = null;
-    let projectPath: string | null = null;
-
-    const storedByRemi = sessionStore.findByRemiSessionId(targetSessionId as UUID);
-    if (storedByRemi) {
-      claudeSessionId = storedByRemi.claudeSessionId;
-      projectPath = storedByRemi.projectPath;
-    }
-
-    if (!claudeSessionId) {
-      const storedByClaude = sessionStore.findByClaudeSessionId(targetSessionId);
-      if (storedByClaude) {
-        claudeSessionId = storedByClaude.claudeSessionId;
-        projectPath = storedByClaude.projectPath;
-      }
-    }
-
-    if (!claudeSessionId) {
-      const transcriptPath = transcriptDiscovery.findTranscriptBySessionId(targetSessionId);
-      if (transcriptPath) {
-        claudeSessionId = targetSessionId;
-        const dirName = path.basename(path.dirname(transcriptPath));
-        projectPath = dirName.replace(/-/g, '/');
-      }
-    }
-
-    if (!claudeSessionId) {
-      sendToConnection(
-        connectionId,
-        createResumeSessionResponse(
-          false,
-          requestId,
-          undefined,
-          `Session ${targetSessionId} not found. No Claude session ID available for resume.`,
-        ),
-      );
-      return;
-    }
-
-    if (!projectPath) {
-      sendToConnection(
-        connectionId,
-        createResumeSessionResponse(
-          false,
-          requestId,
-          undefined,
-          'Cannot resume: original project path is unknown.',
-        ),
-      );
-      return;
-    }
-
-    const dirResult = resolveDirectory(projectPath);
-    if ('error' in dirResult) {
-      const hint = projectPath?.includes('/')
-        ? ' Path may be inaccurate for projects with dashes in their name.'
-        : '';
-      sendToConnection(
-        connectionId,
-        createResumeSessionResponse(
-          false,
-          requestId,
-          undefined,
-          `Project directory not found: ${projectPath}.${hint}`,
-        ),
-      );
-      return;
-    }
-    const workingDirectory = dirResult.resolved;
-
-    const newSessionId = sessionRegistry.createSessionId();
-    log(
-      `Resuming Claude session ${claudeSessionId} as new Remi session ${newSessionId} in ${workingDirectory}`,
-    );
-
-    try {
-      await createNewSession(
-        newSessionId,
-        workingDirectory,
-        (sid, msg) => {
-          const session = sessionRegistry.getSession(sid);
-          if (session?.activeConnectionId) {
-            sendToConnection(session.activeConnectionId, msg);
-          }
-        },
-        ['--resume', claudeSessionId],
-      );
-
-      const result = sessionRegistry.attachConnection(newSessionId, connectionId);
-
-      if (result.success) {
-        sendToConnection(connectionId, createResumeSessionResponse(true, requestId, newSessionId));
-        sendToConnection(
-          connectionId,
-          createHelloAck('1.0.0', newSessionId, {
-            isResume: false,
-            replayCount: 0,
-            nextBulletId: 1,
-          }),
-        );
-        log(`Session ${newSessionId} created via resume (claude: ${claudeSessionId})`);
-      } else {
-        sessionRegistry.closeSession(newSessionId, 'forced');
-        sendToConnection(
-          connectionId,
-          createResumeSessionResponse(false, requestId, undefined, result.error),
-        );
-      }
-    } catch (error) {
-      const msg = errorToString(error);
-      logError('Failed to resume session:', msg);
-      sessionRegistry.closeSession(newSessionId, 'forced');
-      sendToConnection(connectionId, createResumeSessionResponse(false, requestId, undefined, msg));
-    }
-  },
+  ...resumeSessionHandlers,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -1,0 +1,229 @@
+/**
+ * sharedEvents handler for resuming a previously-run Claude Code session:
+ *   onResumeSessionRequest
+ *
+ * Three possible paths:
+ *   1. The target session id is STILL LIVE in this daemon — just attach and
+ *      replay history. (Covers "rejoin my own active session" after a
+ *      network blip.)
+ *   2. The target session id is STORED LOCALLY (Remi store or Claude
+ *      transcript index) and this daemon has no active session — spawn a
+ *      new PTY with `claude --resume <claudeSessionId>` in the stored
+ *      project directory.
+ *   3. Neither: respond with a failure.
+ *
+ * Spawning is delegated back to `cli.ts`'s `createNewSession` via an
+ * injected dep; keeping it opaque here means we don't have to drag the
+ * entire createNewSession closure (PTY + MessageAPI + transcript watcher
+ * + hook setup) out of cli.ts to test this handler.
+ */
+
+import * as path from 'node:path';
+import {
+  createHelloAck,
+  createReplayBatch,
+  createResumeSessionResponse,
+  errorToString,
+} from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { TranscriptDiscovery } from '../../transcript/index.ts';
+import { log, logError } from '../logger.ts';
+import { resolveDirectory } from '../path-resolver.ts';
+import type { SendToConnection } from './trivial-events.ts';
+
+/**
+ * Spawn a new Claude Code session in the given working directory. Mirrors
+ * the signature of cli.ts's `createNewSession` for the arguments the resume
+ * flow actually uses. The PTYSession return value is dropped, the caller
+ * only needs the side effect (session registered in SessionRegistry).
+ */
+export type CreateNewSessionFn = (
+  sessionId: UUID,
+  workingDirectory: string,
+  sendMessage: (sessionId: UUID, message: ProtocolMessage) => void,
+  extraArgs: string[],
+) => Promise<unknown>;
+
+export interface ResumeSessionHandlerDeps {
+  sessionRegistry: SessionRegistry;
+  sessionStore: SessionStore;
+  transcriptDiscovery: TranscriptDiscovery;
+  createNewSession: CreateNewSessionFn;
+  send: SendToConnection;
+}
+
+export type ResumeSessionHandlers = ReturnType<typeof createResumeSessionHandlers>;
+
+export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
+  const { sessionRegistry, sessionStore, transcriptDiscovery, createNewSession, send } = deps;
+
+  return {
+    onResumeSessionRequest: async (
+      connectionId: UUID,
+      targetSessionId: string,
+      requestId: UUID,
+    ): Promise<void> => {
+      log(`Resume session request from ${connectionId} for session ${targetSessionId}`);
+
+      // Path 1: target matches the live session, try to attach.
+      const existingSession = sessionRegistry.getSession(targetSessionId as UUID);
+      if (existingSession) {
+        const result = sessionRegistry.attachConnection(targetSessionId as UUID, connectionId);
+        if (result.success) {
+          send(connectionId, createResumeSessionResponse(true, requestId, targetSessionId as UUID));
+          send(
+            connectionId,
+            createHelloAck('1.0.0', targetSessionId as UUID, {
+              isResume: true,
+              replayCount: result.replayMessages.length,
+              nextBulletId: result.nextBulletId,
+            }),
+          );
+          if (result.replayMessages.length > 0) {
+            send(
+              connectionId,
+              createReplayBatch(targetSessionId as UUID, result.replayMessages, true),
+            );
+          }
+          log(`Session ${targetSessionId} still alive; attached connection`);
+          return;
+        }
+        send(connectionId, createResumeSessionResponse(false, requestId, undefined, result.error));
+        return;
+      }
+
+      // No live session for that id. One session per daemon: if this daemon
+      // already has a DIFFERENT active session, we can't spawn another here.
+      if (sessionRegistry.activeSession !== null) {
+        send(
+          connectionId,
+          createResumeSessionResponse(
+            false,
+            requestId,
+            undefined,
+            "This daemon already has an active session. Use 'remi new' to start a new daemon for resume.",
+          ),
+        );
+        return;
+      }
+
+      // Path 2: transcript-based resume. Resolve a Claude session id + project path.
+      let claudeSessionId: string | null = null;
+      let projectPath: string | null = null;
+
+      const storedByRemi = sessionStore.findByRemiSessionId(targetSessionId as UUID);
+      if (storedByRemi) {
+        claudeSessionId = storedByRemi.claudeSessionId;
+        projectPath = storedByRemi.projectPath;
+      }
+
+      if (!claudeSessionId) {
+        const storedByClaude = sessionStore.findByClaudeSessionId(targetSessionId);
+        if (storedByClaude) {
+          claudeSessionId = storedByClaude.claudeSessionId;
+          projectPath = storedByClaude.projectPath;
+        }
+      }
+
+      if (!claudeSessionId) {
+        const transcriptPath = transcriptDiscovery.findTranscriptBySessionId(targetSessionId);
+        if (transcriptPath) {
+          claudeSessionId = targetSessionId;
+          const dirName = path.basename(path.dirname(transcriptPath));
+          projectPath = dirName.replace(/-/g, '/');
+        }
+      }
+
+      if (!claudeSessionId) {
+        send(
+          connectionId,
+          createResumeSessionResponse(
+            false,
+            requestId,
+            undefined,
+            `Session ${targetSessionId} not found. No Claude session ID available for resume.`,
+          ),
+        );
+        return;
+      }
+
+      if (!projectPath) {
+        send(
+          connectionId,
+          createResumeSessionResponse(
+            false,
+            requestId,
+            undefined,
+            'Cannot resume: original project path is unknown.',
+          ),
+        );
+        return;
+      }
+
+      const dirResult = resolveDirectory(projectPath);
+      if ('error' in dirResult) {
+        const hint = projectPath.includes('/')
+          ? ' Path may be inaccurate for projects with dashes in their name.'
+          : '';
+        send(
+          connectionId,
+          createResumeSessionResponse(
+            false,
+            requestId,
+            undefined,
+            `Project directory not found: ${projectPath}.${hint}`,
+          ),
+        );
+        return;
+      }
+      const workingDirectory = dirResult.resolved;
+
+      const newSessionId = sessionRegistry.createSessionId();
+      log(
+        `Resuming Claude session ${claudeSessionId} as new Remi session ${newSessionId} in ${workingDirectory}`,
+      );
+
+      try {
+        await createNewSession(
+          newSessionId,
+          workingDirectory,
+          (sid, msg) => {
+            const session = sessionRegistry.getSession(sid);
+            if (session?.activeConnectionId) {
+              send(session.activeConnectionId, msg);
+            }
+          },
+          ['--resume', claudeSessionId],
+        );
+
+        const result = sessionRegistry.attachConnection(newSessionId, connectionId);
+
+        if (result.success) {
+          send(connectionId, createResumeSessionResponse(true, requestId, newSessionId));
+          send(
+            connectionId,
+            createHelloAck('1.0.0', newSessionId, {
+              isResume: false,
+              replayCount: 0,
+              nextBulletId: 1,
+            }),
+          );
+          log(`Session ${newSessionId} created via resume (claude: ${claudeSessionId})`);
+        } else {
+          sessionRegistry.closeSession(newSessionId, 'forced');
+          send(
+            connectionId,
+            createResumeSessionResponse(false, requestId, undefined, result.error),
+          );
+        }
+      } catch (error) {
+        const msg = errorToString(error);
+        logError('Failed to resume session:', msg);
+        sessionRegistry.closeSession(newSessionId, 'forced');
+        send(connectionId, createResumeSessionResponse(false, requestId, undefined, msg));
+      }
+    },
+  };
+}

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { createResumeSessionHandlers } from '../../../src/cli/handlers/resume-session-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    getFullBulletContent: () => null,
+  } as unknown as MessageAPI;
+}
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+describe('createResumeSessionHandlers', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+
+  function send(connectionId: UUID, message: ProtocolMessage): boolean {
+    sendCalls.push({ connectionId, message });
+    return true;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-resume-session-'));
+    projectsDir = path.join(tmpDir, 'claude-projects');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+    sendCalls = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers(
+    createNewSession: (
+      sessionId: UUID,
+      workingDirectory: string,
+      sendMessage: (sid: UUID, msg: ProtocolMessage) => void,
+      extraArgs: string[],
+    ) => Promise<unknown> = async () => {
+      throw new Error('createNewSession should not be called in this test');
+    },
+  ) {
+    return createResumeSessionHandlers({
+      sessionRegistry,
+      sessionStore,
+      transcriptDiscovery,
+      createNewSession,
+      send,
+    });
+  }
+
+  test('attaches and replays when the target session is still live', async () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, sessionId, REQ);
+
+    // Expect at minimum: resume_session_response + hello_ack.
+    const types = sendCalls.map((c) => c.message.type);
+    expect(types).toContain('resume_session_response');
+    expect(types).toContain('hello_ack');
+    expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+  });
+
+  test('rejects when another session is active and the target does not match', async () => {
+    const activeId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(activeId, '/other/dir', fakePTY(), fakeMessageAPI());
+
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, '99999999-9999-9999-9999-999999999999', REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.type).toBe('resume_session_response');
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('already has an active session');
+  });
+
+  test('fails when no claude session id can be resolved from any source', async () => {
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, '77777777-7777-7777-7777-777777777777', REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.type).toBe('resume_session_response');
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('No Claude session ID available for resume');
+  });
+
+  test('fails when the resolved project directory does not exist', async () => {
+    // Store a mapping whose projectPath points somewhere that does not exist.
+    sessionStore.save({
+      remiSessionId: '88888888-8888-8888-8888-888888888888' as UUID,
+      claudeSessionId: 'deadbeef-0000-0000-0000-000000000000',
+      projectPath: path.join(tmpDir, 'does-not-exist'),
+      port: 0,
+      pid: null,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, '88888888-8888-8888-8888-888888888888', REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('Project directory not found');
+  });
+
+  test('calls createNewSession with --resume <claudeSessionId> when resolution succeeds', async () => {
+    const realProjectDir = path.join(tmpDir, 'real-project');
+    fs.mkdirSync(realProjectDir, { recursive: true });
+    const claudeSessionId = '44444444-4444-4444-4444-444444444444';
+    sessionStore.save({
+      remiSessionId: 'abababab-abab-abab-abab-abababababab' as UUID,
+      claudeSessionId,
+      projectPath: realProjectDir,
+      port: 0,
+      pid: null,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    const spawnHistory: Array<{ sessionId: UUID; extraArgs: string[] }> = [];
+    const handlers = makeHandlers(
+      async (sessionId, _workingDirectory, _sendMessage, extraArgs): Promise<unknown> => {
+        spawnHistory.push({ sessionId, extraArgs: [...extraArgs] });
+        // Simulate the side effect of a real createNewSession call:
+        // the session must be registered in the SessionRegistry for
+        // the handler's subsequent attachConnection to succeed.
+        sessionRegistry.registerSession(sessionId, '/resumed/dir', fakePTY(), fakeMessageAPI());
+        return undefined;
+      },
+    );
+
+    await handlers.onResumeSessionRequest(CID, 'abababab-abab-abab-abab-abababababab', REQ);
+
+    expect(spawnHistory).toHaveLength(1);
+    expect(spawnHistory[0]?.extraArgs).toEqual(['--resume', claudeSessionId]);
+    const types = sendCalls.map((c) => c.message.type);
+    expect(types).toContain('resume_session_response');
+    expect(types).toContain('hello_ack');
+    const attachedId = spawnHistory[0]?.sessionId as UUID;
+    expect(sessionRegistry.getSession(attachedId)?.activeConnectionId).toBe(CID);
+  });
+
+  test('closes the newly-spawned session and reports failure when createNewSession throws', async () => {
+    const realProjectDir = path.join(tmpDir, 'real-project-2');
+    fs.mkdirSync(realProjectDir, { recursive: true });
+    sessionStore.save({
+      remiSessionId: 'cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd' as UUID,
+      claudeSessionId: '55555555-5555-5555-5555-555555555555',
+      projectPath: realProjectDir,
+      port: 0,
+      pid: null,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    const handlers = makeHandlers(async (sessionId) => {
+      // Simulate partial registration before throwing (as a real createNewSession
+      // might do if the PTY fails after MessageAPI is wired).
+      sessionRegistry.registerSession(sessionId, realProjectDir, fakePTY(), fakeMessageAPI());
+      throw new Error('PTY spawn failed');
+    });
+
+    await handlers.onResumeSessionRequest(CID, 'cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd', REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; success: boolean; error?: string };
+    expect(msg.type).toBe('resume_session_response');
+    expect(msg.success).toBe(false);
+    expect(msg.error).toContain('PTY spawn failed');
+    // Critical: the partially-created session must be cleaned up so a
+    // retry can succeed.
+    expect(sessionRegistry.activeSession).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Wave 6 of the cleanup epic: the biggest remaining sharedEvents handler (167 lines). Three paths:
  1. Target session is still live in this daemon — attach and replay.
  2. Target is stored locally (Remi store or Claude transcript index) and no active session here — spawn a new PTY with `claude --resume <claudeSessionId>`.
  3. Neither — respond with failure.
- `cli.ts`: **2678 → 2523 (−155)**.
- 1635/1635 non-LLM tests pass.

## Changes

**New `packages/daemon/src/cli/handlers/resume-session-events.ts`** (229 lines)
- Explicit dep bundle:
  - `sessionRegistry`, `sessionStore`, `transcriptDiscovery`: the lookup chain for case 1/2 resolution.
  - `createNewSession`: injected back from cli.ts as a `CreateNewSessionFn` so we don't have to drag the 720-line `createNewSession` closure (PTY + MessageAPI + transcript watcher + hook setup) out of cli.ts just to test this handler. Tests substitute a fake that performs the side effect (`registerSession`) the real impl would.
  - `send`: forward to `sendToConnection`.
- Exports `ResumeSessionHandlers` via `ReturnType<>`, bound at the cli.ts construction site (matches #346-#350 pattern).

**`packages/daemon/src/cli.ts`**
- Builds `resumeSessionHandlers` in the handler construction block, spreads into `sharedEvents`.
- Deletes the 167-line inline body.
- Drops `createResumeSessionResponse` from the `@remi/shared` import (only the extracted handler used it).

**`packages/daemon/tests/cli/handlers/resume-session-events.test.ts`** (213 lines, 6 deps-injected tests)
- Live-session attach + replay.
- "Another session active" rejection when target doesn't match.
- "No Claude session id resolvable" when neither store nor transcript index knows the id.
- "Project directory not found" when the stored path is stale.
- Happy path: `createNewSession` called with `['--resume', claudeSessionId]`, response + hello_ack emitted, attach succeeds.
- **Failure path**: `createNewSession` throws after partial registration. `closeSession` runs, handler reports failure, `activeSession` is null — pins the cleanup invariant so a retry can succeed.

## Session context
This PR finishes the sharedEvents extraction. Every handler now lives in `packages/daemon/src/cli/handlers/*.ts`. Only `createNewSession` (the 720-line elephant) and the main-flow orchestration remain in `cli.ts`.

## Test plan
- [x] `bun test packages/daemon/tests/cli/handlers/resume-session-events.test.ts` — 6/6 pass
- [x] Non-LLM full suite — 1635/1635 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `typos` — clean