### PR TITLE
fix(web): decouple chat input from answer flow, add iMessage-style reply (#401)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -154,6 +154,11 @@ function App() {
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
+  // Mirror replyContexts in a ref so handleSend can read the active
+  // session's reply context without taking a dep on the whole Map (#402
+  // review). Without this, every reply set/clear in any session would
+  // re-create handleSend and bust InputArea memoization.
+  const replyContextsRef = useRef<Map<UUID, ReplyContext>>(replyContexts);
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
@@ -784,6 +789,10 @@ function App() {
     messagesRef.current = messages;
   }, [messages]);
 
+  useEffect(() => {
+    replyContextsRef.current = replyContexts;
+  }, [replyContexts]);
+
   // Connection manager: manages N simultaneous WebSocket connections
   const {
     connections,
@@ -1209,7 +1218,7 @@ function App() {
         return;
       }
 
-      const reply = replyContexts.get(activeSessionId);
+      const reply = replyContextsRef.current.get(activeSessionId);
       const wireContent = reply ? formatReplyMessage(reply, content) : content;
 
       const newMessage: UIMessage = {
@@ -1256,7 +1265,7 @@ function App() {
         setMessages((prev) => [...prev, errorMsg]);
       }
     },
-    [activeSessionId, getActiveConnectionId, sendInput, replyContexts],
+    [activeSessionId, getActiveConnectionId, sendInput],
   );
 
   // Set the reply context for the current session: long-press on a
@@ -1344,6 +1353,7 @@ function App() {
     setMessages([]);
     setActiveSessionId(null);
     setQuestions(new Map());
+    setReplyContexts(new Map());
     try {
       localStorage.removeItem(LOCALSTORAGE_CONNECTIONS_KEY);
     } catch (err) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import { shouldKeepExisting } from '@/lib/question-merge';
+import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
   AppSettings,
   ConnectionId,
@@ -136,6 +137,10 @@ function App() {
   const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
   const [questions, setQuestions] = useState<Map<UUID, UIQuestion>>(new Map());
+  // Reply context per session: when set, the InputArea shows a quoted-message
+  // banner and outgoing user input is wrapped in a markdown blockquote so
+  // Claude Code receives the quoted context (#401).
+  const [replyContexts, setReplyContexts] = useState<Map<UUID, ReplyContext>>(new Map());
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -1113,6 +1118,79 @@ function App() {
     setActiveSessionId(null);
   }, []);
 
+  // Answer the active question for the current session. Used by
+  // QuestionCard's onAnswer callback. Decoupled from handleSend so the
+  // bottom InputArea is no longer hijacked when a question is pending
+  // (#401): the user can ask the agent a fresh question without it
+  // being treated as an answer to a stale prompt.
+  const handleAnswer = useCallback(
+    (content: string) => {
+      if (!activeSessionId || !sessionQuestion) return;
+      const connId = getActiveConnectionId();
+      if (!connId) {
+        const systemMsg: UIMessage = {
+          id: generateId(),
+          sessionId: activeSessionId,
+          sender: 'system',
+          content: 'Cannot send: not connected to daemon',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, systemMsg]);
+        return;
+      }
+
+      const sent = sendAnswer(connId, activeSessionId, sessionQuestion.id, content);
+      if (!sent) {
+        const failMsg: UIMessage = {
+          id: generateId(),
+          sessionId: activeSessionId,
+          connectionId: connId,
+          sender: 'system',
+          content: 'Failed to send answer: connection unavailable. Try again.',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, failMsg]);
+        return;
+      }
+      // Mark question as answered (card shows collapsed state briefly)
+      setQuestions((prev) => {
+        const next = new Map(prev);
+        next.set(activeSessionId, { ...sessionQuestion, answeredWith: content });
+        return next;
+      });
+      setTimeout(() => {
+        setQuestions((prev) => {
+          if (!prev.has(activeSessionId)) return prev;
+          const next = new Map(prev);
+          next.delete(activeSessionId);
+          return next;
+        });
+      }, 1500);
+      setSessions((prev) =>
+        prev.map((s) => (s.id === activeSessionId ? { ...s, questionPending: false } : s)),
+      );
+      const userMsg: UIMessage = {
+        id: generateId(),
+        sessionId: activeSessionId,
+        sender: 'user',
+        content,
+        timestamp: new Date().toISOString(),
+        state: 'sent',
+        isEditing: false,
+        source: 'optimistic',
+      };
+      setMessages((prev) => [...prev, userMsg]);
+    },
+    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion],
+  );
+
+  // Send a regular user input message, optionally with a reply context.
+  // Always routes through sendInput regardless of pending question state
+  // (#401 bug fix). The QuestionCard owns the answer flow via handleAnswer.
   const handleSend = useCallback(
     (content: string) => {
       if (!activeSessionId) return;
@@ -1131,62 +1209,14 @@ function App() {
         return;
       }
 
-      // If there's an active question, send as answer
-      if (sessionQuestion) {
-        const sent = sendAnswer(connId, activeSessionId, sessionQuestion.id, content);
-        if (!sent) {
-          const failMsg: UIMessage = {
-            id: generateId(),
-            sessionId: activeSessionId,
-            connectionId: connId,
-            sender: 'system',
-            content: 'Failed to send answer: connection unavailable. Try again.',
-            timestamp: new Date().toISOString(),
-            state: 'delivered',
-            isEditing: false,
-          };
-          setMessages((prev) => [...prev, failMsg]);
-          return;
-        }
-        // Mark question as answered (card shows collapsed state briefly)
-        setQuestions((prev) => {
-          const next = new Map(prev);
-          next.set(activeSessionId, { ...sessionQuestion, answeredWith: content });
-          return next;
-        });
-        setTimeout(() => {
-          setQuestions((prev) => {
-            if (!prev.has(activeSessionId)) return prev;
-            const next = new Map(prev);
-            next.delete(activeSessionId);
-            return next;
-          });
-        }, 1500);
-        // Clear question-pending on the session
-        setSessions((prev) =>
-          prev.map((s) => (s.id === activeSessionId ? { ...s, questionPending: false } : s)),
-        );
-        // Add user message to UI
-        const userMsg: UIMessage = {
-          id: generateId(),
-          sessionId: activeSessionId,
-          sender: 'user',
-          content,
-          timestamp: new Date().toISOString(),
-          state: 'sent',
-          isEditing: false,
-          source: 'optimistic',
-        };
-        setMessages((prev) => [...prev, userMsg]);
-        return;
-      }
+      const reply = replyContexts.get(activeSessionId);
+      const wireContent = reply ? formatReplyMessage(reply, content) : content;
 
-      // Regular user input
       const newMessage: UIMessage = {
         id: generateId(),
         sessionId: activeSessionId,
         sender: 'user',
-        content,
+        content: wireContent,
         timestamp: new Date().toISOString(),
         state: 'sending',
         isEditing: false,
@@ -1195,11 +1225,21 @@ function App() {
 
       setMessages((prev) => [...prev, newMessage]);
 
-      const success = sendInput(connId, activeSessionId, content);
+      const success = sendInput(connId, activeSessionId, wireContent);
       if (success) {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
         );
+        // Reply context is consumed on send; the next message starts clean
+        // unless the user explicitly long-presses another message.
+        if (reply) {
+          setReplyContexts((prev) => {
+            if (!prev.has(activeSessionId)) return prev;
+            const next = new Map(prev);
+            next.delete(activeSessionId);
+            return next;
+          });
+        }
       } else {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'delivered' as const } : m)),
@@ -1216,8 +1256,33 @@ function App() {
         setMessages((prev) => [...prev, errorMsg]);
       }
     },
-    [activeSessionId, getActiveConnectionId, sendInput, sendAnswer, sessionQuestion],
+    [activeSessionId, getActiveConnectionId, sendInput, replyContexts],
   );
+
+  // Set the reply context for the current session: long-press on a
+  // MessageBubble routes here. The InputArea shows a banner + clear
+  // affordance derived from this state.
+  const handleReply = useCallback(
+    (message: UIMessage) => {
+      if (!activeSessionId) return;
+      setReplyContexts((prev) => {
+        const next = new Map(prev);
+        next.set(activeSessionId, { messageId: message.id, content: message.content });
+        return next;
+      });
+    },
+    [activeSessionId],
+  );
+
+  const handleClearReply = useCallback(() => {
+    if (!activeSessionId) return;
+    setReplyContexts((prev) => {
+      if (!prev.has(activeSessionId)) return prev;
+      const next = new Map(prev);
+      next.delete(activeSessionId);
+      return next;
+    });
+  }, [activeSessionId]);
 
   const handlePassphraseSubmit = useCallback(
     async (passphrase: string) => {
@@ -1435,6 +1500,8 @@ function App() {
     0,
   );
 
+  const sessionReplyContext = activeSessionId ? (replyContexts.get(activeSessionId) ?? null) : null;
+
   // Main content
   const main = activeSession ? (
     <ChatView
@@ -1443,6 +1510,10 @@ function App() {
       question={sessionQuestion}
       error={error}
       onSend={handleSend}
+      onAnswer={handleAnswer}
+      onReply={handleReply}
+      replyContext={sessionReplyContext}
+      onClearReply={handleClearReply}
       onBack={handleBack}
       totalUnread={totalUnread}
       onCopyConversation={handleCopyConversation}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -28,8 +28,9 @@ interface ChatViewProps {
   readonly onSend: (message: string) => void;
   /** Answer the active question. Routes through sendAnswer; decoupled from
    *  onSend so the bottom InputArea no longer hijacks input when a question
-   *  is pending (#401). When omitted, falls back to onSend for back-compat. */
-  readonly onAnswer?: (answer: string) => void;
+   *  is pending (#401). Required: a missing handler would silently route
+   *  answers through onSend and re-create the bug. */
+  readonly onAnswer: (answer: string) => void;
   /** Long-press on a message bubble fires this with the message; consumer
    *  records it as the active reply context for the session (#401). */
   readonly onReply?: (message: UIMessage) => void;
@@ -76,7 +77,6 @@ export function ChatView({
   showTimestamps = true,
   className,
 }: ChatViewProps) {
-  const answerHandler = onAnswer ?? onSend;
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
   const { isVisible: keyboardVisible, height: keyboardHeight } = useKeyboard();
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
@@ -127,12 +127,13 @@ export function ChatView({
       {/* Question card in chat mode */}
       {(showQuestionCard || showAnsweredCard) && question && (
         <div className="border-t border-[var(--color-border)] px-3 py-2">
-          <QuestionCard question={question} onAnswer={answerHandler} />
+          <QuestionCard question={question} onAnswer={onAnswer} />
         </div>
       )}
 
       <InputArea
         onSend={onSend}
+        onAnswer={onAnswer}
         onCancel={onCancel}
         question={inputQuestion}
         isAgentBusy={isAgentBusy}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useKeyboard } from '@/hooks/useKeyboard';
+import type { ReplyContext } from '@/lib/reply-format';
 import type { UIMessage, UIQuestion, UISession } from '@/types';
 import { clsx } from 'clsx';
 import { useState } from 'react';
@@ -22,7 +23,20 @@ interface ChatViewProps {
   readonly messages: readonly UIMessage[];
   readonly question?: UIQuestion | null;
   readonly error?: string | null;
+  /** Send a regular user input message. Reply context (when set) is wrapped
+   *  into a markdown blockquote inside this callback's caller (#401). */
   readonly onSend: (message: string) => void;
+  /** Answer the active question. Routes through sendAnswer; decoupled from
+   *  onSend so the bottom InputArea no longer hijacks input when a question
+   *  is pending (#401). When omitted, falls back to onSend for back-compat. */
+  readonly onAnswer?: (answer: string) => void;
+  /** Long-press on a message bubble fires this with the message; consumer
+   *  records it as the active reply context for the session (#401). */
+  readonly onReply?: (message: UIMessage) => void;
+  /** Active reply context for this session, if any (#401). */
+  readonly replyContext?: ReplyContext | null;
+  /** Clear the active reply context (X button on the InputArea banner). */
+  readonly onClearReply?: () => void;
   readonly onCancel?: () => void;
   readonly onRetry?: () => void;
   readonly onBack?: () => void;
@@ -44,6 +58,10 @@ export function ChatView({
   question,
   error,
   onSend,
+  onAnswer,
+  onReply,
+  replyContext,
+  onClearReply,
   onCancel,
   onRetry,
   onBack,
@@ -58,6 +76,7 @@ export function ChatView({
   showTimestamps = true,
   className,
 }: ChatViewProps) {
+  const answerHandler = onAnswer ?? onSend;
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
   const { isVisible: keyboardVisible, height: keyboardHeight } = useKeyboard();
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
@@ -99,6 +118,7 @@ export function ChatView({
         error={error}
         onRetry={onRetry}
         onBulletExpand={onBulletExpand}
+        onReply={onReply}
         viewMode={viewMode}
         keyboardVisible={keyboardVisible}
         showTimestamps={showTimestamps}
@@ -107,7 +127,7 @@ export function ChatView({
       {/* Question card in chat mode */}
       {(showQuestionCard || showAnsweredCard) && question && (
         <div className="border-t border-[var(--color-border)] px-3 py-2">
-          <QuestionCard question={question} onAnswer={onSend} />
+          <QuestionCard question={question} onAnswer={answerHandler} />
         </div>
       )}
 
@@ -117,17 +137,13 @@ export function ChatView({
         question={inputQuestion}
         isAgentBusy={isAgentBusy}
         disabled={!isConnected}
+        replyContext={replyContext ?? null}
+        onClearReply={onClearReply}
         // Session-scoped draft persistence so a half-typed message survives
         // app suspension on iOS (#226) and switching to a different session
         // doesn't leak the draft across.
         draftKey={`remi-draft-${session.id}`}
-        placeholder={
-          !isConnected
-            ? 'Not connected'
-            : question && !question.answeredWith
-              ? 'Type your response...'
-              : 'Type a message...'
-        }
+        placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
       />
     </div>
   );

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -5,9 +5,10 @@
  */
 
 import { hapticImpact } from '@/lib/haptics';
+import { type ReplyContext, previewText } from '@/lib/reply-format';
 import type { UIQuestion } from '@/types';
 import { clsx } from 'clsx';
-import { Send, StopCircle } from 'lucide-react';
+import { CornerUpLeft, Send, StopCircle, X } from 'lucide-react';
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -25,6 +26,12 @@ interface InputAreaProps {
   readonly question?: UIQuestion | null;
   readonly isAgentBusy?: boolean;
   readonly className?: string;
+  /** When set, render the reply banner above the input and submit the
+   *  message wrapped in a markdown blockquote (#401). The wire-format
+   *  wrap happens in App.tsx#handleSend so this component only owns
+   *  the visual banner + clear affordance. */
+  readonly replyContext?: ReplyContext | null;
+  readonly onClearReply?: () => void;
   /**
    * When provided, the typed-but-unsent draft is persisted to localStorage
    * under this key and restored across reloads / app suspensions. Pass a
@@ -71,6 +78,8 @@ export function InputArea({
   question,
   isAgentBusy = false,
   className,
+  replyContext,
+  onClearReply,
   draftKey,
 }: InputAreaProps) {
   // Hydrate draft from localStorage when a draftKey is provided. The lazy
@@ -246,12 +255,38 @@ export function InputArea({
       {isAgentBusy && onCancel && (
         <div className="flex justify-center border-b border-[var(--color-border)] py-2">
           <button
+            type="button"
             onClick={onCancel}
             className="flex items-center gap-2 rounded-full bg-[var(--color-error)]/10 px-4 py-1.5 text-sm text-[var(--color-error)] transition-colors hover:bg-[var(--color-error)]/20"
           >
             <StopCircle className="size-4" />
             Stop
           </button>
+        </div>
+      )}
+
+      {/* Reply banner: shown when long-press set a reply context (#401). */}
+      {replyContext && (
+        <div className="flex items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface-light)] px-4 py-2">
+          <CornerUpLeft className="size-4 shrink-0 text-[var(--color-primary)]" />
+          <div className="min-w-0 flex-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Replying to
+            </p>
+            <p className="truncate text-xs text-[var(--color-text-secondary)]">
+              {previewText(replyContext.content)}
+            </p>
+          </div>
+          {onClearReply && (
+            <button
+              type="button"
+              onClick={onClearReply}
+              className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]"
+              aria-label="Cancel reply"
+            >
+              <X className="size-4" />
+            </button>
+          )}
         </div>
       )}
 

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -20,6 +20,11 @@ import {
 
 interface InputAreaProps {
   readonly onSend: (message: string) => void;
+  /** Answer the active question (#401). Quick-response chips route here so
+   *  tapping Yes/No on a 2-option permission sends `sendAnswer` not the
+   *  literal "y"/"n" via `sendInput`. Required when `question` is set
+   *  with options (the chips are visible). */
+  readonly onAnswer?: (answer: string) => void;
   readonly onCancel?: () => void;
   readonly disabled?: boolean;
   readonly placeholder?: string;
@@ -72,6 +77,7 @@ function QuickResponse({
 
 export function InputArea({
   onSend,
+  onAnswer,
   onCancel,
   disabled = false,
   placeholder = 'Type a message...',
@@ -202,9 +208,14 @@ export function InputArea({
     }
   };
 
-  // Handle quick response
+  // Quick-response chips for an active question. Route through onAnswer so
+  // a tap on Yes/No/option-N is a real `sendAnswer`, not the literal value
+  // sent as a regular user input (#401 / #402 review). When onAnswer is
+  // not provided (e.g. consumer hasn't migrated yet), fall back to onSend
+  // to preserve the prior behavior; this branch is only reachable when the
+  // chips are rendered, which itself requires `question` to be set.
   const handleQuickResponse = (response: string) => {
-    onSend(response);
+    (onAnswer ?? onSend)(response);
   };
 
   // Determine if we should show quick responses

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -4,6 +4,8 @@
  * Displays a single message with WhatsApp-style delivery status.
  */
 
+import { useLongPress } from '@/hooks/useLongPress';
+import { hapticImpact } from '@/lib/haptics';
 import type { UIBullet, UIMessage } from '@/types';
 import type { TranscriptContentBlock } from '@remi/shared/protocol.ts';
 import type { MessageState } from '@remi/shared/types.ts';
@@ -28,6 +30,8 @@ interface MessageBubbleProps {
   readonly message: UIMessage;
   readonly showTimestamp?: boolean;
   readonly onBulletExpand?: (bulletId: number) => void;
+  /** Long-press the bubble to set this message as the reply context (#401). */
+  readonly onReply?: (message: UIMessage) => void;
   readonly viewMode?: ViewMode;
 }
 
@@ -253,6 +257,7 @@ export function MessageBubble({
   message,
   showTimestamp = true,
   onBulletExpand,
+  onReply,
   viewMode = 'compact',
 }: MessageBubbleProps) {
   const isUser = message.sender === 'user';
@@ -261,6 +266,22 @@ export function MessageBubble({
 
   // Use bullets if available, otherwise fall back to raw content
   const hasBullets = message.bullets && message.bullets.length > 0;
+
+  // Long-press to enter "reply to this message" mode (#401). System
+  // messages and tool/streaming bubbles are not reply-able since there
+  // is no useful quoted context for the agent.
+  const isReplyable = !!onReply && !isSystem && !message.isStreaming && !message.tool;
+  const longPressHandlers = useLongPress(
+    () => {
+      if (onReply) onReply(message);
+    },
+    {
+      delayMs: 500,
+      onTrigger: () => {
+        hapticImpact('medium');
+      },
+    },
+  );
 
   // In enhanced chat mode, tool messages render as collapsible cards (not bubbles)
   if (enhanced && message.tool && !isUser) {
@@ -293,6 +314,7 @@ export function MessageBubble({
       className={clsx('flex w-full animate-[slide-up]', isUser ? 'justify-end' : 'justify-start')}
     >
       <div
+        {...(isReplyable ? longPressHandlers : {})}
         className={clsx(
           'rounded-2xl px-4 py-2.5 overflow-hidden',
           'transition-all duration-200',
@@ -311,6 +333,8 @@ export function MessageBubble({
           message.isStreaming && 'animate-pulse',
           // Editing indicator
           message.isEditing && 'border-[var(--color-primary)] border-dashed',
+          // Long-press affordance hint on touch devices
+          isReplyable && 'select-none touch-manipulation',
         )}
       >
         {/* Sender label in enhanced mode */}

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -333,8 +333,12 @@ export function MessageBubble({
           message.isStreaming && 'animate-pulse',
           // Editing indicator
           message.isEditing && 'border-[var(--color-primary)] border-dashed',
-          // Long-press affordance hint on touch devices
-          isReplyable && 'select-none touch-manipulation',
+          // Long-press affordance hint on touch devices only.
+          // `select-none` would break copy-paste on desktop; the
+          // `pointer-coarse:` variant scopes the rule to touch input
+          // (Tailwind's `coarse` media query). `touch-manipulation`
+          // suppresses iOS's tap-delay regardless of pointer type.
+          isReplyable && 'pointer-coarse:select-none touch-manipulation',
         )}
       >
         {/* Sender label in enhanced mode */}

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -19,6 +19,8 @@ interface MessageListProps {
   readonly error?: string | null;
   readonly onRetry?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
+  /** Long-press on a message bubble fires this with the message (#401). */
+  readonly onReply?: (message: UIMessage) => void;
   readonly viewMode?: ViewMode;
   readonly keyboardVisible?: boolean;
   readonly showTimestamps?: boolean;
@@ -125,6 +127,7 @@ export function MessageList({
   error,
   onRetry,
   onBulletExpand,
+  onReply,
   viewMode = 'compact',
   keyboardVisible = false,
   showTimestamps = true,
@@ -222,6 +225,7 @@ export function MessageList({
                 <MessageBubble
                   message={message}
                   onBulletExpand={onBulletExpand}
+                  onReply={onReply}
                   viewMode={viewMode}
                   showTimestamp={showTimestamps}
                 />

--- a/packages/web/src/hooks/useLongPress.ts
+++ b/packages/web/src/hooks/useLongPress.ts
@@ -1,0 +1,85 @@
+/**
+ * Long-press detector hook (#401).
+ *
+ * Returns pointer-event handlers to spread onto an element. Fires
+ * `onLongPress` when the pointer stays down for `delayMs` without
+ * moving past `moveTolerancePx`. Any pointer up / cancel / leave
+ * before the timer fires aborts cleanly.
+ *
+ * Pointermove guard uses a tolerance instead of cancel-on-any-move
+ * so a tiny finger jitter does not break the gesture on touch
+ * devices, which was the most common false-cancel in iMessage-style
+ * implementations.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { PointerEvent } from 'react';
+
+export interface UseLongPressOptions {
+  /** Hold time in milliseconds before firing. Default 500 ms. */
+  readonly delayMs?: number;
+  /** Pointer movement (in px) tolerated before the press is cancelled. Default 8 px. */
+  readonly moveTolerancePx?: number;
+  /** Optional side-effect (e.g. haptic) fired when the press triggers. */
+  readonly onTrigger?: () => void;
+}
+
+export interface LongPressHandlers {
+  readonly onPointerDown: (event: PointerEvent<HTMLElement>) => void;
+  readonly onPointerUp: () => void;
+  readonly onPointerCancel: () => void;
+  readonly onPointerLeave: () => void;
+  readonly onPointerMove: (event: PointerEvent<HTMLElement>) => void;
+}
+
+export function useLongPress(
+  onLongPress: () => void,
+  options: UseLongPressOptions = {},
+): LongPressHandlers {
+  const { delayMs = 500, moveTolerancePx = 8, onTrigger } = options;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startCoords = useRef<{ x: number; y: number } | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    startCoords.current = null;
+  }, []);
+
+  // Cancel if the component unmounts while a press is pending.
+  useEffect(() => cancel, [cancel]);
+
+  const onPointerDown = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      cancel();
+      startCoords.current = { x: event.clientX, y: event.clientY };
+      timer.current = setTimeout(() => {
+        timer.current = null;
+        onTrigger?.();
+        onLongPress();
+      }, delayMs);
+    },
+    [cancel, delayMs, onLongPress, onTrigger],
+  );
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      const start = startCoords.current;
+      if (!start) return;
+      const dx = event.clientX - start.x;
+      const dy = event.clientY - start.y;
+      if (Math.hypot(dx, dy) > moveTolerancePx) cancel();
+    },
+    [cancel, moveTolerancePx],
+  );
+
+  return {
+    onPointerDown,
+    onPointerUp: cancel,
+    onPointerCancel: cancel,
+    onPointerLeave: cancel,
+    onPointerMove,
+  };
+}

--- a/packages/web/src/hooks/useLongPress.ts
+++ b/packages/web/src/hooks/useLongPress.ts
@@ -6,10 +6,17 @@
  * moving past `moveTolerancePx`. Any pointer up / cancel / leave
  * before the timer fires aborts cleanly.
  *
- * Pointermove guard uses a tolerance instead of cancel-on-any-move
- * so a tiny finger jitter does not break the gesture on touch
- * devices, which was the most common false-cancel in iMessage-style
- * implementations.
+ * Pointer events (not touch events) unify mouse + touch + Apple
+ * Pencil and avoid the iOS double-fire of touchstart + mousedown.
+ *
+ * Move tolerance instead of cancel-on-any-move keeps tiny finger
+ * jitter from breaking the gesture on touch devices, which is the
+ * most common false-cancel in iMessage-style implementations.
+ *
+ * Selectable-content skip (#402 review): the hook ignores presses
+ * whose target sits inside a `<code>`, `<pre>`, or `[contenteditable]`
+ * ancestor so iOS text-selection long-press inside a code block does
+ * not accidentally trigger reply mode.
  */
 
 import { useCallback, useEffect, useRef } from 'react';
@@ -30,6 +37,12 @@ export interface LongPressHandlers {
   readonly onPointerCancel: () => void;
   readonly onPointerLeave: () => void;
   readonly onPointerMove: (event: PointerEvent<HTMLElement>) => void;
+}
+
+/** Skip the press when the target sits inside selectable / editable content. */
+function isInSelectableContent(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return target.closest('code, pre, [contenteditable], [contenteditable="true"]') !== null;
 }
 
 export function useLongPress(
@@ -53,6 +66,11 @@ export function useLongPress(
 
   const onPointerDown = useCallback(
     (event: PointerEvent<HTMLElement>) => {
+      // Mouse: only primary button. Right-click / barrel-button must not
+      // trigger reply mode (would surprise desktop users).
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      // Selectable content: defer to the browser's text-selection gesture.
+      if (isInSelectableContent(event.target)) return;
       cancel();
       startCoords.current = { x: event.clientX, y: event.clientY };
       timer.current = setTimeout(() => {

--- a/packages/web/src/lib/reply-format.ts
+++ b/packages/web/src/lib/reply-format.ts
@@ -1,0 +1,40 @@
+/**
+ * Reply / quoted-context message formatter (#401).
+ *
+ * The user can long-press any message bubble to "reply" to it. When a
+ * reply context is active and the user sends a message, the outgoing
+ * payload includes the quoted context as a markdown blockquote so
+ * Claude Code interprets it naturally. The user's own chat history
+ * also renders the blockquote nicely thanks to the existing markdown
+ * styling at `ChatMessage.tsx`.
+ */
+
+/** Captures which message the user is replying to. */
+export interface ReplyContext {
+  readonly messageId: string;
+  readonly content: string;
+}
+
+/** Maximum visible chars in the reply preview before truncation. */
+export const REPLY_PREVIEW_LENGTH = 50;
+
+/**
+ * Render a single-line preview of a message for the reply banner and the
+ * outgoing blockquote line. Collapses runs of whitespace and trims, then
+ * truncates with an ellipsis when over the preview length.
+ */
+export function previewText(content: string, maxLength: number = REPLY_PREVIEW_LENGTH): string {
+  const collapsed = content.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= maxLength) return collapsed;
+  return `${collapsed.slice(0, maxLength)}…`;
+}
+
+/**
+ * Build the wire-format message string when a reply context is set.
+ * The markdown blockquote prefix carries the quoted context to the
+ * agent and renders nicely in the chat history. The user's typed text
+ * is preserved verbatim including newlines.
+ */
+export function formatReplyMessage(reply: ReplyContext, userText: string): string {
+  return `> ${previewText(reply.content)}\n\n${userText}`;
+}

--- a/packages/web/src/lib/reply-format.ts
+++ b/packages/web/src/lib/reply-format.ts
@@ -7,21 +7,36 @@
  * Claude Code interprets it naturally. The user's own chat history
  * also renders the blockquote nicely thanks to the existing markdown
  * styling at `ChatMessage.tsx`.
+ *
+ * Two surfaces are distinct:
+ *   - Banner display: a single-line `previewText(content)` with
+ *     whitespace collapsed and an ellipsis after 50 chars so the X
+ *     button stays clear on narrow screens.
+ *   - Wire payload: full multi-line blockquote so the agent gets the
+ *     complete context, not just a fifty-char excerpt. Capped at
+ *     `MAX_QUOTED_BYTES` to avoid pathological 50 KB transcript echoes
+ *     that would dominate the prompt.
  */
+
+import type { UUID } from '@remi/shared';
 
 /** Captures which message the user is replying to. */
 export interface ReplyContext {
-  readonly messageId: string;
+  readonly messageId: UUID;
   readonly content: string;
 }
 
-/** Maximum visible chars in the reply preview before truncation. */
+/** Single-line preview length used by the reply banner UI. */
 export const REPLY_PREVIEW_LENGTH = 50;
 
+/** Hard cap on quoted content forwarded to the agent on the wire (bytes-ish). */
+export const MAX_QUOTED_BYTES = 2000;
+
 /**
- * Render a single-line preview of a message for the reply banner and the
- * outgoing blockquote line. Collapses runs of whitespace and trims, then
- * truncates with an ellipsis when over the preview length.
+ * Render a single-line preview for the reply banner. Collapses runs of
+ * whitespace and trims, then truncates with an ellipsis past `maxLength`.
+ * The collapse keeps a multi-line quoted message from leaking newlines
+ * into the inline banner.
  */
 export function previewText(content: string, maxLength: number = REPLY_PREVIEW_LENGTH): string {
   const collapsed = content.replace(/\s+/g, ' ').trim();
@@ -31,10 +46,20 @@ export function previewText(content: string, maxLength: number = REPLY_PREVIEW_L
 
 /**
  * Build the wire-format message string when a reply context is set.
- * The markdown blockquote prefix carries the quoted context to the
- * agent and renders nicely in the chat history. The user's typed text
- * is preserved verbatim including newlines.
+ * Full content is preserved as a multi-line markdown blockquote (each
+ * line prefixed with `> `) so the agent can read every line of the
+ * referenced message. Content over `MAX_QUOTED_BYTES` is truncated
+ * with an ellipsis to keep the prompt budget sane on huge transcript
+ * bubbles.
  */
 export function formatReplyMessage(reply: ReplyContext, userText: string): string {
-  return `> ${previewText(reply.content)}\n\n${userText}`;
+  const truncated =
+    reply.content.length > MAX_QUOTED_BYTES
+      ? `${reply.content.slice(0, MAX_QUOTED_BYTES - 1)}…`
+      : reply.content;
+  const quoted = truncated
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+  return `${quoted}\n\n${userText}`;
 }

--- a/packages/web/tests/lib/reply-format.test.ts
+++ b/packages/web/tests/lib/reply-format.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the reply / quoted-context formatter (#401).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { REPLY_PREVIEW_LENGTH, formatReplyMessage, previewText } from '../../src/lib/reply-format';
+
+describe('previewText', () => {
+  test('returns the input verbatim when within the preview length', () => {
+    expect(previewText('Hello world')).toBe('Hello world');
+  });
+
+  test('truncates with an ellipsis past the preview length', () => {
+    const long = 'a'.repeat(REPLY_PREVIEW_LENGTH + 10);
+    const out = previewText(long);
+    expect(out.length).toBe(REPLY_PREVIEW_LENGTH + 1); // 50 chars + ellipsis
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.startsWith('a'.repeat(REPLY_PREVIEW_LENGTH))).toBe(true);
+  });
+
+  test('exact preview length is NOT truncated', () => {
+    const exact = 'a'.repeat(REPLY_PREVIEW_LENGTH);
+    expect(previewText(exact)).toBe(exact);
+  });
+
+  test('collapses runs of whitespace and trims', () => {
+    expect(previewText('  hello   world  \n  again  ')).toBe('hello world again');
+  });
+
+  test('whitespace collapse counts toward the preview length, not the original', () => {
+    // 60 spaces collapse to 0 chars; the trailing word is short.
+    const padded = `${' '.repeat(60)}short`;
+    expect(previewText(padded)).toBe('short');
+  });
+
+  test('respects a custom maxLength', () => {
+    expect(previewText('Hello world', 5)).toBe('Hello…');
+  });
+});
+
+describe('formatReplyMessage', () => {
+  test('wraps the quoted content in a markdown blockquote and appends user text', () => {
+    const result = formatReplyMessage(
+      { messageId: 'm-1', content: 'Refactor the authentication module' },
+      'On it.',
+    );
+    expect(result).toBe('> Refactor the authentication module\n\nOn it.');
+  });
+
+  test('uses the truncated preview when content is long', () => {
+    const long = 'a'.repeat(REPLY_PREVIEW_LENGTH + 20);
+    const result = formatReplyMessage({ messageId: 'm-1', content: long }, 'reply');
+    expect(result.startsWith(`> ${'a'.repeat(REPLY_PREVIEW_LENGTH)}…`)).toBe(true);
+    expect(result.endsWith('reply')).toBe(true);
+  });
+
+  test('preserves multi-line user text verbatim', () => {
+    const result = formatReplyMessage(
+      { messageId: 'm-1', content: 'short' },
+      'line one\n\nline three\n  indented',
+    );
+    expect(result).toBe('> short\n\nline one\n\nline three\n  indented');
+  });
+
+  test('handles empty user text without trailing whitespace', () => {
+    const result = formatReplyMessage({ messageId: 'm-1', content: 'context' }, '');
+    expect(result).toBe('> context\n\n');
+  });
+});

--- a/packages/web/tests/lib/reply-format.test.ts
+++ b/packages/web/tests/lib/reply-format.test.ts
@@ -3,7 +3,15 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { REPLY_PREVIEW_LENGTH, formatReplyMessage, previewText } from '../../src/lib/reply-format';
+import type { UUID } from '@remi/shared';
+import {
+  MAX_QUOTED_BYTES,
+  REPLY_PREVIEW_LENGTH,
+  formatReplyMessage,
+  previewText,
+} from '../../src/lib/reply-format';
+
+const ID = 'm-1' as UUID;
 
 describe('previewText', () => {
   test('returns the input verbatim when within the preview length', () => {
@@ -39,31 +47,51 @@ describe('previewText', () => {
 });
 
 describe('formatReplyMessage', () => {
-  test('wraps the quoted content in a markdown blockquote and appends user text', () => {
-    const result = formatReplyMessage(
-      { messageId: 'm-1', content: 'Refactor the authentication module' },
-      'On it.',
-    );
-    expect(result).toBe('> Refactor the authentication module\n\nOn it.');
+  test('wraps the full quoted content in a markdown blockquote (#402 review)', () => {
+    // Wire payload is the FULL content, not the 50-char preview, so the
+    // agent receives the complete reference, not an excerpt.
+    const long = 'a'.repeat(REPLY_PREVIEW_LENGTH + 20);
+    const result = formatReplyMessage({ messageId: ID, content: long }, 'reply');
+    expect(result).toBe(`> ${long}\n\nreply`);
+    expect(result).not.toContain('…');
   });
 
-  test('uses the truncated preview when content is long', () => {
-    const long = 'a'.repeat(REPLY_PREVIEW_LENGTH + 20);
-    const result = formatReplyMessage({ messageId: 'm-1', content: long }, 'reply');
-    expect(result.startsWith(`> ${'a'.repeat(REPLY_PREVIEW_LENGTH)}…`)).toBe(true);
-    expect(result.endsWith('reply')).toBe(true);
+  test('multi-line quoted content prefixes each line with ">" (#402 review)', () => {
+    const result = formatReplyMessage(
+      { messageId: ID, content: 'line one\nline two\nline three' },
+      'thanks',
+    );
+    expect(result).toBe('> line one\n> line two\n> line three\n\nthanks');
+  });
+
+  test('preserves blank lines inside the quoted content', () => {
+    const result = formatReplyMessage(
+      { messageId: ID, content: 'paragraph one\n\nparagraph two' },
+      'reply',
+    );
+    expect(result).toBe('> paragraph one\n> \n> paragraph two\n\nreply');
   });
 
   test('preserves multi-line user text verbatim', () => {
     const result = formatReplyMessage(
-      { messageId: 'm-1', content: 'short' },
+      { messageId: ID, content: 'short' },
       'line one\n\nline three\n  indented',
     );
     expect(result).toBe('> short\n\nline one\n\nline three\n  indented');
   });
 
-  test('handles empty user text without trailing whitespace', () => {
-    const result = formatReplyMessage({ messageId: 'm-1', content: 'context' }, '');
+  test('handles empty user text without adding stray content', () => {
+    const result = formatReplyMessage({ messageId: ID, content: 'context' }, '');
     expect(result).toBe('> context\n\n');
+  });
+
+  test('truncates content over MAX_QUOTED_BYTES with an ellipsis', () => {
+    const huge = 'x'.repeat(MAX_QUOTED_BYTES + 100);
+    const result = formatReplyMessage({ messageId: ID, content: huge }, 'reply');
+    // Quoted line is "> {chars}" — the chars portion ends in an ellipsis.
+    expect(result.startsWith('> ')).toBe(true);
+    expect(result).toContain('…');
+    // Reply text is preserved verbatim after the blockquote.
+    expect(result.endsWith('\n\nreply')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: typed text in the bottom InputArea no longer routes to `sendAnswer` when a question is pending. The user can ask the agent a fresh question without it being treated as an answer to a stale prompt.
- **Feature**: long-press any message bubble to enter "reply mode". The InputArea shows a quoted-message banner; on send, the message is wrapped in a markdown blockquote so the agent sees the quoted context.

Closes #401.

## Decoupling

`App.tsx#handleSend` previously short-circuited to `sendAnswer` whenever a `sessionQuestion` was set. Split into two callbacks:

- `handleAnswer(content)`: new dedicated answer flow. Routes through `sendAnswer` + question-state mutation. Wired to `QuestionCard.onAnswer`.
- `handleSend(content)`: regular user input. Always routes through `sendInput`. Wired to `InputArea.onSend`.

`ChatView` now accepts `onAnswer`, `onReply`, `replyContext`, and `onClearReply` props. Old single-`onSend` callers still work via fallback (`onAnswer ?? onSend`).

## Reply UX

- `useLongPress` hook (500 ms hold, 8 px movement tolerance, optional haptic trigger). Cancels cleanly on pointer up / move past tolerance / cancel / leave / unmount.
- `MessageBubble` spreads the long-press handlers when reply is enabled and the message is reply-able (skips system / streaming / tool bubbles).
- `App.tsx` tracks `replyContexts: Map<UUID, ReplyContext>` per active session. Set by `handleReply`, cleared on send and on `handleClearReply`.
- `InputArea` renders a banner above the textarea when `replyContext` is set: `Replying to: "<first 50 chars>…"` with an X to clear.
- On send, `handleSend` wraps the message in a markdown blockquote:
  ```
  > <first 50 chars>…

  <user text>
  ```
  The agent reads quoted context naturally; the user's bubble in chat history renders the quote thanks to the existing markdown blockquote styling at `ChatMessage.tsx:128`.

## New helpers

- `packages/web/src/lib/reply-format.ts`: `ReplyContext` type, `previewText` (whitespace-collapse + 50-char ellipsis truncate), `formatReplyMessage`.
- `packages/web/src/hooks/useLongPress.ts`: pointer-event handlers with `onTrigger` callback for haptic side-effects.

## Tests

`packages/web/tests/lib/reply-format.test.ts` — 10 tests:
- `previewText`: under-length passthrough, ellipsis at 51, whitespace collapse, exact-length boundary, custom maxLength.
- `formatReplyMessage`: blockquote shape, long-content truncation in the quote, multi-line user text preserved, empty user text.

`useLongPress` is not unit-tested directly — the codebase's web test suite is lib-only and adding React hook test infrastructure is out of scope. The hook is small (state-machine over setTimeout + pointer math) and exercised through the MessageBubble integration.

## Test plan

- [x] `bun test packages/web/tests/lib/reply-format.test.ts` — 10/10 pass
- [x] `bun test packages/web/tests` — 117/117 pass (no regressions)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] Biome — no new findings (pre-existing `useButtonType` etc. on untouched buttons left alone)
- [ ] Manual on iOS: question pending in chat mode. Type a fresh prompt in the bottom input → sent as regular user message (NOT routed to sendAnswer). Use the QuestionCard's input/buttons to actually answer the question.
- [ ] Manual on iOS: long-press an agent message. Banner appears in InputArea. Type "yes please" → outgoing message is `> {first 50 chars of agent message}…\n\nyes please`.
- [ ] Manual: long-press my own user message. Same banner, same blockquote prefix on send.
- [ ] Manual: long-press, then dismiss with the X button. Next send is plain (no blockquote).
- [ ] Manual: long-press, switch to a different session, switch back. Reply context cleared.