### PR TITLE
release: 0.5.3 (0.5.2 was already tagged)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.5.2-dev.3",
+  "version": "0.5.3-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.5.2-dev.3'; // REMI_COMPILED_VERSION
+      return '0.5.3-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.5.2-dev.3'; // REMI_COMPILED_VERSION
+    return '0.5.3-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 


### PR DESCRIPTION
The previous develop -> main merge (#389) bumped to 0.5.2 but **v0.5.2 was already tagged and released 3 weeks ago**, so the Auto Release job failed with \`fatal: tag 'v0.5.2' already exists\`. No double-publish happened — the failure was BEFORE the push, so nothing leaked.

This PR carries the same release content forward as 0.5.3:

- One commit on top of the prior merge: \`chore: bump version to 0.5.3-dev.1\`
- CI's Auto Release will strip the dev suffix and tag/release \`v0.5.3\`
- Sync-Develop will then merge main back into develop and bump to 0.5.4-dev.1

## Test plan

- [x] CI on develop is green at 7e1b338
- [ ] CI on this PR
- [ ] After merge, Auto Release tags v0.5.3 and the release pipeline publishes