### PR TITLE
fix(daemon): suppress PTY push during auto-approve handling (#413)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1018,22 +1018,28 @@ async function createNewSession(
       onQuestion: (question) => {
         // PTY parser runs as a secondary source so Y/N, multi-choice, and
         // free-text prompts (which hooks never carry) reach the user with
-        // their real options.
+        // their real options. We gate two cases:
         //
-        // We do NOT gate on subagent-context here (#405). The PTY parser
-        // only emits questions for prompts visible on the main terminal
-        // screen, which by construction means the user can see them and
-        // wants to answer them, even if a Task tool is in flight (e.g. a
-        // subagent escalated a question up to the main agent's PTY). The
-        // primary `agent_id` filter at hook-bridge-setup.ts already drops
-        // hook events tagged as subagent-internal; whatever leaks through
-        // and lands on screen is genuinely user-facing.
+        //   1. Auto-approve / hook bridge is currently owning a permission
+        //      cycle (#413). The PTY observes the prompt on screen and
+        //      would emit a redundant question, firing a spurious push for
+        //      a prompt the user wasn't asked to handle (auto-approve
+        //      approved/denied internally) or that the bridge already
+        //      emitted (escalate path).
+        //   2. The hook's hardcoded Yes/Yes-always/No is already emitted by
+        //      HookEventBridge for any tool permission. PTY sees the same
+        //      three options on screen but with different surrounding text,
+        //      so the dedup window cannot catch them — drop here by shape.
         //
-        // We DO drop the hook's hardcoded Yes/Yes-always/No when the PTY
-        // re-emits the same shape: HookEventBridge emits the default
-        // 3-set immediately and the dedup window cannot catch it because
-        // the surrounding text differs.
+        // We do NOT gate on subagent-context (#405): the PTY parser only
+        // emits questions for prompts visible on the main terminal screen,
+        // which by construction the user can see and answer, even if a
+        // Task tool is in flight. The primary `agent_id` filter at
+        // hook-bridge-setup.ts already drops hook events tagged as
+        // subagent-internal; whatever leaks through and lands on screen
+        // is genuinely user-facing.
         if (hookBridge !== null) {
+          if (hookBridge.isHandlingPermission()) return;
           if (looksLikeDefaultPermissionQuestion(question)) return;
         }
         messageApi.handleQuestion(question);

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -117,6 +117,16 @@ export class HookEventBridge {
     this.lastPermissionEmitAt = 0;
   }
 
+  /** True when a PermissionRequest is currently owned by the bridge or
+   *  by auto-approve (within the same dedup window). Callers in the
+   *  PTY question path use this to suppress redundant emissions while
+   *  auto-approve is in flight or the bridge already emitted the
+   *  question for the same prompt cycle (#413). */
+  isHandlingPermission(): boolean {
+    if (this.lastPermissionEmitAt === 0) return false;
+    return Date.now() - this.lastPermissionEmitAt < PERMISSION_DEDUP_WINDOW_MS;
+  }
+
   /** Returns HookServerEvents handlers wired to this bridge */
   hookHandlers(): Partial<HookServerEvents> {
     return {

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -629,4 +629,37 @@ describe('HookEventBridge', () => {
       expect(bridge.isInSubagentContext()).toBe(false);
     });
   });
+
+  describe('isHandlingPermission (#413)', () => {
+    it('returns false on a fresh bridge', () => {
+      const { bridge } = createBridge();
+      expect(bridge.isHandlingPermission()).toBe(false);
+    });
+
+    it('returns true while a permission is being handled within the dedup window', () => {
+      const { bridge } = createBridge();
+      bridge.markPermissionHandled();
+      // Effectively immediate; within window.
+      expect(bridge.isHandlingPermission()).toBe(true);
+    });
+
+    it('returns false after clearPermissionHandled', () => {
+      const { bridge } = createBridge();
+      bridge.markPermissionHandled();
+      bridge.clearPermissionHandled();
+      expect(bridge.isHandlingPermission()).toBe(false);
+    });
+
+    it('returns true after handlePermissionRequest emitted a question', () => {
+      // The escalate path sets lastPermissionEmitAt as a side effect.
+      const { bridge } = createBridge();
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      } as import('../../src/hooks/hook-types.ts').PermissionRequestHookInput);
+      expect(bridge.isHandlingPermission()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

User reported regression: APNS push fires for permissions that auto-approve handles internally. The bridge-level guard from #379/#381 stopped the redundant \`Notification(permission_prompt)\` from emitting a phantom question, but the **PTY parser** still observed the prompt on the terminal screen and emitted its own \`onQuestion\`, reaching \`messageApi.handleQuestion\` and firing a push.

Closes #413.

## Fix

- New \`HookEventBridge.isHandlingPermission()\`: returns true when \`lastPermissionEmitAt\` is within \`PERMISSION_DEDUP_WINDOW_MS\`.
- Gate at \`cli.ts:1018\` PTY \`onQuestion\` callback: \`if (hookBridge.isHandlingPermission()) return;\`.

Cases handled:

- auto-approve approve/deny → bridge doesn't emit; PTY would, now dropped → no push.
- auto-approve escalate → bridge emits via \`escalateToUser\`; PTY's redundant emission dropped → still exactly one push.
- auto-approve cancelled → \`clearPermissionHandled()\` resets the baseline; PTY emissions for whatever comes next are unaffected.
- no auto-approve / no recent permission → gate stays open, PTY emissions reach \`messageApi\` as before.

## Tests

4 new tests for \`isHandlingPermission\` covering fresh-bridge, marked-then-true, cleared-then-false, and the \`handlePermissionRequest\` side-effect path. 1692/1692 daemon tests pass.

## Note

Touches adjacent lines to PR #406 (removes the subagent-context filter from the same if-block). Whichever lands second needs a trivial rebase.

## Validation

- [x] \`bun test\` clean
- [x] \`bun run typecheck\` clean
- [ ] Manual on phone with auto-approve enabled: trigger an auto-approvable Bash → zero notifications.
- [ ] Manual: auto-approve escalates → exactly one notification.
- [ ] Manual: auto-approve disabled → behavior unchanged.