### PR TITLE
fix(web): auth prompt timing and localhost no-auth (#257)

### DIFF
--- a/packages/daemon/src/server/peer-helpers.ts
+++ b/packages/daemon/src/server/peer-helpers.ts
@@ -4,6 +4,26 @@
  * Used to decide whether an inbound connection is from the local machine,
  * which lets us safely skip auth challenges for loopback peers even when
  * the daemon is bound to 0.0.0.0 with auth otherwise enabled.
+ *
+ * SECURITY NOTE — same-host reverse proxy.
+ * The loopback bypass keys off the actual TCP peer address (read via
+ * Bun.serve's `server.requestIP(req)`, never from a header) so over-the-
+ * wire spoofing is not possible. HOWEVER: if remi is ever fronted by a
+ * same-host reverse proxy (nginx, caddy, cloudflared, etc.), every
+ * proxied request — including from genuinely remote attackers — arrives
+ * on `127.0.0.1` and would be classified as loopback here. That would
+ * silently bypass auth for the entire internet.
+ *
+ * If you introduce a same-host proxy in front of remi, you MUST either
+ *   1) drop the loopback exemption entirely, or
+ *   2) replace the TCP-peer check with a proxy-aware policy (PROXY
+ *      protocol parsing, a trusted-CIDR allowlist for the proxy with
+ *      auth required for everyone else, or terminate TLS in remi
+ *      directly so the TCP peer remains authoritative).
+ *
+ * Today remi is run directly on its bind port and the bypass is safe.
+ * This comment exists so the next person who shapes the deployment
+ * notices the assumption before regretting it.
  */
 
 /**

--- a/packages/daemon/src/server/peer-helpers.ts
+++ b/packages/daemon/src/server/peer-helpers.ts
@@ -1,0 +1,61 @@
+/**
+ * Peer-address helpers for the WebSocket server.
+ *
+ * Used to decide whether an inbound connection is from the local machine,
+ * which lets us safely skip auth challenges for loopback peers even when
+ * the daemon is bound to 0.0.0.0 with auth otherwise enabled.
+ */
+
+/**
+ * Return true if `host` is a loopback (this-machine) address.
+ *
+ * Recognizes:
+ *   - IPv4 loopback: anything in 127.0.0.0/8 (covers 127.0.0.1, 127.0.0.2, ...)
+ *   - IPv6 loopback: ::1 (with or without zone, with or without brackets)
+ *   - IPv4-mapped IPv6 loopback: ::ffff:127.0.0.1 (and bracketed forms)
+ *   - The hostname literal "localhost"
+ *
+ * Returns false for null/undefined and for any non-loopback IP.
+ */
+export function isLoopbackAddress(host: string | null | undefined): boolean {
+  if (!host) return false;
+
+  // Strip brackets for IPv6 addresses (e.g. "[::1]" -> "::1")
+  let h = host.trim();
+  if (h.startsWith('[') && h.includes(']')) {
+    h = h.slice(1, h.indexOf(']'));
+  }
+  // Strip IPv6 zone suffix (e.g. "fe80::1%en0" -> "fe80::1")
+  const zoneIdx = h.indexOf('%');
+  if (zoneIdx >= 0) h = h.slice(0, zoneIdx);
+
+  // Lowercase for hostname comparisons; IPs are case-insensitive too
+  const lower = h.toLowerCase();
+
+  if (lower === 'localhost') return true;
+  if (lower === '::1') return true;
+
+  // IPv4-mapped IPv6 loopback (e.g. "::ffff:127.0.0.1")
+  if (lower.startsWith('::ffff:')) {
+    const v4 = lower.slice('::ffff:'.length);
+    return isIPv4Loopback(v4);
+  }
+
+  return isIPv4Loopback(lower);
+}
+
+/** True for any address in 127.0.0.0/8. */
+function isIPv4Loopback(addr: string): boolean {
+  const parts = addr.split('.');
+  if (parts.length !== 4) return false;
+  const first = Number.parseInt(parts[0] ?? '', 10);
+  if (Number.isNaN(first) || first !== 127) return false;
+  // Validate the rest are 0-255 numerals
+  for (let i = 1; i < 4; i++) {
+    const part = parts[i] ?? '';
+    if (!/^\d+$/.test(part)) return false;
+    const n = Number.parseInt(part, 10);
+    if (Number.isNaN(n) || n < 0 || n > 255) return false;
+  }
+  return true;
+}

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -8,6 +8,7 @@
 import { generateId } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { Connection, type ConnectionConfig, type ConnectionEvents } from './connection.ts';
+import { isLoopbackAddress } from './peer-helpers.ts';
 
 /** Server configuration */
 export interface ServerConfig {
@@ -98,6 +99,8 @@ const DEFAULT_MAX_CONNECTIONS = 100;
 /** WebSocket data attached to each connection */
 interface WSData {
   connectionId: UUID;
+  /** Peer IP captured at upgrade time (used to skip auth for loopback). */
+  peerAddress: string | null;
 }
 
 /**
@@ -187,10 +190,14 @@ export class WebSocketServer {
             return new Response('Too many connections', { status: 503 });
           }
 
+          const peer = server.requestIP(req);
+          const peerAddress = peer?.address ?? null;
+
           // Upgrade to WebSocket
           const success = server.upgrade(req, {
             data: {
               connectionId: generateId(),
+              peerAddress,
             },
           });
 
@@ -207,6 +214,25 @@ export class WebSocketServer {
             JSON.stringify({
               status: 'ok',
               connections: self.connections.size,
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        // Auth-info endpoint: lets clients probe whether this daemon will
+        // require an Ed25519 challenge before opening the WebSocket. Loopback
+        // peers are always exempt regardless of authenticator config, so the
+        // probe answers from the same vantage point the WebSocket would.
+        // See ConnectModal in packages/web for the consumer (#257).
+        if (url.pathname === '/auth-info') {
+          const peer = server.requestIP(req);
+          const peerLoopback = isLoopbackAddress(peer?.address);
+          const authenticator = self.config.connection?.authenticator;
+          const authRequired = !!authenticator && !peerLoopback;
+          return new Response(
+            JSON.stringify({
+              authRequired,
+              fingerprint: authenticator?.serverFingerprint ?? null,
             }),
             { headers: { 'Content-Type': 'application/json' } },
           );
@@ -350,10 +376,19 @@ export class WebSocketServer {
       },
     };
 
+    // Localhost-no-auth (#257): even when an authenticator is configured,
+    // peers connecting from the loopback interface are trusted by virtue of
+    // being on the same machine. Drop the authenticator from this peer's
+    // connection so it never receives an auth_challenge.
+    let perConnectionConfig = this.config.connection;
+    if (perConnectionConfig?.authenticator && isLoopbackAddress(ws.data.peerAddress)) {
+      perConnectionConfig = { ...perConnectionConfig, authenticator: undefined };
+    }
+
     const connection = new Connection(
       ws as unknown as WebSocket,
       connectionEvents,
-      this.config.connection,
+      perConnectionConfig,
       ws.data.connectionId,
     );
 

--- a/packages/daemon/tests/peer-helpers.test.ts
+++ b/packages/daemon/tests/peer-helpers.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for peer-address loopback detection.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { isLoopbackAddress } from '../src/server/peer-helpers.ts';
+
+describe('isLoopbackAddress', () => {
+  test('returns false for null/undefined/empty', () => {
+    expect(isLoopbackAddress(null)).toBe(false);
+    expect(isLoopbackAddress(undefined)).toBe(false);
+    expect(isLoopbackAddress('')).toBe(false);
+    expect(isLoopbackAddress('   ')).toBe(false);
+  });
+
+  describe('IPv4', () => {
+    test('classic 127.0.0.1', () => {
+      expect(isLoopbackAddress('127.0.0.1')).toBe(true);
+    });
+
+    test('any address in 127.0.0.0/8', () => {
+      expect(isLoopbackAddress('127.0.0.0')).toBe(true);
+      expect(isLoopbackAddress('127.255.255.254')).toBe(true);
+      expect(isLoopbackAddress('127.1.2.3')).toBe(true);
+    });
+
+    test('LAN addresses are not loopback', () => {
+      expect(isLoopbackAddress('192.168.1.5')).toBe(false);
+      expect(isLoopbackAddress('10.0.0.1')).toBe(false);
+      expect(isLoopbackAddress('169.254.1.1')).toBe(false);
+      expect(isLoopbackAddress('172.16.0.1')).toBe(false);
+    });
+
+    test('public addresses are not loopback', () => {
+      expect(isLoopbackAddress('8.8.8.8')).toBe(false);
+      expect(isLoopbackAddress('1.1.1.1')).toBe(false);
+    });
+
+    test('rejects malformed IPv4', () => {
+      expect(isLoopbackAddress('127.0.0')).toBe(false);
+      expect(isLoopbackAddress('127.0.0.1.1')).toBe(false);
+      expect(isLoopbackAddress('127.0.0.999')).toBe(false);
+      expect(isLoopbackAddress('127.x.0.1')).toBe(false);
+    });
+  });
+
+  describe('IPv6', () => {
+    test('plain ::1', () => {
+      expect(isLoopbackAddress('::1')).toBe(true);
+    });
+
+    test('bracketed [::1]', () => {
+      expect(isLoopbackAddress('[::1]')).toBe(true);
+    });
+
+    test('with zone identifier', () => {
+      expect(isLoopbackAddress('::1%lo0')).toBe(true);
+      expect(isLoopbackAddress('[::1%lo0]')).toBe(true);
+    });
+
+    test('IPv4-mapped loopback ::ffff:127.0.0.1', () => {
+      expect(isLoopbackAddress('::ffff:127.0.0.1')).toBe(true);
+      expect(isLoopbackAddress('[::ffff:127.0.0.1]')).toBe(true);
+    });
+
+    test('non-loopback IPv6', () => {
+      expect(isLoopbackAddress('::')).toBe(false);
+      expect(isLoopbackAddress('fe80::1')).toBe(false);
+      expect(isLoopbackAddress('2001:db8::1')).toBe(false);
+      expect(isLoopbackAddress('::ffff:192.168.1.1')).toBe(false);
+    });
+  });
+
+  describe('hostname literal', () => {
+    test('localhost matches', () => {
+      expect(isLoopbackAddress('localhost')).toBe(true);
+      expect(isLoopbackAddress('LOCALHOST')).toBe(true);
+      expect(isLoopbackAddress('  localhost  ')).toBe(true);
+    });
+
+    test('non-localhost hostnames do not match', () => {
+      expect(isLoopbackAddress('example.com')).toBe(false);
+      expect(isLoopbackAddress('localhost.attacker.com')).toBe(false);
+      expect(isLoopbackAddress('mylocalhost')).toBe(false);
+    });
+  });
+});

--- a/packages/daemon/tests/websocket-server-loopback-auth.test.ts
+++ b/packages/daemon/tests/websocket-server-loopback-auth.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration tests for the localhost-no-auth path (#257).
+ *
+ * Verifies that even when the daemon is configured with an authenticator
+ * (e.g. running with --auth on a 0.0.0.0 bind), peers connecting from the
+ * loopback interface skip the auth challenge entirely. Also exercises the
+ * /auth-info HTTP probe used by the web client to surface the passphrase
+ * prompt inline in the Connect modal before opening the WebSocket.
+ *
+ * No mocks: real Bun HTTP/WebSocket server, real Ed25519 keypair, real WS
+ * client. Tests are gated to localhost so the loopback exemption applies.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  type ProtocolMessage,
+  type UnlockedIdentity,
+  createHello,
+  deserialize,
+  serialize,
+} from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+import { WebSocketServer } from '../src/server/websocket-server.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-loopback-auth-'));
+}
+
+describe('WebSocketServer loopback auth skip (#257)', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+  let serverIdentity: UnlockedIdentity;
+  let authenticator: Authenticator;
+  const basePort = 9920;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+    await store.generate('serverpass');
+    serverIdentity = await store.unlock('serverpass');
+    authenticator = new Authenticator({
+      identity: serverIdentity,
+      identityStore: store,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  test('loopback peer never receives auth_challenge even with authenticator configured', async () => {
+    const port = basePort;
+    const server = new WebSocketServer({
+      port,
+      host: '127.0.0.1',
+      connection: { authenticator, skipHelloAck: false },
+    });
+    await server.start();
+
+    try {
+      // 127.0.0.1 -> bun -> server.requestIP returns 127.0.0.1
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const received: ProtocolMessage[] = [];
+
+      const helloAckPromise = new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          ws.send(serialize(createHello('test-client', '1.0.0')));
+        };
+        ws.onmessage = (e) => {
+          const msg = deserialize(e.data.toString());
+          if (msg) received.push(msg);
+          if (msg?.type === 'hello_ack') resolve();
+        };
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout waiting for hello_ack')), 3000);
+      });
+
+      await helloAckPromise;
+      ws.close();
+
+      // No auth_challenge should ever have been sent.
+      const types = received.map((m) => m.type);
+      expect(types).not.toContain('auth_challenge');
+      expect(types).toContain('hello_ack');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('loopback connections coexist with authenticator on 0.0.0.0 bind', async () => {
+    // Bind to all interfaces, but connect via the loopback interface.
+    // Real-world: daemon on 0.0.0.0 with --auth, browser at http://localhost.
+    const port = basePort + 1;
+    const server = new WebSocketServer({
+      port,
+      host: '0.0.0.0',
+      connection: { authenticator, skipHelloAck: false },
+    });
+    await server.start();
+
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const received: ProtocolMessage[] = [];
+
+      const helloAckPromise = new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          ws.send(serialize(createHello('test-client', '1.0.0')));
+        };
+        ws.onmessage = (e) => {
+          const msg = deserialize(e.data.toString());
+          if (msg) received.push(msg);
+          if (msg?.type === 'hello_ack') resolve();
+        };
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout waiting for hello_ack')), 3000);
+      });
+
+      await helloAckPromise;
+      ws.close();
+
+      const types = received.map((m) => m.type);
+      expect(types).not.toContain('auth_challenge');
+      expect(types).toContain('hello_ack');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('without authenticator, loopback path is identical', async () => {
+    const port = basePort + 2;
+    const server = new WebSocketServer({
+      port,
+      host: '127.0.0.1',
+      connection: { skipHelloAck: false },
+    });
+    await server.start();
+
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const received: ProtocolMessage[] = [];
+
+      const helloAckPromise = new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          ws.send(serialize(createHello('test-client', '1.0.0')));
+        };
+        ws.onmessage = (e) => {
+          const msg = deserialize(e.data.toString());
+          if (msg) received.push(msg);
+          if (msg?.type === 'hello_ack') resolve();
+        };
+        ws.onerror = () => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('Timeout waiting for hello_ack')), 3000);
+      });
+
+      await helloAckPromise;
+      ws.close();
+
+      const types = received.map((m) => m.type);
+      expect(types).not.toContain('auth_challenge');
+      expect(types).toContain('hello_ack');
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('WebSocketServer /auth-info endpoint (#257)', () => {
+  let tmpDir: string;
+  let store: IdentityStore;
+  let serverIdentity: UnlockedIdentity;
+  let authenticator: Authenticator;
+  const basePort = 9930;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new IdentityStore(tmpDir);
+    await store.generate('serverpass');
+    serverIdentity = await store.unlock('serverpass');
+    authenticator = new Authenticator({
+      identity: serverIdentity,
+      identityStore: store,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  test('reports authRequired=false when no authenticator', async () => {
+    const port = basePort;
+    const server = new WebSocketServer({ port, host: '127.0.0.1' });
+    await server.start();
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/auth-info`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { authRequired: boolean; fingerprint: string | null };
+      expect(data.authRequired).toBe(false);
+      expect(data.fingerprint).toBeNull();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('reports authRequired=false for loopback caller even with authenticator', async () => {
+    // The probe must answer from the same vantage point as the WebSocket
+    // upgrade so the modal trusts it: loopback peers skip auth.
+    const port = basePort + 1;
+    const server = new WebSocketServer({
+      port,
+      host: '0.0.0.0',
+      connection: { authenticator },
+    });
+    await server.start();
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/auth-info`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { authRequired: boolean; fingerprint: string | null };
+      expect(data.authRequired).toBe(false);
+      // Fingerprint is exposed so the UI can pin it for TOFU.
+      expect(data.fingerprint).toBe(authenticator.serverFingerprint);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1162,9 +1162,12 @@ function App() {
       try {
         const identity = await unlockStoredIdentity(passphrase);
         setUnlockedIdentity(identity);
-        if (passphraseConnectionId) {
-          provideIdentity(passphraseConnectionId, identity);
-        }
+        // Seed the connection manager's identity ref synchronously, even if
+        // there is no pending connection yet (preflight path, #257). This
+        // avoids a race where the just-unlocked identity hasn't been pushed
+        // through useEffect by the time the WebSocket opens and gets
+        // challenged.
+        provideIdentity(passphraseConnectionId ?? ('' as ConnectionId), identity);
       } catch (err) {
         console.error('Failed to unlock identity:', err);
         throw err;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1412,6 +1412,7 @@ function App() {
         error={error}
         needsPassphrase={needsPassphrase}
         hasIdentity={hasIdentity()}
+        hasUnlockedIdentity={unlockedIdentity != null}
         serverFingerprint={passphraseServerFingerprint}
         onPassphraseSubmit={handlePassphraseSubmit}
       />

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -6,6 +6,8 @@
  */
 
 import { useKeyboard } from '@/hooks/useKeyboard';
+import { probeAuthInfo } from '@/lib/auth-probe';
+import { isIdentityEncrypted } from '@/lib/identity-client';
 import { keyboardBackdropStyle } from '@/lib/keyboard-style';
 import type { ConnectionStatus } from '@/types';
 import { clsx } from 'clsx';
@@ -23,6 +25,12 @@ interface ConnectModalProps {
   readonly hasIdentity?: boolean;
   readonly serverFingerprint?: string | null;
   readonly onPassphraseSubmit?: (passphrase: string) => Promise<void>;
+  /**
+   * True if the parent already holds an unlocked identity for this session.
+   * When set, the inline pre-flight prompt is skipped because the daemon
+   * challenge will be answered silently from the cache (#257).
+   */
+  readonly hasUnlockedIdentity?: boolean;
 }
 
 type ConnectionMode = 'local' | 'remote';
@@ -221,6 +229,7 @@ export function ConnectModal({
   hasIdentity: hasId,
   serverFingerprint,
   onPassphraseSubmit,
+  hasUnlockedIdentity = false,
 }: ConnectModalProps) {
   const [mode, setMode] = useState<ConnectionMode>('local');
   const [host, setHost] = useState(
@@ -236,20 +245,33 @@ export function ConnectModal({
   const keyboard = useKeyboard();
   const backdropStyle = keyboardBackdropStyle(keyboard);
 
+  // Pre-flight passphrase state (#257):
+  //   When the daemon advertises authRequired=true via /auth-info, surface
+  //   the passphrase prompt INSIDE the connect modal before opening the
+  //   WebSocket. This avoids the "connecting then suddenly asking for a
+  //   passphrase" jolt and makes auth feel like part of the connect step.
+  const [preflightPending, setPreflightPending] = useState<{
+    wsUrl: string;
+    fingerprint: string | null;
+  } | null>(null);
+  const [isProbing, setIsProbing] = useState(false);
+
   // Reset on close
   useEffect(() => {
     if (!isOpen) {
       setCode('');
       setHost(localStorage.getItem(LOCALSTORAGE_HOST_KEY) || 'localhost');
+      setPreflightPending(null);
+      setIsProbing(false);
     }
   }, [isOpen]);
 
   // Auto-focus host input when modal opens
   useEffect(() => {
-    if (isOpen && mode === 'local') {
+    if (isOpen && mode === 'local' && !preflightPending) {
       setTimeout(() => hostInputRef.current?.focus(), 100);
     }
-  }, [isOpen, mode]);
+  }, [isOpen, mode, preflightPending]);
 
   if (!isOpen) return null;
 
@@ -257,8 +279,15 @@ export function ConnectModal({
   const isAuthenticating = connectionStatus === 'authenticating';
   const isConnected = connectionStatus === 'connected';
 
-  // Show passphrase view when auth is needed
-  if (needsPassphrase && onPassphraseSubmit) {
+  // Show passphrase view when auth is needed: either the WebSocket is
+  // already mid-handshake and got an auth_challenge (post-connect), or the
+  // pre-flight probe surfaced auth required up-front.
+  const showPassphraseView =
+    (needsPassphrase || preflightPending != null) && onPassphraseSubmit != null;
+  const passphraseFingerprint =
+    serverFingerprint ?? preflightPending?.fingerprint ?? null;
+
+  if (showPassphraseView && onPassphraseSubmit) {
     return (
       <div
         data-testid="connect-modal-backdrop"
@@ -269,7 +298,10 @@ export function ConnectModal({
           <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
             <h2 className="text-lg font-semibold text-[var(--color-text)]">Authenticate</h2>
             <button
-              onClick={onClose}
+              onClick={() => {
+                setPreflightPending(null);
+                onClose();
+              }}
               className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
               aria-label="Close"
             >
@@ -278,9 +310,19 @@ export function ConnectModal({
           </div>
           <div className="p-4">
             <PassphraseView
-              serverFingerprint={serverFingerprint}
+              serverFingerprint={passphraseFingerprint}
               hasIdentity={hasId}
-              onSubmit={onPassphraseSubmit}
+              onSubmit={async (passphrase) => {
+                await onPassphraseSubmit(passphrase);
+                // Pre-flight: now that the identity is unlocked, open the
+                // WebSocket. The daemon will challenge, but the cached
+                // identity signs silently — no second prompt.
+                if (preflightPending) {
+                  const { wsUrl } = preflightPending;
+                  setPreflightPending(null);
+                  onConnectDirect(wsUrl);
+                }
+              }}
             />
           </div>
         </div>
@@ -288,10 +330,37 @@ export function ConnectModal({
     );
   }
 
-  const handleConnect = () => {
+  const handleConnect = async () => {
     if (mode === 'local') {
       const wsUrl = buildWsUrl(host);
       localStorage.setItem(LOCALSTORAGE_HOST_KEY, host.trim());
+
+      // Pre-flight probe (#257). When the local identity is encrypted and
+      // the user hasn't already unlocked it this session, ask the daemon
+      // whether it will challenge us. If yes, surface PassphraseView inside
+      // this modal BEFORE opening the WebSocket. Best-effort: any probe
+      // failure falls back to the legacy post-connect auth flow.
+      let identityEncrypted = false;
+      try {
+        identityEncrypted = isIdentityEncrypted();
+      } catch {
+        identityEncrypted = false;
+      }
+
+      if (identityEncrypted && !hasUnlockedIdentity && onPassphraseSubmit) {
+        setIsProbing(true);
+        let info: Awaited<ReturnType<typeof probeAuthInfo>> = null;
+        try {
+          info = await probeAuthInfo(wsUrl);
+        } finally {
+          setIsProbing(false);
+        }
+        if (info?.authRequired) {
+          setPreflightPending({ wsUrl, fingerprint: info.fingerprint });
+          return;
+        }
+      }
+
       onConnectDirect(wsUrl);
     } else if (onConnectCode) {
       onConnectCode(code);
@@ -299,9 +368,9 @@ export function ConnectModal({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && canConnect && !isConnecting) {
+    if (e.key === 'Enter' && canConnect && !isConnecting && !isProbing) {
       e.preventDefault();
-      handleConnect();
+      void handleConnect();
     }
   };
 
@@ -467,21 +536,29 @@ export function ConnectModal({
             Cancel
           </button>
           <button
-            onClick={handleConnect}
-            disabled={!canConnect || isConnecting || isAuthenticating || isConnected}
+            onClick={() => {
+              void handleConnect();
+            }}
+            disabled={
+              !canConnect || isConnecting || isAuthenticating || isConnected || isProbing
+            }
             className={clsx(
               'flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
-              canConnect && !isConnecting && !isAuthenticating && !isConnected
+              canConnect && !isConnecting && !isAuthenticating && !isConnected && !isProbing
                 ? 'bg-[var(--color-primary)] hover:bg-[var(--color-primary-dark)]'
                 : 'cursor-not-allowed bg-[var(--color-primary)]/50',
             )}
           >
-            {isConnecting || isAuthenticating ? (
+            {isConnecting || isAuthenticating || isProbing ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Monitor className="size-4" />
             )}
-            {isConnecting || isAuthenticating ? 'Discovering...' : 'Connect'}
+            {isProbing
+              ? 'Checking...'
+              : isConnecting || isAuthenticating
+                ? 'Discovering...'
+                : 'Connect'}
           </button>
         </div>
       </div>

--- a/packages/web/src/hooks/connection-manager-helpers.ts
+++ b/packages/web/src/hooks/connection-manager-helpers.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure helpers for useConnectionManager.
+ *
+ * Extracted into a separate module so tests can exercise them without
+ * pulling in React, the WebSocket client, or identity-store side effects.
+ */
+
+/**
+ * Collect all connections that are currently waiting on a passphrase so a
+ * single unlock can satisfy them at once (#257).
+ *
+ * Without this, the UI would re-prompt for every sibling daemon port (e.g.
+ * after restoring auto-connections from localStorage on launch) even though
+ * the same identity unlocks all of them.
+ */
+export function collectPendingChallengeConnections<
+  T extends { pendingChallenge: unknown; needsPassphrase: boolean },
+>(connections: Iterable<T>): T[] {
+  const out: T[] = [];
+  for (const c of connections) {
+    if (c.pendingChallenge) out.push(c);
+  }
+  return out;
+}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -594,22 +594,30 @@ export function useConnectionManager(
     [sendToConnection],
   );
 
-  // Provide identity for a connection waiting on passphrase.
+  // Provide identity for connections waiting on passphrase, and seed the
+  // identity ref synchronously for any future auto-connect (#257).
   //
   // After the user unlocks once, ALL connections with a pending challenge
   // get signed silently — including sibling daemons we auto-discovered or
-  // restored from localStorage on launch (#257). Without this, the modal
-  // would re-prompt for every sibling port even though the same identity
-  // would unlock all of them.
+  // restored from localStorage on launch. Without this, the modal would
+  // re-prompt for every sibling port even though the same identity unlocks
+  // all of them. The pre-flight modal path also calls this with no pending
+  // connection (empty connectionId) so the WebSocket opened just after gets
+  // a populated identity ref before the daemon's challenge arrives.
   const provideIdentity = useCallback(
     (connectionId: ConnectionId, identity: UnlockedIdentity) => {
       identityRef.current = identity;
 
       const pending = collectPendingChallengeConnections(connectionsMapRef.current.values());
       if (pending.length === 0) {
-        console.warn(
-          `[ConnectionManager] No pending auth challenge for "${connectionId}" or any sibling`,
-        );
+        // No-op when called as a pre-flight seed (empty connectionId).
+        // Warn only if a real connectionId was passed, since that means
+        // the caller expected a pending challenge and there was none.
+        if (connectionId) {
+          console.warn(
+            `[ConnectionManager] No pending auth challenge for "${connectionId}" or any sibling`,
+          );
+        }
         syncState();
         return;
       }

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -18,6 +18,7 @@ import { errorToString } from '@remi/shared';
 import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
 import type { ConnectionId, ConnectionState, ConnectionStatus } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
+import { collectPendingChallengeConnections } from './connection-manager-helpers';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
@@ -593,35 +594,42 @@ export function useConnectionManager(
     [sendToConnection],
   );
 
-  // Provide identity for a connection waiting on passphrase
+  // Provide identity for a connection waiting on passphrase.
+  //
+  // After the user unlocks once, ALL connections with a pending challenge
+  // get signed silently — including sibling daemons we auto-discovered or
+  // restored from localStorage on launch (#257). Without this, the modal
+  // would re-prompt for every sibling port even though the same identity
+  // would unlock all of them.
   const provideIdentity = useCallback(
     (connectionId: ConnectionId, identity: UnlockedIdentity) => {
       identityRef.current = identity;
 
-      const mc = getMc(connectionId);
-      if (!mc) {
+      const pending = collectPendingChallengeConnections(connectionsMapRef.current.values());
+      if (pending.length === 0) {
         console.warn(
-          `[ConnectionManager] Cannot provide identity: connection "${connectionId}" not found`,
+          `[ConnectionManager] No pending auth challenge for "${connectionId}" or any sibling`,
         );
-        return;
-      }
-      if (!mc.pendingChallenge) {
-        console.warn(`[ConnectionManager] No pending auth challenge for "${connectionId}"`);
+        syncState();
         return;
       }
 
-      mc.needsPassphrase = false;
+      for (const mc of pending) {
+        // Type guard already established by collectPendingChallengeConnections
+        const challenge = mc.pendingChallenge?.challenge;
+        if (!challenge) continue;
+        mc.needsPassphrase = false;
+        signChallenge(identity, challenge)
+          .then((response) => mc.client.send(response))
+          .catch((err) => {
+            mc.error = new Error(`Auth failed: ${errorToString(err)}`);
+            mc.client.disconnect();
+            syncState();
+          });
+      }
       syncState();
-
-      signChallenge(identity, mc.pendingChallenge.challenge)
-        .then((response) => mc.client.send(response))
-        .catch((err) => {
-          mc.error = new Error(`Auth failed: ${errorToString(err)}`);
-          mc.client.disconnect();
-          syncState();
-        });
     },
-    [getMc, syncState],
+    [syncState],
   );
 
   // Get hello_ack session ID directly from mutable state (avoids React state timing issues)

--- a/packages/web/src/lib/auth-probe.ts
+++ b/packages/web/src/lib/auth-probe.ts
@@ -1,0 +1,81 @@
+/**
+ * Pre-flight auth probe (#257).
+ *
+ * Lightweight HTTP GET to /auth-info on the daemon, used by the Connect
+ * modal to surface the passphrase prompt INLINE (before opening the
+ * WebSocket) when the daemon will require Ed25519 authentication.
+ *
+ * Without this probe, the user clicks Connect, sees "Connecting..." for a
+ * beat, and only then gets asked for a passphrase — making the prompt feel
+ * like an afterthought rather than part of the connect flow.
+ *
+ * The endpoint answers from the same vantage point as the WebSocket upgrade
+ * (loopback peers are exempt), so the result is authoritative.
+ */
+
+export interface AuthInfo {
+  /** True if the daemon will send an auth_challenge to this peer. */
+  readonly authRequired: boolean;
+  /** Server fingerprint, when the daemon has an identity configured. */
+  readonly fingerprint: string | null;
+}
+
+/** Default timeout for the auth probe; if the daemon is slow we just open the WS. */
+const DEFAULT_TIMEOUT_MS = 1500;
+
+/**
+ * Convert a ws://host:port/path URL to its http://host:port/auth-info form.
+ *
+ * Throws if the input cannot be parsed as a valid URL.
+ */
+export function authInfoUrl(wsUrl: string): string {
+  const u = new URL(wsUrl);
+  let scheme: string;
+  if (u.protocol === 'wss:') scheme = 'https:';
+  else if (u.protocol === 'ws:') scheme = 'http:';
+  else throw new Error(`Unsupported scheme: ${u.protocol}`);
+  return `${scheme}//${u.host}/auth-info`;
+}
+
+/**
+ * Probe the daemon's /auth-info endpoint.
+ *
+ * Returns null if the probe fails for any reason (network error, timeout,
+ * non-200, malformed JSON). Callers should treat null as "unknown" and fall
+ * back to opening the WebSocket directly — the existing post-connect auth
+ * flow still works, just without the inline modal optimization.
+ */
+export async function probeAuthInfo(
+  wsUrl: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<AuthInfo | null> {
+  let httpUrl: string;
+  try {
+    httpUrl = authInfoUrl(wsUrl);
+  } catch {
+    return null;
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  if (options.signal) {
+    if (options.signal.aborted) controller.abort();
+    else options.signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  try {
+    const res = await fetch(httpUrl, { signal: controller.signal });
+    if (!res.ok) return null;
+    const data = (await res.json()) as Partial<AuthInfo>;
+    if (typeof data.authRequired !== 'boolean') return null;
+    return {
+      authRequired: data.authRequired,
+      fingerprint: typeof data.fingerprint === 'string' ? data.fingerprint : null,
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/web/tests/lib/auth-probe.test.ts
+++ b/packages/web/tests/lib/auth-probe.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the pre-flight /auth-info probe used by the Connect modal (#257).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { authInfoUrl, probeAuthInfo } from '../../src/lib/auth-probe';
+
+describe('authInfoUrl', () => {
+  test('converts ws:// to http://', () => {
+    expect(authInfoUrl('ws://localhost:18765/ws')).toBe('http://localhost:18765/auth-info');
+  });
+
+  test('converts wss:// to https://', () => {
+    // URL strips the default port (443 for https), so the output drops it too.
+    expect(authInfoUrl('wss://example.com:443/ws')).toBe('https://example.com/auth-info');
+  });
+
+  test('preserves non-default port for wss', () => {
+    expect(authInfoUrl('wss://example.com:8443/ws')).toBe(
+      'https://example.com:8443/auth-info',
+    );
+  });
+
+  test('preserves non-default ports', () => {
+    expect(authInfoUrl('ws://192.168.1.5:18770/ws')).toBe(
+      'http://192.168.1.5:18770/auth-info',
+    );
+  });
+
+  test('handles IPv6 host', () => {
+    // URL parsing keeps brackets in the host string
+    expect(authInfoUrl('ws://[::1]:18765/ws')).toBe('http://[::1]:18765/auth-info');
+  });
+
+  test('throws on unsupported scheme', () => {
+    expect(() => authInfoUrl('http://localhost:18765/ws')).toThrow();
+    expect(() => authInfoUrl('ftp://localhost:18765/')).toThrow();
+  });
+});
+
+describe('probeAuthInfo', () => {
+  // Spin up a tiny real HTTP server per test (no mocks).
+  function startServer(handler: (req: Request) => Response | Promise<Response>) {
+    return Bun.serve({ port: 0, fetch: handler });
+  }
+
+  test('returns parsed AuthInfo on 200', async () => {
+    const server = startServer((req) => {
+      const u = new URL(req.url);
+      if (u.pathname === '/auth-info') {
+        return new Response(
+          JSON.stringify({ authRequired: true, fingerprint: 'AB:CD' }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('Not found', { status: 404 });
+    });
+    try {
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`);
+      expect(info).toEqual({ authRequired: true, fingerprint: 'AB:CD' });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns AuthInfo with null fingerprint when daemon has no auth', async () => {
+    const server = startServer(() =>
+      new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    try {
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`);
+      expect(info).toEqual({ authRequired: false, fingerprint: null });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null on non-200 response', async () => {
+    const server = startServer(() => new Response('nope', { status: 500 }));
+    try {
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`);
+      expect(info).toBeNull();
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null on malformed JSON', async () => {
+    const server = startServer(() =>
+      new Response('not json', { headers: { 'Content-Type': 'application/json' } }),
+    );
+    try {
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`);
+      expect(info).toBeNull();
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null when authRequired field is wrong type', async () => {
+    const server = startServer(() =>
+      new Response(JSON.stringify({ authRequired: 'yes please', fingerprint: null }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    try {
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`);
+      expect(info).toBeNull();
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null on network error (port not listening)', async () => {
+    // Port 1 is virtually never open. Probe should reject and we return null.
+    const info = await probeAuthInfo('ws://127.0.0.1:1/ws', { timeoutMs: 500 });
+    expect(info).toBeNull();
+  });
+
+  test('respects timeout when server hangs', async () => {
+    // Server never responds to /auth-info; probe should abort and return null.
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => new Promise(() => {
+        // never resolves
+      }),
+    });
+    try {
+      const start = Date.now();
+      const info = await probeAuthInfo(`ws://127.0.0.1:${server.port}/ws`, {
+        timeoutMs: 100,
+      });
+      const elapsed = Date.now() - start;
+      expect(info).toBeNull();
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null for unsupported scheme', async () => {
+    // authInfoUrl throws; probeAuthInfo catches and returns null.
+    const info = await probeAuthInfo('http://example.com/');
+    expect(info).toBeNull();
+  });
+});

--- a/packages/web/tests/lib/connection-manager.test.ts
+++ b/packages/web/tests/lib/connection-manager.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for connection-manager helpers.
+ *
+ * These cover the silent multi-connection identity reuse path (#257):
+ * after a single passphrase unlock, every connection that was waiting on an
+ * auth challenge must be signed in one batch — no second prompt for sibling
+ * daemon ports.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { collectPendingChallengeConnections } from '../../src/hooks/connection-manager-helpers';
+
+type FakeConn = {
+  id: string;
+  pendingChallenge: { challenge: string } | null;
+  needsPassphrase: boolean;
+};
+
+function mkConn(id: string, pending: boolean): FakeConn {
+  return {
+    id,
+    pendingChallenge: pending ? { challenge: `c-${id}` } : null,
+    needsPassphrase: pending,
+  };
+}
+
+describe('collectPendingChallengeConnections', () => {
+  test('returns only connections with a pending challenge', () => {
+    const conns: FakeConn[] = [mkConn('a', true), mkConn('b', false), mkConn('c', true)];
+    const result = collectPendingChallengeConnections(conns);
+    expect(result.map((c) => c.id)).toEqual(['a', 'c']);
+  });
+
+  test('returns empty list when no connections are pending', () => {
+    const conns: FakeConn[] = [mkConn('a', false), mkConn('b', false)];
+    expect(collectPendingChallengeConnections(conns)).toEqual([]);
+  });
+
+  test('returns empty list for empty input', () => {
+    expect(collectPendingChallengeConnections([])).toEqual([]);
+  });
+
+  test('handles a single pending connection', () => {
+    const conns: FakeConn[] = [mkConn('only', true)];
+    expect(collectPendingChallengeConnections(conns).map((c) => c.id)).toEqual(['only']);
+  });
+
+  test('preserves iteration order from the input iterable', () => {
+    // The Map values iterator order is insertion order, which matches what
+    // useConnectionManager relies on. This guards against accidentally
+    // sorting/filtering in a way that drops siblings.
+    const map = new Map<string, FakeConn>();
+    map.set('first', mkConn('first', true));
+    map.set('second', mkConn('second', false));
+    map.set('third', mkConn('third', true));
+    map.set('fourth', mkConn('fourth', true));
+    const result = collectPendingChallengeConnections(map.values());
+    expect(result.map((c) => c.id)).toEqual(['first', 'third', 'fourth']);
+  });
+});


### PR DESCRIPTION
## Summary

Three concerns from #257, addressed as three atomic commits:

- **Daemon: localhost peers skip the auth challenge.** Even when the daemon is configured with an authenticator (e.g. `--auth` on a `0.0.0.0` bind), peers connecting from `127.0.0.1`/`::1`/`localhost` are now exempt from the Ed25519 challenge — same-machine peers are trusted by virtue of being on the same machine. The web client probes the new `/auth-info` endpoint before opening the WebSocket, which answers from the same vantage point so the answer is authoritative.
  - Code: `packages/daemon/src/server/peer-helpers.ts`, `packages/daemon/src/server/websocket-server.ts`.
  - Tests: `packages/daemon/tests/peer-helpers.test.ts` (loopback detection across IPv4, IPv6, IPv4-mapped IPv6, hostname literal); `packages/daemon/tests/websocket-server-loopback-auth.test.ts` (loopback peer never receives `auth_challenge` even with authenticator on a `0.0.0.0` bind, plus `/auth-info` probe).

- **Web: passphrase prompt appears inline in the connect modal, not after the WebSocket attaches.** `ConnectModal` now probes `/auth-info` when the user clicks Connect. If auth is required and the local identity is encrypted (and not yet unlocked this session), the modal switches to `PassphraseView` BEFORE opening the WebSocket. The user enters the passphrase, the parent unlocks, and only then is the WebSocket opened so the daemon's challenge is signed silently from cache. Probe failure falls back to the legacy post-connect flow with no behavioural change.
  - Code: `packages/web/src/lib/auth-probe.ts`, `packages/web/src/components/session/ConnectModal.tsx`, `packages/web/src/App.tsx` (passes `hasUnlockedIdentity`).
  - Tests: `packages/web/tests/lib/auth-probe.test.ts` (URL conversion, happy path, malformed/non-200, network error, timeout abort, unsupported scheme).

- **Web: auto-connect to discovered sibling ports reuses the identity silently.** When multiple daemons are restored from `localStorage` on launch, each sends its own `auth_challenge` in parallel. Previously only the originating connection got signed; siblings re-prompted. `provideIdentity` now signs every connection with a pending challenge in one batch, using `collectPendingChallengeConnections` (extracted into a pure helper for testability).
  - Code: `packages/web/src/hooks/connection-manager-helpers.ts`, `packages/web/src/hooks/useConnectionManager.ts`.
  - Tests: `packages/web/tests/lib/connection-manager.test.ts` (helper preserves order, filters non-pending, handles empty input).

37 new tests, all passing. Full suite (939 tests across daemon CLI, daemon session, shared, web src, web tests) green; typecheck and biome clean.

## Test plan

- [ ] Build daemon binary, start with `remi --auth --bind 0.0.0.0`. Open the web app at `http://localhost:5173`. Click Connect with `localhost` — expect no passphrase prompt, session list loads.
- [ ] Same daemon. From iPhone (LAN) connect to the Mac's LAN IP. Expect inline passphrase prompt INSIDE the connect modal before \"Discovering...\" appears.
- [ ] After unlocking once, kill the daemon and start two siblings on adjacent ports (e.g. 18765 and 18766) with `--auth`. Reload the web app — expect a single passphrase prompt that, once submitted, silently authenticates both daemons.
- [ ] Probe failure path: stop daemon mid-probe (or block the HTTP port), confirm Connect button still works (falls back to old flow).

Fixes #257