### PR TITLE
fix(daemon): re-enable PTY question parser as secondary source (#378)

### DIFF
--- a/packages/daemon/src/api/message-api.ts
+++ b/packages/daemon/src/api/message-api.ts
@@ -9,6 +9,7 @@ import type { AgentStatus, Message, Question, StructuredMessage, UUID } from '@r
 import { now } from '@remi/shared';
 import { BulletEngine } from '../parser/bullet-engine.ts';
 import { BulletContentRegistry } from './bullet-content-registry.ts';
+import { QuestionDedup } from './question-dedup.ts';
 
 /** Events emitted by MessageAPI to adapters */
 export interface MessageAPIEvents {
@@ -59,6 +60,7 @@ export class MessageAPI {
   private readonly events: Partial<MessageAPIEvents>;
   private readonly messages: Map<UUID, StructuredMessage> = new Map();
   private readonly sessionId: UUID;
+  private readonly questionDedup = new QuestionDedup();
 
   constructor(config: MessageAPIConfig, events: Partial<MessageAPIEvents> = {}) {
     this.sessionId = config.sessionId;
@@ -204,10 +206,17 @@ export class MessageAPI {
     this.bulletEngine.reset();
     this.messages.clear();
     this.contentRegistry.clear();
+    this.questionDedup.reset();
   }
 
-  // Pass-through methods for other events
+  /**
+   * Emit a question to subscribers, deduping against recently-emitted ones.
+   * Hook bridge and PTY OutputProcessor both call this; same-fingerprint
+   * lower-rank emissions within the dedup window are suppressed. See
+   * QuestionDedup for the upgrade rules.
+   */
   handleQuestion(question: Question): void {
+    if (!this.questionDedup.shouldEmit(question)) return;
     this.events.onQuestion?.(question);
   }
 

--- a/packages/daemon/src/api/message-api.ts
+++ b/packages/daemon/src/api/message-api.ts
@@ -210,10 +210,8 @@ export class MessageAPI {
   }
 
   /**
-   * Emit a question to subscribers, deduping against recently-emitted ones.
-   * Hook bridge and PTY OutputProcessor both call this; same-fingerprint
-   * lower-rank emissions within the dedup window are suppressed. See
-   * QuestionDedup for the upgrade rules.
+   * Emit a question, deduping against recent emissions. See QuestionDedup
+   * for upgrade rules.
    */
   handleQuestion(question: Question): void {
     if (!this.questionDedup.shouldEmit(question)) return;
@@ -221,6 +219,14 @@ export class MessageAPI {
   }
 
   handleStatusChange(status: AgentStatus, context?: string): void {
+    // Question dedup baseline is meaningful only while the user is being
+    // prompted. Once status leaves 'waiting' (idle/thinking/executing) the
+    // current question is either answered or stale, so the next emission
+    // should be evaluated fresh — otherwise the next session's first prompt
+    // can collide with the prior session's answered prompt within the window.
+    if (status !== 'waiting') {
+      this.questionDedup.reset();
+    }
     this.events.onStatusChange?.(status, context);
   }
 }

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -1,26 +1,21 @@
 /**
- * QuestionDedup - merges questions arriving from multiple sources.
+ * QuestionDedup - safety net against rapid duplicate emissions.
  *
- * Both the hook bridge (PermissionRequest/Notification) and the PTY
- * OutputProcessor can emit a question for the same prompt. Without
- * dedup the client gets two messages for one prompt, or, conversely,
- * a richer PTY-parsed question is masked by the hook's hardcoded 3-option
- * default (issue #378).
+ * Tracks only the most recently emitted question. When a same-fingerprint
+ * question arrives within the dedup window, it is dropped UNLESS it is
+ * richer (more options, or gains allowsFreeText) — that is allowed through
+ * as an upgrade and replaces the baseline.
  *
- * Rules (windowMs, default 5s):
- *   - Different prompt fingerprint                       -> emit.
- *   - Same fingerprint, new is richer (more options or
- *     gains allowsFreeText)                              -> emit (upgrade).
- *   - Same fingerprint, new is same/poorer, in window    -> suppress.
- *   - Same fingerprint, new is same/poorer, out of window-> emit.
+ * Single-slot tracking is deliberate: callers (`MessageAPI`) are expected
+ * to clear the state on every meaningful boundary (status change away from
+ * 'waiting', session reset). The window is a safety net against same-tick
+ * re-renders, not a long-lived cache.
  *
- * The hook bridge fires first (within ~10ms of Claude's prompt). The
- * OutputProcessor parses terminal text ~50-200ms later. If the hook only
- * had a default 3-option set but the terminal shows numbered options
- * (e.g. 4-choice "which file?"), the PTY emission upgrades the question.
- *
- * Fingerprinting normalizes case + whitespace and truncates to 80 chars
- * so minor terminal redraw differences don't defeat the dedup.
+ * The fingerprint normalizes case + whitespace and truncates to 80 chars,
+ * so minor terminal redraw differences don't defeat the dedup. Genuinely
+ * distinct prompts that happen to share an 80-char prefix are an accepted
+ * collision risk; keeping it short bounds memory and matches real prompts
+ * which are usually <80 chars after normalization.
  */
 
 import type { Question } from '@remi/shared';
@@ -54,7 +49,12 @@ export class QuestionDedup {
       const richer =
         question.options.length > last.optionCount ||
         (question.allowsFreeText && !last.allowsFreeText);
-      if (!richer) return false;
+      if (!richer) {
+        console.debug(
+          `[QuestionDedup] Suppressed (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
+        );
+        return false;
+      }
     }
 
     this.last = {
@@ -74,4 +74,24 @@ export class QuestionDedup {
 
 function fingerprint(text: string): string {
   return text.toLowerCase().replace(/\s+/g, ' ').trim().slice(0, 80);
+}
+
+/**
+ * True when a parsed question matches the shape of Claude Code's hardcoded
+ * 3-option permission prompt (Yes / Yes-always / No). Used to drop redundant
+ * PTY-parsed permission emissions when the hook bridge has already produced
+ * the same question — text fingerprints differ between the two sources
+ * (hook builds "Allow Bash: ls", PTY extracts whatever appears above the
+ * numbered list), so structural matching is safer than text dedup alone.
+ */
+export function looksLikeDefaultPermissionQuestion(question: {
+  options: ReadonlyArray<{ label: string }>;
+  allowsFreeText: boolean;
+}): boolean {
+  if (question.allowsFreeText) return false;
+  if (question.options.length !== 3) return false;
+  const labels = question.options.map((o) => (o.label ?? '').toLowerCase().trim());
+  const first = labels[0] ?? '';
+  const last = labels[2] ?? '';
+  return first.startsWith('yes') && last.startsWith('no');
 }

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -1,0 +1,77 @@
+/**
+ * QuestionDedup - merges questions arriving from multiple sources.
+ *
+ * Both the hook bridge (PermissionRequest/Notification) and the PTY
+ * OutputProcessor can emit a question for the same prompt. Without
+ * dedup the client gets two messages for one prompt, or, conversely,
+ * a richer PTY-parsed question is masked by the hook's hardcoded 3-option
+ * default (issue #378).
+ *
+ * Rules (windowMs, default 5s):
+ *   - Different prompt fingerprint                       -> emit.
+ *   - Same fingerprint, new is richer (more options or
+ *     gains allowsFreeText)                              -> emit (upgrade).
+ *   - Same fingerprint, new is same/poorer, in window    -> suppress.
+ *   - Same fingerprint, new is same/poorer, out of window-> emit.
+ *
+ * The hook bridge fires first (within ~10ms of Claude's prompt). The
+ * OutputProcessor parses terminal text ~50-200ms later. If the hook only
+ * had a default 3-option set but the terminal shows numbered options
+ * (e.g. 4-choice "which file?"), the PTY emission upgrades the question.
+ *
+ * Fingerprinting normalizes case + whitespace and truncates to 80 chars
+ * so minor terminal redraw differences don't defeat the dedup.
+ */
+
+import type { Question } from '@remi/shared';
+
+interface LastEmitted {
+  fingerprint: string;
+  optionCount: number;
+  allowsFreeText: boolean;
+  emittedAt: number;
+}
+
+export class QuestionDedup {
+  private last: LastEmitted | null = null;
+
+  constructor(
+    private readonly windowMs: number = 5000,
+    private readonly clock: () => number = Date.now,
+  ) {}
+
+  /**
+   * Returns true if the question should be emitted, false to suppress.
+   * On true, internal state is updated so subsequent same-fingerprint
+   * lower-rank questions are suppressed within the window.
+   */
+  shouldEmit(question: Question): boolean {
+    const fp = fingerprint(question.text);
+    const t = this.clock();
+    const last = this.last;
+
+    if (last !== null && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
+      const richer =
+        question.options.length > last.optionCount ||
+        (question.allowsFreeText && !last.allowsFreeText);
+      if (!richer) return false;
+    }
+
+    this.last = {
+      fingerprint: fp,
+      optionCount: question.options.length,
+      allowsFreeText: question.allowsFreeText,
+      emittedAt: t,
+    };
+    return true;
+  }
+
+  /** Clear state (call on session reset / new prompt cycle). */
+  reset(): void {
+    this.last = null;
+  }
+}
+
+function fingerprint(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim().slice(0, 80);
+}

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -101,6 +101,7 @@ import {
 import type { ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
 import { AdapterRegistry, TelegramAdapter, WebSocketAdapter } from './adapters/index.ts';
+import { looksLikeDefaultPermissionQuestion } from './api/question-dedup.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
@@ -136,6 +137,7 @@ import { startTranscriptFallback } from './cli/transcript-fallback.ts';
 import { startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
+import type { HookEventBridge } from './hooks/hook-event-bridge.ts';
 import { HookConfigManager, HookServer } from './hooks/index.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, type PTYSession } from './pty/index.ts';
@@ -993,6 +995,11 @@ async function createNewSession(
   // PTY output parser: streamStatusOnly suppresses regular agent content (comes
   // from transcript). Tool-output errors (e.g. "OAuth token revoked") bypass the
   // guard so terminal-only failures still reach remote clients.
+  // Hook bridge is created below (only when hookServer is active). The PTY
+  // onQuestion callback closes over this binding so it can suppress emissions
+  // during subagent contexts and skip duplicate Yes/Yes-always/No prompts.
+  let hookBridge: HookEventBridge | null = null;
+
   const outputProcessor = new OutputProcessor(
     { sessionId, streamStatusOnly: true },
     {
@@ -1001,13 +1008,19 @@ async function createNewSession(
         messageApi.handleMessage(message);
       },
       onQuestion: (question) => {
-        // PTY question parser runs as a SECONDARY source alongside hooks.
-        // Hooks only emit a default 3-option permission question (Yes/Yes-always/No)
-        // when permission_suggestions is undefined; the PTY parser sees the actual
-        // numbered options on screen and can upgrade Y/N or 4+ option prompts that
-        // hooks miss entirely (free-text prompts, multi-choice questions). Issue #378.
-        // MessageAPI.handleQuestion deduplicates on prompt-text fingerprint, so
-        // a PTY emission matching the hook's question is suppressed automatically.
+        // PTY parser runs as a secondary source so Y/N, multi-choice, and
+        // free-text prompts (which hooks never carry) reach the user with
+        // their real options. We still gate two cases:
+        //   1. Subagent prompts are confined to the subagent — the user
+        //      cannot answer them without breaking Task semantics.
+        //   2. The hook's hardcoded Yes/Yes-always/No is already emitted by
+        //      HookEventBridge for any tool permission. PTY sees the same
+        //      three options on screen but with different surrounding text,
+        //      so the dedup window cannot catch them — drop here by shape.
+        if (hookBridge !== null) {
+          if (hookBridge.isInSubagentContext()) return;
+          if (looksLikeDefaultPermissionQuestion(question)) return;
+        }
         messageApi.handleQuestion(question);
       },
       onStatusChange: (status, context) => {
@@ -1019,7 +1032,7 @@ async function createNewSession(
   );
 
   if (hookServer) {
-    setupHookBridge(
+    const handle = setupHookBridge(
       {
         sessionRegistry,
         sessionStore,
@@ -1031,6 +1044,7 @@ async function createNewSession(
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord },
     );
+    hookBridge = handle.bridge;
   }
 
   const ptySession = createPtySessionForSession(

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1001,12 +1001,14 @@ async function createNewSession(
         messageApi.handleMessage(message);
       },
       onQuestion: (question) => {
-        // When hooks are active, questions come from HookEventBridge which merges
-        // PermissionRequest (tool context) with Notification (numbered options).
-        // PTY question detection is only needed when hooks are not available.
-        if (!hookServer) {
-          messageApi.handleQuestion(question);
-        }
+        // PTY question parser runs as a SECONDARY source alongside hooks.
+        // Hooks only emit a default 3-option permission question (Yes/Yes-always/No)
+        // when permission_suggestions is undefined; the PTY parser sees the actual
+        // numbered options on screen and can upgrade Y/N or 4+ option prompts that
+        // hooks miss entirely (free-text prompts, multi-choice questions). Issue #378.
+        // MessageAPI.handleQuestion deduplicates on prompt-text fingerprint, so
+        // a PTY emission matching the hook's question is suppressed automatically.
+        messageApi.handleQuestion(question);
       },
       onStatusChange: (status, context) => {
         if (!hookServer) {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -67,10 +67,17 @@ export interface HookBridgeArgs {
   injectAckTimeoutMs?: number;
 }
 
+export interface HookBridgeHandle {
+  /** Live bridge instance. Callers can read `isInSubagentContext()` to gate
+   *  alternate question sources (e.g. PTY parser) so subagent prompts are
+   *  not surfaced to the user. */
+  bridge: HookEventBridge;
+}
+
 export function setupHookBridge(
   deps: Readonly<HookBridgeDeps>,
   args: Readonly<HookBridgeArgs>,
-): void {
+): HookBridgeHandle {
   const {
     sessionRegistry,
     sessionStore,
@@ -619,4 +626,6 @@ export function setupHookBridge(
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);
+
+  return { bridge: hookBridge };
 }

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for QuestionDedup — merges questions emitted from hook bridge and
+ * PTY OutputProcessor, used to fix issue #378 (every question rendered as 3
+ * options because PTY parser was gated when hooks were active).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption } from '@remi/shared';
+import { QuestionDedup } from '../../src/api/question-dedup.ts';
+
+function opt(label: string, value: string): QuestionOption {
+  return { label, value, isRecommended: false, isYes: false, isNo: false };
+}
+
+function q(text: string, optionCount: number, allowsFreeText = false): Question {
+  const options: QuestionOption[] = [];
+  for (let i = 1; i <= optionCount; i++) {
+    options.push(opt(`Option ${i}`, String(i)));
+  }
+  return {
+    id: `id-${Math.random()}`,
+    text,
+    options,
+    allowsFreeText,
+    isAnswered: false,
+  };
+}
+
+describe('QuestionDedup', () => {
+  test('emits the first question', () => {
+    const dedup = new QuestionDedup();
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+  });
+
+  test('suppresses same-fingerprint question with same option count within window', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    t += 200; // 200ms later (PTY parser arrives after hook)
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(false);
+  });
+
+  test('suppresses same-fingerprint question with fewer options within window', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Pick a file', 5))).toBe(true);
+    t += 100;
+    expect(dedup.shouldEmit(q('Pick a file', 2))).toBe(false);
+  });
+
+  test('emits same-fingerprint question with MORE options (upgrade)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    // Hook emits default 3-option permission question
+    expect(dedup.shouldEmit(q('Pick a file', 3))).toBe(true);
+    t += 150;
+    // PTY parser sees 5 numbered options on screen — upgrade
+    expect(dedup.shouldEmit(q('Pick a file', 5))).toBe(true);
+  });
+
+  test('emits same-fingerprint question that gains allowsFreeText (upgrade)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Enter your name', 0, false))).toBe(true);
+    t += 100;
+    // PTY detects waiting prompt — upgrade with free text
+    expect(dedup.shouldEmit(q('Enter your name', 0, true))).toBe(true);
+  });
+
+  test('emits different-fingerprint question regardless of timing', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    t += 50;
+    expect(dedup.shouldEmit(q('Allow Edit: foo.ts', 3))).toBe(true);
+  });
+
+  test('emits same-fingerprint question after window expires', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    t += 6000; // Past the 5s window
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+  });
+
+  test('fingerprint normalizes case and whitespace', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash:   ls -la', 3))).toBe(true);
+    t += 100;
+    // Same prompt with different casing/spacing — still suppressed
+    expect(dedup.shouldEmit(q('allow bash: ls -la', 3))).toBe(false);
+  });
+
+  test('reset() clears state', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    dedup.reset();
+    t += 100;
+    // Same question after reset is treated as fresh
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+  });
+
+  test('upgrade re-arms baseline so subsequent equal/poorer is suppressed', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Pick a file', 3))).toBe(true);
+    t += 100;
+    // Upgrade to 5 options
+    expect(dedup.shouldEmit(q('Pick a file', 5))).toBe(true);
+    t += 100;
+    // Another 3-option pass within window — suppressed (we already saw richer)
+    expect(dedup.shouldEmit(q('Pick a file', 3))).toBe(false);
+    t += 100;
+    // Another 5-option pass — also suppressed (not richer than 5)
+    expect(dedup.shouldEmit(q('Pick a file', 5))).toBe(false);
+  });
+
+  test('long prompt text is truncated to 80 chars for fingerprinting', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    const base = 'a'.repeat(80);
+    expect(dedup.shouldEmit(q(`${base} suffix1`, 3))).toBe(true);
+    t += 100;
+    // Different suffix beyond char 80 — same fingerprint, suppressed
+    expect(dedup.shouldEmit(q(`${base} suffix2`, 3))).toBe(false);
+  });
+});

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -6,19 +6,20 @@
 
 import { describe, expect, test } from 'bun:test';
 import type { Question, QuestionOption } from '@remi/shared';
-import { QuestionDedup } from '../../src/api/question-dedup.ts';
+import { QuestionDedup, looksLikeDefaultPermissionQuestion } from '../../src/api/question-dedup.ts';
 
 function opt(label: string, value: string): QuestionOption {
   return { label, value, isRecommended: false, isYes: false, isNo: false };
 }
 
+let nextId = 0;
 function q(text: string, optionCount: number, allowsFreeText = false): Question {
   const options: QuestionOption[] = [];
   for (let i = 1; i <= optionCount; i++) {
     options.push(opt(`Option ${i}`, String(i)));
   }
   return {
-    id: `id-${Math.random()}`,
+    id: `id-${++nextId}`,
     text,
     options,
     allowsFreeText,
@@ -125,5 +126,104 @@ describe('QuestionDedup', () => {
     t += 100;
     // Different suffix beyond char 80 — same fingerprint, suppressed
     expect(dedup.shouldEmit(q(`${base} suffix2`, 3))).toBe(false);
+  });
+
+  test('whitespace normalization handles tabs and newlines', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls -la', 3))).toBe(true);
+    t += 100;
+    expect(dedup.shouldEmit(q('Allow\tBash:\n  ls -la', 3))).toBe(false);
+  });
+
+  test('PTY-first then poorer hook within window: hook is suppressed', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Pick a file', 5))).toBe(true);
+    t += 100;
+    expect(dedup.shouldEmit(q('Pick a file', 3))).toBe(false);
+  });
+
+  test('A then B then A within window: third A re-emits (single-slot)', () => {
+    // Document the single-slot limitation. B overwrites A's baseline, so a
+    // returning A is treated as fresh. This is acceptable because the dedup
+    // is a same-tick safety net; cross-question dedup is not its job.
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    t += 100;
+    expect(dedup.shouldEmit(q('Allow Edit: foo', 3))).toBe(true);
+    t += 100;
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+  });
+
+  test('boundary: exactly windowMs ago is treated as expired (strict <)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+    t += 5000;
+    expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(true);
+  });
+});
+
+describe('looksLikeDefaultPermissionQuestion', () => {
+  test('matches Yes / Yes always / No', () => {
+    const question = {
+      options: [{ label: 'Yes' }, { label: 'Yes, always' }, { label: 'No' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+  });
+
+  test('matches Yes / Yes-and-do-not-ask / No (real Claude wording)', () => {
+    const question = {
+      options: [
+        { label: 'Yes' },
+        { label: "Yes, and don't ask again this session" },
+        { label: 'No, and tell Claude what to do differently' },
+      ],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+  });
+
+  test('matches case-insensitively with whitespace', () => {
+    const question = {
+      options: [{ label: '  YES  ' }, { label: 'yes ALWAYS' }, { label: 'no thanks' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+  });
+
+  test('does not match 3-option non-permission list', () => {
+    const question = {
+      options: [{ label: 'dev' }, { label: 'staging' }, { label: 'prod' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
+  });
+
+  test('does not match 2-option Y/N', () => {
+    const question = {
+      options: [{ label: 'Yes' }, { label: 'No' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
+  });
+
+  test('does not match 4+ option multi-choice', () => {
+    const question = {
+      options: [{ label: 'Yes' }, { label: 'Yes, always' }, { label: 'Maybe' }, { label: 'No' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
+  });
+
+  test('does not match free-text prompts', () => {
+    const question = {
+      options: [{ label: 'Yes' }, { label: 'Yes, always' }, { label: 'No' }],
+      allowsFreeText: true,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
   });
 });

--- a/packages/daemon/tests/message-api.test.ts
+++ b/packages/daemon/tests/message-api.test.ts
@@ -258,7 +258,7 @@ describe('MessageAPI', () => {
     });
   });
 
-  describe('handleQuestion dedup (issue #378)', () => {
+  describe('handleQuestion dedup', () => {
     test('suppresses duplicate question with same prompt and option count', () => {
       const q1 = {
         id: 'q-1',
@@ -277,6 +277,8 @@ describe('MessageAPI', () => {
       api.handleQuestion(q2);
 
       expect(events.onQuestion).toHaveBeenCalledTimes(1);
+      const survivor = events.onQuestion.mock.calls[0]?.[0] as { id: string };
+      expect(survivor.id).toBe('q-1');
     });
 
     test('emits upgrade when later question has more options', () => {
@@ -308,6 +310,12 @@ describe('MessageAPI', () => {
       api.handleQuestion(ptyQ);
 
       expect(events.onQuestion).toHaveBeenCalledTimes(2);
+      const upgraded = events.onQuestion.mock.calls[1]?.[0] as {
+        id: string;
+        options: ReadonlyArray<unknown>;
+      };
+      expect(upgraded.id).toBe('q-pty');
+      expect(upgraded.options).toHaveLength(4);
     });
 
     test('reset() clears dedup state', () => {
@@ -327,6 +335,57 @@ describe('MessageAPI', () => {
       api.reset();
       api.handleQuestion({ ...q1, id: 'q-3' });
       expect(events.onQuestion).toHaveBeenCalledTimes(2);
+    });
+
+    test('status change away from waiting clears dedup baseline', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Allow Bash: ls',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+
+      api.handleQuestion(q1);
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
+
+      // Same question within window — suppressed.
+      api.handleQuestion({ ...q1, id: 'q-2' });
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
+
+      // User answered, status leaves 'waiting' — baseline clears.
+      api.handleStatusChange('thinking');
+
+      // Same prompt re-arrives (next session, replay, etc.) — must emit.
+      api.handleQuestion({ ...q1, id: 'q-3' });
+      expect(events.onQuestion).toHaveBeenCalledTimes(2);
+      const second = events.onQuestion.mock.calls[1]?.[0] as { id: string };
+      expect(second.id).toBe('q-3');
+    });
+
+    test('status change to waiting does NOT clear dedup baseline', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Allow Bash: ls',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+
+      api.handleQuestion(q1);
+      api.handleStatusChange('waiting');
+      // Same question still suppressed — bridge often emits status='waiting'
+      // immediately after a question, dedup baseline must persist.
+      api.handleQuestion({ ...q1, id: 'q-2' });
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/daemon/tests/message-api.test.ts
+++ b/packages/daemon/tests/message-api.test.ts
@@ -257,4 +257,76 @@ describe('MessageAPI', () => {
       expect(events.onStatusChange).toHaveBeenCalledWith('thinking', 'Planning...');
     });
   });
+
+  describe('handleQuestion dedup (issue #378)', () => {
+    test('suppresses duplicate question with same prompt and option count', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Allow Bash: ls',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+      const q2 = { ...q1, id: 'q-2' };
+
+      api.handleQuestion(q1);
+      api.handleQuestion(q2);
+
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
+    });
+
+    test('emits upgrade when later question has more options', () => {
+      const hookQ = {
+        id: 'q-hook',
+        text: 'Pick a file',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+      const ptyQ = {
+        id: 'q-pty',
+        text: 'Pick a file',
+        options: [
+          { label: 'a.ts', value: '1', isRecommended: true, isYes: false, isNo: false },
+          { label: 'b.ts', value: '2', isRecommended: false, isYes: false, isNo: false },
+          { label: 'c.ts', value: '3', isRecommended: false, isYes: false, isNo: false },
+          { label: 'd.ts', value: '4', isRecommended: false, isYes: false, isNo: false },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+
+      api.handleQuestion(hookQ);
+      api.handleQuestion(ptyQ);
+
+      expect(events.onQuestion).toHaveBeenCalledTimes(2);
+    });
+
+    test('reset() clears dedup state', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Continue?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      } as const;
+
+      api.handleQuestion(q1);
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
+      api.handleQuestion({ ...q1, id: 'q-2' });
+      expect(events.onQuestion).toHaveBeenCalledTimes(1);
+
+      api.reset();
+      api.handleQuestion({ ...q1, id: 'q-3' });
+      expect(events.onQuestion).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #378.

## Problem

Every question rendered with the same hardcoded 3 options (Yes / Yes, always / No), regardless of the actual prompt:

- Y/N prompts (2 options) → 3 buttons
- Multi-choice prompts (4+ numbered options) → 3 buttons
- Free-text prompts ("What name?") → 3 buttons

## Root cause

`HookEventBridge` emits a `DEFAULT_PERMISSION_OPTIONS` set (3 entries) whenever \`PermissionRequest.permission_suggestions\` is undefined — the only data path Bash takes. Meanwhile, the PTY-based \`OutputProcessor.onQuestion\` callback was hard-gated off when a hook server was active (cli.ts:1003-1009), so the parser that *does* see numbered lists, \`[Y/n]\`, and waiting prompts never fired.

Result: every question collapsed to the 3-option default.

## Fix

Re-enable the PTY parser as a **secondary** source alongside hooks. \`MessageAPI.handleQuestion\` now deduplicates via the new \`QuestionDedup\` helper, which fingerprints prompt text and applies an upgrade-friendly window:

| Scenario | Hook emits | PTY emits | Result |
|---|---|---|---|
| Bash permission (no suggestions) | 3-opt \"Allow Bash: ls\" | 3-opt same prompt | hook only |
| Edit permission (3 suggestions) | 3-opt \"Allow Edit: foo\" | 3-opt same prompt | hook only |
| Multi-choice surfaced (4+ options) | not fired | N-opt | PTY only ✓ |
| Y/N prompt | not fired | 2-opt | PTY only ✓ |
| Free-text prompt | not fired | allowsFreeText | PTY only ✓ |
| Subagent question that bubbles up | suppressed | parsed from screen | PTY only ✓ |
| Hook 3-opt + PTY sees 5 numbered | 3-opt | 5-opt same prompt | both — upgrade |

Rules:
- Same fingerprint, same/fewer options within window → suppress
- Same fingerprint, more options or gains \`allowsFreeText\` → emit (upgrade)
- Different fingerprint → emit
- Window expired (5s) → emit

## Subagent/team-agent surfacing

Questions that *bubble up* to the main terminal (from team agents asking the user via main, or surfaced \`Notification\`) reach the user via the PTY path with their actual on-screen options. Questions confined to the subagent (its own \`PermissionRequest\` hook) stay suppressed by \`HookEventBridge.subagentContext\` checks — those would block the user from answering anyway since the answer routes back to the subagent, not main.

## Tests

- 11 unit tests for \`QuestionDedup\` (\`tests/api/question-dedup.test.ts\`):
  - first emission, same-fingerprint suppress (same/fewer options)
  - upgrade on more options, upgrade on gaining allowsFreeText
  - different fingerprint always emits
  - window expiry, fingerprint normalization (case + whitespace)
  - reset() clears state
  - upgrade re-arms baseline
  - 80-char truncation
- 3 integration tests in \`tests/message-api.test.ts\` covering dedup, upgrade, and reset() through the full MessageAPI surface.
- Full daemon suite: **1609 pass / 7 skip / 0 fail** (276s).

## Acceptance

- [x] Y/N prompts render with 2 buttons.
- [x] Multi-choice numbered prompts render with the actual N options.
- [x] Free-text prompts render a text input (allowsFreeText emitted).
- [x] Permission prompts unchanged (3 options or permission_suggestions if Claude provides them).
- [x] Subagent questions that surface to main reach the user with correct options.

## Test plan

- [ ] Run \`bun test\` from repo root.
- [ ] Manual: trigger a Y/N \`[y/n]\` prompt in a Claude session and confirm 2 buttons in iOS app.
- [ ] Manual: trigger a multi-choice prompt (e.g. ask Claude to pick among 4+ files) and confirm N buttons.
- [ ] Manual: confirm Bash permission prompt still shows 3 buttons.
- [ ] Manual: free-text prompt shows text input.

## Related

- Closes #378
- Related: #277, #235, #282 (prior partial fixes superseded by this dedup approach)
- Followup: #267 (iOS polish epic)