### PR TITLE
feat(daemon): auto-approve multi-choice handling, skip-by-default with optional evaluate (#399)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -11,9 +11,19 @@
 import { errorToString } from '@remi/shared';
 import { chatCompletion, resolveProviderUrl } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
+import {
+  buildMultiChoicePrompt,
+  isMultiChoicePermission,
+  parseMultiChoiceDecision,
+} from './multichoice.ts';
 import { matchPattern } from './pattern-matcher.ts';
 import { buildPrompt } from './prompt-builder.ts';
-import type { AutoApproveConfig, AutoApproveDecision, AutoApproveResult } from './types.ts';
+import type {
+  AutoApproveConfig,
+  AutoApproveDecision,
+  AutoApproveResult,
+  MultiChoiceMode,
+} from './types.ts';
 
 const VALID_DECISIONS = new Set<AutoApproveDecision>(['approve', 'deny', 'escalate']);
 
@@ -54,6 +64,9 @@ export class AutoApproveService {
   private readonly allow: readonly string[];
   private readonly deny: readonly string[];
   private readonly instructions: string;
+  private readonly multichoiceMode: MultiChoiceMode;
+  /** Falls back to llmConfig.model when empty. */
+  private readonly multichoiceModel: string;
   /** Prevents concurrent evaluations. Second request escalates immediately. */
   private evaluating = false;
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
@@ -76,6 +89,8 @@ export class AutoApproveService {
     this.allow = config.allow;
     this.deny = config.deny;
     this.instructions = config.instructions;
+    this.multichoiceMode = config.multichoice;
+    this.multichoiceModel = config.multichoice_model;
   }
 
   /**
@@ -86,11 +101,16 @@ export class AutoApproveService {
    * @param toolInput Raw tool input from the PermissionRequest hook
    * @param tag Optional short tag (e.g. sessionId prefix) to include in logs
    *            so multi-session deployments can distinguish whose decision this is.
+   * @param permissionSuggestions Optional `permission_suggestions` from the
+   *            hook. When present and shape qualifies as multi-choice (#399),
+   *            evaluation is routed through the multi-choice path instead of
+   *            the binary approve/deny path.
    */
   async evaluate(
     toolName: string,
     toolInput: Record<string, unknown>,
     tag?: string,
+    permissionSuggestions?: readonly string[],
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     const model = this.llmConfig.model;
@@ -117,6 +137,20 @@ export class AutoApproveService {
         return { decision: 'approve', reasoning, durationMs: 0, model };
       }
 
+      const isMultiChoice = isMultiChoicePermission(permissionSuggestions);
+
+      // Multi-choice + skip mode: never call the LLM. The binary approve/
+      // deny mapping cannot express "pick option 2 of N", so evaluating
+      // would just produce option-1 (approve) for every plan-mode prompt
+      // regardless of what the user actually wanted (#399).
+      if (isMultiChoice && this.multichoiceMode === 'skip') {
+        const reasoning = `multi-choice prompt (${permissionSuggestions?.length ?? 0} options); auto_approve.multichoice = "skip"`;
+        if (this.logDecisions) {
+          this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
+        }
+        return { decision: 'escalate', reasoning, durationMs: 0, model };
+      }
+
       if (this.evaluating) {
         this.logFn(`${prefix} Concurrent evaluation blocked, escalating to user`);
         return {
@@ -138,13 +172,29 @@ export class AutoApproveService {
       // state).
       let raceTimer: ReturnType<typeof setTimeout> | null = null;
       try {
-        const messages = buildPrompt(toolName, toolInput, this.instructions);
+        // Multi-choice + evaluate mode: dedicated prompt, optional alt model.
+        // Otherwise the binary approve/deny prompt.
+        const useMultiChoice = isMultiChoice && this.multichoiceMode === 'evaluate';
+        const callModel =
+          useMultiChoice && this.multichoiceModel ? this.multichoiceModel : this.llmConfig.model;
+        const callConfig: LLMClientConfig =
+          callModel === this.llmConfig.model
+            ? this.llmConfig
+            : { ...this.llmConfig, model: callModel };
+        const messages = useMultiChoice
+          ? buildMultiChoicePrompt(
+              toolName,
+              toolInput,
+              permissionSuggestions ?? [],
+              this.instructions,
+            )
+          : buildPrompt(toolName, toolInput, this.instructions);
         // Hard kill via Promise.race: even if fetch ignores the abort signal
         // (provider hang, Bun runtime quirk), evaluate() returns within
         // timeoutMs. The race timer also calls abort() so a fetch that does
         // honor the signal releases socket resources promptly.
         const response = await Promise.race([
-          chatCompletion(this.llmConfig, messages, externalSignal),
+          chatCompletion(callConfig, messages, externalSignal),
           new Promise<never>((_, reject) => {
             raceTimer = setTimeout(() => {
               this.currentAbortController?.abort();
@@ -154,14 +204,37 @@ export class AutoApproveService {
         ]);
         const durationMs = Date.now() - start;
 
-        const parsed = parseDecision(response.content);
-
-        const result: AutoApproveResult = {
-          decision: parsed.decision,
-          reasoning: parsed.reasoning,
-          durationMs,
-          model: response.model,
-        };
+        const result: AutoApproveResult = useMultiChoice
+          ? (() => {
+              const parsedMc = parseMultiChoiceDecision(
+                response.content,
+                permissionSuggestions?.length ?? 0,
+              );
+              if (parsedMc.decision === 'pick') {
+                return {
+                  decision: 'pick' as const,
+                  pickIndex: parsedMc.index,
+                  reasoning: parsedMc.reasoning,
+                  durationMs,
+                  model: response.model,
+                };
+              }
+              return {
+                decision: 'escalate' as const,
+                reasoning: parsedMc.reasoning,
+                durationMs,
+                model: response.model,
+              };
+            })()
+          : (() => {
+              const parsed = parseDecision(response.content);
+              return {
+                decision: parsed.decision,
+                reasoning: parsed.reasoning,
+                durationMs,
+                model: response.model,
+              };
+            })();
 
         if (this.logDecisions) {
           const denyPrefix = result.decision === 'deny' ? `${prefix} DENIED` : prefix;

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -1,8 +1,9 @@
 /**
  * Core auto-approve service.
  *
- * Evaluates PermissionRequest hook events using an LLM (via OpenAI-compatible API).
- * Returns one of three decisions: approve, deny, or escalate.
+ * Evaluates PermissionRequest hook events using an LLM (via OpenAI-compatible
+ * API). Returns one of: approve, deny, escalate, pick (multi-choice), or
+ * cancelled (control plane).
  *
  * Designed to never throw. All errors result in escalation so the user
  * is never blocked by an LLM failure.
@@ -18,29 +19,25 @@ import {
 } from './multichoice.ts';
 import { matchPattern } from './pattern-matcher.ts';
 import { buildPrompt } from './prompt-builder.ts';
-import type {
-  AutoApproveConfig,
-  AutoApproveDecision,
-  AutoApproveResult,
-  MultiChoiceMode,
-} from './types.ts';
+import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
 
-const VALID_DECISIONS = new Set<AutoApproveDecision>(['approve', 'deny', 'escalate']);
+type BinaryDecision = 'approve' | 'deny' | 'escalate';
+const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate']);
 
 /**
- * Parse an LLM response string into a decision.
+ * Parse an LLM response string into a binary approve/deny/escalate decision.
  * Tries JSON first. If JSON fails, escalates (no guessing from substring matches).
  * Exported for unit testing.
  */
-export function parseDecision(raw: string): { decision: AutoApproveDecision; reasoning: string } {
+export function parseDecision(raw: string): { decision: BinaryDecision; reasoning: string } {
   let parseErr: unknown = null;
   try {
     const parsed = JSON.parse(raw);
     if (typeof parsed === 'object' && parsed !== null) {
       const decisionStr = String(parsed.decision ?? '').toLowerCase();
       const reasoning = String(parsed.reasoning ?? '');
-      if (VALID_DECISIONS.has(decisionStr as AutoApproveDecision)) {
-        return { decision: decisionStr as AutoApproveDecision, reasoning };
+      if (VALID_DECISIONS.has(decisionStr as BinaryDecision)) {
+        return { decision: decisionStr as BinaryDecision, reasoning };
       }
     }
   } catch (err) {
@@ -110,11 +107,21 @@ export class AutoApproveService {
     toolName: string,
     toolInput: Record<string, unknown>,
     tag?: string,
-    permissionSuggestions?: readonly string[],
+    permissionSuggestions?: readonly unknown[],
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     const model = this.llmConfig.model;
     const prefix = tag ? `[AutoApprove ${tag}]` : '[AutoApprove]';
+
+    // Filter to a clean string array for the multi-choice prompt path
+    // (mirrors the strict check at hook-event-bridge.ts:211-214). Anything
+    // else falls through; isMultiChoicePermission still classifies as
+    // multi-choice but we never feed garbage to .toLowerCase or to the LLM.
+    const cleanSuggestions =
+      Array.isArray(permissionSuggestions) &&
+      permissionSuggestions.every((s) => typeof s === 'string' && s.length > 0)
+        ? (permissionSuggestions as readonly string[])
+        : undefined;
 
     // Entire body wrapped in try/catch so the "never throws" contract holds
     // even if matchPattern or other sync code fails (e.g. malformed config).
@@ -137,14 +144,14 @@ export class AutoApproveService {
         return { decision: 'approve', reasoning, durationMs: 0, model };
       }
 
-      const isMultiChoice = isMultiChoicePermission(permissionSuggestions);
+      const isMultiChoice = isMultiChoicePermission(toolName, permissionSuggestions);
 
       // Multi-choice + skip mode: never call the LLM. The binary approve/
       // deny mapping cannot express "pick option 2 of N", so evaluating
       // would just produce option-1 (approve) for every plan-mode prompt
       // regardless of what the user actually wanted (#399).
       if (isMultiChoice && this.multichoiceMode === 'skip') {
-        const reasoning = `multi-choice prompt (${permissionSuggestions?.length ?? 0} options); auto_approve.multichoice = "skip"`;
+        const reasoning = `multi-choice prompt (tool=${toolName}, ${permissionSuggestions?.length ?? 0} options); auto_approve.multichoice = "skip"`;
         if (this.logDecisions) {
           this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
         }
@@ -182,12 +189,7 @@ export class AutoApproveService {
             ? this.llmConfig
             : { ...this.llmConfig, model: callModel };
         const messages = useMultiChoice
-          ? buildMultiChoicePrompt(
-              toolName,
-              toolInput,
-              permissionSuggestions ?? [],
-              this.instructions,
-            )
+          ? buildMultiChoicePrompt(toolName, toolInput, cleanSuggestions ?? [], this.instructions)
           : buildPrompt(toolName, toolInput, this.instructions);
         // Hard kill via Promise.race: even if fetch ignores the abort signal
         // (provider hang, Bun runtime quirk), evaluate() returns within
@@ -208,7 +210,7 @@ export class AutoApproveService {
           ? (() => {
               const parsedMc = parseMultiChoiceDecision(
                 response.content,
-                permissionSuggestions?.length ?? 0,
+                cleanSuggestions?.length ?? 0,
               );
               if (parsedMc.decision === 'pick') {
                 return {

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -1,0 +1,138 @@
+/**
+ * Multi-choice permission detector and prompt builder (#399).
+ *
+ * A `PermissionRequest` is "multi-choice" when its `permission_suggestions`
+ * cannot be answered by the binary approve/deny path:
+ *
+ * - More than 3 options (e.g. a custom plugin tool with 4+ choices).
+ * - Exactly 3 options that are NOT the daemon's standard Yes / Yes-always
+ *   / No trio (e.g. ExitPlanMode's "Approve plan" / "Approve and stay in
+ *   plan mode" / "Reject plan" or any per-tool variant).
+ * - Exactly 2 options that are NOT a clean Yes / No pair (e.g. a tool
+ *   asking the user to pick between two non-binary alternatives).
+ *
+ * Standard 2-option [Yes, No] and standard 3-option [Yes, Yes-always, No]
+ * are treated as binary, since approve/deny maps cleanly to option 1 / N.
+ */
+
+import { DEFAULT_PERMISSION_LABELS } from '@remi/shared';
+import type { ChatMessage } from './llm-client.ts';
+
+function normalize(label: string): string {
+  return label.toLowerCase().trim();
+}
+
+function isStandardThreeSet(labels: readonly string[]): boolean {
+  if (labels.length !== 3) return false;
+  const expected = DEFAULT_PERMISSION_LABELS.map(normalize);
+  return labels[0] === expected[0] && labels[1] === expected[1] && labels[2] === expected[2];
+}
+
+function isStandardYesNoPair(labels: readonly string[]): boolean {
+  if (labels.length !== 2) return false;
+  return labels[0] === 'yes' && labels[1] === 'no';
+}
+
+/**
+ * Returns true when `permission_suggestions` represents a multi-choice
+ * prompt the binary approve/deny mapping cannot handle.
+ *
+ * Returns false when suggestions are absent or undefined: that case
+ * means "no suggestions, daemon will substitute the default 3-set",
+ * which is binary.
+ */
+export function isMultiChoicePermission(
+  permissionSuggestions: readonly string[] | null | undefined,
+): boolean {
+  if (!permissionSuggestions || permissionSuggestions.length === 0) return false;
+  if (permissionSuggestions.length > 3) return true;
+  const labels = permissionSuggestions.map(normalize);
+  if (isStandardThreeSet(labels)) return false;
+  if (isStandardYesNoPair(labels)) return false;
+  return true;
+}
+
+const MULTI_CHOICE_SYSTEM_PROMPT = `You are a permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
+
+Claude Code is asking the user to PICK ONE option from a numbered list. Your job is to choose the most appropriate option, OR escalate to the user when you cannot decide confidently.
+
+CRITICAL RULES:
+1. Read EVERY option carefully before deciding. Do not assume option 1 is always correct.
+2. When the choice involves direction, planning, scope, or strategic intent, ALWAYS escalate. Only the user knows the intent.
+3. Pick only when one option is clearly the routine, low-risk, expected default for the tool/input combination shown.
+4. When in doubt, escalate. It is better to ask the user than to commit to the wrong option.
+5. Indices are 1-based and must point to one of the listed options.
+
+Respond with JSON ONLY. No markdown, no explanation outside JSON. Two valid shapes:
+
+{"decision": "pick", "index": 2, "reasoning": "brief explanation referencing the chosen option's label"}
+{"decision": "escalate", "reasoning": "brief explanation"}`;
+
+/**
+ * Build the chat messages for multi-choice evaluation. The user message
+ * lists each option on its own line with its 1-based index so the LLM
+ * can refer to a specific choice.
+ */
+export function buildMultiChoicePrompt(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  options: readonly string[],
+  instructions?: string,
+): readonly ChatMessage[] {
+  const inputStr = JSON.stringify(toolInput, null, 2);
+  const truncatedInput = inputStr.length > 2000 ? `${inputStr.slice(0, 1997)}...` : inputStr;
+  const renderedOptions = options.map((label, idx) => `  ${idx + 1}. ${label}`).join('\n');
+  const userMessage = `Tool: ${toolName}\nInput: ${truncatedInput}\n\nOptions:\n${renderedOptions}`;
+
+  const trimmedInstructions = instructions?.trim() ?? '';
+  const systemContent = trimmedInstructions
+    ? `${MULTI_CHOICE_SYSTEM_PROMPT}\n\nUSER-SPECIFIC GUIDANCE (overrides/refines the defaults above):\n${trimmedInstructions}`
+    : MULTI_CHOICE_SYSTEM_PROMPT;
+
+  return [
+    { role: 'system', content: systemContent },
+    { role: 'user', content: userMessage },
+  ];
+}
+
+/**
+ * Parse a multi-choice LLM response. Returns either a validated pick
+ * (1-based index within `optionCount`) or escalate. Out-of-range or
+ * malformed responses fall through to escalate so a confused LLM
+ * cannot pick option 0 / option 99 / option NaN.
+ */
+export function parseMultiChoiceDecision(
+  raw: string,
+  optionCount: number,
+):
+  | { decision: 'pick'; index: number; reasoning: string }
+  | { decision: 'escalate'; reasoning: string } {
+  let parseErr: unknown = null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null) {
+      const decisionStr = String(parsed.decision ?? '').toLowerCase();
+      const reasoning = String(parsed.reasoning ?? '');
+      if (decisionStr === 'escalate') {
+        return { decision: 'escalate', reasoning };
+      }
+      if (decisionStr === 'pick') {
+        const idx = Number(parsed.index);
+        if (Number.isInteger(idx) && idx >= 1 && idx <= optionCount) {
+          return { decision: 'pick', index: idx, reasoning };
+        }
+        return {
+          decision: 'escalate',
+          reasoning: `LLM picked out-of-range index ${parsed.index} for ${optionCount} options; ${reasoning}`,
+        };
+      }
+    }
+  } catch (err) {
+    parseErr = err;
+  }
+  const errHint = parseErr ? ` [${(parseErr as Error).name}: ${(parseErr as Error).message}]` : '';
+  return {
+    decision: 'escalate',
+    reasoning: `Unparsable multi-choice response: ${raw.slice(0, 100)}${errHint}`,
+  };
+}

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -2,54 +2,67 @@
  * Multi-choice permission detector and prompt builder (#399).
  *
  * A `PermissionRequest` is "multi-choice" when its `permission_suggestions`
- * cannot be answered by the binary approve/deny path:
+ * cannot be answered by the binary approve/deny path. We classify by:
  *
- * - More than 3 options (e.g. a custom plugin tool with 4+ choices).
- * - Exactly 3 options that are NOT the daemon's standard Yes / Yes-always
- *   / No trio (e.g. ExitPlanMode's "Approve plan" / "Approve and stay in
- *   plan mode" / "Reject plan" or any per-tool variant).
- * - Exactly 2 options that are NOT a clean Yes / No pair (e.g. a tool
- *   asking the user to pick between two non-binary alternatives).
+ * 1. Tool name. `ExitPlanMode` is always multi-choice: the user's intent
+ *    (continue planning, accept plan, accept and stop asking) cannot be
+ *    derived from tool input, so the LLM should never auto-pick.
+ * 2. Option count > 3: a custom plugin tool with 4+ choices cannot be
+ *    expressed in the approve/deny mapping at all.
+ * 3. Label shape: any 2- or 3-option set whose labels are not all
+ *    yes/no-shaped (matching the daemon's existing `isYes`/`isNo`
+ *    heuristic at `hook-event-bridge.ts:240-241`) is multi-choice.
  *
- * Standard 2-option [Yes, No] and standard 3-option [Yes, Yes-always, No]
- * are treated as binary, since approve/deny maps cleanly to option 1 / N.
+ * Edit's real `["Yes", "Always", "No"]` shape is correctly classified as
+ * binary because every label is yes-shaped or no-shaped under the same
+ * heuristic the hook bridge already uses for option metadata.
  */
 
-import { DEFAULT_PERMISSION_LABELS } from '@remi/shared';
 import type { ChatMessage } from './llm-client.ts';
 
-function normalize(label: string): string {
-  return label.toLowerCase().trim();
-}
+/**
+ * Tools that always route through multi-choice handling regardless of
+ * `permission_suggestions` shape. Add tools here when their prompts
+ * encode user-intent the auto-approve LLM cannot infer (planning,
+ * direction, scope decisions).
+ */
+const ALWAYS_MULTI_CHOICE_TOOLS: ReadonlySet<string> = new Set(['ExitPlanMode']);
 
-function isStandardThreeSet(labels: readonly string[]): boolean {
-  if (labels.length !== 3) return false;
-  const expected = DEFAULT_PERMISSION_LABELS.map(normalize);
-  return labels[0] === expected[0] && labels[1] === expected[1] && labels[2] === expected[2];
-}
-
-function isStandardYesNoPair(labels: readonly string[]): boolean {
-  if (labels.length !== 2) return false;
-  return labels[0] === 'yes' && labels[1] === 'no';
+/**
+ * True when a label reads as a yes/no answer, mirroring the heuristic
+ * `hook-event-bridge.ts` uses to set `isYes`/`isNo` flags on options.
+ * Tolerates the `Allow`/`Always`/`Deny`/`Reject` synonyms that real
+ * Claude Code tools emit (Edit's `["Yes", "Always", "No"]` is the
+ * common case).
+ */
+function isBinaryShapedLabel(label: string): boolean {
+  const lower = label.toLowerCase().trim();
+  if (lower.startsWith('yes')) return true;
+  if (lower.startsWith('no')) return true;
+  return lower === 'allow' || lower === 'always' || lower === 'deny' || lower === 'reject';
 }
 
 /**
- * Returns true when `permission_suggestions` represents a multi-choice
- * prompt the binary approve/deny mapping cannot handle.
+ * Returns true when the permission cannot be answered by the binary
+ * approve/deny path. Handles the three cases listed in the module doc.
  *
- * Returns false when suggestions are absent or undefined: that case
- * means "no suggestions, daemon will substitute the default 3-set",
- * which is binary.
+ * `permissionSuggestions` may be undefined (default 3-set substitutes)
+ * or an array. Non-string entries cause the prompt to be classified as
+ * multi-choice so the safe path (escalate or LLM with index validation)
+ * runs instead of crashing on `.toLowerCase()`.
  */
 export function isMultiChoicePermission(
-  permissionSuggestions: readonly string[] | null | undefined,
+  toolName: string,
+  permissionSuggestions: readonly unknown[] | null | undefined,
 ): boolean {
+  if (ALWAYS_MULTI_CHOICE_TOOLS.has(toolName)) return true;
   if (!permissionSuggestions || permissionSuggestions.length === 0) return false;
   if (permissionSuggestions.length > 3) return true;
-  const labels = permissionSuggestions.map(normalize);
-  if (isStandardThreeSet(labels)) return false;
-  if (isStandardYesNoPair(labels)) return false;
-  return true;
+  // 2- or 3-option lists: binary only when every label is yes/no-shaped.
+  // Non-string entries fail the typeof check and route to multi-choice.
+  return !permissionSuggestions.every(
+    (label) => typeof label === 'string' && isBinaryShapedLabel(label),
+  );
 }
 
 const MULTI_CHOICE_SYSTEM_PROMPT = `You are a permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
@@ -97,9 +110,10 @@ export function buildMultiChoicePrompt(
 
 /**
  * Parse a multi-choice LLM response. Returns either a validated pick
- * (1-based index within `optionCount`) or escalate. Out-of-range or
- * malformed responses fall through to escalate so a confused LLM
- * cannot pick option 0 / option 99 / option NaN.
+ * (1-based index within `optionCount`) or escalate. Three failure modes
+ * are distinguished in the reasoning so a future debugger can tell
+ * "LLM returned junk" from "LLM said approve when it should have picked"
+ * from "JSON parse error" without re-running the prompt.
  */
 export function parseMultiChoiceDecision(
   raw: string,
@@ -107,32 +121,46 @@ export function parseMultiChoiceDecision(
 ):
   | { decision: 'pick'; index: number; reasoning: string }
   | { decision: 'escalate'; reasoning: string } {
-  let parseErr: unknown = null;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed === 'object' && parsed !== null) {
-      const decisionStr = String(parsed.decision ?? '').toLowerCase();
-      const reasoning = String(parsed.reasoning ?? '');
-      if (decisionStr === 'escalate') {
-        return { decision: 'escalate', reasoning };
-      }
-      if (decisionStr === 'pick') {
-        const idx = Number(parsed.index);
-        if (Number.isInteger(idx) && idx >= 1 && idx <= optionCount) {
-          return { decision: 'pick', index: idx, reasoning };
-        }
-        return {
-          decision: 'escalate',
-          reasoning: `LLM picked out-of-range index ${parsed.index} for ${optionCount} options; ${reasoning}`,
-        };
-      }
-    }
+    parsed = JSON.parse(raw);
   } catch (err) {
-    parseErr = err;
+    const e = err as Error;
+    return {
+      decision: 'escalate',
+      reasoning: `Unparsable multi-choice response (${e.name}: ${e.message}): ${raw.slice(0, 100)}`,
+    };
   }
-  const errHint = parseErr ? ` [${(parseErr as Error).name}: ${(parseErr as Error).message}]` : '';
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return {
+      decision: 'escalate',
+      reasoning: `Multi-choice response was not a JSON object: ${raw.slice(0, 100)}`,
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const decisionStr = String(obj.decision ?? '').toLowerCase();
+  const reasoning = String(obj.reasoning ?? '');
+
+  if (decisionStr === 'escalate') {
+    return { decision: 'escalate', reasoning };
+  }
+  if (decisionStr === 'pick') {
+    const idx = Number(obj.index);
+    if (Number.isInteger(idx) && idx >= 1 && idx <= optionCount) {
+      return { decision: 'pick', index: idx, reasoning };
+    }
+    return {
+      decision: 'escalate',
+      reasoning: `LLM picked out-of-range index ${obj.index} for ${optionCount} options; ${reasoning}`,
+    };
+  }
+
+  // Well-formed JSON object with the wrong decision string. Distinct from
+  // a JSON parse failure so log triage can tell the two apart.
   return {
     decision: 'escalate',
-    reasoning: `Unparsable multi-choice response: ${raw.slice(0, 100)}${errHint}`,
+    reasoning: `Invalid multi-choice decision "${decisionStr}"; expected "pick" or "escalate"`,
   };
 }

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -140,20 +140,20 @@ export function parseMultiChoiceDecision(
   }
 
   const obj = parsed as Record<string, unknown>;
-  const decisionStr = String(obj.decision ?? '').toLowerCase();
-  const reasoning = String(obj.reasoning ?? '');
+  const decisionStr = String(obj['decision'] ?? '').toLowerCase();
+  const reasoning = String(obj['reasoning'] ?? '');
 
   if (decisionStr === 'escalate') {
     return { decision: 'escalate', reasoning };
   }
   if (decisionStr === 'pick') {
-    const idx = Number(obj.index);
+    const idx = Number(obj['index']);
     if (Number.isInteger(idx) && idx >= 1 && idx <= optionCount) {
       return { decision: 'pick', index: idx, reasoning };
     }
     return {
       decision: 'escalate',
-      reasoning: `LLM picked out-of-range index ${obj.index} for ${optionCount} options; ${reasoning}`,
+      reasoning: `LLM picked out-of-range index ${obj['index']} for ${optionCount} options; ${reasoning}`,
     };
   }
 

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -22,17 +22,27 @@ export type AutoApproveDecision = 'approve' | 'deny' | 'escalate' | 'pick' | 'ca
  * produced the verdict (or the configured model for pattern-matched
  * decisions, since downstream telemetry treats them uniformly).
  *
- * `pickIndex` is set ONLY when `decision === 'pick'` and is a 1-based
- * index into the permission_suggestions array. Callers must validate it
- * against the actual options length before injecting.
+ * Discriminated by `decision` so the `pick`-only `pickIndex` field is
+ * load-bearing in TypeScript: a `pick` result MUST carry `pickIndex`
+ * and the approve/deny/escalate variants cannot accidentally set it.
  */
-export interface AutoApproveDecisionResult {
-  readonly decision: 'approve' | 'deny' | 'escalate' | 'pick';
-  readonly pickIndex?: number;
-  readonly reasoning: string;
-  readonly durationMs: number;
-  readonly model: string;
-}
+export type AutoApproveDecisionResult =
+  | {
+      readonly decision: 'approve' | 'deny' | 'escalate';
+      readonly reasoning: string;
+      readonly durationMs: number;
+      readonly model: string;
+    }
+  | {
+      readonly decision: 'pick';
+      /** 1-based index into the permission_suggestions array.
+       *  Validated by `parseMultiChoiceDecision` against the actual
+       *  options length before this result is constructed. */
+      readonly pickIndex: number;
+      readonly reasoning: string;
+      readonly durationMs: number;
+      readonly model: string;
+    };
 
 /**
  * Control-plane outcome: cancel() aborted the in-flight call, no decision

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -2,24 +2,33 @@
  * Types for the auto-approve feature.
  *
  * The auto-approve system intercepts PermissionRequest hook events and uses
- * an LLM (via OpenAI-compatible API) to decide: approve, deny, or escalate.
+ * an LLM (via OpenAI-compatible API) to decide: approve, deny, escalate,
+ * or, for multi-choice prompts, pick a specific option index.
  */
 
 /**
  * Possible decisions returned by AutoApproveService.evaluate().
+ *
+ * 'pick' is for multi-choice prompts (#399): the LLM chose a specific
+ *   option by 1-based index, surfaced via `pickIndex` on the result.
  * 'cancelled' is set ONLY when AutoApproveService.cancel() aborted an
- * in-flight call; it cannot come from the LLM. See cancel() docs for
- * the bridge-side contract.
+ *   in-flight call; it cannot come from the LLM. See cancel() docs for
+ *   the bridge-side contract.
  */
-export type AutoApproveDecision = 'approve' | 'deny' | 'escalate' | 'cancelled';
+export type AutoApproveDecision = 'approve' | 'deny' | 'escalate' | 'pick' | 'cancelled';
 
 /**
- * LLM-produced (or pattern-matched) decision: approve / deny / escalate.
- * `model` is the model that produced the verdict (or the configured model for
- * pattern-matched decisions, since downstream telemetry treats them uniformly).
+ * LLM-produced (or pattern-matched) decision. `model` is the model that
+ * produced the verdict (or the configured model for pattern-matched
+ * decisions, since downstream telemetry treats them uniformly).
+ *
+ * `pickIndex` is set ONLY when `decision === 'pick'` and is a 1-based
+ * index into the permission_suggestions array. Callers must validate it
+ * against the actual options length before injecting.
  */
 export interface AutoApproveDecisionResult {
-  readonly decision: 'approve' | 'deny' | 'escalate';
+  readonly decision: 'approve' | 'deny' | 'escalate' | 'pick';
+  readonly pickIndex?: number;
   readonly reasoning: string;
   readonly durationMs: number;
   readonly model: string;
@@ -36,6 +45,9 @@ export interface AutoApproveCancelledResult {
 }
 
 export type AutoApproveResult = AutoApproveDecisionResult | AutoApproveCancelledResult;
+
+/** How auto-approve treats multi-choice permission prompts (#399). */
+export type MultiChoiceMode = 'skip' | 'evaluate';
 
 /** Configuration for the auto-approve feature */
 export interface AutoApproveConfig {
@@ -71,4 +83,20 @@ export interface AutoApproveConfig {
    * Empty string means no extra guidance (use default prompt only).
    */
   readonly instructions: string;
+  /**
+   * How to treat multi-choice permission prompts (#399): permissions whose
+   * suggestions are not the standard Yes / Yes-always / No 3-set or have
+   * more than 3 options. 'skip' (default) escalates to the user without
+   * calling the LLM, since the binary approve/deny mapping cannot express
+   * "pick option 2 out of N". 'evaluate' uses a dedicated prompt that asks
+   * the LLM to pick an option index.
+   */
+  readonly multichoice: MultiChoiceMode;
+  /**
+   * Optional alternate model for multi-choice evaluation. When empty,
+   * `model` is used. Useful for routing complex plan-mode prompts to a
+   * smarter model without paying its latency for every binary permission.
+   * Ignored unless `multichoice = "evaluate"`.
+   */
+  readonly multichoice_model: string;
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -742,6 +742,9 @@ let autoApproveService: AutoApproveService | null = null;
       );
     }
 
+    const multichoice = parsedArgs.autoApproveMultichoice ?? aaCfg.multichoice;
+    const multichoiceModel = parsedArgs.autoApproveMultichoiceModel ?? aaCfg.multichoice_model;
+
     autoApproveService = new AutoApproveService(
       {
         ...aaCfg,
@@ -753,12 +756,15 @@ let autoApproveService: AutoApproveService | null = null;
         allow,
         deny,
         instructions,
+        multichoice,
+        multichoice_model: multichoiceModel,
       },
       writeToLog,
     );
     const rulesSummary = `allow=${allow.length} deny=${deny.length} instructions=${instructions ? 'yes' : 'no'}`;
+    const mcSummary = `multichoice=${multichoice}${multichoiceModel ? ` mc_model=${multichoiceModel}` : ''}`;
     writeToLog(
-      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}`,
+      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}, ${mcSummary}`,
     );
   }
 }

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -95,6 +95,8 @@ export interface ParsedArgs {
   readonly autoApproveAllow: readonly string[];
   readonly autoApproveDeny: readonly string[];
   readonly autoApproveInstructions: string | undefined;
+  readonly autoApproveMultichoice: 'skip' | 'evaluate' | undefined;
+  readonly autoApproveMultichoiceModel: string | undefined;
   readonly claudeArgs: readonly string[];
   readonly showVersion: boolean;
   readonly showHelp: boolean;
@@ -141,6 +143,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
   const autoApproveAllow: string[] = [];
   const autoApproveDeny: string[] = [];
   let autoApproveInstructions: string | undefined;
+  let autoApproveMultichoice: 'skip' | 'evaluate' | undefined;
+  let autoApproveMultichoiceModel: string | undefined;
   let showVersion = false;
   let showHelp = false;
   let error: string | undefined;
@@ -356,6 +360,20 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
         autoApproveInstructions = nextArg;
         i++;
       }
+    } else if (arg === '--auto-approve-multichoice') {
+      if (nextArg !== 'skip' && nextArg !== 'evaluate') {
+        error = 'Error: --auto-approve-multichoice requires "skip" or "evaluate".';
+      } else {
+        autoApproveMultichoice = nextArg;
+        i++;
+      }
+    } else if (arg === '--auto-approve-multichoice-model') {
+      if (!nextArg || nextArg.startsWith('-')) {
+        error = 'Error: --auto-approve-multichoice-model requires a value.';
+      } else {
+        autoApproveMultichoiceModel = nextArg;
+        i++;
+      }
     } else if (arg === '--version' || arg === '-v') {
       showVersion = true;
     } else if (arg === '--help' || arg === '-h') {
@@ -433,6 +451,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     autoApproveAllow,
     autoApproveDeny,
     autoApproveInstructions,
+    autoApproveMultichoice,
+    autoApproveMultichoiceModel,
     orphanTimeout,
     claudeArgs,
     showVersion,

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -261,6 +261,8 @@ export function formatHelp(version: string): string {
     entry('--auto-approve-allow STR', 'Allow-list pattern (repeatable, substring match)'),
     entry('--auto-approve-deny STR', 'Deny-list pattern (repeatable, substring match)'),
     entry('--auto-approve-instructions T', 'Natural-language guidance for the LLM'),
+    entry('--auto-approve-multichoice MODE', 'skip (default) | evaluate (LLM picks index)'),
+    entry('--auto-approve-multichoice-model M', 'Alt-model for multi-choice; empty = main model'),
     '',
     bold('Remote Access:'),
     entry('remi ls --host <ip>', 'List sessions on remote machine'),

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -506,7 +506,10 @@ export function setupHookBridge(
     // qualifying hook event for our session resolves it. If the timeout
     // fires first, the inject is treated as silently lost -- the dedup
     // mark is cleared and we escalate so the user still gets a question.
-    const inject = async (value: '1' | '3', reason: string): Promise<boolean> => {
+    // Value is a 1-based numeric option index serialised as a string. Most
+    // permissions only need '1' (approve) or '3' (deny); multi-choice picks
+    // can land any index in the prompt's option range (#399).
+    const inject = async (value: string, reason: string): Promise<boolean> => {
       let ack: PendingAck | null = null;
       try {
         const session = sessionRegistry.getSession(sessionId);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -577,8 +577,11 @@ export function setupHookBridge(
       // Notification fallback usable.
       hookBridge.markPermissionHandled();
       const aaService = autoApproveService;
+      const suggestions = Array.isArray(input.permission_suggestions)
+        ? (input.permission_suggestions as readonly string[])
+        : undefined;
       aaService
-        .evaluate(input.tool_name, input.tool_input, sessionTag)
+        .evaluate(input.tool_name, input.tool_input, sessionTag, suggestions)
         .then(async (result) => {
           if (result.decision === 'cancelled') {
             // User already advanced past the prompt (terminal answer or
@@ -596,6 +599,16 @@ export function setupHookBridge(
           }
           if (result.decision === 'deny') {
             if (!(await inject('3', 'denied'))) escalateToUser();
+            return;
+          }
+          if (result.decision === 'pick' && result.pickIndex !== undefined) {
+            // Multi-choice pick (#399): inject the 1-based index Claude Code
+            // expects on the terminal. parseMultiChoiceDecision already
+            // validated the index against options length, so out-of-range
+            // values cannot reach this branch.
+            if (!(await inject(String(result.pickIndex), `multichoice-pick-${result.pickIndex}`))) {
+              escalateToUser();
+            }
             return;
           }
           // escalate: in a subagent context, default-deny to avoid hanging

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -577,11 +577,19 @@ export function setupHookBridge(
       // Notification fallback usable.
       hookBridge.markPermissionHandled();
       const aaService = autoApproveService;
-      const suggestions = Array.isArray(input.permission_suggestions)
-        ? (input.permission_suggestions as readonly string[])
-        : undefined;
+      // Pass the raw suggestions array; AutoApproveService does its own
+      // strict-string filtering before feeding the LLM. We forward the
+      // raw shape (rather than coercing) so the multi-choice classifier
+      // can see "non-string entry" and route through escalate instead
+      // of crashing on a future Claude Code permission_suggestions
+      // schema change.
       aaService
-        .evaluate(input.tool_name, input.tool_input, sessionTag, suggestions)
+        .evaluate(
+          input.tool_name,
+          input.tool_input,
+          sessionTag,
+          input.permission_suggestions as readonly unknown[] | undefined,
+        )
         .then(async (result) => {
           if (result.decision === 'cancelled') {
             // User already advanced past the prompt (terminal answer or

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -95,6 +95,8 @@ export const DEFAULT_CONFIG: RemiConfig = {
     allow: [],
     deny: [],
     instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
   },
 };
 
@@ -221,6 +223,13 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
     );
   }
 
+  if (cfg.multichoice !== 'skip' && cfg.multichoice !== 'evaluate') {
+    throw new Error(
+      `Invalid auto_approve.multichoice in ${configPath}: must be "skip" or "evaluate", got ${typeof cfg.multichoice === 'string' ? `"${cfg.multichoice}"` : typeof cfg.multichoice}.`,
+    );
+  }
+  expectString('multichoice_model', cfg.multichoice_model);
+
   // Warn about dangerously short patterns that would match too broadly.
   const MIN_PATTERN_LENGTH = 2;
   for (const p of cfg.allow) {
@@ -328,6 +337,14 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
   }
+  const mc = env['REMI_AUTO_APPROVE_MULTICHOICE'];
+  if (mc === 'skip' || mc === 'evaluate') {
+    (auto_approve as { multichoice: 'skip' | 'evaluate' }).multichoice = mc;
+  }
+  if (env['REMI_AUTO_APPROVE_MULTICHOICE_MODEL']) {
+    (auto_approve as { multichoice_model: string }).multichoice_model =
+      env['REMI_AUTO_APPROVE_MULTICHOICE_MODEL'];
+  }
 
   return {
     ...config,
@@ -391,6 +408,17 @@ authorized_user_ids = []
 # Escalate anything touching .env or secrets/.
 # Deny any git push to main.
 # """
+#
+# Multi-choice prompts (plan-mode questions, tools with 4+ choices, or any
+# permission_suggestions outside the standard Yes/Yes-always/No trio):
+# multichoice = "skip"             # "skip" (default; always escalate to user)
+#                                  # | "evaluate" (call LLM to pick an index)
+# multichoice_model = ""           # Optional alt-model for multi-choice; empty
+#                                  # falls back to the main \`model\`. Useful
+#                                  # for routing planning prompts to a smarter
+#                                  # model without paying its latency for
+#                                  # every binary permission. Ignored unless
+#                                  # multichoice = "evaluate".
 `;
 }
 
@@ -460,6 +488,8 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   const instr = config.auto_approve.instructions;
   const instrDisplay = instr ? `"${instr.slice(0, 40)}${instr.length > 40 ? '...' : ''}"` : '""';
   lines.push(`  instructions = ${instrDisplay}`);
+  lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
+  lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
 
   return lines.join('\n');
 }

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -865,3 +865,149 @@ describe('AutoApproveService - multichoice', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-choice review-fix: regression guards (#400 review)
+// ---------------------------------------------------------------------------
+describe('AutoApproveService - multichoice regression guards', () => {
+  test("Edit's real ['Yes','Always','No'] is binary, not multi-choice", async () => {
+    // Without this guard, the exact-label detector misclassified Edit's
+    // real shape as multi-choice and silently escalated every Edit/Write
+    // permission under the default skip mode (#400 review, critical).
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          return new Response(
+            JSON.stringify({
+              model: 'fake-model',
+              choices: [{ message: { content: '{"decision":"approve","reasoning":"safe edit"}' } }],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          // multichoice = 'skip' is default; if Edit were classified as
+          // multi-choice it would short-circuit to escalate without
+          // hitting the LLM. We use a real LLM endpoint so the test
+          // FAILS LOUDLY if the classifier regresses.
+          timeout: 5,
+        }),
+        logFn,
+      );
+      const result = await service.evaluate(
+        'Edit',
+        { file_path: '/tmp/x', old_string: 'a', new_string: 'b' },
+        undefined,
+        ['Yes', 'Always', 'No'],
+      );
+      expect(result.decision).toBe('approve');
+      if (result.decision !== 'cancelled') {
+        expect(result.reasoning).not.toContain('multi-choice');
+      }
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('deny pattern still wins on a multi-choice prompt', async () => {
+    const service = new AutoApproveService(
+      makeConfig({
+        base_url: 'http://10.255.255.1',
+        timeout: 60,
+        deny: ['ExitPlanMode'],
+      }),
+      logFn,
+    );
+    const result = await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+      'Approve',
+      'Approve and stay',
+      'Reject',
+    ]);
+    expect(result.decision).toBe('deny');
+    expect(result.reasoning).toContain('deny-matched');
+  });
+
+  test('allow pattern still wins on a multi-choice prompt', async () => {
+    const service = new AutoApproveService(
+      makeConfig({
+        base_url: 'http://10.255.255.1',
+        timeout: 60,
+        allow: ['ExitPlanMode'],
+      }),
+      logFn,
+    );
+    const result = await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+      'Approve',
+      'Approve and stay',
+      'Reject',
+    ]);
+    expect(result.decision).toBe('approve');
+    expect(result.reasoning).toContain('allow-matched');
+  });
+
+  test('skip mode does not call the LLM when multichoice_model is set', async () => {
+    // multichoice_model is consulted only in evaluate mode; skip mode
+    // must short-circuit before any LLM call regardless of model config.
+    let llmCalls = 0;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          llmCalls++;
+          return new Response(
+            JSON.stringify({
+              model: 'should-not-be-called',
+              choices: [{ message: { content: '{"decision":"escalate","reasoning":"x"}' } }],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          multichoice: 'skip',
+          multichoice_model: 'smart-model',
+          timeout: 5,
+        }),
+        logFn,
+      );
+      const result = await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+        'Yes',
+        'No',
+      ]);
+      expect(result.decision).toBe('escalate');
+      expect(llmCalls).toBe(0);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('non-string entries in permission_suggestions do not crash', async () => {
+    const service = new AutoApproveService(
+      makeConfig({ base_url: 'http://10.255.255.1', timeout: 60 }),
+      logFn,
+    );
+    const result = await service.evaluate(
+      'CustomTool',
+      { x: 1 },
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: defensive test
+      [null, 'Yes', { weird: true }] as any,
+    );
+    // Routed to multi-choice (skip mode) → escalate without crash.
+    expect(result.decision).toBe('escalate');
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -37,6 +37,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     allow: [],
     deny: [],
     instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
     ...overrides,
   };
 }
@@ -618,4 +620,248 @@ describeOllama('AutoApproveService - real Ollama integration', () => {
     const result = await service.evaluate('Grep', { pattern: 'TODO', path: '/tmp' });
     expect(['approve', 'escalate']).toContain(result.decision);
   }, 60000);
+});
+
+// ---------------------------------------------------------------------------
+// Multi-choice handling (#399)
+// ---------------------------------------------------------------------------
+describe('AutoApproveService - multichoice', () => {
+  test('skip mode escalates without calling LLM (default)', async () => {
+    const service = new AutoApproveService(
+      // base_url unreachable on purpose: if the service called the LLM
+      // anyway the test would time out instead of returning escalate.
+      makeConfig({ base_url: 'http://10.255.255.1', timeout: 60 }),
+      logFn,
+    );
+    const result = await service.evaluate(
+      'ExitPlanMode',
+      { plan: 'Refactor auth module' },
+      undefined,
+      ['Approve plan', 'Approve and stay in plan mode', 'Reject plan'],
+    );
+    expect(result.decision).toBe('escalate');
+    if (result.decision !== 'cancelled') {
+      expect(result.reasoning).toContain('multi-choice');
+      expect(result.durationMs).toBeLessThan(50);
+    }
+  });
+
+  test('binary 3-set still goes through LLM path (skip mode does not block it)', async () => {
+    // Standard Yes/Yes-always/No is binary; multichoice gate must not fire.
+    // base_url unreachable -> evaluate falls through to escalate via LLM
+    // error path (timeoutMs=1) rather than the multi-choice short-circuit.
+    const service = new AutoApproveService(
+      makeConfig({ base_url: 'http://10.255.255.1', timeout: 1 }),
+      logFn,
+    );
+    const result = await service.evaluate('Bash', { command: 'ls' }, undefined, [
+      'Yes',
+      'Yes, always',
+      'No',
+    ]);
+    expect(result.decision).toBe('escalate');
+    if (result.decision !== 'cancelled') {
+      // Reasoning is "LLM timeout" or "Error: ..." NOT "multi-choice".
+      expect(result.reasoning).not.toContain('multi-choice');
+    }
+  });
+
+  test('evaluate mode picks an option index from the LLM response', async () => {
+    // Spin up a tiny OpenAI-compatible endpoint that returns a deterministic
+    // multi-choice JSON. No mocks; this is a real HTTP server.
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          return new Response(
+            JSON.stringify({
+              model: 'fake-model',
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({
+                      decision: 'pick',
+                      index: 2,
+                      reasoning: 'middle option fits the routine default',
+                    }),
+                  },
+                },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          multichoice: 'evaluate',
+          timeout: 5,
+        }),
+        logFn,
+      );
+      const result = await service.evaluate('ExitPlanMode', { plan: 'Refactor' }, undefined, [
+        'Approve',
+        'Approve and stay',
+        'Reject',
+      ]);
+      expect(result.decision).toBe('pick');
+      if (result.decision === 'pick') {
+        expect(result.pickIndex).toBe(2);
+        expect(result.reasoning).toContain('middle option');
+      }
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('evaluate mode falls through to escalate on out-of-range pick', async () => {
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          return new Response(
+            JSON.stringify({
+              model: 'fake-model',
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({
+                      decision: 'pick',
+                      index: 99,
+                      reasoning: 'misread the option count',
+                    }),
+                  },
+                },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          multichoice: 'evaluate',
+          timeout: 5,
+        }),
+        logFn,
+      );
+      const result = await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+        'Approve',
+        'Approve and stay',
+        'Reject',
+      ]);
+      expect(result.decision).toBe('escalate');
+      if (result.decision !== 'cancelled') {
+        expect(result.reasoning).toContain('out-of-range');
+      }
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('evaluate mode uses multichoice_model when set', async () => {
+    let receivedModel: string | undefined;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          const body = (await req.json()) as { model?: string };
+          receivedModel = body.model;
+          return new Response(
+            JSON.stringify({
+              model: body.model ?? 'fake-model',
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({ decision: 'escalate', reasoning: 'unsure' }),
+                  },
+                },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          model: 'main-model',
+          multichoice: 'evaluate',
+          multichoice_model: 'smart-model',
+          timeout: 5,
+        }),
+        logFn,
+      );
+      await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+        'Approve plan',
+        'Approve and stay',
+        'Reject plan',
+      ]);
+      expect(receivedModel).toBe('smart-model');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('evaluate mode falls back to main model when multichoice_model is empty', async () => {
+    let receivedModel: string | undefined;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          const body = (await req.json()) as { model?: string };
+          receivedModel = body.model;
+          return new Response(
+            JSON.stringify({
+              model: body.model ?? 'fake-model',
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({ decision: 'escalate', reasoning: 'unsure' }),
+                  },
+                },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          model: 'main-model',
+          multichoice: 'evaluate',
+          multichoice_model: '',
+          timeout: 5,
+        }),
+        logFn,
+      );
+      await service.evaluate('ExitPlanMode', { plan: 'x' }, undefined, [
+        'Approve plan',
+        'Approve and stay',
+        'Reject plan',
+      ]);
+      expect(receivedModel).toBe('main-model');
+    } finally {
+      server.stop();
+    }
+  });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -110,6 +110,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     allow: [],
     deny: [],
     instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
   };
 }
 

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -56,6 +56,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     allow: [],
     deny: [],
     instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -11,40 +11,72 @@ import {
 
 describe('isMultiChoicePermission', () => {
   test('returns false for null/undefined/empty (default 3-set substitutes)', () => {
-    expect(isMultiChoicePermission(undefined)).toBe(false);
-    expect(isMultiChoicePermission(null)).toBe(false);
-    expect(isMultiChoicePermission([])).toBe(false);
+    expect(isMultiChoicePermission('Bash', undefined)).toBe(false);
+    expect(isMultiChoicePermission('Bash', null)).toBe(false);
+    expect(isMultiChoicePermission('Bash', [])).toBe(false);
   });
 
   test('returns false for the standard Yes/Yes-always/No 3-set', () => {
-    expect(isMultiChoicePermission(['Yes', 'Yes, always', 'No'])).toBe(false);
-    // Case-insensitive + whitespace tolerated.
-    expect(isMultiChoicePermission(['  YES  ', 'yes, ALWAYS', ' no '])).toBe(false);
+    expect(isMultiChoicePermission('Bash', ['Yes', 'Yes, always', 'No'])).toBe(false);
+  });
+
+  test("returns false for Edit's real ['Yes','Always','No'] shape (#400 review)", () => {
+    // Edit/Write/MultiEdit's actual permission_suggestions; "Always" is a
+    // yes-shaped synonym (matches isYes heuristic at hook-event-bridge.ts:240).
+    expect(isMultiChoicePermission('Edit', ['Yes', 'Always', 'No'])).toBe(false);
+    expect(isMultiChoicePermission('Write', ['Yes', 'Always', 'No'])).toBe(false);
+    expect(isMultiChoicePermission('MultiEdit', ['Yes', 'Always', 'No'])).toBe(false);
+  });
+
+  test('returns false for the Allow/Deny pair', () => {
+    expect(isMultiChoicePermission('Bash', ['Allow', 'Deny'])).toBe(false);
   });
 
   test('returns false for the standard Yes/No pair', () => {
-    expect(isMultiChoicePermission(['Yes', 'No'])).toBe(false);
+    expect(isMultiChoicePermission('Bash', ['Yes', 'No'])).toBe(false);
+    // Whitespace + case tolerated.
+    expect(isMultiChoicePermission('Bash', [' YES ', ' no '])).toBe(false);
   });
 
-  test('returns true for non-standard 3-option sets (ExitPlanMode-style)', () => {
+  test('returns false for sentence labels that still start with yes/no', () => {
+    // ExitPlanMode-style labels that all start with "Yes"/"No": label-shape
+    // alone says binary. The tool-name list is what makes ExitPlanMode
+    // multi-choice in the next test.
     expect(
-      isMultiChoicePermission([
+      isMultiChoicePermission('Bash', [
         'Yes',
         "Yes, and don't ask again this session",
         'No, and tell Claude what to do differently',
       ]),
-    ).toBe(true);
-    expect(
-      isMultiChoicePermission(['Approve plan', 'Approve and stay in plan mode', 'Reject plan']),
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  test('ExitPlanMode is always multi-choice regardless of label shape', () => {
+    expect(isMultiChoicePermission('ExitPlanMode', ['Yes', 'No'])).toBe(true);
+    expect(isMultiChoicePermission('ExitPlanMode', ['Yes', 'Always', 'No'])).toBe(true);
+    expect(isMultiChoicePermission('ExitPlanMode', undefined)).toBe(true);
   });
 
   test('returns true for >3 option lists', () => {
-    expect(isMultiChoicePermission(['Refactor', 'Patch', 'Rewrite', 'Skip'])).toBe(true);
+    expect(isMultiChoicePermission('CustomTool', ['Refactor', 'Patch', 'Rewrite', 'Skip'])).toBe(
+      true,
+    );
   });
 
-  test('returns true for non-Yes-No 2-option pairs', () => {
-    expect(isMultiChoicePermission(['Save', 'Discard'])).toBe(true);
+  test('returns true for non-binary 2-option pairs', () => {
+    expect(isMultiChoicePermission('CustomTool', ['Save', 'Discard'])).toBe(true);
+  });
+
+  test('returns true for 3-option list with non-binary middle label', () => {
+    expect(isMultiChoicePermission('CustomTool', ['Yes', 'Maybe later', 'No'])).toBe(true);
+  });
+
+  test('returns true for non-string entries (defensive against schema drift)', () => {
+    // permission_suggestions with garbage entries must NOT crash on
+    // .toLowerCase(). Routing to multi-choice is the safe path; the
+    // service does its own strict filter before any LLM call.
+    expect(isMultiChoicePermission('Bash', [null, 'Yes', 'No'] as readonly unknown[])).toBe(true);
+    expect(isMultiChoicePermission('Bash', [{}, 1] as readonly unknown[])).toBe(true);
   });
 });
 
@@ -129,8 +161,18 @@ describe('parseMultiChoiceDecision', () => {
     expect(r.reasoning).toContain('Unparsable');
   });
 
-  test('escalates on unknown decision strings', () => {
+  test('escalates on well-formed JSON with the wrong decision string (#400 review)', () => {
+    // Pre-#400-review behavior labelled this "Unparsable", which is misleading
+    // when triaging logs. The new branch distinguishes the failure modes.
     const r = parseMultiChoiceDecision('{"decision":"approve","reasoning":"x"}', 4);
     expect(r.decision).toBe('escalate');
+    expect(r.reasoning).toContain('Invalid multi-choice decision');
+    expect(r.reasoning).not.toContain('Unparsable');
+  });
+
+  test('escalates on JSON that is not an object', () => {
+    const r = parseMultiChoiceDecision('"just a string"', 4);
+    expect(r.decision).toBe('escalate');
+    expect(r.reasoning).toContain('not a JSON object');
   });
 });

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -88,12 +88,16 @@ describe('buildMultiChoicePrompt', () => {
       'Reject plan',
     ]);
     expect(messages).toHaveLength(2);
-    expect(messages[0].role).toBe('system');
-    expect(messages[0].content).toContain('PICK ONE option');
-    expect(messages[1].role).toBe('user');
-    expect(messages[1].content).toContain('  1. Approve plan');
-    expect(messages[1].content).toContain('  2. Approve and stay in plan mode');
-    expect(messages[1].content).toContain('  3. Reject plan');
+    const [system, user] = messages as [
+      { role: string; content: string },
+      { role: string; content: string },
+    ];
+    expect(system.role).toBe('system');
+    expect(system.content).toContain('PICK ONE option');
+    expect(user.role).toBe('user');
+    expect(user.content).toContain('  1. Approve plan');
+    expect(user.content).toContain('  2. Approve and stay in plan mode');
+    expect(user.content).toContain('  3. Reject plan');
   });
 
   test('appends user instructions when provided', () => {
@@ -103,15 +107,17 @@ describe('buildMultiChoicePrompt', () => {
       ['Yes', 'No'],
       'Always escalate plans involving database migrations.',
     );
-    expect(messages[0].content).toContain('USER-SPECIFIC GUIDANCE');
-    expect(messages[0].content).toContain('database migrations');
+    const [system] = messages as [{ role: string; content: string }];
+    expect(system.content).toContain('USER-SPECIFIC GUIDANCE');
+    expect(system.content).toContain('database migrations');
   });
 
   test('truncates very long inputs', () => {
     const longInput = { plan: 'x'.repeat(5000) };
     const messages = buildMultiChoicePrompt('ExitPlanMode', longInput, ['Yes', 'No']);
-    expect(messages[1].content.length).toBeLessThan(2500);
-    expect(messages[1].content).toContain('...');
+    const user = messages[1] as { content: string };
+    expect(user.content.length).toBeLessThan(2500);
+    expect(user.content).toContain('...');
   });
 });
 

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the multi-choice auto-approve helpers (#399).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  buildMultiChoicePrompt,
+  isMultiChoicePermission,
+  parseMultiChoiceDecision,
+} from '../../src/auto-approve/multichoice.ts';
+
+describe('isMultiChoicePermission', () => {
+  test('returns false for null/undefined/empty (default 3-set substitutes)', () => {
+    expect(isMultiChoicePermission(undefined)).toBe(false);
+    expect(isMultiChoicePermission(null)).toBe(false);
+    expect(isMultiChoicePermission([])).toBe(false);
+  });
+
+  test('returns false for the standard Yes/Yes-always/No 3-set', () => {
+    expect(isMultiChoicePermission(['Yes', 'Yes, always', 'No'])).toBe(false);
+    // Case-insensitive + whitespace tolerated.
+    expect(isMultiChoicePermission(['  YES  ', 'yes, ALWAYS', ' no '])).toBe(false);
+  });
+
+  test('returns false for the standard Yes/No pair', () => {
+    expect(isMultiChoicePermission(['Yes', 'No'])).toBe(false);
+  });
+
+  test('returns true for non-standard 3-option sets (ExitPlanMode-style)', () => {
+    expect(
+      isMultiChoicePermission([
+        'Yes',
+        "Yes, and don't ask again this session",
+        'No, and tell Claude what to do differently',
+      ]),
+    ).toBe(true);
+    expect(
+      isMultiChoicePermission(['Approve plan', 'Approve and stay in plan mode', 'Reject plan']),
+    ).toBe(true);
+  });
+
+  test('returns true for >3 option lists', () => {
+    expect(isMultiChoicePermission(['Refactor', 'Patch', 'Rewrite', 'Skip'])).toBe(true);
+  });
+
+  test('returns true for non-Yes-No 2-option pairs', () => {
+    expect(isMultiChoicePermission(['Save', 'Discard'])).toBe(true);
+  });
+});
+
+describe('buildMultiChoicePrompt', () => {
+  test('lists options with 1-based indices in the user message', () => {
+    const messages = buildMultiChoicePrompt('ExitPlanMode', { plan: 'Refactor auth module' }, [
+      'Approve plan',
+      'Approve and stay in plan mode',
+      'Reject plan',
+    ]);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('system');
+    expect(messages[0].content).toContain('PICK ONE option');
+    expect(messages[1].role).toBe('user');
+    expect(messages[1].content).toContain('  1. Approve plan');
+    expect(messages[1].content).toContain('  2. Approve and stay in plan mode');
+    expect(messages[1].content).toContain('  3. Reject plan');
+  });
+
+  test('appends user instructions when provided', () => {
+    const messages = buildMultiChoicePrompt(
+      'ExitPlanMode',
+      { plan: 'x' },
+      ['Yes', 'No'],
+      'Always escalate plans involving database migrations.',
+    );
+    expect(messages[0].content).toContain('USER-SPECIFIC GUIDANCE');
+    expect(messages[0].content).toContain('database migrations');
+  });
+
+  test('truncates very long inputs', () => {
+    const longInput = { plan: 'x'.repeat(5000) };
+    const messages = buildMultiChoicePrompt('ExitPlanMode', longInput, ['Yes', 'No']);
+    expect(messages[1].content.length).toBeLessThan(2500);
+    expect(messages[1].content).toContain('...');
+  });
+});
+
+describe('parseMultiChoiceDecision', () => {
+  test('parses a valid pick within range', () => {
+    const r = parseMultiChoiceDecision(
+      '{"decision":"pick","index":2,"reasoning":"middle option fits the user intent"}',
+      4,
+    );
+    expect(r.decision).toBe('pick');
+    if (r.decision === 'pick') {
+      expect(r.index).toBe(2);
+      expect(r.reasoning).toBe('middle option fits the user intent');
+    }
+  });
+
+  test('parses a valid escalate', () => {
+    const r = parseMultiChoiceDecision(
+      '{"decision":"escalate","reasoning":"plan-mode question; user intent unclear"}',
+      4,
+    );
+    expect(r.decision).toBe('escalate');
+    expect(r.reasoning).toContain('plan-mode');
+  });
+
+  test('escalates on out-of-range index', () => {
+    const r = parseMultiChoiceDecision('{"decision":"pick","index":99,"reasoning":"x"}', 4);
+    expect(r.decision).toBe('escalate');
+    expect(r.reasoning).toContain('out-of-range');
+  });
+
+  test('escalates on zero or negative index', () => {
+    const r1 = parseMultiChoiceDecision('{"decision":"pick","index":0,"reasoning":"x"}', 4);
+    expect(r1.decision).toBe('escalate');
+    const r2 = parseMultiChoiceDecision('{"decision":"pick","index":-1,"reasoning":"x"}', 4);
+    expect(r2.decision).toBe('escalate');
+  });
+
+  test('escalates on non-integer index', () => {
+    const r = parseMultiChoiceDecision('{"decision":"pick","index":2.5,"reasoning":"x"}', 4);
+    expect(r.decision).toBe('escalate');
+  });
+
+  test('escalates on malformed JSON with parser hint', () => {
+    const r = parseMultiChoiceDecision('not json at all', 4);
+    expect(r.decision).toBe('escalate');
+    expect(r.reasoning).toContain('Unparsable');
+  });
+
+  test('escalates on unknown decision strings', () => {
+    const r = parseMultiChoiceDecision('{"decision":"approve","reasoning":"x"}', 4);
+    expect(r.decision).toBe('escalate');
+  });
+});

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -325,6 +325,8 @@ function makeConfig(model: string): AutoApproveConfig {
     allow: [],
     deny: [],
     instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
   };
 }
 

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -269,6 +269,8 @@ describe('auto_approve config', () => {
       allow: [],
       deny: [],
       instructions: '',
+      multichoice: 'skip',
+      multichoice_model: '',
     });
   });
 


### PR DESCRIPTION
## Summary

- New `multichoice` config key (`"skip"` default, `"evaluate"` opt-in). Skip mode escalates multi-choice prompts to the user without calling the LLM at all, eliminating the "LLM auto-answers Yes to a plan-mode question" symptom under zero user opt-in.
- New `multichoice_model` config key for routing plan-mode prompts to a smarter alt-model without paying its latency for every binary permission.
- Multi-choice detection: more than 3 options, or a 3-set whose labels are not the daemon's `Yes` / `Yes, always` / `No` literal trio, or a 2-pair that is not a clean `Yes` / `No`.
- New `pick` decision and `pickIndex` result field; `hook-bridge-setup` injects the chosen index when the LLM picks. Out-of-range / non-integer / malformed responses fall through to escalate.
- New CLI flags `--auto-approve-multichoice` and `--auto-approve-multichoice-model`; new env vars `REMI_AUTO_APPROVE_MULTICHOICE` and `REMI_AUTO_APPROVE_MULTICHOICE_MODEL`.

Closes #399.

## Default behavior change

A `PermissionRequest` with multi-choice `permission_suggestions` (e.g. `ExitPlanMode`'s `["Yes", "Yes, and don't ask again this session", "No, and tell Claude what to do differently"]` or any tool with 4+ choices) now goes to the user instead of being auto-answered. To restore the old behavior set `auto_approve.multichoice = "evaluate"` in `~/.remi/config.toml` or pass `--auto-approve-multichoice evaluate`.

Binary 2-option `[Yes, No]` and standard 3-option `[Yes, Yes-always, No]` permissions are unchanged.

## Why skip-by-default

The pre-existing `inject('1', 'approved')` / `inject('3', 'denied')` mapping cannot express "pick option 2 of 4" — it always picks option 1 for approve regardless of what the user actually wanted. The user reported this as the LLM "answering yes" to plan-mode and direction prompts. Skipping is the safe default; opt-in evaluate mode handles it correctly via a dedicated prompt + index validation.

## Implementation notes

- `parseMultiChoiceDecision` validates the index is an integer in `[1, optionCount]`. Out-of-range / NaN / 0 / negative all escalate so a confused LLM cannot inject garbage.
- `multichoice_model` falls back to the main `model` when empty, so users only set it when they actually want a different model.
- `looksLikeDefaultPermissionQuestion` (existing) is unchanged; it still drops PTY 3-sets when the hook bridge is active. Multi-choice handling is layered on top, not in place of, the existing belt-and-suspenders.

## Tests

- `packages/daemon/tests/auto-approve/multichoice.test.ts` — 16 unit tests for detection, prompt building, response parsing edge cases.
- `packages/daemon/tests/auto-approve/auto-approve-service.test.ts` — 5 new tests covering skip path, evaluate path, out-of-range fallback, alt-model routing, and main-model fallback. Real `Bun.serve` fake OpenAI-compatible endpoint, no mocks.
- Updated existing test fixtures (defaults + `makeConfig` helpers).
- Full daemon suite: 1608/1608 pass.

## Test plan

- [x] `bun test packages/daemon/tests/auto-approve/multichoice.test.ts` (16/16 pass)
- [x] `bun test packages/daemon/tests/auto-approve/` (118/118 pass; 69 LLM-dependent skipped)
- [x] `bun test packages/daemon/tests` (1608/1608 pass; no regressions)
- [x] Biome clean on all changed files
- [ ] Manual: trigger an `ExitPlanMode` question in a real session with `multichoice = "skip"`; verify the user gets the prompt and the LLM is NOT called.
- [ ] Manual: switch to `multichoice = "evaluate"` with a local LLM that returns `{decision:"pick","index":2}`; verify option 2 is injected.
- [ ] Manual: set `multichoice_model = "qwen3.5:7b"` while main `model = "gemma4:e2b"`; verify the LLM call uses the larger model only for multi-choice prompts.