### PR TITLE
feat(daemon): demote agent_id from kill-switch to metadata (#419)

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -55,8 +55,23 @@ export class QuestionPresenceTracker {
    * Hook fired (PermissionRequest or Notification(permission_prompt)).
    * Stash the question; do NOT push yet. Push happens when PTY confirms
    * the prompt is visible, or never if status moves past 'waiting' first.
+   *
+   * Replacement policy: the newer hook wins. This is correct for the
+   * same-prompt double-fire case (PermissionRequest then Notification
+   * for the same prompt) but is a known weak spot for concurrent
+   * subagents (phase 4, #419) — if two different agents have prompts
+   * in flight, the second silently overwrites the first. The PTY
+   * presence gate still prevents the wrong push from firing for an
+   * off-screen agent; what is lost is option-label accuracy when the
+   * on-screen agent's hook arrived earlier. An agent_id-aware tracker
+   * would fix this structurally; tracked as a follow-up.
    */
   recordPendingHook(question: Question): void {
+    if (this.pending !== null) {
+      console.debug(
+        `[QuestionPresenceTracker] Overwriting pending hook (old="${this.pending.text.slice(0, 60)}", new="${question.text.slice(0, 60)}")`,
+      );
+    }
     this.pending = question;
   }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -420,31 +420,36 @@ export function setupHookBridge(
       log(`[Hooks] Dropped post-SessionEnd Notification: type=${input.notification_type}`);
       return;
     }
-    // Subagent notifications must not bubble up to the user (phantom prompts).
-    if (isSubagentEvent(input)) {
-      log(`[Hooks] Dropped subagent Notification: agent=${input.agent_id?.slice(0, 8)}`);
-      return;
-    }
+    // Phase 4 (#419): subagent notifications previously dropped here
+    // based on agent_id presence. Now we forward; QuestionPresenceTracker
+    // gates the push by PTY presence. A hot-switched subagent view that
+    // renders a permission prompt on the user's PTY produces a push;
+    // a background subagent does not (PTY never confirms presence).
     handlers.onNotification?.(input);
   });
   hookServer.on('PermissionRequest', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
 
-    // Subagent PermissionRequest: Claude Code sets `agent_id` on events
-    // originating from Task/Agent-spawned subagents or team members. Those
-    // events share the main session_id and transcript but are handled
-    // internally by Claude Code, so they MUST NOT be injected into our main PTY.
+    // Phase 4 (#419): subagent PermissionRequest events (events with
+    // agent_id set, originating from Task/Agent-spawned subagents) used
+    // to be dropped at this seam. Under phase 3's PTY-presence model,
+    // "what's on screen" is the truth: a hot-switched subagent view
+    // that renders a permission prompt IS user-answerable, and dropping
+    // the hook here loses the rich tool/option metadata. Forward the
+    // event; the tracker pairs it with PTY confirmation. Auto-approve
+    // and the inSubagent default-deny safety net below still gate
+    // injection independently.
     if (isSubagentEvent(input)) {
       log(
-        `[Hooks] Dropped subagent PermissionRequest: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
+        `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
       );
-      return;
     }
 
-    // Legacy nested-Task context kept as a secondary safety net for the
-    // rare case where agent_id is absent but the hook bridge's nested-task
-    // tracker caught the descent.
+    // Nested-Task context (secondary safety net for cases where
+    // agent_id is absent). Used by the auto-approve default-deny path
+    // below to avoid hanging a subagent whose only escalation route is
+    // a main-PTY prompt the user cannot see.
     const inSubagent = hookBridge.isInSubagentContext();
     const sessionTag = sessionId.slice(0, 8);
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -363,9 +363,17 @@ export function setupHookBridge(
 
   // Subagent/team-member events carry `agent_id` (confirmed via
   // REMI_HOOK_DEBUG capture 2026-04-16). They share main's session_id and
-  // transcript, so session-id filtering cannot distinguish them. Drop these
-  // at the hook layer so status updates, auto-approve, question emission,
-  // and PTY injection all stay scoped to the main interactive session.
+  // transcript, so session-id filtering cannot distinguish them.
+  //
+  // Split policy:
+  //   - `PreToolUse` / `PostToolUse` / `SessionStart`: dropped here so
+  //     status updates and Task-tool tracking stay scoped to the main
+  //     interactive session.
+  //   - `PermissionRequest` / `Notification(permission_prompt)`: forwarded
+  //     (phase 4, #419). Push is gated by PTY presence in the tracker,
+  //     not by agent_id. A hot-switched subagent view that renders a
+  //     permission prompt IS user-answerable; dropping the hook loses
+  //     the rich tool/option metadata for that case.
   const isSubagentEvent = (input: { agent_id?: string }): boolean =>
     typeof input.agent_id === 'string' && input.agent_id.length > 0;
 
@@ -450,7 +458,12 @@ export function setupHookBridge(
     // agent_id is absent). Used by the auto-approve default-deny path
     // below to avoid hanging a subagent whose only escalation route is
     // a main-PTY prompt the user cannot see.
-    const inSubagent = hookBridge.isInSubagentContext();
+    //
+    // Read live (not captured) at each branch: auto-approve evaluate()
+    // is async, so the Task context can open or close between when this
+    // listener fires and when the .then()/.catch() runs. Capturing
+    // would TOCTOU — a Task that closed mid-eval would still trigger
+    // default-deny, and a Task that opened mid-eval would escape it.
     const sessionTag = sessionId.slice(0, 8);
 
     // Inject an answer into the PTY. Returns true on success. On failure
@@ -535,7 +548,7 @@ export function setupHookBridge(
           }
           // escalate: in a subagent context, default-deny to avoid hanging
           // the subagent. The user could not answer it anyway.
-          if (inSubagent) {
+          if (hookBridge.isInSubagentContext()) {
             log(`[AutoApprove ${sessionTag}] Subagent context; escalate->deny to prevent hang`);
             // If inject fails, the subagent is hung regardless (no main
             // PTY to escalate to). Log and accept.
@@ -548,7 +561,7 @@ export function setupHookBridge(
           // Last line of defense; must not leave an unhandled rejection.
           try {
             logError(`[AutoApprove ${sessionTag}] Unexpected error:`, err);
-            if (inSubagent) {
+            if (hookBridge.isInSubagentContext()) {
               await inject('3', 'subagent-error-default-deny');
               return;
             }
@@ -561,8 +574,11 @@ export function setupHookBridge(
     }
 
     // No auto-approve. In a subagent context, still must not hang the
-    // subagent: default-deny rather than emit a question the user can't answer.
-    if (inSubagent) {
+    // subagent: default-deny rather than emit a question the user can't
+    // answer. Synchronous fallback — read live for symmetry with the
+    // async branches above; no TOCTOU here but the consistent shape
+    // helps a future maintainer.
+    if (hookBridge.isInSubagentContext()) {
       log(`[${sessionTag}] Subagent context without auto-approve; default-deny`);
       inject('3', 'subagent-no-aa-default-deny').catch((err) => {
         logError(`[${sessionTag}] Failed to inject default-deny:`, err);

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -82,8 +82,18 @@ export class HookEventBridge {
     this.events = events;
   }
 
-  /** True when the main agent is inside a Task tool call (subagent running).
-   *  Callers can use this to short-circuit auto-approve entirely during team work. */
+  /** True when the main agent is inside a *synchronous* Task tool call
+   *  (subagent running and bracketed by PreToolUse(Task)/PostToolUse(Task)
+   *  on the main session). Callers use this to short-circuit auto-approve
+   *  during team work.
+   *
+   *  Async / background-spawned subagents (TaskCreate, TeamCreate) and
+   *  team members emit hook events with `agent_id` set but do NOT bracket
+   *  their lifetime with a PreToolUse on the main session — so this
+   *  method returns `false` even when such a subagent is active. The
+   *  primary filter for those is `agent_id` (handled at the
+   *  hook-bridge-setup listener layer). This method is defense in depth
+   *  for the synchronous case where `agent_id` is absent. */
   isInSubagentContext(): boolean {
     return this.subagentContext.isInSubagentContext();
   }

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -117,13 +117,13 @@ export class HookEventBridge {
 
   handleNotification(input: NotificationHookInput): void {
     if (input.notification_type === 'permission_prompt') {
-      // Subagent/team context: don't bubble inter-agent questions to the user.
-      if (this.subagentContext.isInSubagentContext()) {
-        console.debug(
-          `[HookEventBridge] Suppressed subagent Notification(permission_prompt): ${(input.message || '').substring(0, 80)}`,
-        );
-        return;
-      }
+      // Phase 4 (#419): the subagentContext drop previously sat here.
+      // It was redundant defense: cli.ts hook-bridge-setup already
+      // forwards subagent events (phase 4 removed the agent_id gate)
+      // and the tracker handles presence by PTY confirmation. Keep
+      // SubagentContextTracker for the auto-approve default-deny path
+      // (still consumed via hookBridge.isInSubagentContext()).
+      //
       // Forward the question — push semantics live in the tracker
       // (cli.ts wiring). A trailing Notification arriving after
       // PermissionRequest replaces the pending record, which is fine
@@ -170,16 +170,12 @@ export class HookEventBridge {
   }
 
   handlePermissionRequest(input: PermissionRequestHookInput): void {
-    // Subagent/team context: suppress inter-agent questions from reaching the user.
-    // The main agent is blocked waiting for Task to return and cannot generate
-    // questions during this window. Any PermissionRequest here is from a subagent.
-    if (this.subagentContext.isInSubagentContext()) {
-      console.debug(
-        `[HookEventBridge] Suppressed subagent PermissionRequest: tool=${input.tool_name}`,
-      );
-      return;
-    }
-
+    // Phase 4 (#419): the subagentContext drop previously sat here.
+    // After phase 3 wired in the QuestionPresenceTracker, push semantics
+    // are presence-gated regardless of subagent context — a subagent
+    // prompt that does not render on the user's PTY does not push, and
+    // one that does is genuinely answerable. The tracker handles both
+    // cases; this method now only builds the question payload.
     const toolName = input.tool_name || 'unknown tool';
     const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
     const promptText = inputSummary ? `Allow ${toolName}: ${inputSummary}` : `Allow ${toolName}?`;

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1155,23 +1155,23 @@ describe('setupHookBridge', () => {
     build({ autoApprove: true, autoApproveThrows: true });
 
     hookServer.fire('SessionStart', {
-      session_id: 'claude-thr-task',
+      session_id: 'claude-throws-task',
       hook_event_name: 'SessionStart',
-      transcript_path: path.join(tmpDir, 'thrtask.jsonl'),
+      transcript_path: path.join(tmpDir, 'throws-task.jsonl'),
       source: 'startup',
       model: 'test',
     });
 
     hookServer.fire('PreToolUse', {
-      session_id: 'claude-thr-task',
+      session_id: 'claude-throws-task',
       hook_event_name: 'PreToolUse',
       tool_name: 'Task',
       tool_input: {},
-      tool_use_id: 'tu_task_thr',
+      tool_use_id: 'tu_task_throws',
     });
 
     hookServer.fire('PermissionRequest', {
-      session_id: 'claude-thr-task',
+      session_id: 'claude-throws-task',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -263,22 +263,34 @@ describe('setupHookBridge', () => {
     expect(() => build()).not.toThrow();
   });
 
-  test('PermissionRequest with agent_id is dropped before reaching inject', async () => {
-    build({ autoApprove: true });
+  test('Phase 4 (#419): PermissionRequest with agent_id is forwarded through auto-approve', async () => {
+    // Pre-phase-4, agent_id-tagged events were dropped at the listener
+    // boundary. Phase 4 demoted agent_id from kill-switch to metadata:
+    // the auto-approve LLM evaluates and injects just like a main-agent
+    // event. The push to iOS is still gated by PTY presence downstream,
+    // so a background subagent's auto-approved permission silently
+    // executes; a hot-switched subagent's prompt would surface via the
+    // tracker's PTY confirmation path.
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-123',
+      transcript_path: path.join(tmpDir, 'sub.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
 
     hookServer.fire('PermissionRequest', {
-      session_id: 'claude-123',
+      session_id: 'claude-sub-123',
       agent_id: 'subagent-abc',
       agent_type: 'task',
       tool_name: 'Bash',
-      tool_input: { command: 'rm -rf /' },
+      tool_input: { command: 'ls' },
     });
 
-    // Let any queued microtasks run.
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    // Wait for evaluate() + inject() to resolve.
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    // Subagent PermissionRequests must NOT inject into the main PTY.
-    expect(ptySubmits).toEqual([]);
+    expect(ptySubmits).toEqual(['1']);
   });
 
   test('PermissionRequest with auto-approve APPROVE injects "1" (status: executing)', async () => {
@@ -863,6 +875,206 @@ describe('setupHookBridge', () => {
 
     expect(pushed.length).toBe(1);
     expect(pushed[0]?.options.map((o) => o.label)).toEqual(['Yes', 'No']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase 4 (#419): agent_id demoted from kill-switch to metadata.
+  // Subagent PermissionRequest + Notification events flow through to the
+  // tracker; push is gated by PTY presence, not by the agent_id tag.
+  // -------------------------------------------------------------------------
+
+  test('Phase 4 wiring: subagent PermissionRequest + PTY-visible prompt fires a push', async () => {
+    // The user hot-switches to a subagent's view; the subagent's prompt
+    // is on the user's PTY screen. The hook fires with agent_id set.
+    // Under the new contract, this is an answerable prompt: tracker
+    // records the hook, PTY confirms, push fires with merged metadata.
+    const pushed: Question[] = [];
+    const localApi = fakeMessageAPI(messageApiLog);
+    sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits), localApi);
+    const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+
+    setupHookBridge(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        transcriptWatchers: transcriptWatchers as unknown as Map<
+          UUID,
+          import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+        >,
+        transcriptFallbackTimers,
+        autoApproveService: null, // no auto-approve -> escalate path
+        currentPort: () => 8765,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: tmpDir,
+        messageApi: localApi,
+        sendAndRecord: () => {},
+        tracker,
+      },
+    );
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-A',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subA.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-A',
+      agent_id: 'subagent-A',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Edit',
+      tool_input: { file_path: '/tmp/foo.ts' },
+      permission_suggestions: ['Yes', 'Always', 'No'],
+    });
+
+    // Hook recorded the question in the tracker (no push yet).
+    expect(tracker.hasPendingForTest()).toBe(true);
+    expect(pushed.length).toBe(0);
+
+    // PTY parser confirms the prompt is on the user's terminal.
+    tracker.onPTYPromptVisible({
+      id: generateId(),
+      text: 'Allow Edit: /tmp/foo.ts?',
+      options: [
+        { label: '1', value: '1', isRecommended: false, isYes: false, isNo: false },
+        { label: '2', value: '2', isRecommended: false, isYes: false, isNo: false },
+        { label: '3', value: '3', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    expect(pushed.length).toBe(1);
+    expect(pushed[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
+  });
+
+  test('Phase 4 wiring: subagent PermissionRequest with no PTY confirmation drops cleanly', async () => {
+    // Background subagent path: hook fires (agent_id set), no PTY emit
+    // because the user is not hot-switched into this subagent's view.
+    // The tracker holds the pending; a subsequent status transition
+    // (PostToolUse -> 'thinking') clears it. No push reaches iOS.
+    const pushed: Question[] = [];
+    const localApi = fakeMessageAPI(messageApiLog);
+    sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits), localApi);
+    const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+
+    setupHookBridge(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        transcriptWatchers: transcriptWatchers as unknown as Map<
+          UUID,
+          import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+        >,
+        transcriptFallbackTimers,
+        autoApproveService: null,
+        currentPort: () => 8765,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: tmpDir,
+        messageApi: localApi,
+        sendAndRecord: () => {},
+        tracker,
+      },
+    );
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-B',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subB.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-B',
+      agent_id: 'subagent-B',
+      agent_type: 'task',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    expect(tracker.hasPendingForTest()).toBe(true);
+    expect(pushed.length).toBe(0);
+
+    // Subagent finished without the user seeing the prompt (background).
+    hookServer.fire('PostToolUse', {
+      session_id: 'claude-sub-B',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      tool_response: { exit_code: 0 },
+    });
+
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(pushed.length).toBe(0);
+  });
+
+  test('Phase 4 wiring: subagent Notification(permission_prompt) records in tracker', async () => {
+    // Notification(permission_prompt) used to be dropped at the listener
+    // when agent_id was present. Under phase 4 it flows to the tracker
+    // just like its PermissionRequest sibling.
+    const { tracker } = build({ realTracker: true });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-N',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subN.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('Notification', {
+      session_id: 'claude-sub-N',
+      agent_id: 'subagent-N',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+
+    expect(tracker.hasPendingForTest()).toBe(true);
+  });
+
+  test('Phase 4 wiring: subagent PermissionRequest with auto-approve still injects normally', async () => {
+    // Pre-phase-4 this path returned early (dropped). Now it goes through
+    // auto-approve like a main-agent prompt. The push is suppressed
+    // structurally: inject succeeds, status flips to executing, tracker
+    // had no pending (handlePermissionRequest is only called via
+    // escalateToUser, which auto-approve never enters on the approve
+    // branch), so nothing pushes.
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-AA',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subAA.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-AA',
+      agent_id: 'subagent-AA',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(ptySubmits).toEqual(['1']);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1077,6 +1077,146 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual(['1']);
   });
 
+  test('Phase 4 wiring: subagent PermissionRequest + auto-approve deny injects "3"', async () => {
+    // Mirrors the approve case but on the deny branch. A refactor that
+    // accidentally routed deny to escalateToUser would break the
+    // non-hang guarantee for background subagents.
+    build({ autoApprove: true, autoApproveDecision: 'deny' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-deny',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subdeny.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-deny',
+      agent_id: 'subagent-deny',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(ptySubmits).toEqual(['3']);
+  });
+
+  test('Phase 4 wiring: escalate + active Task context default-denies (no hang)', async () => {
+    // PR #424 review pr-test-analyzer Gap 2 (criticality 8): when
+    // auto-approve cannot decide ('escalate') AND a Task tool call is
+    // open on the main session, the bridge must inject '3' rather than
+    // surface a question (the user can't answer a subagent's prompt
+    // visible only to the subagent). With the TOCTOU fix from this
+    // commit, the subagent context is read live in the .then(), so a
+    // Task that opens mid-eval is correctly caught.
+    build({ autoApprove: true, autoApproveDecision: 'escalate' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-esc-task',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'esctask.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    // Open a synchronous Task context.
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-esc-task',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'general-purpose', prompt: 'do stuff' },
+      tool_use_id: 'tu_task_esc',
+    });
+
+    // Subagent-internal Bash PermissionRequest (no agent_id; the
+    // Task-context safety net catches it).
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-esc-task',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(ptySubmits).toEqual(['3']);
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
+  test('Phase 4 wiring: autoApproveThrows + active Task context default-denies', async () => {
+    // PR #424 review pr-test-analyzer Gap 3 (criticality 7): the
+    // .catch() handler's `if (hookBridge.isInSubagentContext())` branch.
+    // A dropped guard would route the catch through escalateToUser
+    // instead of inject-deny, hanging the subagent.
+    build({ autoApprove: true, autoApproveThrows: true });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-thr-task',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'thrtask.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-thr-task',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: {},
+      tool_use_id: 'tu_task_thr',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-thr-task',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(ptySubmits).toEqual(['3']);
+  });
+
+  test('Phase 4 wiring: no auto-approve + active Task context default-denies', async () => {
+    // PR #424 review pr-test-analyzer #4 (criticality 6): the
+    // synchronous fallback `if (hookBridge.isInSubagentContext())` at
+    // the bottom of the listener (no autoApproveService case). Uses a
+    // Task context, not an agent_id-tagged event, so the
+    // SubagentContextTracker bookkeeping is what carries the gate.
+    build(); // no autoApprove
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-noaa-task',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'noaatask.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-noaa-task',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: {},
+      tool_use_id: 'tu_task_noaa',
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-noaa-task',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    expect(ptySubmits).toEqual(['3']);
+    expect(messageApiLog.questionCalls).toBe(0);
+  });
+
   // -------------------------------------------------------------------------
   // Issue #387: cancel stale auto-approve LLM eval on advance signals
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -409,8 +409,13 @@ describe('HookEventBridge', () => {
     });
   });
 
-  describe('subagent context filtering (issue #316)', () => {
-    it('suppresses PermissionRequest while inside a Task tool call', () => {
+  describe('subagent context filtering (issue #316, phase 4 #419)', () => {
+    it('forwards PermissionRequest during a Task tool call (tracker handles presence)', () => {
+      // Phase 4 (#419): the subagentContext drop in handlePermissionRequest
+      // is removed. The bridge now forwards every question; whether a push
+      // fires is decided by the QuestionPresenceTracker downstream, based
+      // on PTY confirmation. A hot-switched subagent view that renders
+      // a permission prompt on the user's PTY IS user-answerable.
       const { bridge, questions } = createBridge();
 
       // Main agent spawns subagent via Task
@@ -432,8 +437,9 @@ describe('HookEventBridge', () => {
         tool_input: { command: 'nmap --version' },
       } as PermissionRequestHookInput);
 
-      // User should NOT see this question
-      expect(questions).toHaveLength(0);
+      // Bridge forwards the question; the tracker (cli.ts wiring) gates push.
+      expect(questions).toHaveLength(1);
+      expect(questions[0]?.text).toContain('nmap --version');
 
       // Task completes; context exits
       bridge.handlePostToolUse({
@@ -447,7 +453,7 @@ describe('HookEventBridge', () => {
 
       expect(bridge.isInSubagentContext()).toBe(false);
 
-      // Now a real user-facing PermissionRequest SHOULD pass through
+      // Post-Task PermissionRequest passes through unchanged.
       bridge.handlePermissionRequest({
         ...makeCommon(),
         hook_event_name: 'PermissionRequest',
@@ -455,11 +461,14 @@ describe('HookEventBridge', () => {
         tool_input: { command: 'dig example.com' },
       } as PermissionRequestHookInput);
 
-      expect(questions).toHaveLength(1);
-      expect(questions[0]?.text).toContain('dig example.com');
+      expect(questions).toHaveLength(2);
+      expect(questions[1]?.text).toContain('dig example.com');
     });
 
-    it('suppresses Notification(permission_prompt) while in subagent context', () => {
+    it('forwards Notification(permission_prompt) during a Task tool call', () => {
+      // Mirror of the PermissionRequest test above. The bridge no longer
+      // drops Notification(permission_prompt) based on subagent context;
+      // the tracker collapses hook+PTY events into a single push.
       const { bridge, questions } = createBridge();
 
       bridge.handlePreToolUse({
@@ -470,7 +479,6 @@ describe('HookEventBridge', () => {
         tool_use_id: 'tu_1',
       } as PreToolUseHookInput);
 
-      // Notification(permission_prompt) that would fire during subagent work
       bridge.handleNotification({
         ...makeCommon(),
         hook_event_name: 'Notification',
@@ -478,7 +486,8 @@ describe('HookEventBridge', () => {
         message: 'Claude needs your permission to use Bash',
       } as NotificationHookInput);
 
-      expect(questions).toHaveLength(0);
+      expect(questions).toHaveLength(1);
+      expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
     });
 
     it('concurrent Task calls: context exits only when all complete', () => {
@@ -511,13 +520,17 @@ describe('HookEventBridge', () => {
 
       expect(bridge.isInSubagentContext()).toBe(true); // B still running
 
+      // Phase 4: PermissionRequest forwards even in subagent context; the
+      // tracker handles push gating downstream. This test now only
+      // verifies the subagentContext bookkeeping (reset semantics), not
+      // bridge-level suppression.
       bridge.handlePermissionRequest({
         ...makeCommon(),
         hook_event_name: 'PermissionRequest',
         tool_name: 'Bash',
         tool_input: { command: 'ls' },
       } as PermissionRequestHookInput);
-      expect(questions).toHaveLength(0);
+      expect(questions).toHaveLength(1);
 
       // Close B
       bridge.handlePostToolUse({

--- a/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
@@ -65,7 +65,11 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
 
     expect(bridge.isInSubagentContext()).toBe(true);
 
-    // Subagent's Bash PermissionRequest should now be suppressed
+    // Phase 4 (#419): PermissionRequest events during a Task tool call
+    // are no longer dropped at the bridge level. The tracker (cli.ts
+    // wiring) gates push by PTY presence. This test now asserts the
+    // bookkeeping: handlePermissionRequest forwards both events, and
+    // isInSubagentContext() tracks tool_use_id correctly.
     expect(
       await post(url, {
         hook_event_name: 'PermissionRequest',
@@ -78,7 +82,8 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
       }),
     ).toBe(200);
 
-    expect(questions).toHaveLength(0);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]?.text).toContain('nmap -sV');
 
     // PostToolUse(Task) with matching tool_use_id closes context
     expect(
@@ -97,7 +102,7 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
 
     expect(bridge.isInSubagentContext()).toBe(false);
 
-    // Now a real user-directed PermissionRequest should pass through
+    // Post-Task PermissionRequest still forwards.
     expect(
       await post(url, {
         hook_event_name: 'PermissionRequest',
@@ -110,14 +115,17 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
       }),
     ).toBe(200);
 
-    expect(questions).toHaveLength(1);
+    expect(questions).toHaveLength(2);
+    expect(questions[1]?.text).toContain('dig example.com');
   });
 
-  test('agent_id present: subagent PermissionRequest does not emit user question', async () => {
-    // Verified via REMI_HOOK_DEBUG 2026-04-16: Task/Agent subagents and team
-    // members tag their hook events with `agent_id`. Main events don't.
-    // This test models the cli.ts hook-server-level filter: bridge handler is
-    // not called for agent-tagged events.
+  test('Phase 4 (#419): subagent PermissionRequest with agent_id forwards to the bridge', async () => {
+    // Pre-phase-4 the cli.ts hook listener dropped events with agent_id
+    // set, suppressing user-visible questions for Task/Agent subagents.
+    // Phase 4 demoted agent_id to metadata: events forward to the
+    // bridge and the QuestionPresenceTracker (cli.ts) gates push by
+    // PTY presence. This test models the new cli.ts behavior: no
+    // listener-level drop, both events reach the bridge.
     const questions: Question[] = [];
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},
@@ -126,11 +134,7 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
     });
     server = new HookServer({ port: 0 });
     const h = bridge.hookHandlers();
-    // Simulate cli.ts: skip dispatch when agent_id is set.
-    server.on('PermissionRequest', (input) => {
-      if (typeof input.agent_id === 'string' && input.agent_id.length > 0) return;
-      h.onPermissionRequest?.(input);
-    });
+    server.on('PermissionRequest', (input) => h.onPermissionRequest?.(input));
     server.start();
     const url = `http://127.0.0.1:${server.port}/hooks`;
 
@@ -149,10 +153,12 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
       }),
     ).toBe(200);
 
-    // Must NOT emit a user-visible question
-    expect(questions).toHaveLength(0);
+    // Bridge forwarded the question; cli.ts wiring would route it to
+    // tracker.recordPendingHook (push only on PTY confirmation).
+    expect(questions).toHaveLength(1);
+    expect(questions[0]?.text).toContain('nmap --version');
 
-    // Main PermissionRequest (no agent_id) still passes through
+    // Main PermissionRequest (no agent_id) forwards too.
     expect(
       await post(url, {
         hook_event_name: 'PermissionRequest',
@@ -165,8 +171,8 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
       }),
     ).toBe(200);
 
-    expect(questions).toHaveLength(1);
-    expect(questions[0]?.text).toContain('dig example.com');
+    expect(questions).toHaveLength(2);
+    expect(questions[1]?.text).toContain('dig example.com');
   });
 
   test('PreToolUse without tool_use_id degrades gracefully (no context)', async () => {


### PR DESCRIPTION
## Summary

Phase 4 of epic #415 (already merged via PR #423). Was originally scoped inside the epic but deferred to ship the first three phases. Closes #419 and completes the epic.

Pre-phase-4, subagent-tagged events (\`agent_id\` set) were dropped at the listener boundary on the assumption that subagent prompts could not be answered by the user. That assumption is wrong under phase 3's PTY-presence model: a hot-switched subagent view IS the user's PTY, and the prompt IS answerable. Dropping the hook lost the rich tool/option metadata for that case.

\`QuestionPresenceTracker\` (phase 3) decides push by PTY presence, not by subagent tag. A subagent prompt visible on the user's terminal produces a push with full hook options; a background subagent's prompt produces no push (no PTY confirmation → tracker drops on status change).

## Changes

**\`hook-bridge-setup.ts\`:**
- Notification listener: drop the \`isSubagentEvent\` early-return
- PermissionRequest listener: drop the \`isSubagentEvent\` early-return

**\`hook-event-bridge.ts\`:**
- \`handleNotification\`: drop the \`subagentContext.isInSubagentContext()\` gate
- \`handlePermissionRequest\`: drop the matching subagentContext gate

**What stays (defense in depth):**
- The \`SubagentContextTracker\` class + Task tool_use_id bookkeeping (used via \`hookBridge.isInSubagentContext()\` in the auto-approve default-deny path, which still prevents hanging a subagent whose only escalation route is an unanswerable main-PTY prompt).
- \`isSubagentEvent\` on PreToolUse/PostToolUse/SessionStart listeners (about tool-use tracking correctness, not push gating).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check packages/daemon\` clean
- [x] \`bun test packages/daemon\`: **1654 pass / 0 fail** (+4 new wiring tests, ~5 existing tests with flipped assertions to match new contract)
- [x] 4 new acceptance tests in \`hook-bridge-setup.test.ts\`:
  - subagent PermissionRequest + PTY-visible prompt → push fires with merged hook options
  - subagent PermissionRequest + no PTY visibility + PostToolUse → tracker cleared, no push
  - subagent Notification(permission_prompt) records in tracker
  - subagent PermissionRequest + auto-approve approve → inject \`1\` normally
- [ ] Real-device APNS smoke after merge: hot-switched subagent prompt should produce a push; background subagent should not.

## Notes

- Targets \`develop\` directly (epic #415 already merged). Merge style: regular merge commit, NOT squash (per repo memory \`[no_squash_develop_main]\`).
- The 2 existing 'suppresses subagent...' tests in \`hook-event-bridge.test.ts\` were rewritten as 'forwards...' tests pinning the new contract.
- Net diff: ~300 insertions, ~70 deletions. Most of the addition is the new wiring tests.

Closes #419. Completes epic #415.