### PR TITLE
fix(daemon): source-agnostic SessionStart restart (#416)

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -422,18 +422,22 @@ export function setupHookBridge(
     typeof input.agent_id === 'string' && input.agent_id.length > 0;
 
   hookServer.on('SessionStart', (input) => {
-    // SessionStart with an explicit main-transition source (/clear /compact
-    // /resume) is the authoritative signal that our main Claude took a new
-    // session_id while our PTY kept running. Pre-empt the classifier by
-    // treating the old session as ended, so the classifier sees a 'restart'
-    // and cleanly switches the lock.
-    if (input.source === 'clear' || input.source === 'compact' || input.source === 'resume') {
-      if (claudeSessionId && input.session_id && input.session_id !== claudeSessionId) {
-        log(
-          `[Hooks] Main lifecycle transition (${input.source}): ${claudeSessionId} -> ${input.session_id}`,
-        );
-        mainSessionEnded = true; // classifier will pick this up as 'restart'
-      }
+    // Any SessionStart whose session_id differs from our lock while our PTY is
+    // still running is a main-session rotation: pre-empt the classifier by
+    // marking the old session ended so it sees a 'restart' and switches the
+    // lock cleanly. Source-agnostic by design: Claude Code's documented
+    // sources are 'startup'|'resume'|'clear'|'compact' (hook-types.ts:61),
+    // but new flows (session switch UX, background→foreground handoff, future
+    // sources) rotate session_id without firing any of those. Without this
+    // widening, every event from the new session_id classifies as 'foreign'
+    // and the daemon wedges (epic #415, phase 1 / issue #416). Subagent
+    // SessionStarts are not a risk here: they share the main session_id and
+    // carry agent_id, which is filtered downstream.
+    if (claudeSessionId && input.session_id && input.session_id !== claudeSessionId) {
+      log(
+        `[Hooks] Main lifecycle transition (source=${input.source ?? 'unknown'}): ${claudeSessionId} -> ${input.session_id}`,
+      );
+      mainSessionEnded = true; // classifier will pick this up as 'restart'
     }
     initFromHookEvent(input);
     handlers.onSessionStart?.(input);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -422,18 +422,20 @@ export function setupHookBridge(
     typeof input.agent_id === 'string' && input.agent_id.length > 0;
 
   hookServer.on('SessionStart', (input) => {
-    // Any SessionStart whose session_id differs from our lock while our PTY is
-    // still running is a main-session rotation: pre-empt the classifier by
-    // marking the old session ended so it sees a 'restart' and switches the
-    // lock cleanly. Source-agnostic by design: Claude Code's documented
-    // sources are 'startup'|'resume'|'clear'|'compact' (hook-types.ts:61),
-    // but new flows (session switch UX, background→foreground handoff, future
-    // sources) rotate session_id without firing any of those. Without this
-    // widening, every event from the new session_id classifies as 'foreign'
-    // and the daemon wedges (epic #415, phase 1 / issue #416). Subagent
-    // SessionStarts are not a risk here: they share the main session_id and
-    // carry agent_id, which is filtered downstream.
-    if (claudeSessionId && input.session_id && input.session_id !== claudeSessionId) {
+    // Pre-empt the classifier into 'restart' on any session_id rotation while
+    // our PTY is alive, regardless of `source` (Claude Code rotates session_id
+    // through flows that omit source or carry undocumented values; the narrow
+    // source-allowlist that used to gate this would wedge the lock).
+    // isSubagentEvent guard mirrors the pattern used by other hookServer
+    // handlers: subagents share the main session_id today, but if a future
+    // version ever fires SessionStart with agent_id set and a different
+    // session_id, we must not tear down main's watcher.
+    if (
+      !isSubagentEvent(input) &&
+      claudeSessionId &&
+      input.session_id &&
+      input.session_id !== claudeSessionId
+    ) {
       log(
         `[Hooks] Main lifecycle transition (source=${input.source ?? 'unknown'}): ${claudeSessionId} -> ${input.session_id}`,
       );

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -58,7 +58,11 @@ export interface StopHookInput extends HookCommonInput {
 
 export interface SessionStartHookInput extends HookCommonInput {
   hook_event_name: 'SessionStart';
-  source: 'startup' | 'resume' | 'clear' | 'compact';
+  /** Documented values at time of writing: 'startup' | 'resume' | 'clear' |
+   *  'compact'. Typed as an open optional string because Claude Code rotates
+   *  session_id through flows that emit other source values (or omit the
+   *  field entirely), and restart detection downstream is source-agnostic. */
+  source?: string;
   model: string;
 }
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -415,6 +415,99 @@ describe('setupHookBridge', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Issue #416 / epic #415 phase 1: SessionStart source-agnostic restart.
+  // Claude Code's documented sources are 'startup'|'resume'|'clear'|'compact'
+  // (hook-types.ts:61). New flows (session switch UX, background<->foreground
+  // handoff, future sources) rotate session_id without firing any of those
+  // four. Without the source-agnostic pre-empt, every event from the new
+  // session_id classifies as 'foreign' and the daemon wedges (observed live
+  // in practicum 2026-05-13: lock=6ea65ea4 incoming=7dcb5339, ~hundreds of
+  // dropped events in one rotation).
+  // -------------------------------------------------------------------------
+
+  test('SessionStart with unknown source AND new session_id pre-empts classifier (issue #416)', () => {
+    build();
+
+    // Lock onto claude-A.
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    const stopCalls: number[] = [];
+    transcriptWatchers.set(SID, {
+      filePath: path.join(tmpDir, 'a.jsonl'),
+      stop: () => {
+        stopCalls.push(1);
+      },
+    } as never);
+
+    // Claude Code emits a SessionStart with an unfamiliar source (representing
+    // a future session-switch flow) and a different session_id while our PTY
+    // is still running. Pre-fix this dropped through the classifier as
+    // 'foreign' for every subsequent event.
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-B',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+      hook_event_name: 'SessionStart',
+      source: 'switch_chat_future_value',
+    });
+
+    // Restart side effects fired: old watcher torn down, messageApi reset.
+    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+    expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
+
+    // And the lock actually transitioned: a follow-up event from claude-B
+    // must reach the handler instead of being dropped as 'Dropped foreign'.
+    // PreToolUse routes to handleStatusChange('executing', tool_name).
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-B',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+    expect(messageApiLog.statusCalls).toContain('executing');
+  });
+
+  test('SessionStart with undefined source AND new session_id pre-empts classifier (issue #416)', () => {
+    // Defensive companion test: some Claude Code versions omit `source`
+    // entirely on session transitions. The fix must trigger on session_id
+    // mismatch alone, regardless of whether source is present.
+    build();
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    const stopCalls: number[] = [];
+    transcriptWatchers.set(SID, {
+      filePath: path.join(tmpDir, 'a.jsonl'),
+      stop: () => {
+        stopCalls.push(1);
+      },
+    } as never);
+
+    // No `source` field at all.
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-B',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+    expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
+
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-B',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+    expect(messageApiLog.statusCalls).toContain('executing');
+  });
+
+  // -------------------------------------------------------------------------
   // Regression #379 / #377: pre-emptive Notification dedup during slow
   // auto-approve evaluation. The PermissionRequest hook handler must mark
   // the bridge as "handling permission" BEFORE invoking aaService.evaluate,

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -414,21 +414,14 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
   });
 
-  // -------------------------------------------------------------------------
-  // Issue #416 / epic #415 phase 1: SessionStart source-agnostic restart.
-  // Claude Code's documented sources are 'startup'|'resume'|'clear'|'compact'
-  // (hook-types.ts:61). New flows (session switch UX, background<->foreground
-  // handoff, future sources) rotate session_id without firing any of those
-  // four. Without the source-agnostic pre-empt, every event from the new
-  // session_id classifies as 'foreign' and the daemon wedges (observed live
-  // in practicum 2026-05-13: lock=6ea65ea4 incoming=7dcb5339, ~hundreds of
-  // dropped events in one rotation).
-  // -------------------------------------------------------------------------
+  // SessionStart restart pre-empt is source-agnostic: any rotation of
+  // session_id while PTY is running fires it. These tests cover the new-
+  // source, undefined-source, same-session_id (must NOT fire), missing
+  // session_id (defensive), and subagent (agent_id set, must NOT fire) axes.
 
   test('SessionStart with unknown source AND new session_id pre-empts classifier (issue #416)', () => {
     build();
 
-    // Lock onto claude-A.
     hookServer.fire('SessionStart', {
       session_id: 'claude-A',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
@@ -443,10 +436,6 @@ describe('setupHookBridge', () => {
       },
     } as never);
 
-    // Claude Code emits a SessionStart with an unfamiliar source (representing
-    // a future session-switch flow) and a different session_id while our PTY
-    // is still running. Pre-fix this dropped through the classifier as
-    // 'foreign' for every subsequent event.
     hookServer.fire('SessionStart', {
       session_id: 'claude-B',
       transcript_path: path.join(tmpDir, 'b.jsonl'),
@@ -454,13 +443,9 @@ describe('setupHookBridge', () => {
       source: 'switch_chat_future_value',
     });
 
-    // Restart side effects fired: old watcher torn down, messageApi reset.
     expect(stopCalls.length).toBeGreaterThanOrEqual(1);
     expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
 
-    // And the lock actually transitioned: a follow-up event from claude-B
-    // must reach the handler instead of being dropped as 'Dropped foreign'.
-    // PreToolUse routes to handleStatusChange('executing', tool_name).
     hookServer.fire('PreToolUse', {
       session_id: 'claude-B',
       tool_name: 'Bash',
@@ -470,9 +455,7 @@ describe('setupHookBridge', () => {
   });
 
   test('SessionStart with undefined source AND new session_id pre-empts classifier (issue #416)', () => {
-    // Defensive companion test: some Claude Code versions omit `source`
-    // entirely on session transitions. The fix must trigger on session_id
-    // mismatch alone, regardless of whether source is present.
+    // Some Claude Code versions omit `source` entirely on session transitions.
     build();
 
     hookServer.fire('SessionStart', {
@@ -489,7 +472,6 @@ describe('setupHookBridge', () => {
       },
     } as never);
 
-    // No `source` field at all.
     hookServer.fire('SessionStart', {
       session_id: 'claude-B',
       transcript_path: path.join(tmpDir, 'b.jsonl'),
@@ -505,6 +487,99 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
     expect(messageApiLog.statusCalls).toContain('executing');
+  });
+
+  test('SessionStart with same session_id does NOT pre-empt (issue #416)', () => {
+    // Locks the `input.session_id !== claudeSessionId` guard against silent
+    // refactor regression: a duplicate SessionStart for the same session
+    // (e.g. SDK reconnect, source=startup repeat) must be a no-op.
+    build();
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    const stopCalls: number[] = [];
+    transcriptWatchers.set(SID, {
+      filePath: path.join(tmpDir, 'a.jsonl'),
+      stop: () => {
+        stopCalls.push(1);
+      },
+    } as never);
+    const resetsBefore = messageApiLog.resetCalls.n;
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+    });
+
+    expect(stopCalls.length).toBe(0);
+    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
+  });
+
+  test('SessionStart with missing session_id does NOT pre-empt (issue #416)', () => {
+    // Defensive: malformed/incomplete event must be inert, not tear down.
+    build();
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    const stopCalls: number[] = [];
+    transcriptWatchers.set(SID, {
+      filePath: path.join(tmpDir, 'a.jsonl'),
+      stop: () => {
+        stopCalls.push(1);
+      },
+    } as never);
+    const resetsBefore = messageApiLog.resetCalls.n;
+
+    hookServer.fire('SessionStart', {
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+    });
+
+    expect(stopCalls.length).toBe(0);
+    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
+  });
+
+  test('SessionStart with agent_id set does NOT pre-empt even on session_id mismatch (issue #416)', () => {
+    // isSubagentEvent guard: a subagent firing SessionStart with its own
+    // session_id (hypothetical future Claude Code shape) must not tear down
+    // main's watcher. Closes the gap the pre-PR narrow `source` gate covered
+    // by accident.
+    build();
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    const stopCalls: number[] = [];
+    transcriptWatchers.set(SID, {
+      filePath: path.join(tmpDir, 'a.jsonl'),
+      stop: () => {
+        stopCalls.push(1);
+      },
+    } as never);
+    const resetsBefore = messageApiLog.resetCalls.n;
+
+    hookServer.fire('SessionStart', {
+      session_id: 'subagent-B',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+      hook_event_name: 'SessionStart',
+      agent_id: 'subagent-id-xyz',
+    });
+
+    expect(stopCalls.length).toBe(0);
+    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #416. Phase 1 of epic #415.

## Summary

- `hook-bridge-setup.ts` SessionStart handler is now source-agnostic. Any SessionStart whose `session_id` differs from the locked `claudeSessionId` while PTY is still running counts as a restart, regardless of `source` value.
- Adds 2 tests: unknown-source rotation, and undefined-source rotation. Both verify the watcher tears down AND the new session_id passes filterBySession on the next PreToolUse.

## Why

`hook-bridge-setup.ts:430-437` only pre-empted the classifier when `source ∈ {clear, compact, resume}`. Any other transition (silent rotation, future Claude Code session-switch UX, `source=undefined`) left `mainSessionEnded=false`. The classifier at `session-lock-classifier.ts:54` then returned `'foreign'` for every event from the new `session_id` while our PTY was alive, wedging the lock.

Observed live in practicum on 2026-05-13: `lock=6ea65ea4 incoming=7dcb5339` for hundreds of dropped events in one rotation. Auto-approve silently inactive. Multiple sessions stuck.

The classifier itself (`session-lock-classifier.ts:43-57`) is already source-agnostic; it relies on PTY-running + SessionEnd, not on `source`. The bug was only in the pre-empt call site.

## Why this is safe

Subagent/team-member SessionStarts share the main `session_id` and carry `agent_id`, which is filtered downstream by `isSubagentEvent()` at `hook-bridge-setup.ts:421-422`. The widened pre-empt only triggers on `session_id` mismatch, which subagents do not have. The change does not loosen any safety check; it only accepts more legitimate restarts.

## Tests

Two new tests in `tests/cli/session-phases/hook-bridge-setup.test.ts`:

1. **Unknown source value** (e.g. \`switch_chat_future_value\`) + new `session_id` → watcher torn down, `messageApi.reset()` called, next PreToolUse from the new session reaches the handler (`statusCalls` contains `'executing'`).
2. **Undefined source** (no `source` field at all) + new `session_id` → same result. Defensive companion: some Claude Code versions omit `source` entirely on transitions.

Existing `source=clear` test unchanged and still passing.

Verified:
- `bun test packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` → 26 pass.
- `bun test packages/daemon/tests/{api,cli,hooks,mdns,notifications,remote,session} packages/shared/tests packages/signaling/tests` → 1142 pass.
- `bun run typecheck` → clean.
- `bunx biome check` on changed files → clean.

Auto-approve tests skipped per repo memory (`skip_llm_tests` — module not touched this PR).

## Test plan

- [x] CI green.
- [ ] Manual: trigger Claude session_id rotation in a live PTY (e.g. observed practicum-style rotation, /resume into a different session), verify `~/.remi/remi.log` shows `Main lifecycle transition (source=…)` and no subsequent `Dropped foreign` spam.

## Related

- Epic #415 (PTY-presence question detection redesign).
- Phase 2 #417 (`permission_suggestions` union), phase 3 #418 (PTY-presence gate), phase 4 #419 (demote `agent_id`) follow.