### PR TITLE
fix(web): persist chat input draft per session (#226 part 3)

### DIFF
--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -117,6 +117,10 @@ export function ChatView({
         question={inputQuestion}
         isAgentBusy={isAgentBusy}
         disabled={!isConnected}
+        // Session-scoped draft persistence so a half-typed message survives
+        // app suspension on iOS (#226) and switching to a different session
+        // doesn't leak the draft across.
+        draftKey={`remi-draft-${session.id}`}
         placeholder={
           !isConnected
             ? 'Not connected'

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -25,6 +25,14 @@ interface InputAreaProps {
   readonly question?: UIQuestion | null;
   readonly isAgentBusy?: boolean;
   readonly className?: string;
+  /**
+   * When provided, the typed-but-unsent draft is persisted to localStorage
+   * under this key and restored across reloads / app suspensions. Pass a
+   * session-scoped value (e.g. `remi-draft-${sessionId}`) so drafts don't
+   * leak between sessions. Issue #226: iOS dropped the draft when the app
+   * was backgrounded; persistence + hydration fixes that.
+   */
+  readonly draftKey?: string;
 }
 
 /** Quick response button for yes/no and numbered options */
@@ -63,11 +71,48 @@ export function InputArea({
   question,
   isAgentBusy = false,
   className,
+  draftKey,
 }: InputAreaProps) {
-  const [value, setValue] = useState('');
+  // Hydrate draft from localStorage when a draftKey is provided. The lazy
+  // initializer runs only on mount; subsequent draftKey changes (session
+  // switches) re-hydrate via the effect below.
+  const [value, setValue] = useState<string>(() => {
+    if (!draftKey) return '';
+    try {
+      return localStorage.getItem(draftKey) ?? '';
+    } catch {
+      return '';
+    }
+  });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
+
+  // Re-hydrate when the active session (and therefore draftKey) changes.
+  useEffect(() => {
+    if (!draftKey) return;
+    try {
+      setValue(localStorage.getItem(draftKey) ?? '');
+    } catch {
+      setValue('');
+    }
+  }, [draftKey]);
+
+  // Persist on every keystroke. Empty drafts remove the key so localStorage
+  // doesn't grow unboundedly with one entry per session that was once
+  // visited.
+  useEffect(() => {
+    if (!draftKey) return;
+    try {
+      if (value) {
+        localStorage.setItem(draftKey, value);
+      } else {
+        localStorage.removeItem(draftKey);
+      }
+    } catch {
+      // Storage may be full or disabled (private mode); drop silently.
+    }
+  }, [value, draftKey]);
 
   // Scroll input into view when focused on iOS (keyboard pushes content up)
   const handleFocus = useCallback(() => {


### PR DESCRIPTION
## Summary

Partial fix for #226 — covers part 3 (\"draft text lost when app goes to background\"). Parts 1 and 2 noted in commit message.

iOS suspends the WKWebView aggressively, and the textarea state in InputArea only lived in component memory. Half-typed messages disappeared every time the user backgrounded the app. \`InputArea\` now accepts an optional \`draftKey\` prop; when set, the unsent value is hydrated from localStorage on mount, re-hydrated when \`draftKey\` changes (session switch), and persisted on every keystroke. Empty drafts remove the storage entry so we don't accumulate one per visited session.

ChatView passes a session-scoped key (\`remi-draft-\${session.id}\`) so drafts don't leak between sessions.

## What is NOT in this PR

- **#226 part 1** (Connect modal hidden by keyboard on iOS): the same area is touched by #266 (autoCorrect/inputMode); to avoid a merge dance I deferred a CSS-level inset until #266 lands. The new \`inputMode=url\` already nudges iOS into scrolling the field above the keyboard in practice.
- **#226 part 2** (chat auto-scroll on keyboard open): already implemented in \`MessageList.tsx\` via the \`keyboardVisible\` \`useEffect\`. Verified during this work; nothing to change.

So #226 will close after this PR + a small follow-up after #266 merges.

## Test plan

- [x] \`bun run build\` (web) — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bunx biome check\` — clean (no new warnings)
- [ ] iOS simulator: type a draft, background the app via home gesture, return → draft restored
- [ ] iOS simulator: type a draft, switch session via session list, return → draft restored for the original session, empty for the other