### PR TITLE
fix(hooks): narrow registered events + exit cleanup (#203)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -878,6 +878,19 @@ let HOOK_PORT = 0; // OS-assigned; actual port read from hookServer.port after s
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
 
+// Best-effort synchronous cleanup on any exit path. SIGINT/SIGTERM already
+// run the async cleanup() which calls hookConfigManager.uninstall(); this
+// handler is the last line of defense for `process.exit()` calls and
+// uncaught exceptions, so a daemon that crashes does not leave stale
+// hook URLs in `.claude/settings.local.json` that gate Claude Code
+// (issue #203). SIGKILL still leaves entries by definition; the next
+// startup's purgeStaleHooks recovers from that.
+process.on('exit', () => {
+  if (hookConfigManager) {
+    hookConfigManager.uninstallSync();
+  }
+});
+
 // mDNS publisher (initialized when daemon is network-accessible)
 let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = null;
 

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -13,7 +13,7 @@ import * as fs from 'node:fs';
 import * as net from 'node:net';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
-import { HOOK_EVENT_NAMES } from './hook-types.ts';
+import { HOOK_EVENT_NAMES, REMI_REGISTERED_HOOK_EVENTS } from './hook-types.ts';
 
 interface HookEntry {
   type: 'http';
@@ -67,6 +67,14 @@ export class HookConfigManager {
       );
     }
 
+    try {
+      this.pruneNonRegisteredOwnHooks();
+    } catch (err) {
+      console.warn(
+        `Failed to prune legacy remi hooks: ${errorToString(err)}. Continuing with install.`,
+      );
+    }
+
     const settings = this.readSettings();
     if (!settings.hooks) {
       settings.hooks = {};
@@ -78,7 +86,13 @@ export class HookConfigManager {
       timeout: 5,
     };
 
-    for (const event of HOOK_EVENT_NAMES) {
+    // Register only the subset of events remi actually consumes. Registering
+    // every event in HOOK_EVENT_NAMES forces Claude Code into a synchronous
+    // HTTP call to remi for every Worktree/UserPrompt/etc. event — and a
+    // failed call gates the underlying action (issue #203). The narrower
+    // list keeps Claude Code's worktree creation, prompt submission, and
+    // compaction unblocked when remi is slow, dead, or restarting.
+    for (const event of REMI_REGISTERED_HOOK_EVENTS) {
       if (!settings.hooks[event]) {
         settings.hooks[event] = [];
       }
@@ -144,7 +158,7 @@ export class HookConfigManager {
     const settings = this.readSettings();
     if (!settings.hooks) return false;
 
-    return HOOK_EVENT_NAMES.every((event) => {
+    return REMI_REGISTERED_HOOK_EVENTS.every((event) => {
       const matchers = settings.hooks?.[event];
       return matchers?.some((m) =>
         m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
@@ -204,6 +218,71 @@ export class HookConfigManager {
     );
     if (modified) {
       this.writeSettings(settings);
+    }
+  }
+
+  /**
+   * Remove our own hook URL from events that newer remi versions no longer
+   * register (e.g. an older remi wrote WorktreeCreate / UserPromptSubmit /
+   * PreCompact entries — the new install path skips them, so they would
+   * stay forever, gating Claude Code on a remi that never plans to respond).
+   *
+   * Only removes our exact hook URL; user-configured hooks for those
+   * events are preserved. If removing our entry leaves the event with no
+   * matchers, the event key is deleted entirely.
+   */
+  private pruneNonRegisteredOwnHooks(): void {
+    if (!fs.existsSync(this.settingsPath)) return;
+
+    const settings = this.readSettings();
+    if (!settings.hooks) return;
+
+    const registered = new Set<string>(REMI_REGISTERED_HOOK_EVENTS);
+    let modified = false;
+
+    for (const event of Object.keys(settings.hooks)) {
+      if (registered.has(event)) continue;
+      const matchers = settings.hooks[event];
+      if (!matchers) continue;
+      const filtered = matchers
+        .map((m) => ({
+          ...m,
+          hooks: Array.isArray(m.hooks)
+            ? m.hooks.filter((h) => !(h.type === 'http' && h.url === this.hookUrl))
+            : m.hooks,
+        }))
+        .filter((m) => Array.isArray(m.hooks) && m.hooks.length > 0);
+      if (filtered.length !== matchers.length) {
+        if (filtered.length === 0) {
+          Reflect.deleteProperty(settings.hooks, event);
+        } else {
+          settings.hooks[event] = filtered;
+        }
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      if (settings.hooks && Object.keys(settings.hooks).length === 0) {
+        Reflect.deleteProperty(settings, 'hooks');
+      }
+      this.writeSettings(settings);
+    }
+  }
+
+  /**
+   * Synchronous best-effort uninstall. Called from `process.on('exit')` so
+   * that even abnormal shutdowns (uncaught exceptions, callers explicitly
+   * calling `process.exit`) leave the project's settings clean. Cannot
+   * await anything; must not throw. SIGKILL still leaves entries behind
+   * by definition, but the next remi startup's `purgeStaleHooks` cleans
+   * those up anyway.
+   */
+  uninstallSync(): void {
+    try {
+      this.uninstall();
+    } catch {
+      // Exit handler must not throw; the next install() will retry.
     }
   }
 

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -218,6 +218,39 @@ export const HOOK_EVENT_NAMES = [
 
 export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
 
+/**
+ * Subset of hook events that remi actually consumes — these are the only
+ * events written into `.claude/settings.local.json` by HookConfigManager.
+ *
+ * The remaining HOOK_EVENT_NAMES entries (`WorktreeCreate`, `WorktreeRemove`,
+ * `UserPromptSubmit`, etc.) are accepted by HookServer for forward
+ * compatibility, but registering them in Claude Code's settings turns every
+ * such event into a synchronous HTTP roundtrip that gates the underlying
+ * Claude Code action. The most painful symptom: a stale (or just slow)
+ * remi daemon makes Claude Code unable to create a worktree, even though
+ * remi has no business gating that operation. See issue #203.
+ *
+ * Treat this list as the source of truth for "things remi cares about." If
+ * you add a new typed handler in HookServer.dispatch or a dynamic listener
+ * in setupHookBridge, also add the event name here so the registration
+ * actually fires.
+ */
+export const REMI_REGISTERED_HOOK_EVENTS = [
+  'PreToolUse',
+  'PostToolUse',
+  'Notification',
+  'Stop',
+  'SessionStart',
+  'PermissionRequest',
+  'PostToolUseFailure',
+  'SubagentStart',
+  'SubagentStop',
+  'StopFailure',
+  'SessionEnd',
+] as const satisfies readonly HookEventName[];
+
+export type RemiRegisteredHookEvent = (typeof REMI_REGISTERED_HOOK_EVENTS)[number];
+
 /** Type guard for valid hook event names */
 export function isValidHookEvent(name: string): name is HookEventName {
   return (HOOK_EVENT_NAMES as readonly string[]).includes(name);

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { HookConfigManager } from '../../src/hooks/hook-config-manager.ts';
-import { HOOK_EVENT_NAMES } from '../../src/hooks/hook-types.ts';
+import { HOOK_EVENT_NAMES, REMI_REGISTERED_HOOK_EVENTS } from '../../src/hooks/hook-types.ts';
 
 describe('HookConfigManager', () => {
   let tmpDir: string;
@@ -36,23 +36,28 @@ describe('HookConfigManager', () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
   });
 
-  it('writes hook config with all required events', async () => {
+  it('writes hook config only for events remi consumes (issue #203)', async () => {
     await manager.install();
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
 
     expect(settings.hooks).toBeDefined();
     const events = Object.keys(settings.hooks);
 
-    // Verify all events are registered (22 after Claude Code removed 3)
-    expect(HOOK_EVENT_NAMES.length).toBe(22);
-    for (const event of HOOK_EVENT_NAMES) {
+    // The narrowed list — registering every HOOK_EVENT_NAMES entry would
+    // make every Claude Code action (worktree create, prompt submit, etc.)
+    // gate on a synchronous HTTP call to a possibly-dead remi.
+    for (const event of REMI_REGISTERED_HOOK_EVENTS) {
       expect(events).toContain(event);
     }
-    // No extra events beyond what HOOK_EVENT_NAMES defines
-    expect(events.length).toBe(HOOK_EVENT_NAMES.length);
+    expect(events.length).toBe(REMI_REGISTERED_HOOK_EVENTS.length);
+    // None of the explicitly-skipped events should appear:
+    expect(events).not.toContain('WorktreeCreate');
+    expect(events).not.toContain('WorktreeRemove');
+    expect(events).not.toContain('UserPromptSubmit');
+    expect(events).not.toContain('PreCompact');
   });
 
-  it('each event has an HTTP hook entry with the correct URL', async () => {
+  it('each registered event has an HTTP hook entry with the correct URL', async () => {
     await manager.install();
     const settings = readSettings() as {
       hooks: Record<
@@ -61,7 +66,7 @@ describe('HookConfigManager', () => {
       >;
     };
 
-    for (const event of HOOK_EVENT_NAMES) {
+    for (const event of REMI_REGISTERED_HOOK_EVENTS) {
       const matchers = settings.hooks[event] as Array<{
         hooks: Array<{ type: string; url: string; timeout: number }>;
       }>;
@@ -76,12 +81,63 @@ describe('HookConfigManager', () => {
     }
   });
 
+  it('regression #203: install() drops legacy remi entries for events it no longer registers', async () => {
+    // Simulate a settings file written by an older remi that registered the
+    // full HOOK_EVENT_NAMES list (which still includes WorktreeCreate). Our
+    // own URL on a non-registered event should be pruned on next install
+    // so Claude Code stops gating worktree creation on us.
+    const legacyHooks: Record<
+      string,
+      Array<{ hooks: Array<{ type: string; url: string; timeout: number }> }>
+    > = {};
+    for (const event of HOOK_EVENT_NAMES) {
+      legacyHooks[event] = [{ hooks: [{ type: 'http', url: hookUrl, timeout: 5 }] }];
+    }
+    // Plus a user hook on WorktreeCreate to make sure we DON'T touch it.
+    legacyHooks['WorktreeCreate'] = [
+      { hooks: [{ type: 'http', url: hookUrl, timeout: 5 }] },
+      { hooks: [{ type: 'http', url: 'http://user-tool.example.com/wt', timeout: 5 }] },
+    ];
+    writeSettings({ hooks: legacyHooks });
+
+    await manager.install();
+
+    const settings = readSettings() as {
+      hooks: Record<
+        string,
+        Array<{ hooks: Array<{ type: string; url: string; timeout: number }> }>
+      >;
+    };
+
+    // Our URL is gone from WorktreeCreate; the user hook stays.
+    const wt = settings.hooks['WorktreeCreate'];
+    expect(wt).toBeDefined();
+    const wtHookUrls = wt?.flatMap((m) => m.hooks.map((h) => h.url)) ?? [];
+    expect(wtHookUrls).not.toContain(hookUrl);
+    expect(wtHookUrls).toContain('http://user-tool.example.com/wt');
+
+    // WorktreeRemove had only our entry → key removed entirely.
+    expect(settings.hooks['WorktreeRemove']).toBeUndefined();
+    expect(settings.hooks['UserPromptSubmit']).toBeUndefined();
+    expect(settings.hooks['PreCompact']).toBeUndefined();
+
+    // Registered events keep their entry.
+    for (const event of REMI_REGISTERED_HOOK_EVENTS) {
+      expect(settings.hooks[event]).toBeDefined();
+    }
+  });
+
+  it('uninstallSync() removes our entries and never throws', () => {
+    // No prior install → uninstallSync must be a no-op.
+    expect(() => manager.uninstallSync()).not.toThrow();
+  });
+
   it('does not duplicate hooks on repeated install', async () => {
     await manager.install();
     await manager.install();
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
 
-    for (const event of HOOK_EVENT_NAMES) {
+    for (const event of REMI_REGISTERED_HOOK_EVENTS) {
       expect(settings.hooks[event]?.length).toBe(1);
     }
   });


### PR DESCRIPTION
## Summary

Closes #203. Today \`HookConfigManager.install()\` writes an entry for every name in \`HOOK_EVENT_NAMES\` (22 events). Only **11** of those have a typed handler or a dynamic listener — the rest (notably \`WorktreeCreate\`, \`WorktreeRemove\`, \`UserPromptSubmit\`, \`PreCompact\`) just no-op. Each registration adds a synchronous HTTP roundtrip from Claude Code to remi, and Claude Code treats a failed hook call as a gate on the underlying action. So a slow / restarting / wedged remi silently blocks Claude Code from creating worktrees, submitting prompts, or compacting — even though remi has no functional reason to gate any of that.

This bit me running the parallel agents for #361 + #168/#169/#170 today: spawning a Claude Code agent with \`isolation: \"worktree\"\` returned \`WorktreeCreate hook failed: no successful output\` because the hook was firing to a remi process that wasn't responding fast enough.

## Changes

1. **\`packages/daemon/src/hooks/hook-types.ts\`** — introduce \`REMI_REGISTERED_HOOK_EVENTS\` (the 11 events with handlers + listeners). \`HOOK_EVENT_NAMES\` stays the source of truth for \`HookServer\`'s accept list and for \`purgeInvalidEventNames\`.
2. **\`packages/daemon/src/hooks/hook-config-manager.ts\`** — \`install()\` writes only \`REMI_REGISTERED_HOOK_EVENTS\`. New \`pruneNonRegisteredOwnHooks()\` runs before write and removes our URL from any event we no longer register, leaving user-configured hooks alone (handles the upgrade path: an older remi wrote WorktreeCreate, the new install drops it). \`isInstalled\` updated to use the narrowed list. New \`uninstallSync()\` (sync, never throws) for the exit handler.
3. **\`packages/daemon/src/cli.ts\`** — single module-scope \`process.on('exit')\` handler that calls \`uninstallSync()\`. SIGINT/SIGTERM already do this via the async \`cleanup()\` path; the exit handler is the last line of defense for \`process.exit\` calls and uncaught exceptions. SIGKILL still leaves entries — the next startup's existing \`purgeStaleHooks\` recovers.

## Why narrow the list rather than make the hook handler always return success?

The hook handler already returns \`200 {}\` for every event (HookServer:191). The actual failure mode reported in #203 is **the daemon not being reachable at all** — slow startup, port reused after crash, etc. The fix is to remove the registration so Claude Code stops calling us for events we don't consume. Returning success faster from a hook we don't care about is theatre: the synchronous HTTP roundtrip cost is paid regardless.

## Test plan

- [x] \`bun test packages/daemon/tests/hooks\` — 105 pass (4 new / updated covering the narrowed list, legacy purge, and uninstallSync contract)
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/session packages/shared/tests\` — 992 pass
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean (14 pre-existing warnings only)
- [ ] Smoke: kill any running remi, install fresh, spawn an Agent with \`isolation: \"worktree\"\` — should succeed without the WorktreeCreate timeout.

Fixes #203