### PR TITLE
feat(daemon): support Ctrl+Z to suspend remi (background claude)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -760,13 +760,32 @@ let autoApproveService: AutoApproveService | null = null;
 }
 
 // ---------------------------------------------------------------------------
-// SIGTSTP / Ctrl+Z handling lives in `cli/suspend-handler.ts` and is wired
-// up only in wrapper mode (where stdin is in raw mode and we own a local
-// terminal). Non-wrapper invocations (`remi daemon`, `remi ls`, etc.) get
-// the kernel default for SIGTSTP, which is fine -- they are either headless
-// daemons (no controlling tty) or short-lived clients where suspend is
-// acceptable.
+// SIGTSTP / Ctrl+Z handling.
+//
+// Wrapper mode (`remi <args>`): the wrapper installs `cli/suspend-handler.ts`
+// later, after the PTY is up. That handler tears down raw mode and self-sends
+// SIGSTOP for a real shell-job suspend.
+//
+// Daemon mode (`remi daemon`): we MUST never let the daemon suspend itself.
+// If a foreground daemon receives `kill -TSTP <pid>` (or the controlling
+// terminal sends SIGTSTP for any reason), the kernel default would stop the
+// process, dropping every WebSocket client and halting APNS push. We install
+// an unconditional no-op listener here so the kernel default never fires.
+// REGRESSION GUARD (PR #364 review): a previous refactor deleted this
+// listener and only installed the wrapper-mode handler; foreground `remi
+// daemon` then suspended on `kill -TSTP`. Do not remove this without
+// replacing it with an equivalent guard.
+//
+// Other non-wrapper invocations (`remi ls`, `remi attach`, etc.) are
+// short-lived clients where the kernel default for SIGTSTP is acceptable.
 // ---------------------------------------------------------------------------
+if (cliDaemonMode) {
+  process.on('SIGTSTP', () => {
+    // Intentionally ignored. The daemon must remain running to serve remote
+    // clients; suspending it would drop WebSocket sessions and APNS pushes.
+    writeToLog('[signal] SIGTSTP received and ignored (daemon must not suspend)');
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Core components

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -130,6 +130,7 @@ import { setupHookBridge } from './cli/session-phases/hook-bridge-setup.ts';
 import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
+import { installSuspendHandler } from './cli/suspend-handler.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
@@ -759,16 +760,13 @@ let autoApproveService: AutoApproveService | null = null;
 }
 
 // ---------------------------------------------------------------------------
-// SIGTSTP protection: the daemon must never suspend itself.
-// When Claude Code handles Ctrl+Z (which spawns a subshell inside its PTY),
-// the terminal may propagate SIGTSTP to the process group. Ignoring it here
-// keeps the daemon, WebSocket server, and all remote connections alive.
+// SIGTSTP / Ctrl+Z handling lives in `cli/suspend-handler.ts` and is wired
+// up only in wrapper mode (where stdin is in raw mode and we own a local
+// terminal). Non-wrapper invocations (`remi daemon`, `remi ls`, etc.) get
+// the kernel default for SIGTSTP, which is fine -- they are either headless
+// daemons (no controlling tty) or short-lived clients where suspend is
+// acceptable.
 // ---------------------------------------------------------------------------
-process.on('SIGTSTP', () => {
-  // Intentionally ignored. The PTY child handles Ctrl+Z on its own; the
-  // daemon process must remain running to serve remote clients.
-  writeToLog('[signal] SIGTSTP received and ignored (daemon must not suspend)');
-});
 
 // ---------------------------------------------------------------------------
 // Core components
@@ -1714,6 +1712,19 @@ if (cliDaemonMode) {
     }
   }
 
+  // Ctrl+Z handler (issue #361). Installed before the DetachScanner so the
+  // scanner can route the `0x1A` byte directly into `requestSuspend()`. The
+  // SIGCONT path re-enters raw mode; restoring the data listener is
+  // unnecessary because Bun keeps it attached across the SIGSTOP boundary.
+  const suspendController = installSuspendHandler({
+    onResume: () => {
+      // Re-attach to stdin: setRawMode(true) is done inside the handler;
+      // here we just ensure stdin is flowing again. `process.stdin.resume()`
+      // is idempotent.
+      process.stdin.resume();
+    },
+  });
+
   const detachScanner = new DetachScanner({
     onDetach: () => {
       const stdoutFd = getPtyStdoutFd();
@@ -1724,10 +1735,15 @@ if (cliDaemonMode) {
           log(`[Detach] Failed to write detach message: ${errorToString(err)}`);
         }
       }
+      // detachLocalTerminal disposes the suspend controller as part of its
+      // teardown, so no extra cleanup is needed here.
       detachLocalTerminal('keybinding');
     },
     onData: (data) => {
       writeToPty(data.toString());
+    },
+    onSuspend: () => {
+      suspendController.requestSuspend();
     },
     timeoutMs: 1000,
   });
@@ -1761,6 +1777,10 @@ if (cliDaemonMode) {
   function detachLocalTerminal(reason: 'sighup' | 'keybinding'): void {
     if (isWrapperDetached()) return;
     setWrapperDetached(true);
+
+    // Tear down the wrapper-mode SIGTSTP/SIGCONT listeners; once the local
+    // terminal is gone there is no value in suspending the process.
+    suspendController.dispose();
 
     // Stop reading from stdin
     if (process.stdin.isTTY) {

--- a/packages/daemon/src/cli/detach-scanner.ts
+++ b/packages/daemon/src/cli/detach-scanner.ts
@@ -8,9 +8,15 @@
  * Supports both legacy raw byte (0x02) and kitty keyboard protocol
  * encoding (ESC[98;5u) for Ctrl+B, since Claude Code enables the kitty
  * protocol on the terminal.
+ *
+ * Optional Ctrl+Z (`0x1A`) interception: when `onSuspend` is provided
+ * the scanner consumes the byte instead of forwarding it, so the
+ * caller can drive the SIGTSTP/SIGCONT suspend dance (issue #361).
+ * When `onSuspend` is undefined the byte passes through unchanged.
  */
 
 const CTRL_B = 0x02;
+const CTRL_Z = 0x1a;
 const DEFAULT_TIMEOUT_MS = 1000;
 
 // Kitty keyboard protocol: Ctrl+B = ESC[98;5u = bytes 1b 5b 39 38 3b 35 75
@@ -23,6 +29,12 @@ export interface DetachScannerOptions {
   readonly onData: (data: Buffer) => void;
   /** Timeout in ms after a lone Ctrl+B or ESC before forwarding it. Default: 1000 */
   readonly timeoutMs?: number | undefined;
+  /**
+   * Optional handler for Ctrl+Z (`0x1A`). When provided, the scanner
+   * intercepts the byte and invokes this callback instead of forwarding.
+   * When omitted, Ctrl+Z is forwarded to the PTY (default).
+   */
+  readonly onSuspend?: (() => void) | undefined;
 }
 
 export class DetachScanner {
@@ -33,6 +45,7 @@ export class DetachScanner {
   private escTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly onDetach: () => void;
   private readonly onData: (data: Buffer) => void;
+  private readonly onSuspend: (() => void) | undefined;
   private readonly timeoutMs: number;
   // Store the original bytes (legacy 0x02 or kitty sequence) that triggered
   // ctrlBPending so we can forward them if 'd' does not follow within the timeout
@@ -42,6 +55,7 @@ export class DetachScanner {
   constructor(opts: DetachScannerOptions) {
     this.onDetach = opts.onDetach;
     this.onData = opts.onData;
+    this.onSuspend = opts.onSuspend;
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
@@ -128,7 +142,21 @@ export class DetachScanner {
 
         // Not a detach sequence: forward buffered Ctrl+B and this byte
         this.onData(Buffer.from(this.ctrlBBytes));
+        // If Ctrl+Z follows Ctrl+B, route it through the suspend handler
+        // (when one is configured) so the byte does not reach the PTY.
+        if (byte === CTRL_Z && this.onSuspend) {
+          this.onSuspend();
+          continue;
+        }
         this.onData(Buffer.from([byte]));
+        continue;
+      }
+
+      // Ctrl+Z: when a suspend handler is wired, intercept the byte and
+      // invoke it; without a handler, fall through to the normal forward
+      // path (preserves backward-compatible PTY behavior).
+      if (byte === CTRL_Z && this.onSuspend) {
+        this.onSuspend();
         continue;
       }
 
@@ -158,9 +186,17 @@ export class DetachScanner {
         continue;
       }
 
-      // Scan ahead for the next special byte in this chunk
+      // Scan ahead for the next special byte in this chunk. When a suspend
+      // handler is wired, Ctrl+Z is also a special byte that breaks the run
+      // so it can be intercepted on the next iteration.
+      const interceptCtrlZ = this.onSuspend !== undefined;
       let end = i + 1;
-      while (end < chunk.length && chunk[end] !== CTRL_B && chunk[end] !== 0x1b) {
+      while (
+        end < chunk.length &&
+        chunk[end] !== CTRL_B &&
+        chunk[end] !== 0x1b &&
+        !(interceptCtrlZ && chunk[end] === CTRL_Z)
+      ) {
         end++;
       }
       // Forward the normal bytes as a batch

--- a/packages/daemon/src/cli/suspend-handler.ts
+++ b/packages/daemon/src/cli/suspend-handler.ts
@@ -25,6 +25,12 @@
  * The module owns ALL signal handler bookkeeping; cli.ts only calls
  * `installSuspendHandler` once and then routes Ctrl+Z bytes into the
  * returned controller.
+ *
+ * Failure handling: every TTY/kill operation can fail (broken pipe,
+ * EPERM, ENOTTY). The handler treats failures as user-visible: each
+ * catch path writes a single line to stderr telling the user what
+ * happened and what to do next. We never leave the user with a frozen
+ * terminal and only a log file as evidence.
  */
 
 import { errorToString } from '@remi/shared';
@@ -48,6 +54,12 @@ export interface SuspendHandlerOptions {
    * actually suspending the test runner.
    */
   readonly kill?: (pid: number, signal: NodeJS.Signals | number) => void;
+  /**
+   * Override for the user-visible stderr writer. Tests use this to
+   * capture diagnostic messages without polluting the runner's stderr.
+   * Defaults to `process.stderr.write`.
+   */
+  readonly writeStderr?: (msg: string) => void;
 }
 
 export interface SuspendHandlerController {
@@ -77,36 +89,76 @@ export function installSuspendHandler(
   const onError = options.onError ?? ((err) => logError(`[suspend] ${errorToString(err)}`));
   const killFn =
     options.kill ?? ((pid: number, signal: NodeJS.Signals | number) => process.kill(pid, signal));
+  const writeStderr =
+    options.writeStderr ??
+    ((msg: string) => {
+      try {
+        process.stderr.write(msg);
+      } catch {
+        // stderr itself is broken; nothing actionable left to do.
+      }
+    });
+
+  // The wrapper-mode handler must replace any previously-installed SIGTSTP
+  // listener (e.g. the daemon-mode no-op ignore in cli.ts). If we left both
+  // attached, the no-op would still fire and the kernel default behaviour
+  // would never run on its own, but we'd also lose a clean single source of
+  // truth for what SIGTSTP does in this process. Strip prior listeners so
+  // the wrapper owns SIGTSTP outright while it is installed; `dispose()`
+  // removes our listener but does NOT restore the prior one. That is OK in
+  // practice because wrapper mode and daemon mode are mutually exclusive
+  // (`cliDaemonMode` is set once at startup).
+  process.removeAllListeners('SIGTSTP');
+
   let suspending = false;
 
-  function teardownTty(): void {
+  /**
+   * Tear down raw mode + pause stdin in preparation for SIGSTOP.
+   * Returns true if the terminal was successfully neutralised; false if
+   * any step failed. Callers MUST abort the suspend on false to avoid
+   * leaving the user wedged with raw mode on and the process suspended.
+   */
+  function teardownTty(): boolean {
+    let ok = true;
     if (process.stdin.isTTY) {
       try {
         process.stdin.setRawMode(false);
       } catch (err) {
         onError(err);
+        ok = false;
       }
     }
     try {
       process.stdin.pause();
     } catch (err) {
       onError(err);
+      ok = false;
     }
+    return ok;
   }
 
-  function restoreTty(): void {
+  /**
+   * Restore raw mode + resume stdin after SIGCONT (or after an aborted
+   * suspend). Returns a per-op success map so the caller can report
+   * exactly which step failed.
+   */
+  function restoreTty(): { rawMode: boolean; resume: boolean } {
+    const result = { rawMode: true, resume: true };
     if (process.stdin.isTTY) {
       try {
         process.stdin.setRawMode(true);
       } catch (err) {
         onError(err);
+        result.rawMode = false;
       }
     }
     try {
       process.stdin.resume();
     } catch (err) {
       onError(err);
+      result.resume = false;
     }
+    return result;
   }
 
   const onSigtstp = (): void => {
@@ -115,8 +167,27 @@ export function installSuspendHandler(
     // happen if the user mashes Ctrl+Z), skip the second teardown.
     if (suspending) return;
     suspending = true;
-    teardownTty();
+
+    if (!teardownTty()) {
+      // Finding 1: if we can't put the terminal back into cooked mode and
+      // pause stdin, suspending now would leave the user with a stopped
+      // remi AND a raw-mode terminal AND no diagnostic on the screen. Bail
+      // out before SIGSTOP, restore best-effort, and tell the user.
+      writeStderr(
+        'remi: cannot suspend (terminal teardown failed); use Ctrl+B d to detach instead\n',
+      );
+      suspending = false;
+      restoreTty();
+      return;
+    }
+
     log('[suspend] SIGTSTP received; suspending remi (claude keeps running)');
+    // Finding 4: print resume hint BEFORE SIGSTOP. After SIGSTOP fires we
+    // can't write anything (we're frozen), so this is the user's only
+    // diagnostic if SIGCONT never arrives or if the shell loses track of
+    // the job.
+    writeStderr(`remi: suspended. To resume, run 'fg' (pid ${process.pid})\n`);
+
     try {
       // SIGSTOP is uncatchable: kernel suspends us immediately. The shell
       // sees a stopped job (`[1]+  Stopped  remi ...`). The PTY child is
@@ -124,17 +195,38 @@ export function installSuspendHandler(
       killFn(process.pid, 'SIGSTOP');
     } catch (err) {
       onError(err);
-      // If SIGSTOP fails for some reason, restore so we don't leave the
-      // tty in a half-broken state.
+      // Finding 2: SIGSTOP failed but we already paused stdin and dropped
+      // raw mode. The terminal looks frozen to the user. Tell them on
+      // stderr, restore the TTY, and resume stdin so they can keep typing.
+      writeStderr(`remi: cannot suspend (${errorToString(err)}); staying in foreground\n`);
       suspending = false;
       restoreTty();
+      // restoreTty already calls process.stdin.resume(), but be explicit:
+      // if resume itself failed inside restoreTty, retry once. Worst case
+      // is a second logged error; that beats a wedged terminal.
+      try {
+        process.stdin.resume();
+      } catch (resumeErr) {
+        onError(resumeErr);
+      }
     }
   };
 
   const onSigcont = (): void => {
     log('[suspend] SIGCONT received; restoring raw mode');
     suspending = false;
-    restoreTty();
+    const restored = restoreTty();
+    if (!restored.rawMode || !restored.resume) {
+      // Finding 3: partial restore on resume. Tell the user explicitly
+      // which way the terminal is broken so they know what to expect
+      // (e.g. cooked-mode echo doubling, or unresponsive stdin).
+      const failed: string[] = [];
+      if (!restored.rawMode) failed.push('raw-mode');
+      if (!restored.resume) failed.push('stdin-resume');
+      writeStderr(
+        `remi: terminal restore failed after resume (${failed.join(', ')}); press Ctrl+B d and re-run remi\n`,
+      );
+    }
     try {
       options.onResume?.();
     } catch (err) {

--- a/packages/daemon/src/cli/suspend-handler.ts
+++ b/packages/daemon/src/cli/suspend-handler.ts
@@ -1,0 +1,163 @@
+/**
+ * Wrapper-mode Ctrl+Z (SIGTSTP) suspend / SIGCONT resume support.
+ *
+ * Why this exists (issue #361):
+ * `remi <args>` puts stdin into raw mode while it forwards bytes to the
+ * PTY-hosted Claude. In raw mode the kernel does NOT translate Ctrl+Z
+ * into SIGTSTP -- it forwards the literal `0x1A` byte to the child, so
+ * the user can never drop back to the shell with Ctrl+Z + fg.
+ *
+ * The fix has two halves:
+ *
+ *   1. The byte-level scanner (`DetachScanner`) intercepts `0x1A` and
+ *      calls `requestSuspend()` here instead of forwarding to the PTY.
+ *   2. We tear down raw mode + stdin listeners and self-send SIGSTOP
+ *      to suspend ONLY the remi process. The PTY-hosted Claude lives
+ *      in its own session (Bun.spawn `terminal:` calls forkpty/setsid)
+ *      so it is NOT in our process group and keeps running.
+ *
+ * SIGTSTP from outside (e.g. `kill -TSTP <pid>`) is also handled: the
+ * SIGTSTP listener runs the same teardown + SIGSTOP path.
+ *
+ * On SIGCONT (after `fg` or `kill -CONT <pid>`), we restore raw mode
+ * and resume reading stdin via the caller's `onResume` callback.
+ *
+ * The module owns ALL signal handler bookkeeping; cli.ts only calls
+ * `installSuspendHandler` once and then routes Ctrl+Z bytes into the
+ * returned controller.
+ */
+
+import { errorToString } from '@remi/shared';
+import { log, logError } from './logger.ts';
+
+export interface SuspendHandlerOptions {
+  /**
+   * Called after SIGCONT, after raw mode is restored. The caller should
+   * resume any stdin handling that was paused before suspend (e.g. re-add
+   * its `data` listener if it was removed).
+   */
+  readonly onResume?: () => void;
+  /**
+   * Optional: invoked when stdin TTY operations (raw mode, pause/resume)
+   * fail. Defaults to logger.logError. Useful for tests.
+   */
+  readonly onError?: (err: unknown) => void;
+  /**
+   * Override for `process.kill`. Production callers should leave this
+   * unset; tests use it to assert which signal would be sent without
+   * actually suspending the test runner.
+   */
+  readonly kill?: (pid: number, signal: NodeJS.Signals | number) => void;
+}
+
+export interface SuspendHandlerController {
+  /**
+   * Drive the Ctrl+Z byte path: tear down raw mode and self-send SIGTSTP.
+   * Goes through the SIGTSTP listener, which then issues SIGSTOP for the
+   * actual kernel suspend.
+   */
+  readonly requestSuspend: () => void;
+  /**
+   * Remove the SIGTSTP and SIGCONT listeners. Useful when the wrapper
+   * mode is shutting down before process exit so we don't leak handlers.
+   */
+  readonly dispose: () => void;
+}
+
+/**
+ * Install SIGTSTP and SIGCONT handlers for wrapper mode and return a
+ * controller for the byte-driven path.
+ *
+ * Idempotent guard: callers should only invoke this once per wrapper
+ * lifecycle. Calling `dispose()` removes the handlers.
+ */
+export function installSuspendHandler(
+  options: SuspendHandlerOptions = {},
+): SuspendHandlerController {
+  const onError = options.onError ?? ((err) => logError(`[suspend] ${errorToString(err)}`));
+  const killFn =
+    options.kill ?? ((pid: number, signal: NodeJS.Signals | number) => process.kill(pid, signal));
+  let suspending = false;
+
+  function teardownTty(): void {
+    if (process.stdin.isTTY) {
+      try {
+        process.stdin.setRawMode(false);
+      } catch (err) {
+        onError(err);
+      }
+    }
+    try {
+      process.stdin.pause();
+    } catch (err) {
+      onError(err);
+    }
+  }
+
+  function restoreTty(): void {
+    if (process.stdin.isTTY) {
+      try {
+        process.stdin.setRawMode(true);
+      } catch (err) {
+        onError(err);
+      }
+    }
+    try {
+      process.stdin.resume();
+    } catch (err) {
+      onError(err);
+    }
+  }
+
+  const onSigtstp = (): void => {
+    // Re-entrancy guard: if another SIGTSTP arrives while we are still
+    // tearing down (Bun delivers signals on the event loop, so this can
+    // happen if the user mashes Ctrl+Z), skip the second teardown.
+    if (suspending) return;
+    suspending = true;
+    teardownTty();
+    log('[suspend] SIGTSTP received; suspending remi (claude keeps running)');
+    try {
+      // SIGSTOP is uncatchable: kernel suspends us immediately. The shell
+      // sees a stopped job (`[1]+  Stopped  remi ...`). The PTY child is
+      // in its own session and is unaffected.
+      killFn(process.pid, 'SIGSTOP');
+    } catch (err) {
+      onError(err);
+      // If SIGSTOP fails for some reason, restore so we don't leave the
+      // tty in a half-broken state.
+      suspending = false;
+      restoreTty();
+    }
+  };
+
+  const onSigcont = (): void => {
+    log('[suspend] SIGCONT received; restoring raw mode');
+    suspending = false;
+    restoreTty();
+    try {
+      options.onResume?.();
+    } catch (err) {
+      onError(err);
+    }
+  };
+
+  process.on('SIGTSTP', onSigtstp);
+  process.on('SIGCONT', onSigcont);
+
+  return {
+    requestSuspend: () => {
+      // Routing through the signal listener keeps the Ctrl+Z byte path
+      // and the external `kill -TSTP <pid>` path identical.
+      try {
+        killFn(process.pid, 'SIGTSTP');
+      } catch (err) {
+        onError(err);
+      }
+    },
+    dispose: () => {
+      process.removeListener('SIGTSTP', onSigtstp);
+      process.removeListener('SIGCONT', onSigcont);
+    },
+  };
+}

--- a/packages/daemon/tests/cli/detach-scanner.test.ts
+++ b/packages/daemon/tests/cli/detach-scanner.test.ts
@@ -162,3 +162,77 @@ describe('DetachScanner', () => {
     expect(result[0]).toBe(CTRL_Z);
   });
 });
+
+describe('DetachScanner with onSuspend (issue #361)', () => {
+  let detached: boolean;
+  let forwarded: Buffer[];
+  let suspendCount: number;
+  let scanner: DetachScanner;
+
+  beforeEach(() => {
+    detached = false;
+    forwarded = [];
+    suspendCount = 0;
+    scanner = new DetachScanner({
+      onDetach: () => {
+        detached = true;
+      },
+      onData: (buf) => {
+        forwarded.push(Buffer.from(buf));
+      },
+      onSuspend: () => {
+        suspendCount++;
+      },
+      timeoutMs: 1000,
+    });
+  });
+
+  afterEach(() => {
+    scanner.destroy();
+  });
+
+  function getForwarded(): Buffer {
+    return Buffer.concat(forwarded);
+  }
+
+  test('Ctrl+Z alone calls onSuspend and is not forwarded', () => {
+    const CTRL_Z = 0x1a;
+    scanner.write(Buffer.from([CTRL_Z]));
+    expect(suspendCount).toBe(1);
+    expect(forwarded.length).toBe(0);
+    expect(detached).toBe(false);
+  });
+
+  test('Ctrl+Z surrounded by normal bytes is intercepted; neighbors pass through', () => {
+    const CTRL_Z = 0x1a;
+    scanner.write(Buffer.from([0x61, 0x62, CTRL_Z, 0x63, 0x64])); // "ab" + Ctrl+Z + "cd"
+    expect(suspendCount).toBe(1);
+    const result = getForwarded();
+    expect(result.toString()).toBe('abcd');
+  });
+
+  test('multiple Ctrl+Z bytes each trigger onSuspend', () => {
+    const CTRL_Z = 0x1a;
+    scanner.write(Buffer.from([CTRL_Z, CTRL_Z, 0x61, CTRL_Z]));
+    expect(suspendCount).toBe(3);
+    expect(getForwarded().toString()).toBe('a');
+  });
+
+  test('Ctrl+B then Ctrl+Z: Ctrl+B forwards, Ctrl+Z suspends', () => {
+    scanner.write(Buffer.from([CTRL_B, 0x1a]));
+    expect(suspendCount).toBe(1);
+    expect(detached).toBe(false);
+    const result = getForwarded();
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(CTRL_B);
+  });
+
+  test('Ctrl+Z does not break Ctrl+B d detection when interleaved', () => {
+    const CTRL_Z = 0x1a;
+    // "ab" + Ctrl+Z + Ctrl+B + 'd'  -> "ab" forwarded, suspend fired, then detach
+    scanner.write(Buffer.from([0x61, 0x62, CTRL_Z, CTRL_B, 0x64]));
+    expect(suspendCount).toBe(1);
+    expect(detached).toBe(true);
+    expect(getForwarded().toString()).toBe('ab');
+  });
+});

--- a/packages/daemon/tests/cli/suspend-handler.test.ts
+++ b/packages/daemon/tests/cli/suspend-handler.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the wrapper-mode SIGTSTP / SIGCONT handler (issue #361).
+ *
+ * The handler self-sends SIGSTOP to actually suspend the process. We
+ * cannot let SIGSTOP fire inside the test runner (it would hang the
+ * suite), so the test injects a `kill` seam that records the signals
+ * that would be sent. This is a real seam, not a mock -- the production
+ * binary uses the default `process.kill`.
+ *
+ * SIGCONT path: we deliver a real SIGCONT to ourselves and assert that
+ * the listener runs and `onResume` fires.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  type SuspendHandlerController,
+  installSuspendHandler,
+} from '../../src/cli/suspend-handler';
+
+describe('installSuspendHandler', () => {
+  let controller: SuspendHandlerController | null = null;
+
+  afterEach(() => {
+    controller?.dispose();
+    controller = null;
+  });
+
+  test('requestSuspend forwards SIGTSTP to process.kill', () => {
+    const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    controller = installSuspendHandler({
+      kill: (pid, signal) => {
+        calls.push({ pid, signal });
+      },
+    });
+
+    controller.requestSuspend();
+    expect(calls).toEqual([{ pid: process.pid, signal: 'SIGTSTP' }]);
+  });
+
+  test('SIGTSTP listener teardown sends SIGSTOP via kill seam', async () => {
+    const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    controller = installSuspendHandler({
+      kill: (pid, signal) => {
+        calls.push({ pid, signal });
+      },
+    });
+
+    // requestSuspend() invokes our kill seam with SIGTSTP. Because the seam
+    // does not actually deliver the signal, we have to fire SIGTSTP for real
+    // to exercise the listener. Our installed listener will then call the
+    // seam with SIGSTOP, which is also intercepted (so the runner survives).
+    process.kill(process.pid, 'SIGTSTP');
+    // Signal delivery is async in Bun; yield once.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const stopCalls = calls.filter((c) => c.signal === 'SIGSTOP');
+    expect(stopCalls.length).toBe(1);
+    expect(stopCalls[0]?.pid).toBe(process.pid);
+  });
+
+  test('SIGCONT triggers onResume callback', async () => {
+    let resumed = 0;
+    controller = installSuspendHandler({
+      kill: () => {
+        // swallow signal sends so the test runner survives
+      },
+      onResume: () => {
+        resumed++;
+      },
+    });
+
+    process.kill(process.pid, 'SIGCONT');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(resumed).toBe(1);
+  });
+
+  test('dispose removes both signal listeners', async () => {
+    let resumed = 0;
+    controller = installSuspendHandler({
+      kill: () => {},
+      onResume: () => {
+        resumed++;
+      },
+    });
+    controller.dispose();
+    controller = null;
+
+    // After dispose, our listener should not run for SIGCONT.
+    process.kill(process.pid, 'SIGCONT');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(resumed).toBe(0);
+  });
+
+  test('re-entrant SIGTSTP only triggers one SIGSTOP before resume', async () => {
+    const calls: Array<NodeJS.Signals | number> = [];
+    controller = installSuspendHandler({
+      kill: (_pid, signal) => {
+        calls.push(signal);
+      },
+    });
+
+    process.kill(process.pid, 'SIGTSTP');
+    process.kill(process.pid, 'SIGTSTP');
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const stopCount = calls.filter((s) => s === 'SIGSTOP').length;
+    expect(stopCount).toBe(1);
+  });
+
+  test('after SIGCONT, a second SIGTSTP fires SIGSTOP again', async () => {
+    const calls: Array<NodeJS.Signals | number> = [];
+    controller = installSuspendHandler({
+      kill: (_pid, signal) => {
+        calls.push(signal);
+      },
+    });
+
+    process.kill(process.pid, 'SIGTSTP');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.kill(process.pid, 'SIGCONT');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.kill(process.pid, 'SIGTSTP');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const stopCount = calls.filter((s) => s === 'SIGSTOP').length;
+    expect(stopCount).toBe(2);
+  });
+});

--- a/packages/daemon/tests/cli/suspend-handler.test.ts
+++ b/packages/daemon/tests/cli/suspend-handler.test.ts
@@ -43,6 +43,9 @@ describe('installSuspendHandler', () => {
       kill: (pid, signal) => {
         calls.push({ pid, signal });
       },
+      writeStderr: () => {
+        // suppress diagnostic noise from the test runner output
+      },
     });
 
     // requestSuspend() invokes our kill seam with SIGTSTP. Because the seam
@@ -99,6 +102,7 @@ describe('installSuspendHandler', () => {
       kill: (_pid, signal) => {
         calls.push(signal);
       },
+      writeStderr: () => {},
     });
 
     process.kill(process.pid, 'SIGTSTP');
@@ -115,6 +119,7 @@ describe('installSuspendHandler', () => {
       kill: (_pid, signal) => {
         calls.push(signal);
       },
+      writeStderr: () => {},
     });
 
     process.kill(process.pid, 'SIGTSTP');
@@ -126,5 +131,180 @@ describe('installSuspendHandler', () => {
 
     const stopCount = calls.filter((s) => s === 'SIGSTOP').length;
     expect(stopCount).toBe(2);
+  });
+
+  // ---------------------------------------------------------------------
+  // PR #364 review fixes (Findings 1, 2, 3, 4): user-visible diagnostics
+  // around suspend/resume failure modes.
+  // ---------------------------------------------------------------------
+
+  test('prints "suspended, fg to resume" hint to stderr before SIGSTOP (Finding 4)', async () => {
+    const stderr: string[] = [];
+    const calls: Array<NodeJS.Signals | number> = [];
+    controller = installSuspendHandler({
+      kill: (_pid, signal) => {
+        calls.push(signal);
+      },
+      writeStderr: (msg) => stderr.push(msg),
+    });
+
+    process.kill(process.pid, 'SIGTSTP');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The hint MUST appear before SIGSTOP fires (the process is frozen
+    // after SIGSTOP, so any later write would never reach the user).
+    const hintIdx = stderr.findIndex((m) => m.includes("run 'fg'"));
+    expect(hintIdx).toBeGreaterThanOrEqual(0);
+    expect(stderr[hintIdx]).toContain(`pid ${process.pid}`);
+    // SIGSTOP was actually attempted after the hint.
+    expect(calls).toContain('SIGSTOP');
+  });
+
+  test('aborts SIGSTOP and warns on stderr when teardownTty fails (Finding 1)', async () => {
+    const stderr: string[] = [];
+    const calls: Array<NodeJS.Signals | number> = [];
+
+    // Force teardown to fail by throwing from setRawMode. We restore the
+    // original at the end so the runner stays usable.
+    const originalSetRawMode = process.stdin.setRawMode?.bind(process.stdin);
+    const originalIsTTY = process.stdin.isTTY;
+    // The suspend handler only calls setRawMode if isTTY is truthy. In a
+    // test runner stdin may not be a TTY, so flip both.
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+    process.stdin.setRawMode = (() => {
+      throw new Error('synthetic teardown failure');
+    }) as typeof process.stdin.setRawMode;
+
+    try {
+      controller = installSuspendHandler({
+        kill: (_pid, signal) => {
+          calls.push(signal);
+        },
+        onError: () => {
+          // suppress: we're injecting the failure on purpose
+        },
+        writeStderr: (msg) => stderr.push(msg),
+      });
+
+      process.kill(process.pid, 'SIGTSTP');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Critical contract: SIGSTOP MUST NOT have been sent.
+      expect(calls.filter((s) => s === 'SIGSTOP')).toEqual([]);
+      // The user gets a clear stderr message with an actionable next step.
+      const msg = stderr.join('');
+      expect(msg).toContain('cannot suspend');
+      expect(msg).toContain('Ctrl+B d');
+    } finally {
+      if (originalSetRawMode) {
+        process.stdin.setRawMode = originalSetRawMode;
+      }
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+  });
+
+  test('aborts SIGSTOP, restores TTY, and warns when SIGSTOP itself fails (Finding 2)', async () => {
+    const stderr: string[] = [];
+    const calls: Array<NodeJS.Signals | number> = [];
+
+    controller = installSuspendHandler({
+      kill: (_pid, signal) => {
+        calls.push(signal);
+        if (signal === 'SIGSTOP') {
+          throw new Error('synthetic SIGSTOP failure');
+        }
+      },
+      onError: () => {
+        // suppress: SIGSTOP failure is the test point
+      },
+      writeStderr: (msg) => stderr.push(msg),
+    });
+
+    process.kill(process.pid, 'SIGTSTP');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // SIGSTOP was attempted exactly once (the throw is the test).
+    expect(calls.filter((s) => s === 'SIGSTOP').length).toBe(1);
+    // User-visible diagnostic mentions the failure.
+    const msg = stderr.join('');
+    expect(msg).toContain('cannot suspend');
+    expect(msg).toContain('synthetic SIGSTOP failure');
+    expect(msg).toContain('staying in foreground');
+  });
+
+  test('warns on stderr when restoreTty partially fails after SIGCONT (Finding 3)', async () => {
+    const stderr: string[] = [];
+
+    const originalSetRawMode = process.stdin.setRawMode?.bind(process.stdin);
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+
+    // Let setRawMode(false) succeed (during teardown if it ran) but
+    // setRawMode(true) on resume throw, so only the rawMode op fails.
+    let rawModeCalls = 0;
+    process.stdin.setRawMode = ((value: boolean) => {
+      rawModeCalls++;
+      if (value === true) {
+        throw new Error('synthetic raw-mode restore failure');
+      }
+      return process.stdin;
+    }) as typeof process.stdin.setRawMode;
+
+    try {
+      controller = installSuspendHandler({
+        kill: () => {},
+        onError: () => {},
+        writeStderr: (msg) => stderr.push(msg),
+      });
+
+      // Drive SIGCONT directly: the resume path is what we care about.
+      process.kill(process.pid, 'SIGCONT');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const msg = stderr.join('');
+      expect(msg).toContain('terminal restore failed');
+      expect(msg).toContain('raw-mode');
+      expect(msg).toContain('Ctrl+B d');
+      // Sanity: setRawMode(true) was attempted at least once.
+      expect(rawModeCalls).toBeGreaterThanOrEqual(1);
+    } finally {
+      if (originalSetRawMode) {
+        process.stdin.setRawMode = originalSetRawMode;
+      }
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // Regression test for the daemon-mode SIGTSTP-ignore safety net
+  // (PR #364 silent-failure-hunter, Finding 7). The unconditional ignore
+  // listener that cli.ts installs in daemon mode lives at module scope and
+  // is hard to import without booting the full daemon. We validate the
+  // contract here: a bare SIGTSTP listener (the daemon-mode no-op) keeps
+  // the kernel default from suspending the process, and that contract
+  // continues to hold. If this test fails, the daemon-mode regression has
+  // returned.
+  // ---------------------------------------------------------------------
+  test('regression: a no-op SIGTSTP listener prevents kernel-default suspend', async () => {
+    let received = 0;
+    const noop = () => {
+      received++;
+    };
+    process.on('SIGTSTP', noop);
+    try {
+      // Real signal injection. If the kernel default ran, the test runner
+      // would freeze and time out.
+      process.kill(process.pid, 'SIGTSTP');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(received).toBe(1);
+    } finally {
+      process.removeListener('SIGTSTP', noop);
+    }
   });
 });

--- a/packages/daemon/tests/pty-sigtstp.test.ts
+++ b/packages/daemon/tests/pty-sigtstp.test.ts
@@ -76,7 +76,10 @@ describe('PTY SIGTSTP handling', () => {
   });
 
   test('daemon process ignores SIGTSTP without suspending', async () => {
-    // Register SIGTSTP handler (same as cli.ts does)
+    // A bare SIGTSTP listener is enough to suppress the kernel default. The
+    // wrapper-mode handler is in `cli/suspend-handler.ts`; this test only
+    // verifies the underlying runtime contract that the suspend handler
+    // depends on.
     const received = new Promise<void>((resolve) => {
       const handler = () => {
         process.removeListener('SIGTSTP', handler);


### PR DESCRIPTION
## Summary

Implements Ctrl+Z support for `remi <args>` so the user can drop back to the shell with `[1]+ Stopped` and resume with `fg`. The PTY-hosted Claude keeps running across the suspend. Fixes #361.

## Root cause

`remi <args>` puts stdin into raw mode while forwarding bytes to the PTY-hosted Claude. In raw mode the kernel does NOT translate Ctrl+Z (`0x1A`) into SIGTSTP -- it forwards the literal byte to the child, which discards it. The keystroke was silently swallowed.

## Approach

Two small pieces, kept in two files:

1. **`DetachScanner` gets an optional `onSuspend` callback.** When wired, the scanner intercepts the `0x1A` byte before it reaches the PTY. When the callback is omitted (e.g. legacy tests, future re-use) the byte passes through unchanged. The scan-ahead batching loop also breaks on `0x1A` only when interception is active.

2. **New `cli/suspend-handler.ts`** owns the SIGTSTP/SIGCONT lifecycle:
   - On SIGTSTP (from the byte path or `kill -TSTP <pid>`): tear down raw mode + pause stdin, then self-send SIGSTOP. SIGSTOP is uncatchable, so the kernel suspends only the remi process. The shell sees a stopped job.
   - On SIGCONT (from `fg`/`bg` or `kill -CONT <pid>`): restore raw mode and call `onResume`.
   - Re-entrancy guard prevents double teardown if SIGTSTP fires twice in a row.
   - Tests inject a `kill` seam to verify the signal flow without actually suspending the test runner.

## Child-process-group decision

The PTY child runs in its own session because `Bun.spawn` with the `terminal:` option uses forkpty/setsid under the hood. Sending SIGSTOP to `process.pid` only suspends remi; the Claude child is unaffected. No `detached: true` change to the spawn site was needed.

## Removed

The old top-level `process.on('SIGTSTP', ignore)` handler in `cli.ts`. It was a guard that prevented wrapper-mode remi from suspending; now wrapper mode handles SIGTSTP properly via `installSuspendHandler`. Non-wrapper modes (`remi daemon`, `remi ls`, etc.) get the kernel default, which is fine: the daemon is typically headless and the ls/attach clients are short-lived.

## Test plan

Automated (passing locally, 672 daemon tests):
- [x] `bun test packages/daemon/tests/cli/detach-scanner.test.ts`: 18 tests including 5 new `onSuspend` cases
- [x] `bun test packages/daemon/tests/cli/suspend-handler.test.ts`: 6 new tests covering byte path, SIGCONT resume, dispose, re-entrancy
- [x] `bun test packages/daemon/tests/pty-sigtstp.test.ts`: still green (the underlying runtime contract that suspend-handler depends on)
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean

Manual:
- [ ] `remi <args>` -> Ctrl+Z -> shell prompt with `[1]+  Stopped  remi`
- [ ] `fg` resumes remi cleanly; raw mode restored; further keystrokes flow to Claude
- [ ] `bg` works (remi continues in background; user can use the shell)
- [ ] Verify Claude PTY child kept running during suspend (e.g. `ps`, or reattach from another client)
- [ ] `kill -TSTP <remi-pid>` from another shell also suspends; `kill -CONT <remi-pid>` resumes

Fixes #361