### PR TITLE
fix(daemon): suppress duplicate APNS push within prompt cycle (#409)

### DIFF
--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -24,6 +24,7 @@ import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } fro
 import type { MessageAPIEvents } from '../../api/message-api.ts';
 import { MessageAPI } from '../../api/message-api.ts';
 import { sendPushTrigger } from '../../notifications/push-client.ts';
+import { PushDedup } from '../../notifications/push-dedup.ts';
 import type { SessionRegistry } from '../../session/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import type { DeviceTokenEntry } from '../handlers/trivial-events.ts';
@@ -90,6 +91,12 @@ export function createMessageApiForSession(
     sessionRegistry.recordOutgoingMessage(recordId, message);
   };
 
+  // Per-session push-dedup baseline. PTY + Hook double-emit one prompt
+  // with different ids; without this, the user gets two lock-screen
+  // notifications per prompt (#409). Reset whenever status leaves
+  // 'waiting' so a fresh prompt cycle starts with a clean baseline.
+  const pushDedup = new PushDedup();
+
   const callbacks: MessageAPIEvents = {
     onStructuredMessage: (structured) => {
       try {
@@ -126,6 +133,13 @@ export function createMessageApiForSession(
       const hasActiveClient =
         sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
       if (deviceTokens.size > 0 && !hasActiveClient) {
+        // Push-dedup gate (#409): suppress the PTY/Hook double-emission
+        // for one prompt cycle. Mirrors the client's richer-wins guard
+        // so phone and in-app converge on the same option set.
+        if (!pushDedup.shouldPush(question)) {
+          log(`Push suppressed by dedup for session ${questionSessionId}`);
+          return;
+        }
         const session = sessionRegistry.getSession(sessionId);
         const sessionName = session?.name || 'Agent';
         const cfg = pushConfig();
@@ -149,6 +163,13 @@ export function createMessageApiForSession(
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);
+      // Reset the push-dedup baseline whenever Claude moves past the
+      // 'waiting' state — same lifecycle as QuestionDedup so a new
+      // prompt cycle starts fresh and is not silently absorbed by a
+      // stale prior push (#409).
+      if (status !== 'waiting') {
+        pushDedup.reset();
+      }
       const msg: ProtocolMessage = {
         type: 'session_update',
         id: generateId(),

--- a/packages/daemon/src/notifications/push-dedup.ts
+++ b/packages/daemon/src/notifications/push-dedup.ts
@@ -1,0 +1,84 @@
+/**
+ * Push-trigger dedup for question notifications (#409).
+ *
+ * The PTY parser and HookEventBridge both emit a `question` for the
+ * same prompt cycle (different ids, different fingerprints, both pass
+ * `QuestionDedup`'s text-based gate). Each one then fires an APNS
+ * push from `message-api-setup.ts#onQuestion`, so the user sees two
+ * lock-screen notifications per prompt.
+ *
+ * Mirrors the shape-aware client-side richer-wins guard in
+ * `packages/web/src/lib/question-merge.ts`. Within
+ * `QUESTION_DEDUP_WINDOW_MS`:
+ *
+ *   - new is default-3-set AND last was non-default → suppress
+ *   - new is non-default AND last was default → fire (upgrade)
+ *   - new has strictly more options than last → fire (upgrade)
+ *   - otherwise → suppress
+ *
+ * Beyond the window: always fire. Reset on every meaningful status
+ * boundary (status leaves 'waiting' / session reset) to mirror
+ * `QuestionDedup`'s lifecycle.
+ */
+
+import { QUESTION_DEDUP_WINDOW_MS } from '@remi/shared';
+import { looksLikeDefaultPermissionQuestion } from '../api/question-dedup.ts';
+
+interface LastPush {
+  emittedAt: number;
+  optionCount: number;
+  isDefaultShape: boolean;
+}
+
+export interface PushDedupQuestion {
+  readonly options: ReadonlyArray<{ label: string }>;
+  readonly allowsFreeText: boolean;
+}
+
+export class PushDedup {
+  private last: LastPush | null = null;
+
+  constructor(
+    private readonly windowMs: number = QUESTION_DEDUP_WINDOW_MS,
+    private readonly clock: () => number = Date.now,
+  ) {}
+
+  /**
+   * Returns true if the push should fire, false to suppress. On true,
+   * the internal baseline updates so subsequent equal-or-poorer pushes
+   * within the window are dropped.
+   */
+  shouldPush(question: PushDedupQuestion): boolean {
+    const t = this.clock();
+    const incomingIsDefault = looksLikeDefaultPermissionQuestion(question);
+    const incomingCount = question.options.length;
+
+    if (this.last !== null && t - this.last.emittedAt < this.windowMs) {
+      // Default-3-set is the bland fallback shape; never let it
+      // upgrade or duplicate a push that already covers the prompt
+      // with a richer shape.
+      if (incomingIsDefault && !this.last.isDefaultShape) return false;
+      // Same direction the other way: the daemon's first push for
+      // this prompt was the bland default and the PTY now surfaced a
+      // richer shape → upgrade the lock-screen options.
+      if (!incomingIsDefault && this.last.isDefaultShape) {
+        this.last = { emittedAt: t, optionCount: incomingCount, isDefaultShape: false };
+        return true;
+      }
+      // Same shape class: only allow strictly more options (upgrade).
+      if (incomingCount <= this.last.optionCount) return false;
+    }
+
+    this.last = {
+      emittedAt: t,
+      optionCount: incomingCount,
+      isDefaultShape: incomingIsDefault,
+    };
+    return true;
+  }
+
+  /** Clear baseline (call on status change away from 'waiting'). */
+  reset(): void {
+    this.last = null;
+  }
+}

--- a/packages/daemon/tests/notifications/push-dedup.test.ts
+++ b/packages/daemon/tests/notifications/push-dedup.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the push-trigger dedup (#409).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption } from '@remi/shared';
+import { PushDedup } from '../../src/notifications/push-dedup.ts';
+
+function opt(label: string): QuestionOption {
+  return { label, value: label, isRecommended: false, isYes: false, isNo: false };
+}
+
+function q(options: readonly string[], allowsFreeText = false): Question {
+  return {
+    id: 'q-id',
+    text: 'prompt text',
+    options: options.map(opt),
+    allowsFreeText,
+    isAnswered: false,
+  };
+}
+
+const defaultThreeSet = ['Yes', 'Yes, always', 'No'];
+const customThreeSet = [
+  'Yes',
+  "Yes, and don't ask again this session",
+  'No, and tell Claude what to do differently',
+];
+
+describe('PushDedup', () => {
+  test('first push always fires', () => {
+    const dedup = new PushDedup();
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+  });
+
+  test('default 3-set after default 3-set within window: suppressed', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    t += 100;
+    // Same shape, same count → not richer, suppress.
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+  });
+
+  test('non-default after default within window: fires (upgrade)', () => {
+    // The bug case: PTY sees [y/n], emits 2-option Yes/No AFTER the
+    // hook bridge fired the default 3-set. The lock-screen options
+    // need to upgrade to the real Yes/No so tapping Yes maps to the
+    // correct value.
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    t += 100;
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+  });
+
+  test('default after non-default within window: suppressed', () => {
+    // The other ordering: PTY parser fires first with 2-option
+    // Yes/No, hook bridge fires the bland 3-set after. Suppress the
+    // bland duplicate; the user's first push already covers the
+    // prompt with the correct options.
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    t += 100;
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+  });
+
+  test('strict-more-options upgrade fires', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    t += 100;
+    // Non-default, more options → upgrade.
+    expect(dedup.shouldPush(q(['Refactor', 'Patch', 'Skip', 'Other']))).toBe(true);
+  });
+
+  test('equal-rank non-default twice within window: suppressed', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    t += 100;
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(false);
+  });
+
+  test('beyond window: same rank fires', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    t += 6000;
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+  });
+
+  test('reset clears the baseline', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    dedup.reset();
+    t += 100;
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+  });
+
+  test('boundary: exactly windowMs ago is treated as expired (strict <)', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    t += 5000;
+    // At the boundary, the prior baseline expires and the same-rank
+    // emission fires as a new prompt cycle.
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+  });
+
+  test('upgrade re-arms baseline so subsequent equal-or-poorer is suppressed', () => {
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    t += 100;
+    // Upgrade to 4 options
+    expect(dedup.shouldPush(q(['a', 'b', 'c', 'd']))).toBe(true);
+    t += 100;
+    // Subsequent 3-option non-default → not strictly more → suppress.
+    expect(dedup.shouldPush(q(['a', 'b', 'c']))).toBe(false);
+    t += 100;
+    // Default 3-set → still poorer → suppress.
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+  });
+
+  test('Edit-style 3-set with custom labels is treated as default (looksLikeDefault)', () => {
+    // looksLikeDefaultPermissionQuestion uses startsWith('yes')/('no'),
+    // so Edit's "[Yes, ..., No, ...]" matches default-shape. This is
+    // intentional: treating both as the same "binary permission shape"
+    // means a duplicate Edit-style emission within window is suppressed.
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(customThreeSet))).toBe(true);
+    t += 100;
+    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

User reports "still getting two notifications per question". The PTY parser and HookEventBridge both emit a question for the same prompt cycle (different ids, different fingerprints, both pass \`QuestionDedup\`). Each emission fired an APNS push, so the lock screen got two notifications per prompt.

Closes #409.

## Fix

Mirror the client-side richer-wins guard (#401/#407) at the push-trigger level. New \`PushDedup\` class in \`packages/daemon/src/notifications/push-dedup.ts\`. Shape-aware:

- new is default-3-set AND last was non-default → suppress
- new is non-default AND last was default → fire (upgrade lock-screen options)
- new has strictly more options → fire (upgrade)
- otherwise → suppress
- beyond \`QUESTION_DEDUP_WINDOW_MS\` → always fire

Wired into the \`onQuestion\` handler. Reset on \`status !== 'waiting'\` (mirrors \`QuestionDedup\` lifecycle).

## Tests

11 new unit tests in \`packages/daemon/tests/notifications/push-dedup.test.ts\` covering all branches. 1699/1699 daemon tests pass.

## Test plan

- [x] \`bun test\` clean
- [x] \`bun run typecheck\` clean
- [ ] Manual on phone: trigger a Yes/No prompt while phone is locked → exactly one notification.
- [ ] Manual: trigger a multi-choice plan-mode prompt → one notification with the rich options.