### PR TITLE
fix(web): scan daemon port range when no port given (#393)

### DIFF
--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -239,6 +239,10 @@ export function ConnectModal({
   // (the auth pre-flight probe) so the UI can surface a different message.
   const [isScanning, setIsScanning] = useState(false);
   const [scanError, setScanError] = useState<string | null>(null);
+  // Cancels an in-flight port scan when the modal closes or the component
+  // unmounts; without this, 20 fetches keep racing for ~1.5s with nowhere
+  // to deliver their results.
+  const scanAbortRef = useRef<AbortController | null>(null);
 
   // Reset on close
   useEffect(() => {
@@ -249,8 +253,19 @@ export function ConnectModal({
       setIsProbing(false);
       setIsScanning(false);
       setScanError(null);
+      scanAbortRef.current?.abort();
+      scanAbortRef.current = null;
     }
   }, [isOpen]);
+
+  // Cancel any in-flight scan on unmount.
+  useEffect(
+    () => () => {
+      scanAbortRef.current?.abort();
+      scanAbortRef.current = null;
+    },
+    [],
+  );
 
   // Auto-focus host input when modal opens
   useEffect(() => {
@@ -334,18 +349,27 @@ export function ConnectModal({
           setScanError('Hostname is required');
           return;
         }
+        // New controller per scan; aborting any prior in-flight scan
+        // prevents a slow first attempt from completing AFTER the user
+        // started a second one with a different hostname.
+        scanAbortRef.current?.abort();
+        const controller = new AbortController();
+        scanAbortRef.current = controller;
         setIsScanning(true);
         let discovered: number | null = null;
         try {
-          discovered = await discoverDaemonPort(parsed.hostname);
+          discovered = await discoverDaemonPort(parsed.hostname, {
+            signal: controller.signal,
+          });
         } finally {
           setIsScanning(false);
+          if (scanAbortRef.current === controller) scanAbortRef.current = null;
         }
+        if (controller.signal.aborted) return;
         if (discovered === null) {
           const last = DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1;
           setScanError(
-            `No remi daemon found on ${parsed.hostname}:${DEFAULT_BASE_PORT}–${last}. ` +
-              `Is the daemon running? You can also try host:port directly.`,
+            `No remi daemon found on ${parsed.hostname}:${DEFAULT_BASE_PORT}–${last}. Is the daemon running? You can also try host:port directly.`,
           );
           return;
         }
@@ -462,7 +486,12 @@ export function ConnectModal({
                   ref={hostInputRef}
                   type="text"
                   value={host}
-                  onChange={(e) => setHost(e.target.value)}
+                  onChange={(e) => {
+                    setHost(e.target.value);
+                    // Stale "no daemon found" banner would otherwise
+                    // stick around while the user is editing the input.
+                    if (scanError) setScanError(null);
+                  }}
                   onKeyDown={handleKeyDown}
                   disabled={isConnecting}
                   placeholder="localhost"

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -9,6 +9,13 @@ import { useKeyboard } from '@/hooks/useKeyboard';
 import { probeAuthInfo } from '@/lib/auth-probe';
 import { isIdentityEncrypted } from '@/lib/identity-client';
 import { keyboardBackdropStyle } from '@/lib/keyboard-style';
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_PORT_RANGE,
+  buildWsUrl,
+  discoverDaemonPort,
+  parseHostInput,
+} from '@/lib/port-discovery';
 import type { ConnectionStatus } from '@/types';
 import { clsx } from 'clsx';
 import { AlertCircle, CheckCircle2, Globe, Key, Loader2, Monitor, Shield, X } from 'lucide-react';
@@ -35,35 +42,7 @@ interface ConnectModalProps {
 
 type ConnectionMode = 'local' | 'remote';
 
-const DEFAULT_PORT = 18765;
 const LOCALSTORAGE_HOST_KEY = 'remi-last-host';
-
-/** Build WebSocket URL from host and optional port */
-function buildWsUrl(host: string): string {
-  const trimmed = host.trim();
-  // If user entered a full ws:// URL, use it as-is (backward compat)
-  if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
-    return trimmed;
-  }
-  // IPv6 addresses contain multiple colons; don't split on port
-  const hasMultipleColons = (trimmed.match(/:/g) || []).length > 1;
-  if (hasMultipleColons) {
-    // Treat as IPv6 hostname without port
-    const hostname = trimmed.startsWith('[') ? trimmed : `[${trimmed}]`;
-    return `ws://${hostname}:${DEFAULT_PORT}/ws`;
-  }
-  // Extract port if provided (e.g., "192.168.1.5:18770")
-  const parts = trimmed.split(':');
-  const hostname = parts[0];
-  let port = DEFAULT_PORT;
-  if (parts.length > 1 && parts[1]) {
-    const parsed = Number.parseInt(parts[1], 10);
-    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 65535) {
-      port = parsed;
-    }
-  }
-  return `ws://${hostname}:${port}/ws`;
-}
 
 /** Code input with auto-formatting */
 function CodeInput({
@@ -255,6 +234,11 @@ export function ConnectModal({
     fingerprint: string | null;
   } | null>(null);
   const [isProbing, setIsProbing] = useState(false);
+  // Active when the user typed only a hostname and we're scanning the
+  // daemon port range to find a responder (#393). Distinct from `isProbing`
+  // (the auth pre-flight probe) so the UI can surface a different message.
+  const [isScanning, setIsScanning] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
 
   // Reset on close
   useEffect(() => {
@@ -263,6 +247,8 @@ export function ConnectModal({
       setHost(localStorage.getItem(LOCALSTORAGE_HOST_KEY) || 'localhost');
       setPreflightPending(null);
       setIsProbing(false);
+      setIsScanning(false);
+      setScanError(null);
     }
   }, [isOpen]);
 
@@ -284,8 +270,7 @@ export function ConnectModal({
   // pre-flight probe surfaced auth required up-front.
   const showPassphraseView =
     (needsPassphrase || preflightPending != null) && onPassphraseSubmit != null;
-  const passphraseFingerprint =
-    serverFingerprint ?? preflightPending?.fingerprint ?? null;
+  const passphraseFingerprint = serverFingerprint ?? preflightPending?.fingerprint ?? null;
 
   if (showPassphraseView && onPassphraseSubmit) {
     return (
@@ -332,8 +317,40 @@ export function ConnectModal({
 
   const handleConnect = async () => {
     if (mode === 'local') {
-      const wsUrl = buildWsUrl(host);
+      setScanError(null);
+      const parsed = parseHostInput(host);
       localStorage.setItem(LOCALSTORAGE_HOST_KEY, host.trim());
+
+      // Resolve a concrete port. If the user typed only a hostname (no
+      // explicit port), scan the daemon range so we still find a sibling
+      // when 18765 itself is empty (#393). User-supplied ports always win.
+      let wsUrl: string;
+      if (parsed.kind === 'wsurl') {
+        wsUrl = parsed.url;
+      } else if (parsed.explicitPort != null) {
+        wsUrl = buildWsUrl(parsed, parsed.explicitPort);
+      } else {
+        if (!parsed.hostname) {
+          setScanError('Hostname is required');
+          return;
+        }
+        setIsScanning(true);
+        let discovered: number | null = null;
+        try {
+          discovered = await discoverDaemonPort(parsed.hostname);
+        } finally {
+          setIsScanning(false);
+        }
+        if (discovered === null) {
+          const last = DEFAULT_BASE_PORT + DEFAULT_PORT_RANGE - 1;
+          setScanError(
+            `No remi daemon found on ${parsed.hostname}:${DEFAULT_BASE_PORT}–${last}. ` +
+              `Is the daemon running? You can also try host:port directly.`,
+          );
+          return;
+        }
+        wsUrl = buildWsUrl(parsed, discovered);
+      }
 
       // Pre-flight probe (#257). When the local identity is encrypted and
       // the user hasn't already unlocked it this session, ask the daemon
@@ -368,7 +385,7 @@ export function ConnectModal({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && canConnect && !isConnecting && !isProbing) {
+    if (e.key === 'Enter' && canConnect && !isConnecting && !isProbing && !isScanning) {
       e.preventDefault();
       void handleConnect();
     }
@@ -493,17 +510,28 @@ export function ConnectModal({
           )}
 
           {/* Status/Error */}
-          {(isConnecting || isAuthenticating || isConnected || error) && (
+          {(isScanning ||
+            isConnecting ||
+            isAuthenticating ||
+            isConnected ||
+            error ||
+            scanError) && (
             <div
               className={clsx(
                 'mt-4 flex items-center gap-2 rounded-lg p-3',
-                error && 'bg-[var(--color-error)]/10 text-[var(--color-error)]',
-                (isConnecting || isAuthenticating) &&
+                (error || scanError) && 'bg-[var(--color-error)]/10 text-[var(--color-error)]',
+                (isScanning || isConnecting || isAuthenticating) &&
                   'bg-[var(--color-warning)]/10 text-[var(--color-warning)]',
                 isConnected && 'bg-[var(--color-success)]/10 text-[var(--color-success)]',
               )}
             >
-              {(isConnecting || isAuthenticating) && (
+              {isScanning && (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  <span className="text-sm">Searching for daemon...</span>
+                </>
+              )}
+              {!isScanning && (isConnecting || isAuthenticating) && (
                 <>
                   <Loader2 className="size-4 animate-spin" />
                   <span className="text-sm">
@@ -517,10 +545,10 @@ export function ConnectModal({
                   <span className="text-sm">Connected</span>
                 </>
               )}
-              {error && (
+              {(error || scanError) && (
                 <>
                   <AlertCircle className="size-4" />
-                  <span className="text-sm">{error}</span>
+                  <span className="text-sm">{error ?? scanError}</span>
                 </>
               )}
             </div>
@@ -540,25 +568,37 @@ export function ConnectModal({
               void handleConnect();
             }}
             disabled={
-              !canConnect || isConnecting || isAuthenticating || isConnected || isProbing
+              !canConnect ||
+              isConnecting ||
+              isAuthenticating ||
+              isConnected ||
+              isProbing ||
+              isScanning
             }
             className={clsx(
               'flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
-              canConnect && !isConnecting && !isAuthenticating && !isConnected && !isProbing
+              canConnect &&
+                !isConnecting &&
+                !isAuthenticating &&
+                !isConnected &&
+                !isProbing &&
+                !isScanning
                 ? 'bg-[var(--color-primary)] hover:bg-[var(--color-primary-dark)]'
                 : 'cursor-not-allowed bg-[var(--color-primary)]/50',
             )}
           >
-            {isConnecting || isAuthenticating || isProbing ? (
+            {isConnecting || isAuthenticating || isProbing || isScanning ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Monitor className="size-4" />
             )}
-            {isProbing
-              ? 'Checking...'
-              : isConnecting || isAuthenticating
-                ? 'Discovering...'
-                : 'Connect'}
+            {isScanning
+              ? 'Scanning...'
+              : isProbing
+                ? 'Checking...'
+                : isConnecting || isAuthenticating
+                  ? 'Discovering...'
+                  : 'Connect'}
           </button>
         </div>
       </div>

--- a/packages/web/src/lib/port-discovery.ts
+++ b/packages/web/src/lib/port-discovery.ts
@@ -4,28 +4,37 @@
  * When the Connect modal is given a hostname without an explicit port, the
  * legacy code defaulted to 18765 and gave up if nothing answered. That fails
  * the common case where a user closed the daemon on 18765 but a sibling on
- * 18766/18767 is still serving — the daemon already advertises its real port
+ * 18766/18767 is still serving; the daemon already advertises its real port
  * over mDNS and replies with sibling ports on `SessionListResponse`, but only
  * AFTER the first WebSocket handshake succeeds.
  *
- * This module probes the daemon port range in parallel via the cheap
- * `/auth-info` HTTP endpoint and returns the first responder. It does NOT
- * race WebSockets (20 concurrent WS handshakes are heavier than 20 fetches,
- * and the upgrade path drags auth state along).
+ * This module races HTTP `/auth-info` probes (rather than full WebSocket
+ * upgrades) across the daemon port range and resolves to the first responder.
+ * Probes are cheap, parallel, and avoid dragging auth state through 20
+ * concurrent WS handshakes that all but one would tear back down.
  *
- * The default range matches `DaemonConfig` defaults (`base_port=18765`,
- * `port_range=20`).
+ * Port range matches `DaemonConfig` defaults; values are pinned to
+ * `DEFAULT_BASE_PORT` and `DEFAULT_PORT_RANGE` below.
  */
 
 import { authInfoUrl } from './auth-probe';
 
-/** Default base port — must match `DaemonConfig.base_port` in the daemon config. */
-export const DEFAULT_BASE_PORT = 18765;
+/** Must match `DaemonConfig.base_port` in `packages/daemon/src/config/config.ts`. */
+export const DEFAULT_BASE_PORT = 18765 as const;
 
-/** Default port range — must match `DaemonConfig.port_range`. */
-export const DEFAULT_PORT_RANGE = 20;
+/** Must match `DaemonConfig.port_range` in `packages/daemon/src/config/config.ts`. */
+export const DEFAULT_PORT_RANGE = 20 as const;
 
-/** Per-port probe timeout. Keep short so the whole scan fails fast on bad hosts. */
+/**
+ * Per-port probe timeout in milliseconds.
+ *
+ * Budget: a healthy LAN daemon answers `/auth-info` in single-digit ms; an
+ * unreachable host returns ECONNREFUSED in microseconds. The interesting
+ * case is a host that ACCEPTs the TCP connection but never responds (broken
+ * proxy, half-dead daemon). 1500 ms gives enough slack for slow VPN paths
+ * while keeping the worst-case scan under ~2 s before the modal surfaces an
+ * error.
+ */
 const PROBE_TIMEOUT_MS = 1500;
 
 /** Bracket a bare IPv6 literal so URL parsers accept it. */
@@ -65,8 +74,10 @@ async function probePort(
     const res = await fetch(httpUrl, { signal: controller.signal });
     return res.ok ? port : null;
   } catch {
-    // Three failure modes collapse to null: connection refused, timeout,
-    // and outer abort. The caller only cares whether *any* port answered.
+    // Failure modes collapse to null: connection refused, timeout, outer
+    // abort, mixed-content / CORS rejection. The caller only needs to know
+    // whether *any* port answered. Distinguishing the cause for better UX
+    // is tracked separately; see #393 review thread.
     return null;
   } finally {
     clearTimeout(timer);
@@ -76,13 +87,14 @@ async function probePort(
 
 /**
  * Discover the first daemon port responding on `hostname` within the given
- * range. Returns `null` if no port answers before the per-probe timeout.
+ * range. Returns `null` on any of: no port answered before the per-probe
+ * timeout, `portRange <= 0`, or the outer `signal` already aborted at call.
  *
  * Implementation: fans out fetches in parallel and resolves the moment the
  * first probe succeeds, aborting the rest. Sequential ordering is NOT
- * preserved — if both 18765 and 18766 answer, whichever wins the network
- * race wins. This is intentional; the daemon hands back sibling ports after
- * the first hello, so picking either one converges the same way.
+ * preserved; if 18765 and 18766 both answer, whichever wins the network race
+ * wins. This is intentional, since the daemon hands back sibling ports after
+ * the first hello — picking either one converges the same way.
  */
 export async function discoverDaemonPort(
   hostname: string,
@@ -100,14 +112,23 @@ export async function discoverDaemonPort(
   if (portRange <= 0) return null;
 
   const winner = new AbortController();
+  // Track the listener so the success path can detach it; without this, a
+  // long-lived caller that reuses one signal across many discover calls
+  // accumulates listeners until the signal eventually aborts.
+  let outerAbortListener: (() => void) | null = null;
   if (options.signal) {
     if (options.signal.aborted) return null;
-    options.signal.addEventListener('abort', () => winner.abort(), { once: true });
+    outerAbortListener = () => winner.abort();
+    options.signal.addEventListener('abort', outerAbortListener, { once: true });
   }
 
   const ports: number[] = [];
   for (let i = 0; i < portRange; i++) ports.push(basePort + i);
 
+  // Hand-rolled rather than `Promise.any`: we want to resolve `null` when
+  // every probe fails, but `Promise.any` would *reject* with AggregateError
+  // in that case. Inverting the success/failure shape of `probePort` to
+  // make `Promise.any` work is uglier than the explicit counter below.
   return new Promise<number | null>((resolve) => {
     let pending = ports.length;
     let resolved = false;
@@ -115,21 +136,22 @@ export async function discoverDaemonPort(
       if (resolved) return;
       resolved = true;
       winner.abort();
+      if (outerAbortListener && options.signal) {
+        options.signal.removeEventListener('abort', outerAbortListener);
+      }
       resolve(port);
     };
     for (const port of ports) {
-      probePort(hostname, port, timeoutMs, winner.signal).then(
-        (result) => {
-          if (result !== null) {
-            finish(result);
-            return;
-          }
-          if (--pending === 0) finish(null);
-        },
-        () => {
-          if (--pending === 0) finish(null);
-        },
-      );
+      // probePort is reject-proof: every error path returns `null`. So we
+      // only handle the fulfilled branch and rely on the counter to bottom
+      // out on `null` if no probe wins.
+      probePort(hostname, port, timeoutMs, winner.signal).then((result) => {
+        if (result !== null) {
+          finish(result);
+          return;
+        }
+        if (--pending === 0) finish(null);
+      });
     }
   });
 }
@@ -142,11 +164,9 @@ export type ParsedHost =
 /**
  * Parse the Connect modal's host input.
  *
- * - `ws://...` / `wss://...`: pass through verbatim (backward compat).
- * - `host:port`: explicit port, scan skipped.
- * - `host`: explicit port is null; caller should run port discovery.
- * - IPv6 literals are tolerated either bare (`::1`) or bracketed (`[::1]`).
- *   When bare, multiple colons are treated as the address with no port.
+ * Bare IPv6 literals (multiple colons, no brackets) are treated as having
+ * no explicit port: without brackets we can't tell which colon delimits the
+ * port. Users can write `[::1]:18770` to force one.
  */
 export function parseHostInput(input: string): ParsedHost {
   const trimmed = input.trim();
@@ -173,8 +193,6 @@ export function parseHostInput(input: string): ParsedHost {
 
   const colonCount = (trimmed.match(/:/g) || []).length;
   if (colonCount > 1) {
-    // Bare IPv6 literal — no way to distinguish a trailing port without
-    // brackets, so we don't try. User can supply [::1]:18770 to force one.
     return { kind: 'host', hostname: trimmed, explicitPort: null };
   }
 

--- a/packages/web/src/lib/port-discovery.ts
+++ b/packages/web/src/lib/port-discovery.ts
@@ -1,0 +1,197 @@
+/**
+ * Daemon port discovery (#393).
+ *
+ * When the Connect modal is given a hostname without an explicit port, the
+ * legacy code defaulted to 18765 and gave up if nothing answered. That fails
+ * the common case where a user closed the daemon on 18765 but a sibling on
+ * 18766/18767 is still serving — the daemon already advertises its real port
+ * over mDNS and replies with sibling ports on `SessionListResponse`, but only
+ * AFTER the first WebSocket handshake succeeds.
+ *
+ * This module probes the daemon port range in parallel via the cheap
+ * `/auth-info` HTTP endpoint and returns the first responder. It does NOT
+ * race WebSockets (20 concurrent WS handshakes are heavier than 20 fetches,
+ * and the upgrade path drags auth state along).
+ *
+ * The default range matches `DaemonConfig` defaults (`base_port=18765`,
+ * `port_range=20`).
+ */
+
+import { authInfoUrl } from './auth-probe';
+
+/** Default base port — must match `DaemonConfig.base_port` in the daemon config. */
+export const DEFAULT_BASE_PORT = 18765;
+
+/** Default port range — must match `DaemonConfig.port_range`. */
+export const DEFAULT_PORT_RANGE = 20;
+
+/** Per-port probe timeout. Keep short so the whole scan fails fast on bad hosts. */
+const PROBE_TIMEOUT_MS = 1500;
+
+/** Bracket a bare IPv6 literal so URL parsers accept it. */
+function bracketHost(hostname: string): string {
+  if (hostname.includes(':') && !hostname.startsWith('[')) {
+    return `[${hostname}]`;
+  }
+  return hostname;
+}
+
+/**
+ * Probe one (host, port) pair via /auth-info. Resolves to the port number on
+ * success, or `null` on any failure (including abort).
+ */
+async function probePort(
+  hostname: string,
+  port: number,
+  timeoutMs: number,
+  outerSignal: AbortSignal,
+): Promise<number | null> {
+  if (outerSignal.aborted) return null;
+
+  const wsUrl = `ws://${bracketHost(hostname)}:${port}/ws`;
+  let httpUrl: string;
+  try {
+    httpUrl = authInfoUrl(wsUrl);
+  } catch {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const onOuterAbort = () => controller.abort();
+  outerSignal.addEventListener('abort', onOuterAbort, { once: true });
+
+  try {
+    const res = await fetch(httpUrl, { signal: controller.signal });
+    return res.ok ? port : null;
+  } catch {
+    // Three failure modes collapse to null: connection refused, timeout,
+    // and outer abort. The caller only cares whether *any* port answered.
+    return null;
+  } finally {
+    clearTimeout(timer);
+    outerSignal.removeEventListener('abort', onOuterAbort);
+  }
+}
+
+/**
+ * Discover the first daemon port responding on `hostname` within the given
+ * range. Returns `null` if no port answers before the per-probe timeout.
+ *
+ * Implementation: fans out fetches in parallel and resolves the moment the
+ * first probe succeeds, aborting the rest. Sequential ordering is NOT
+ * preserved — if both 18765 and 18766 answer, whichever wins the network
+ * race wins. This is intentional; the daemon hands back sibling ports after
+ * the first hello, so picking either one converges the same way.
+ */
+export async function discoverDaemonPort(
+  hostname: string,
+  options: {
+    basePort?: number;
+    portRange?: number;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<number | null> {
+  const basePort = options.basePort ?? DEFAULT_BASE_PORT;
+  const portRange = options.portRange ?? DEFAULT_PORT_RANGE;
+  const timeoutMs = options.timeoutMs ?? PROBE_TIMEOUT_MS;
+
+  if (portRange <= 0) return null;
+
+  const winner = new AbortController();
+  if (options.signal) {
+    if (options.signal.aborted) return null;
+    options.signal.addEventListener('abort', () => winner.abort(), { once: true });
+  }
+
+  const ports: number[] = [];
+  for (let i = 0; i < portRange; i++) ports.push(basePort + i);
+
+  return new Promise<number | null>((resolve) => {
+    let pending = ports.length;
+    let resolved = false;
+    const finish = (port: number | null) => {
+      if (resolved) return;
+      resolved = true;
+      winner.abort();
+      resolve(port);
+    };
+    for (const port of ports) {
+      probePort(hostname, port, timeoutMs, winner.signal).then(
+        (result) => {
+          if (result !== null) {
+            finish(result);
+            return;
+          }
+          if (--pending === 0) finish(null);
+        },
+        () => {
+          if (--pending === 0) finish(null);
+        },
+      );
+    }
+  });
+}
+
+/** Parsed user input from the Connect modal host field. */
+export type ParsedHost =
+  | { kind: 'wsurl'; url: string }
+  | { kind: 'host'; hostname: string; explicitPort: number | null };
+
+/**
+ * Parse the Connect modal's host input.
+ *
+ * - `ws://...` / `wss://...`: pass through verbatim (backward compat).
+ * - `host:port`: explicit port, scan skipped.
+ * - `host`: explicit port is null; caller should run port discovery.
+ * - IPv6 literals are tolerated either bare (`::1`) or bracketed (`[::1]`).
+ *   When bare, multiple colons are treated as the address with no port.
+ */
+export function parseHostInput(input: string): ParsedHost {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
+    return { kind: 'wsurl', url: trimmed };
+  }
+
+  // Bracketed IPv6 with optional port: [::1] or [::1]:18770
+  if (trimmed.startsWith('[')) {
+    const closing = trimmed.indexOf(']');
+    if (closing > 0) {
+      const hostname = trimmed.slice(1, closing);
+      const rest = trimmed.slice(closing + 1);
+      let explicitPort: number | null = null;
+      if (rest.startsWith(':')) {
+        const parsed = Number.parseInt(rest.slice(1), 10);
+        if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 65535) {
+          explicitPort = parsed;
+        }
+      }
+      return { kind: 'host', hostname, explicitPort };
+    }
+  }
+
+  const colonCount = (trimmed.match(/:/g) || []).length;
+  if (colonCount > 1) {
+    // Bare IPv6 literal — no way to distinguish a trailing port without
+    // brackets, so we don't try. User can supply [::1]:18770 to force one.
+    return { kind: 'host', hostname: trimmed, explicitPort: null };
+  }
+
+  const parts = trimmed.split(':');
+  const hostname = parts[0] ?? '';
+  let explicitPort: number | null = null;
+  if (parts.length > 1 && parts[1]) {
+    const parsed = Number.parseInt(parts[1], 10);
+    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 65535) {
+      explicitPort = parsed;
+    }
+  }
+  return { kind: 'host', hostname, explicitPort };
+}
+
+/** Build the canonical `ws://host:port/ws` URL for a parsed host + chosen port. */
+export function buildWsUrl(parsed: ParsedHost, port: number): string {
+  if (parsed.kind === 'wsurl') return parsed.url;
+  return `ws://${bracketHost(parsed.hostname)}:${port}/ws`;
+}

--- a/packages/web/tests/lib/port-discovery.test.ts
+++ b/packages/web/tests/lib/port-discovery.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the daemon port discovery helper used by Connect (#393).
+ *
+ * Following the project rule: no mocks. We spin up real Bun HTTP servers
+ * on dynamic ports and let the helper probe them.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_PORT_RANGE,
+  buildWsUrl,
+  discoverDaemonPort,
+  parseHostInput,
+} from '../../src/lib/port-discovery';
+
+function authInfoServer() {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      const u = new URL(req.url);
+      if (u.pathname === '/auth-info') {
+        return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('Not found', { status: 404 });
+    },
+  });
+}
+
+describe('parseHostInput', () => {
+  test('plain hostname has no explicit port', () => {
+    expect(parseHostInput('localhost')).toEqual({
+      kind: 'host',
+      hostname: 'localhost',
+      explicitPort: null,
+    });
+  });
+
+  test('hostname with port surfaces the explicit port', () => {
+    expect(parseHostInput('192.168.1.5:18770')).toEqual({
+      kind: 'host',
+      hostname: '192.168.1.5',
+      explicitPort: 18770,
+    });
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(parseHostInput('  myhost:18765  ')).toEqual({
+      kind: 'host',
+      hostname: 'myhost',
+      explicitPort: 18765,
+    });
+  });
+
+  test('treats invalid port suffix as no explicit port', () => {
+    expect(parseHostInput('host:abc')).toEqual({
+      kind: 'host',
+      hostname: 'host',
+      explicitPort: null,
+    });
+    expect(parseHostInput('host:99999')).toEqual({
+      kind: 'host',
+      hostname: 'host',
+      explicitPort: null,
+    });
+    expect(parseHostInput('host:0')).toEqual({
+      kind: 'host',
+      hostname: 'host',
+      explicitPort: null,
+    });
+  });
+
+  test('passes ws:// URLs through unchanged', () => {
+    expect(parseHostInput('ws://foo:18765/ws')).toEqual({
+      kind: 'wsurl',
+      url: 'ws://foo:18765/ws',
+    });
+    expect(parseHostInput('wss://foo/ws')).toEqual({
+      kind: 'wsurl',
+      url: 'wss://foo/ws',
+    });
+  });
+
+  test('bare IPv6 literal has no explicit port', () => {
+    // Without brackets we can't tell which colon delimits the port, so
+    // we never infer one. Users can supply `[::1]:18770` to force one.
+    expect(parseHostInput('::1')).toEqual({
+      kind: 'host',
+      hostname: '::1',
+      explicitPort: null,
+    });
+    expect(parseHostInput('fe80::1')).toEqual({
+      kind: 'host',
+      hostname: 'fe80::1',
+      explicitPort: null,
+    });
+  });
+
+  test('bracketed IPv6 with optional port', () => {
+    expect(parseHostInput('[::1]')).toEqual({
+      kind: 'host',
+      hostname: '::1',
+      explicitPort: null,
+    });
+    expect(parseHostInput('[::1]:18770')).toEqual({
+      kind: 'host',
+      hostname: '::1',
+      explicitPort: 18770,
+    });
+  });
+});
+
+describe('buildWsUrl', () => {
+  test('builds ws://host:port/ws for plain host', () => {
+    const parsed = parseHostInput('localhost');
+    expect(buildWsUrl(parsed, 18765)).toBe('ws://localhost:18765/ws');
+  });
+
+  test('brackets bare IPv6 hosts', () => {
+    const parsed = parseHostInput('::1');
+    expect(buildWsUrl(parsed, 18765)).toBe('ws://[::1]:18765/ws');
+  });
+
+  test('does not double-bracket already-bracketed hosts', () => {
+    const parsed = parseHostInput('[::1]');
+    expect(buildWsUrl(parsed, 18770)).toBe('ws://[::1]:18770/ws');
+  });
+
+  test('passes wsurl through verbatim', () => {
+    const parsed = parseHostInput('ws://foo/ws');
+    expect(buildWsUrl(parsed, 12345)).toBe('ws://foo/ws');
+  });
+});
+
+describe('discoverDaemonPort', () => {
+  test('finds the only daemon in the range', async () => {
+    const server = authInfoServer();
+    try {
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort: server.port,
+        portRange: 5,
+        timeoutMs: 800,
+      });
+      expect(found).toBe(server.port);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('finds a daemon when it sits past the base port', async () => {
+    // Sibling daemons usually sit at base+1/base+2 in real life; the
+    // scan must not stop at the first refused-connection.
+    const server = authInfoServer();
+    try {
+      const basePort = server.port - 3;
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort,
+        portRange: 6,
+        timeoutMs: 800,
+      });
+      expect(found).toBe(server.port);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns one of the responding ports when multiple daemons answer', async () => {
+    // Two siblings at base and base+1; whoever wins the race is fine.
+    const a = authInfoServer();
+    const b = authInfoServer();
+    try {
+      const basePort = Math.min(a.port, b.port);
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort,
+        portRange: Math.abs(a.port - b.port) + 2,
+        timeoutMs: 800,
+      });
+      expect([a.port, b.port]).toContain(found);
+    } finally {
+      a.stop();
+      b.stop();
+    }
+  });
+
+  test('returns null when no daemon answers in the range', async () => {
+    // High-port range that should be empty on the test box.
+    const found = await discoverDaemonPort('127.0.0.1', {
+      basePort: 49100,
+      portRange: 4,
+      timeoutMs: 200,
+    });
+    expect(found).toBeNull();
+  });
+
+  test('returns null when the abort signal is already aborted', async () => {
+    const server = authInfoServer();
+    const ctl = new AbortController();
+    ctl.abort();
+    try {
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort: server.port,
+        portRange: 1,
+        timeoutMs: 800,
+        signal: ctl.signal,
+      });
+      expect(found).toBeNull();
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('returns null when portRange is zero', async () => {
+    const found = await discoverDaemonPort('127.0.0.1', {
+      basePort: 18765,
+      portRange: 0,
+    });
+    expect(found).toBeNull();
+  });
+
+  test('default range constants match the daemon defaults', () => {
+    // These are duplicated client-side; if the daemon ever changes them,
+    // this test should fail to remind us to update both.
+    expect(DEFAULT_BASE_PORT).toBe(18765);
+    expect(DEFAULT_PORT_RANGE).toBe(20);
+  });
+});

--- a/packages/web/tests/lib/port-discovery.test.ts
+++ b/packages/web/tests/lib/port-discovery.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for the daemon port discovery helper used by Connect (#393).
  *
- * Following the project rule: no mocks. We spin up real Bun HTTP servers
- * on dynamic ports and let the helper probe them.
+ * Real Bun HTTP servers on dynamic ports; no mocks.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -224,5 +223,100 @@ describe('discoverDaemonPort', () => {
     // this test should fail to remind us to update both.
     expect(DEFAULT_BASE_PORT).toBe(18765);
     expect(DEFAULT_PORT_RANGE).toBe(20);
+  });
+
+  test('aborts loser fetches when one port wins the race', async () => {
+    // Track whether the slow server's request handler observed an abort.
+    // If `winner.abort()` does not propagate through the per-probe
+    // controller, the slow handler runs to completion and the flag stays
+    // false, even if `discoverDaemonPort` returned the fast port.
+    let slowAborted = false;
+    const slow = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        await new Promise<void>((resolve) => {
+          if (req.signal.aborted) {
+            slowAborted = true;
+            resolve();
+            return;
+          }
+          req.signal.addEventListener(
+            'abort',
+            () => {
+              slowAborted = true;
+              resolve();
+            },
+            { once: true },
+          );
+          setTimeout(resolve, 1500);
+        });
+        if (req.signal.aborted) return new Response('aborted', { status: 499 });
+        return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+    const fast = authInfoServer();
+    try {
+      const basePort = Math.min(slow.port, fast.port);
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort,
+        portRange: Math.abs(slow.port - fast.port) + 2,
+        timeoutMs: 2000,
+      });
+      expect(found).toBe(fast.port);
+      // Allow the abort event loop to flush.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(slowAborted).toBe(true);
+    } finally {
+      slow.stop();
+      fast.stop();
+    }
+  });
+
+  test('per-probe timeout fires against a hung server', async () => {
+    // Server accepts the connection but never replies. Without the
+    // per-probe timer, the scan would hang indefinitely.
+    const hung = Bun.serve({
+      port: 0,
+      fetch: () => new Promise<Response>(() => {}),
+    });
+    try {
+      const start = Date.now();
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort: hung.port,
+        portRange: 1,
+        timeoutMs: 150,
+      });
+      const elapsed = Date.now() - start;
+      expect(found).toBeNull();
+      // Generous upper bound; the point is "didn't hang for 1.5s default".
+      expect(elapsed).toBeLessThan(1000);
+    } finally {
+      hung.stop();
+    }
+  });
+
+  test('outer signal aborted mid-flight cancels the scan promptly', async () => {
+    const hung = Bun.serve({
+      port: 0,
+      fetch: () => new Promise<Response>(() => {}),
+    });
+    const ctl = new AbortController();
+    setTimeout(() => ctl.abort(), 50);
+    try {
+      const start = Date.now();
+      const found = await discoverDaemonPort('127.0.0.1', {
+        basePort: hung.port,
+        portRange: 1,
+        timeoutMs: 5000,
+        signal: ctl.signal,
+      });
+      const elapsed = Date.now() - start;
+      expect(found).toBeNull();
+      expect(elapsed).toBeLessThan(800);
+    } finally {
+      hung.stop();
+    }
   });
 });

--- a/packages/web/tests/lib/port-discovery.test.ts
+++ b/packages/web/tests/lib/port-discovery.test.ts
@@ -28,6 +28,27 @@ function authInfoServer() {
   });
 }
 
+/**
+ * Bind a server adjacent to `anchorPort`. Walks +1, +2, ... until it finds
+ * a free port (most attempts succeed in 1–3 tries). Used by tests that need
+ * a tight scan range; CI runners allocate random ports thousands apart, so
+ * we cannot rely on `Bun.serve({ port: 0 })` placing two servers near each
+ * other. Returns the bound server.
+ */
+function bindNear(
+  anchorPort: number,
+  fetch: (req: Request) => Response | Promise<Response>,
+): { port: number; stop(): void } {
+  for (let offset = 1; offset < 50; offset++) {
+    try {
+      return Bun.serve({ port: anchorPort + offset, fetch });
+    } catch {
+      // Port in use; try next.
+    }
+  }
+  throw new Error(`bindNear: could not bind any port in [${anchorPort + 1}, ${anchorPort + 49}]`);
+}
+
 describe('parseHostInput', () => {
   test('plain hostname has no explicit port', () => {
     expect(parseHostInput('localhost')).toEqual({
@@ -166,14 +187,21 @@ describe('discoverDaemonPort', () => {
   });
 
   test('returns one of the responding ports when multiple daemons answer', async () => {
-    // Two siblings at base and base+1; whoever wins the race is fine.
+    // Two adjacent siblings; whoever wins the race is fine.
     const a = authInfoServer();
-    const b = authInfoServer();
+    const b = bindNear(a.port, (req) => {
+      const u = new URL(req.url);
+      if (u.pathname === '/auth-info') {
+        return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('Not found', { status: 404 });
+    });
     try {
-      const basePort = Math.min(a.port, b.port);
       const found = await discoverDaemonPort('127.0.0.1', {
-        basePort,
-        portRange: Math.abs(a.port - b.port) + 2,
+        basePort: a.port,
+        portRange: b.port - a.port + 1,
         timeoutMs: 800,
       });
       expect([a.port, b.port]).toContain(found);
@@ -228,40 +256,34 @@ describe('discoverDaemonPort', () => {
   test('aborts loser fetches when one port wins the race', async () => {
     // Track whether the slow server's request handler observed an abort.
     // If `winner.abort()` does not propagate through the per-probe
-    // controller, the slow handler runs to completion and the flag stays
-    // false, even if `discoverDaemonPort` returned the fast port.
+    // controller, the handler hangs forever (no setTimeout success path)
+    // and `slowAborted` stays false even though the fast port wins.
     let slowAborted = false;
-    const slow = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        await new Promise<void>((resolve) => {
-          if (req.signal.aborted) {
+    const fast = authInfoServer();
+    const slow = bindNear(fast.port, async (req) => {
+      await new Promise<void>((resolve) => {
+        if (req.signal.aborted) {
+          slowAborted = true;
+          resolve();
+          return;
+        }
+        req.signal.addEventListener(
+          'abort',
+          () => {
             slowAborted = true;
             resolve();
-            return;
-          }
-          req.signal.addEventListener(
-            'abort',
-            () => {
-              slowAborted = true;
-              resolve();
-            },
-            { once: true },
-          );
-          setTimeout(resolve, 1500);
-        });
-        if (req.signal.aborted) return new Response('aborted', { status: 499 });
-        return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
-          headers: { 'Content-Type': 'application/json' },
-        });
-      },
+          },
+          { once: true },
+        );
+      });
+      // The abort fired; the client already saw AbortError on its fetch
+      // and will not read this response.
+      return new Response('aborted', { status: 499 });
     });
-    const fast = authInfoServer();
     try {
-      const basePort = Math.min(slow.port, fast.port);
       const found = await discoverDaemonPort('127.0.0.1', {
-        basePort,
-        portRange: Math.abs(slow.port - fast.port) + 2,
+        basePort: fast.port,
+        portRange: slow.port - fast.port + 1,
         timeoutMs: 2000,
       });
       expect(found).toBe(fast.port);


### PR DESCRIPTION
## Summary

- Adds `discoverDaemonPort(host)` that fans `/auth-info` HTTP probes across the daemon range (18765..18784) in parallel and returns the first responder.
- Connect modal calls it whenever the user typed only a hostname; `host:port` and `ws://...` inputs still skip the scan.
- Surfaces a `Scanning...` button label, a `Searching for daemon...` status banner, and a clear error when nothing answers.

Closes #393.

## Why

A user closes the wrapper daemon on 18765 while sibling daemons remain on 18766/18767. With only the hostname in Connect, the legacy code tried 18765 and gave up. Typing `host:18766` worked, confirming the gap is purely client-side port discovery. The daemon already broadcasts sibling ports via `SessionListResponse.daemonPorts[]`, but only AFTER the first hello — so we have to find one daemon to reach the others.

## Implementation notes

- HTTP `/auth-info` is the cheap probe (already used by the auth pre-flight). It returns immediately and answers from the same vantage point as the WebSocket upgrade.
- Race-style: first `/auth-info` 200 wins, the other in-flight requests are aborted via a shared `AbortController`. No sequential `host:18765 → host:18766 → ...` waterfall.
- IPv6: `parseHostInput` accepts bare (`::1`) and bracketed (`[::1]:18770`) forms; `buildWsUrl` brackets bare hosts before constructing the URL.
- Constants `DEFAULT_BASE_PORT = 18765` and `DEFAULT_PORT_RANGE = 20` live in the new helper and a self-pinning test will fail loudly if the daemon ever changes them.

## Tests

`packages/web/tests/lib/port-discovery.test.ts` — 18 tests, real Bun servers, no mocks. Covers:

- `parseHostInput`: plain host, host:port, ws:// passthrough, IPv6 bare/bracketed, invalid port suffixes, whitespace.
- `buildWsUrl`: plain, IPv6 bracketing, ws:// passthrough.
- `discoverDaemonPort`: one daemon in range, daemon past the base port, multiple daemons (first wins), empty range, pre-aborted signal, zero range, default-constants self-pin.

## Test plan

- [x] `bun test packages/web/tests/lib/port-discovery.test.ts` (18/18 pass)
- [x] `bun test packages/web/tests/` (88/88 pass — no regressions)
- [x] `bun run build` from `packages/web` (tsc + vite both clean)
- [x] Biome on changed files (no new lint findings; pre-existing `useButtonType` errors on untouched buttons left alone)
- [ ] Manual: stop daemon on 18765, start sibling on 18766, type only `localhost` in Connect → should resolve to 18766 and show sessions.
- [ ] Manual: type `localhost:18770` (no daemon) → should still fail without scanning.
- [ ] Manual: type `localhost` with no daemons running → should show the "No remi daemon found on localhost:18765–18784" error.