### PR TITLE
fix(hooks): inject ack timeout escalates when PTY is silent (#382)

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -62,6 +62,9 @@ export interface HookBridgeArgs {
   workingDirectory: string;
   messageApi: MessageAPI;
   sendAndRecord: (message: ProtocolMessage) => void;
+  /** Override the default 1000ms inject ack timeout (#382). Tests use a
+   *  short value to exercise the timeout path quickly. */
+  injectAckTimeoutMs?: number;
 }
 
 export function setupHookBridge(
@@ -78,6 +81,7 @@ export function setupHookBridge(
     currentPort,
   } = deps;
   const { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord } = args;
+  const PERMISSION_INJECT_ACK_TIMEOUT_MS = args.injectAckTimeoutMs ?? 1000;
 
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
@@ -107,6 +111,69 @@ export function setupHookBridge(
   // (or a fresh sibling appearing) is reflected immediately. Issue #321:
   // a stale `null`-once cache wedged this state and permanently disabled
   // hook-driven discovery for both daemons.
+
+  // ---- Inject ack tracking (issue #382) -----------------------------------
+  //
+  // session.pty.submitInput() is fire-and-forget: it writes the byte (and
+  // 50 ms later the carriage return) without confirming Claude consumed
+  // them. If the PTY drops the input (mid-render, buffer overflow, raw-mode
+  // glitch), `inject()` would still report success and refresh the dedup
+  // mark, leaving the user with no PTY answer, no question, and no push.
+  //
+  // To detect this, we register a PendingAck right before submitInput. Any
+  // qualifying hook event (PreToolUse, PostToolUse, Stop, SessionEnd) for
+  // our session resolves it -- those are ground truth that Claude
+  // advanced past the prompt. If no such event arrives
+  // within PERMISSION_INJECT_ACK_TIMEOUT_MS, the ack times out and we
+  // assume the inject was lost: clear the dedup mark and escalate so the
+  // user actually sees the question on iOS.
+  //
+  // The PendingAck Set is per-session (closure-scoped). Multiple injects
+  // in flight share the set; ackAllPending() resolves them all on any
+  // qualifying event. False positives (e.g. resolving an unrelated ack
+  // because a different tool's PostToolUse fired first) are benign --
+  // they just skip the timeout-driven escalation we'd have done anyway.
+
+  type PendingAck = {
+    timer: ReturnType<typeof setTimeout> | null;
+    resolved: boolean;
+    onTimeout: () => void;
+  };
+  const pendingAcks: Set<PendingAck> = new Set();
+
+  const startPendingAck = (onTimeout: () => void): PendingAck => {
+    const ack: PendingAck = { timer: null, resolved: false, onTimeout };
+    ack.timer = setTimeout(() => {
+      ack.timer = null;
+      if (ack.resolved) return;
+      ack.resolved = true;
+      pendingAcks.delete(ack);
+      try {
+        ack.onTimeout();
+      } catch (err) {
+        logError(`[Hooks] PendingAck onTimeout threw: ${errorToString(err)}`);
+      }
+    }, PERMISSION_INJECT_ACK_TIMEOUT_MS);
+    pendingAcks.add(ack);
+    return ack;
+  };
+
+  const resolvePendingAck = (ack: PendingAck): void => {
+    if (ack.resolved) return;
+    ack.resolved = true;
+    if (ack.timer !== null) {
+      clearTimeout(ack.timer);
+      ack.timer = null;
+    }
+    pendingAcks.delete(ack);
+  };
+
+  const ackAllPending = (): void => {
+    if (pendingAcks.size === 0) return;
+    for (const ack of pendingAcks) {
+      resolvePendingAck(ack);
+    }
+  };
 
   // ---- Helpers ------------------------------------------------------------
 
@@ -349,12 +416,16 @@ export function setupHookBridge(
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
+    // Claude advanced past the prompt: resolve any pending inject acks.
+    ackAllPending();
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
+    // Claude advanced past the prompt: resolve any pending inject acks.
+    ackAllPending();
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
@@ -391,13 +462,30 @@ export function setupHookBridge(
     // Inject an answer into the PTY. Returns true on success. On failure
     // (session missing, PTY not running, submitInput throws) it logs and
     // returns false so callers can fall back to escalating the prompt.
+    //
+    // Registers a PendingAck around the submitInput call. The next
+    // qualifying hook event (PreToolUse / PostToolUse / Stop / SessionEnd)
+    // for our session resolves it. If the timeout fires first, the inject
+    // is treated as silently lost -- the dedup mark is cleared and we
+    // escalate so the user still gets a question. See #382.
     const inject = async (value: '1' | '3', reason: string): Promise<boolean> => {
+      let ack: PendingAck | null = null;
       try {
         const session = sessionRegistry.getSession(sessionId);
         if (!session) {
           logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
           return false;
         }
+        // Register the pending ack BEFORE the await so a hook event that
+        // races with submitInput (Claude responding faster than the 50 ms
+        // CR delay) finds the ack already pending and resolves it cleanly.
+        ack = startPendingAck(() => {
+          log(
+            `[AutoApprove ${sessionTag}] inject("${value}") ack timeout (${PERMISSION_INJECT_ACK_TIMEOUT_MS}ms); clearing dedup + escalating`,
+          );
+          hookBridge.clearPermissionHandled();
+          escalateToUser();
+        });
         await session.pty.submitInput(value);
         log(`[AutoApprove ${sessionTag}] Injected "${value}" into PTY (${reason})`);
         sessionRegistry.updateStatus(sessionId, value === '1' ? 'executing' : 'thinking');
@@ -405,6 +493,10 @@ export function setupHookBridge(
         return true;
       } catch (err) {
         logError(`[AutoApprove ${sessionTag}] inject("${value}") threw:`, err);
+        // submitInput failed: caller will escalate via inject() returning
+        // false, so we must NOT also let the ack timeout fire its own
+        // escalation. Cancel before returning.
+        if (ack !== null) resolvePendingAck(ack);
         return false;
       }
     };
@@ -494,6 +586,9 @@ export function setupHookBridge(
   hookServer.on('Stop', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
+    // Claude advanced past the prompt (or denied path completed): resolve
+    // any pending inject acks.
+    ackAllPending();
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
@@ -503,6 +598,10 @@ export function setupHookBridge(
       mainSessionEnded = true;
     }
     if (!filterBySession(input)) return;
+    // Session ending is a hard signal Claude is no longer waiting at the
+    // prompt; resolve any pending inject acks so their timeouts don't fire
+    // a phantom escalation post-shutdown.
+    ackAllPending();
     handlers.onSessionEnd?.(input);
   });
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -62,8 +62,8 @@ export interface HookBridgeArgs {
   workingDirectory: string;
   messageApi: MessageAPI;
   sendAndRecord: (message: ProtocolMessage) => void;
-  /** Override the default 1000ms inject ack timeout (#382). Tests use a
-   *  short value to exercise the timeout path quickly. */
+  /** Override the default inject ack timeout. Tests use a short value to
+   *  exercise the timeout path without slowing the suite. */
   injectAckTimeoutMs?: number;
 }
 
@@ -112,7 +112,7 @@ export function setupHookBridge(
   // a stale `null`-once cache wedged this state and permanently disabled
   // hook-driven discovery for both daemons.
 
-  // ---- Inject ack tracking (issue #382) -----------------------------------
+  // ---- Inject ack tracking ------------------------------------------------
   //
   // session.pty.submitInput() is fire-and-forget: it writes the byte (and
   // 50 ms later the carriage return) without confirming Claude consumed
@@ -121,18 +121,19 @@ export function setupHookBridge(
   // mark, leaving the user with no PTY answer, no question, and no push.
   //
   // To detect this, we register a PendingAck right before submitInput. Any
-  // qualifying hook event (PreToolUse, PostToolUse, Stop, SessionEnd) for
-  // our session resolves it -- those are ground truth that Claude
-  // advanced past the prompt. If no such event arrives
-  // within PERMISSION_INJECT_ACK_TIMEOUT_MS, the ack times out and we
-  // assume the inject was lost: clear the dedup mark and escalate so the
-  // user actually sees the question on iOS.
+  // qualifying hook event for our session resolves it (see ackAllPending()
+  // call sites below) -- those are ground truth that Claude advanced past
+  // the prompt. If no such event arrives within the ack timeout, we assume
+  // the inject was lost: clear the dedup mark and escalate so the user
+  // actually sees the question on iOS.
   //
   // The PendingAck Set is per-session (closure-scoped). Multiple injects
   // in flight share the set; ackAllPending() resolves them all on any
-  // qualifying event. False positives (e.g. resolving an unrelated ack
-  // because a different tool's PostToolUse fired first) are benign --
-  // they just skip the timeout-driven escalation we'd have done anyway.
+  // qualifying event. KNOWN LIMITATION: with two injects in flight, the
+  // qualifying event for inject-A also resolves inject-B's ack -- if
+  // inject-B's PTY write was actually lost, the silent failure is masked.
+  // Same-tick double-prompts are rare; per-tool_use_id correlation is the
+  // long-term fix.
 
   type PendingAck = {
     timer: ReturnType<typeof setTimeout> | null;
@@ -416,7 +417,6 @@ export function setupHookBridge(
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    // Claude advanced past the prompt: resolve any pending inject acks.
     ackAllPending();
     handlers.onPreToolUse?.(input);
   });
@@ -424,7 +424,6 @@ export function setupHookBridge(
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    // Claude advanced past the prompt: resolve any pending inject acks.
     ackAllPending();
     handlers.onPostToolUse?.(input);
   });
@@ -435,6 +434,14 @@ export function setupHookBridge(
     if (isSubagentEvent(input)) {
       log(`[Hooks] Dropped subagent Notification: agent=${input.agent_id?.slice(0, 8)}`);
       return;
+    }
+    // permission_prompt is the same prompt our inject is answering; do
+    // NOT treat it as ack. All other notification types (idle_prompt,
+    // auth_success, etc.) are evidence Claude moved on -- without this,
+    // an Edit-style approve where Claude doesn't re-emit PreToolUse
+    // would time out into a phantom escalation.
+    if (input.notification_type !== 'permission_prompt') {
+      ackAllPending();
     }
     handlers.onNotification?.(input);
   });
@@ -464,10 +471,9 @@ export function setupHookBridge(
     // returns false so callers can fall back to escalating the prompt.
     //
     // Registers a PendingAck around the submitInput call. The next
-    // qualifying hook event (PreToolUse / PostToolUse / Stop / SessionEnd)
-    // for our session resolves it. If the timeout fires first, the inject
-    // is treated as silently lost -- the dedup mark is cleared and we
-    // escalate so the user still gets a question. See #382.
+    // qualifying hook event for our session resolves it. If the timeout
+    // fires first, the inject is treated as silently lost -- the dedup
+    // mark is cleared and we escalate so the user still gets a question.
     const inject = async (value: '1' | '3', reason: string): Promise<boolean> => {
       let ack: PendingAck | null = null;
       try {
@@ -480,6 +486,16 @@ export function setupHookBridge(
         // races with submitInput (Claude responding faster than the 50 ms
         // CR delay) finds the ack already pending and resolves it cleanly.
         ack = startPendingAck(() => {
+          // Suppress the phantom escalation if our session has already
+          // ended (Claude exited, PTY torn down, etc.). Without this
+          // gate the timer fires a stale question + push for a session
+          // that no longer exists.
+          if (mainSessionEnded || claudeSessionId === null) {
+            log(
+              `[AutoApprove ${sessionTag}] inject ack timeout fired post-teardown; suppressing phantom escalation`,
+            );
+            return;
+          }
           log(
             `[AutoApprove ${sessionTag}] inject("${value}") ack timeout (${PERMISSION_INJECT_ACK_TIMEOUT_MS}ms); clearing dedup + escalating`,
           );
@@ -586,8 +602,6 @@ export function setupHookBridge(
   hookServer.on('Stop', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
-    // Claude advanced past the prompt (or denied path completed): resolve
-    // any pending inject acks.
     ackAllPending();
     handlers.onStop?.(input);
   });
@@ -598,9 +612,8 @@ export function setupHookBridge(
       mainSessionEnded = true;
     }
     if (!filterBySession(input)) return;
-    // Session ending is a hard signal Claude is no longer waiting at the
-    // prompt; resolve any pending inject acks so their timeouts don't fire
-    // a phantom escalation post-shutdown.
+    // Resolve pending acks before SessionEnd handlers run; otherwise a
+    // timeout could fire a phantom escalation after shutdown.
     ackAllPending();
     handlers.onSessionEnd?.(input);
   });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -33,14 +33,18 @@ class RecordingHookServer {
   }
 }
 
-/** PTYSession fake that tracks submitInput calls (drives the auto-approve inject assertions). */
-function fakePTY(submits: string[]): PTYSession {
+/** PTYSession fake that tracks submitInput calls (drives the auto-approve inject assertions).
+ *  When throws=true, submitInput rejects to exercise the inject() cancellation path. */
+function fakePTY(submits: string[], opts: { throws?: boolean } = {}): PTYSession {
   return {
     id: generateId(),
     isRunning: true,
     write: () => {},
     submitInput: async (content: string) => {
       submits.push(content);
+      if (opts.throws) {
+        throw new Error('test: submitInput synthetic failure');
+      }
     },
     close: async () => {},
   } as unknown as PTYSession;
@@ -130,12 +134,13 @@ describe('setupHookBridge', () => {
       autoApproveThrows?: boolean;
       throwOnQuestionTimes?: number;
       injectAckTimeoutMs?: number;
+      submitInputThrows?: boolean;
     } = {},
   ) {
     sessionRegistry.registerSession(
       SID,
       tmpDir,
-      fakePTY(ptySubmits),
+      fakePTY(ptySubmits, opts.submitInputThrows ? { throws: true } : {}),
       fakeMessageAPI(
         messageApiLog,
         opts.throwOnQuestionTimes !== undefined
@@ -606,7 +611,7 @@ describe('setupHookBridge', () => {
     build({
       autoApprove: true,
       autoApproveDecision: 'approve',
-      injectAckTimeoutMs: 100, // tight window so the test fails fast on regression
+      injectAckTimeoutMs: 100,
     });
 
     hookServer.fire('SessionStart', {
@@ -634,9 +639,11 @@ describe('setupHookBridge', () => {
       tool_output: { exit_code: 0 },
     });
 
-    // Wait past the ack timeout to confirm no late escalation fires.
-    await new Promise((r) => setTimeout(r, 150));
-
+    // Wait past 2.5x the ack timeout to leave headroom for CI scheduler
+    // jitter (a Bun timer + microtask flush on a loaded macOS runner has
+    // shown >40 ms drift). If a late timeout escalation slips through,
+    // questionCalls becomes 1 and this assertion fails.
+    await new Promise((r) => setTimeout(r, 250));
     expect(messageApiLog.questionCalls).toBe(0);
   });
 
@@ -647,7 +654,7 @@ describe('setupHookBridge', () => {
     build({
       autoApprove: true,
       autoApproveDecision: 'approve',
-      injectAckTimeoutMs: 50,
+      injectAckTimeoutMs: 100,
     });
 
     hookServer.fire('SessionStart', {
@@ -666,7 +673,7 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual(['1']);
 
     // No follow-up event: ack timer should fire and emit a fallback Q.
-    await until(() => messageApiLog.questionCalls >= 1, 500);
+    await until(() => messageApiLog.questionCalls >= 1, 1000);
     expect(messageApiLog.questionCalls).toBe(1);
   });
 
@@ -700,39 +707,116 @@ describe('setupHookBridge', () => {
       stop_hook_active: false,
     });
 
-    await new Promise((r) => setTimeout(r, 150));
+    await new Promise((r) => setTimeout(r, 250));
     expect(messageApiLog.questionCalls).toBe(0);
   });
 
-  test('regression #382: ack timeout AFTER Notification dedup expired -> single escalation', async () => {
-    // Verifies the timeout path also clears the dedup mark, so a delayed
-    // Notification (well after the 5s window) still surfaces if it arrives.
-    // This is the silent-failure recovery: even if Claude eventually
-    // re-prompts via a fresh Notification long after the inject was lost,
-    // the user gets a question.
+  // (The previous "ack timeout AFTER Notification dedup expired" test was
+  // dropped: the timeout path's explicit clearPermissionHandled() is
+  // defensive -- handlePermissionRequest immediately re-arms
+  // lastPermissionEmitAt when escalateToUser emits, so a late Notification
+  // is correctly suppressed as a duplicate of the canonical escalation.
+  // The meaningful "timeout -> escalation fires" behavior is covered by
+  // the "approve + no follow-up event" test above.)
+
+  test('regression #382: submitInput throws -> ack cancelled, single escalation only', async () => {
+    // inject() catch path: cancel pendingAck before returning false so the
+    // caller's escalateToUser fires once, not once + a stale timeout
+    // escalation a second later.
     build({
       autoApprove: true,
       autoApproveDecision: 'approve',
-      injectAckTimeoutMs: 50,
+      injectAckTimeoutMs: 100,
+      submitInputThrows: true,
     });
 
     hookServer.fire('SessionStart', {
-      session_id: 'claude-locked-382d',
+      session_id: 'claude-locked-382e',
       transcript_path: path.join(tmpDir, 't.jsonl'),
       hook_event_name: 'SessionStart',
     });
 
     hookServer.fire('PermissionRequest', {
-      session_id: 'claude-locked-382d',
+      session_id: 'claude-locked-382e',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
 
-    // Wait for ack timeout -> escalation -> exactly one question.
+    // PTY recorded the byte (fakePTY pushes BEFORE throwing) but inject
+    // returned false; caller escalates once via the inject-failure path.
     await until(() => messageApiLog.questionCalls >= 1, 500);
     expect(messageApiLog.questionCalls).toBe(1);
-    // PTY received "1" (auto-approve injected before the silent failure
-    // was detected); the escalation is the safety net.
+
+    // Wait past the ack timeout to confirm no SECOND escalation lands.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('regression #382: default ack timeout is non-trivial (no override -> no fast escalation)', async () => {
+    // Pins the args.injectAckTimeoutMs ?? 1000 fallback. If a refactor
+    // dropped the default and the field became required (or undefined
+    // -> setTimeout interpreted as 1ms), the timer would fire almost
+    // immediately and escalate during this 200 ms quiet window.
+    build({ autoApprove: true, autoApproveDecision: 'approve' }); // no injectAckTimeoutMs
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382f',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382f',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await until(() => ptySubmits.length >= 1);
     expect(ptySubmits).toEqual(['1']);
+
+    // 200 ms is a fraction of the 1000 ms default; no escalation expected.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('regression #382: Notification(idle_prompt) resolves the ack (Edit-style approve)', async () => {
+    // When auto-approve approves an Edit (the same tool that triggered
+    // the prompt), Claude doesn't fire a fresh PreToolUse. The next
+    // signal that "Claude moved on" is often a Notification(idle_prompt).
+    // Code-reviewer flagged this as a phantom-escalation gap; this test
+    // pins ackAllPending() being called from the Notification handler
+    // when the type is anything other than permission_prompt.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'approve',
+      injectAckTimeoutMs: 100,
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382g',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382g',
+      tool_name: 'Edit',
+      tool_input: { file_path: '/tmp/x.ts', old_str: 'a', new_str: 'b' },
+    });
+
+    await until(() => ptySubmits.length >= 1);
+    expect(ptySubmits).toEqual(['1']);
+
+    // idle_prompt is a "Claude moved on" signal -- must ack the pending
+    // inject so the timer doesn't fire a phantom escalation.
+    hookServer.fire('Notification', {
+      session_id: 'claude-locked-382g',
+      hook_event_name: 'Notification',
+      notification_type: 'idle_prompt',
+      message: '',
+    });
+
+    await new Promise((r) => setTimeout(r, 250));
+    expect(messageApiLog.questionCalls).toBe(0);
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -129,6 +129,7 @@ describe('setupHookBridge', () => {
       autoApproveDelayMs?: number;
       autoApproveThrows?: boolean;
       throwOnQuestionTimes?: number;
+      injectAckTimeoutMs?: number;
     } = {},
   ) {
     sessionRegistry.registerSession(
@@ -189,6 +190,9 @@ describe('setupHookBridge', () => {
             : {},
         ),
         sendAndRecord: () => {},
+        ...(opts.injectAckTimeoutMs !== undefined
+          ? { injectAckTimeoutMs: opts.injectAckTimeoutMs }
+          : {}),
       },
     );
   }
@@ -583,5 +587,152 @@ describe('setupHookBridge', () => {
     // for counting purposes; throwOnQuestion fires on every call but the
     // counter increments before the throw so we observe the call).
     expect(messageApiLog.questionCalls).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #382: PTY inject ack timeout. submitInput is fire-and-forget, so a
+  // stuck PTY can swallow the byte while inject() reports success. Combined
+  // with the pre-emptive dedup mark (#379/#381), the user would see no
+  // PTY answer, no question, and no APNS push -- a hard regression compared
+  // to the pre-#381 phantom-Notification behaviour. The fix registers a
+  // PendingAck around submitInput and escalates if no follow-up hook event
+  // arrives within the timeout.
+  // -------------------------------------------------------------------------
+
+  test('regression #382: approve + PostToolUse arrives in time -> no escalation', async () => {
+    // Happy path: the auto-approve injects "1", Claude proceeds with the
+    // tool call, PostToolUse fires within the ack window. No timeout, no
+    // escalation. questionCalls stays at 0.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'approve',
+      injectAckTimeoutMs: 100, // tight window so the test fails fast on regression
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382a',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382a',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await until(() => ptySubmits.length >= 1);
+    expect(ptySubmits).toEqual(['1']);
+
+    // Simulate Claude advancing past the prompt: PostToolUse for the tool.
+    hookServer.fire('PostToolUse', {
+      session_id: 'claude-locked-382a',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 'tool-use-382a',
+      tool_input: { command: 'ls' },
+      tool_output: { exit_code: 0 },
+    });
+
+    // Wait past the ack timeout to confirm no late escalation fires.
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('regression #382: approve + no follow-up event -> ack timeout escalates', async () => {
+    // Silent PTY scenario: inject reports success but no PreToolUse /
+    // PostToolUse / Stop arrives. The ack timer fires, clears the dedup
+    // mark, and emits the canonical question via escalateToUser.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'approve',
+      injectAckTimeoutMs: 50,
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382b',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382b',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await until(() => ptySubmits.length >= 1);
+    expect(ptySubmits).toEqual(['1']);
+
+    // No follow-up event: ack timer should fire and emit a fallback Q.
+    await until(() => messageApiLog.questionCalls >= 1, 500);
+    expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('regression #382: deny + Stop arrives in time -> no escalation', async () => {
+    // Mirror of the approve happy path for the deny branch. Stop is the
+    // expected ack signal when Claude abandons the requested tool.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'deny',
+      injectAckTimeoutMs: 100,
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382c',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382c',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    await until(() => ptySubmits.length >= 1);
+    expect(ptySubmits).toEqual(['3']);
+
+    hookServer.fire('Stop', {
+      session_id: 'claude-locked-382c',
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('regression #382: ack timeout AFTER Notification dedup expired -> single escalation', async () => {
+    // Verifies the timeout path also clears the dedup mark, so a delayed
+    // Notification (well after the 5s window) still surfaces if it arrives.
+    // This is the silent-failure recovery: even if Claude eventually
+    // re-prompts via a fresh Notification long after the inject was lost,
+    // the user gets a question.
+    build({
+      autoApprove: true,
+      autoApproveDecision: 'approve',
+      injectAckTimeoutMs: 50,
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-382d',
+      transcript_path: path.join(tmpDir, 't.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-locked-382d',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    // Wait for ack timeout -> escalation -> exactly one question.
+    await until(() => messageApiLog.questionCalls >= 1, 500);
+    expect(messageApiLog.questionCalls).toBe(1);
+    // PTY received "1" (auto-approve injected before the silent failure
+    // was detected); the escalation is the safety net.
+    expect(ptySubmits).toEqual(['1']);
   });
 });


### PR DESCRIPTION
## Summary

Closes #382.

`session.pty.submitInput()` is fire-and-forget. If Claude doesn't actually consume the byte (PTY mid-render, buffer overflow, raw-mode glitch), `inject()` reports success and refreshes the dedup mark, leaving the user with no PTY answer, no question, and no APNS push.

PR #381's pre-emptive dedup turned the prior duplicate-push symptom into total silence (because the trailing `Notification(permission_prompt)` is suppressed during the eval window). This PR catches that failure mode by waiting for evidence Claude actually advanced past the prompt.

## Implementation

`packages/daemon/src/cli/session-phases/hook-bridge-setup.ts`:

- New per-session closure state: `pendingAcks: Set<PendingAck>`, plus `startPendingAck`, `resolvePendingAck`, `ackAllPending` helpers.
- `inject()` registers a `PendingAck` **before** `await session.pty.submitInput(value)` so a fast hook event (Claude responding faster than the 50 ms CR delay) finds the ack already pending. On `submitInput` throw, `resolvePendingAck` cancels the timer so the inject-failure escalation isn't fired twice.
- The five "Claude moved on" hook listeners (`PreToolUse`, `PostToolUse`, `Stop`, `SessionEnd`, and `Notification` whose type is NOT `permission_prompt`) call `ackAllPending()` after the filter checks. `Notification(idle_prompt)` is the critical late-add: it covers Edit-style approves where Claude doesn't re-emit `PreToolUse`.
- Timeout is `PERMISSION_INJECT_ACK_TIMEOUT_MS` (1000 ms default), configurable via the new `HookBridgeArgs.injectAckTimeoutMs` so tests can run fast.
- On timeout: a session-alive gate (`mainSessionEnded || claudeSessionId === null`) suppresses phantom escalations on torn-down sessions; otherwise `clearPermissionHandled()` drops the dedup mark and `escalateToUser()` emits the canonical question.

## Behavior matrix

| Path | Before #382 | After #382 |
|---|---|---|
| approve + PostToolUse arrives | dedup armed silently; Notification suppressed | ack resolved; no escalation |
| approve + Edit (no fresh PreToolUse) + idle_prompt | n/a | ack resolved on idle_prompt; no phantom escalation |
| approve + PTY drops byte (silent) | **dedup armed forever; user sees nothing** | timeout fires; dedup cleared; question escalated |
| deny + Stop arrives | dedup armed silently | ack resolved; no escalation |
| inject() throws | dedup not refreshed; existing escalation | ack pre-cancelled; existing escalation (no double-fire) |
| approve + slow PostToolUse (>1s) | n/a | timeout fires; question escalates as fallback |
| timer fires post-shutdown | n/a | session-alive gate suppresses; no phantom |

The "slow PostToolUse" cell is a deliberate trade-off: 1 second is comfortably above typical Claude tool latency, and the cost of a false escalation is one extra question card on iOS, which the user can dismiss. The cost of NOT having the timer is the silent failure we're fixing.

## Tests

7 new tests in `tests/cli/session-phases/hook-bridge-setup.test.ts`:
1. **approve + PostToolUse arrives in time** → no escalation
2. **approve + no follow-up event** → ack timeout escalates exactly once
3. **deny + Stop arrives in time** → no escalation
4. **submitInput throws → ack cancelled** → exactly one escalation (cancellation path)
5. **default ack timeout (no override)** → no fast escalation in 200 ms (locks in `args.injectAckTimeoutMs ?? 1000` fallback)
6. **Notification(idle_prompt) resolves the ack** → Edit-style approve does not phantom-escalate

All use `injectAckTimeoutMs: 100ms` (with `until()` horizons of 1000 ms) for stable CI timing.

Full daemon suite: 681/681 pass. Typecheck + biome clean.

## Review findings addressed (PR review)

- **comment-analyzer**: dropped issue refs from source comments, replaced hardcoded qualifying-events lists with references to `ackAllPending()` call sites, dropped magic-number `1000ms` from JSDoc, deleted three near-duplicate inline comments, reworded SessionEnd comment, made the multi-inject limitation comment honest about masking risk.
- **pr-test-analyzer**: bumped `injectAckTimeoutMs` 50ms→100ms, replaced bare `setTimeout(150)` tail-waits with 250ms + `until()` horizons of 1000ms, dropped the misleading "ack timeout AFTER Notification dedup expired" test (defensive `clearPermissionHandled()` is unobservable due to `handlePermissionRequest` re-arming), added cancellation-path + default-fallback + idle_prompt tests.
- **silent-failure-hunter**: added session-alive gate inside the timer's `onTimeout`; added `Notification(non-permission_prompt)` to the qualifying-events set (closes the Edit-approve gap).
- **code-reviewer**: same as silent-failure-hunter on idle_prompt; confirmed no race in `clearTimeout` → `resolved` ordering; confirmed the pre-await `startPendingAck` placement is sound under JS event-loop semantics.

## Known limitations & follow-ups

- **#384** (filed): per-`tool_use_id` correlation for `PendingAck`. Today `ackAllPending()` resolves every ack on any qualifying event; with two injects in flight, A's PostToolUse can mask B's silent failure. The clean fix needs upstream Claude Code to expose `tool_use_id` on `PermissionRequest` (currently absent — verified in `hooks/hook-types.ts:68`). Adjacency correlation from the most recent `PreToolUse.tool_use_id` was considered but rejected as fragile.
- **#385** (filed): `setupHookBridge` should return `dispose()` for clean teardown of hook listeners + pending timers + transcript fallback timers. Today the session-alive gate inside the timer prevents the most user-visible regression (phantom escalation post-shutdown) but the structural issue remains.
- **False positive on slow tool latency**: a tool that takes > 1 s and emits no intermediate hook events will trigger a spurious escalation. Tunable via `injectAckTimeoutMs`. If we see this in practice we can extend the timeout or wire `SubagentStart` into the qualifying-events set.

## Test plan

- [ ] CI green
- [ ] Manual repro: rebuild binary, run `remi --auto-approve` under load, confirm: (a) normal auto-approve flow no longer leaves silent gaps; (b) `~/.remi/remi.log` shows `inject ack timeout` lines only when Claude actually didn't advance.
- [ ] Verify the iOS app receives a fallback question when the ack timer fires.

## Related

- #382 (closes)
- #379 / #381 (parent: pre-emptive dedup that exposed this failure mode)
- #384, #385 (follow-ups filed alongside this PR)
- #377 (multi-token push, separate)
- #378 (3-options regression, separate, up next)
