### PR TITLE
refactor(cli): extract transcript fallback poll into its own module

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -142,10 +142,8 @@ import {
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
-import {
-  extractClaudeSessionId as extractClaudeSessionIdImpl,
-  startTranscriptWatcher as startTranscriptWatcherImpl,
-} from './cli/transcript-watcher-setup.ts';
+import { startTranscriptFallback } from './cli/transcript-fallback.ts';
+import { startTranscriptWatcher as startTranscriptWatcherImpl } from './cli/transcript-watcher-setup.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
@@ -1536,92 +1534,25 @@ async function createNewSession(
     exitCode: null,
   });
 
-  // Transcript watcher: normally started by hook event (provides path directly).
-  // When sibling daemons serve the same directory, hook events are skipped and
-  // this fallback becomes the primary discovery path.
-  const startupTime = Date.now();
-  const fallbackInterval = setInterval(() => {
-    if (transcriptWatchers.has(sessionId)) {
-      clearInterval(fallbackInterval);
-      transcriptFallbackTimers.delete(sessionId);
-      return;
-    }
-    if (!sessionRegistry.hasSession(sessionId)) {
-      clearInterval(fallbackInterval);
-      transcriptFallbackTimers.delete(sessionId);
-      return;
-    }
-    // Look for a transcript file that is actively being written to.
-    // When sibling daemons serve the same directory, exclude transcripts they've
-    // already claimed (by claudeSessionId in sessions.json) to avoid double-watching.
-    const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
-    const siblingClaudeIds = new Set<string>();
-    for (const entry of sessionStore.list()) {
-      if (entry.remiSessionId !== sessionId && entry.claudeSessionId && !entry.exitedAt) {
-        siblingClaudeIds.add(entry.claudeSessionId);
-      }
-    }
-    const transcriptPath =
-      siblingClaudeIds.size > 0
-        ? transcriptDiscovery.findLatestTranscriptExcluding(workingDirectory, siblingClaudeIds)
-        : transcriptDiscovery.findLatestTranscript(workingDirectory);
-    if (transcriptPath) {
-      try {
-        const stat = fs.statSync(transcriptPath);
-        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
-          clearInterval(fallbackInterval);
-          transcriptFallbackTimers.delete(sessionId);
-          log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
-          startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
-          extractClaudeSessionId(transcriptPath, sessionId);
-          return;
-        }
-      } catch (err) {
-        log(`[Hooks] Fallback stat failed for ${transcriptPath}: ${errorToString(err)}`);
-      }
-    }
-    // Give up after 30 seconds
-    if (Date.now() - startupTime > 30000) {
-      clearInterval(fallbackInterval);
-      transcriptFallbackTimers.delete(sessionId);
-      if (transcriptPath) {
-        try {
-          const stat = fs.statSync(transcriptPath);
-          const isRecent =
-            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-          if (isRecent) {
-            log('[Hooks] Transcript fallback: found recent transcript on final check.');
-            startTranscriptWatcher(sessionId, transcriptPath, messageApi, sendAndRecord);
-            extractClaudeSessionId(transcriptPath, sessionId);
-            return;
-          }
-
-          logError(
-            `[Hooks] Transcript fallback timed out without a fresh transcript. Skipping stale file: ${transcriptPath}`,
-          );
-          return;
-        } catch {
-          logError(
-            '[Hooks] Transcript fallback timed out and transcript stat failed on final check.',
-          );
-          return;
-        }
-      }
-
-      logError('[Hooks] Transcript fallback timed out without any transcript file.');
-    }
-  }, 2000);
-  transcriptFallbackTimers.set(sessionId, fallbackInterval);
+  startTranscriptFallback(
+    {
+      sessionRegistry,
+      sessionStore,
+      transcriptDiscovery,
+      transcriptWatchers,
+      transcriptFallbackTimers,
+    },
+    sessionId,
+    workingDirectory,
+    messageApi,
+    sendAndRecord,
+  );
 
   return ptySession;
 }
 
-// Thin wrappers over cli/transcript-watcher-setup.ts that bind the cli.ts-local
-// state (sessionStore, transcriptWatchers map) so call sites inside
-// createNewSession and the fallback-poll block don't change.
-function extractClaudeSessionId(transcriptPath: string, sessionId: UUID): string | null {
-  return extractClaudeSessionIdImpl({ sessionStore }, transcriptPath, sessionId);
-}
+// Thin wrapper over cli/transcript-watcher-setup.ts binding transcriptWatchers
+// so the 2 call sites inside the hook bridge stay unchanged.
 function startTranscriptWatcher(
   sessionId: UUID,
   transcriptPath: string,

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -1,0 +1,151 @@
+/**
+ * Transcript-watcher fallback poll for the hook-miss case.
+ *
+ * Normally the Claude Code hook event stream tells us the exact transcript
+ * path (SessionStart carries `transcript_path`). When sibling daemons share
+ * the same project directory, hook events are intentionally skipped because
+ * all Claudes POST to all hook URLs and we can't tell which one we own.
+ * This poll becomes the primary discovery path in that case.
+ *
+ * Every 2 seconds, look for a transcript file whose mtime is recent or is
+ * newer than the PTY startup. If found, start the watcher and cancel the
+ * poll. Give up after 30 seconds and log the reason.
+ */
+
+import * as fs from 'node:fs';
+import { errorToString } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { MessageAPI } from '../api/message-api.ts';
+import type { SessionRegistry, SessionStore } from '../session/index.ts';
+import type { TranscriptDiscovery } from '../transcript/index.ts';
+import type { TranscriptWatcher } from '../transcript/index.ts';
+import { log, logError } from './logger.ts';
+import { extractClaudeSessionId, startTranscriptWatcher } from './transcript-watcher-setup.ts';
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_POLL_TIMEOUT_MS = 30000;
+const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
+
+export interface TranscriptFallbackDeps {
+  sessionRegistry: SessionRegistry;
+  sessionStore: SessionStore;
+  transcriptDiscovery: TranscriptDiscovery;
+  transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  /** Override for tests. Defaults to 2000ms. */
+  pollIntervalMs?: number;
+  /** Override for tests. Defaults to 30000ms. */
+  pollTimeoutMs?: number;
+}
+
+/**
+ * Start polling for a transcript path to watch. Registers the interval in
+ * `transcriptFallbackTimers` so cleanup can cancel it; the poll self-clears
+ * on success, on session loss, or after the timeout.
+ */
+export function startTranscriptFallback(
+  deps: TranscriptFallbackDeps,
+  sessionId: UUID,
+  workingDirectory: string,
+  messageApi: MessageAPI,
+  sendAndRecord: (message: ProtocolMessage) => void,
+): void {
+  const {
+    sessionRegistry,
+    sessionStore,
+    transcriptDiscovery,
+    transcriptWatchers,
+    transcriptFallbackTimers,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
+  } = deps;
+
+  const startupTime = Date.now();
+
+  const attachWatcher = (transcriptPath: string): void => {
+    startTranscriptWatcher(
+      { transcriptWatchers },
+      sessionId,
+      transcriptPath,
+      messageApi,
+      sendAndRecord,
+    );
+    extractClaudeSessionId({ sessionStore }, transcriptPath, sessionId);
+  };
+
+  const stopPoll = (): void => {
+    clearInterval(fallbackInterval);
+    transcriptFallbackTimers.delete(sessionId);
+  };
+
+  const fallbackInterval = setInterval(() => {
+    if (transcriptWatchers.has(sessionId)) {
+      stopPoll();
+      return;
+    }
+    if (!sessionRegistry.hasSession(sessionId)) {
+      stopPoll();
+      return;
+    }
+
+    // Exclude transcripts already claimed by sibling daemons (their
+    // claudeSessionId is stored in sessions.json) to avoid double-watching.
+    const siblingClaudeIds = new Set<string>();
+    for (const entry of sessionStore.list()) {
+      if (entry.remiSessionId !== sessionId && entry.claudeSessionId && !entry.exitedAt) {
+        siblingClaudeIds.add(entry.claudeSessionId);
+      }
+    }
+    const transcriptPath =
+      siblingClaudeIds.size > 0
+        ? transcriptDiscovery.findLatestTranscriptExcluding(workingDirectory, siblingClaudeIds)
+        : transcriptDiscovery.findLatestTranscript(workingDirectory);
+
+    if (transcriptPath) {
+      try {
+        const stat = fs.statSync(transcriptPath);
+        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
+          stopPoll();
+          log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
+          attachWatcher(transcriptPath);
+          return;
+        }
+      } catch (err) {
+        log(`[Hooks] Fallback stat failed for ${transcriptPath}: ${errorToString(err)}`);
+      }
+    }
+
+    // Timeout branch. Still accept the transcript if it became recent
+    // during the final interval, otherwise log and give up.
+    if (Date.now() - startupTime > pollTimeoutMs) {
+      stopPoll();
+      if (transcriptPath) {
+        try {
+          const stat = fs.statSync(transcriptPath);
+          const isRecent =
+            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
+          if (isRecent) {
+            log('[Hooks] Transcript fallback: found recent transcript on final check.');
+            attachWatcher(transcriptPath);
+            return;
+          }
+
+          logError(
+            `[Hooks] Transcript fallback timed out without a fresh transcript. Skipping stale file: ${transcriptPath}`,
+          );
+          return;
+        } catch {
+          logError(
+            '[Hooks] Transcript fallback timed out and transcript stat failed on final check.',
+          );
+          return;
+        }
+      }
+
+      logError('[Hooks] Transcript fallback timed out without any transcript file.');
+    }
+  }, pollIntervalMs);
+
+  transcriptFallbackTimers.set(sessionId, fallbackInterval);
+}

--- a/packages/daemon/tests/cli/transcript-fallback.test.ts
+++ b/packages/daemon/tests/cli/transcript-fallback.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import { startTranscriptFallback } from '../../src/cli/transcript-fallback.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+  } as unknown as MessageAPI;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('startTranscriptFallback', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+  let projectPath: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  let logs: string[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tfallback-'));
+    projectsDir = path.join(tmpDir, 'claude-projects');
+    projectPath = path.join(tmpDir, 'my-project');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.mkdirSync(projectPath, { recursive: true });
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+    transcriptWatchers = new Map();
+    transcriptFallbackTimers = new Map();
+    logs = [];
+    configureLogger({ writeLog: (m) => logs.push(m) });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    for (const timer of transcriptFallbackTimers.values()) {
+      clearInterval(timer);
+    }
+    transcriptFallbackTimers.clear();
+    for (const w of transcriptWatchers.values()) w.stop();
+    transcriptWatchers.clear();
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Write a transcript file inside the encoded project directory. */
+  function writeTranscript(claudeId: string, entries: object[]): string {
+    const encodedDir = path.join(projectsDir, projectPath.replace(/\//g, '-'));
+    fs.mkdirSync(encodedDir, { recursive: true });
+    const filePath = path.join(encodedDir, `${claudeId}.jsonl`);
+    fs.writeFileSync(filePath, entries.map((e) => JSON.stringify(e)).join('\n'));
+    return filePath;
+  }
+
+  function registerSession(): UUID {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, projectPath, fakePTY(), fakeMessageAPI());
+    return sessionId;
+  }
+
+  const sendAndRecord = (_: ProtocolMessage) => {};
+
+  test('registers a timer in transcriptFallbackTimers', () => {
+    const sid = registerSession();
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 10000, // Long enough that the timer is still alive when we assert.
+        pollTimeoutMs: 10000,
+      },
+      sid,
+      projectPath,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    expect(transcriptFallbackTimers.has(sid)).toBe(true);
+  });
+
+  test('self-clears when a watcher already exists for the session', async () => {
+    const sid = registerSession();
+    // Pre-populate watchers so the first tick bails out.
+    transcriptWatchers.set(sid, { stop: () => {} } as unknown as TranscriptWatcher);
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 500,
+      },
+      sid,
+      projectPath,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    await sleep(60);
+
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+  });
+
+  test('self-clears when the session is no longer registered', async () => {
+    const sid = registerSession();
+    sessionRegistry.closeSession(sid, 'forced');
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 500,
+      },
+      sid,
+      projectPath,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    await sleep(60);
+
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+  });
+
+  test('attaches a watcher when a fresh transcript appears on disk', async () => {
+    const sid = registerSession();
+    const claudeId = '11111111-2222-3333-4444-555555555555';
+    const entry = {
+      type: 'user',
+      uuid: 'u1',
+      sessionId: claudeId,
+      cwd: projectPath,
+      timestamp: new Date().toISOString(),
+      message: { role: 'user', content: 'hi' },
+    };
+    writeTranscript(claudeId, [entry]);
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 30,
+        pollTimeoutMs: 1000,
+      },
+      sid,
+      projectPath,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    // Wait for at least one poll tick + async watcher start.
+    for (let i = 0; i < 20; i++) {
+      if (transcriptWatchers.has(sid)) break;
+      await sleep(30);
+    }
+
+    expect(transcriptWatchers.has(sid)).toBe(true);
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+  });
+
+  test('times out when no transcript ever appears', async () => {
+    // No transcript on disk.
+    const sid = registerSession();
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 100,
+      },
+      sid,
+      projectPath,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    // Need at least (timeout + one poll interval) to let the timeout branch fire.
+    await sleep(200);
+
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+    expect(transcriptWatchers.has(sid)).toBe(false);
+    expect(
+      logs.some((m) =>
+        m.includes('[error] [Hooks] Transcript fallback timed out without any transcript file'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Sub-phase F of the createNewSession elephant: extracts the hook-miss fallback poll (75-line branching interval) that scans for a recently-written JSONL when Claude Code hook events can't tell us which transcript is ours (sibling-daemons-in-same-dir case).
- `cli.ts`: **2481 → 2412 (−69)**.

## Changes

**New `packages/daemon/src/cli/transcript-fallback.ts`** (151 lines)
- `startTranscriptFallback(deps, sessionId, workingDirectory, messageApi, sendAndRecord)` installs the interval and registers it in the shared `transcriptFallbackTimers` map.
- Injectable `pollIntervalMs` / `pollTimeoutMs` for tests (default 2000 / 30000).
- Delegates to `extractClaudeSessionId` + `startTranscriptWatcher` from `cli/transcript-watcher-setup.ts` (the prior extraction).
- Preserves the inline block behavior exactly: skip when a watcher is already present, skip when the session is gone, exclude sibling-owned transcripts, accept files with mtime ≥ startup or within the 5-minute recency window, final-chance check on timeout.

**`packages/daemon/src/cli.ts`**
- Replaces the 75-line inline block with a 12-line call site.
- Drops the `extractClaudeSessionId` thin wrapper (no remaining callers in cli.ts now that the fallback poll is out).

**`packages/daemon/tests/cli/transcript-fallback.test.ts`** (235 lines, 5 real-fs tests)
- Registers a timer in `transcriptFallbackTimers`.
- Self-clears when a watcher is already present.
- Self-clears when the session has been closed.
- Attaches a watcher when a fresh transcript appears (writes a real JSONL in the encoded projects dir, polls until watcher is registered).
- Timeout path logs the "no transcript file" error and clears the timer without attaching.

## Sequencing
Second sub-phase cut of the elephant after #352 (transcript-watcher helpers). Remaining in createNewSession: MessageAPI setup (Phase A, ~99 lines), OutputProcessor (Phase B, ~25), hook bridge (Phase C, ~386 — the big one), PTY session (Phase D, ~84), register + save (Phase E, ~20).

## Test plan
- [x] `bun test packages/daemon/tests/cli/transcript-fallback.test.ts` — 5/5 pass
- [x] Non-LLM full suite — 1644/1644 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — clean
- [x] `typos` — clean