### PR TITLE
fix(auto-approve): object suggestions classifier + LLM re-engage + session lock adoption

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -49,12 +49,14 @@ export class QuestionPresenceTracker {
    *  user will see. */
   private pending: Question | null = null;
 
-  /** True between the most recent `onPTYPromptVisible` and the next
-   *  `onStatusChange` that leaves `'waiting'`. Consumed by the
-   *  auto-approve inject path to gate subagent injection: a background
-   *  subagent's permission prompt never renders on the main PTY, so
-   *  this flag stays false and the inject is dropped instead of
-   *  typing into the main agent's input. */
+  /** True while a permission prompt is on the main PTY. Set by
+   *  `onPTYPromptVisible`; reset by `onStatusChange` out of `'waiting'`
+   *  AND by `clearPending` (the auto-approve cancelled branch confirms
+   *  Claude advanced past the prompt without a status transition we can
+   *  observe). Consumed by the auto-approve inject path to gate subagent
+   *  injection: a background subagent's permission prompt never renders
+   *  on the main PTY, so this flag stays false and the inject is
+   *  dropped instead of typing into the main agent's input. */
   private ptyShowingQuestion = false;
 
   constructor(private readonly push: PushQuestion) {}
@@ -133,25 +135,26 @@ export class QuestionPresenceTracker {
   }
 
   /**
-   * Drop any pending hook record without firing a push. Used by the
-   * auto-approve cancelled branch where Claude has advanced past the
-   * prompt without a status transition we can observe — leaving the
-   * pending in place would merge stale option labels onto the NEXT
-   * unrelated prompt's PTY emit.
+   * Drop any pending hook record without firing a push, and clear the
+   * PTY-presence flag. Used by the auto-approve cancelled branch where
+   * Claude has advanced past the prompt without a status transition we
+   * can observe — leaving the pending in place would merge stale option
+   * labels onto the NEXT unrelated prompt, and leaving `ptyShowingQuestion`
+   * set would let the inject gate pass for a subagent prompt that arrives
+   * after the screen is already past the previous prompt.
    */
   clearPending(): void {
     this.pending = null;
+    this.ptyShowingQuestion = false;
   }
 
   /**
-   * True when the PTY parser has reported a permission prompt is on
-   * screen and no status transition since has cleared it. Used by the
-   * auto-approve inject path to gate subagent injection: only inject
-   * "1"/"3" when a prompt is actually visible to consume the input.
-   * A background subagent emits PermissionRequest hooks but its
-   * prompt never reaches the main PTY, so this stays false and the
-   * inject is dropped (caller falls through to escalateToUser, where
-   * the lack of PTY confirmation also prevents a spurious push).
+   * True when `onPTYPromptVisible` has fired and neither a non-`waiting`
+   * status transition nor `clearPending` has cleared it since. Auto-
+   * approve consumers MUST NOT inject PTY input for a subagent unless
+   * this returns true — a background subagent emits hooks but its
+   * prompt never reaches the main PTY, and injecting would type into
+   * the parent agent's input.
    */
   isPromptVisibleOnPTY(): boolean {
     return this.ptyShowingQuestion;

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -49,6 +49,14 @@ export class QuestionPresenceTracker {
    *  user will see. */
   private pending: Question | null = null;
 
+  /** True between the most recent `onPTYPromptVisible` and the next
+   *  `onStatusChange` that leaves `'waiting'`. Consumed by the
+   *  auto-approve inject path to gate subagent injection: a background
+   *  subagent's permission prompt never renders on the main PTY, so
+   *  this flag stays false and the inject is dropped instead of
+   *  typing into the main agent's input. */
+  private ptyShowingQuestion = false;
+
   constructor(private readonly push: PushQuestion) {}
 
   /**
@@ -101,6 +109,7 @@ export class QuestionPresenceTracker {
         ? { ...ptyQuestion, options: [...this.pending.options] }
         : ptyQuestion;
     this.pending = null;
+    this.ptyShowingQuestion = true;
     try {
       this.push(merged);
     } catch (err) {
@@ -119,6 +128,7 @@ export class QuestionPresenceTracker {
   onStatusChange(status: AgentStatus): void {
     if (status !== 'waiting') {
       this.pending = null;
+      this.ptyShowingQuestion = false;
     }
   }
 
@@ -131,6 +141,20 @@ export class QuestionPresenceTracker {
    */
   clearPending(): void {
     this.pending = null;
+  }
+
+  /**
+   * True when the PTY parser has reported a permission prompt is on
+   * screen and no status transition since has cleared it. Used by the
+   * auto-approve inject path to gate subagent injection: only inject
+   * "1"/"3" when a prompt is actually visible to consume the input.
+   * A background subagent emits PermissionRequest hooks but its
+   * prompt never reaches the main PTY, so this stays false and the
+   * inject is dropped (caller falls through to escalateToUser, where
+   * the lack of PTY confirmation also prevents a spurious push).
+   */
+  isPromptVisibleOnPTY(): boolean {
+    return this.ptyShowingQuestion;
   }
 
   /**

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -16,7 +16,9 @@
  *    cannot be expressed in the approve/deny mapping at all.
  * 3. String-label shape: any 2- or 3-label set whose labels are not all
  *    yes/no-shaped (matching the daemon's existing `isYes`/`isNo`
- *    heuristic at `hook-event-bridge.ts:240-241`) is multi-choice.
+ *    heuristic in `hook-event-bridge.ts`) is multi-choice. A single
+ *    non-binary string label is treated as multi-choice and routed to
+ *    escalate (no meaningful pick from a 1-item menu).
  *
  * Edit's real `["Yes", "Always", "No"]` shape is correctly classified as
  * binary because every label is yes-shaped or no-shaped under the same
@@ -73,6 +75,10 @@ export function isMultiChoicePermission(
   // UI shows the default Yes/Yes-always/No, so this is binary.
   if (stringLabels.length === 0) return false;
   if (stringLabels.length > 3) return true;
+  // 1-label edge case: only valid as binary if the single label is
+  // yes/no-shaped (a lone "Yes"). Anything else (e.g. ["Continue"])
+  // has no meaningful binary mapping and routes to multi-choice so
+  // the safe escalate path runs.
   // 2- or 3-label lists: binary only when every label is yes/no-shaped.
   return !stringLabels.every(isBinaryShapedLabel);
 }

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -2,20 +2,27 @@
  * Multi-choice permission detector and prompt builder (#399).
  *
  * A `PermissionRequest` is "multi-choice" when its `permission_suggestions`
- * cannot be answered by the binary approve/deny path. We classify by:
+ * lists pickable UI options that the binary approve/deny path cannot
+ * express. Classification considers only STRING entries — object entries
+ * (e.g. `{type:"addRules",...}`, `{type:"addDirectories",...}`,
+ * `{type:"setMode",...}`) are rule-suggestion metadata Claude Code attaches
+ * to a standard Yes/Yes-always/No prompt and are NOT pickable options.
+ * The classifier walks three rules:
  *
  * 1. Tool name. `ExitPlanMode` is always multi-choice: the user's intent
  *    (continue planning, accept plan, accept and stop asking) cannot be
  *    derived from tool input, so the LLM should never auto-pick.
- * 2. Option count > 3: a custom plugin tool with 4+ choices cannot be
- *    expressed in the approve/deny mapping at all.
- * 3. Label shape: any 2- or 3-option set whose labels are not all
+ * 2. String-label count > 3: a custom plugin tool with 4+ string choices
+ *    cannot be expressed in the approve/deny mapping at all.
+ * 3. String-label shape: any 2- or 3-label set whose labels are not all
  *    yes/no-shaped (matching the daemon's existing `isYes`/`isNo`
  *    heuristic at `hook-event-bridge.ts:240-241`) is multi-choice.
  *
  * Edit's real `["Yes", "Always", "No"]` shape is correctly classified as
  * binary because every label is yes-shaped or no-shaped under the same
- * heuristic the hook bridge already uses for option metadata.
+ * heuristic the hook bridge already uses for option metadata. A
+ * `[{type:"addRules",...}]` payload is binary because it carries zero
+ * string labels — the UI prompt is the default Yes/Yes-always/No.
  */
 
 import type { ChatMessage } from './llm-client.ts';
@@ -47,9 +54,11 @@ function isBinaryShapedLabel(label: string): boolean {
  * approve/deny path. Handles the three cases listed in the module doc.
  *
  * `permissionSuggestions` may be undefined (default 3-set substitutes)
- * or an array. Non-string entries cause the prompt to be classified as
- * multi-choice so the safe path (escalate or LLM with index validation)
- * runs instead of crashing on `.toLowerCase()`.
+ * or a mixed array of strings (pickable UI labels) and objects (typed
+ * rule-suggestion metadata such as `{type:"addRules",...}`). Only the
+ * STRING entries are pickable; object entries co-exist with the standard
+ * Yes/Yes-always/No prompt and must not flip the classification to
+ * multi-choice.
  */
 export function isMultiChoicePermission(
   toolName: string,
@@ -57,24 +66,37 @@ export function isMultiChoicePermission(
 ): boolean {
   if (ALWAYS_MULTI_CHOICE_TOOLS.has(toolName)) return true;
   if (!permissionSuggestions || permissionSuggestions.length === 0) return false;
-  if (permissionSuggestions.length > 3) return true;
-  // 2- or 3-option lists: binary only when every label is yes/no-shaped.
-  // Non-string entries fail the typeof check and route to multi-choice.
-  return !permissionSuggestions.every(
-    (label) => typeof label === 'string' && isBinaryShapedLabel(label),
+  const stringLabels = permissionSuggestions.filter(
+    (s): s is string => typeof s === 'string' && s.trim().length > 0,
   );
+  // Object-only payload (rule-suggestion metadata, no pickable labels):
+  // UI shows the default Yes/Yes-always/No, so this is binary.
+  if (stringLabels.length === 0) return false;
+  if (stringLabels.length > 3) return true;
+  // 2- or 3-label lists: binary only when every label is yes/no-shaped.
+  return !stringLabels.every(isBinaryShapedLabel);
 }
 
 const MULTI_CHOICE_SYSTEM_PROMPT = `You are a permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
 
 Claude Code is asking the user to PICK ONE option from a numbered list. Your job is to choose the most appropriate option, OR escalate to the user when you cannot decide confidently.
 
-CRITICAL RULES:
+ALWAYS ESCALATE — only the user can answer these:
+- Direction / planning / scope: "continue planning", "accept plan", "switch to phase 2", "narrow the scope to just X"
+- Design or architecture choices: "use library A vs B", "this approach vs that approach", "store it here vs there"
+- Steering or strategic intent: "should we proceed", "is this what you wanted", "ready to ship"
+- Any option whose effect is irreversible or has session-wide permanence (labels mentioning "always", "permanent", "for this session", "remember this")
+- Anything where two or more options are plausibly correct and the right pick depends on the user's goal
+
+PICK an option ONLY when:
+- One option is the clear routine default for this tool/input — the choice a careful developer makes on autopilot
+- The action is mechanical and reversible (e.g., picking the local mirror vs the remote one for a read-only fetch)
+- No option has design, scope, or directional consequences
+
+OTHER RULES:
 1. Read EVERY option carefully before deciding. Do not assume option 1 is always correct.
-2. When the choice involves direction, planning, scope, or strategic intent, ALWAYS escalate. Only the user knows the intent.
-3. Pick only when one option is clearly the routine, low-risk, expected default for the tool/input combination shown.
-4. When in doubt, escalate. It is better to ask the user than to commit to the wrong option.
-5. Indices are 1-based and must point to one of the listed options.
+2. When in doubt, escalate. It is always better to ask than to commit to the wrong option.
+3. Indices are 1-based and must point to one of the listed options.
 
 Respond with JSON ONLY. No markdown, no explanation outside JSON. Two valid shapes:
 

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -11,30 +11,35 @@ const SYSTEM_PROMPT = `You are a security-aware permission evaluator for Claude 
 
 Claude Code is requesting permission to use a tool. You must decide one of three actions:
 
-- "approve": The operation is clearly safe, read-only, or routine development work.
+- "approve": The operation is clearly safe, read-only, or a routine development action whose effects are reversible.
 - "deny": The operation is clearly dangerous, destructive, or should never be auto-approved.
-- "escalate": You are unsure, or the operation needs human judgment.
+- "escalate": You are unsure, or the operation needs human judgment (design, direction, scope, or irreversible side effects).
 
 CRITICAL RULES:
 1. When in doubt, ALWAYS escalate. It is better to ask the user than to approve something risky.
 2. Deny should be rare. Only deny clearly destructive operations. Prefer escalate over deny.
-3. Compound commands (chained with &&, ||, ;) should be evaluated as a whole. If ANY part is risky, escalate.
+3. Reversibility test: if the action's effect can be undone with a routine follow-up (delete a created file, revert a local edit, re-run a build), it leans APPROVE. If undoing requires git surgery, talking to a remote, restoring from backup, or is impossible, it leans ESCALATE.
+4. Compound commands (chained with &&, ||, ;, |) are evaluated as a whole. APPROVE only when every part is safe AND reversible. If ANY part is risky, irreversible, or unfamiliar, escalate.
+5. Design / direction / steering decisions always escalate. The LLM cannot infer user intent for "which approach", "which library", "what to name it", "should we proceed".
 
 DEFAULT GUIDELINES:
 
 APPROVE these operations:
 - Read/Glob/Grep: all file reads and searches
 - Bash: git status, git log, git diff, git branch, git show, git stash list
-- Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date
+- Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
 - Bash: package info (bun --version, node --version, etc.)
+- Bash: cd into a directory chained with any otherwise-approvable command (cd && ls, cd && git status)
+- Bash: writes to /tmp, $TMPDIR, or process-local scratch paths the agent can clean up
 
 ESCALATE these operations (ask the user):
-- Write/Edit: any file modifications
-- Bash: git add, git commit, git push, git checkout, git merge, git rebase
-- Bash: file creation, modification, or deletion
-- Bash: package install (bun add, npm install, pip install, etc.)
+- Write/Edit/NotebookEdit: any file modifications outside scratch paths
+- Bash: git add, git commit, git push, git checkout, git merge, git rebase, git reset
+- Bash: file creation, modification, or deletion under the project tree
+- Bash: package install (bun add, npm install, pip install, uv add, etc.)
+- Bash: anything that talks to a remote (curl POST, gh api with POST/PUT/DELETE, ssh)
 - Bash: any command you are not sure about
 - Any tool not listed above
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -109,20 +109,26 @@ export function setupHookBridge(
    * the hook-bridge's `claudeSessionId` closure was never updated from
    * the store, so `filterBySession` kept reading null and dropped every
    * hook for the entire session lifetime. This helper closes that gap:
-   * it adopts the stored value lazily on the next hook event after the
-   * fallback completes, switching from "drop everything because siblings
-   * exist" to "drop only events whose session_id != ours". Side effects
-   * are deliberately omitted (no log spam for steady-state hooks, no
-   * watcher restart) because the fallback already wired those up.
+   * each hook event re-reads the store and adopts the discovered id when
+   * it differs from the closure (initial adopt, or rotation after a
+   * /clear in the multi-wrapper case where hooks were never authoritative).
+   * Log only on change to avoid spam on steady-state hooks. Wrapped in
+   * try/catch so an EMFILE / permission flake on the sessions file does
+   * not propagate into the hook dispatch loop; on failure we leave the
+   * closure untouched (the existing sibling-guard path remains active).
    */
   const adoptLockFromStore = (): void => {
-    if (claudeSessionId !== null) return;
-    const stored = sessionStore.findByRemiSessionId(sessionId);
-    if (stored?.claudeSessionId) {
-      claudeSessionId = stored.claudeSessionId;
+    try {
+      const stored = sessionStore.findByRemiSessionId(sessionId);
+      const storedId = stored?.claudeSessionId ?? null;
+      if (storedId === null || storedId === claudeSessionId) return;
+      const previous = claudeSessionId;
+      claudeSessionId = storedId;
       log(
-        `[Hooks] Lock adopted from sessionStore (fallback discovery): claude=${claudeSessionId.slice(0, 8)}`,
+        `[Hooks] Lock ${previous === null ? 'adopted' : 'updated'} from sessionStore: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
       );
+    } catch (err) {
+      logError(`[Hooks] adoptLockFromStore failed: ${errorToString(err)}`);
     }
   };
 
@@ -509,24 +515,42 @@ export function setupHookBridge(
     // permissions only need '1' (approve) or '3' (deny); multi-choice picks
     // can land any index in the prompt's option range (#399).
     //
-    // PTY-presence gate (subagent-only): a background subagent (Task tool
-    // with agent_id set) emits PermissionRequest hooks for its own tool
-    // calls, but its prompts never render on the main PTY — only a
-    // hot-switched subagent view does. Without this gate, auto-approve
-    // would type "1"/"3" into the MAIN AGENT's input every time a
-    // background subagent asked for permission. Read-live so the
-    // hot-switched case (PTY has rendered the subagent prompt between
-    // the hook firing and the LLM eval returning) still injects.
-    const inject = async (value: string, reason: string): Promise<boolean> => {
+    // PTY-presence gate (subagent-only): a background subagent emits
+    // PermissionRequest hooks for its own tool calls, but its prompts
+    // never render on the main PTY — only a hot-switched subagent view
+    // does. Without this gate, auto-approve would type "1"/"3" into the
+    // MAIN AGENT's input every time a background subagent asked for
+    // permission.
+    //
+    // Detect subagent context two ways: (a) explicit `agent_id` on the
+    // hook event (Task tool with agent_id set), and (b)
+    // `hookBridge.isInSubagentContext()` (nested-Task tracker — the
+    // secondary safety net for legacy events without agent_id). Both
+    // are read at inject time, not captured, so the hot-switched case
+    // (PTY has rendered the subagent prompt between the hook firing
+    // and the LLM eval returning) still injects.
+    //
+    // Asymmetry: the default-deny path (subagent-escalate / subagent-
+    // error) passes `bypassSubagentPtyGate=true` to keep firing even
+    // without PTY confirmation, because the alternative is hanging the
+    // subagent indefinitely with no one to answer. That is a
+    // deliberately-different trade-off from the approve/deny/pick path,
+    // which falls through to escalateToUser when gated.
+    const inject = async (
+      value: string,
+      reason: string,
+      bypassSubagentPtyGate = false,
+    ): Promise<boolean> => {
       try {
         const session = sessionRegistry.getSession(sessionId);
         if (!session) {
           logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
           return false;
         }
-        if (isSubagentEvent(input) && !tracker.isPromptVisibleOnPTY()) {
+        const inSubagentContext = isSubagentEvent(input) || hookBridge.isInSubagentContext();
+        if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
           log(
-            `[AutoApprove ${sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type})`,
+            `[AutoApprove ${sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
           );
           return false;
         }
@@ -597,12 +621,15 @@ export function setupHookBridge(
             return;
           }
           // escalate: in a subagent context, default-deny to avoid hanging
-          // the subagent. The user could not answer it anyway.
+          // the subagent. The user could not answer it anyway. Bypass the
+          // subagent PTY gate (`bypassSubagentPtyGate=true`) because the
+          // alternative is letting the subagent hang forever; typing '3'
+          // into the parent PTY is accepted as the lesser evil here. The
+          // approve/deny/pick branches above use the gate because they
+          // have a fallback (escalateToUser); this branch does not.
           if (hookBridge.isInSubagentContext()) {
             log(`[AutoApprove ${sessionTag}] Subagent context; escalate->deny to prevent hang`);
-            // If inject fails, the subagent is hung regardless (no main
-            // PTY to escalate to). Log and accept.
-            await inject('3', 'subagent-escalate-default-deny');
+            await inject('3', 'subagent-escalate-default-deny', true);
             return;
           }
           escalateToUser();
@@ -612,7 +639,7 @@ export function setupHookBridge(
           try {
             logError(`[AutoApprove ${sessionTag}] Unexpected error:`, err);
             if (hookBridge.isInSubagentContext()) {
-              await inject('3', 'subagent-error-default-deny');
+              await inject('3', 'subagent-error-default-deny', true);
               return;
             }
             escalateToUser();
@@ -630,7 +657,7 @@ export function setupHookBridge(
     // helps a future maintainer.
     if (hookBridge.isInSubagentContext()) {
       log(`[${sessionTag}] Subagent context without auto-approve; default-deny`);
-      inject('3', 'subagent-no-aa-default-deny').catch((err) => {
+      inject('3', 'subagent-no-aa-default-deny', true).catch((err) => {
         logError(`[${sessionTag}] Failed to inject default-deny:`, err);
       });
       return;

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -467,17 +467,33 @@ export function setupHookBridge(
     const sessionTag = sessionId.slice(0, 8);
 
     // Inject an answer into the PTY. Returns true on success. On failure
-    // (session missing, PTY not running, submitInput throws) it logs and
-    // returns false so callers can fall back to escalating the prompt.
+    // (session missing, PTY not running, submitInput throws, subagent
+    // off-screen gate trips) it logs and returns false so callers can
+    // fall back to escalating the prompt.
     //
     // Value is a 1-based numeric option index serialised as a string. Most
     // permissions only need '1' (approve) or '3' (deny); multi-choice picks
     // can land any index in the prompt's option range (#399).
+    //
+    // PTY-presence gate (subagent-only): a background subagent (Task tool
+    // with agent_id set) emits PermissionRequest hooks for its own tool
+    // calls, but its prompts never render on the main PTY — only a
+    // hot-switched subagent view does. Without this gate, auto-approve
+    // would type "1"/"3" into the MAIN AGENT's input every time a
+    // background subagent asked for permission. Read-live so the
+    // hot-switched case (PTY has rendered the subagent prompt between
+    // the hook firing and the LLM eval returning) still injects.
     const inject = async (value: string, reason: string): Promise<boolean> => {
       try {
         const session = sessionRegistry.getSession(sessionId);
         if (!session) {
           logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
+          return false;
+        }
+        if (isSubagentEvent(input) && !tracker.isPromptVisibleOnPTY()) {
+          log(
+            `[AutoApprove ${sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type})`,
+          );
           return false;
         }
         await session.pty.submitInput(value);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -99,6 +99,33 @@ export function setupHookBridge(
   // Before SessionStart fires, we let events through (claudeSessionId is null).
   let claudeSessionId: string | null = null;
 
+  /**
+   * When `hasSiblingInDir()` is true (multiple Remi wrappers in the same
+   * project directory) the hook-event-based locking path defers to the
+   * filesystem fallback in transcript-fallback.ts, which discovers our
+   * own Claude session ID by looking at `~/.claude/projects/<dir>/` and
+   * excluding sibling-claimed transcripts. The fallback writes the
+   * discovered id to `sessionStore.updateClaudeSessionId(...)` — but
+   * the hook-bridge's `claudeSessionId` closure was never updated from
+   * the store, so `filterBySession` kept reading null and dropped every
+   * hook for the entire session lifetime. This helper closes that gap:
+   * it adopts the stored value lazily on the next hook event after the
+   * fallback completes, switching from "drop everything because siblings
+   * exist" to "drop only events whose session_id != ours". Side effects
+   * are deliberately omitted (no log spam for steady-state hooks, no
+   * watcher restart) because the fallback already wired those up.
+   */
+  const adoptLockFromStore = (): void => {
+    if (claudeSessionId !== null) return;
+    const stored = sessionStore.findByRemiSessionId(sessionId);
+    if (stored?.claudeSessionId) {
+      claudeSessionId = stored.claudeSessionId;
+      log(
+        `[Hooks] Lock adopted from sessionStore (fallback discovery): claude=${claudeSessionId.slice(0, 8)}`,
+      );
+    }
+  };
+
   // Our PTY is the ground truth for "main interactive session". A hook event
   // with a different session_id is NEVER our main:
   //  - Subagent spawn (TaskCreate/TeamCreate), different session_id, no own PTY
@@ -199,6 +226,12 @@ export function setupHookBridge(
     hook_event_name?: string;
   }): void {
     if (!input.session_id) return;
+
+    // If the transcript-fallback has already discovered our Claude
+    // session ID (the multi-wrapper-in-same-dir case), adopt it before
+    // classifying so the classifier sees the right currentLock instead
+    // of a stale null.
+    adoptLockFromStore();
 
     const classification = classifySessionEvent({
       currentLock: claudeSessionId,
@@ -357,6 +390,7 @@ export function setupHookBridge(
   // is known, block events when siblings exist (they could be from the
   // sibling's Claude).
   const filterBySession = (input: { session_id?: string }): boolean => {
+    adoptLockFromStore();
     if (claudeSessionId) return input.session_id === claudeSessionId;
     return !hasSiblingInDir();
   };

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -213,6 +213,22 @@ describe('QuestionPresenceTracker', () => {
     expect(pushes.length).toBe(0);
   });
 
+  it('clearPending — also resets ptyShowingQuestion so the inject gate cannot leak', () => {
+    // Sequence: PTY confirms a prompt (flag=true) -> auto-approve eval
+    // returns 'cancelled' (Claude advanced past the prompt) -> bridge
+    // calls clearPending. Without resetting ptyShowingQuestion, the very
+    // next subagent PermissionRequest arriving before any onStatusChange
+    // would find the gate open and inject "1"/"3" into a PTY that is no
+    // longer showing a prompt.
+    const tracker = new QuestionPresenceTracker(() => {});
+    tracker.onPTYPromptVisible(makePTYQuestion());
+    expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+
+    tracker.clearPending();
+
+    expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+  });
+
   it('push sink throws — error is caught, tracker stays in a clean state', () => {
     // APNS fan-out or WebSocket send can throw mid-push. The tracker
     // must not crash the daemon process; log and move on. Pending is

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -227,4 +227,53 @@ describe('QuestionPresenceTracker', () => {
     expect(() => tracker.onPTYPromptVisible(ptyQ)).not.toThrow();
     expect(tracker.hasPendingForTest()).toBe(false);
   });
+
+  describe('isPromptVisibleOnPTY (subagent auto-approve gate)', () => {
+    it('starts false before any PTY confirmation', () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+
+    it('stays false when only a hook has recorded — PTY has not confirmed yet', () => {
+      // Background subagent fires PermissionRequest; LLM eval is running;
+      // the prompt is NOT on the main PTY. The gate must report false so
+      // hook-bridge-setup drops the inject instead of typing "1" into
+      // the main agent's input.
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.recordPendingHook(makeHookQuestion('Bash'));
+      expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+
+    it('flips to true once PTY confirms a prompt is on screen', () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.onPTYPromptVisible(makePTYQuestion());
+      expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+    });
+
+    it('flips back to false when status leaves waiting (prompt consumed)', () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.onPTYPromptVisible(makePTYQuestion());
+      expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+      tracker.onStatusChange('executing');
+      expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+
+    it("stays true while status stays 'waiting'", () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.onPTYPromptVisible(makePTYQuestion());
+      tracker.onStatusChange('waiting');
+      expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+    });
+
+    it('also flips false on transition to thinking or idle', () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.onPTYPromptVisible(makePTYQuestion());
+      tracker.onStatusChange('thinking');
+      expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+
+      tracker.onPTYPromptVisible(makePTYQuestion());
+      tracker.onStatusChange('idle');
+      expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -259,9 +259,12 @@ describe('AutoApproveService - error handling', () => {
   });
 
   test('evaluate-mode index-mismatch guard escalates without calling the LLM', async () => {
-    // permission_suggestions = ['Yes', {}, 'No']: empty object drops in
-    // normalisation -> normalisedSuggestions=['Yes','No'] (length 2) while
-    // raw length stays 3. The LLM's pick index would address the
+    // permission_suggestions = ['Save', 'Discard', {}]: 2 non-binary string
+    // labels route to multi-choice (after the object-only fix, the bare
+    // `{}` is not enough on its own — we need real picky labels). In
+    // evaluate mode, the empty object drops in normalisation, so
+    // normalisedSuggestions=['Save','Discard'] (length 2) while the raw
+    // array length stays 3. The LLM's pick index would address the
     // normalised list but inject() sends it to the PTY, which interprets
     // against the original positions. Escalating before any LLM call is
     // the only safe path. `base_url` points at a black hole so a missed
@@ -277,10 +280,10 @@ describe('AutoApproveService - error handling', () => {
       (msg) => callLogs.push(msg),
     );
     const start = Date.now();
-    const result = await service.evaluate('Bash', { command: 'ls' }, undefined, [
-      'Yes',
+    const result = await service.evaluate('CustomTool', { x: 1 }, undefined, [
+      'Save',
+      'Discard',
       {} as unknown,
-      'No',
     ]);
     expect(result.decision).toBe('escalate');
     expect(result.reasoning).toContain('unreadable entries');
@@ -1118,6 +1121,12 @@ describe('AutoApproveService - multichoice regression guards', () => {
   });
 
   test('non-string entries in permission_suggestions do not crash', async () => {
+    // Garbage entries (null, raw objects) co-exist with picky labels.
+    // The string subset ['Maybe', 'Yes', 'No'] has a non-binary label
+    // ('Maybe') → multi-choice → skip mode short-circuits to escalate
+    // before any LLM call. The test pins that the classifier ignores
+    // non-string entries (rather than crashing on .toLowerCase()) AND
+    // that classification reads the string subset, not the raw length.
     const service = new AutoApproveService(
       makeConfig({ base_url: 'http://10.255.255.1', timeout: 60 }),
       logFn,
@@ -1127,9 +1136,61 @@ describe('AutoApproveService - multichoice regression guards', () => {
       { x: 1 },
       undefined,
       // biome-ignore lint/suspicious/noExplicitAny: defensive test
-      [null, 'Yes', { weird: true }] as any,
+      [null, 'Maybe', 'Yes', { weird: true }, 'No'] as any,
     );
-    // Routed to multi-choice (skip mode) → escalate without crash.
     expect(result.decision).toBe('escalate');
+    expect(result.reasoning).toContain('multi-choice prompt');
+  });
+
+  test('object-only permission_suggestions stay on the binary path (regression #424.dev3)', async () => {
+    // Claude Code attaches typed `addRules` / `addDirectories` /
+    // `setMode` objects to standard Bash prompts. They are
+    // rule-suggestion metadata, NOT pickable UI options — the user
+    // still sees Yes/Yes-always/No. Classifying as multi-choice +
+    // default `multichoice = "skip"` silently escalated every Bash
+    // command after PR #421. This test pins the binary route.
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname === '/chat/completions') {
+          return new Response(
+            JSON.stringify({
+              model: 'fake-model',
+              choices: [
+                { message: { content: '{"decision":"approve","reasoning":"git status is safe"}' } },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+    try {
+      const service = new AutoApproveService(
+        makeConfig({
+          provider: `http://127.0.0.1:${server.port}`,
+          base_url: `http://127.0.0.1:${server.port}`,
+          timeout: 5,
+          // multichoice = 'skip' is default; a regression would
+          // short-circuit to escalate without hitting the LLM.
+        }),
+        logFn,
+      );
+      const result = await service.evaluate('Bash', { command: 'git status' }, undefined, [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Bash', ruleContent: 'git status' }],
+          behavior: 'allow',
+          destination: 'localSettings',
+        },
+      ] as readonly unknown[]);
+      expect(result.decision).toBe('approve');
+      if (result.decision !== 'cancelled') {
+        expect(result.reasoning).not.toContain('multi-choice');
+      }
+    } finally {
+      server.stop();
+    }
   });
 });

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -71,18 +71,25 @@ describe('isMultiChoicePermission', () => {
     expect(isMultiChoicePermission('CustomTool', ['Yes', 'Maybe later', 'No'])).toBe(true);
   });
 
-  test('returns true for non-string entries (defensive against schema drift)', () => {
-    // permission_suggestions with garbage entries must NOT crash on
-    // .toLowerCase(). Routing to multi-choice is the safe path; the
-    // service does its own strict filter before any LLM call.
-    expect(isMultiChoicePermission('Bash', [null, 'Yes', 'No'] as readonly unknown[])).toBe(true);
-    expect(isMultiChoicePermission('Bash', [{}, 1] as readonly unknown[])).toBe(true);
+  test('ignores non-string entries when classifying around real string labels', () => {
+    // Garbage entries (null, raw numbers, bare objects) carry no
+    // pickable label. Classification reads only the string subset, so
+    // ['Yes', 'No'] plus a stray null is still binary. Defensive against
+    // schema drift without flipping every real Claude Code prompt into
+    // an unconditional escalate.
+    expect(isMultiChoicePermission('Bash', [null, 'Yes', 'No'] as readonly unknown[])).toBe(false);
+    // No string labels at all -> default UI options (Yes/Yes-always/No)
+    // -> binary.
+    expect(isMultiChoicePermission('Bash', [{}, 1] as readonly unknown[])).toBe(false);
   });
 
-  test('returns true for the typed-object addDirectories shape', () => {
-    // Concrete shape observed live from Claude Code (2026-05-13).
-    // Locks the classifier so a future change adding a string-only fast
-    // path cannot regress this case into a silent binary route.
+  test('returns false for object-only rule-suggestion metadata (the regression fix)', () => {
+    // Concrete shapes observed live from Claude Code (2026-05-13 onwards).
+    // These are typed rule suggestions Claude Code attaches to a normal
+    // Bash permission prompt; the user still sees the standard
+    // Yes/Yes-always/No UI. Classifying them as multi-choice + the
+    // default `multichoice = "skip"` regresses every Bash auto-approve
+    // into a silent escalate. Lock the binary route.
     expect(
       isMultiChoicePermission('Bash', [
         {
@@ -91,13 +98,33 @@ describe('isMultiChoicePermission', () => {
           destination: 'session',
         },
       ] as readonly unknown[]),
-    ).toBe(true);
-  });
-
-  test('returns true for the typed-object setMode shape', () => {
+    ).toBe(false);
     expect(
       isMultiChoicePermission('Bash', [
         { type: 'setMode', mode: 'bypassPermissions', destination: 'session' },
+      ] as readonly unknown[]),
+    ).toBe(false);
+    expect(
+      isMultiChoicePermission('Bash', [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Bash', ruleContent: 'rm -rf derivatives/preproc/sub-NDARAA948VFH' }],
+          behavior: 'allow',
+          destination: 'localSettings',
+        },
+      ] as readonly unknown[]),
+    ).toBe(false);
+  });
+
+  test('returns true when 4+ STRING labels are present alongside object metadata', () => {
+    // Mixed payload with enough real labels to overflow the binary path.
+    expect(
+      isMultiChoicePermission('CustomTool', [
+        'Refactor',
+        'Patch',
+        'Rewrite',
+        'Skip',
+        { type: 'addRules', rules: [], behavior: 'allow', destination: 'session' },
       ] as readonly unknown[]),
     ).toBe(true);
   });
@@ -141,6 +168,29 @@ describe('buildMultiChoicePrompt', () => {
     const user = messages[1] as { content: string };
     expect(user.content.length).toBeLessThan(2500);
     expect(user.content).toContain('...');
+  });
+
+  test('system prompt makes the design/direction/steering escalate rule explicit', () => {
+    // The prompt must steer the LLM away from picking on direction,
+    // design, scope, or steering questions. Locks the rule so a future
+    // prompt rewrite cannot quietly drop it.
+    const messages = buildMultiChoicePrompt('ExitPlanMode', {}, ['A', 'B']);
+    const system = messages[0] as { content: string };
+    const lower = system.content.toLowerCase();
+    expect(lower).toContain('always escalate');
+    expect(lower).toContain('direction');
+    expect(lower).toContain('design');
+    expect(lower).toContain('scope');
+  });
+
+  test('system prompt flags irreversible/permanent options as escalate', () => {
+    // Options that mention "always", "permanent", or session-wide
+    // commitment must escalate. Locks the rule.
+    const messages = buildMultiChoicePrompt('ExitPlanMode', {}, ['A', 'B']);
+    const system = messages[0] as { content: string };
+    const lower = system.content.toLowerCase();
+    expect(lower).toContain('irreversible');
+    expect(lower).toContain('always');
   });
 });
 

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -128,6 +128,30 @@ describe('isMultiChoicePermission', () => {
       ] as readonly unknown[]),
     ).toBe(true);
   });
+
+  test('single non-binary string label (with or without objects) routes to multi-choice', () => {
+    // A 1-option string label has no meaningful binary mapping and must
+    // route to multi-choice so the safe escalate path runs. The LLM's
+    // ALWAYS-ESCALATE rules then prevent a nonsensical pick from a
+    // 1-item menu. Without this property, a future Claude Code payload
+    // like `["Continue"]` would slip into the binary path.
+    expect(isMultiChoicePermission('CustomTool', ['Continue'])).toBe(true);
+    // Mixed with rule-suggestion objects — same outcome.
+    expect(
+      isMultiChoicePermission('CustomTool', [
+        { type: 'addRules', rules: [], behavior: 'allow', destination: 'session' },
+        'Continue',
+      ] as readonly unknown[]),
+    ).toBe(true);
+  });
+
+  test('single yes-shaped string label is still binary (degenerate but well-defined)', () => {
+    // Lone "Yes" — degenerate prompt with no negative option — still
+    // classifies as binary because the existing isYes/isNo heuristic
+    // covers it. Locked in to document the boundary between this and
+    // the previous test.
+    expect(isMultiChoicePermission('CustomTool', ['Yes'])).toBe(false);
+  });
 });
 
 describe('buildMultiChoicePrompt', () => {

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -65,4 +65,28 @@ describe('buildPrompt', () => {
     expect(defaultIdx).toBeGreaterThanOrEqual(0);
     expect(userIdx).toBeGreaterThan(defaultIdx);
   });
+
+  test('system prompt states the reversibility rule', () => {
+    // Locks the rule the user asked for: reversible side effects can
+    // approve; irreversible side effects escalate. Without this, the
+    // model has no principled way to decide on routine compound commands.
+    const [system] = buildPrompt('Bash', { command: 'cd /tmp && ls' });
+    expect(system?.content.toLowerCase()).toContain('reversib');
+  });
+
+  test('system prompt states the design/direction/steering rule', () => {
+    // Design/scope/steering questions must always escalate — the model
+    // cannot infer user intent for these.
+    const [system] = buildPrompt('Bash', { command: 'ls' });
+    const lower = system?.content.toLowerCase() ?? '';
+    expect(lower).toContain('design');
+    expect(lower).toContain('direction');
+  });
+
+  test('system prompt evaluates compound commands as a whole', () => {
+    // Compound commands (&&, ||, ;, |) must be evaluated as one
+    // unit; one risky part escalates the whole chain.
+    const [system] = buildPrompt('Bash', { command: 'ls && cat foo' });
+    expect(system?.content).toContain('Compound commands');
+  });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -302,6 +302,48 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual(['1']);
   });
 
+  test('PTY gate covers legacy subagents: nested-Task PermissionRequest WITHOUT agent_id is dropped when no PTY presence', async () => {
+    // The agent_id-based detector misses legacy Claude Code versions and any
+    // future flows where the subagent hook fires without agent_id. The
+    // secondary safety net is `hookBridge.isInSubagentContext()` (PreToolUse
+    // Task with tool_use_id increments the tracker; PostToolUse decrements).
+    // Inject must consult BOTH detectors; otherwise a nested Bash hook with
+    // no agent_id would inject into the parent agent's PTY input.
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-nested-1',
+      transcript_path: path.join(tmpDir, 'nested.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    // Engage nested-Task subagent context (no agent_id, just Task spawn).
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-nested-1',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_use_id: 'task-use-1',
+      tool_input: { prompt: 'nested work' },
+    });
+
+    // PermissionRequest fires from inside the Task: NO agent_id (legacy
+    // path), but isInSubagentContext() is true and PTY has not confirmed
+    // any prompt is on screen.
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-nested-1',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Pre-fix the inject would have typed '1' into the parent PTY because
+    // isSubagentEvent was false. Post-fix the OR gate trips on
+    // isInSubagentContext() and the inject is skipped.
+    expect(ptySubmits).toEqual([]);
+  });
+
   test('PermissionRequest with auto-approve APPROVE injects "1" (status: executing)', async () => {
     build({ autoApprove: true });
 
@@ -537,6 +579,133 @@ describe('setupHookBridge', () => {
       setTimeout(() => {
         // No inject — filterBySession matched on the adopted lock and
         // dropped the foreign event.
+        expect(ptySubmits).toEqual([]);
+        resolve();
+      }, 50);
+    });
+  });
+
+  test('sibling-in-dir + sessionStore rotation: adoptLockFromStore re-adopts the new claudeSessionId', () => {
+    // After initial adoption from sessionStore (claude-A), the user runs
+    // /clear in the sibling-wrapper scenario. The transcript-fallback
+    // rediscovers and writes claude-B to the store. The hook-bridge MUST
+    // pick up the rotation; pre-fix, the `if (claudeSessionId !== null)
+    // return` short-circuit blocked the re-read and every hook for
+    // claude-B was silently dropped.
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(liveSessionsRegistry.dirPath, 'sibling-rotate.json'),
+      JSON.stringify({
+        sessionId: 'sibling-session-id-rotate',
+        pid: process.pid,
+        wsPort: 18997,
+        hookPort: 18003,
+        projectPath: tmpDir,
+        name: 'sibling-rotate',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    sessionStore.save({
+      remiSessionId: SID,
+      claudeSessionId: 'claude-A-initial',
+      projectPath: tmpDir,
+      port: 8765,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    // Initial adoption: hook for claude-A passes the filter.
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-A-initial',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(ptySubmits).toEqual(['1']);
+
+        // Fallback rediscovers after /clear and writes the new id.
+        sessionStore.save({
+          remiSessionId: SID,
+          claudeSessionId: 'claude-B-rotated',
+          projectPath: tmpDir,
+          port: 8765,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          exitedAt: null,
+          exitCode: null,
+        });
+
+        // Hook for claude-B arrives. Lock must rotate; otherwise filterBySession
+        // sees claudeSessionId='claude-A-initial' and drops the event.
+        hookServer.fire('PermissionRequest', {
+          session_id: 'claude-B-rotated',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'pwd' },
+        });
+
+        setTimeout(() => {
+          expect(ptySubmits).toEqual(['1', '1']);
+          resolve();
+        }, 50);
+      }, 50);
+    });
+  });
+
+  test('adoptLockFromStore catches sessionStore throws and keeps the daemon running', () => {
+    // EMFILE / permissions / mid-write JSON.parse failures inside
+    // sessionStore.read can throw out of findByRemiSessionId. Pre-fix
+    // those propagated into the hook dispatch loop. The try/catch wrapper
+    // must contain them: log via logError and fall through to the
+    // existing sibling-guard path (claudeSessionId stays null, hooks
+    // drop until siblings clear).
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(liveSessionsRegistry.dirPath, 'sibling-throw.json'),
+      JSON.stringify({
+        sessionId: 'sibling-session-id-throw',
+        pid: process.pid,
+        wsPort: 18996,
+        hookPort: 18004,
+        projectPath: tmpDir,
+        name: 'sibling-throw',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    // Replace findByRemiSessionId with one that throws to simulate
+    // EMFILE-class failures from fs.readFileSync inside SessionStore.read.
+    sessionStore.findByRemiSessionId = () => {
+      throw Object.assign(new Error('test: EMFILE'), { code: 'EMFILE' });
+    };
+
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    // Fire a hook — this triggers adoptLockFromStore which would throw.
+    // We expect the hook dispatch to survive (no thrown exception, hook
+    // is filtered out because the closure remains null + sibling present).
+    expect(() =>
+      hookServer.fire('PermissionRequest', {
+        session_id: 'claude-throw-test',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      }),
+    ).not.toThrow();
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // No inject — sibling is present and adoptLockFromStore could not
+        // resolve a lock, so filterBySession's `!hasSiblingInDir()` arm
+        // returns false. The daemon stays alive instead of crashing.
         expect(ptySubmits).toEqual([]);
         resolve();
       }, 50);

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -263,20 +263,29 @@ describe('setupHookBridge', () => {
     expect(() => build()).not.toThrow();
   });
 
-  test('Phase 4 (#419): PermissionRequest with agent_id is forwarded through auto-approve', async () => {
+  test('Phase 4 (#419): PermissionRequest with agent_id is forwarded through auto-approve, gated by PTY presence', async () => {
     // Pre-phase-4, agent_id-tagged events were dropped at the listener
     // boundary. Phase 4 demoted agent_id from kill-switch to metadata:
-    // the auto-approve LLM evaluates and injects just like a main-agent
-    // event. The push to iOS is still gated by PTY presence downstream,
-    // so a background subagent's auto-approved permission silently
-    // executes; a hot-switched subagent's prompt would surface via the
-    // tracker's PTY confirmation path.
-    build({ autoApprove: true, autoApproveDecision: 'approve' });
+    // the auto-approve LLM evaluates and forwards to the inject path.
+    // Inject is then gated by tracker.isPromptVisibleOnPTY() — true for
+    // a hot-switched subagent view, false for a background subagent.
+    // This test simulates the hot-switched case (PTY confirms presence)
+    // so inject proceeds end to end.
+    const { tracker } = build({ autoApprove: true, autoApproveDecision: 'approve' });
 
     hookServer.fire('SessionStart', {
       session_id: 'claude-sub-123',
       transcript_path: path.join(tmpDir, 'sub.jsonl'),
       hook_event_name: 'SessionStart',
+    });
+
+    // PTY rendered the subagent's prompt on the user's screen.
+    tracker.onPTYPromptVisible({
+      id: 'pty-pr1',
+      text: 'Allow Bash?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1046,13 +1055,17 @@ describe('setupHookBridge', () => {
     expect(tracker.hasPendingForTest()).toBe(true);
   });
 
-  test('Phase 4 wiring: subagent PermissionRequest with auto-approve still injects normally', async () => {
-    // Pre-phase-4 this path returned early (dropped). Now it goes through
-    // auto-approve like a main-agent prompt. The push is suppressed
-    // structurally: inject succeeds, status flips to executing, tracker
-    // had no pending (handlePermissionRequest is only called via
-    // escalateToUser, which auto-approve never enters on the approve
-    // branch), so nothing pushes.
+  test('subagent PermissionRequest with no PTY-visible prompt: inject is dropped, fallback escalates', async () => {
+    // Regression guard for the dev.3 misfiring: a background subagent's
+    // PermissionRequest cannot answer by injecting into the MAIN PTY
+    // because the subagent's prompt isn't there — "1" would land in the
+    // main agent's input. inject() must gate on
+    // tracker.isPromptVisibleOnPTY(); when false (no PTY confirmation),
+    // it returns false so the approve branch falls through to
+    // escalateToUser, which records into the tracker. The PassthroughTracker
+    // collapses that into a push (one question call). In production the
+    // real tracker would wait for PTY confirmation that never arrives →
+    // pending dropped on next status change → no spurious push.
     build({ autoApprove: true, autoApproveDecision: 'approve' });
 
     hookServer.fire('SessionStart', {
@@ -1074,13 +1087,56 @@ describe('setupHookBridge', () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
+    // Inject was gated → no submit. Escalation fires → one question call.
+    expect(ptySubmits).toEqual([]);
+    expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('subagent PermissionRequest with PTY-visible prompt (hot-switched view) still injects', async () => {
+    // Preserves PR #419's hot-switched-subagent case: when the user
+    // has switched to the subagent's view, its permission prompt IS
+    // rendered on the main PTY. Simulate that by firing
+    // onPTYPromptVisible BEFORE the PermissionRequest so the tracker's
+    // ptyShowingQuestion flag is true when inject's gate checks it.
+    const { tracker } = build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-hot',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subhot.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    // PTY rendered the subagent's prompt on the user's screen.
+    tracker.onPTYPromptVisible({
+      id: 'pty-q-1',
+      text: 'Allow Bash?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-hot',
+      agent_id: 'subagent-hot',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
     expect(ptySubmits).toEqual(['1']);
   });
 
-  test('Phase 4 wiring: subagent PermissionRequest + auto-approve deny injects "3"', async () => {
-    // Mirrors the approve case but on the deny branch. A refactor that
-    // accidentally routed deny to escalateToUser would break the
-    // non-hang guarantee for background subagents.
+  test('subagent PermissionRequest + auto-approve deny with no PTY presence: inject dropped, escalates', async () => {
+    // Mirrors the approve case for the deny branch — same gate, same
+    // fallthrough. The non-hang guarantee for background subagents is
+    // now structural: with no PTY presence the subagent has no answerable
+    // prompt to hang on (the inject never could have reached it), so
+    // dropping is correct.
     build({ autoApprove: true, autoApproveDecision: 'deny' });
 
     hookServer.fire('SessionStart', {
@@ -1094,6 +1150,40 @@ describe('setupHookBridge', () => {
     hookServer.fire('PermissionRequest', {
       session_id: 'claude-sub-deny',
       agent_id: 'subagent-deny',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(ptySubmits).toEqual([]);
+    expect(messageApiLog.questionCalls).toBe(1);
+  });
+
+  test('subagent PermissionRequest + auto-approve deny with PTY-visible prompt injects "3"', async () => {
+    const { tracker } = build({ autoApprove: true, autoApproveDecision: 'deny' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-sub-deny-hot',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'subdenyhot.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    tracker.onPTYPromptVisible({
+      id: 'pty-q-2',
+      text: 'Allow Bash: rm -rf /?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sub-deny-hot',
+      agent_id: 'subagent-deny-hot',
       agent_type: 'general-purpose',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -426,6 +426,123 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.statusCalls).toContain('executing');
   });
 
+  test('sibling-in-dir + fallback-discovered claudeSessionId: lock adopted from sessionStore on next hook', () => {
+    // The dev.3 inconsistency the user hit: when 2+ Remi wrappers share a
+    // project directory, hasSiblingInDir() defers hook-event-based locking
+    // to the transcript-fallback poll. The fallback discovers our own
+    // Claude session ID by inspecting `~/.claude/projects/<dir>/` and writes
+    // it to sessionStore. Pre-fix, the hook-bridge's `claudeSessionId`
+    // closure never read from sessionStore, so filterBySession kept
+    // returning false (no lock + siblings) and dropped EVERY hook for the
+    // entire session lifetime. The fix: adoptLockFromStore() reads
+    // sessionStore.findByRemiSessionId(...)?.claudeSessionId lazily on the
+    // next hook event after fallback completes.
+    //
+    // Test setup: seed a sibling and pre-populate sessionStore as the
+    // fallback would have done. Fire a PermissionRequest for our session
+    // and assert the auto-approve inject fires (proving filterBySession
+    // adopted the lock).
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(liveSessionsRegistry.dirPath, 'sibling-in-dir.json'),
+      JSON.stringify({
+        sessionId: 'sibling-session-id',
+        pid: process.pid,
+        wsPort: 18999,
+        hookPort: 18001,
+        projectPath: tmpDir,
+        name: 'sibling',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    // Pre-populate the store as transcript-fallback would have done after
+    // discovering our Claude transcript via filesystem polling.
+    sessionStore.save({
+      remiSessionId: SID,
+      claudeSessionId: 'claude-mine-via-fallback',
+      projectPath: tmpDir,
+      port: 8765,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    // Hot-switched PTY presence so the subagent gate doesn't shadow this
+    // assertion (irrelevant to the lock-adoption check itself).
+    // The first hook arrives WHILE hasSiblingInDir is still true. Pre-fix
+    // this dropped silently. Post-fix, adoptLockFromStore pulls the lock
+    // from sessionStore and filterBySession returns true.
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-mine-via-fallback',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // If the lock was adopted, auto-approve fired and injected '1'.
+        // If not (regression), ptySubmits is empty.
+        expect(ptySubmits).toEqual(['1']);
+        resolve();
+      }, 50);
+    });
+  });
+
+  test("sibling-in-dir + fallback-discovered lock: foreign session's hooks still drop", () => {
+    // Mirror of the test above, but with a hook event from a DIFFERENT
+    // session_id (i.e. the sibling's Claude). Lock-adoption must not turn
+    // into "accept anything"; the adopted lock should be enforced like
+    // the normal locked path.
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(liveSessionsRegistry.dirPath, 'sibling-in-dir-2.json'),
+      JSON.stringify({
+        sessionId: 'sibling-session-id-2',
+        pid: process.pid,
+        wsPort: 18998,
+        hookPort: 18002,
+        projectPath: tmpDir,
+        name: 'sibling-2',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    sessionStore.save({
+      remiSessionId: SID,
+      claudeSessionId: 'claude-mine-v2',
+      projectPath: tmpDir,
+      port: 8765,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    build({ autoApprove: true, autoApproveDecision: 'approve' });
+
+    // Foreign session_id — sibling's Claude firing through our hook URL.
+    hookServer.fire('PermissionRequest', {
+      session_id: 'claude-sibling-not-ours',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // No inject — filterBySession matched on the adopted lock and
+        // dropped the foreign event.
+        expect(ptySubmits).toEqual([]);
+        resolve();
+      }, 50);
+    });
+  });
+
   test('SessionStart with source=clear pre-empts classifier and tears down watcher', () => {
     build();
 


### PR DESCRIPTION
## Summary

Three related fixes that restore auto-approve correctness when (a) Claude Code attaches object-typed `permission_suggestions` metadata, (b) a subagent emits a permission hook that never reaches the main PTY, and (c) two Remi wrappers share a project directory.

### 1. `multichoice.ts` — object suggestions are not pickable

Claude Code now attaches typed rule-suggestion metadata to standard Yes/Yes-always/No prompts (e.g. `[{type:"addRules",...}]`, `[{type:"addDirectories",...}]`, `[{type:"setMode",...}]`). Pre-fix, the classifier saw the object, failed the `typeof === 'string'` check inside `every()`, and incorrectly flipped the prompt to multi-choice mode — sending it to the multi-choice LLM path with zero usable labels. Fix: filter to string entries before counting/shape-checking; object-only payloads fall through to the binary approve/deny path.

### 2. `question-presence-tracker.ts` — PTY-visible gate for inject

Background subagents emit `PermissionRequest` hooks but their prompts never render on the parent PTY. Pre-fix, the auto-approve inject path would still type `"1\n"` / `"3\n"` into the main agent's input. Fix: tracker now exposes `isPromptVisibleOnPTY()` (true between `onPTYPromptVisible` and the next non-`waiting` status). Inject path gates on this; otherwise drops the inject and lets the normal escalate path run.

### 3. `hook-bridge-setup.ts` — adopt `claudeSessionId` from `sessionStore`

When sibling Remi wrappers share a project directory, `hasSiblingInDir()` defers hook-event-based locking to the transcript-fallback poll. The fallback writes the discovered Claude session ID to `sessionStore`, but the hook-bridge closure variable was never re-read from the store — `filterBySession` stayed locked to `null` and silently dropped every hook for the session lifetime. Fix: `adoptLockFromStore()` reads `sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId` lazily on the next hook event after fallback completes; called at the top of both `filterBySession()` and `initFromHookEvent()`.

### 4. `prompt-builder.ts` — reversibility + steering escalation rules

Added explicit reversibility test (\"undoing requires git surgery / remote / backup → escalate\"), explicit design/direction/scope escalation rule, expanded approve list (cd-chains, /tmp writes, pwd, env), and tightened escalate list (Write/Edit outside scratch, anything talking to a remote, git reset).

## Test plan
- [x] `bun test packages/daemon/tests/auto-approve/multichoice.test.ts` — object-suggestion cases pass
- [x] `bun test packages/daemon/tests/auto-approve/prompt-builder.test.ts` — new escalation rules covered
- [x] `bun test packages/daemon/tests/auto-approve/auto-approve-service.test.ts` — service contract intact
- [x] `bun test packages/daemon/tests/api/question-presence-tracker.test.ts` — PTY-visible gate behavior
- [x] `bun test packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` — sibling-dir + sessionStore adoption
- [ ] Manual: confirm `{type:"addRules",...}` suggestion runs binary path on real Claude Code prompt
- [ ] Manual: confirm subagent permission hook does NOT type into parent input
- [ ] Manual: two `remi attach` wrappers in same dir — both get correct per-session hook routing

## Notes for reviewer
Second commit message (`5b3a46b add some fix for llm re-engage`) is rough — kept as-is to preserve history; full intent is captured here. Squashing on merge would clean it up if you prefer.