### PR TITLE
refactor(cli): extract transcript-watcher setup helpers

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -142,6 +142,10 @@ import {
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
+import {
+  extractClaudeSessionId as extractClaudeSessionIdImpl,
+  startTranscriptWatcher as startTranscriptWatcherImpl,
+} from './cli/transcript-watcher-setup.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
@@ -158,12 +162,7 @@ import {
   type StoredSession,
 } from './session/index.ts';
 import { findAvailableTcpPort } from './session/port-utils.ts';
-import {
-  TranscriptDiscovery,
-  TranscriptMessageBridge,
-  TranscriptWatcher,
-} from './transcript/index.ts';
-import type { AssistantEntry } from './transcript/index.ts';
+import { TranscriptDiscovery, type TranscriptWatcher } from './transcript/index.ts';
 
 // ---------------------------------------------------------------------------
 // Logging: In wrapper mode, all daemon logs go to ~/.remi/remi.log
@@ -1617,66 +1616,25 @@ async function createNewSession(
   return ptySession;
 }
 
-/** Extract Claude session ID from transcript filename and persist it. Returns the extracted ID or null. */
+// Thin wrappers over cli/transcript-watcher-setup.ts that bind the cli.ts-local
+// state (sessionStore, transcriptWatchers map) so call sites inside
+// createNewSession and the fallback-poll block don't change.
 function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): string | null {
-  // Transcript filenames are plain UUIDs (e.g. "abc123-def456.jsonl").
-  // The underscore split is defensive in case a prefixed format is ever introduced.
-  const basename = path.basename(transcriptPath, '.jsonl');
-  const parts = basename.split('_');
-  const candidateId = parts[parts.length - 1];
-  if (candidateId && candidateId.length >= 8) {
-    sessionStore.updateClaudeSessionId(sessionId, candidateId);
-    log(`Claude session ID: ${candidateId}`);
-    return candidateId;
-  }
-  return null;
+  return extractClaudeSessionIdImpl({ sessionStore }, transcriptPath, sessionId);
 }
-
-/** Start watching a transcript file for a session. */
 function startTranscriptWatcher(
   sessionId: UUID,
   transcriptPath: string,
   messageApi: MessageAPI,
   sendAndRecord: (message: ProtocolMessage) => void,
 ): void {
-  log(`[Transcript] Watching: ${transcriptPath}`);
-  log(`[Transcript] File exists: ${fs.existsSync(transcriptPath)}`);
-
-  const bridge = new TranscriptMessageBridge({ sessionId }, messageApi, {
-    onTranscriptContent: (message) => {
-      log(`[Transcript] Delivering content (${message.type}) to clients`);
-      sendAndRecord(message);
-    },
-  });
-
-  const watcher = new TranscriptWatcher(
-    {
-      filePath: transcriptPath,
-      readExisting: true,
-      pollIntervalMs: 1000,
-    },
-    {
-      onAssistantMessage: (entry: AssistantEntry) => {
-        log(
-          `[Transcript] Assistant entry: ${entry.uuid?.slice(0, 8)} (${entry.message?.content?.length ?? 0} blocks)`,
-        );
-        bridge.handleAssistantEntry(entry);
-      },
-      onUserMessage: (entry) => {
-        log(`[Transcript] User entry: ${entry.uuid?.slice(0, 8)}`);
-        bridge.handleUserEntry(entry);
-      },
-      onError: (error) => {
-        logError(`[Transcript] Error for session ${sessionId}:`, error.message);
-      },
-    },
+  startTranscriptWatcherImpl(
+    { transcriptWatchers },
+    sessionId,
+    transcriptPath,
+    messageApi,
+    sendAndRecord,
   );
-
-  transcriptWatchers.set(sessionId, watcher);
-  watcher.start().catch((error) => {
-    logError(`[Transcript] Failed to start watcher for session ${sessionId}:`, error);
-  });
-  log(`[Transcript] Watcher started for session ${sessionId}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -1,0 +1,105 @@
+/**
+ * Transcript-watcher helpers used during session creation and during the
+ * hook-miss fallback poll.
+ *
+ * `extractClaudeSessionId` reads the Claude session id out of a transcript
+ * filename and persists it in the local SessionStore. `startTranscriptWatcher`
+ * wires a `TranscriptMessageBridge` + `TranscriptWatcher` for the given file
+ * and registers the watcher in the shared `transcriptWatchers` map so other
+ * code (status refresh, cleanup, fallback teardown) can find it by session id.
+ *
+ * Both helpers are pure over their inputs — no module-level singletons — so
+ * tests can supply tmpdir-backed stores and an in-memory Map.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { MessageAPI } from '../api/message-api.ts';
+import type { SessionStore } from '../session/index.ts';
+import { TranscriptMessageBridge, TranscriptWatcher } from '../transcript/index.ts';
+import type { AssistantEntry } from '../transcript/index.ts';
+import { log, logError } from './logger.ts';
+
+export interface ExtractClaudeSessionIdDeps {
+  sessionStore: SessionStore;
+}
+
+/**
+ * Extract the Claude session id from a transcript filename and persist it.
+ * Returns the extracted id, or null if the filename does not expose one.
+ *
+ * Transcript filenames are plain UUIDs (`abc123-def456.jsonl`). The
+ * underscore split is defensive in case a prefixed format is ever introduced.
+ */
+export function extractClaudeSessionId(
+  deps: ExtractClaudeSessionIdDeps,
+  transcriptPath: string,
+  sessionId: UUID,
+): string | null {
+  const basename = path.basename(transcriptPath, '.jsonl');
+  const parts = basename.split('_');
+  const candidateId = parts[parts.length - 1];
+  if (candidateId && candidateId.length >= 8) {
+    deps.sessionStore.updateClaudeSessionId(sessionId, candidateId);
+    log(`Claude session ID: ${candidateId}`);
+    return candidateId;
+  }
+  return null;
+}
+
+export interface StartTranscriptWatcherDeps {
+  transcriptWatchers: Map<UUID, TranscriptWatcher>;
+}
+
+/**
+ * Start watching a transcript file for a session. Registers the watcher in
+ * the shared map so other callers can look it up, stop it, or force a reread.
+ */
+export function startTranscriptWatcher(
+  deps: StartTranscriptWatcherDeps,
+  sessionId: UUID,
+  transcriptPath: string,
+  messageApi: MessageAPI,
+  sendAndRecord: (message: ProtocolMessage) => void,
+): void {
+  log(`[Transcript] Watching: ${transcriptPath}`);
+  log(`[Transcript] File exists: ${fs.existsSync(transcriptPath)}`);
+
+  const bridge = new TranscriptMessageBridge({ sessionId }, messageApi, {
+    onTranscriptContent: (message) => {
+      log(`[Transcript] Delivering content (${message.type}) to clients`);
+      sendAndRecord(message);
+    },
+  });
+
+  const watcher = new TranscriptWatcher(
+    {
+      filePath: transcriptPath,
+      readExisting: true,
+      pollIntervalMs: 1000,
+    },
+    {
+      onAssistantMessage: (entry: AssistantEntry) => {
+        log(
+          `[Transcript] Assistant entry: ${entry.uuid?.slice(0, 8)} (${entry.message?.content?.length ?? 0} blocks)`,
+        );
+        bridge.handleAssistantEntry(entry);
+      },
+      onUserMessage: (entry) => {
+        log(`[Transcript] User entry: ${entry.uuid?.slice(0, 8)}`);
+        bridge.handleUserEntry(entry);
+      },
+      onError: (error) => {
+        logError(`[Transcript] Error for session ${sessionId}:`, error.message);
+      },
+    },
+  );
+
+  deps.transcriptWatchers.set(sessionId, watcher);
+  watcher.start().catch((error) => {
+    logError(`[Transcript] Failed to start watcher for session ${sessionId}:`, error);
+  });
+  log(`[Transcript] Watcher started for session ${sessionId}`);
+}

--- a/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
+++ b/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import {
+  extractClaudeSessionId,
+  startTranscriptWatcher,
+} from '../../src/cli/transcript-watcher-setup.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+  } as unknown as MessageAPI;
+}
+
+describe('transcript-watcher-setup', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tws-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    configureLogger({ writeLog: () => {} });
+    // Seed a session so updateClaudeSessionId has a row to update
+    sessionStore.save({
+      remiSessionId: SID,
+      claudeSessionId: null,
+      projectPath: tmpDir,
+      port: 0,
+      pid: null,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('extractClaudeSessionId', () => {
+    test('reads UUID from a plain filename and persists it', () => {
+      const claudeId = '11111111-2222-3333-4444-555555555555';
+      const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
+
+      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+
+      expect(result).toBe(claudeId);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(claudeId);
+    });
+
+    test('accepts prefixed _UUID filenames (picks the last segment)', () => {
+      const claudeId = '66666666-7777-8888-9999-000000000000';
+      const filePath = path.join(tmpDir, `prefix_${claudeId}.jsonl`);
+
+      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+
+      expect(result).toBe(claudeId);
+    });
+
+    test('returns null and does not persist when the filename has no usable id', () => {
+      const filePath = path.join(tmpDir, 'ab.jsonl'); // under 8 chars
+      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      expect(result).toBeNull();
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBeNull();
+    });
+  });
+
+  describe('startTranscriptWatcher', () => {
+    test('registers a watcher in the shared map and reads an existing transcript', async () => {
+      const claudeId = 'abcdef01-2345-6789-abcd-ef0123456789';
+      const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
+      fs.writeFileSync(
+        filePath,
+        `${JSON.stringify({
+          type: 'user',
+          uuid: 'u1',
+          sessionId: claudeId,
+          cwd: tmpDir,
+          timestamp: new Date().toISOString(),
+          message: { role: 'user', content: 'hi' },
+        })}\n`,
+      );
+
+      const transcriptWatchers = new Map<UUID, TranscriptWatcher>();
+      const sendCalls: ProtocolMessage[] = [];
+      const sendAndRecord = (m: ProtocolMessage) => sendCalls.push(m);
+
+      startTranscriptWatcher(
+        { transcriptWatchers },
+        SID,
+        filePath,
+        fakeMessageAPI(),
+        sendAndRecord,
+      );
+
+      expect(transcriptWatchers.has(SID)).toBe(true);
+      // Give the watcher's start() a tick to read existing content.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const watcher = transcriptWatchers.get(SID);
+      expect(watcher).toBeDefined();
+      watcher?.stop();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Sub-phase 0 of the createNewSession elephant (705-line function): pulls the two helpers that always travel together (`extractClaudeSessionId` + `startTranscriptWatcher`) out of cli.ts into their own module.
- Prep for bigger sub-phase extractions. MessageAPI setup, hook bridge setup, and transcript-fallback poll all need these; now they can import directly instead of closing over cli.ts-local state.
- `cli.ts`: **2481 → 2481 … 2523 → 2481 (−42)**.

## Changes

**New `packages/daemon/src/cli/transcript-watcher-setup.ts`** (105 lines)
- `extractClaudeSessionId(deps, transcriptPath, sessionId)`: parses the Claude session id out of a transcript filename, persists via injected `SessionStore`. Returns the id or null.
- `startTranscriptWatcher(deps, sessionId, transcriptPath, messageApi, sendAndRecord)`: wires `TranscriptMessageBridge` + `TranscriptWatcher` and registers the watcher in the shared `transcriptWatchers` map.
- Both are pure over inputs — tests supply tmpdir SessionStore + in-memory Map.

**`packages/daemon/src/cli.ts`**
- Imports the impls under aliases.
- Keeps thin wrappers that bind `sessionStore` + `transcriptWatchers` so the 6 call sites (4 in createNewSession hook setup, 2 in the transcript fallback poll) are unchanged.

**`packages/daemon/tests/cli/transcript-watcher-setup.test.ts`** (116 lines, 4 tests)
- UUID extraction from plain and underscored-prefix filenames.
- Null rejection for too-short basenames.
- Watcher registration + real-JSONL read via tmpdir.

## Test plan
- [x] `bun test packages/daemon/tests/cli/transcript-watcher-setup.test.ts` — 4/4 pass
- [x] Non-LLM full suite — 1639/1639 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — clean
- [x] `typos` — clean