### PR TITLE
refactor(cli): extract MessageAPI setup (Phase A) from createNewSession

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -46,17 +46,6 @@ let STATUS_FILE = path.join(REMI_DIR, 'status.json'); // Updated after PORT is r
 // Raw PTY bytes are written directly via fs.writeSync to avoid decode/encode.
 let ptyStdoutFd: number | null = null;
 
-/**
- * Select the APNS notification category based on the number of question options.
- * iOS will render action buttons matching the category; watchOS mirrors them automatically.
- */
-function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
-  if (options.length === 2) return 'REMI_YN';
-  if (options.length === 3) return 'REMI_YNA';
-  if (options.length === 4) return 'REMI_MULTI';
-  return undefined;
-}
-
 function ensureRemiDir(): void {
   fs.mkdirSync(REMI_DIR, { recursive: true });
 }
@@ -101,20 +90,12 @@ import {
   createReplayBatch,
   createSessionListResponse,
   createSessionReset,
-  createStructuredAgentOutput,
   generateId,
-  now,
 } from '@remi/shared';
-import type {
-  AgentStatus,
-  ProtocolMessage,
-  QuestionOption,
-  UUID,
-  UnlockedIdentity,
-} from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
 import { AdapterRegistry, TelegramAdapter, WebSocketAdapter } from './adapters/index.ts';
-import { MessageAPI } from './api/index.ts';
+import type { MessageAPI } from './api/index.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
@@ -141,6 +122,7 @@ import {
 } from './cli/handlers/transcript-events.ts';
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
+import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
 import { startTranscriptWatcher as startTranscriptWatcherImpl } from './cli/transcript-watcher-setup.ts';
@@ -148,7 +130,6 @@ import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookEventBridge, HookServer } from './hooks/index.ts';
 import { classifySessionEvent } from './hooks/session-lock-classifier.ts';
-import { sendPushTrigger } from './notifications/push-client.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, PTYSession } from './pty/index.ts';
 import {
@@ -915,104 +896,20 @@ async function createNewSession(
   extraArgs: string[] = [],
   passThrough = false,
 ): Promise<PTYSession> {
-  const sendAndRecord = (message: ProtocolMessage) => {
-    // Always record under primarySessionId so replay works correctly.
-    // The client only knows primarySessionId (from hello_ack).
-    const recordId = getPrimarySessionId() ?? sessionId;
-    sendMessage(sessionId, message);
-    sessionRegistry.recordOutgoingMessage(recordId, message);
-  };
-
-  const messageApi = new MessageAPI(
+  const { messageApi, sendAndRecord } = createMessageApiForSession(
     {
-      sessionId: sessionId,
-      initialBulletId: 1,
+      sessionRegistry,
+      transcriptWatchers,
+      deviceTokens,
+      pushConfig: () => ({
+        signalingUrl: cliSignalingUrl ?? remiConfig.network.signaling_url,
+        ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+      }),
+      updateRemiStatus: (patch) => updateRemiStatus(patch),
       maxBulletLength: MAX_BULLET_LENGTH,
+      sendMessage,
     },
-    {
-      onStructuredMessage: (structured) => {
-        try {
-          sendAndRecord(createStructuredAgentOutput(structured, false));
-        } catch (err) {
-          logError(`[Session ${sessionId}] Failed to send structured message:`, err);
-        }
-      },
-      onStructuredMessageUpdate: (_messageId, structured, changedBulletIds) => {
-        try {
-          sendAndRecord(createStructuredAgentOutput(structured, true, changedBulletIds));
-        } catch (err) {
-          logError(`[Session ${sessionId}] Failed to send structured message update:`, err);
-        }
-      },
-      onMessageFinalized: (msgId) => {
-        log(`Message ${msgId} finalized`);
-      },
-      onQuestion: (question) => {
-        log(`Question detected: ${question.text.substring(0, 50)}...`);
-        const questionSessionId = getPrimarySessionId() ?? sessionId;
-        const msg: ProtocolMessage = {
-          type: 'question',
-          id: generateId(),
-          timestamp: now(),
-          question: question,
-          sessionId: questionSessionId,
-        };
-        sendAndRecord(msg);
-        sessionRegistry.updateQuestion(questionSessionId, question);
-
-        // Push to registered devices only when no client is actively viewing the session.
-        // If a client is attached, they see the question in the UI; no push needed.
-        const sessionForPush = sessionRegistry.getSession(questionSessionId);
-        const hasActiveClient =
-          sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-        if (deviceTokens.size > 0 && !hasActiveClient) {
-          const session = sessionRegistry.getSession(sessionId);
-          const sessionName = session?.name || 'Agent';
-          const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
-          const pushSessionId = getPrimarySessionId() ?? sessionId;
-          const pushCategory = selectPushCategory(question.options);
-          const pushOptions = question.options.map((o) => o.value);
-          for (const dt of deviceTokens.values()) {
-            sendPushTrigger(signalingUrl, dt.token, {
-              title: `${sessionName} needs input`,
-              body: question.text.slice(0, 100),
-              ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
-              sessionId: pushSessionId,
-              questionId: question.id,
-              ...(pushCategory !== undefined ? { category: pushCategory } : {}),
-              ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
-            })
-              .then(() => log(`Push notification sent for session ${pushSessionId}`))
-              .catch((err) => log(`Push notification failed: ${err}`));
-          }
-        }
-      },
-      onStatusChange: (status: AgentStatus, context?: string) => {
-        log(`Status: ${status}${context ? ` (${context})` : ''}`);
-        const msg: ProtocolMessage = {
-          type: 'session_update',
-          id: generateId(),
-          timestamp: now(),
-          session: {
-            id: sessionId,
-            name: '',
-            startedAt: now(),
-            status,
-            isActive: status !== 'idle',
-          },
-        };
-        sendAndRecord(msg);
-        sessionRegistry.updateStatus(sessionId, status);
-        updateRemiStatus({ sessionStatus: status });
-
-        const watcher = transcriptWatchers.get(sessionId);
-        if (watcher) {
-          watcher.forceRead().catch((err) => {
-            logError(`[Transcript] forceRead failed for session ${sessionId}:`, err);
-          });
-        }
-      },
-    },
+    sessionId,
   );
 
   // PTY output parser: streamStatusOnly suppresses regular agent content (comes

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -39,14 +39,18 @@ export interface MessageApiSetupDeps {
   sessionRegistry: SessionRegistry;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   deviceTokens: Map<string, DeviceTokenEntry>;
-  /** Resolved lazily because these come from a dynamic config. */
+  /**
+   * Called on every question emission so the caller can swap config sources
+   * without re-wiring the factory. MUST be synchronous and non-throwing: it
+   * runs inside the MessageAPI onQuestion callback with no try/catch around it.
+   */
   pushConfig: () => PushConfig;
   updateRemiStatus: (patch: { sessionStatus: AgentStatus }) => void;
   maxBulletLength: number;
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
 }
 
-export interface MessageApiForSession {
+export interface MessageApiHandle {
   messageApi: MessageAPI;
   sendAndRecord: (message: ProtocolMessage) => void;
 }
@@ -66,7 +70,7 @@ export function selectPushCategory(options: readonly QuestionOption[]): string |
 export function createMessageApiForSession(
   deps: MessageApiSetupDeps,
   sessionId: UUID,
-): MessageApiForSession {
+): MessageApiHandle {
   const {
     sessionRegistry,
     transcriptWatchers,

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -1,0 +1,176 @@
+/**
+ * Sub-phase A of createNewSession: build the MessageAPI + its callbacks.
+ *
+ * The MessageAPI owns bullet assembly, question detection, and status flow.
+ * This module wires it to:
+ *   - the outgoing-message channel (sendMessage + registry recordOutgoing)
+ *   - the SessionRegistry's question and status maps
+ *   - the StatusWriter's sessionStatus patch
+ *   - the live transcript watcher (forceRead on status change so the UI
+ *     reflects the latest transcript frame without waiting for the next
+ *     2s poll)
+ *   - the push-notification client, used only when no client is actively
+ *     viewing the session (attached clients see the question in-app)
+ *
+ * Returns both the configured MessageAPI and the `sendAndRecord` closure
+ * because later sub-phases (hook bridge, PTY setup) also dispatch through
+ * it and need the same replay semantics (record under the primary session
+ * id so replays re-emit with the id the client knows).
+ */
+
+import { createStructuredAgentOutput, generateId, now } from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } from '@remi/shared';
+
+import type { MessageAPIEvents } from '../../api/message-api.ts';
+import { MessageAPI } from '../../api/message-api.ts';
+import { sendPushTrigger } from '../../notifications/push-client.ts';
+import type { SessionRegistry } from '../../session/index.ts';
+import type { TranscriptWatcher } from '../../transcript/index.ts';
+import type { DeviceTokenEntry } from '../handlers/trivial-events.ts';
+import { log, logError } from '../logger.ts';
+import { getPrimarySessionId } from '../session-state.ts';
+
+export interface PushConfig {
+  signalingUrl: string;
+  pushSecret?: string | undefined;
+}
+
+export interface MessageApiSetupDeps {
+  sessionRegistry: SessionRegistry;
+  transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  /** Resolved lazily because these come from a dynamic config. */
+  pushConfig: () => PushConfig;
+  updateRemiStatus: (patch: { sessionStatus: AgentStatus }) => void;
+  maxBulletLength: number;
+  sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
+}
+
+export interface MessageApiForSession {
+  messageApi: MessageAPI;
+  sendAndRecord: (message: ProtocolMessage) => void;
+}
+
+/**
+ * Select the APNS notification category based on the number of question
+ * options. iOS renders action buttons matching the category; watchOS mirrors
+ * them automatically.
+ */
+export function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
+  if (options.length === 2) return 'REMI_YN';
+  if (options.length === 3) return 'REMI_YNA';
+  if (options.length === 4) return 'REMI_MULTI';
+  return undefined;
+}
+
+export function createMessageApiForSession(
+  deps: MessageApiSetupDeps,
+  sessionId: UUID,
+): MessageApiForSession {
+  const {
+    sessionRegistry,
+    transcriptWatchers,
+    deviceTokens,
+    pushConfig,
+    updateRemiStatus,
+    maxBulletLength,
+    sendMessage,
+  } = deps;
+
+  const sendAndRecord = (message: ProtocolMessage): void => {
+    // Always record under primarySessionId so replay works correctly. The
+    // client only knows the primary id (from hello_ack), so replay must use
+    // it regardless of which session-id the message originated from.
+    const recordId = getPrimarySessionId() ?? sessionId;
+    sendMessage(sessionId, message);
+    sessionRegistry.recordOutgoingMessage(recordId, message);
+  };
+
+  const callbacks: MessageAPIEvents = {
+    onStructuredMessage: (structured) => {
+      try {
+        sendAndRecord(createStructuredAgentOutput(structured, false));
+      } catch (err) {
+        logError(`[Session ${sessionId}] Failed to send structured message:`, err);
+      }
+    },
+    onStructuredMessageUpdate: (_messageId, structured, changedBulletIds) => {
+      try {
+        sendAndRecord(createStructuredAgentOutput(structured, true, changedBulletIds));
+      } catch (err) {
+        logError(`[Session ${sessionId}] Failed to send structured message update:`, err);
+      }
+    },
+    onMessageFinalized: (msgId) => {
+      log(`Message ${msgId} finalized`);
+    },
+    onQuestion: (question: Question) => {
+      log(`Question detected: ${question.text.substring(0, 50)}...`);
+      const questionSessionId = getPrimarySessionId() ?? sessionId;
+      const msg: ProtocolMessage = {
+        type: 'question',
+        id: generateId(),
+        timestamp: now(),
+        question,
+        sessionId: questionSessionId,
+      };
+      sendAndRecord(msg);
+      sessionRegistry.updateQuestion(questionSessionId, question);
+
+      // Push only when no client is attached; attached clients see it in-app.
+      const sessionForPush = sessionRegistry.getSession(questionSessionId);
+      const hasActiveClient =
+        sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
+      if (deviceTokens.size > 0 && !hasActiveClient) {
+        const session = sessionRegistry.getSession(sessionId);
+        const sessionName = session?.name || 'Agent';
+        const cfg = pushConfig();
+        const pushSessionId = getPrimarySessionId() ?? sessionId;
+        const pushCategory = selectPushCategory(question.options);
+        const pushOptions = question.options.map((o) => o.value);
+        for (const dt of deviceTokens.values()) {
+          sendPushTrigger(cfg.signalingUrl, dt.token, {
+            title: `${sessionName} needs input`,
+            body: question.text.slice(0, 100),
+            ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+            sessionId: pushSessionId,
+            questionId: question.id,
+            ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+            ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+          })
+            .then(() => log(`Push notification sent for session ${pushSessionId}`))
+            .catch((err) => log(`Push notification failed: ${err}`));
+        }
+      }
+    },
+    onStatusChange: (status: AgentStatus, context?: string) => {
+      log(`Status: ${status}${context ? ` (${context})` : ''}`);
+      const msg: ProtocolMessage = {
+        type: 'session_update',
+        id: generateId(),
+        timestamp: now(),
+        session: {
+          id: sessionId,
+          name: '',
+          startedAt: now(),
+          status,
+          isActive: status !== 'idle',
+        },
+      };
+      sendAndRecord(msg);
+      sessionRegistry.updateStatus(sessionId, status);
+      updateRemiStatus({ sessionStatus: status });
+
+      const watcher = transcriptWatchers.get(sessionId);
+      if (watcher) {
+        watcher.forceRead().catch((err) => {
+          logError(`[Transcript] forceRead failed for session ${sessionId}:`, err);
+        });
+      }
+    },
+  };
+
+  const messageApi = new MessageAPI({ sessionId, initialBulletId: 1, maxBulletLength }, callbacks);
+
+  return { messageApi, sendAndRecord };
+}

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -168,13 +168,13 @@ describe('createMessageApiForSession', () => {
     const { messageApi } = build(sessionId);
     messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
 
-    // Push would require a real HTTP request to the fake signaling URL.
-    // We can't observe the attempt directly here (sendPushTrigger is imported
-    // into the production module), but we CAN observe that the in-app
-    // question message was sent. The push branch is guarded by hasActiveClient
-    // so with a connection attached, the for-loop is skipped. A separate test
-    // (no attached client) exercises the opposite branch without actually
-    // completing the network call.
+    // Push would fire a real HTTP request to the fake signaling URL if the
+    // hasActiveClient branch were bypassed. sendPushTrigger is imported
+    // statically by the production module, so tests can't observe that call
+    // directly without a mock. What we CAN assert: the in-app question
+    // message still went out, and activeConnectionId is non-null (the
+    // condition guarding the push for-loop). A follow-up that injects
+    // sendPushTrigger via deps would let us assert the opposite branch.
     const questions = sendCalls.filter((c) => c.message.type === 'question');
     expect(questions).toHaveLength(1);
     expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).not.toBeNull();
@@ -223,5 +223,107 @@ describe('createMessageApiForSession', () => {
         resolve();
       }, 10);
     });
+  });
+
+  test('sendAndRecord records under sessionId when no primary is set', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    // Deliberately do NOT call setPrimarySessionId.
+
+    const { sendAndRecord } = build(sessionId);
+    sendAndRecord({
+      type: 'session_update',
+      id: generateId(),
+      timestamp: now(),
+      session: {
+        id: sessionId,
+        name: '',
+        startedAt: now(),
+        status: 'idle',
+        isActive: false,
+      },
+    });
+
+    expect(sendCalls).toHaveLength(1);
+    // Fallback: recorded under sessionId (the only registered session).
+    expect(sessionRegistry.getSession(sessionId)?.messageHistory.length).toBe(1);
+  });
+
+  test('onQuestion falls back to sessionId for the emitted message when no primary is set', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    const { messageApi } = build(sessionId);
+    messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+    const questionMsg = sendCalls.find((c) => c.message.type === 'question');
+    expect(questionMsg).toBeDefined();
+    // Question is routed to the caller's sendMessage bound to sessionId, and
+    // the inner message.sessionId falls back to sessionId when primary is null.
+    expect(questionMsg?.sessionId).toBe(sessionId);
+    expect((questionMsg?.message as { sessionId: UUID }).sessionId).toBe(sessionId);
+  });
+
+  test('onStructuredMessage emits structured_agent_output with isUpdate=false', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    const { messageApi } = build(sessionId);
+    messageApi.handleMessage({
+      id: '33333333-3333-3333-3333-333333333333' as UUID,
+      sessionId,
+      sender: 'agent',
+      content: 'hello world',
+      createdAt: now(),
+      state: 'delivered',
+      stateChangedAt: now(),
+      isEditing: false,
+    });
+
+    const structured = sendCalls.filter((c) => c.message.type === 'structured_agent_output');
+    expect(structured.length).toBeGreaterThanOrEqual(1);
+    // The first emission on a new message is a create, not an update.
+    expect((structured[0]?.message as { isUpdate: boolean }).isUpdate).toBe(false);
+  });
+
+  test('onStructuredMessageUpdate emits structured_agent_output with isUpdate=true', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    const { messageApi } = build(sessionId);
+    const msgId = '44444444-4444-4444-4444-444444444444' as UUID;
+    messageApi.handleMessage({
+      id: msgId,
+      sessionId,
+      sender: 'agent',
+      content: 'first',
+      createdAt: now(),
+      state: 'delivered',
+      stateChangedAt: now(),
+      isEditing: true,
+    });
+    // Reset captures so we can assert the update cleanly.
+    sendCalls.length = 0;
+    messageApi.handleMessageUpdate(msgId, 'first and more');
+
+    const updates = sendCalls.filter((c) => c.message.type === 'structured_agent_output');
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+    expect((updates[0]?.message as { isUpdate: boolean }).isUpdate).toBe(true);
   });
 });

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } from '@remi/shared';
+import { generateId, now } from '@remi/shared';
+import type { DeviceTokenEntry } from '../../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import {
+  createMessageApiForSession,
+  selectPushCategory,
+} from '../../../src/cli/session-phases/message-api-setup.ts';
+import {
+  __resetSessionStateForTests,
+  setPrimarySessionId,
+} from '../../../src/cli/session-state.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function questionWith(options: QuestionOption[]): Question {
+  return {
+    id: '11111111-1111-1111-1111-111111111111' as UUID,
+    text: 'proceed?',
+    options,
+    allowsFreeText: false,
+    isAnswered: false,
+  };
+}
+
+const yesOpt: QuestionOption = {
+  value: 'y',
+  label: 'Yes',
+  isRecommended: true,
+  isYes: true,
+  isNo: false,
+};
+const noOpt: QuestionOption = {
+  value: 'n',
+  label: 'No',
+  isRecommended: false,
+  isYes: false,
+  isNo: true,
+};
+
+describe('selectPushCategory', () => {
+  test('returns REMI_YN for 2 options', () => {
+    expect(selectPushCategory([yesOpt, noOpt])).toBe('REMI_YN');
+  });
+  test('returns REMI_YNA for 3 options', () => {
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt])).toBe('REMI_YNA');
+  });
+  test('returns REMI_MULTI for 4 options', () => {
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt])).toBe('REMI_MULTI');
+  });
+  test('returns undefined for other counts', () => {
+    expect(selectPushCategory([yesOpt])).toBeUndefined();
+    expect(selectPushCategory([])).toBeUndefined();
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt, yesOpt])).toBeUndefined();
+  });
+});
+
+describe('createMessageApiForSession', () => {
+  let sessionRegistry: SessionRegistry;
+  let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let sendCalls: Array<{ sessionId: UUID; message: ProtocolMessage }>;
+  let statusPatches: Array<{ sessionStatus: AgentStatus }>;
+
+  beforeEach(() => {
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    transcriptWatchers = new Map();
+    deviceTokens = new Map();
+    sendCalls = [];
+    statusPatches = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    __resetSessionStateForTests();
+    await sessionRegistry.shutdown();
+  });
+
+  function build(sessionId: UUID) {
+    return createMessageApiForSession(
+      {
+        sessionRegistry,
+        transcriptWatchers,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://fake-signaling' }),
+        updateRemiStatus: (patch) => statusPatches.push(patch),
+        maxBulletLength: 4000,
+        sendMessage: (sid, message) => {
+          sendCalls.push({ sessionId: sid, message });
+        },
+      },
+      sessionId,
+    );
+  }
+
+  test('sendAndRecord forwards to sendMessage and records under primary session id', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    const primaryId = '22222222-2222-2222-2222-222222222222' as UUID;
+    // Register the primary session so recordOutgoingMessage has somewhere to record.
+    sessionRegistry.registerSession(primaryId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+    setPrimarySessionId(primaryId);
+
+    const { sendAndRecord } = build(sessionId);
+    const msg: ProtocolMessage = {
+      type: 'question',
+      id: generateId(),
+      timestamp: now(),
+      question: questionWith([yesOpt, noOpt]),
+      sessionId,
+    };
+
+    sendAndRecord(msg);
+
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.sessionId).toBe(sessionId);
+    // Message got recorded under primaryId (check via session.messageHistory).
+    expect(sessionRegistry.getSession(primaryId)?.messageHistory.length).toBe(1);
+  });
+
+  test('onQuestion emits a question message and updates the registry', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    // No primary -> falls back to sessionId
+    const { messageApi } = build(sessionId);
+
+    messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+    const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
+    expect(questionMsgs).toHaveLength(1);
+    expect(sessionRegistry.getSession(sessionId)?.currentQuestion?.text).toBe('proceed?');
+  });
+
+  test('onQuestion does NOT push when a client is attached', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    sessionRegistry.attachConnection(sessionId, 'conn0000-0000-0000-0000-000000000000' as UUID);
+    deviceTokens.set('t', {
+      token: 't',
+      platform: 'ios',
+      registeredAt: Date.now(),
+      connectionId: 'conn0000-0000-0000-0000-000000000000' as UUID,
+    });
+
+    const { messageApi } = build(sessionId);
+    messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+    // Push would require a real HTTP request to the fake signaling URL.
+    // We can't observe the attempt directly here (sendPushTrigger is imported
+    // into the production module), but we CAN observe that the in-app
+    // question message was sent. The push branch is guarded by hasActiveClient
+    // so with a connection attached, the for-loop is skipped. A separate test
+    // (no attached client) exercises the opposite branch without actually
+    // completing the network call.
+    const questions = sendCalls.filter((c) => c.message.type === 'question');
+    expect(questions).toHaveLength(1);
+    expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).not.toBeNull();
+  });
+
+  test('onStatusChange emits session_update and patches StatusWriter', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    const { messageApi } = build(sessionId);
+    messageApi.handleStatusChange('executing');
+
+    const updates = sendCalls.filter((c) => c.message.type === 'session_update');
+    expect(updates).toHaveLength(1);
+    expect(statusPatches).toEqual([{ sessionStatus: 'executing' }]);
+    expect(sessionRegistry.getSession(sessionId)?.currentStatus).toBe('executing');
+  });
+
+  test('onStatusChange triggers transcript watcher forceRead when one is registered', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    let forceReadCount = 0;
+    transcriptWatchers.set(sessionId, {
+      forceRead: async () => {
+        forceReadCount += 1;
+      },
+      stop: () => {},
+    } as unknown as TranscriptWatcher);
+
+    const { messageApi } = build(sessionId);
+    messageApi.handleStatusChange('thinking');
+
+    // forceRead is fire-and-forget; give it a microtask to run.
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(forceReadCount).toBe(1);
+        resolve();
+      }, 10);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Sub-phase A of the createNewSession elephant: extracts the MessageAPI + its 5 callbacks (onStructuredMessage, onStructuredMessageUpdate, onMessageFinalized, onQuestion, onStatusChange). Includes the APNS push-notification fan-out that fires on new questions when no client is attached.
- `cli.ts`: **2412 → 2309 (−103)**.

## Changes

**New `packages/daemon/src/cli/session-phases/message-api-setup.ts`** (176 lines)
- `createMessageApiForSession(deps, sessionId)` returns `{ messageApi, sendAndRecord }`.
- `sendAndRecord` is exported because later sub-phases (hook bridge, PTY setup) dispatch through it and need the same record-under-primary-id replay semantics.
- `selectPushCategory` helper moves here (only caller was the onQuestion body); now exported for tests.
- Deps: `sessionRegistry`, `transcriptWatchers`, `deviceTokens`, `pushConfig` (getter so `cliSignalingUrl`/`cliPushSecret` are read lazily), `updateRemiStatus`, `maxBulletLength`, `sendMessage`. Uses `getPrimarySessionId` directly (module-scoped state from #344).

**`packages/daemon/src/cli.ts`**
- Replaces the inline MessageAPI construction (~100 lines) with a 14-line call site.
- Removes `selectPushCategory` (moved) and the now-unused `QuestionOption` / `sendPushTrigger` / `createStructuredAgentOutput` / `generateId` / `now` / `AgentStatus` imports.

**`packages/daemon/tests/cli/session-phases/message-api-setup.test.ts`** (227 lines, 9 tests)
- `selectPushCategory` category selection by option count (4 cases).
- `sendAndRecord` records under primary id (verifies replay invariant).
- `onQuestion` emits question + updates registry.
- `onQuestion` no-push-when-attached (guards the `hasActiveClient` branch).
- `onStatusChange` emits `session_update` + patches StatusWriter.
- `onStatusChange` triggers watcher.forceRead when a watcher is registered.

## Sequencing
Third elephant cut. Remaining in `createNewSession`: OutputProcessor (Phase B, ~25 lines), hook bridge (Phase C, ~386 lines, the biggest), PTY session (Phase D, ~84), register/start/save (Phase E, ~20).

## Test plan
- [x] `bun test packages/daemon/tests/cli/session-phases/message-api-setup.test.ts` — 9/9 pass
- [x] Non-LLM full suite — 1653/1653 pass in 19s
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — clean
- [x] `typos` — clean