### PR TITLE
feat(daemon): notify clients when binary updates on disk (#287)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -92,6 +92,7 @@ const cleanupStatusFile = (): void => statusWriter.cleanup();
 loadDotenvFile();
 
 import {
+  createDaemonUpdateAvailable,
   createHelloAck,
   createReplayBatch,
   createSessionListResponse,
@@ -132,6 +133,7 @@ import { createPtySessionForSession } from './cli/session-phases/pty-session-set
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { installSuspendHandler } from './cli/suspend-handler.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
+import { startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookServer } from './hooks/index.ts';
@@ -878,6 +880,12 @@ let HOOK_PORT = 0; // OS-assigned; actual port read from hookServer.port after s
 let hookServer: HookServer | null = null;
 let hookConfigManager: HookConfigManager | null = null;
 
+// Watches `dist/remi` (or whatever process.execPath resolves to) for a fresh
+// build and notifies attached clients so users know to restart their session.
+// Initialised in both wrapper and daemon modes after the WebSocket server
+// is up; cleaned up alongside hookServer in cleanup(). Issue #287.
+let updateWatcher: import('./cli/update-watcher.ts').UpdateWatcher | null = null;
+
 // Best-effort synchronous cleanup on any exit path. SIGINT/SIGTERM already
 // run the async cleanup() which calls hookConfigManager.uninstall(); this
 // handler is the last line of defense for `process.exit()` calls and
@@ -893,6 +901,28 @@ process.on('exit', () => {
 
 // mDNS publisher (initialized when daemon is network-accessible)
 let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = null;
+
+/**
+ * Start the on-disk binary watcher. Idempotent — repeated calls are no-ops.
+ * Polls every 60s; on the first detected change, broadcasts a single
+ * `daemon_update_available` to every attached client and stops itself.
+ */
+function startBinaryUpdateWatcher(): void {
+  if (updateWatcher) return;
+  updateWatcher = startUpdateWatcher({
+    binaryPath: process.execPath,
+    intervalMs: 60_000,
+    onUpdateDetected: () => {
+      log(`[update] Newer remi binary detected at ${process.execPath}; notifying clients`);
+      try {
+        registry.broadcast(createDaemonUpdateAvailable(REMI_VERSION, process.execPath));
+      } catch (err) {
+        logError(`[update] broadcast failed: ${errorToString(err)}`);
+      }
+    },
+    onError: (err) => logError(`[update] ${err.message}`),
+  });
+}
 
 // Watcher for live-sessions directory (pushes session list updates on new daemon startup)
 let liveSessionsWatcher: import('node:fs').FSWatcher | null = null;
@@ -1321,6 +1351,11 @@ async function cleanup(): Promise<void> {
     hookConfigManager = null;
   }
 
+  if (updateWatcher) {
+    updateWatcher.stop();
+    updateWatcher = null;
+  }
+
   if (mdnsPublisher) {
     try {
       await mdnsPublisher.stop();
@@ -1466,6 +1501,10 @@ if (cliDaemonMode) {
     name: path.basename(workingDirectory),
     startedAt: new Date().toISOString(),
   });
+
+  // Notify attached clients when a new dist/remi build replaces this binary
+  // on disk so they know to restart their session (#287).
+  startBinaryUpdateWatcher();
 
   // Create the PTY session
   try {
@@ -1659,6 +1698,10 @@ if (cliDaemonMode) {
       name: path.basename(workingDirectory),
       startedAt: new Date().toISOString(),
     });
+
+    // Notify attached clients when a new dist/remi build replaces this binary
+    // on disk so they know to restart their session (#287).
+    startBinaryUpdateWatcher();
 
     // Watch for new daemons registering in live-sessions and push updates to clients.
     // This lets clients auto-connect when a sibling session starts in the same directory.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -906,16 +906,30 @@ let mdnsPublisher: import('./mdns/mdns-publisher.ts').MdnsPublisher | null = nul
  * Start the on-disk binary watcher. Idempotent — repeated calls are no-ops.
  * Polls every 60s; on the first detected change, broadcasts a single
  * `daemon_update_available` to every attached client and stops itself.
+ *
+ * Skips activation when `process.execPath` does not look like the compiled
+ * remi binary. `bun run packages/daemon/src/cli.ts` (dev) or an npm-wrapper
+ * install that invokes a runtime (bun, node) directly would otherwise have
+ * the watcher tracking the runtime instead of remi — and a `brew upgrade
+ * bun` would silently misfire as "remi update available". The guard mirrors
+ * `daemon-manager.ts`'s existing endsWith('/remi') convention. Issue #287
+ * review (PR #370).
  */
 function startBinaryUpdateWatcher(): void {
   if (updateWatcher) return;
+  const execPath = process.execPath;
+  const isRemiBinary = execPath.endsWith('/remi') || execPath.endsWith('\\remi');
+  if (!isRemiBinary) {
+    log(`[update] Watcher disabled: execPath ${execPath} is not the remi binary`);
+    return;
+  }
   updateWatcher = startUpdateWatcher({
-    binaryPath: process.execPath,
+    binaryPath: execPath,
     intervalMs: 60_000,
     onUpdateDetected: () => {
-      log(`[update] Newer remi binary detected at ${process.execPath}; notifying clients`);
+      log(`[update] Newer remi binary detected at ${execPath}; notifying clients`);
       try {
-        registry.broadcast(createDaemonUpdateAvailable(REMI_VERSION, process.execPath));
+        registry.broadcast(createDaemonUpdateAvailable(REMI_VERSION, execPath));
       } catch (err) {
         logError(`[update] broadcast failed: ${errorToString(err)}`);
       }

--- a/packages/daemon/src/cli/update-watcher.ts
+++ b/packages/daemon/src/cli/update-watcher.ts
@@ -1,0 +1,103 @@
+/**
+ * Detect when the running remi binary has been rebuilt on disk.
+ *
+ * Long-lived wrapper processes load their code at startup, so a fresh
+ * `dist/remi` build does NOT take effect until the user kills + restarts
+ * the session. Issue #287 calls this out as the single most frustrating
+ * thing about iterating on remi: every shipped fix is invisible to
+ * already-running wrappers. We can't safely hot-swap the running PTY,
+ * but we CAN tell the user so they know to restart.
+ *
+ * On startup, record the inode + mtime of `process.execPath`. Poll
+ * every `intervalMs`; when the inode or mtime changes from what we
+ * recorded, fire `onUpdateDetected(currentMtime)` exactly once and
+ * stop polling. The caller decides what to do with the signal — today
+ * cli.ts logs and sends a `daemon_update_available` protocol message
+ * so attached clients can surface a "restart to pick up update" banner.
+ *
+ * Pure file-system poll, no signal-handling, no exec — small and
+ * testable. Real fs writes drive the test.
+ */
+
+import * as fs from 'node:fs';
+import { errorToString } from '@remi/shared';
+
+export interface UpdateWatcherDeps {
+  /** Path of the binary to watch — typically `process.execPath`. */
+  readonly binaryPath: string;
+  /** Poll cadence. */
+  readonly intervalMs: number;
+  /** Called once when a newer mtime / different inode is observed. */
+  readonly onUpdateDetected: (newMtimeMs: number) => void;
+  /**
+   * Called for unexpected stat errors. Errors do not stop the watcher
+   * (transient I/O hiccups happen); only ENOENT during shutdown does.
+   * Defaults to a no-op so tests don't have to wire it up.
+   */
+  readonly onError?: (err: Error) => void;
+}
+
+export interface UpdateWatcher {
+  /** Stop polling and release the timer. Idempotent. */
+  stop(): void;
+  /**
+   * Initial baseline. `null` if the binary was missing or unreadable
+   * at start; in that case the watcher will never fire (we have no
+   * baseline to compare against).
+   */
+  readonly baselineMtimeMs: number | null;
+}
+
+/** Start watching. Returns an UpdateWatcher with a `stop()` method. */
+export function startUpdateWatcher(deps: UpdateWatcherDeps): UpdateWatcher {
+  const onError = deps.onError ?? (() => {});
+
+  let baseline: { mtimeMs: number; ino: number } | null = null;
+  try {
+    const st = fs.statSync(deps.binaryPath);
+    baseline = { mtimeMs: st.mtimeMs, ino: st.ino };
+  } catch (err) {
+    onError(new Error(`update-watcher: cannot stat ${deps.binaryPath}: ${errorToString(err)}`));
+  }
+
+  let fired = false;
+  const timer = setInterval(() => {
+    if (fired || !baseline) return;
+    let st: fs.Stats;
+    try {
+      st = fs.statSync(deps.binaryPath);
+    } catch (err) {
+      // ENOENT: binary was removed (during a build that swaps the file).
+      // The next iteration will see the new file. Don't escalate.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') onError(new Error(errorToString(err)));
+      return;
+    }
+
+    // mtime moves backwards on a tar restore but never matters for us;
+    // any change away from the baseline (forward OR inode swap) means
+    // the file has been rewritten. Inode change covers atomic-rename
+    // builds where mtime might be older than the previous file's.
+    if (st.mtimeMs !== baseline.mtimeMs || st.ino !== baseline.ino) {
+      fired = true;
+      try {
+        deps.onUpdateDetected(st.mtimeMs);
+      } catch (err) {
+        onError(err instanceof Error ? err : new Error(errorToString(err)));
+      }
+      clearInterval(timer);
+    }
+  }, deps.intervalMs);
+
+  // Don't keep the event loop alive just for the watcher.
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+
+  return {
+    baselineMtimeMs: baseline?.mtimeMs ?? null,
+    stop(): void {
+      clearInterval(timer);
+    },
+  };
+}

--- a/packages/daemon/tests/cli/update-watcher.test.ts
+++ b/packages/daemon/tests/cli/update-watcher.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { startUpdateWatcher } from '../../src/cli/update-watcher.ts';
+
+describe('startUpdateWatcher (#287)', () => {
+  let tmpDir: string;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-update-watcher-'));
+    binaryPath = path.join(tmpDir, 'fake-remi');
+    // Ensure mtime resolution lets us distinguish writes — most platforms
+    // give us 1ms resolution but some test runners run fast enough that two
+    // back-to-back writes register identical mtimes. Add a small explicit
+    // delta below where needed.
+    fs.writeFileSync(binaryPath, 'v0', { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('records baseline mtime on start', () => {
+    const baseline = fs.statSync(binaryPath).mtimeMs;
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 50,
+      onUpdateDetected: () => {},
+    });
+    try {
+      expect(watcher.baselineMtimeMs).toBe(baseline);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  test('fires onUpdateDetected once when binary mtime changes', async () => {
+    const detected: number[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 25,
+      onUpdateDetected: (m) => detected.push(m),
+    });
+    try {
+      // Bump mtime forward by a wide margin so the file system definitely
+      // sees a different value, even on coarse-resolution mtime stores.
+      const future = new Date(Date.now() + 2_000);
+      fs.utimesSync(binaryPath, future, future);
+      // Wait for at least two poll intervals so the watcher had a chance.
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(detected).toHaveLength(1);
+      // And no further fires from a second modification — the watcher
+      // is one-shot by design.
+      const later = new Date(Date.now() + 4_000);
+      fs.utimesSync(binaryPath, later, later);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(detected).toHaveLength(1);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  test('fires when the binary is replaced via atomic rename (different inode)', async () => {
+    // Builders typically write to a tmp file and rename; the new file may
+    // share the same mtime as the old one if the system clock is coarse.
+    // Inode change is the reliable signal in that case.
+    const detected: number[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 25,
+      onUpdateDetected: (m) => detected.push(m),
+    });
+    try {
+      const tmpReplacement = `${binaryPath}.tmp`;
+      fs.writeFileSync(tmpReplacement, 'v1', { mode: 0o755 });
+      fs.renameSync(tmpReplacement, binaryPath);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(detected).toHaveLength(1);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  test('survives transient ENOENT during the rename window', async () => {
+    // Between the write of binary.tmp and rename(binary.tmp -> binary)
+    // the watcher might stat() and see ENOENT. That must not crash and
+    // must not fire onUpdateDetected (the file is back almost immediately).
+    const errors: Error[] = [];
+    const detected: number[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 25,
+      onUpdateDetected: (m) => detected.push(m),
+      onError: (err) => errors.push(err),
+    });
+    try {
+      // Briefly remove the binary.
+      fs.unlinkSync(binaryPath);
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      // Recreate at a NEW mtime so the watcher fires on the next tick.
+      const future = new Date(Date.now() + 2_000);
+      fs.writeFileSync(binaryPath, 'v1', { mode: 0o755 });
+      fs.utimesSync(binaryPath, future, future);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      // ENOENT is silently absorbed (no onError call), and the recreated
+      // file with a new mtime fires onUpdateDetected exactly once.
+      expect(errors).toHaveLength(0);
+      expect(detected).toHaveLength(1);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  test('reports null baseline + never fires when binary is missing at start', async () => {
+    const missing = path.join(tmpDir, 'does-not-exist');
+    const detected: number[] = [];
+    const errors: Error[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath: missing,
+      intervalMs: 25,
+      onUpdateDetected: (m) => detected.push(m),
+      onError: (err) => errors.push(err),
+    });
+    try {
+      // Initial stat fails → onError called once with the stat failure.
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(watcher.baselineMtimeMs).toBeNull();
+
+      // Even if the file appears later, we have no baseline to compare
+      // against, so onUpdateDetected stays unfired. This is by design —
+      // a missing binary at startup means we cannot know what version
+      // we are running, so a "newer" signal would be meaningless.
+      fs.writeFileSync(missing, 'v1', { mode: 0o755 });
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(detected).toEqual([]);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  test('stop() is idempotent and stops further polling', async () => {
+    const detected: number[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 25,
+      onUpdateDetected: (m) => detected.push(m),
+    });
+    watcher.stop();
+    watcher.stop(); // second call must not throw
+
+    // Mutate the file and confirm no detection fires after stop.
+    const future = new Date(Date.now() + 2_000);
+    fs.utimesSync(binaryPath, future, future);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(detected).toEqual([]);
+  });
+
+  test('onError thrown from onUpdateDetected does not break the watcher', async () => {
+    const errors: Error[] = [];
+    const watcher = startUpdateWatcher({
+      binaryPath,
+      intervalMs: 25,
+      onUpdateDetected: () => {
+        throw new Error('client handler exploded');
+      },
+      onError: (err) => errors.push(err),
+    });
+    try {
+      const future = new Date(Date.now() + 2_000);
+      fs.utimesSync(binaryPath, future, future);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.message).toContain('client handler exploded');
+    } finally {
+      watcher.stop();
+    }
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,7 @@ export type {
   DetachSessionAckMessage,
   RegisterDeviceTokenMessage,
   SessionResetMessage,
+  DaemonUpdateAvailableMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -123,6 +124,7 @@ export {
   createDetachSessionAck,
   createRegisterDeviceToken,
   createSessionReset,
+  createDaemonUpdateAvailable,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -99,7 +99,8 @@ export type ProtocolMessage =
   | DetachSessionMessage
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
-  | SessionResetMessage;
+  | SessionResetMessage
+  | DaemonUpdateAvailableMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -532,6 +533,30 @@ export interface RegisterDeviceTokenMessage {
   readonly platform: 'ios' | 'android';
 }
 
+/**
+ * Daemon notifies attached clients that a newer remi binary is on disk.
+ *
+ * The running wrapper is locked to its startup-time code and cannot be
+ * hot-swapped without disrupting the user's PTY session. This message
+ * lets the client surface a "restart this session to pick up vNEW"
+ * banner so the user knows their fix landed but is not yet live.
+ *
+ * Fired at most once per wrapper lifetime by the on-disk binary watcher
+ * (cli/update-watcher.ts). Issue #287.
+ */
+export interface DaemonUpdateAvailableMessage {
+  readonly type: 'daemon_update_available';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Version this wrapper is running. */
+  readonly currentVersion: string;
+  /**
+   * Path of the binary detected as updated. Useful for diagnostics if
+   * the user has multiple remi installs (Homebrew vs npm vs symlink).
+   */
+  readonly binaryPath: string;
+}
+
 /** Notification that a Claude session restarted within the same Remi session */
 export interface SessionResetMessage {
   readonly type: 'session_reset';
@@ -651,6 +676,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'detach_session',
     'detach_session_ack',
     'register_device_token',
+    'daemon_update_available',
     'session_reset',
   ];
 
@@ -1279,6 +1305,24 @@ export function createRegisterDeviceToken(
     timestamp: now(),
     token,
     platform,
+  };
+}
+
+/**
+ * Create a daemon-update-available notification. Daemon fires this once
+ * when its on-disk binary has been replaced (issue #287); the client
+ * surfaces a "restart to pick up update" prompt.
+ */
+export function createDaemonUpdateAvailable(
+  currentVersion: string,
+  binaryPath: string,
+): DaemonUpdateAvailableMessage {
+  return {
+    type: 'daemon_update_available',
+    id: generateId(),
+    timestamp: now(),
+    currentVersion,
+    binaryPath,
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the daemon-side of #287. Long-lived wrappers (one per Claude Code session) load their code at startup, so a fresh \`dist/remi\` build never reaches them — every shipped fix stays invisible until the user restarts the session. Today's eight merged develop fixes (APNS, sibling lock, Ctrl+Z, hook narrowing, modal layout, auth timing, etc.) all suffer from this.

Hot-swapping the running PTY is too risky to do silently. The next-best behaviour is to **tell the user**, so they restart on their own schedule.

### What's in this PR

- **\`packages/daemon/src/cli/update-watcher.ts\`** — polls \`process.execPath\` every 60s. First detected mtime or inode change fires \`onUpdateDetected\` exactly once and stops itself. Atomic-rename builds (write tmp + rename) are covered by inode-change detection. Transient ENOENT during the rename window is silently absorbed.
- **\`packages/shared/src/protocol.ts\`** — new \`daemon_update_available\` message type with \`currentVersion\` + \`binaryPath\`. Added to the protocol union and \`validTypes\` list.
- **\`packages/daemon/src/cli.ts\`** — wires \`startBinaryUpdateWatcher()\` after the live-sessions register in both daemon and wrapper modes. The callback broadcasts the new message via \`registry.broadcast\`. Cleanup joins the existing \`hookServer.stop\` path.

### What's NOT in this PR

Client-side rendering of the \"restart to pick up update\" banner. The protocol message is now available; the iOS / web side can subscribe in a follow-up. This separation keeps the daemon change small and shippable today.

## Test plan

- [x] 7 new unit tests in \`packages/daemon/tests/cli/update-watcher.test.ts\` covering: baseline mtime recording, mtime-change detection, inode-change detection (atomic-rename build), ENOENT survival, missing-binary-at-start path (no baseline → never fires), idempotent stop, and client-handler-throws isolation.
- [x] \`bun test packages/daemon/tests/cli packages/daemon/tests/session packages/shared/tests\` — 894 pass.
- [x] \`bun run typecheck\` — clean.
- [x] \`bunx biome check\` (touched files) — clean.
- [ ] Manual: run wrapper, rebuild \`dist/remi\` in a second terminal, observe the new \`Push notification sent\`-style log line in \`~/.remi/remi.log\` ("Newer remi binary detected at ...; notifying clients") and confirm a connected client receives the protocol message.

## Follow-up

Track the client-side banner UI as a follow-up — opening that issue now if it doesn't already exist.

Fixes #287