### PR TITLE
refactor(web): extract push-answer URL resolver with full test coverage (#278)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,6 +13,7 @@ import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
+import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import type {
   AppSettings,
   ConnectionId,
@@ -892,54 +893,38 @@ function App() {
 
       const answerMsg = createAnswer(sessionId as UUID, questionId as UUID, answer);
 
-      // Find the session in our session list to get its connectionId
-      const session = sessionsRef.current.find((s) => s.id === sessionId);
-      const connectionId = session?.connectionId;
+      // Read the persisted URL list once; pass into the pure resolver.
+      let storedUrls: string[] = [];
+      try {
+        const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
+        if (stored) storedUrls = JSON.parse(stored) as string[];
+      } catch {
+        // localStorage unavailable or corrupted; resolver treats empty as cold-start.
+      }
 
-      // Check if the connection is already live
-      const conn = connectionId
-        ? connectionsRef.current.find((c) => c.connectionId === connectionId)
-        : undefined;
+      const target = resolvePushAnswerTarget({
+        sessionId,
+        sessions: sessionsRef.current,
+        connections: connectionsRef.current,
+        storedUrls,
+      });
 
-      // Fast path: connection is live, try to send immediately
-      if (conn?.status === 'connected' && connectionId) {
-        const sent = pushAnswerSendRef.current(connectionId, answerMsg);
+      if (target.kind === 'live' && target.connectionId) {
+        const sent = pushAnswerSendRef.current(target.connectionId as ConnectionId, answerMsg);
         if (sent) return;
-        // Send returned false (dead socket); fall through to reconnect
+        // Send returned false (dead socket); fall through and let the
+        // reconnect path below pick this URL up.
       }
 
-      // Resolve the daemon URL: from existing connection, or from localStorage (cold start)
-      let connUrl = conn?.url;
-      if (!connUrl) {
-        try {
-          const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
-          if (stored) {
-            const urls: string[] = JSON.parse(stored);
-            if (urls.length > 0) {
-              connUrl = urls[0];
-            }
-          }
-        } catch {
-          // localStorage unavailable or corrupted; ignore
-        }
-      }
-
-      if (!connUrl) {
+      if (target.kind === 'unreachable' || !target.url) {
         notifyFailure();
         return;
       }
 
-      // Check if a connection to this URL is already being established (e.g. auto-connect on mount)
-      const existingConn = connectionsRef.current.find(
-        (c) =>
-          c.url === connUrl &&
-          (c.status === 'connecting' ||
-            c.status === 'authenticating' ||
-            c.status === 'reconnecting'),
-      );
-      const targetConnId = existingConn
-        ? existingConn.connectionId
-        : connectDirectRef.current(connUrl);
+      const targetConnId: ConnectionId =
+        target.kind === 'pending' && target.connectionId
+          ? (target.connectionId as ConnectionId)
+          : connectDirectRef.current(target.url);
 
       // Wait for connection with 10s timeout, then send answer
       const ANSWER_TIMEOUT_MS = 10_000;

--- a/packages/web/src/lib/push-answer-resolver.ts
+++ b/packages/web/src/lib/push-answer-resolver.ts
@@ -1,0 +1,110 @@
+/**
+ * Helpers for routing a push-notification answer back to the right daemon.
+ *
+ * When the user taps an "Allow" / "Deny" action on the iOS lock screen,
+ * `App.tsx` receives a `push-notification-answer` CustomEvent with the
+ * sessionId, questionId, and answer value. The handler then needs to:
+ *
+ *   1. Locate the session in the in-memory session list to find its
+ *      `connectionId` (so the answer goes to the right daemon when the
+ *      iOS client is attached to multiple).
+ *   2. If a live connection exists, send immediately.
+ *   3. Otherwise pick a daemon URL to (re)connect to — preferably the URL
+ *      the dead connection had, falling back to the first URL persisted
+ *      to localStorage (cold-start path: app was suspended, lock-screen
+ *      tap brought it back, no connection map exists yet).
+ *   4. Wait briefly for the connection, send.
+ *
+ * Steps 1-3 are pure data manipulation that this module owns; step 4 is
+ * the React/refs layer in App.tsx. Keeping the URL-resolution pure here
+ * is the only way to unit-test it — the web package does not currently
+ * ship a DOM/component test runner. Issue #278.
+ */
+
+interface SessionRef {
+  readonly id: string;
+  readonly connectionId?: string | null;
+}
+
+interface ConnectionRef {
+  readonly connectionId: string;
+  readonly url: string;
+  readonly status:
+    | 'connected'
+    | 'connecting'
+    | 'authenticating'
+    | 'reconnecting'
+    | 'disconnected'
+    | 'error';
+}
+
+export interface ResolvedAnswerTarget {
+  /**
+   * `live` — the connection is up; caller should send `answerMsg` directly
+   * via `connectionId`.
+   * `reconnect` — caller should `connectDirect(url)` and then poll for the
+   * connection becoming `connected` before sending.
+   * `pending` — a connect to this URL is already in flight; caller should
+   * poll the existing `connectionId` for `connected` then send.
+   * `unreachable` — no live connection, no usable URL anywhere; caller
+   * should surface a notification telling the user to open the app.
+   */
+  readonly kind: 'live' | 'reconnect' | 'pending' | 'unreachable';
+  readonly connectionId?: string;
+  readonly url?: string;
+}
+
+/**
+ * Look up the answer's session in `sessions`, find its connection in
+ * `connections`, and decide what to do. The function does NOT mutate or
+ * dispatch anything — it just reports the decision.
+ */
+export function resolvePushAnswerTarget(input: {
+  readonly sessionId: string;
+  readonly sessions: readonly SessionRef[];
+  readonly connections: readonly ConnectionRef[];
+  readonly storedUrls: readonly string[];
+}): ResolvedAnswerTarget {
+  const { sessionId, sessions, connections, storedUrls } = input;
+
+  const session = sessions.find((s) => s.id === sessionId);
+  const connectionId = session?.connectionId ?? undefined;
+
+  // 1. Live connection for this session — send immediately.
+  if (connectionId) {
+    const conn = connections.find((c) => c.connectionId === connectionId);
+    if (conn?.status === 'connected') {
+      return { kind: 'live', connectionId, url: conn.url };
+    }
+    // 2. We know the URL but the connection is down; reconnect.
+    if (conn?.url) {
+      const inflight = connections.find(
+        (c) =>
+          c.url === conn.url &&
+          (c.status === 'connecting' ||
+            c.status === 'authenticating' ||
+            c.status === 'reconnecting'),
+      );
+      if (inflight) {
+        return { kind: 'pending', connectionId: inflight.connectionId, url: conn.url };
+      }
+      return { kind: 'reconnect', url: conn.url };
+    }
+  }
+
+  // 3. Cold start: no session-bound URL, fall back to localStorage.
+  const cold = storedUrls[0];
+  if (!cold) return { kind: 'unreachable' };
+
+  const inflight = connections.find(
+    (c) =>
+      c.url === cold &&
+      (c.status === 'connecting' ||
+        c.status === 'authenticating' ||
+        c.status === 'reconnecting'),
+  );
+  if (inflight) {
+    return { kind: 'pending', connectionId: inflight.connectionId, url: cold };
+  }
+  return { kind: 'reconnect', url: cold };
+}

--- a/packages/web/tests/lib/push-answer-resolver.test.ts
+++ b/packages/web/tests/lib/push-answer-resolver.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+import { resolvePushAnswerTarget } from '../../src/lib/push-answer-resolver';
+
+const session = (id: string, connectionId: string | null = null) => ({ id, connectionId });
+const conn = (
+  connectionId: string,
+  url: string,
+  status:
+    | 'connected'
+    | 'connecting'
+    | 'authenticating'
+    | 'reconnecting'
+    | 'disconnected'
+    | 'error',
+) => ({ connectionId, url, status }) as const;
+
+describe('resolvePushAnswerTarget (#278)', () => {
+  test('live connection — answer goes straight through', () => {
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's1',
+        sessions: [session('s1', 'c1')],
+        connections: [conn('c1', 'ws://daemon-a/ws', 'connected')],
+        storedUrls: [],
+      }),
+    ).toEqual({ kind: 'live', connectionId: 'c1', url: 'ws://daemon-a/ws' });
+  });
+
+  test('multi-daemon: routes to the connection that owns the session, not just any live one', () => {
+    // Two attached daemons; the question came from daemon B. The answer
+    // must NOT go to daemon A's WebSocket.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's2',
+        sessions: [session('s1', 'c-A'), session('s2', 'c-B')],
+        connections: [
+          conn('c-A', 'ws://daemon-a/ws', 'connected'),
+          conn('c-B', 'ws://daemon-b/ws', 'connected'),
+        ],
+        storedUrls: [],
+      }),
+    ).toEqual({ kind: 'live', connectionId: 'c-B', url: 'ws://daemon-b/ws' });
+  });
+
+  test('connection known but down — reconnect to its URL', () => {
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's1',
+        sessions: [session('s1', 'c1')],
+        connections: [conn('c1', 'ws://daemon-a/ws', 'disconnected')],
+        storedUrls: ['ws://daemon-z/ws'],
+      }),
+    ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+  });
+
+  test('connection in-flight — caller should poll the existing attempt instead of starting another', () => {
+    // The auto-reconnect-on-mount may already be reaching the same URL; the
+    // resolver picks that connection so the caller does not race a new one.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's1',
+        sessions: [session('s1', 'c1')],
+        connections: [
+          conn('c1', 'ws://daemon-a/ws', 'disconnected'),
+          conn('c2', 'ws://daemon-a/ws', 'connecting'),
+        ],
+        storedUrls: [],
+      }),
+    ).toEqual({ kind: 'pending', connectionId: 'c2', url: 'ws://daemon-a/ws' });
+  });
+
+  test('cold start: no session in memory — fall back to first localStorage URL', () => {
+    // App was suspended; lock-screen tap brought it back; sessions list is
+    // empty until reconnect. localStorage holds the URLs we were attached to.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's-unknown',
+        sessions: [],
+        connections: [],
+        storedUrls: ['ws://daemon-a/ws', 'ws://daemon-b/ws'],
+      }),
+    ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+  });
+
+  test('cold start: localStorage url already mid-connect — reuse the in-flight attempt', () => {
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's-unknown',
+        sessions: [],
+        connections: [conn('c-boot', 'ws://daemon-a/ws', 'authenticating')],
+        storedUrls: ['ws://daemon-a/ws'],
+      }),
+    ).toEqual({ kind: 'pending', connectionId: 'c-boot', url: 'ws://daemon-a/ws' });
+  });
+
+  test('unreachable: nothing live, nothing stored — caller surfaces a "open the app" notification', () => {
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's-unknown',
+        sessions: [],
+        connections: [],
+        storedUrls: [],
+      }),
+    ).toEqual({ kind: 'unreachable' });
+  });
+
+  test('session has connectionId but no matching connection record — fall through to cold-start path', () => {
+    // The session list says we were attached, but the connection got pruned.
+    // Without a URL to reconnect to and no localStorage, we are stuck.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's1',
+        sessions: [session('s1', 'c-stale')],
+        connections: [],
+        storedUrls: [],
+      }),
+    ).toEqual({ kind: 'unreachable' });
+  });
+
+  test('session has connectionId but no matching record — uses storedUrls fallback', () => {
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's1',
+        sessions: [session('s1', 'c-stale')],
+        connections: [],
+        storedUrls: ['ws://daemon-a/ws'],
+      }),
+    ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #278's actionable-notification chain (lock-screen Allow / Deny tap → daemon answer) is fully scaffolded today, verified by code walk:

- **Daemon** (\`message-api-setup.ts\`) selects \`REMI_YN\` / \`REMI_YNA\` / \`REMI_MULTI\` category and forwards \`opt_X\` data per question option.
- **Signaling** (\`signaling/index.ts\`) forwards category + options to APNS as custom data.
- **iOS native** (\`AppDelegate.swift\`) registers categories with action buttons.
- **iOS web** (\`notifications.ts\`) parses \`actionId.startsWith('OPT_')\` and dispatches \`push-notification-answer\` with \`{sessionId, questionId, answer}\`.
- **App.tsx** listens, finds the right session/connection, sends or reconnects + waits.

The end-to-end chain is intact; the remaining risk lived in App.tsx's inline 60-line \`handlePushAnswer\` — it does multi-daemon routing, dead-socket fallback, cold-start URL resolution from localStorage, and in-flight-attempt reuse, all without tests because the web package has no DOM test runner.

## What this PR ships

\`packages/web/src/lib/push-answer-resolver.ts\` — pure data-manipulation helper that takes \`{sessionId, sessions, connections, storedUrls}\` and returns \`{kind, connectionId?, url?}\` where \`kind\` is one of \`live\` / \`reconnect\` / \`pending\` / \`unreachable\`. App.tsx now calls this and just acts on the decision.

## Test plan

- [x] \`packages/web/tests/lib/push-answer-resolver.test.ts\` — 9 tests covering: live happy path, multi-daemon session-correct routing, known-but-down reconnect, in-flight reuse (no double connect), cold-start localStorage fallback, cold-start in-flight reuse, fully unreachable, stale connectionId with no fallback, stale connectionId with fallback URL. All pass.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run build\` (web) clean.
- [x] \`bunx biome check\` — 14 pre-existing warnings only.
- [ ] iOS simulator: register a question while disconnected, tap the lock-screen action, observe the answer reaching the daemon.

## What is NOT in this PR

The signaling worker's \`/push\` endpoint has no integration tests today — none of the existing test files cover it. That's a separate testing follow-up; calling it out here so it isn't lost.

Fixes #278