### PR TITLE
fix(daemon): add CORS headers to HTTP endpoints (#403)

### DIFF
--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -208,6 +208,18 @@ export class WebSocketServer {
           return new Response('WebSocket upgrade failed', { status: 400 });
         }
 
+        // CORS headers for HTTP endpoints. The daemon is a local-network
+        // service that already accepts arbitrary WebSocket clients;
+        // wildcard CORS does not add a security risk and is required for
+        // the Capacitor iOS app (origin `capacitor://localhost`) to fetch
+        // /auth-info during port-scan discovery. Without it, every probe
+        // fails silently and the port-scan added in #393 reports "no
+        // daemon found" even when daemons are actively serving (#403).
+        const jsonCorsHeaders: Record<string, string> = {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        };
+
         // Health check endpoint
         if (url.pathname === '/health') {
           return new Response(
@@ -215,7 +227,7 @@ export class WebSocketServer {
               status: 'ok',
               connections: self.connections.size,
             }),
-            { headers: { 'Content-Type': 'application/json' } },
+            { headers: jsonCorsHeaders },
           );
         }
 
@@ -234,11 +246,14 @@ export class WebSocketServer {
               authRequired,
               fingerprint: authenticator?.serverFingerprint ?? null,
             }),
-            { headers: { 'Content-Type': 'application/json' } },
+            { headers: jsonCorsHeaders },
           );
         }
 
-        return new Response('Not found', { status: 404 });
+        return new Response('Not found', {
+          status: 404,
+          headers: { 'Access-Control-Allow-Origin': '*' },
+        });
       },
 
       websocket: {

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -105,6 +105,28 @@ describe('WebSocketServer', () => {
       const response = await fetch(`http://localhost:${testPort}/unknown`);
       expect(response.status).toBe(404);
     });
+
+    test('/health includes CORS header so cross-origin clients can fetch (#403)', async () => {
+      await server.start();
+      const response = await fetch(`http://localhost:${testPort}/health`);
+      expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    });
+
+    test('/auth-info includes CORS header (#403)', async () => {
+      await server.start();
+      const response = await fetch(`http://localhost:${testPort}/auth-info`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('access-control-allow-origin')).toBe('*');
+      const data = await response.json();
+      expect(typeof data.authRequired).toBe('boolean');
+    });
+
+    test('404 fallthrough includes CORS header (#403)', async () => {
+      await server.start();
+      const response = await fetch(`http://localhost:${testPort}/nonexistent`);
+      expect(response.status).toBe(404);
+      expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    });
   });
 
   describe('Connection management', () => {


### PR DESCRIPTION
## Summary

The Capacitor iOS app loads from origin \`capacitor://localhost\` and treats fetches to LAN-IP daemons as cross-origin. Without \`Access-Control-Allow-Origin\`, every probe to /auth-info fails silently with a network error before any data leaves the device. Port-scan added in #393 elevated /auth-info to the only signal for "is there a daemon here", so a silent CORS failure now reports "No remi daemon found" even when daemons are actively serving.

Closes #403.

## Fix

Added \`Access-Control-Allow-Origin: *\` to:
- \`/health\`
- \`/auth-info\`
- 404 fallthrough (defensive)

The daemon is a local-network service that already accepts arbitrary clients on its WebSocket; wildcard CORS does not add a security risk. WebSocket connections are not subject to same-origin policy, which is why direct \`host:port\` already worked.

## Tests

\`packages/daemon/tests/websocket-server.test.ts\`: three new tests asserting the CORS header is present on each path.

## Validation

- [x] \`bun test packages/daemon/tests\` — 1622/1622 pass
- [x] \`bun run typecheck\` clean
- [x] Real device test: rebuilt daemon (0.5.3), iPhone Capacitor app connects via port-scan to the new daemon. Confirmed working in user testing.