### PR TITLE
fix(hooks): pre-empt Notification dedup before auto-approve eval (#379, #377)

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -422,6 +422,19 @@ export function setupHookBridge(
 
     // Auto-approve gate: evaluate before creating a Question object.
     if (autoApproveService) {
+      // Pre-emptively mark this PermissionRequest as in-flight so the
+      // Notification(permission_prompt) hook that Claude Code emits a few ms
+      // later is suppressed by the bridge's dedup window. Without this, slow
+      // LLM evaluation (>tens of ms) lets Notification slip through and emit
+      // a phantom Question with the default 3-option set, firing a push for
+      // a prompt auto-approve is about to handle silently. See #379 (race)
+      // and #377 (resulting duplicate push).
+      // The inject() path below ALSO calls markPermissionHandled() on success,
+      // which refreshes the timestamp; the escalateToUser() path emits the
+      // canonical question via handlePermissionRequest, which itself sets
+      // lastPermissionEmitAt. Calling here is purely additive coverage for
+      // the eval-in-progress window.
+      hookBridge.markPermissionHandled();
       const aaService = autoApproveService;
       aaService
         .evaluate(input.tool_name, input.tool_input, sessionTag)

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -412,28 +412,29 @@ export function setupHookBridge(
     // Safe escalation to the user. Used when inject fails or when auto-approve
     // is off and we're in main context. Wrapped so bridge/push failures don't
     // leave the hook handler with a dangling unhandled rejection.
+    // On throw we clear the pre-emptive dedup mark so the trailing
+    // Notification(permission_prompt) can surface a fallback question
+    // instead of being silently suppressed for 5 s.
     const escalateToUser = () => {
       try {
         handlers.onPermissionRequest?.(input);
       } catch (err) {
         logError(`[AutoApprove ${sessionTag}] escalateToUser threw:`, err);
+        hookBridge.clearPermissionHandled();
       }
     };
 
     // Auto-approve gate: evaluate before creating a Question object.
     if (autoApproveService) {
-      // Pre-emptively mark this PermissionRequest as in-flight so the
-      // Notification(permission_prompt) hook that Claude Code emits a few ms
-      // later is suppressed by the bridge's dedup window. Without this, slow
-      // LLM evaluation (>tens of ms) lets Notification slip through and emit
-      // a phantom Question with the default 3-option set, firing a push for
-      // a prompt auto-approve is about to handle silently. See #379 (race)
-      // and #377 (resulting duplicate push).
-      // The inject() path below ALSO calls markPermissionHandled() on success,
-      // which refreshes the timestamp; the escalateToUser() path emits the
-      // canonical question via handlePermissionRequest, which itself sets
-      // lastPermissionEmitAt. Calling here is purely additive coverage for
-      // the eval-in-progress window.
+      // Pre-empt the Notification(permission_prompt) dedup window before
+      // kicking off async evaluation: Claude Code emits Notification ~10 ms
+      // after PermissionRequest, well inside any LLM eval latency, and
+      // without this mark a phantom 3-option question + push would fire
+      // for a prompt auto-approve is about to handle silently.
+      // Refresh after eval is the inject()/handlePermissionRequest's
+      // responsibility; this call only covers the eval-in-progress gap.
+      // Failure paths must call clearPermissionHandled() to keep the
+      // Notification fallback usable.
       hookBridge.markPermissionHandled();
       const aaService = autoApproveService;
       aaService
@@ -469,6 +470,10 @@ export function setupHookBridge(
             escalateToUser();
           } catch (inner) {
             logError(`[AutoApprove ${sessionTag}] catch handler threw:`, inner);
+            // Both eval AND escalation failed: clear the dedup mark so the
+            // trailing Notification(permission_prompt) becomes the fallback
+            // question. Otherwise the user sees nothing for 5 s.
+            hookBridge.clearPermissionHandled();
           }
         });
       return;

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -72,9 +72,15 @@ export class HookEventBridge {
     return this.subagentContext.isInSubagentContext();
   }
 
-  /** Mark that a PermissionRequest was handled externally (e.g. by auto-approve).
-   *  Sets the dedup timestamp so the subsequent Notification(permission_prompt)
-   *  is suppressed instead of generating a phantom notification. */
+  /** Mark that a PermissionRequest is being handled externally (e.g. by
+   *  auto-approve). Sets the dedup timestamp so the subsequent
+   *  Notification(permission_prompt) is suppressed instead of generating a
+   *  phantom notification.
+   *
+   *  Callers should invoke this BEFORE starting a slow operation (e.g. LLM
+   *  evaluation) so the dedup window is open when Notification arrives,
+   *  AND again after the operation resolves successfully (to refresh the
+   *  timestamp in case the operation outlived the original window). */
   markPermissionHandled(): void {
     this.lastPermissionEmitAt = Date.now();
   }

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -77,12 +77,24 @@ export class HookEventBridge {
    *  Notification(permission_prompt) is suppressed instead of generating a
    *  phantom notification.
    *
-   *  Callers should invoke this BEFORE starting a slow operation (e.g. LLM
-   *  evaluation) so the dedup window is open when Notification arrives,
-   *  AND again after the operation resolves successfully (to refresh the
-   *  timestamp in case the operation outlived the original window). */
+   *  Call this BEFORE starting a slow op (e.g. LLM evaluation) so the
+   *  Notification arriving mid-flight is suppressed. Callers must ensure
+   *  the timestamp is refreshed if the op can outlive PERMISSION_DEDUP_WINDOW_MS,
+   *  either by re-invoking this method or via a downstream write to
+   *  lastPermissionEmitAt (e.g. handlePermissionRequest does this on the
+   *  escalation path). */
   markPermissionHandled(): void {
     this.lastPermissionEmitAt = Date.now();
+  }
+
+  /** Clear the dedup mark so the NEXT Notification(permission_prompt) is
+   *  treated as a fresh standalone notification. Use when an externally-
+   *  handled PermissionRequest path FAILS (escalation throws, catch handler
+   *  exhausts) so the Notification fallback can still surface a question
+   *  to the user. Without this, a swallowed escalation leaves the bridge
+   *  silently suppressed for the rest of the dedup window. */
+  clearPermissionHandled(): void {
+    this.lastPermissionEmitAt = 0;
   }
 
   /** Returns HookServerEvents handlers wired to this bridge */

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -101,7 +101,13 @@ describe('setupHookBridge', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function build(opts: { autoApprove?: boolean } = {}) {
+  function build(
+    opts: {
+      autoApprove?: boolean;
+      autoApproveDecision?: 'approve' | 'deny' | 'escalate';
+      autoApproveDelayMs?: number;
+    } = {},
+  ) {
     sessionRegistry.registerSession(
       SID,
       tmpDir,
@@ -110,11 +116,20 @@ describe('setupHookBridge', () => {
     );
 
     // Minimal AutoApproveService stub. Only invoked when opts.autoApprove is
-    // true; then we hand back a service whose `.evaluate` resolves to
-    // 'approve' so the auto-approve inject path exercises.
+    // true; default decision is 'approve' (existing tests rely on this).
+    // `autoApproveDelayMs` simulates LLM eval latency so dedup-window tests
+    // can fire Notification while evaluate() is still in flight (#379).
     const autoApproveService = opts.autoApprove
       ? ({
-          evaluate: async () => ({ decision: 'approve', reason: 'test-autoapprove' }),
+          evaluate: async () => {
+            if (opts.autoApproveDelayMs && opts.autoApproveDelayMs > 0) {
+              await new Promise((r) => setTimeout(r, opts.autoApproveDelayMs));
+            }
+            return {
+              decision: opts.autoApproveDecision ?? 'approve',
+              reason: 'test-autoapprove',
+            };
+          },
         } as unknown as import('../../../src/auto-approve/index.ts').AutoApproveService)
       : null;
 
@@ -337,5 +352,87 @@ describe('setupHookBridge', () => {
     // assert only the tear-down signals, not the final map state.
     expect(stopCalls.length).toBeGreaterThanOrEqual(1);
     expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression #379 / #377: pre-emptive Notification dedup during slow
+  // auto-approve evaluation. The PermissionRequest hook handler must mark
+  // the bridge as "handling permission" BEFORE invoking aaService.evaluate,
+  // so a Notification(permission_prompt) arriving while the LLM is still
+  // running is suppressed instead of emitting a phantom Question (which
+  // would fire a duplicate APNS push the user can't dismiss).
+  // -------------------------------------------------------------------------
+
+  test('regression #379: slow auto-approve approve does NOT leak a Notification question', async () => {
+    // 80ms eval delay simulates ollama latency. Notification fires inside
+    // the window; without the pre-emptive markPermissionHandled, this
+    // Notification would emit a 3-option question and trigger a push.
+    build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 80 });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-379',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-379',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    // Notification fires ~10ms after PermissionRequest in real Claude Code;
+    // schedule it well within the eval window so the race is exercised.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-379',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    // Wait for evaluate() + inject() to fully resolve.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // Approved: PTY received "1" once.
+    expect(ptySubmits).toEqual(['1']);
+    // Notification path must have been suppressed by the pre-emptive dedup.
+    // Total questions emitted: zero (the auto-approve path is silent on success).
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('regression #379: escalate path emits the canonical Question exactly once', async () => {
+    // When auto-approve cannot decide (e.g. 'escalate'), the user MUST see
+    // a question. The Notification arriving during eval must still be
+    // suppressed; the canonical question comes from handlePermissionRequest
+    // via escalateToUser. Net: questionCalls === 1.
+    build({ autoApprove: true, autoApproveDecision: 'escalate', autoApproveDelayMs: 80 });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-379b',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-379b',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-379b',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // No injection happened (escalate, main context).
+    expect(ptySubmits).toEqual([]);
+    // Exactly one question: the escalation, not the suppressed Notification.
+    expect(messageApiLog.questionCalls).toBe(1);
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -52,7 +52,11 @@ interface MessageApiCallLog {
   questionCalls: number;
 }
 
-function fakeMessageAPI(log: MessageApiCallLog): MessageAPI {
+function fakeMessageAPI(
+  log: MessageApiCallLog,
+  opts: { throwOnQuestionTimes?: number } = {},
+): MessageAPI {
+  let throwsLeft = opts.throwOnQuestionTimes ?? 0;
   return {
     handleMessage: () => {},
     handleStatusChange: (status: string) => {
@@ -60,11 +64,28 @@ function fakeMessageAPI(log: MessageApiCallLog): MessageAPI {
     },
     handleQuestion: () => {
       log.questionCalls += 1;
+      if (throwsLeft > 0) {
+        throwsLeft -= 1;
+        throw new Error('test: handleQuestion synthetic failure');
+      }
     },
     reset: () => {
       log.resetCalls.n += 1;
     },
   } as unknown as MessageAPI;
+}
+
+/** Poll a predicate until true or timeout. Used in lieu of fixed-duration
+ *  setTimeout waits in async tests so we don't depend on CI scheduler luck. */
+async function until(predicate: () => boolean, timeoutMs = 1000, pollMs = 5): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  if (!predicate()) {
+    throw new Error(`until() timed out after ${timeoutMs}ms`);
+  }
 }
 
 const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
@@ -106,24 +127,35 @@ describe('setupHookBridge', () => {
       autoApprove?: boolean;
       autoApproveDecision?: 'approve' | 'deny' | 'escalate';
       autoApproveDelayMs?: number;
+      autoApproveThrows?: boolean;
+      throwOnQuestionTimes?: number;
     } = {},
   ) {
     sessionRegistry.registerSession(
       SID,
       tmpDir,
       fakePTY(ptySubmits),
-      fakeMessageAPI(messageApiLog),
+      fakeMessageAPI(
+        messageApiLog,
+        opts.throwOnQuestionTimes !== undefined
+          ? { throwOnQuestionTimes: opts.throwOnQuestionTimes }
+          : {},
+      ),
     );
 
     // Minimal AutoApproveService stub. Only invoked when opts.autoApprove is
     // true; default decision is 'approve' (existing tests rely on this).
     // `autoApproveDelayMs` simulates LLM eval latency so dedup-window tests
     // can fire Notification while evaluate() is still in flight (#379).
+    // `autoApproveThrows` exercises the outer .catch() handler.
     const autoApproveService = opts.autoApprove
       ? ({
           evaluate: async () => {
             if (opts.autoApproveDelayMs && opts.autoApproveDelayMs > 0) {
               await new Promise((r) => setTimeout(r, opts.autoApproveDelayMs));
+            }
+            if (opts.autoApproveThrows) {
+              throw new Error('test: ollama down');
             }
             return {
               decision: opts.autoApproveDecision ?? 'approve',
@@ -150,7 +182,12 @@ describe('setupHookBridge', () => {
         hookServer: hookServer as unknown as HookServer,
         sessionId: SID,
         workingDirectory: tmpDir,
-        messageApi: fakeMessageAPI(messageApiLog),
+        messageApi: fakeMessageAPI(
+          messageApiLog,
+          opts.throwOnQuestionTimes !== undefined
+            ? { throwOnQuestionTimes: opts.throwOnQuestionTimes }
+            : {},
+        ),
         sendAndRecord: () => {},
       },
     );
@@ -392,12 +429,45 @@ describe('setupHookBridge', () => {
     });
 
     // Wait for evaluate() + inject() to fully resolve.
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await until(() => ptySubmits.length >= 1);
 
     // Approved: PTY received "1" once.
     expect(ptySubmits).toEqual(['1']);
     // Notification path must have been suppressed by the pre-emptive dedup.
     // Total questions emitted: zero (the auto-approve path is silent on success).
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('regression #379: slow auto-approve DENY does NOT leak a Notification question', async () => {
+    // Mirror of the approve test; the deny path also injects (with "3")
+    // and must benefit from the same pre-emptive dedup. Without it, the
+    // mid-flight Notification would emit a phantom approve-style 3-option
+    // question while the daemon was about to silently deny.
+    build({ autoApprove: true, autoApproveDecision: 'deny', autoApproveDelayMs: 80 });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-379-deny',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-379-deny',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-379-deny',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    await until(() => ptySubmits.length >= 1);
+
+    expect(ptySubmits).toEqual(['3']);
     expect(messageApiLog.questionCalls).toBe(0);
   });
 
@@ -428,11 +498,90 @@ describe('setupHookBridge', () => {
       message: 'Claude needs your permission to use Bash',
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await until(() => messageApiLog.questionCalls >= 1);
 
     // No injection happened (escalate, main context).
     expect(ptySubmits).toEqual([]);
     // Exactly one question: the escalation, not the suppressed Notification.
     expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('regression #379: evaluate() throws -> escalates to user, Notification suppressed', async () => {
+    // Outer .catch() runs when ollama dies mid-eval. Main-session context
+    // hits escalateToUser -> handlePermissionRequest emits canonical Q. The
+    // Notification fired during the eval window must still be suppressed.
+    build({ autoApprove: true, autoApproveThrows: true, autoApproveDelayMs: 80 });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-379c',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-379c',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-379c',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    await until(() => messageApiLog.questionCalls >= 1);
+
+    expect(ptySubmits).toEqual([]);
+    expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('regression #381 audit: escalate throws -> dedup mark cleared so Notification fallback fires', async () => {
+    // Silent-failure-hunter B2: if escalateToUser() throws (push fan-out
+    // failure, WS send on a half-closed adapter, etc.) the user used to be
+    // left with NOTHING — pre-emptive dedup suppressed the trailing
+    // Notification. Now the catch handler clears the dedup mark, so the
+    // Notification fallback gets to surface a question.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'escalate',
+      autoApproveDelayMs: 30,
+      throwOnQuestionTimes: 1, // first onQuestion (escalation) throws; Notification fallback succeeds
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-381a',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-381a',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    // Wait until escalation has been attempted (questionCalls increments
+    // even when the call throws — fakeMessageAPI counts on entry).
+    await until(() => messageApiLog.questionCalls >= 1);
+
+    // Now fire the Notification AFTER escalation has thrown. Without the
+    // clearPermissionHandled() call in escalateToUser's catch, the dedup
+    // mark would still be active and this Notification would be suppressed.
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-381a',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    await until(() => messageApiLog.questionCalls >= 2);
+
+    // Two attempts: 1 escalation (threw), 1 Notification fallback (succeeded
+    // for counting purposes; throwOnQuestion fires on every call but the
+    // counter increments before the throw so we observe the call).
+    expect(messageApiLog.questionCalls).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes #379. Closes the race-half of #377 (the multi-token half remains in #377 as a separate task).

When auto-approve is configured for a `PermissionRequest`, the LLM evaluation runs async and can outlast the 5s Notification dedup window. Claude Code's `Notification(permission_prompt)` hook fires ~10ms after `PermissionRequest`. With `lastPermissionEmitAt` only being set after `inject()` succeeded, slow eval let the Notification slip through, emit a phantom Question with the default 3-option set, and fire an APNS push for a prompt auto-approve was about to handle silently.

This PR moves the dedup mark to **before** `aaService.evaluate(...)` so the window opens at request entry, not at eval resolve. Failure paths now also clear the mark so the trailing Notification can act as a fallback when escalation throws.

## Changes

- `packages/daemon/src/cli/session-phases/hook-bridge-setup.ts`:
  - Call `hookBridge.markPermissionHandled()` immediately on entry to the auto-approve gate, prior to `aaService.evaluate(...)`.
  - On `escalateToUser()` throw: call `clearPermissionHandled()` so the trailing Notification surfaces a fallback question.
  - On the outer `.catch()` inner-catch (eval AND escalation both threw): same clear.
- `packages/daemon/src/hooks/hook-event-bridge.ts`:
  - Add `clearPermissionHandled()` (resets `lastPermissionEmitAt = 0`).
  - Update `markPermissionHandled` JSDoc to describe the dual-call contract.
- `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts`:
  - Replace fixed-duration tail-waits with a polling `until()` helper.
  - Extend `build()` with `autoApproveDecision`, `autoApproveDelayMs`, `autoApproveThrows`, `throwOnQuestionTimes`.
  - Add 5 tests: slow-approve dedup, slow-deny dedup, escalate-once, evaluate-throws-escalates-once, escalate-throws-clears-dedup-Notification-fallback-fires.

## Behavior matrix

| Path | Before | After |
|---|---|---|
| auto-approve approve, slow eval | Notification leaks → phantom question + push | Suppressed; auto-approve silent |
| auto-approve deny, slow eval | Notification leaks → phantom question + push | Suppressed; auto-approve silent |
| auto-approve escalate, slow eval | Notification leaks → 2 questions | Suppressed; canonical question once |
| evaluate() throws, main context | Notification leaks → 2 questions | Suppressed; canonical question once via escalate |
| escalateToUser() throws | Notification suppressed → user sees nothing | Dedup cleared → Notification becomes fallback |
| eval AND escalate both throw | Notification suppressed → user sees nothing | Dedup cleared → Notification becomes fallback |
| no auto-approve, main context | unchanged | unchanged |

## Tests

12/12 pass on `hook-bridge-setup.test.ts`. Full daemon suite (675 tests) green. Typecheck + biome clean.

## Review findings addressed (PR review)

- **comment-analyzer**: dropped inline issue refs from source comments, tightened block-comment, softened JSDoc contract.
- **pr-test-analyzer**: added deny + eval-rejects tests, replaced fixed waits with polling, kept the test surface specific to behaviors not implementation.
- **silent-failure-hunter (B2/B3)**: added `clearPermissionHandled()` and call it from the two failure paths so the Notification fallback isn't silently lost when escalation throws. Added regression test for the recovery.
- **code-reviewer**: confirmed no over-suppression of `handlePermissionRequest` (it doesn't check the dedup window) — corrected the misleading "over-suppression risk" callout from the original PR description.

## Known follow-ups (NOT in this PR)

- **#382** (NEW, P1): `inject()` returns true while `submitInput` is fire-and-forget. A stuck PTY combined with the new pre-emptive dedup hides the failure entirely. Likely cause of "APNS not firing" reported during manual testing of this PR. Needs a PTY ack mechanism — bigger scope, separate PR.
- **#377 multi-token half**: push fan-out across `deviceTokens.values()` produces N pushes when multiple tokens are registered for the same physical device. Needs an iOS-side stable installation id.
- **#378** (3 options always): `OutputProcessor` currently gated off when hooks active, so multi-choice and Y/N prompts lose option fidelity. Up next on the same series.

## Test plan

- [ ] CI green
- [ ] Manual repro: kill stale daemons, build binary, run `remi --auto-approve`, trigger PermissionRequests; confirm: (a) auto-approved prompts produce zero pushes, (b) escalations produce exactly one push, (c) `~/.remi/remi.log` shows `Suppressed duplicate Notification(permission_prompt)` entries during eval windows.
- [ ] Verify push for a true escalation still arrives on iOS lock screen.
- [ ] If "APNS not firing" reproduces: capture and attach to **#382** rather than re-opening this issue.
