### PR TITLE
refactor(daemon): close #168, #169, #170 — typed metadata + options-object createHello + onConnect tests

### DIFF
--- a/packages/daemon/scripts/test-resume.ts
+++ b/packages/daemon/scripts/test-resume.ts
@@ -30,7 +30,7 @@ async function runTest() {
 
     ws1.onopen = () => {
       console.log('  Connected, sending hello...');
-      const hello = createHello(CLIENT_ID, '1.0.0', process.cwd());
+      const hello = createHello(CLIENT_ID, '1.0.0', { directory: process.cwd() });
       ws1.send(JSON.stringify(hello));
     };
 

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -7,6 +7,38 @@
 
 import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
 
+/**
+ * Adapter-specific metadata that varies by transport.
+ *
+ * Each adapter populates only the fields it knows about; the daemon reads
+ * only the ones relevant to its branch. Replaces the previous
+ * `Record<string, unknown>` shape so renames break the build instead of
+ * silently producing wrong behavior.
+ */
+export interface AdapterPlatformData {
+  /** Working directory the client requested for the Claude Code session. */
+  readonly directory?: string | null;
+
+  /** Session ID the client wants to resume. */
+  readonly resumeSessionId?: UUID | null;
+
+  /**
+   * Connection mode. `'query'` means the client is a utility (ls, kill, etc.)
+   * that should not auto-attach. `'attach'` (or undefined) means the daemon
+   * should auto-attach to the primary session if available.
+   */
+  readonly mode?: 'query' | 'attach' | undefined;
+
+  /** Telegram chat ID for forum-topic-backed sessions. */
+  readonly chatId?: number;
+
+  /** Telegram forum topic ID. */
+  readonly topicId?: number;
+
+  /** Relay connection code (signaling server pairing). */
+  readonly code?: string | null;
+}
+
 /** Metadata about a connection */
 export interface AdapterMetadata {
   /** Type of adapter (websocket, telegram, etc.) */
@@ -15,8 +47,8 @@ export interface AdapterMetadata {
   /** Human-readable name for the connection */
   readonly displayName?: string;
 
-  /** Platform-specific metadata */
-  readonly platformData?: Record<string, unknown>;
+  /** Adapter-specific metadata. Each adapter populates only its own fields. */
+  readonly platformData?: AdapterPlatformData;
 }
 
 /** Events emitted from adapter to daemon */

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -163,7 +163,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
 
   function sendHello(): void {
     const clientId = generateId();
-    ws.send(serialize(createHello(clientId, '1.0.0', undefined, sessionId as UUID)));
+    ws.send(serialize(createHello(clientId, '1.0.0', { resumeSessionId: sessionId as UUID })));
   }
 
   return new Promise<AttachClientResult>((resolve) => {

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -65,7 +65,7 @@ export async function runDetachClient(opts: DetachClientOptions): Promise<void> 
 
     function sendHello(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+      ws.send(serialize(createHello(clientId, '1.0.0', { mode: 'query' })));
     }
 
     function handleMessage(msg: ProtocolMessage): void {

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -57,7 +57,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       trackConnection(connectionId, metadata.adapterType);
       onConnectionAdded();
 
-      const resumeSessionId = metadata.platformData?.['resumeSessionId'] as UUID | undefined;
+      const resumeSessionId = metadata.platformData?.resumeSessionId ?? undefined;
       const currentPrimary = getPrimarySessionId();
 
       // Unified connection flow: one session per daemon, both modes behave the same.
@@ -75,7 +75,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       }
 
       // Try to attach to the primary (only) session.
-      const isQueryMode = metadata.platformData?.['mode'] === 'query';
+      const isQueryMode = metadata.platformData?.mode === 'query';
       if (currentPrimary) {
         // Only auto-attach if the client wants to attach, not a utility client like ls/kill.
         if (!isQueryMode) {

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -61,7 +61,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
 
     function sendHello(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+      ws.send(serialize(createHello(clientId, '1.0.0', { mode: 'query' })));
     }
 
     function handleMessage(msg: ProtocolMessage): void {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -219,7 +219,7 @@ export async function fetchSessions(
 
     function sendHelloAndRequestList(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+      ws.send(serialize(createHello(clientId, '1.0.0', { mode: 'query' })));
     }
 
     let sentListRequest = false;

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -100,7 +100,7 @@ export async function fetchRecentDirectories(
 
     function sendHello(): void {
       const clientId = generateId();
-      ws.send(serialize(createHello(clientId, '1.0.0', undefined, undefined, undefined, 'query')));
+      ws.send(serialize(createHello(clientId, '1.0.0', { mode: 'query' })));
     }
 
     function handleMessage(msg: ProtocolMessage): void {

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { ProtocolMessage, UUID } from '@remi/shared';
-import { generateId } from '@remi/shared';
+import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createConnectionHandlers } from '../../../src/cli/handlers/connection-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
@@ -21,9 +21,10 @@ function fakePTY(): PTYSession {
   } as unknown as PTYSession;
 }
 
-function fakeMessageAPI(): MessageAPI {
+function fakeMessageAPI(bulletCount = 0): MessageAPI {
   return {
     getFullBulletContent: () => null,
+    bulletCount,
   } as unknown as MessageAPI;
 }
 
@@ -148,6 +149,155 @@ describe('createConnectionHandlers', () => {
       expect(msg.code).toBe('SESSION_NOT_FOUND');
       // Attach should NOT have happened.
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+    });
+
+    test('attaches when resumeSessionId matches the primary session', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { resumeSessionId: sessionId },
+      });
+
+      // No error; helloAck sent and attach succeeded.
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; sessionId?: UUID };
+      expect(msg.type).toBe('hello_ack');
+      expect(msg.sessionId).toBe(sessionId);
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(cancelOrphanCalls).toBe(1);
+    });
+
+    test('helloAck reports replay metadata and replayBatch follows when history exists', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI(3));
+      setPrimarySessionId(sessionId);
+
+      // Attach + detach to leave a "previous session" with history; the next
+      // attach goes through the resume path with replayMessages populated.
+      const previousConn = generateId();
+      sessionRegistry.attachConnection(sessionId, previousConn);
+      const m1: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
+      const m2: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
+      sessionRegistry.recordOutgoingMessage(sessionId, m1);
+      sessionRegistry.recordOutgoingMessage(sessionId, m2);
+      sessionRegistry.detachConnection(previousConn);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: {},
+      });
+
+      expect(sendCalls).toHaveLength(2);
+      const ack = sendCalls[0]?.message as {
+        type: string;
+        isResume?: boolean;
+        replayCount?: number;
+        nextBulletId?: number;
+      };
+      expect(ack.type).toBe('hello_ack');
+      expect(ack.isResume).toBe(true);
+      expect(ack.replayCount).toBe(2);
+      expect(ack.nextBulletId).toBe(4);
+
+      const replay = sendCalls[1]?.message as {
+        type: string;
+        messages?: readonly ProtocolMessage[];
+      };
+      expect(replay.type).toBe('replay_batch');
+      expect(replay.messages?.length).toBe(2);
+    });
+
+    test('second concurrent connection is queued and still receives helloAck + replay', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI(2));
+      setPrimarySessionId(sessionId);
+
+      // First connection takes the active slot.
+      const firstConn = generateId();
+      sessionRegistry.attachConnection(sessionId, firstConn);
+      const recorded: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
+      sessionRegistry.recordOutgoingMessage(sessionId, recorded);
+
+      // Second connection arrives while the first is still active.
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: {},
+      });
+
+      // Active connection is still the first; CID is queued.
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(firstConn);
+      expect(sessionRegistry.waitingConnectionCount).toBe(1);
+
+      // Queued client still gets helloAck + replay so it can render history.
+      expect(sendCalls).toHaveLength(2);
+      const ack = sendCalls[0]?.message as {
+        type: string;
+        isResume?: boolean;
+        replayCount?: number;
+      };
+      expect(ack.type).toBe('hello_ack');
+      expect(ack.isResume).toBe(true);
+      expect(ack.replayCount).toBe(1);
+
+      const replay = sendCalls[1]?.message as {
+        type: string;
+        messages?: readonly ProtocolMessage[];
+      };
+      expect(replay.type).toBe('replay_batch');
+      expect(replay.messages?.length).toBe(1);
+    });
+
+    test('query-mode connection does not displace an existing active connection', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      const firstConn = generateId();
+      sessionRegistry.attachConnection(sessionId, firstConn);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { mode: 'query' },
+      });
+
+      // Active connection stays; query-mode client did not grab the slot or
+      // queue (utility clients ls/kill should not contend for write access).
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(firstConn);
+      expect(sessionRegistry.waitingConnectionCount).toBe(0);
+      expect(sendCalls).toHaveLength(1);
+      const ack = sendCalls[0]?.message as { type: string; isResume?: boolean };
+      expect(ack.type).toBe('hello_ack');
+      // Plain helloAck (no resume info) since we skipped attachConnection.
+      expect(ack.isResume).toBeUndefined();
+      expect(cancelOrphanCalls).toBe(0);
+    });
+
+    test('omitted platformData is treated like no metadata fields', async () => {
+      // Adapters with no platform-specific extras (e.g. simple ones) may pass
+      // metadata without a platformData field at all. The handler must not
+      // crash and should auto-attach exactly like an empty platformData.
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, { adapterType: 'websocket' });
+
+      expect(sendCalls).toHaveLength(1);
+      expect((sendCalls[0]?.message as { type: string }).type).toBe('hello_ack');
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+    });
+
+    test('tracks the connection on the AdapterRegistry before any branch decision', async () => {
+      // No primary session = NO_SESSION error path; tracking still happens.
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'telegram',
+        platformData: {},
+      });
+      expect(trackedConnections).toEqual([{ id: CID, type: 'telegram' }]);
+      expect(connectionAddedCount).toBe(1);
     });
   });
 

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -87,6 +87,9 @@ describe('runLsClient', () => {
     // biome-ignore lint/style/noNonNullAssertion: length checked above
     const hello = deserialize(receivedMessages[0]!);
     expect(hello?.type).toBe('hello');
+    // ls is a utility client; it must declare query mode so the daemon does
+    // not auto-attach (which would steal the active slot from a real client).
+    expect((hello as { mode?: string } | null)?.mode).toBe('query');
     // biome-ignore lint/style/noNonNullAssertion: length checked above
     const listReq = deserialize(receivedMessages[1]!);
     expect(listReq?.type).toBe('session_list_request');

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -29,29 +29,33 @@ describe('Protocol factory functions', () => {
     });
 
     test('includes directory when provided', () => {
-      const msg = createHello('client-1' as UUID, '1.0.0', '/some/path');
+      const msg = createHello('client-1' as UUID, '1.0.0', { directory: '/some/path' });
       expect(msg.directory).toBe('/some/path');
     });
 
     test('includes empty string directory', () => {
-      const msg = createHello('client-1' as UUID, '1.0.0', '');
+      const msg = createHello('client-1' as UUID, '1.0.0', { directory: '' });
       // Empty string is a valid directory (cwd)
       expect('directory' in msg).toBe(true);
     });
 
     test('includes resumeSessionId when provided', () => {
       const sessionId = 'abc-123' as UUID;
-      const msg = createHello('client-1' as UUID, '1.0.0', undefined, sessionId);
+      const msg = createHello('client-1' as UUID, '1.0.0', { resumeSessionId: sessionId });
       expect(msg.resumeSessionId).toBe(sessionId);
     });
 
     test('includes lastReceivedIndex when provided', () => {
-      const msg = createHello('client-1' as UUID, '1.0.0', undefined, undefined, 42);
+      const msg = createHello('client-1' as UUID, '1.0.0', { lastReceivedIndex: 42 });
       expect(msg.lastReceivedIndex).toBe(42);
     });
 
     test('round-trips through serialize/deserialize', () => {
-      const original = createHello('client-1' as UUID, '1.0.0', '/dir', 'sess-1' as UUID, 5);
+      const original = createHello('client-1' as UUID, '1.0.0', {
+        directory: '/dir',
+        resumeSessionId: 'sess-1' as UUID,
+        lastReceivedIndex: 5,
+      });
       const serialized = serialize(original);
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -455,7 +455,9 @@ describe('WebSocketServer', () => {
       const ws = new WebSocket(`ws://localhost:${testPort + 12}/ws`);
 
       ws.onopen = () => {
-        ws.send(serialize(createHello('test-client' as UUID, '1.0.0', undefined, resumeId)));
+        ws.send(
+          serialize(createHello('test-client' as UUID, '1.0.0', { resumeSessionId: resumeId })),
+        );
       };
 
       const received = await Promise.race([
@@ -488,7 +490,9 @@ describe('WebSocketServer', () => {
       const ws = new WebSocket(`ws://localhost:${testPort + 13}/ws`);
 
       ws.onopen = () => {
-        ws.send(serialize(createHello('test-client' as UUID, '1.0.0', '/my/project')));
+        ws.send(
+          serialize(createHello('test-client' as UUID, '1.0.0', { directory: '/my/project' })),
+        );
       };
 
       const received = await Promise.race([

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -507,5 +507,71 @@ describe('WebSocketServer', () => {
       ws.close();
       await server.stop();
     });
+
+    test('passes mode through onClientConnect for query-mode clients', async () => {
+      const receivedPromise = new Promise<'query' | undefined>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 14 },
+          {
+            onClientConnect: (connection) => {
+              resolve(connection.connectionMode);
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 14}/ws`);
+
+      ws.onopen = () => {
+        ws.send(serialize(createHello('test-client' as UUID, '1.0.0', { mode: 'query' })));
+      };
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 5000),
+        ),
+      ]);
+
+      expect(received).toBe('query');
+
+      ws.close();
+      await server.stop();
+    });
+
+    test('connectionMode is undefined when hello omits mode', async () => {
+      const receivedPromise = new Promise<'query' | undefined>((resolve) => {
+        server = new WebSocketServer(
+          { port: testPort + 15 },
+          {
+            onClientConnect: (connection) => {
+              resolve(connection.connectionMode);
+            },
+          },
+        );
+      });
+
+      await server.start();
+
+      const ws = new WebSocket(`ws://localhost:${testPort + 15}/ws`);
+
+      ws.onopen = () => {
+        ws.send(serialize(createHello('test-client' as UUID, '1.0.0')));
+      };
+
+      const received = await Promise.race([
+        receivedPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Event not received')), 5000),
+        ),
+      ]);
+
+      expect(received).toBeUndefined();
+
+      ws.close();
+      await server.stop();
+    });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,7 @@ export type {
   DetachSessionAckMessage,
   RegisterDeviceTokenMessage,
   SessionResetMessage,
+  CreateHelloOptions,
 } from './protocol.ts';
 
 export {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -657,17 +657,30 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
   return validTypes.includes(obj['type'] as string);
 }
 
+/** Optional fields for {@link createHello}. */
+export interface CreateHelloOptions {
+  /** Working directory for the Claude Code session. */
+  readonly directory?: string | undefined;
+  /** Session ID to resume (for reconnecting to an existing session). */
+  readonly resumeSessionId?: UUID | undefined;
+  /** Index of last received message (for efficient replay). */
+  readonly lastReceivedIndex?: number | undefined;
+  /** Connection mode: 'query' for utility clients (ls, kill) that should not auto-attach. */
+  readonly mode?: 'query' | undefined;
+}
+
 /**
  * Create a hello message.
+ *
+ * Optional fields are passed via the `options` object so adding new optionals
+ * never requires threading `undefined` through positional callsites.
  */
 export function createHello(
   clientId: UUID,
   clientVersion: string,
-  directory?: string,
-  resumeSessionId?: UUID,
-  lastReceivedIndex?: number,
-  mode?: 'query',
+  options: CreateHelloOptions = {},
 ): HelloMessage {
+  const { directory, resumeSessionId, lastReceivedIndex, mode } = options;
   return {
     type: 'hello',
     id: generateId(),

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -1066,31 +1066,35 @@ describe('Message factory functions', () => {
 
   describe('createHello() with optional params', () => {
     test('includes directory when provided', () => {
-      const msg = createHello('client-1', '1.0.0', '/home/user/project');
+      const msg = createHello('client-1', '1.0.0', { directory: '/home/user/project' });
       expect(msg.directory).toBe('/home/user/project');
     });
 
     test('includes resumeSessionId when provided', () => {
       const sessionId = generateId();
-      const msg = createHello('client-1', '1.0.0', undefined, sessionId);
+      const msg = createHello('client-1', '1.0.0', { resumeSessionId: sessionId });
       expect(msg.resumeSessionId).toBe(sessionId);
     });
 
     test('includes lastReceivedIndex when provided', () => {
-      const msg = createHello('client-1', '1.0.0', undefined, undefined, 42);
+      const msg = createHello('client-1', '1.0.0', { lastReceivedIndex: 42 });
       expect(msg.lastReceivedIndex).toBe(42);
     });
 
     test('includes all optional params together', () => {
       const sessionId = generateId();
-      const msg = createHello('client-1', '1.0.0', '/path', sessionId, 10);
+      const msg = createHello('client-1', '1.0.0', {
+        directory: '/path',
+        resumeSessionId: sessionId,
+        lastReceivedIndex: 10,
+      });
       expect(msg.directory).toBe('/path');
       expect(msg.resumeSessionId).toBe(sessionId);
       expect(msg.lastReceivedIndex).toBe(10);
     });
 
     test('includes mode when provided', () => {
-      const msg = createHello('client-1', '1.0.0', undefined, undefined, undefined, 'query');
+      const msg = createHello('client-1', '1.0.0', { mode: 'query' });
       expect(msg.mode).toBe('query');
     });
 
@@ -1101,12 +1105,25 @@ describe('Message factory functions', () => {
     });
 
     test('mode survives serialize/deserialize round-trip', () => {
-      const msg = createHello('client-1', '1.0.0', undefined, undefined, undefined, 'query');
+      const msg = createHello('client-1', '1.0.0', { mode: 'query' });
       const serialized = serialize(msg);
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();
       expect(deserialized?.type).toBe('hello');
       expect((deserialized as typeof msg).mode).toBe('query');
+    });
+
+    test('explicit undefined options field is treated like missing', () => {
+      const msg = createHello('client-1', '1.0.0', {
+        directory: undefined,
+        resumeSessionId: undefined,
+        lastReceivedIndex: undefined,
+        mode: undefined,
+      });
+      expect('directory' in msg).toBe(false);
+      expect('resumeSessionId' in msg).toBe(false);
+      expect('lastReceivedIndex' in msg).toBe(false);
+      expect('mode' in msg).toBe(false);
     });
   });
 

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -204,7 +204,12 @@ export function useConnectionManager(
       if (mc.helloSent) return;
       mc.helloSent = true;
       const resumeId = mc.sessionId ?? undefined;
-      mc.client.send(createHello(clientId, clientVersion, mc.directory, resumeId));
+      mc.client.send(
+        createHello(clientId, clientVersion, {
+          directory: mc.directory,
+          resumeSessionId: resumeId,
+        }),
+      );
     },
     [clientId, clientVersion],
   );

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -149,7 +149,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       if (helloSentRef.current) return;
       helloSentRef.current = true;
       const resumeId = lastSessionIdRef.current ?? undefined;
-      client.send(createHello(clientId, clientVersion, directoryRef.current, resumeId));
+      client.send(
+        createHello(clientId, clientVersion, {
+          directory: directoryRef.current,
+          resumeSessionId: resumeId,
+        }),
+      );
     },
     [clientId, clientVersion],
   );


### PR DESCRIPTION
Closes three small daemon tech-debt items surfaced by the PR #167 review.

## Commits

1. **refactor(shared): createHello takes options object for optionals** (`b8528a9`)
   Replaces the trailing positional optionals (`directory`, `resumeSessionId`, `lastReceivedIndex`, `mode`) with a single `CreateHelloOptions` object. Utility clients now write `createHello(id, '1.0.0', { mode: 'query' })` instead of `createHello(id, '1.0.0', undefined, undefined, undefined, 'query')`. All callsites in daemon CLI clients, scripts, web hooks, and tests are updated.

2. **refactor(daemon): type AdapterMetadata.platformData** (`586bf58`)
   Replaces `Record<string, unknown>` with a named `AdapterPlatformData` interface. `onConnect` in `connection-events.ts` now reads `metadata.platformData?.resumeSessionId` and `metadata.platformData?.mode` directly, no more string-key + cast. Renaming an adapter-side key now breaks the build instead of silently producing wrong behavior. Each adapter populates only the fields it owns (WebSocket: directory/resumeSessionId/mode, Telegram: chatId/topicId/directory, Relay: code).

3. **test(daemon): cover onConnect query-mode and resume branches** (`ce11098`)
   Adds the missing unit coverage flagged by the PR #167 review:
   - `connection-events.test.ts`: resumeSessionId-matches-primary attach, helloAck replay metadata + replayBatch when history exists, busy-session queueing with read-only replay, query-mode does not displace active connection or queue, omitted-platformData behavior, tracking happens before NO_SESSION branch
   - `websocket-server.test.ts`: `Connection.connectionMode` getter passes 'query' through from hello (and is undefined when omitted), matching the existing connectionDirectory pattern
   - `ls-client.test.ts`: assert the hello carries `mode: 'query'` so utility clients do not auto-attach
   - All tests use the real `SessionRegistry` (no mocks).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean on touched files
- [x] `bun test packages/daemon/tests/cli packages/daemon/tests/session packages/shared/tests packages/daemon/tests/websocket-server.test.ts` — 892 pass, 0 fail
- [x] `bun test packages/daemon/tests/cli/handlers/connection-events.test.ts` — 11 pass (was 5)
- [ ] Run full integration suite on CI (unchanged behavior; only types and tests moved)

Fixes #168
Fixes #169
Fixes #170