### PR TITLE
fix(web): disable iOS dictation on Connect modal inputs (#266)

### DIFF
--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -82,6 +82,13 @@ function CodeInput({
       disabled={disabled}
       placeholder="ABCD-1234"
       maxLength={9}
+      // Connection codes are uppercase alphanumerics — strip iOS dictation
+      // and predictive entry the same way the host field does (#266).
+      autoCorrect="off"
+      autoCapitalize="characters"
+      spellCheck={false}
+      autoComplete="off"
+      inputMode="text"
       className={clsx(
         'w-full rounded-xl bg-[var(--color-surface-light)] px-4 py-3',
         'text-center text-2xl font-mono tracking-widest',
@@ -349,6 +356,16 @@ export function ConnectModal({
                   onKeyDown={handleKeyDown}
                   disabled={isConnecting}
                   placeholder="localhost"
+                  // iOS WKWebView keyboards otherwise insert dictation
+                  // suggestions alongside the typed string, producing the
+                  // doubled-text seen in #266 ("localhostlocalhost"). For a
+                  // hostname these affordances are pure noise; turn them off
+                  // and ask for the URL keyboard.
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
+                  autoComplete="off"
+                  inputMode="url"
                   className={clsx(
                     'w-full rounded-xl bg-[var(--color-surface-light)] px-4 py-3',
                     'text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-muted)]',


### PR DESCRIPTION
## Summary

Closes #266. iOS WKWebView's predictive keyboard inserts the dictated/predicted word **in addition to** the typed string when neither \`autoCorrect\` nor \`autoComplete\` is set, producing \"localhostlocalhost\" when typing \"localhost\" in the Connect modal hostname field.

For a hostname or a short uppercase connection code these affordances are pure noise — disable them and ask iOS for the right keyboard while we're there.

- Hostname field: \`autoCorrect=off\`, \`autoCapitalize=off\`, \`autoComplete=off\`, \`spellCheck=false\`, \`inputMode=url\`.
- Code field: same flags but \`autoCapitalize=characters\` (codes are uppercase), \`inputMode=text\` (digit-letter mix has no better hint).

## Test plan

- [x] \`bun run build\` (web) — clean
- [ ] iOS simulator: open Connect modal, type \"localhost\" — appears once, URL keyboard
- [ ] iOS simulator: switch to remote mode, type a code with digits — uppercase, no autocomplete suggestions

The behavioral test for this requires a Capacitor build + simulator interaction; see #234/#226 sprint for the broader iOS smoke-test plan.