### PR TITLE
fix(daemon): deterministic PTY->transcript binding (phase 1, #428)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1088,12 +1088,23 @@ async function createNewSession(
     messageApi,
     locallyOwned,
   );
-  await ptySession.start();
+
+  // If the spawn or any post-spawn wiring throws, mark the pre-saved
+  // store entry as exited so sibling daemons reading the store don't
+  // see a phantom "live" session with our claudeSessionId reserved.
+  // Without this, the failed-spawn entry stays exitedAt=null and the
+  // pid-aliveness self-heal in SessionStore only fires after our
+  // daemon process itself exits.
+  try {
+    await ptySession.start();
+  } catch (err) {
+    sessionStore.markExited(sessionId, null);
+    throw err;
+  }
 
   startTranscriptFallback(
     {
       sessionRegistry,
-      sessionStore,
       transcriptDiscovery,
       transcriptWatchers,
       transcriptFallbackTimers,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -105,6 +105,7 @@ import { QuestionPresenceTracker } from './api/question-presence-tracker.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
+import { resolveClaudeBinding } from './cli/claude-binding.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
@@ -1028,6 +1029,30 @@ async function createNewSession(
     },
   );
 
+  // Deterministic PTY -> transcript binding (#427). Resolve the
+  // claudeSessionId Claude will write under BEFORE spawning, so sibling
+  // daemons in the same cwd cannot race-claim each other's transcripts
+  // through mtime-based discovery.
+  const binding = resolveClaudeBinding(extraArgs, {
+    displayName: `remi:${remiStatus.wsPort}`,
+  });
+  log(
+    `[Binding] claude=${binding.claudeSessionId.slice(0, 8)} source=${binding.source} for remi=${sessionId.slice(0, 8)}`,
+  );
+
+  // Persist the binding before spawn so siblings observing the store
+  // during the race window see our claim immediately.
+  sessionStore.save({
+    remiSessionId: sessionId,
+    claudeSessionId: binding.claudeSessionId,
+    projectPath: workingDirectory,
+    port: PORT,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
   if (hookServer) {
     setupHookBridge(
       {
@@ -1052,7 +1077,7 @@ async function createNewSession(
       sendMessage,
       cleanup,
     },
-    { sessionId, workingDirectory, extraArgs, passThrough },
+    { sessionId, workingDirectory, extraArgs: binding.args, passThrough },
   );
 
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
@@ -1065,17 +1090,6 @@ async function createNewSession(
   );
   await ptySession.start();
 
-  sessionStore.save({
-    remiSessionId: sessionId,
-    claudeSessionId: null,
-    projectPath: workingDirectory,
-    port: PORT,
-    pid: process.pid,
-    startedAt: new Date().toISOString(),
-    exitedAt: null,
-    exitCode: null,
-  });
-
   startTranscriptFallback(
     {
       sessionRegistry,
@@ -1086,6 +1100,7 @@ async function createNewSession(
     },
     sessionId,
     workingDirectory,
+    binding.claudeSessionId,
     messageApi,
     sendAndRecord,
   );

--- a/packages/daemon/src/cli/claude-binding.ts
+++ b/packages/daemon/src/cli/claude-binding.ts
@@ -29,8 +29,14 @@ import { randomUUID } from 'node:crypto';
 export interface ClaudeBindingResult {
   /** The session id Claude will use; either pre-existing in args or freshly minted. */
   readonly claudeSessionId: string;
-  /** The args to pass to `Bun.spawn`. Equal to input args plus any injection. */
-  readonly args: string[];
+  /**
+   * The args to pass to `Bun.spawn`. Equal to input args plus any injection.
+   * Invariant by source: `fresh` and `user-resume-fork` always contain an
+   * injected `--session-id <claudeSessionId>` pair; `user-session-id` and
+   * `user-resume` never inject because the binding is already in the user's
+   * args (or, in the resume case, implicit in `--resume`).
+   */
+  readonly args: readonly string[];
   /** How the binding was determined; useful for diagnostics + tests. */
   readonly source: 'user-session-id' | 'user-resume' | 'user-resume-fork' | 'fresh';
 }

--- a/packages/daemon/src/cli/claude-binding.ts
+++ b/packages/daemon/src/cli/claude-binding.ts
@@ -1,0 +1,116 @@
+/**
+ * Resolve the deterministic Claude session-id binding for a PTY spawn.
+ *
+ * The daemon needs to know which transcript .jsonl the spawned `claude` will
+ * write to before Claude has written its first line. Otherwise sibling daemons
+ * sharing a cwd race through `findLatestTranscript` (newest-by-mtime) and can
+ * adopt each other's transcripts — leading to cross-daemon answer routing
+ * (#427).
+ *
+ * Resolution order:
+ *   1. User passed `--session-id <uuid>` explicitly: respect it.
+ *   2. User passed `--resume <uuid>` without `--fork-session`: Claude reuses
+ *      that session id, so it's also our binding.
+ *   3. User passed `--resume <uuid> --fork-session`: Claude creates a NEW
+ *      session id; pre-assign one and inject `--session-id` so we know it.
+ *   4. Otherwise (fresh spawn): pre-assign and inject `--session-id`.
+ *
+ * Cases (2) and (3) can be combined: when `--resume` is present we inject
+ * `--session-id` only if `--fork-session` is also there, because Claude with
+ * `--resume <X>` alone preserves X.
+ *
+ * The function is pure and returns the augmented args. It does not touch the
+ * store; the caller is responsible for persisting `claudeSessionId` to
+ * `sessionStore` BEFORE `Bun.spawn` so siblings see it on first race tick.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+export interface ClaudeBindingResult {
+  /** The session id Claude will use; either pre-existing in args or freshly minted. */
+  readonly claudeSessionId: string;
+  /** The args to pass to `Bun.spawn`. Equal to input args plus any injection. */
+  readonly args: string[];
+  /** How the binding was determined; useful for diagnostics + tests. */
+  readonly source: 'user-session-id' | 'user-resume' | 'user-resume-fork' | 'fresh';
+}
+
+const SESSION_ID_FLAGS = new Set(['--session-id']);
+const RESUME_FLAGS = new Set(['-r', '--resume']);
+const FORK_FLAGS = new Set(['--fork-session']);
+const NAME_FLAGS = new Set(['-n', '--name']);
+
+/**
+ * Find a flag's value in an argv list. Supports both `--flag value` and
+ * `--flag=value` shapes. Returns undefined if absent or if the flag has no
+ * following value.
+ */
+function findFlagValue(args: readonly string[], flagSet: ReadonlySet<string>): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg) continue;
+    if (flagSet.has(arg)) {
+      const next = args[i + 1];
+      if (next && !next.startsWith('-')) return next;
+      continue;
+    }
+    const eq = arg.indexOf('=');
+    if (eq > 0 && flagSet.has(arg.slice(0, eq))) {
+      return arg.slice(eq + 1);
+    }
+  }
+  return undefined;
+}
+
+/** True if any of the bare flags (no value expected) is present. */
+function hasBareFlag(args: readonly string[], flagSet: ReadonlySet<string>): boolean {
+  return args.some((a) => flagSet.has(a));
+}
+
+function isUuidLike(value: string | undefined): value is string {
+  if (!value) return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+/**
+ * Resolve the claudeSessionId we will lock for this PTY and return augmented
+ * spawn args. `displayName` is appended via `-n` only when the user did not
+ * already set one, so an operator peeking at the PTY (or at /resume picker)
+ * can tell which daemon owns this session.
+ */
+export function resolveClaudeBinding(
+  extraArgs: readonly string[],
+  options: { readonly displayName?: string } = {},
+): ClaudeBindingResult {
+  const args = [...extraArgs];
+
+  const existingSessionId = findFlagValue(args, SESSION_ID_FLAGS);
+  const resumeId = findFlagValue(args, RESUME_FLAGS);
+  const isFork = hasBareFlag(args, FORK_FLAGS);
+  const hasName = hasBareFlag(args, NAME_FLAGS);
+
+  let claudeSessionId: string;
+  let source: ClaudeBindingResult['source'];
+
+  if (isUuidLike(existingSessionId)) {
+    claudeSessionId = existingSessionId;
+    source = 'user-session-id';
+  } else if (isUuidLike(resumeId) && !isFork) {
+    claudeSessionId = resumeId;
+    source = 'user-resume';
+  } else if (isUuidLike(resumeId) && isFork) {
+    claudeSessionId = randomUUID();
+    args.push('--session-id', claudeSessionId);
+    source = 'user-resume-fork';
+  } else {
+    claudeSessionId = randomUUID();
+    args.push('--session-id', claudeSessionId);
+    source = 'fresh';
+  }
+
+  if (!hasName && options.displayName) {
+    args.push('-n', options.displayName);
+  }
+
+  return { claudeSessionId, args, source };
+}

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -100,22 +100,17 @@ export function setupHookBridge(
   let claudeSessionId: string | null = null;
 
   /**
-   * When `hasSiblingInDir()` is true (multiple Remi wrappers in the same
-   * project directory) the hook-event-based locking path defers to the
-   * filesystem fallback in transcript-fallback.ts, which discovers our
-   * own Claude session ID by looking at `~/.claude/projects/<dir>/` and
-   * excluding sibling-claimed transcripts. The fallback writes the
-   * discovered id to `sessionStore.updateClaudeSessionId(...)` — but
-   * the hook-bridge's `claudeSessionId` closure was never updated from
-   * the store, so `filterBySession` kept reading null and dropped every
-   * hook for the entire session lifetime. This helper closes that gap:
-   * each hook event re-reads the store and adopts the discovered id when
-   * it differs from the closure (initial adopt, or rotation after a
-   * /clear in the multi-wrapper case where hooks were never authoritative).
-   * Log only on change to avoid spam on steady-state hooks. Wrapped in
-   * try/catch so an EMFILE / permission flake on the sessions file does
-   * not propagate into the hook dispatch loop; on failure we leave the
-   * closure untouched (the existing sibling-guard path remains active).
+   * Adopt the canonical claudeSessionId from `sessionStore`. After phase 1
+   * (#427), `cli.ts:createNewSession` pre-writes the binding to the store
+   * BEFORE Bun.spawn, so the value is authoritative the moment the bridge
+   * starts receiving hook events — no inference from filesystem mtime,
+   * no risk of latching a sibling daemon's id. The same call also covers
+   * subsequent rotations: if a hook-driven restart (/clear, /resume) flips
+   * the closure to null and writes a new id to the store, the next event
+   * re-adopts the new value. Logs only on change to avoid spam on
+   * steady-state hooks. Wrapped in try/catch so an EMFILE / permission
+   * flake on the sessions file does not propagate into the hook dispatch
+   * loop; on failure we leave the closure untouched.
    */
   const adoptLockFromStore = (): void => {
     try {

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -1,15 +1,20 @@
 /**
  * Transcript-watcher fallback poll for the hook-miss case.
  *
- * Normally the Claude Code hook event stream tells us the exact transcript
- * path (SessionStart carries `transcript_path`). When sibling daemons share
- * the same project directory, hook events are intentionally skipped because
- * all Claudes POST to all hook URLs and we can't tell which one we own.
- * This poll becomes the primary discovery path in that case.
+ * Since #427 / phase 1, the daemon pre-assigns a `claudeSessionId` and passes
+ * `--session-id <uuid>` to `claude` so Claude writes to a known path. This
+ * poll waits for that exact file to appear under
+ * `~/.claude/projects/<encoded-cwd>/<claudeSessionId>.jsonl` and then starts
+ * the watcher. No mtime sort, no sibling exclusion, no inference.
  *
- * Every 2 seconds, look for a transcript file whose mtime is recent or is
- * newer than the PTY startup. If found, start the watcher and cancel the
- * poll. Give up after 30 seconds and log the reason.
+ * Normally the Claude Code hook event stream tells us the exact transcript
+ * path (SessionStart carries `transcript_path`), in which case the hook
+ * bridge starts the watcher and this poll self-cancels on the next tick. The
+ * poll is the primary path only when hook events are unavailable (e.g.
+ * settings.local.json absent, hook server disabled, or in the sibling-in-dir
+ * case where the bridge defers to filesystem ground-truth).
+ *
+ * Poll every 2 seconds. Give up after 30 seconds and log the reason.
  */
 
 import * as fs from 'node:fs';
@@ -21,11 +26,10 @@ import type { SessionRegistry, SessionStore } from '../session/index.ts';
 import type { TranscriptDiscovery } from '../transcript/index.ts';
 import type { TranscriptWatcher } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
-import { extractClaudeSessionId, startTranscriptWatcher } from './transcript-watcher-setup.ts';
+import { startTranscriptWatcher } from './transcript-watcher-setup.ts';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_POLL_TIMEOUT_MS = 30000;
-const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
@@ -40,20 +44,34 @@ export interface TranscriptFallbackDeps {
 }
 
 /**
- * Start polling for a transcript path to watch. Registers the interval in
- * `transcriptFallbackTimers` so cleanup can cancel it; the poll self-clears
- * on success, on session loss, or after the timeout.
+ * Build the deterministic transcript path Claude will write to for a given
+ * (projectPath, claudeSessionId) pair. Exposed so callers (and tests) can
+ * agree on the same encoding rule as Claude Code itself.
+ */
+export function expectedTranscriptPath(
+  transcriptDiscovery: TranscriptDiscovery,
+  projectPath: string,
+  claudeSessionId: string,
+): string {
+  return `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`;
+}
+
+/**
+ * Start polling for the pre-assigned transcript path to appear. Registers
+ * the interval in `transcriptFallbackTimers` so cleanup can cancel it; the
+ * poll self-clears on success, on session loss, or after the timeout.
  */
 export function startTranscriptFallback(
   deps: TranscriptFallbackDeps,
   sessionId: UUID,
   workingDirectory: string,
+  claudeSessionId: string,
   messageApi: MessageAPI,
   sendAndRecord: (message: ProtocolMessage) => void,
 ): void {
   const {
     sessionRegistry,
-    sessionStore,
+    sessionStore: _sessionStore,
     transcriptDiscovery,
     transcriptWatchers,
     transcriptFallbackTimers,
@@ -61,18 +79,18 @@ export function startTranscriptFallback(
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
   } = deps;
 
-  const startupTime = Date.now();
+  // SessionStore writes happen pre-spawn in cli.ts; this poll only consumes
+  // the binding it was given. Kept in the interface so future recovery
+  // paths (e.g. /resume swap re-binding) can persist updates without
+  // having to thread a second dep object.
+  void _sessionStore;
 
-  const attachWatcher = (transcriptPath: string): void => {
-    startTranscriptWatcher(
-      { transcriptWatchers },
-      sessionId,
-      transcriptPath,
-      messageApi,
-      sendAndRecord,
-    );
-    extractClaudeSessionId({ sessionStore }, transcriptPath, sessionId);
-  };
+  const startupTime = Date.now();
+  const expectedPath = expectedTranscriptPath(
+    transcriptDiscovery,
+    workingDirectory,
+    claudeSessionId,
+  );
 
   const stopPoll = (): void => {
     clearInterval(fallbackInterval);
@@ -89,61 +107,30 @@ export function startTranscriptFallback(
       return;
     }
 
-    // Exclude transcripts already claimed by sibling daemons (their
-    // claudeSessionId is stored in sessions.json) to avoid double-watching.
-    const siblingClaudeIds = new Set<string>();
-    for (const entry of sessionStore.list()) {
-      if (entry.remiSessionId !== sessionId && entry.claudeSessionId && !entry.exitedAt) {
-        siblingClaudeIds.add(entry.claudeSessionId);
-      }
-    }
-    const transcriptPath =
-      siblingClaudeIds.size > 0
-        ? transcriptDiscovery.findLatestTranscriptExcluding(workingDirectory, siblingClaudeIds)
-        : transcriptDiscovery.findLatestTranscript(workingDirectory);
-
-    if (transcriptPath) {
+    if (fs.existsSync(expectedPath)) {
       try {
-        const stat = fs.statSync(transcriptPath);
-        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
-          stopPoll();
-          log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
-          attachWatcher(transcriptPath);
-          return;
-        }
+        stopPoll();
+        log(
+          `[Fallback] Bound transcript appeared: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)})`,
+        );
+        startTranscriptWatcher(
+          { transcriptWatchers },
+          sessionId,
+          expectedPath,
+          messageApi,
+          sendAndRecord,
+        );
       } catch (err) {
-        log(`[Hooks] Fallback stat failed for ${transcriptPath}: ${errorToString(err)}`);
+        logError(`[Fallback] Failed to start watcher for ${expectedPath}: ${errorToString(err)}`);
       }
+      return;
     }
 
-    // Timeout branch. Still accept the transcript if it became recent
-    // during the final interval, otherwise log and give up.
     if (Date.now() - startupTime > pollTimeoutMs) {
       stopPoll();
-      if (transcriptPath) {
-        try {
-          const stat = fs.statSync(transcriptPath);
-          const isRecent =
-            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-          if (isRecent) {
-            log('[Hooks] Transcript fallback: found recent transcript on final check.');
-            attachWatcher(transcriptPath);
-            return;
-          }
-
-          logError(
-            `[Hooks] Transcript fallback timed out without a fresh transcript. Skipping stale file: ${transcriptPath}`,
-          );
-          return;
-        } catch {
-          logError(
-            '[Hooks] Transcript fallback timed out and transcript stat failed on final check.',
-          );
-          return;
-        }
-      }
-
-      logError('[Hooks] Transcript fallback timed out without any transcript file.');
+      logError(
+        `[Fallback] Timed out waiting for transcript: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude may have failed to start, or wrote to an unexpected path.`,
+      );
     }
   }, pollIntervalMs);
 

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -22,7 +22,7 @@ import { errorToString } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionRegistry, SessionStore } from '../session/index.ts';
+import type { SessionRegistry } from '../session/index.ts';
 import type { TranscriptDiscovery } from '../transcript/index.ts';
 import type { TranscriptWatcher } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
@@ -33,7 +33,6 @@ const DEFAULT_POLL_TIMEOUT_MS = 30000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
   transcriptDiscovery: TranscriptDiscovery;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -71,19 +70,12 @@ export function startTranscriptFallback(
 ): void {
   const {
     sessionRegistry,
-    sessionStore: _sessionStore,
     transcriptDiscovery,
     transcriptWatchers,
     transcriptFallbackTimers,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
   } = deps;
-
-  // SessionStore writes happen pre-spawn in cli.ts; this poll only consumes
-  // the binding it was given. Kept in the interface so future recovery
-  // paths (e.g. /resume swap re-binding) can persist updates without
-  // having to thread a second dep object.
-  void _sessionStore;
 
   const startupTime = Date.now();
   const expectedPath = expectedTranscriptPath(
@@ -108,8 +100,11 @@ export function startTranscriptFallback(
     }
 
     if (fs.existsSync(expectedPath)) {
+      // Do NOT stopPoll before the watcher is wired. A throw inside
+      // startTranscriptWatcher (e.g. transient EMFILE on the watcher's
+      // openSync) used to kill the poll while leaving the session
+      // unwatched — silent failure with no retry.
       try {
-        stopPoll();
         log(
           `[Fallback] Bound transcript appeared: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)})`,
         );
@@ -120,8 +115,12 @@ export function startTranscriptFallback(
           messageApi,
           sendAndRecord,
         );
+        stopPoll();
       } catch (err) {
-        logError(`[Fallback] Failed to start watcher for ${expectedPath}: ${errorToString(err)}`);
+        logError(
+          `[Fallback] Failed to start watcher for ${expectedPath}; will retry: ${errorToString(err)}`,
+        );
+        // Fall through without stopping the poll so the next tick retries.
       }
       return;
     }

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -16,6 +16,10 @@ import { applyEnvOverrides, loadConfig } from '../../src/config/config.ts';
  */
 
 async function isOllamaAvailable(): Promise<boolean> {
+  // SKIP_LLM_TESTS=1 lets a developer pin GPU-heavy LLM tests off without
+  // killing the local Ollama daemon (which they may want running for other
+  // workflows). Honored by every Ollama-gated test in this directory.
+  if (process.env['SKIP_LLM_TESTS'] === '1') return false;
   try {
     const res = await fetch('http://localhost:11434/api/tags', {
       signal: AbortSignal.timeout(2000),

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -31,6 +31,10 @@ import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 
 async function isOllamaAvailable(): Promise<boolean> {
+  // SKIP_LLM_TESTS=1 lets a developer pin GPU-heavy LLM tests off without
+  // killing the local Ollama daemon (which they may want running for other
+  // workflows). Honored by every Ollama-gated test in this directory.
+  if (process.env['SKIP_LLM_TESTS'] === '1') return false;
   try {
     const res = await fetch('http://localhost:11434/api/tags', {
       signal: AbortSignal.timeout(2000),

--- a/packages/daemon/tests/cli/claude-binding.test.ts
+++ b/packages/daemon/tests/cli/claude-binding.test.ts
@@ -36,6 +36,28 @@ describe('resolveClaudeBinding', () => {
     expect(claudeSessionId).toBe(id);
   });
 
+  test('user-provided --resume=<uuid> (equals form) is respected', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding([`--resume=${id}`]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+    expect(args).not.toContain('--session-id');
+  });
+
+  test('malformed --session-id=uuid=foo (second = in value) falls back to fresh', () => {
+    // Documents safe-degradation behavior: isUuidLike rejects the trailing
+    // garbage, so we mint a fresh id and inject our own --session-id rather
+    // than trusting a malformed value.
+    const malformed = '--session-id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee=foo';
+    const { source, claudeSessionId, args } = resolveClaudeBinding([malformed]);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+    // The user's malformed arg is preserved verbatim AND our fresh --session-id
+    // is injected; Claude will reject one of them or honor the last.
+    expect(args[0]).toBe(malformed);
+    expect(args).toContain('--session-id');
+  });
+
   test('--resume alone: binding equals the resumed id', () => {
     const id = '11111111-2222-3333-4444-555555555555';
     const { claudeSessionId, args, source } = resolveClaudeBinding(['--resume', id]);

--- a/packages/daemon/tests/cli/claude-binding.test.ts
+++ b/packages/daemon/tests/cli/claude-binding.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveClaudeBinding } from '../../src/cli/claude-binding.ts';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('resolveClaudeBinding', () => {
+  test('fresh spawn: mints a UUID and injects --session-id', () => {
+    const { claudeSessionId, args, source } = resolveClaudeBinding([]);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+    expect(args).toContain('--session-id');
+    expect(args[args.indexOf('--session-id') + 1]).toBe(claudeSessionId);
+  });
+
+  test('two fresh spawns get distinct ids', () => {
+    const a = resolveClaudeBinding([]);
+    const b = resolveClaudeBinding([]);
+    expect(a.claudeSessionId).not.toBe(b.claudeSessionId);
+  });
+
+  test('user-provided --session-id is respected (no fresh mint)', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const { claudeSessionId, args, source } = resolveClaudeBinding(['--session-id', id]);
+    expect(source).toBe('user-session-id');
+    expect(claudeSessionId).toBe(id);
+    // Should NOT have duplicated the flag.
+    const occurrences = args.filter((a) => a === '--session-id').length;
+    expect(occurrences).toBe(1);
+  });
+
+  test('user-provided --session-id= (equals form) is respected', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const { claudeSessionId, source } = resolveClaudeBinding([`--session-id=${id}`]);
+    expect(source).toBe('user-session-id');
+    expect(claudeSessionId).toBe(id);
+  });
+
+  test('--resume alone: binding equals the resumed id', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding(['--resume', id]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+    // No injected --session-id because claude --resume preserves the id.
+    expect(args).not.toContain('--session-id');
+  });
+
+  test('--resume -r short form', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, source } = resolveClaudeBinding(['-r', id]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+  });
+
+  test('--resume with --fork-session: mints a fresh id and injects --session-id', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding([
+      '--resume',
+      id,
+      '--fork-session',
+    ]);
+    expect(source).toBe('user-resume-fork');
+    expect(claudeSessionId).not.toBe(id);
+    expect(args).toContain('--session-id');
+    // Resume is still passed through so claude knows what to fork from.
+    expect(args).toContain('--resume');
+    expect(args).toContain('--fork-session');
+  });
+
+  test('appends -n displayName when not already present', () => {
+    const { args } = resolveClaudeBinding([], { displayName: 'remi:19920' });
+    expect(args).toContain('-n');
+    expect(args[args.indexOf('-n') + 1]).toBe('remi:19920');
+  });
+
+  test('respects user-provided -n / --name (no override)', () => {
+    const a = resolveClaudeBinding(['-n', 'my-session'], { displayName: 'remi:19920' });
+    expect(a.args.filter((x) => x === '-n').length).toBe(1);
+    expect(a.args[a.args.indexOf('-n') + 1]).toBe('my-session');
+
+    const b = resolveClaudeBinding(['--name', 'my-session'], { displayName: 'remi:19920' });
+    expect(b.args).not.toContain('-n');
+    expect(b.args.filter((x) => x === '--name').length).toBe(1);
+  });
+
+  test('ignores non-UUID values in --session-id and falls back to fresh', () => {
+    const { source, claudeSessionId } = resolveClaudeBinding(['--session-id', 'not-a-uuid']);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+  });
+
+  test('preserves the original arg order plus appended injections', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const input = ['--model', 'sonnet', '--session-id', id, '--add-dir', '/tmp'];
+    const { args } = resolveClaudeBinding(input);
+    // First five args must match input verbatim (no rewriting of user flags).
+    for (let i = 0; i < input.length; i++) {
+      expect(args[i]).toBe(input[i] as string);
+    }
+  });
+
+  test('does not mutate the input array', () => {
+    const input: string[] = [];
+    resolveClaudeBinding(input, { displayName: 'remi:19920' });
+    expect(input.length).toBe(0);
+  });
+});

--- a/packages/daemon/tests/cli/transcript-fallback.test.ts
+++ b/packages/daemon/tests/cli/transcript-fallback.test.ts
@@ -9,7 +9,6 @@ import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts'
 import { startTranscriptFallback } from '../../src/cli/transcript-fallback.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../src/session/session-registry.ts';
-import { SessionStore } from '../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
@@ -39,7 +38,6 @@ describe('startTranscriptFallback', () => {
   let projectsDir: string;
   let projectPath: string;
   let sessionRegistry: SessionRegistry;
-  let sessionStore: SessionStore;
   let transcriptDiscovery: TranscriptDiscovery;
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -52,7 +50,6 @@ describe('startTranscriptFallback', () => {
     fs.mkdirSync(projectsDir, { recursive: true });
     fs.mkdirSync(projectPath, { recursive: true });
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
-    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     transcriptFallbackTimers = new Map();
@@ -98,7 +95,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -123,7 +119,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -149,7 +144,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -183,7 +177,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -224,7 +217,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -251,7 +243,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,

--- a/packages/daemon/tests/cli/transcript-fallback.test.ts
+++ b/packages/daemon/tests/cli/transcript-fallback.test.ts
@@ -89,6 +89,9 @@ describe('startTranscriptFallback', () => {
 
   const sendAndRecord = (_: ProtocolMessage) => {};
 
+  const KNOWN_CLAUDE_ID = '11111111-2222-3333-4444-555555555555';
+  const OTHER_CLAUDE_ID = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+
   test('registers a timer in transcriptFallbackTimers', () => {
     const sid = registerSession();
 
@@ -104,6 +107,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -128,6 +132,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -153,6 +158,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -162,18 +168,17 @@ describe('startTranscriptFallback', () => {
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
   });
 
-  test('attaches a watcher when a fresh transcript appears on disk', async () => {
+  test('attaches a watcher when the bound transcript appears on disk', async () => {
     const sid = registerSession();
-    const claudeId = '11111111-2222-3333-4444-555555555555';
     const entry = {
       type: 'user',
       uuid: 'u1',
-      sessionId: claudeId,
+      sessionId: KNOWN_CLAUDE_ID,
       cwd: projectPath,
       timestamp: new Date().toISOString(),
       message: { role: 'user', content: 'hi' },
     };
-    writeTranscript(claudeId, [entry]);
+    writeTranscript(KNOWN_CLAUDE_ID, [entry]);
 
     startTranscriptFallback(
       {
@@ -187,6 +192,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -201,7 +207,44 @@ describe('startTranscriptFallback', () => {
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
   });
 
-  test('times out when no transcript ever appears', async () => {
+  test('ignores a sibling daemons transcript with a different UUID', async () => {
+    // Race scenario: a sibling daemon's claude wrote its transcript first.
+    // The new fallback waits for OUR pre-bound id, not "newest in the dir".
+    const sid = registerSession();
+    const entry = {
+      type: 'user',
+      uuid: 'u1',
+      sessionId: OTHER_CLAUDE_ID,
+      cwd: projectPath,
+      timestamp: new Date().toISOString(),
+      message: { role: 'user', content: 'hi' },
+    };
+    writeTranscript(OTHER_CLAUDE_ID, [entry]);
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 150,
+      },
+      sid,
+      projectPath,
+      KNOWN_CLAUDE_ID,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    await sleep(200);
+
+    expect(transcriptWatchers.has(sid)).toBe(false);
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+  });
+
+  test('times out when the bound transcript never appears', async () => {
     // No transcript on disk.
     const sid = registerSession();
 
@@ -217,6 +260,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -226,10 +270,6 @@ describe('startTranscriptFallback', () => {
 
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
     expect(transcriptWatchers.has(sid)).toBe(false);
-    expect(
-      logs.some((m) =>
-        m.includes('[error] [Hooks] Transcript fallback timed out without any transcript file'),
-      ),
-    ).toBe(true);
+    expect(logs.some((m) => m.includes('[Fallback] Timed out waiting for transcript'))).toBe(true);
   });
 });

--- a/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
+++ b/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration test for #427/#428: two daemons in the SAME cwd must never
+ * cross-bind each other's Claude transcripts.
+ *
+ * Exercises the actual binding chain — resolveClaudeBinding, SessionStore,
+ * and startTranscriptFallback wired together the same way createNewSession
+ * wires them in cli.ts. Does not mock Bun.spawn: instead we simulate two
+ * "claude" processes by writing the .jsonl files each binding expects.
+ *
+ * Pre-fix this scenario was the silent killer behind cross-daemon answer
+ * routing: both daemons' fallbacks called findLatestTranscript and grabbed
+ * whichever .jsonl had the freshest mtime, regardless of which Claude wrote
+ * it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { resolveClaudeBinding } from '../../src/cli/claude-binding.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import {
+  expectedTranscriptPath,
+  startTranscriptFallback,
+} from '../../src/cli/transcript-fallback.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Model one daemon's state — its own sessionStore, its own watchers map,
+ * its own transcript-fallback timer map. In production each daemon is a
+ * separate process; here we keep them isolated within one test process by
+ * giving each its own state bundle.
+ */
+interface DaemonFixture {
+  readonly label: string;
+  readonly remiSessionId: UUID;
+  readonly sessionStore: SessionStore;
+  readonly sessionRegistry: SessionRegistry;
+  readonly transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  readonly transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  claudeSessionId?: string;
+}
+
+describe('two daemons in the same cwd never cross-bind (#427)', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+  let projectPath: string;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let logs: string[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-cross-bind-'));
+    projectsDir = path.join(tmpDir, 'claude-projects');
+    projectPath = path.join(tmpDir, 'shared-project');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.mkdirSync(projectPath, { recursive: true });
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+    logs = [];
+    configureLogger({ writeLog: (m) => logs.push(m) });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDaemon(label: string): DaemonFixture {
+    const sessionStore = new SessionStore(path.join(tmpDir, `sessions-${label}.json`));
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const remiSessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(remiSessionId, projectPath, fakePTY(), fakeMessageAPI());
+    return {
+      label,
+      remiSessionId,
+      sessionStore,
+      sessionRegistry,
+      transcriptWatchers: new Map(),
+      transcriptFallbackTimers: new Map(),
+    };
+  }
+
+  /**
+   * Simulate the create-session flow up to (but not including) Bun.spawn:
+   * resolve a binding, persist to store, and start the fallback poll.
+   * Mirrors the order in cli.ts:createNewSession.
+   */
+  function startDaemonBinding(d: DaemonFixture): void {
+    const binding = resolveClaudeBinding([], { displayName: `remi:${d.label}` });
+    d.claudeSessionId = binding.claudeSessionId;
+    d.sessionStore.save({
+      remiSessionId: d.remiSessionId,
+      claudeSessionId: binding.claudeSessionId,
+      projectPath,
+      port: 0,
+      pid: 0,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+    startTranscriptFallback(
+      {
+        sessionRegistry: d.sessionRegistry,
+        sessionStore: d.sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers: d.transcriptWatchers,
+        transcriptFallbackTimers: d.transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 2000,
+      },
+      d.remiSessionId,
+      projectPath,
+      binding.claudeSessionId,
+      fakeMessageAPI(),
+      (_: ProtocolMessage) => {},
+    );
+  }
+
+  /** Write a fake transcript .jsonl to disk as if Claude had just started. */
+  function writeClaudeTranscript(claudeId: string): string {
+    const encodedDir = path.join(projectsDir, projectPath.replace(/\//g, '-'));
+    fs.mkdirSync(encodedDir, { recursive: true });
+    const filePath = path.join(encodedDir, `${claudeId}.jsonl`);
+    fs.writeFileSync(
+      filePath,
+      `${JSON.stringify({
+        type: 'user',
+        uuid: generateId(),
+        sessionId: claudeId,
+        cwd: projectPath,
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'boot' },
+      })}\n`,
+    );
+    return filePath;
+  }
+
+  async function shutdownAll(daemons: DaemonFixture[]): Promise<void> {
+    for (const d of daemons) {
+      for (const t of d.transcriptFallbackTimers.values()) clearInterval(t);
+      d.transcriptFallbackTimers.clear();
+      for (const w of d.transcriptWatchers.values()) w.stop();
+      d.transcriptWatchers.clear();
+      await d.sessionRegistry.shutdown();
+    }
+  }
+
+  test('two daemons race-binding produce distinct claudeSessionIds', () => {
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    // Race: bindings resolved + saved synchronously back-to-back, like two
+    // daemons booting at the same instant.
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    expect(a.claudeSessionId).toBeDefined();
+    expect(b.claudeSessionId).toBeDefined();
+    expect(a.claudeSessionId).not.toBe(b.claudeSessionId);
+
+    // Each store has its OWN entry; no leakage across daemon stores.
+    const storedA = a.sessionStore.findByRemiSessionId(a.remiSessionId);
+    const storedB = b.sessionStore.findByRemiSessionId(b.remiSessionId);
+    expect(storedA?.claudeSessionId).toBe(a.claudeSessionId!);
+    expect(storedB?.claudeSessionId).toBe(b.claudeSessionId!);
+
+    return shutdownAll([a, b]);
+  });
+
+  test('each daemon binds its OWN transcript even when both files exist', async () => {
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    // Both "claudes" write their transcripts concurrently. Daemon B's
+    // file lands FIRST so pre-fix code (newest-mtime sort) would have
+    // pointed daemon A at B's file.
+    const bPath = writeClaudeTranscript(b.claudeSessionId!);
+    await sleep(15);
+    const aPath = writeClaudeTranscript(a.claudeSessionId!);
+
+    // Wait for both fallbacks to bind.
+    for (let i = 0; i < 50; i++) {
+      if (a.transcriptWatchers.has(a.remiSessionId) && b.transcriptWatchers.has(b.remiSessionId)) {
+        break;
+      }
+      await sleep(30);
+    }
+
+    const watcherA = a.transcriptWatchers.get(a.remiSessionId);
+    const watcherB = b.transcriptWatchers.get(b.remiSessionId);
+
+    expect(watcherA).toBeDefined();
+    expect(watcherB).toBeDefined();
+    expect(watcherA!.filePath).toBe(aPath);
+    expect(watcherB!.filePath).toBe(bPath);
+    expect(watcherA!.filePath).not.toBe(watcherB!.filePath);
+
+    return shutdownAll([a, b]);
+  });
+
+  test('daemon ignores sibling-only transcripts even if its own never appears', async () => {
+    // Mirror the cruel case: daemon A is alive but its claude crashed
+    // before writing any transcript; daemon B's transcript is present.
+    // Pre-fix, A would have adopted B's file. Now, A times out cleanly.
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    writeClaudeTranscript(b.claudeSessionId!);
+    // Deliberately DO NOT write A's transcript.
+
+    // Wait past A's fallback timeout (configured 2000ms in startDaemonBinding).
+    await sleep(2200);
+
+    expect(a.transcriptWatchers.has(a.remiSessionId)).toBe(false);
+    // A timed out cleanly with a typed error log, not by adopting B's file.
+    expect(logs.some((m) => m.includes('[Fallback] Timed out waiting for transcript'))).toBe(true);
+
+    // B should be bound correctly to its own file.
+    await sleep(50);
+    const watcherB = b.transcriptWatchers.get(b.remiSessionId);
+    expect(watcherB?.filePath).toBe(
+      expectedTranscriptPath(transcriptDiscovery, projectPath, b.claudeSessionId!),
+    );
+
+    return shutdownAll([a, b]);
+  });
+
+  test('expected paths derived from binding match what fallback waits for', () => {
+    // Defense-in-depth: the path the fallback polls for must equal the
+    // path the .jsonl filename derives from the bound UUID. If these
+    // ever drift (e.g. someone changes the encoding rule on one side
+    // only), this test fires immediately.
+    const a = makeDaemon('A');
+    startDaemonBinding(a);
+    const derived = expectedTranscriptPath(transcriptDiscovery, projectPath, a.claudeSessionId!);
+    const expectedDir = transcriptDiscovery.getProjectTranscriptDir(projectPath);
+    expect(derived.startsWith(expectedDir)).toBe(true);
+    expect(derived.endsWith(`${a.claudeSessionId!}.jsonl`)).toBe(true);
+    return shutdownAll([a]);
+  });
+});

--- a/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
+++ b/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
@@ -8,9 +8,8 @@
  * "claude" processes by writing the .jsonl files each binding expects.
  *
  * Pre-fix this scenario was the silent killer behind cross-daemon answer
- * routing: both daemons' fallbacks called findLatestTranscript and grabbed
- * whichever .jsonl had the freshest mtime, regardless of which Claude wrote
- * it.
+ * routing: both daemons' fallbacks sorted the project directory by mtime
+ * and grabbed the newest .jsonl regardless of which Claude wrote it.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -131,7 +130,6 @@ describe('two daemons in the same cwd never cross-bind (#427)', () => {
     startTranscriptFallback(
       {
         sessionRegistry: d.sessionRegistry,
-        sessionStore: d.sessionStore,
         transcriptDiscovery,
         transcriptWatchers: d.transcriptWatchers,
         transcriptFallbackTimers: d.transcriptFallbackTimers,


### PR DESCRIPTION
Phase 1 of epic #427. Closes #428.

## What

Daemon now pre-assigns the Claude session UUID at spawn time and passes `--session-id <uuid>` to `claude` so it knows exactly which `~/.claude/projects/<cwd>/<uuid>.jsonl` belongs to its PTY before Claude writes a single line.

## Why

Two `remi` daemons running in the same cwd were silently routing responses to each other's sessions. Root cause: `transcript-fallback.ts` used `findLatestTranscript()` (newest-by-mtime) with a sibling-exclusion set built from `sessionStore` claudeSessionIds. At startup race both daemons had `claudeSessionId: null` in the store, so the exclusion set was empty and both grabbed the same `.jsonl` by mtime. The loser then wrote the WRONG id back to the store via `extractClaudeSessionId`, and `adoptLockFromStore` (0b043f7) made the bad binding self-reinforcing for hook routing.

See #427 for the full diagnosis.

## Changes

- **`packages/daemon/src/cli/claude-binding.ts`** (new): pure resolver
  - Fresh spawn: mint UUID + inject `--session-id`
  - User `--session-id <uuid>` is respected (no double-inject)
  - User `--resume <uuid>` alone: use the resumed id as the binding (Claude preserves it)
  - User `--resume <uuid> --fork-session`: mint a fresh id + inject `--session-id` (fork would otherwise produce an unpredictable id)
  - Optional `-n remi:<port>` so a human peeking at the PTY (or `/resume` picker) sees which daemon owns this Claude
- **`cli.ts:createNewSession`**: resolve binding pre-spawn, persist `claudeSessionId` to `sessionStore` BEFORE `Bun.spawn` so siblings observing the store during the race tick see the claim immediately
- **`transcript-fallback.ts`**: rewritten to wait for the exact bound `.jsonl` to appear. No more mtime sort, no sibling-exclusion set. Sibling daemons in the same cwd can no longer adopt each other's transcripts even when both files race to disk

## Tests

- **11 unit tests for `claude-binding.ts`** covering fresh mint, all user-flag override paths, fork-session, name flag precedence, equal-form parsing, input-array purity
- **5 unit tests for `transcript-fallback.ts`** including a new sibling-isolation case (sibling's id on disk first must be ignored)
- **4 integration tests** in `tests/integration/same-cwd-no-cross-binding.test.ts` exercising the actual chain (`resolveClaudeBinding` -> `sessionStore.save` -> `startTranscriptFallback`) with two daemons in one cwd. Covers the exact failure modes that broke pre-fix: race-binding distinct ids, B's file written first, A's claude crashes before writing
- **2-line patch to `auto-approve` tests** so `SKIP_LLM_TESTS=1` actually skips Ollama-gated tests (was silently ignored before)

**Result:** 1915 pass / 69 skip (LLM-gated, opted out) / 0 fail across daemon + shared with `SKIP_LLM_TESTS=1`. Typecheck and biome clean.

## What's not in this PR

- **Protocol changes** to expose `claudeSessionId` + `transcriptPath` on the wire (`hello_ack`, `session_list_response`, `question`): phase 2 (#429)
- **Client composite-key + UI surface**: phase 3 (#430)
- **`extractClaudeSessionId` and `findLatestTranscript*`**: still defined in source but no longer called from the spawn path. Left for `ls`/`recent` flows; will be revisited in phase 3 cleanup
- **`/clear` and `/resume` swap inside the SAME PTY**: existing hook-bridge "session_id rotation = restart" code handles this when hooks are configured. Verified by inspection; no new code needed for phase 1

## Acceptance

- [x] Two daemons launched in the same cwd never collide on `claudeSessionId`
- [x] Discovery is deterministic: no mtime sort in the spawn path
- [x] Existing tests still pass; new tests cover the race window