### PR TITLE
fix(web): keep richer pending question when poorer arrives (#396)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@capacitor/network": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/status-bar": "^8.0.1",
+        "@remi/shared": "workspace:*",
         "@tailwindcss/vite": "^4.1.18",
         "clsx": "^2.1.1",
         "konsta": "^5.0.6",

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -18,7 +18,7 @@
  * which are usually <80 chars after normalization.
  */
 
-import type { Question } from '@remi/shared';
+import { QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
 
 interface LastEmitted {
   fingerprint: string;
@@ -31,7 +31,7 @@ export class QuestionDedup {
   private last: LastEmitted | null = null;
 
   constructor(
-    private readonly windowMs: number = 5000,
+    private readonly windowMs: number = QUESTION_DEDUP_WINDOW_MS,
     private readonly clock: () => number = Date.now,
   ) {}
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -16,7 +16,7 @@
  *     the redundant Notification.
  */
 
-import { generateId } from '@remi/shared';
+import { DEFAULT_PERMISSION_LABELS, generateId } from '@remi/shared';
 import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
 import type { HookServerEvents } from './hook-server.ts';
 import type {
@@ -41,11 +41,31 @@ export interface HookBridgeEvents {
 }
 
 /** Default permission options. Claude Code always offers these for tool
- *  permissions; the Notification hook message never contains numbered options. */
+ *  permissions; the Notification hook message never contains numbered options.
+ *  Labels are imported from `@remi/shared` so the web client's question-merge
+ *  guard recognises them as the bland fallback (#396). */
 const DEFAULT_PERMISSION_OPTIONS: readonly QuestionOption[] = [
-  { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
-  { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
-  { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+  {
+    label: DEFAULT_PERMISSION_LABELS[0],
+    value: '1',
+    isRecommended: true,
+    isYes: true,
+    isNo: false,
+  },
+  {
+    label: DEFAULT_PERMISSION_LABELS[1],
+    value: '2',
+    isRecommended: false,
+    isYes: true,
+    isNo: false,
+  },
+  {
+    label: DEFAULT_PERMISSION_LABELS[2],
+    value: '3',
+    isRecommended: false,
+    isYes: false,
+    isNo: true,
+  },
 ];
 
 /** Dedup window: suppress Notification(permission_prompt) arriving within

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,12 @@ export type {
 
 export { ok, err, isOk, isErr } from './types.ts';
 
+// Permission/question defaults shared by daemon and client (#396)
+export {
+  DEFAULT_PERMISSION_LABELS,
+  QUESTION_DEDUP_WINDOW_MS,
+} from './permission-defaults.ts';
+
 // Protocol
 export type {
   ProtocolMessage,

--- a/packages/shared/src/permission-defaults.ts
+++ b/packages/shared/src/permission-defaults.ts
@@ -1,0 +1,27 @@
+/**
+ * Hardcoded fallback values shared by the daemon's HookEventBridge and the
+ * web client's question-merge guard (#396).
+ *
+ * Both layers need to know what the daemon emits when a `PermissionRequest`
+ * arrives without `permission_suggestions`: the daemon uses these as the
+ * default option labels; the client uses them to detect "this incoming
+ * question is the bland fallback, not a richer custom 3-set worth keeping
+ * over a freshly rendered multi-choice." Keeping the values in one place
+ * prevents the two layers from drifting out of sync.
+ */
+
+/**
+ * Default option labels for permission prompts when Claude Code does not
+ * provide `permission_suggestions`. Order matters: daemon assigns numeric
+ * values 1-3 to the entries in this order.
+ */
+export const DEFAULT_PERMISSION_LABELS = ['Yes', 'Yes, always', 'No'] as const;
+
+/**
+ * Window during which the daemon's `QuestionDedup` and the client's
+ * `shouldKeepExisting` agree that two emissions belong to the same prompt
+ * cycle. Tuned for the observed hook-vs-PTY race; long enough to absorb
+ * realistic terminal-redraw cascades, short enough that a stale rich
+ * question does not pin the UI when the user takes a coffee break.
+ */
+export const QUESTION_DEDUP_WINDOW_MS = 5000;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@assistant-ui/react": "^0.11.53",
+    "@remi/shared": "workspace:*",
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.1",
     "@capacitor/cli": "^8.0.0",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -14,6 +14,7 @@ import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
+import { shouldKeepExisting } from '@/lib/question-merge';
 import type {
   AppSettings,
   ConnectionId,
@@ -425,6 +426,17 @@ function App() {
           timestamp: new Date().toISOString(),
         };
         setQuestions((prev) => {
+          // Richer-wins guard (#396). The daemon emits two questions for
+          // one prompt cycle (HookEventBridge default 3-set + PTY-parsed
+          // multi-choice with full sentences); their ids differ so the
+          // session-keyed map otherwise lets the second arrival overwrite
+          // the first regardless of richness. Keeping the richer pending
+          // question here prevents the "multi-choice flickers, then
+          // collapses to Yes/Yes-always/No" symptom users reported.
+          const existing = prev.get(questionSessionId);
+          if (existing && shouldKeepExisting(existing, uiQuestion)) {
+            return prev;
+          }
           const next = new Map(prev);
           next.set(questionSessionId, uiQuestion);
           return next;

--- a/packages/web/src/lib/question-merge.ts
+++ b/packages/web/src/lib/question-merge.ts
@@ -1,0 +1,94 @@
+/**
+ * Client-side richer-wins guard for question rendering (#396).
+ *
+ * The daemon emits questions from two sources for the same prompt cycle:
+ * `HookEventBridge` (synchronous on `PermissionRequest`, often with the
+ * default Yes / Yes-always / No 3-set when `permission_suggestions` is
+ * undefined) and the PTY parser (terminal-extracted, frequently richer
+ * with full-sentence options for plan-mode prompts and tools that
+ * present numbered choices). The two emissions arrive on the wire as
+ * separate `question` messages with different ids; the consumer in
+ * `App.tsx` keys its question map by sessionId, so the second arrival
+ * overwrites the first regardless of richness.
+ *
+ * Daemon-side dedup is the wrong place to fix this: making it more
+ * aggressive would silently drop a second legitimate `PermissionRequest`
+ * fired in the same waiting status window (e.g. parallel tool calls in
+ * one agent turn). The fix lives at the rendering boundary instead:
+ * keep the richer pending question on screen and ignore subsequent
+ * poorer emissions for the same session within a short window.
+ *
+ * Stale-question guard: if the existing question's timestamp is older
+ * than the freshness window, allow replacement. A user who left the app
+ * yesterday and reconnects today should see the latest prompt, not a
+ * cached richer one. Aligned with the daemon's `QuestionDedup` 5 s
+ * window so the two layers agree on what counts as "the same prompt
+ * instance".
+ */
+
+import type { UIQuestion } from '@/types';
+
+/** How long a pending question is considered fresh enough to defend. */
+export const QUESTION_FRESHNESS_MS = 5000;
+
+/**
+ * Returns true when the question matches the daemon's hardcoded fallback
+ * "Yes / Yes, always / No" 3-option set (literal labels in
+ * `DEFAULT_PERMISSION_OPTIONS` at `hook-event-bridge.ts`). Distinct from
+ * the daemon-side `looksLikeDefaultPermissionQuestion`, which uses a
+ * loose startsWith check to drop PTY re-emissions of the SAME terminal
+ * prompt; here we want a strict match so a richer custom 3-set with
+ * sentence labels (e.g. Edit's "Yes, and don't ask again this session"
+ * and "No, and tell Claude what to do differently") is NOT classified
+ * as the poor default.
+ */
+function isDefaultThreeSetShape(question: UIQuestion): boolean {
+  const opts = question.structuredOptions;
+  if (!opts || opts.length !== 3) return false;
+  const labels = opts.map((o) => (o.label ?? '').toLowerCase().trim());
+  return labels[0] === 'yes' && labels[1] === 'yes, always' && labels[2] === 'no';
+}
+
+/** Number of structured options on a question, treating absent as zero. */
+function optionCount(question: UIQuestion): number {
+  return question.structuredOptions?.length ?? 0;
+}
+
+/**
+ * Decide whether to keep an existing pending question instead of replacing
+ * it with a newly-arrived one. Returns `true` to keep `existing`.
+ *
+ * - Already answered: don't keep; treat the incoming as a fresh prompt.
+ * - Existing is stale (older than the freshness window): don't keep.
+ * - Existing has strictly more options than incoming: keep.
+ * - Equal option count, incoming is the default 3-set shape and existing
+ *   is not: keep (covers the cross-fingerprint hook overwrite race).
+ * - Otherwise: don't keep (let the new question replace).
+ */
+export function shouldKeepExisting(
+  existing: UIQuestion,
+  incoming: UIQuestion,
+  options: { freshnessMs?: number; now?: () => number } = {},
+): boolean {
+  if (existing.answeredWith) return false;
+
+  const freshnessMs = options.freshnessMs ?? QUESTION_FRESHNESS_MS;
+  const clock = options.now ?? Date.now;
+  const existingMs = Date.parse(existing.timestamp);
+  if (Number.isFinite(existingMs) && clock() - existingMs >= freshnessMs) {
+    return false;
+  }
+
+  const existingCount = optionCount(existing);
+  const incomingCount = optionCount(incoming);
+
+  if (existingCount > incomingCount) return true;
+  if (
+    existingCount === incomingCount &&
+    isDefaultThreeSetShape(incoming) &&
+    !isDefaultThreeSetShape(existing)
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/web/src/lib/question-merge.ts
+++ b/packages/web/src/lib/question-merge.ts
@@ -1,94 +1,141 @@
 /**
- * Client-side richer-wins guard for question rendering (#396).
+ * Client-side richer-wins guard for question rendering (#396; backstory
+ * in #378).
  *
- * The daemon emits questions from two sources for the same prompt cycle:
+ * The daemon emits two questions for the same prompt cycle:
  * `HookEventBridge` (synchronous on `PermissionRequest`, often with the
  * default Yes / Yes-always / No 3-set when `permission_suggestions` is
  * undefined) and the PTY parser (terminal-extracted, frequently richer
- * with full-sentence options for plan-mode prompts and tools that
- * present numbered choices). The two emissions arrive on the wire as
- * separate `question` messages with different ids; the consumer in
- * `App.tsx` keys its question map by sessionId, so the second arrival
- * overwrites the first regardless of richness.
+ * with full-sentence options for plan-mode prompts). The two emissions
+ * arrive on the wire as separate `question` messages with different ids;
+ * the consumer in `App.tsx` keys its question map by sessionId, so the
+ * second arrival otherwise overwrites the first regardless of richness.
  *
- * Daemon-side dedup is the wrong place to fix this: making it more
- * aggressive would silently drop a second legitimate `PermissionRequest`
- * fired in the same waiting status window (e.g. parallel tool calls in
- * one agent turn). The fix lives at the rendering boundary instead:
- * keep the richer pending question on screen and ignore subsequent
- * poorer emissions for the same session within a short window.
+ * The fix lives at the rendering boundary instead of the daemon-side
+ * dedup: keep the richer pending question on screen and ignore poorer
+ * emissions for the same session within the freshness window. Daemon
+ * dedup remains as the safety net for genuinely-distinct prompts that
+ * cross a status transition.
  *
- * Stale-question guard: if the existing question's timestamp is older
- * than the freshness window, allow replacement. A user who left the app
- * yesterday and reconnects today should see the latest prompt, not a
- * cached richer one. Aligned with the daemon's `QuestionDedup` 5 s
- * window so the two layers agree on what counts as "the same prompt
- * instance".
+ * Replay-after-answer guard: if the existing question was already
+ * answered AND the incoming arrival has the same id (a `replay_batch`
+ * re-feed of the same wire message), keep the existing one so the
+ * `answeredWith` state is not silently wiped and the user is not
+ * re-prompted for a question they already resolved.
+ *
+ * Stale guard: if existing was emitted longer ago than the freshness
+ * window, fall back to last-wins so a reconnect after lunch shows the
+ * latest prompt rather than a cached richer one. The window is imported
+ * from `@remi/shared` so daemon and client always agree on what counts
+ * as "the same prompt instance".
  */
 
+import { QUESTION_DEDUP_WINDOW_MS, DEFAULT_PERMISSION_LABELS } from '@remi/shared';
 import type { UIQuestion } from '@/types';
 
-/** How long a pending question is considered fresh enough to defend. */
-export const QUESTION_FRESHNESS_MS = 5000;
+/** Re-export so consumers can mirror the freshness contract. */
+export const QUESTION_FRESHNESS_MS = QUESTION_DEDUP_WINDOW_MS;
+
+export interface ShouldKeepExistingOptions {
+  readonly freshnessMs?: number;
+  readonly now?: () => number;
+}
 
 /**
- * Returns true when the question matches the daemon's hardcoded fallback
- * "Yes / Yes, always / No" 3-option set (literal labels in
- * `DEFAULT_PERMISSION_OPTIONS` at `hook-event-bridge.ts`). Distinct from
- * the daemon-side `looksLikeDefaultPermissionQuestion`, which uses a
- * loose startsWith check to drop PTY re-emissions of the SAME terminal
- * prompt; here we want a strict match so a richer custom 3-set with
- * sentence labels (e.g. Edit's "Yes, and don't ask again this session"
- * and "No, and tell Claude what to do differently") is NOT classified
- * as the poor default.
+ * Detects the daemon's hardcoded fallback labels. Strict literal match
+ * (lowercased + trimmed) against `DEFAULT_PERMISSION_LABELS`; a richer
+ * custom 3-set like Edit's "Yes, and don't ask again this session" /
+ * "No, and tell Claude what to do differently" is intentionally NOT
+ * classified as the bland default.
  */
 function isDefaultThreeSetShape(question: UIQuestion): boolean {
   const opts = question.structuredOptions;
   if (!opts || opts.length !== 3) return false;
   const labels = opts.map((o) => (o.label ?? '').toLowerCase().trim());
-  return labels[0] === 'yes' && labels[1] === 'yes, always' && labels[2] === 'no';
+  const expected = DEFAULT_PERMISSION_LABELS.map((l) => l.toLowerCase());
+  return labels[0] === expected[0] && labels[1] === expected[1] && labels[2] === expected[2];
 }
 
-/** Number of structured options on a question, treating absent as zero. */
 function optionCount(question: UIQuestion): number {
   return question.structuredOptions?.length ?? 0;
 }
 
+type Decision =
+  | 'replay-of-answered'
+  | 'richer-count'
+  | 'richer-shape'
+  | 'answered'
+  | 'stale'
+  | 'malformed-timestamp'
+  | 'incoming-richer-count'
+  | 'incoming-equal-or-poorer';
+
+function logSuppression(decision: Decision, existing: UIQuestion, incoming: UIQuestion): void {
+  console.debug(
+    `[question-merge] ${decision} (existing.id=${existing.id} ${optionCount(existing)}opts, incoming.id=${incoming.id} ${optionCount(incoming)}opts, session=${existing.sessionId})`,
+  );
+}
+
 /**
- * Decide whether to keep an existing pending question instead of replacing
- * it with a newly-arrived one. Returns `true` to keep `existing`.
- *
- * - Already answered: don't keep; treat the incoming as a fresh prompt.
- * - Existing is stale (older than the freshness window): don't keep.
- * - Existing has strictly more options than incoming: keep.
- * - Equal option count, incoming is the default 3-set shape and existing
- *   is not: keep (covers the cross-fingerprint hook overwrite race).
- * - Otherwise: don't keep (let the new question replace).
+ * Decide whether to keep the existing pending question. `true` means the
+ * incoming arrival is dropped at the render boundary; `false` means
+ * replace as usual.
  */
 export function shouldKeepExisting(
   existing: UIQuestion,
   incoming: UIQuestion,
-  options: { freshnessMs?: number; now?: () => number } = {},
+  options: ShouldKeepExistingOptions = {},
 ): boolean {
+  // Replay-after-answer: a `replay_batch` re-feed of the original
+  // question carries the same id. Keep the answered state intact so
+  // the user is not re-prompted for a question they already resolved.
+  if (existing.answeredWith && existing.id === incoming.id) {
+    logSuppression('replay-of-answered', existing, incoming);
+    return true;
+  }
+
+  // Different question id with an answered existing: a genuinely new
+  // prompt is arriving (the answer ack will demote `answeredWith`
+  // shortly). Let the new one through.
   if (existing.answeredWith) return false;
 
   const freshnessMs = options.freshnessMs ?? QUESTION_FRESHNESS_MS;
   const clock = options.now ?? Date.now;
   const existingMs = Date.parse(existing.timestamp);
-  if (Number.isFinite(existingMs) && clock() - existingMs >= freshnessMs) {
+  if (!Number.isFinite(existingMs)) {
+    // Fail-closed: a corrupted/legacy timestamp must not pin the UI.
+    logSuppression('malformed-timestamp', existing, incoming);
+    return false;
+  }
+  // Clamp negative ages (clock skew where existing is in the future)
+  // to zero so the defense window applies normally rather than stretching
+  // forever via the negative-ageMs side path.
+  const age = Math.max(0, clock() - existingMs);
+  if (age >= freshnessMs) {
+    logSuppression('stale', existing, incoming);
     return false;
   }
 
   const existingCount = optionCount(existing);
   const incomingCount = optionCount(incoming);
 
-  if (existingCount > incomingCount) return true;
+  if (existingCount > incomingCount) {
+    logSuppression('richer-count', existing, incoming);
+    return true;
+  }
   if (
     existingCount === incomingCount &&
     isDefaultThreeSetShape(incoming) &&
     !isDefaultThreeSetShape(existing)
   ) {
+    logSuppression('richer-shape', existing, incoming);
     return true;
   }
+  // Either incoming is richer, or both are equal-and-bland. Replace.
+  logSuppression(
+    incomingCount > existingCount ? 'incoming-richer-count' : 'incoming-equal-or-poorer',
+    existing,
+    incoming,
+  );
   return false;
 }

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -137,11 +137,67 @@ describe('shouldKeepExisting', () => {
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
-  test('handles malformed timestamp by allowing replacement', () => {
+  test('malformed timestamp falls open and allows replacement (fail-closed)', () => {
     const existing = uiq('Plan', fourSentenceOptions, { timestamp: 'not-a-date' });
     const incoming = uiq('Allow Bash', yesYesalwaysNo);
-    // Date.parse returns NaN; freshness check is skipped, so the richer
-    // logic kicks in and keeps the existing one.
+    // A corrupted/legacy timestamp must not pin the UI: the guard
+    // returns false so the new emission renders normally.
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('keeps an answered question when same id is replayed (#396)', () => {
+    // replay_batch path: phone wakes from background, the daemon re-feeds
+    // earlier question messages. Without the same-id guard, the user is
+    // re-prompted for a question they already answered.
+    const existing = uiq('Which approach?', fourSentenceOptions, {
+      answeredWith: 'Refactor the authentication module',
+    });
+    // Same id as existing — replay of the same wire message.
+    const incoming: UIQuestion = { ...existing, prompt: existing.prompt };
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  test('replaces answered question when a different id arrives (new prompt)', () => {
+    const existing = uiq('Which approach?', fourSentenceOptions, {
+      answeredWith: 'Refactor the authentication module',
+    });
+    // Different id; treat as a genuinely new prompt.
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('future-timestamped existing is not defended forever (clock skew clamp)', () => {
+    // Phone clock 60s ahead of daemon clock. Without the clamp, age is
+    // negative and stays under freshnessMs forever, pinning the existing
+    // question. The clamp treats the negative age as zero so the window
+    // applies normally.
+    const future = new Date(2_000_000).toISOString();
+    const existing = uiq('Old plan', fourSentenceOptions, { timestamp: future });
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    // 6 seconds after the existing's claimed time => stale, replace.
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(2_006_001) })).toBe(false);
+  });
+
+  test('boundary: exactly freshnessMs ago is treated as stale (>=)', () => {
+    const existing = uiq('Plan', fourSentenceOptions, {
+      timestamp: new Date(1_000_000).toISOString(),
+    });
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    // Strict >= boundary: 5000ms exactly is stale, allow replacement.
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_005_000) })).toBe(false);
+  });
+
+  test('default-shape detection is case-insensitive', () => {
+    const existing = uiq('Custom prompt', [
+      { label: 'Yes' },
+      { label: "Yes, and don't ask again this session" },
+      { label: 'No' },
+    ]);
+    const incoming = uiq('Allow Bash: ls', [
+      { label: '  YES  ' },
+      { label: 'yes, ALWAYS' },
+      { label: ' no ' },
+    ]);
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 });

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the client-side richer-wins guard (#396).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { shouldKeepExisting } from '../../src/lib/question-merge';
+import type { UIQuestion, UIQuestionOption, UUID } from '../../src/types';
+
+let nextId = 0;
+function uiq(
+  prompt: string,
+  options: ReadonlyArray<{ label: string; isYes?: boolean; isNo?: boolean }>,
+  extra: { timestamp?: string; answeredWith?: string } = {},
+): UIQuestion {
+  const structured: UIQuestionOption[] = options.map((o, i) => ({
+    label: o.label,
+    value: String(i + 1),
+    isYes: o.isYes,
+    isNo: o.isNo,
+  }));
+  const ts = extra.timestamp ?? new Date(1_000_000).toISOString();
+  return {
+    id: `q-${++nextId}` as UUID,
+    sessionId: 'session-1' as UUID,
+    type:
+      structured.length === 0 ? 'free_text' : structured.length === 2 ? 'yes_no' : 'multi_option',
+    prompt,
+    structuredOptions: structured.length > 0 ? structured : undefined,
+    options: structured.length > 0 ? structured.map((o) => o.label) : undefined,
+    timestamp: ts,
+    ...(extra.answeredWith !== undefined ? { answeredWith: extra.answeredWith } : {}),
+  };
+}
+
+const yesYesalwaysNo = [
+  { label: 'Yes', isYes: true },
+  { label: 'Yes, always', isYes: true },
+  { label: 'No', isNo: true },
+];
+
+const fourSentenceOptions = [
+  { label: 'Refactor the authentication module' },
+  { label: 'Patch the immediate bug only' },
+  { label: 'Rewrite from scratch using a library' },
+  { label: 'Skip and document the issue' },
+];
+
+const fixedNow = (ms: number) => () => ms;
+
+describe('shouldKeepExisting', () => {
+  test('keeps a multi-choice when a default 3-set arrives next', () => {
+    const existing = uiq('Which approach?', fourSentenceOptions);
+    const incoming = uiq('Claude needs your permission to use Bash', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  test('keeps a 3-set with custom labels when default 3-set arrives next', () => {
+    // Edit tool's permission_suggestions (rich) followed by the hook's
+    // default fallback (poor) at equal option count.
+    const existing = uiq('Allow Edit: src/foo.ts', [
+      { label: 'Yes' },
+      { label: "Yes, and don't ask again this session" },
+      { label: 'No, and tell Claude what to do differently' },
+    ]);
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  test('replaces when incoming has more options', () => {
+    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = uiq('Pick a destination', fourSentenceOptions);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('replaces when both are default 3-sets (truly equivalent)', () => {
+    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = uiq('Allow Edit: foo', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('replaces when existing was answered (new prompt cycle)', () => {
+    const existing = uiq('Which approach?', fourSentenceOptions, {
+      answeredWith: 'Refactor the authentication module',
+    });
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('replaces when existing is older than the freshness window', () => {
+    const stale = new Date(1_000_000).toISOString();
+    const existing = uiq('Old plan question', fourSentenceOptions, { timestamp: stale });
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    // 6 seconds later: stale, allow replacement.
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_006_001) })).toBe(false);
+  });
+
+  test('keeps within window even at the edge (4999 ms)', () => {
+    const existing = uiq('Which approach?', fourSentenceOptions, {
+      timestamp: new Date(1_000_000).toISOString(),
+    });
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_004_999) })).toBe(true);
+  });
+
+  test('replaces when incoming has same count and existing is also a 3-set default', () => {
+    // Edge case: identical default-shape pairs come through; the second
+    // is no worse than the first so we let it replace (last wins).
+    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('replaces when existing has fewer options regardless of shape', () => {
+    const existing = uiq('Run this?', [
+      { label: 'Yes', isYes: true },
+      { label: 'No', isNo: true },
+    ]);
+    const incoming = uiq('Run this?', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('keeps 4-option richer when poorer 4-option arrives (not a default 3-set)', () => {
+    // Equal count but neither is the default 3-set shape — let it through.
+    // We only special-case the daemon's hardcoded fallback.
+    const existing = uiq('Pick a city', [
+      { label: 'New York' },
+      { label: 'San Francisco' },
+      { label: 'Austin' },
+      { label: 'Other' },
+    ]);
+    const incoming = uiq('Pick a city', [
+      { label: 'NYC' },
+      { label: 'SF' },
+      { label: 'ATX' },
+      { label: 'Other' },
+    ]);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
+  test('handles malformed timestamp by allowing replacement', () => {
+    const existing = uiq('Plan', fourSentenceOptions, { timestamp: 'not-a-date' });
+    const incoming = uiq('Allow Bash', yesYesalwaysNo);
+    // Date.parse returns NaN; freshness check is skipped, so the richer
+    // logic kicks in and keeps the existing one.
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- New `shouldKeepExisting` helper in `packages/web/src/lib/question-merge.ts`. Called before replacing a pending question for the same session in `App.tsx`.
- Keeps the existing question when it has strictly more options, or when counts are equal AND incoming matches the daemon's hardcoded `Yes` / `Yes, always` / `No` literal labels but existing does not.
- 5 s freshness window aligned with the daemon's `QuestionDedup`. Already-answered questions are never kept; stale ones fall back to last-wins.

Closes #396.

## Why client-side

The daemon emits two questions for one prompt cycle: `HookEventBridge` synchronous on `PermissionRequest` (often with the default 3-set when `permission_suggestions` is undefined) and the PTY parser shortly after with terminal-extracted options. Both reach the wire as `question` messages with different ids; the web client keys its question map by sessionId, so the second arrival overwrites the first regardless of richness.

A first attempt tightened daemon-side dedup to suppress equal-or-poorer emissions regardless of text, but the silent-failure review flagged a real concern: two legitimate `PermissionRequest`s in the same `waiting` window (e.g. parallel tool calls in one agent turn) would silently drop the second. Moving the guard to the rendering boundary keeps wire traffic intact and only changes what gets shown.

## Implementation notes

- `isDefaultThreeSetShape` uses an exact-label match on the daemon's hardcoded labels rather than the daemon-side `startsWith` heuristic. A rich custom 3-set like Edit's "Yes, and don't ask again this session" / "No, and tell Claude what to do differently" is correctly classified as NOT default, so it defends against being overwritten by the bland fallback.
- Already-answered: `existing.answeredWith` set => allow replacement; the next emission is a fresh prompt.
- Stale: `Date.parse(existing.timestamp)` more than 5 s old => allow replacement.
- Malformed timestamp (`NaN` parse): freshness check is skipped; richness logic still applies.

## Tests

`packages/web/tests/lib/question-merge.test.ts` — 11 tests, real types, no mocks. Covers:

- Multi-choice (4-option) keeps when default 3-set arrives next.
- Rich 3-set custom labels keep when default 3-set arrives next.
- Replace when incoming has more options.
- Replace when both are default 3-sets (truly equivalent).
- Already-answered: replace allowed (new prompt cycle).
- Stale (>5 s): replace allowed.
- Edge of window (4999 ms): keep.
- Equal-count non-default-shape pair: replace (let through).
- Malformed timestamp: richness logic still applies.

## Test plan

- [x] `bun test packages/web/tests/lib/question-merge.test.ts` (11/11 pass)
- [x] `bun test packages/web/tests` (102/102 pass; no regressions)
- [x] `bun run build` from `packages/web` (tsc + vite both clean)
- [x] Biome on changed files (no new findings)
- [ ] Manual: trigger a plan-mode multi-choice question on iOS, confirm full-sentence options stay rendered (no flip to Yes/Yes-always/No after ~1 s).
- [ ] Manual: trigger Bash permission, confirm Yes/Yes-always/No still renders.
- [ ] Manual: answer a multi-choice, then have Claude immediately ask another. Confirm second prompt renders even though the first is fresh in the map (already-answered guard).