### PR TITLE
feat(daemon): permission_suggestions accepts object entries (#417)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -27,9 +27,8 @@ const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate'])
 /**
  * Convert one `permission_suggestions` entry into an LLM-ready label, or
  * null when the entry carries no useful content. Strings pass through;
- * objects are JSON-serialised (truncated to keep the prompt small) so the
- * LLM can read a structured option like `{"type":"addDirectories",...}`.
- * Exported for unit testing.
+ * objects are JSON-serialised so the LLM can read a structured option like
+ * `{"type":"addDirectories",...}` (very long serialisations are truncated).
  */
 export function normalisePermissionSuggestion(entry: unknown): string | null {
   if (typeof entry === 'string') {
@@ -137,11 +136,6 @@ export class AutoApproveService {
     const model = this.llmConfig.model;
     const prefix = tag ? `[AutoApprove ${tag}]` : '[AutoApprove]';
 
-    // Normalise the heterogeneous permission_suggestions union (string |
-    // {type, ...}) into LLM-ready labels. Strings pass through; object
-    // entries are JSON-serialised so the LLM can reason about structured
-    // options like addDirectories/setMode. null/undefined/empty entries
-    // are dropped so they never reach .toLowerCase or the prompt.
     const normalisedSuggestions = Array.isArray(permissionSuggestions)
       ? permissionSuggestions
           .map((s) => normalisePermissionSuggestion(s))
@@ -180,6 +174,26 @@ export class AutoApproveService {
         if (this.logDecisions) {
           this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
         }
+        return { decision: 'escalate', reasoning, durationMs: 0, model };
+      }
+
+      // Index-mismatch guard: when normalisation dropped one or more raw
+      // entries (empty object, Map/Set serialising to "{}", null, etc.),
+      // the LLM's pick-index would address the normalised list while
+      // inject() sends that index to the PTY, which interprets it against
+      // the original positions. Different orderings mean a "pick No"
+      // decision could land on a different option in the terminal. Escalate
+      // instead of risk silently injecting the wrong choice.
+      if (
+        isMultiChoice &&
+        this.multichoiceMode === 'evaluate' &&
+        Array.isArray(permissionSuggestions) &&
+        normalisedSuggestions !== undefined &&
+        normalisedSuggestions.length !== permissionSuggestions.length
+      ) {
+        const dropped = permissionSuggestions.length - normalisedSuggestions.length;
+        const reasoning = `permission_suggestions had ${dropped} unreadable entries (length ${permissionSuggestions.length} -> ${normalisedSuggestions.length}); cannot safely map LLM pick to PTY index`;
+        this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
         return { decision: 'escalate', reasoning, durationMs: 0, model };
       }
 

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -25,6 +25,30 @@ type BinaryDecision = 'approve' | 'deny' | 'escalate';
 const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate']);
 
 /**
+ * Convert one `permission_suggestions` entry into an LLM-ready label, or
+ * null when the entry carries no useful content. Strings pass through;
+ * objects are JSON-serialised (truncated to keep the prompt small) so the
+ * LLM can read a structured option like `{"type":"addDirectories",...}`.
+ * Exported for unit testing.
+ */
+export function normalisePermissionSuggestion(entry: unknown): string | null {
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (entry !== null && typeof entry === 'object') {
+    try {
+      const serialised = JSON.stringify(entry);
+      if (!serialised || serialised === '{}') return null;
+      return serialised.length > 200 ? `${serialised.slice(0, 197)}...` : serialised;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
  * Parse an LLM response string into a binary approve/deny/escalate decision.
  * Tries JSON first. If JSON fails, escalates (no guessing from substring matches).
  * Exported for unit testing.
@@ -113,15 +137,16 @@ export class AutoApproveService {
     const model = this.llmConfig.model;
     const prefix = tag ? `[AutoApprove ${tag}]` : '[AutoApprove]';
 
-    // Filter to a clean string array for the multi-choice prompt path
-    // (mirrors the strict check at hook-event-bridge.ts:211-214). Anything
-    // else falls through; isMultiChoicePermission still classifies as
-    // multi-choice but we never feed garbage to .toLowerCase or to the LLM.
-    const cleanSuggestions =
-      Array.isArray(permissionSuggestions) &&
-      permissionSuggestions.every((s) => typeof s === 'string' && s.length > 0)
-        ? (permissionSuggestions as readonly string[])
-        : undefined;
+    // Normalise the heterogeneous permission_suggestions union (string |
+    // {type, ...}) into LLM-ready labels. Strings pass through; object
+    // entries are JSON-serialised so the LLM can reason about structured
+    // options like addDirectories/setMode. null/undefined/empty entries
+    // are dropped so they never reach .toLowerCase or the prompt.
+    const normalisedSuggestions = Array.isArray(permissionSuggestions)
+      ? permissionSuggestions
+          .map((s) => normalisePermissionSuggestion(s))
+          .filter((s): s is string => s !== null)
+      : undefined;
 
     // Entire body wrapped in try/catch so the "never throws" contract holds
     // even if matchPattern or other sync code fails (e.g. malformed config).
@@ -189,7 +214,12 @@ export class AutoApproveService {
             ? this.llmConfig
             : { ...this.llmConfig, model: callModel };
         const messages = useMultiChoice
-          ? buildMultiChoicePrompt(toolName, toolInput, cleanSuggestions ?? [], this.instructions)
+          ? buildMultiChoicePrompt(
+              toolName,
+              toolInput,
+              normalisedSuggestions ?? [],
+              this.instructions,
+            )
           : buildPrompt(toolName, toolInput, this.instructions);
         // Hard kill via Promise.race: even if fetch ignores the abort signal
         // (provider hang, Bun runtime quirk), evaluate() returns within
@@ -210,7 +240,7 @@ export class AutoApproveService {
           ? (() => {
               const parsedMc = parseMultiChoiceDecision(
                 response.content,
-                cleanSuggestions?.length ?? 0,
+                normalisedSuggestions?.length ?? 0,
               );
               if (parsedMc.decision === 'pick') {
                 return {

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -233,19 +233,21 @@ export class HookEventBridge {
 
     let options: QuestionOption[];
 
-    // Only trust permission_suggestions if every entry is a usable string.
-    // Some Claude Code versions / tool paths have been observed sending non-string
-    // entries (null, numbers, objects), which crashed `suggestion.toLowerCase()`
-    // and bubbled up as a "[AutoApprove] Unexpected error" in callers.
+    // permission_suggestions is a union of string labels and structured
+    // object entries (e.g. {type:"addDirectories",directories:[...]},
+    // {type:"setMode",mode:"..."}). The iOS question card renders text
+    // labels only, so we filter to strings here; the raw array (objects
+    // included) is forwarded to AutoApproveService separately so the LLM
+    // can reason about non-string options.
     const suggestions = input.permission_suggestions;
-    const suggestionsUsable =
-      Array.isArray(suggestions) &&
-      suggestions.length >= 2 &&
-      suggestions.every((s) => typeof s === 'string' && s.length > 0);
+    const stringSuggestions = Array.isArray(suggestions)
+      ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
+      : [];
 
-    if (suggestionsUsable) {
-      // Use the suggestions provided by Claude Code (e.g. Edit sends ["Yes","Always","No"])
-      options = suggestions.map((suggestion, idx) => {
+    if (stringSuggestions.length >= 2) {
+      // Real Yes/Always/No-style label set from Claude Code (Edit's
+      // ["Yes","Always","No"]). Map labels directly into options.
+      options = stringSuggestions.map((suggestion, idx) => {
         const lower = suggestion.toLowerCase();
         const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
         const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
@@ -258,18 +260,11 @@ export class HookEventBridge {
         };
       });
     } else {
-      // No suggestions (e.g. Bash). Use default 3-option set.
-      // The Notification hook that follows has no numbered options either
-      // (just plain text like "Claude needs your permission to use Bash"),
-      // so waiting for it adds latency without gaining information.
-      // When `permission_suggestions` is present but fails validation, log it so
-      // upstream regressions in Claude Code don't go undetected; the genuine
-      // "no suggestions" path (undefined) stays quiet.
-      if (suggestions !== undefined) {
-        console.warn(
-          `[HookEventBridge] PermissionRequest had unusable permission_suggestions (tool=${toolName}, value=${JSON.stringify(suggestions)}); using default options`,
-        );
-      }
+      // Either no suggestions (Bash) or only structured object entries
+      // (addDirectories, setMode). The iOS card cannot render either case
+      // meaningfully, so fall back to the default binary 3-set; auto-
+      // approve still gets the raw value via the bridge-setup path and
+      // routes object-only arrays through the multi-choice classifier.
       options = [...DEFAULT_PERMISSION_OPTIONS];
     }
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -234,19 +234,14 @@ export class HookEventBridge {
     let options: QuestionOption[];
 
     // permission_suggestions is a union of string labels and structured
-    // object entries (e.g. {type:"addDirectories",directories:[...]},
-    // {type:"setMode",mode:"..."}). The iOS question card renders text
-    // labels only, so we filter to strings here; the raw array (objects
-    // included) is forwarded to AutoApproveService separately so the LLM
-    // can reason about non-string options.
+    // object entries (e.g. {type:"addDirectories",...}, {type:"setMode",...}).
+    // The iOS question card renders text labels only, so filter to strings.
     const suggestions = input.permission_suggestions;
     const stringSuggestions = Array.isArray(suggestions)
       ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
       : [];
 
     if (stringSuggestions.length >= 2) {
-      // Real Yes/Always/No-style label set from Claude Code (Edit's
-      // ["Yes","Always","No"]). Map labels directly into options.
       options = stringSuggestions.map((suggestion, idx) => {
         const lower = suggestion.toLowerCase();
         const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
@@ -261,10 +256,7 @@ export class HookEventBridge {
       });
     } else {
       // Either no suggestions (Bash) or only structured object entries
-      // (addDirectories, setMode). The iOS card cannot render either case
-      // meaningfully, so fall back to the default binary 3-set; auto-
-      // approve still gets the raw value via the bridge-setup path and
-      // routes object-only arrays through the multi-choice classifier.
+      // that the iOS card cannot render. Fall back to the default 3-set.
       options = [...DEFAULT_PERMISSION_OPTIONS];
     }
 

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -69,12 +69,11 @@ export interface SessionStartHookInput extends HookCommonInput {
 // --- 20 new events ---
 
 /**
- * One entry in `permission_suggestions`. Strings are the original shape
- * (e.g. Edit's `["Yes", "Always", "No"]`). Objects carry tool-specific
- * structured options that Claude Code added later — observed shapes
- * include `{type: "addDirectories", directories: [...], destination}` and
- * `{type: "setMode", mode: "...", destination}`. The shape is open: future
- * Claude Code versions may add new `type` values without notice.
+ * One entry in `permission_suggestions`. Strings are the binary-label
+ * shape (e.g. Edit's `["Yes", "Always", "No"]`). Objects carry tool-
+ * specific structured options discriminated by `type` — for example
+ * `{type:"addDirectories",...}` or `{type:"setMode",...}`. The wider
+ * shape is open: callers must treat unknown `type` values as opaque.
  */
 export type PermissionSuggestion = string | { type: string; [k: string]: unknown };
 

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -68,12 +68,22 @@ export interface SessionStartHookInput extends HookCommonInput {
 
 // --- 20 new events ---
 
+/**
+ * One entry in `permission_suggestions`. Strings are the original shape
+ * (e.g. Edit's `["Yes", "Always", "No"]`). Objects carry tool-specific
+ * structured options that Claude Code added later — observed shapes
+ * include `{type: "addDirectories", directories: [...], destination}` and
+ * `{type: "setMode", mode: "...", destination}`. The shape is open: future
+ * Claude Code versions may add new `type` values without notice.
+ */
+export type PermissionSuggestion = string | { type: string; [k: string]: unknown };
+
 /** Fired when a permission dialog is about to show */
 export interface PermissionRequestHookInput extends HookCommonInput {
   hook_event_name: 'PermissionRequest';
   tool_name: string;
   tool_input: Record<string, unknown>;
-  permission_suggestions?: string[];
+  permission_suggestions?: PermissionSuggestion[];
 }
 
 /** Fired after a tool call fails */

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { AutoApproveService, parseDecision } from '../../src/auto-approve/auto-approve-service.ts';
+import {
+  AutoApproveService,
+  normalisePermissionSuggestion,
+  parseDecision,
+} from '../../src/auto-approve/auto-approve-service.ts';
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 import { applyEnvOverrides, loadConfig } from '../../src/config/config.ts';
 
@@ -131,6 +135,75 @@ describe('parseDecision', () => {
     // This was the regex fallback bug: substring "approve" in reasoning
     const r = parseDecision('I would not approve this dangerous command');
     expect(r.decision).toBe('escalate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalisePermissionSuggestion - converts heterogeneous entries to LLM
+// labels. Strings pass through; objects are JSON-serialised so the LLM
+// can read addDirectories/setMode/etc shapes.
+// ---------------------------------------------------------------------------
+describe('normalisePermissionSuggestion', () => {
+  test('passes a plain string through', () => {
+    expect(normalisePermissionSuggestion('Yes')).toBe('Yes');
+  });
+
+  test('trims surrounding whitespace on strings', () => {
+    expect(normalisePermissionSuggestion('  Always  ')).toBe('Always');
+  });
+
+  test('drops empty / whitespace-only strings', () => {
+    expect(normalisePermissionSuggestion('')).toBeNull();
+    expect(normalisePermissionSuggestion('   ')).toBeNull();
+  });
+
+  test('JSON-serialises addDirectories object entry', () => {
+    const out = normalisePermissionSuggestion({
+      type: 'addDirectories',
+      directories: ['/Users/foo/.claude/agents'],
+      destination: 'session',
+    });
+    expect(out).toContain('"type":"addDirectories"');
+    expect(out).toContain('/Users/foo/.claude/agents');
+    expect(out).toContain('"destination":"session"');
+  });
+
+  test('JSON-serialises setMode object entry', () => {
+    const out = normalisePermissionSuggestion({
+      type: 'setMode',
+      mode: 'bypassPermissions',
+      destination: 'session',
+    });
+    expect(out).toContain('"type":"setMode"');
+    expect(out).toContain('"mode":"bypassPermissions"');
+  });
+
+  test('truncates very long serialisations to keep the prompt small', () => {
+    const giant = {
+      type: 'addDirectories',
+      directories: Array.from({ length: 50 }, (_, i) => `/Users/foo/dir-${i}/with-a-long-path`),
+    };
+    const out = normalisePermissionSuggestion(giant);
+    expect(out).not.toBeNull();
+    expect(out?.length).toBeLessThanOrEqual(200);
+    expect(out?.endsWith('...')).toBe(true);
+  });
+
+  test('drops null / undefined / non-object primitives', () => {
+    expect(normalisePermissionSuggestion(null)).toBeNull();
+    expect(normalisePermissionSuggestion(undefined)).toBeNull();
+    expect(normalisePermissionSuggestion(42)).toBeNull();
+    expect(normalisePermissionSuggestion(true)).toBeNull();
+  });
+
+  test('drops the empty object shape (no useful payload)', () => {
+    expect(normalisePermissionSuggestion({})).toBeNull();
+  });
+
+  test('returns null on a circular-reference object instead of throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    expect(normalisePermissionSuggestion(circular)).toBeNull();
   });
 });
 

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -205,6 +205,23 @@ describe('normalisePermissionSuggestion', () => {
     circular['self'] = circular;
     expect(normalisePermissionSuggestion(circular)).toBeNull();
   });
+
+  test('drops Map and Set (both stringify to "{}")', () => {
+    // The auto-approve service depends on this null return: a non-null
+    // serialisation that round-trips to an empty-shape would inflate
+    // normalisedSuggestions.length and confuse the index-mismatch guard.
+    expect(normalisePermissionSuggestion(new Map())).toBeNull();
+    expect(normalisePermissionSuggestion(new Set())).toBeNull();
+  });
+
+  test('keeps toJSON output when it produces a non-empty JSON shape', () => {
+    // Documents the accepted behavior: an object with a custom toJSON
+    // that returns a value gets serialised via that value. The index-
+    // mismatch guard in evaluate() catches downstream issues if any.
+    const obj = { toJSON: () => ({ type: 'custom', n: 1 }) };
+    const out = normalisePermissionSuggestion(obj);
+    expect(out).toBe('{"type":"custom","n":1}');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -239,6 +256,38 @@ describe('AutoApproveService - error handling', () => {
     );
     await service.evaluate('Bash', { command: 'ls' });
     expect(errorLogs.some((l) => l.includes('[AutoApprove] ERROR'))).toBe(true);
+  });
+
+  test('evaluate-mode index-mismatch guard escalates without calling the LLM', async () => {
+    // permission_suggestions = ['Yes', {}, 'No']: empty object drops in
+    // normalisation -> normalisedSuggestions=['Yes','No'] (length 2) while
+    // raw length stays 3. The LLM's pick index would address the
+    // normalised list but inject() sends it to the PTY, which interprets
+    // against the original positions. Escalating before any LLM call is
+    // the only safe path. `base_url` points at a black hole so a missed
+    // guard would surface as a timeout instead of a fast escalate.
+    const callLogs: string[] = [];
+    const service = new AutoApproveService(
+      makeConfig({
+        base_url: 'http://localhost:1',
+        timeout: 5,
+        multichoice: 'evaluate',
+        log_decisions: true,
+      }),
+      (msg) => callLogs.push(msg),
+    );
+    const start = Date.now();
+    const result = await service.evaluate('Bash', { command: 'ls' }, undefined, [
+      'Yes',
+      {} as unknown,
+      'No',
+    ]);
+    expect(result.decision).toBe('escalate');
+    expect(result.reasoning).toContain('unreadable entries');
+    expect(Date.now() - start).toBeLessThan(2000); // no LLM call attempted
+    expect(callLogs.some((l) => l.includes('escalate') && l.includes('unreadable entries'))).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -78,6 +78,29 @@ describe('isMultiChoicePermission', () => {
     expect(isMultiChoicePermission('Bash', [null, 'Yes', 'No'] as readonly unknown[])).toBe(true);
     expect(isMultiChoicePermission('Bash', [{}, 1] as readonly unknown[])).toBe(true);
   });
+
+  test('returns true for the typed-object addDirectories shape', () => {
+    // Concrete shape observed live from Claude Code (2026-05-13).
+    // Locks the classifier so a future change adding a string-only fast
+    // path cannot regress this case into a silent binary route.
+    expect(
+      isMultiChoicePermission('Bash', [
+        {
+          type: 'addDirectories',
+          directories: ['/Users/foo/.claude/agents'],
+          destination: 'session',
+        },
+      ] as readonly unknown[]),
+    ).toBe(true);
+  });
+
+  test('returns true for the typed-object setMode shape', () => {
+    expect(
+      isMultiChoicePermission('Bash', [
+        { type: 'setMode', mode: 'bypassPermissions', destination: 'session' },
+      ] as readonly unknown[]),
+    ).toBe(true);
+  });
 });
 
 describe('buildMultiChoicePrompt', () => {

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -248,6 +248,10 @@ describe('HookEventBridge', () => {
 
       expect(questions.length).toBe(1);
       expect(questions[0]?.options.map((o) => o.label)).toEqual(expected);
+      // isYes / isNo are the load-bearing flags the iOS response handler
+      // uses to route taps; verify they survive the filtered-string path.
+      expect(questions[0]?.options[0]?.isYes).toBe(true);
+      expect(questions[0]?.options[1]?.isNo).toBe(true);
     });
   }
 

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -187,20 +187,24 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.options[2]?.isNo).toBe(true);
   });
 
-  // Matrix of inputs that must NOT reach the `.toLowerCase()` path and must
-  // fall back to the default 3-option set. Observed in the wild as
-  // "suggestion.toLowerCase is not a function".
-  const badSuggestionCases: Array<[string, unknown]> = [
+  // Inputs that yield fewer than 2 usable string labels: must fall back to
+  // the default 3-option set so the iOS card always renders something the
+  // user can act on. Object entries (e.g. {type:"addDirectories",...}) are
+  // an expected shape and are silently filtered out of UI options here;
+  // the auto-approve path receives the raw array separately and handles
+  // them via the multi-choice classifier.
+  const fallbackCases: Array<[string, unknown]> = [
     ['all non-string entries', [null, 42, { label: 'Yes' }]],
-    ['mixed valid + null', ['Yes', null, 'No']],
-    ['mixed valid + empty string', ['Yes', '', 'No']],
-    ['single valid element (below min length 2)', ['Yes']],
+    ['pure object array (addDirectories)', [{ type: 'addDirectories', directories: ['/x'] }]],
+    ['object + null', [{ type: 'setMode', mode: 'plan' }, null]],
+    ['single string + object', ['Yes', { type: 'addDirectories', directories: ['/x'] }]],
+    ['single valid element', ['Yes']],
     ['empty array', []],
     ['string passed directly (not an array)', 'Yes'],
     ['number passed directly (not an array)', 7],
     ['array-like object', { 0: 'Yes', 1: 'No', length: 2 }],
   ];
-  for (const [label, value] of badSuggestionCases) {
+  for (const [label, value] of fallbackCases) {
     it(`PermissionRequest falls back to default options: ${label}`, () => {
       const { bridge, statuses, questions } = createBridge();
 
@@ -218,6 +222,32 @@ describe('HookEventBridge', () => {
       expect(questions[0]?.options[0]?.label).toBe('Yes');
       expect(questions[0]?.options[1]?.label).toBe('Yes, always');
       expect(questions[0]?.options[2]?.label).toBe('No');
+    });
+  }
+
+  // Mixed arrays where at least 2 string entries survive the filter:
+  // render those strings as the option set. This accepts Claude Code's
+  // newer permission_suggestions union where object entries (addDirectories
+  // etc) sit alongside Yes/No string labels.
+  const partialStringCases: Array<[string, unknown[], string[]]> = [
+    ['strings + object entry', ['Yes', { type: 'addDirectories' }, 'No'], ['Yes', 'No']],
+    ['strings + null', ['Yes', null, 'No'], ['Yes', 'No']],
+    ['strings + empty string', ['Yes', '', 'No'], ['Yes', 'No']],
+  ];
+  for (const [label, value, expected] of partialStringCases) {
+    it(`PermissionRequest uses filtered string labels: ${label}`, () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Edit',
+        tool_input: {},
+        permission_suggestions: value as unknown as string[],
+      } as PermissionRequestHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.options.map((o) => o.label)).toEqual(expected);
     });
   }
 


### PR DESCRIPTION
Closes #417. Phase 2 of epic #415.

## Summary

- `PermissionRequestHookInput.permission_suggestions` widens to a `string | {type: string, [k: string]: unknown}` union to reflect Claude Code's current contract (e.g. `[{type: "addDirectories", directories: [...], destination: "session"}]`).
- The bridge UI fallback filters to usable strings and uses them when at least 2 remain; otherwise falls back to the default Yes / Yes-always / No 3-set. The "unusable permission_suggestions" warn log is dropped — object entries are an expected shape now, not an alert-worthy anomaly.
- `AutoApproveService.evaluate` builds a `normalisedSuggestions` array where string entries pass through and object entries are JSON-serialised (truncated to 200 chars). The multi-choice prompt builder and `parseMultiChoiceDecision` both use this normalised array so the LLM can reason about structured options like addDirectories. The default `multichoice = 'skip'` still escalates object-only arrays without calling the LLM, keeping the conservative #399 default in place.

## Why

Practicum hit this live on 2026-05-13. The daemon log showed:

```
[HookEventBridge] PermissionRequest had unusable permission_suggestions
  (tool=Bash,
   value=[{"type":"addDirectories","directories":["/path/.claude/agents"],"destination":"session"}]);
   using default options
```

`hook-event-bridge.ts:241-244` only accepted string arrays. anthropics/claude-code #49525 documents the wider shape (including `{type: "setMode", mode: "..."}`); our log confirmed `addDirectories` in the wild. Auto-approve's own strict-string filter then dropped the object entries on the floor, so even in multi-choice evaluate mode the LLM saw an empty option list.

## Tests

`packages/daemon/tests/hooks/hook-event-bridge.test.ts` (44 pass):
- Refactored `badSuggestionCases` → `fallbackCases` to add: pure-object array (`[{addDirectories}]`), object + null, single string + object. All still fall back to the default 3-set on the UI side.
- New `partialStringCases` matrix: `['Yes', {addDirectories}, 'No']` → 2 string options; `['Yes', null, 'No']` → 2 string options; `['Yes', '', 'No']` → 2 string options. Previously these fell back to default 3; the new behavior is more informative when Claude Code mixes object entries with Yes/No labels.

`packages/daemon/tests/auto-approve/auto-approve-service.test.ts` (24 pass for parseDecision + the new normalisePermissionSuggestion block):
- 9 unit tests for `normalisePermissionSuggestion`: plain string, whitespace trimming, empty drop, addDirectories serialisation, setMode serialisation, 200-char truncation, null/undefined/primitive drop, empty-object drop, circular-reference safety (no throw).

Verified locally:
- `bun test packages/daemon/tests/hooks/hook-event-bridge.test.ts` → 44 pass.
- `bun test packages/daemon/tests/auto-approve/{auto-approve-service,multichoice,pattern-matcher,llm-client,cancel,prompt-builder}.test.ts` → 145 pass.
- Full daemon+shared+signaling suite (excluding ollama-dependent llm-judgment) → 1146 pass.
- `bun run typecheck` → clean.
- `bunx biome check` on changed files → clean.

Pre-existing flake in `packages/daemon/tests/cli/shell-path.test.ts` (resolveShellPath subprocess timeout) reproduces on the epic base unchanged; not introduced by this PR.

## Test plan

- [x] CI green (will run on the epic→develop PR; phase PRs don't trigger CI).
- [ ] Manual: addDirectories-style permission flow in practicum, verify no "unusable permission_suggestions" warn in `~/.remi/remi.log`.
- [ ] Manual with `multichoice = 'evaluate'`: addDirectories prompt → LLM receives the JSON-serialised entry → either picks or escalates (no empty-options crash).

## Related

- Epic #415 (PTY-presence question detection redesign).
- Phase 1 #416 (merged), phase 3 #418 (PTY-presence gate), phase 4 #419 (demote `agent_id`).
- Upstream context: anthropics/claude-code #49525 (PermissionRequest response schema includes `updatedPermissions` objects).