### PR TITLE
fix(web): default 3-set never replaces a non-default question (#407)

### DIFF
--- a/packages/web/src/lib/question-merge.ts
+++ b/packages/web/src/lib/question-merge.ts
@@ -118,20 +118,29 @@ export function shouldKeepExisting(
 
   const existingCount = optionCount(existing);
   const incomingCount = optionCount(incoming);
+  const existingIsDefault = isDefaultThreeSetShape(existing);
+  const incomingIsDefault = isDefaultThreeSetShape(incoming);
 
+  // The daemon's hardcoded Yes / Yes-always / No is the bland fallback
+  // shape; it must never replace a non-default question regardless of
+  // option count (#407). The previous rule "more options = richer" let
+  // the 3-set replace a 2-option Yes/No emitted by the PTY parser, so
+  // the user saw three options for what they expected to be a yes/no.
+  if (incomingIsDefault && !existingIsDefault) {
+    logSuppression('richer-shape', existing, incoming);
+    return true;
+  }
+  if (!incomingIsDefault && existingIsDefault) {
+    logSuppression('incoming-richer-count', existing, incoming);
+    return false;
+  }
+
+  // Same shape class on both sides: rank by option count, then fall
+  // through to "replace" so the most recent same-rank emission wins.
   if (existingCount > incomingCount) {
     logSuppression('richer-count', existing, incoming);
     return true;
   }
-  if (
-    existingCount === incomingCount &&
-    isDefaultThreeSetShape(incoming) &&
-    !isDefaultThreeSetShape(existing)
-  ) {
-    logSuppression('richer-shape', existing, incoming);
-    return true;
-  }
-  // Either incoming is richer, or both are equal-and-bland. Replace.
   logSuppression(
     incomingCount > existingCount ? 'incoming-richer-count' : 'incoming-equal-or-poorer',
     existing,

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -72,6 +72,31 @@ describe('shouldKeepExisting', () => {
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
+  test('keeps a 2-option Yes/No when default 3-set arrives next (#407)', () => {
+    // The reported regression: PTY parser detects [y/n], emits 2-option
+    // Yes/No. Hook bridge then emits the bland default 3-set. Ranking by
+    // count alone made the 3-set "richer" and replaced the 2-option,
+    // showing three buttons for what the user expected to be a yes/no.
+    // The default-3-set must always lose to a non-default shape.
+    const existing = uiq('Continue?', [
+      { label: 'Yes', isYes: true },
+      { label: 'No', isNo: true },
+    ]);
+    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  test('replaces when existing is the bland default and incoming is non-default (#407)', () => {
+    // Symmetric: if the daemon's hook fired the 3-set first and the PTY
+    // then surfaced a real 2-option Yes/No, the richer one wins.
+    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = uiq('Continue?', [
+      { label: 'Yes', isYes: true },
+      { label: 'No', isNo: true },
+    ]);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+  });
+
   test('replaces when both are default 3-sets (truly equivalent)', () => {
     const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
     const incoming = uiq('Allow Edit: foo', yesYesalwaysNo);
@@ -110,13 +135,17 @@ describe('shouldKeepExisting', () => {
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
-  test('replaces when existing has fewer options regardless of shape', () => {
+  test('shape outranks count: keeps a 2-option Yes/No over a 3-set default (#407)', () => {
+    // Pre-#407 this asserted the opposite — that the default 3-set
+    // replaces the 2-option Yes/No. That was the bug: the bland default
+    // is the daemon's "no real options" fallback and must never replace
+    // a non-default shape regardless of count.
     const existing = uiq('Run this?', [
       { label: 'Yes', isYes: true },
       { label: 'No', isNo: true },
     ]);
     const incoming = uiq('Run this?', yesYesalwaysNo);
-    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
   test('keeps 4-option richer when poorer 4-option arrives (not a default 3-set)', () => {


### PR DESCRIPTION
## Summary

User reported still seeing three options for a yes/no question after #401/#402's client-side guard landed. The guard ranked emissions by option count, so the daemon's 3-set default \`[Yes, Yes-always, No]\` (3 options) won over a PTY-detected 2-option \`[Yes, No]\` (2 options) — three buttons rendered for what was actually a yes/no.

Closes #407.

## Fix

Default-3-set is the daemon's "no real options" fallback. Treat it as the lowest rank regardless of count:

- incoming is default-shape AND existing is not → keep existing
- incoming is non-default AND existing is default → replace
- both same shape class → rank by option count

Pre-fix shape check only ran at equal counts, missing the 2-vs-3 case.

## Tests

- New regression test for the reported bug (2-option Yes/No vs incoming default 3-set → keep).
- Symmetric test (default 3-set existing vs incoming 2-option Yes/No → replace).
- Old "replaces when existing has fewer options regardless of shape" was asserting the buggy behavior; flipped to the new contract.

## Validation

- [x] \`bun test packages/web/tests\` — 121/121 pass
- [x] \`bun run typecheck\` clean