### PR TITLE
feat(protocol): surface binding on wire + daemon stale guard (phase 2, #429)

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -64,10 +64,22 @@ export interface AdapterEvents {
   onDisconnect: (connectionId: UUID, reason: string) => void;
 
   /** User input received */
-  onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (
+    connectionId: UUID,
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Answer to question received */
-  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -110,12 +110,12 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (connectionId, sessionId, content, raw) => {
-        this.events.onUserInput?.(connectionId, sessionId, content, raw);
+      onUserInput: (connectionId, sessionId, content, raw, claudeSessionId) => {
+        this.events.onUserInput?.(connectionId, sessionId, content, raw, claudeSessionId);
       },
 
-      onAnswer: (connectionId, sessionId, questionId, answer) => {
-        this.events.onAnswer?.(connectionId, sessionId, questionId, answer);
+      onAnswer: (connectionId, sessionId, questionId, answer, claudeSessionId) => {
+        this.events.onAnswer?.(connectionId, sessionId, questionId, answer, claudeSessionId);
       },
 
       onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1010,9 +1010,18 @@ async function createNewSession(
       sendMessage,
       // Lazy read so the binding seen on each question emission is the
       // current value — survives /resume rotation via hook-bridge's
-      // updateClaudeSessionId write into the store.
-      getClaudeSessionId: () =>
-        (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? null) as UUID | null,
+      // updateClaudeSessionId write into the store. Wrapped in try/catch
+      // so a transient sessions.json I/O hiccup cannot kill question
+      // emission (the dep contract is non-throwing).
+      getClaudeSessionId: () => {
+        try {
+          return (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ??
+            null) as UUID | null;
+        } catch (err) {
+          logError(`[Binding] getClaudeSessionId lookup failed: ${errorToString(err)}`);
+          return null;
+        }
+      },
     },
     sessionId,
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -842,13 +842,25 @@ const sessionRegistry = new SessionRegistry(
     },
     onConnectionPromoted: (sessionId, connectionId, result) => {
       log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
+      const stored = sessionStore.findByRemiSessionId(sessionId);
+      const claudeId = stored?.claudeSessionId ?? null;
+      const projPath = stored?.projectPath ?? null;
+      const tpath =
+        claudeId && projPath
+          ? `${transcriptDiscovery.getProjectTranscriptDir(projPath)}/${claudeId}.jsonl`
+          : null;
       const sent = registry.sendRaw(
         connectionId,
-        createHelloAck('1.0.0', sessionId, {
-          isResume: result.replayMessages.length > 0,
-          replayCount: result.replayMessages.length,
-          nextBulletId: result.nextBulletId,
-        }),
+        createHelloAck(
+          '1.0.0',
+          sessionId,
+          {
+            isResume: result.replayMessages.length > 0,
+            replayCount: result.replayMessages.length,
+            nextBulletId: result.nextBulletId,
+          },
+          { claudeSessionId: claudeId, transcriptPath: tpath },
+        ),
       );
       if (!sent) {
         log(`Promoted connection ${connectionId} is unreachable; detaching`);
@@ -996,6 +1008,11 @@ async function createNewSession(
       updateRemiStatus: (patch) => updateRemiStatus(patch),
       maxBulletLength: MAX_BULLET_LENGTH,
       sendMessage,
+      // Lazy read so the binding seen on each question emission is the
+      // current value — survives /resume rotation via hook-bridge's
+      // updateClaudeSessionId write into the store.
+      getClaudeSessionId: () =>
+        (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? null) as UUID | null,
     },
     sessionId,
   );
@@ -1150,6 +1167,7 @@ const trivialHandlers: TrivialHandlers = createTrivialHandlers({
 
 const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
+  sessionStore,
   send: sendToConnection,
 });
 

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -13,7 +13,7 @@ import { createBulletExpandResponse, createError, errorToString } from '@remi/sh
 import type { UUID } from '@remi/shared';
 
 import type { SessionRegistry, SessionStore } from '../../session/index.ts';
-import { log } from '../logger.ts';
+import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
@@ -32,13 +32,16 @@ export interface InputHandlerDeps {
  *     accept the message unconditionally. The client cannot have known
  *     the binding to check against.
  *   - If the client sent it but no daemon binding is recorded yet
- *     (extreme race: input received before transcript-fallback wrote
- *     the id), accept rather than refuse. The pre-spawn save in
- *     createNewSession makes this branch rare.
+ *     (extreme race: message arrived before the pre-spawn save in
+ *     cli.ts:createNewSession completed), accept rather than refuse.
  *   - If both are present and differ, the user typed against an old
  *     view (e.g. /resume rotated the binding between question and
  *     answer); refuse and emit STALE_BINDING with both ids so the
  *     client can rekey its UI.
+ *   - If the sessionStore lookup throws (I/O error on the sessions
+ *     file): fail-open with a logError. Refusing on a transient store
+ *     hiccup would silently swallow legitimate input; accepting at
+ *     least surfaces the problem in logs while letting the user work.
  */
 function guardBinding(
   sessionStore: SessionStore,
@@ -48,8 +51,13 @@ function guardBinding(
   claudeSessionId: UUID | undefined,
 ): boolean {
   if (claudeSessionId === undefined) return true;
-  const stored = sessionStore.findByRemiSessionId(sessionId);
-  const bound = stored?.claudeSessionId;
+  let bound: string | undefined;
+  try {
+    bound = sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? undefined;
+  } catch (err) {
+    logError(`[Binding] sessionStore lookup failed; accepting message: ${errorToString(err)}`);
+    return true;
+  }
   if (!bound) return true;
   if (bound === claudeSessionId) return true;
   log(

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -12,32 +12,86 @@
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry } from '../../session/index.ts';
+import type { SessionRegistry, SessionStore } from '../../session/index.ts';
 import { log } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
+  sessionStore: SessionStore;
   send: SendToConnection;
+}
+
+/**
+ * Compare an incoming message's claudeSessionId against the daemon's
+ * current binding for the target remi session (#429). Returns true when
+ * the message is safe to forward to the PTY, false when stale.
+ *
+ * Stale-binding semantics:
+ *   - If the client did not send claudeSessionId (pre-#429 client),
+ *     accept the message unconditionally. The client cannot have known
+ *     the binding to check against.
+ *   - If the client sent it but no daemon binding is recorded yet
+ *     (extreme race: input received before transcript-fallback wrote
+ *     the id), accept rather than refuse. The pre-spawn save in
+ *     createNewSession makes this branch rare.
+ *   - If both are present and differ, the user typed against an old
+ *     view (e.g. /resume rotated the binding between question and
+ *     answer); refuse and emit STALE_BINDING with both ids so the
+ *     client can rekey its UI.
+ */
+function guardBinding(
+  sessionStore: SessionStore,
+  send: SendToConnection,
+  connectionId: UUID,
+  sessionId: UUID,
+  claudeSessionId: UUID | undefined,
+): boolean {
+  if (claudeSessionId === undefined) return true;
+  const stored = sessionStore.findByRemiSessionId(sessionId);
+  const bound = stored?.claudeSessionId;
+  if (!bound) return true;
+  if (bound === claudeSessionId) return true;
+  log(
+    `[Binding] STALE_BINDING refused for session ${sessionId.slice(0, 8)}: incoming=${claudeSessionId.slice(0, 8)} bound=${bound.slice(0, 8)}`,
+  );
+  send(
+    connectionId,
+    createError(
+      'STALE_BINDING',
+      'The Claude session this message was for has rotated; the binding has moved',
+      {
+        sessionId,
+        incomingClaudeSessionId: claudeSessionId,
+        boundClaudeSessionId: bound,
+      },
+    ),
+  );
+  return false;
 }
 
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, send } = deps;
+  const { sessionRegistry, sessionStore, send } = deps;
 
   return {
     onUserInput: async (
       connectionId: UUID,
-      _sessionId: UUID,
+      sessionId: UUID,
       content: string,
       raw?: boolean,
+      claudeSessionId?: UUID,
     ): Promise<void> => {
       log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
 
       const session = sessionRegistry.getSessionForConnection(connectionId);
       if (!session) {
         log(`No session found for connection ${connectionId}`);
+        return;
+      }
+
+      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 
@@ -60,6 +114,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       sessionId: UUID,
       questionId: UUID,
       answer: string,
+      claudeSessionId?: UUID,
     ): Promise<void> => {
       log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
 
@@ -74,6 +129,10 @@ export function createInputHandlers(deps: InputHandlerDeps) {
           connectionId,
           createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
         );
+        return;
+      }
+
+      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -56,7 +56,17 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
 
   return {
     onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean): void => {
-      const daemonSessions = sessionRegistry.listSessions();
+      // Decorate daemon-sourced sessions with their pre-assigned Claude
+      // binding (#429). transcriptPath is derived from the same encoding
+      // rule transcript-discovery uses, so the client can show "you are
+      // talking to port X / claude <short-uuid>" without round-tripping.
+      const daemonSessionsRaw = sessionRegistry.listSessions();
+      const daemonSessions = daemonSessionsRaw.map((s) => {
+        const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
+        if (!stored?.claudeSessionId) return s;
+        const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
+        return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+      });
       let allSessions = [...daemonSessions];
 
       if (includeExternal) {

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -18,12 +18,13 @@ import {
   createError,
   createKillSessionResponse,
   createSessionListResponse,
+  errorToString,
 } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
-import { log } from '../logger.ts';
+import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SessionHandlerDeps {
@@ -60,12 +61,22 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       // binding (#429). transcriptPath is derived from the same encoding
       // rule transcript-discovery uses, so the client can show "you are
       // talking to port X / claude <short-uuid>" without round-tripping.
+      // A failed lookup on any one entry must not nuke the entire list
+      // response — the connection would hang waiting for a reply. Fall
+      // back to the undecorated entry on per-entry failure.
       const daemonSessionsRaw = sessionRegistry.listSessions();
       const daemonSessions = daemonSessionsRaw.map((s) => {
-        const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
-        if (!stored?.claudeSessionId) return s;
-        const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
-        return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+        try {
+          const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
+          if (!stored?.claudeSessionId) return s;
+          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
+          return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+        } catch (err) {
+          logError(
+            `[SessionList] Failed to decorate session ${s.sessionId.slice(0, 8)}; serving raw entry: ${errorToString(err)}`,
+          );
+          return s;
+        }
       });
       let allSessions = [...daemonSessions];
 

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -51,9 +51,11 @@ export interface MessageApiSetupDeps {
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
   /**
    * Returns the current Claude session UUID this PTY is bound to (#429).
-   * Called on every question emission; returns null if no binding is known
-   * (the daemon's pre-spawn save always sets one, so null is rare). Same
-   * synchronous/non-throwing contract as pushConfig.
+   * Called on every question emission; returns null if no binding is
+   * recorded for this session (the normal spawn path sets one pre-spawn,
+   * so null is rare in production). Same synchronous/non-throwing
+   * contract as pushConfig — implementations must absorb their own I/O
+   * errors rather than throwing into the emission path.
    */
   getClaudeSessionId?: () => UUID | null;
 }

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -49,6 +49,13 @@ export interface MessageApiSetupDeps {
   updateRemiStatus: (patch: { sessionStatus: AgentStatus }) => void;
   maxBulletLength: number;
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
+  /**
+   * Returns the current Claude session UUID this PTY is bound to (#429).
+   * Called on every question emission; returns null if no binding is known
+   * (the daemon's pre-spawn save always sets one, so null is rare). Same
+   * synchronous/non-throwing contract as pushConfig.
+   */
+  getClaudeSessionId?: () => UUID | null;
 }
 
 export interface MessageApiHandle {
@@ -80,6 +87,7 @@ export function createMessageApiForSession(
     updateRemiStatus,
     maxBulletLength,
     sendMessage,
+    getClaudeSessionId,
   } = deps;
 
   const sendAndRecord = (message: ProtocolMessage): void => {
@@ -118,12 +126,14 @@ export function createMessageApiForSession(
     onQuestion: (question: Question) => {
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
+      const claudeSessionId = getClaudeSessionId?.() ?? undefined;
       const msg: ProtocolMessage = {
         type: 'question',
         id: generateId(),
         timestamp: now(),
         question,
         sessionId: questionSessionId,
+        ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
       sessionRegistry.updateQuestion(questionSessionId, question);

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -241,30 +241,38 @@ export class RelayAdapter implements ConnectionAdapter {
     if (!this.clientConnectionId) return;
     const connectionId = this.clientConnectionId;
     switch (msg['type']) {
-      case 'user_input':
+      case 'user_input': {
         if (typeof msg['content'] !== 'string' || typeof msg['sessionId'] !== 'string') {
           console.warn('Invalid user_input payload: missing content or sessionId');
           return;
         }
+        const claudeId =
+          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
         this.events.onUserInput?.(
           connectionId,
           msg['sessionId'],
           msg['content'],
           msg['raw'] === true,
+          claudeId,
         );
         break;
-      case 'answer':
+      }
+      case 'answer': {
         if (typeof msg['questionId'] !== 'string' || typeof msg['answer'] !== 'string') {
           console.warn('Invalid answer payload: missing questionId or answer');
           return;
         }
+        const claudeId =
+          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
         this.events.onAnswer?.(
           connectionId,
           typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '',
           msg['questionId'],
           msg['answer'],
+          claudeId,
         );
         break;
+      }
       case 'session_list_request':
         if (typeof msg['id'] !== 'string') {
           console.warn('Invalid session_list_request payload: missing id');

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -60,10 +60,10 @@ export interface ConnectionEvents {
   onDisconnect: (reason: string) => void;
 
   /** User input received */
-  onUserInput: (sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (sessionId: UUID, content: string, raw?: boolean, claudeSessionId?: UUID) => void;
 
   /** Answer to question received */
-  onAnswer: (sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (sessionId: UUID, questionId: UUID, answer: string, claudeSessionId?: UUID) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (sessionId: UUID, bulletId: number, requestId: UUID) => void;
@@ -405,7 +405,12 @@ export class Connection {
     this.sendAck(message.id, 'delivered');
 
     // Notify
-    this.events.onUserInput?.(message.sessionId, message.content, message.raw);
+    this.events.onUserInput?.(
+      message.sessionId,
+      message.content,
+      message.raw,
+      message.claudeSessionId,
+    );
   }
 
   private handleAnswer(message: AnswerMessage): void {
@@ -418,7 +423,12 @@ export class Connection {
     this.sendAck(message.id, 'delivered');
 
     // Notify
-    this.events.onAnswer?.(message.sessionId, message.questionId, message.answer);
+    this.events.onAnswer?.(
+      message.sessionId,
+      message.questionId,
+      message.answer,
+      message.claudeSessionId,
+    );
   }
 
   private handleBulletExpandRequest(message: BulletExpandRequestMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -43,10 +43,22 @@ export interface ServerEvents {
   onClientDisconnect: (connectionId: UUID, reason: string) => void;
 
   /** User input from client */
-  onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (
+    connectionId: UUID,
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Answer from client */
-  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Bullet expand request from client */
   onBulletExpandRequest: (
@@ -338,12 +350,18 @@ export class WebSocketServer {
         this.events.onClientDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (sessionId, content, raw) => {
-        this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw);
+      onUserInput: (sessionId, content, raw, claudeSessionId) => {
+        this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw, claudeSessionId);
       },
 
-      onAnswer: (sessionId, questionId, answer) => {
-        this.events.onAnswer?.(ws.data.connectionId, sessionId, questionId, answer);
+      onAnswer: (sessionId, questionId, answer, claudeSessionId) => {
+        this.events.onAnswer?.(
+          ws.data.connectionId,
+          sessionId,
+          questionId,
+          answer,
+          claudeSessionId,
+        );
       },
 
       onBulletExpandRequest: (sessionId, bulletId, requestId) => {

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -271,6 +271,10 @@ export class TranscriptDiscovery {
       source: 'transcript',
       canAttach: false, // External sessions can't be attached to via daemon
       canResume: status !== 'active', // Only offer resume for idle/completed sessions, not actively running ones
+      // For external entries the filename UUID IS the Claude session id;
+      // path comes from the same disk scan.
+      claudeSessionId: file.sessionId,
+      transcriptPath: file.filePath,
     };
   }
 

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -432,5 +432,35 @@ describe('createInputHandlers', () => {
       expect(capture.writes).toEqual([]);
       expect(sendCalls.filter((c) => c.message.type === 'error').length).toBe(1);
     });
+
+    test('client-sent claudeSessionId but no daemon binding yet: accept (race window)', async () => {
+      // Pre-spawn save in production makes this rare, but the contract
+      // is fail-open for the race window. Construct it by registering
+      // a session without saving the store entry.
+      const capture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(capture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+      // Deliberately do NOT call sessionStore.save here.
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+
+      const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
+      await handlers.onAnswer(CID, sessionId, QID, 'y', claudeId);
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
   });
 });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
@@ -6,6 +9,7 @@ import { createInputHandlers } from '../../../src/cli/handlers/input-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
 
 /**
  * Minimal PTY/MessageAPI fakes, loosely inspired by the cast-through-unknown
@@ -46,11 +50,15 @@ const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 
 describe('createInputHandlers', () => {
   let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let tmpDir: string;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
 
   beforeEach(() => {
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-input-events-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     sendCalls = [];
     send = (connectionId, message) => {
       sendCalls.push({ connectionId, message });
@@ -62,6 +70,7 @@ describe('createInputHandlers', () => {
   afterEach(async () => {
     __resetLoggerForTests();
     await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   describe('onUserInput', () => {
@@ -76,7 +85,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
 
       expect(ptyCapture.writes).toEqual(['\x1b[A']);
@@ -94,7 +103,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onUserInput(CID, sessionId, 'hello world', false);
 
       expect(ptyCapture.submits).toEqual(['hello world']);
@@ -104,7 +113,7 @@ describe('createInputHandlers', () => {
     test('logs and returns when no session is attached to the connection', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       await handlers.onUserInput(
         CID,
@@ -133,7 +142,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       // Should not throw
       await handlers.onUserInput(CID, sessionId, 'x', true);
 
@@ -164,7 +173,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
@@ -194,7 +203,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       // Pass a bogus sessionId, handler should still find the session via connection
       await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
@@ -219,7 +228,7 @@ describe('createInputHandlers', () => {
       // must signal the drop back to the iOS client so the user is not left
       // wondering whether their tap landed.
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -250,7 +259,7 @@ describe('createInputHandlers', () => {
       });
 
       const stale = 'stal0000-0000-0000-0000-000000000000' as UUID;
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -269,7 +278,7 @@ describe('createInputHandlers', () => {
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
 
@@ -279,7 +288,7 @@ describe('createInputHandlers', () => {
 
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
 
@@ -298,7 +307,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -316,11 +325,112 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map([[7, 'full expanded content']])),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
 
       expect(sendCalls).toHaveLength(1);
       expect(sendCalls[0]?.message.type).toBe('bullet_expand_response');
+    });
+  });
+
+  describe('STALE_BINDING guard (#429)', () => {
+    function registerSessionWithBinding(claudeId: string): {
+      sessionId: UUID;
+      capture: { writes: string[]; submits: string[] };
+    } {
+      const capture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(capture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: claudeId,
+        projectPath: '/test/dir',
+        port: 0,
+        pid: 0,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      return { sessionId, capture };
+    }
+
+    test('answer with matching claudeSessionId is forwarded', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [{ value: 'y', label: 'Y', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y', bound);
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('answer with stale claudeSessionId is refused with STALE_BINDING', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y', stale);
+
+      expect(capture.submits).toEqual([]);
+      const errs = sendCalls.filter((c) => c.message.type === 'error');
+      expect(errs).toHaveLength(1);
+      const err = errs[0]?.message as { code?: string; details?: Record<string, unknown> };
+      expect(err.code).toBe('STALE_BINDING');
+      expect(err.details?.['boundClaudeSessionId']).toBe(bound);
+      expect(err.details?.['incomingClaudeSessionId']).toBe(stale);
+    });
+
+    test('answer without claudeSessionId (legacy client) is accepted', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('user_input with stale claudeSessionId is refused', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onUserInput(CID, sessionId, 'ls', false, stale);
+
+      expect(capture.submits).toEqual([]);
+      expect(capture.writes).toEqual([]);
+      expect(sendCalls.filter((c) => c.message.type === 'error').length).toBe(1);
     });
   });
 });

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -103,6 +103,50 @@ describe('createSessionHandlers', () => {
       expect(msg.sessions).toHaveLength(1);
     });
 
+    test('decorates daemon sessions with claudeSessionId + transcriptPath (#429)', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      const claudeId = '11111111-2222-3333-4444-555555555555';
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: claudeId,
+        projectPath: '/test/dir',
+        port: PORT,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      const msg = sendCalls[0]?.message as unknown as {
+        sessions: Array<{
+          sessionId: string;
+          claudeSessionId?: string;
+          transcriptPath?: string;
+        }>;
+      };
+      expect(msg.sessions).toHaveLength(1);
+      expect(msg.sessions[0]?.claudeSessionId).toBe(claudeId);
+      expect(msg.sessions[0]?.transcriptPath).toContain(`/${claudeId}.jsonl`);
+    });
+
+    test('falls back to undecorated entry when sessionStore lookup misses', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      // Deliberately do NOT call sessionStore.save.
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      const msg = sendCalls[0]?.message as unknown as {
+        sessions: Array<{ claudeSessionId?: string; transcriptPath?: string }>;
+      };
+      expect(msg.sessions).toHaveLength(1);
+      expect(msg.sessions[0]?.claudeSessionId).toBeUndefined();
+      expect(msg.sessions[0]?.transcriptPath).toBeUndefined();
+    });
+
     test('omits the current daemon port from daemonPorts', () => {
       // Register one session entry for a DIFFERENT port alongside ours.
       liveSessionsRegistry.register({

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -326,4 +326,92 @@ describe('createMessageApiForSession', () => {
     expect(updates.length).toBeGreaterThanOrEqual(1);
     expect((updates[0]?.message as { isUpdate: boolean }).isUpdate).toBe(true);
   });
+
+  describe('getClaudeSessionId on questions (#429)', () => {
+    function buildWithBinding(sessionId: UUID, get: () => UUID | null) {
+      return createMessageApiForSession(
+        {
+          sessionRegistry,
+          transcriptWatchers,
+          deviceTokens,
+          pushConfig: () => ({ signalingUrl: 'ws://fake-signaling' }),
+          updateRemiStatus: (patch) => statusPatches.push(patch),
+          maxBulletLength: 4000,
+          sendMessage: (sid, message) => {
+            sendCalls.push({ sessionId: sid, message });
+          },
+          getClaudeSessionId: get,
+        },
+        sessionId,
+      );
+    }
+
+    test('question carries claudeSessionId returned by the lazy getter', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { messageApi } = buildWithBinding(sessionId, () => claudeId);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+      const q = sendCalls.find((c) => c.message.type === 'question');
+      expect(q).toBeDefined();
+      expect((q?.message as { claudeSessionId?: string }).claudeSessionId).toBe(claudeId);
+    });
+
+    test('getter rotation: second question reflects the new binding', () => {
+      // Simulates /resume rotation between two question emissions —
+      // the lazy getter must re-read on each emission, not capture once.
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const before = '11111111-2222-3333-4444-555555555555' as UUID;
+      const after = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      let current: UUID = before;
+      const { messageApi } = buildWithBinding(sessionId, () => current);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+      // Force a status reset so questionDedup doesn't suppress the
+      // second emission.
+      messageApi.handleStatusChange('idle');
+      current = after;
+      messageApi.handleQuestion(
+        questionWith([
+          { ...yesOpt, value: 'y2', label: 'Y2' },
+          { ...noOpt, value: 'n2', label: 'N2' },
+        ]),
+      );
+
+      const questions = sendCalls
+        .filter((c) => c.message.type === 'question')
+        .map((c) => (c.message as { claudeSessionId?: string }).claudeSessionId);
+      expect(questions).toEqual([before, after]);
+    });
+
+    test('getter returning null omits claudeSessionId from the wire message', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const { messageApi } = buildWithBinding(sessionId, () => null);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+      const q = sendCalls.find((c) => c.message.type === 'question');
+      expect(q).toBeDefined();
+      expect('claudeSessionId' in (q?.message ?? {})).toBe(false);
+    });
+  });
 });

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Verifies the relay adapter's routeMessage forwards `claudeSessionId`
+ * to onUserInput / onAnswer (#429). Pre-fix the field was silently
+ * dropped, so relay-mode clients bypassed the daemon's stale-binding
+ * guard entirely.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
+import { RelayAdapter } from '../src/remote/relay-adapter.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const SID = 'sess0000-0000-0000-0000-000000000000' as UUID;
+const QID = 'ques0000-0000-0000-0000-000000000000' as UUID;
+const CSID = '11111111-2222-3333-4444-555555555555';
+
+function makeAdapter(events: object): RelayAdapter {
+  const adapter = new RelayAdapter({ signalingUrl: 'wss://ignored.example.com' }, events);
+  // routeMessage is private and needs clientConnectionId; this matches
+  // the assignment that happens in the real auth flow.
+  (adapter as unknown as { clientConnectionId: UUID }).clientConnectionId = CID;
+  return adapter;
+}
+
+function callRoute(adapter: RelayAdapter, msg: Record<string, unknown>): void {
+  (adapter as unknown as { routeMessage: (m: Record<string, unknown>) => void }).routeMessage(msg);
+}
+
+describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
+  test('user_input with claudeSessionId is forwarded as the 5th arg', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+      raw: false,
+      claudeSessionId: CSID,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBe(CSID);
+  });
+
+  test('user_input without claudeSessionId forwards undefined (back-compat)', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+
+  test('answer with claudeSessionId is forwarded as the 5th arg', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onAnswer: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _questionId: UUID,
+        _answer: string,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: 'y',
+      claudeSessionId: CSID,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBe(CSID);
+  });
+
+  test('non-string claudeSessionId is dropped to undefined (defensive)', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onAnswer: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _questionId: UUID,
+        _answer: string,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: 'y',
+      claudeSessionId: 42,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -84,6 +84,7 @@ export type {
   RegisterDeviceTokenMessage,
   SessionResetMessage,
   DaemonUpdateAvailableMessage,
+  TranscriptBindingChangedMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -131,6 +132,7 @@ export {
   createRegisterDeviceToken,
   createSessionReset,
   createDaemonUpdateAvailable,
+  createTranscriptBindingChanged,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -100,7 +100,8 @@ export type ProtocolMessage =
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
   | SessionResetMessage
-  | DaemonUpdateAvailableMessage;
+  | DaemonUpdateAvailableMessage
+  | TranscriptBindingChangedMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -126,6 +127,22 @@ export interface HelloAckMessage {
   readonly timestamp: Timestamp;
   readonly serverVersion: string;
   readonly sessionId: UUID;
+  /**
+   * Claude Code session UUID this daemon's PTY is bound to (#427/#429).
+   * Always populated post-phase-1 because the daemon pre-assigns the id
+   * before spawning Claude. Null only when this hello_ack predates a
+   * resolved binding (e.g. resume-attaching to a session whose lock was
+   * lost across a daemon crash). Clients should key sessions by
+   * (connectionId, claudeSessionId) to keep two daemons in the same cwd
+   * from cross-contaminating.
+   */
+  readonly claudeSessionId?: UUID | null | undefined;
+  /**
+   * Absolute path to the .jsonl transcript file Claude writes to.
+   * Pre-assigned alongside claudeSessionId; the file may not yet exist on
+   * disk when this ack is sent. Null when claudeSessionId is null.
+   */
+  readonly transcriptPath?: string | null | undefined;
   /** Whether this is a resumed session */
   readonly isResume?: boolean | undefined;
   /** Number of messages to be replayed (if resume) */
@@ -163,6 +180,15 @@ export interface UserInputMessage {
   readonly content: string;
   /** When true, content is raw terminal bytes (no Enter appended) */
   readonly raw?: boolean;
+  /**
+   * Claude Code session UUID the client believed it was talking to when
+   * the user typed this. Daemon rejects with code='stale_binding' when
+   * present and != current binding (e.g. the PTY swapped to another
+   * session via /resume between the user typing and the message
+   * landing). Omitted by pre-#429 clients; daemon accepts without
+   * checking in that case.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Acknowledgment */
@@ -192,6 +218,13 @@ export interface QuestionMessage {
   readonly question: Question;
   /** Session that owns this question */
   readonly sessionId?: UUID | undefined;
+  /**
+   * Claude Code session UUID the question came from. The answer carrying
+   * this id back lets the daemon reject the write if the binding has
+   * moved (e.g. user ran /resume between the question firing and their
+   * tap). Populated when the daemon has a binding; omitted otherwise.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Answer to a question */
@@ -202,6 +235,12 @@ export interface AnswerMessage {
   readonly sessionId: UUID;
   readonly questionId: UUID;
   readonly answer: string;
+  /**
+   * Echoes the claudeSessionId from the QuestionMessage. Daemon refuses
+   * with code='stale_binding' when present and != current binding.
+   * Omitted by pre-#429 clients.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Session state update */
@@ -292,6 +331,26 @@ export interface SessionListResponseMessage {
   readonly requestId: UUID;
   /** Other daemon ports on this machine (for auto-connect) */
   readonly daemonPorts?: readonly number[];
+}
+
+/**
+ * Notifies the client that the PTY's bound Claude session has changed,
+ * e.g. user ran /resume or /clear inside the PTY (#429). Clients should
+ * rekey UI state by the new (sessionId, claudeSessionId) tuple and update
+ * any displayed binding indicator.
+ */
+export interface TranscriptBindingChangedMessage {
+  readonly type: 'transcript_binding_changed';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session id whose binding rotated. */
+  readonly sessionId: UUID;
+  /** The new Claude session id Claude is now writing under. */
+  readonly claudeSessionId: UUID;
+  /** Absolute path to the new transcript .jsonl. */
+  readonly transcriptPath: string;
+  /** Diagnostic: 'restart' for /clear|/compact, 'resume' for /resume, 'unknown' otherwise. */
+  readonly reason: 'restart' | 'resume' | 'unknown';
 }
 
 /** Token usage information from a transcript entry */
@@ -678,6 +737,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'register_device_token',
     'daemon_update_available',
     'session_reset',
+    'transcript_binding_changed',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -727,6 +787,7 @@ export function createHelloAck(
   serverVersion: string,
   sessionId: UUID,
   resumeInfo?: { isResume: boolean; replayCount: number; nextBulletId: number },
+  binding?: { claudeSessionId: UUID | null; transcriptPath: string | null },
 ): HelloAckMessage {
   return {
     type: 'hello_ack',
@@ -738,6 +799,10 @@ export function createHelloAck(
       isResume: resumeInfo.isResume,
       replayCount: resumeInfo.replayCount,
       nextBulletId: resumeInfo.nextBulletId,
+    }),
+    ...(binding && {
+      claudeSessionId: binding.claudeSessionId,
+      transcriptPath: binding.transcriptPath,
     }),
   };
 }
@@ -775,7 +840,12 @@ export function createStructuredAgentOutput(
 /**
  * Create a user input message.
  */
-export function createUserInput(sessionId: UUID, content: string, raw?: boolean): UserInputMessage {
+export function createUserInput(
+  sessionId: UUID,
+  content: string,
+  raw?: boolean,
+  claudeSessionId?: UUID,
+): UserInputMessage {
   return {
     type: 'user_input',
     id: generateId(),
@@ -783,6 +853,7 @@ export function createUserInput(sessionId: UUID, content: string, raw?: boolean)
     sessionId,
     content,
     ...(raw && { raw }),
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
@@ -862,20 +933,30 @@ export function createError(
 /**
  * Create a question message.
  */
-export function createQuestion(question: Question, sessionId?: UUID): QuestionMessage {
+export function createQuestion(
+  question: Question,
+  sessionId?: UUID,
+  claudeSessionId?: UUID,
+): QuestionMessage {
   return {
     type: 'question',
     id: generateId(),
     timestamp: now(),
     question,
     ...(sessionId !== undefined && { sessionId }),
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
 /**
  * Create an answer message for a question.
  */
-export function createAnswer(sessionId: UUID, questionId: UUID, answer: string): AnswerMessage {
+export function createAnswer(
+  sessionId: UUID,
+  questionId: UUID,
+  answer: string,
+  claudeSessionId?: UUID,
+): AnswerMessage {
   return {
     type: 'answer',
     id: generateId(),
@@ -883,6 +964,7 @@ export function createAnswer(sessionId: UUID, questionId: UUID, answer: string):
     sessionId,
     questionId,
     answer,
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
@@ -1335,6 +1417,27 @@ export function createSessionReset(sessionId: UUID, reason: string): SessionRese
     id: generateId(),
     timestamp: now(),
     sessionId,
+    reason,
+  };
+}
+
+/**
+ * Create a transcript-binding-changed notification (PTY's bound Claude
+ * session UUID rotated, e.g. /resume, /clear).
+ */
+export function createTranscriptBindingChanged(
+  sessionId: UUID,
+  claudeSessionId: UUID,
+  transcriptPath: string,
+  reason: 'restart' | 'resume' | 'unknown' = 'unknown',
+): TranscriptBindingChangedMessage {
+  return {
+    type: 'transcript_binding_changed',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    claudeSessionId,
+    transcriptPath,
     reason,
   };
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -130,19 +130,18 @@ export interface HelloAckMessage {
   /**
    * Claude Code session UUID this daemon's PTY is bound to (#427/#429).
    * Always populated post-phase-1 because the daemon pre-assigns the id
-   * before spawning Claude. Null only when this hello_ack predates a
-   * resolved binding (e.g. resume-attaching to a session whose lock was
-   * lost across a daemon crash). Clients should key sessions by
-   * (connectionId, claudeSessionId) to keep two daemons in the same cwd
-   * from cross-contaminating.
+   * before spawning Claude. Null only on the promotion path when the
+   * store lookup misses (crashed daemon, store cleared). Clients should
+   * key sessions by (connectionId, claudeSessionId) to keep two daemons
+   * in the same cwd from cross-contaminating.
    */
-  readonly claudeSessionId?: UUID | null | undefined;
+  readonly claudeSessionId?: UUID | null;
   /**
    * Absolute path to the .jsonl transcript file Claude writes to.
    * Pre-assigned alongside claudeSessionId; the file may not yet exist on
    * disk when this ack is sent. Null when claudeSessionId is null.
    */
-  readonly transcriptPath?: string | null | undefined;
+  readonly transcriptPath?: string | null;
   /** Whether this is a resumed session */
   readonly isResume?: boolean | undefined;
   /** Number of messages to be replayed (if resume) */
@@ -182,7 +181,7 @@ export interface UserInputMessage {
   readonly raw?: boolean;
   /**
    * Claude Code session UUID the client believed it was talking to when
-   * the user typed this. Daemon rejects with code='stale_binding' when
+   * the user typed this. Daemon rejects with code='STALE_BINDING' when
    * present and != current binding (e.g. the PTY swapped to another
    * session via /resume between the user typing and the message
    * landing). Omitted by pre-#429 clients; daemon accepts without
@@ -237,7 +236,7 @@ export interface AnswerMessage {
   readonly answer: string;
   /**
    * Echoes the claudeSessionId from the QuestionMessage. Daemon refuses
-   * with code='stale_binding' when present and != current binding.
+   * with code='STALE_BINDING' when present and != current binding.
    * Omitted by pre-#429 clients.
    */
   readonly claudeSessionId?: UUID | undefined;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -287,15 +287,16 @@ export interface DiscoverableSession {
    * Claude Code session UUID this entry's Claude is bound to (#427/#429).
    * For daemon-sourced entries, this is the pre-assigned binding from
    * SessionStore. For transcript-sourced entries it equals sessionId.
-   * Optional because legacy/edge cases (daemon entry whose Claude was
-   * spawned before #428) may have no recorded binding.
+   * Optional because the SessionStore lookup may miss on the daemon-list
+   * path (e.g. a daemon entry whose sessions.json record was lost across
+   * a crash before the client requested the list).
    */
   readonly claudeSessionId?: string | undefined;
 
   /**
    * Absolute path to the .jsonl transcript Claude writes to. Populated
-   * for all entries where it can be derived; omitted only when the entry
-   * predates #428's binding model and no transcript file was discovered.
+   * for all entries where the binding is known. Omitted in the same
+   * lookup-miss case described above.
    */
   readonly transcriptPath?: string | undefined;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -283,6 +283,22 @@ export interface DiscoverableSession {
   /** Whether this dead session can be resumed via Claude Code --resume */
   readonly canResume: boolean;
 
+  /**
+   * Claude Code session UUID this entry's Claude is bound to (#427/#429).
+   * For daemon-sourced entries, this is the pre-assigned binding from
+   * SessionStore. For transcript-sourced entries it equals sessionId.
+   * Optional because legacy/edge cases (daemon entry whose Claude was
+   * spawned before #428) may have no recorded binding.
+   */
+  readonly claudeSessionId?: string | undefined;
+
+  /**
+   * Absolute path to the .jsonl transcript Claude writes to. Populated
+   * for all entries where it can be derived; omitted only when the entry
+   * predates #428's binding model and no transcript file was discovered.
+   */
+  readonly transcriptPath?: string | undefined;
+
   /** WebSocket port of the daemon hosting this session (for auto-connect) */
   readonly wsPort?: number;
 

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -53,7 +53,7 @@ describe('binding fields on the wire (#429)', () => {
 
   test('question carries claudeSessionId when provided', () => {
     const msg = createQuestion(
-      { id: QID, text: 'continue?', options: [], freeText: false },
+      { id: QID, text: 'continue?', options: [], allowsFreeText: false, isAnswered: false },
       RID,
       CID,
     );

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Round-trip tests for the binding-aware protocol additions in phase 2
+ * (#429). Each new field should survive serialize → deserialize without
+ * loss so client and daemon agree on the same wire shape.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '../src/index.ts';
+import {
+  createAnswer,
+  createHelloAck,
+  createQuestion,
+  createTranscriptBindingChanged,
+  createUserInput,
+  deserialize,
+  serialize,
+} from '../src/index.ts';
+
+const RID = 'remi0000-0000-0000-0000-000000000001' as UUID;
+const CID = 'claude00-0000-0000-0000-000000000002' as UUID;
+const QID = 'ques0000-0000-0000-0000-000000000003' as UUID;
+
+describe('binding fields on the wire (#429)', () => {
+  test('hello_ack carries claudeSessionId + transcriptPath when binding present', () => {
+    const msg = createHelloAck('1.0.0', RID, undefined, {
+      claudeSessionId: CID,
+      transcriptPath: '/home/u/.claude/projects/-x/abc.jsonl',
+    });
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.transcriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
+  });
+
+  test('hello_ack with null binding (no resolved id yet)', () => {
+    const msg = createHelloAck('1.0.0', RID, undefined, {
+      claudeSessionId: null,
+      transcriptPath: null,
+    });
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBeNull();
+    expect(round.transcriptPath).toBeNull();
+  });
+
+  test('hello_ack without binding arg omits the fields (back-compat)', () => {
+    const msg = createHelloAck('1.0.0', RID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect('claudeSessionId' in round).toBe(false);
+    expect('transcriptPath' in round).toBe(false);
+  });
+
+  test('question carries claudeSessionId when provided', () => {
+    const msg = createQuestion(
+      { id: QID, text: 'continue?', options: [], freeText: false },
+      RID,
+      CID,
+    );
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'question') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.sessionId).toBe(RID);
+  });
+
+  test('answer carries claudeSessionId echo when provided', () => {
+    const msg = createAnswer(RID, QID, 'y', CID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'answer') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.questionId).toBe(QID);
+    expect(round.answer).toBe('y');
+  });
+
+  test('user_input carries claudeSessionId when provided', () => {
+    const msg = createUserInput(RID, 'ls', false, CID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'user_input') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.content).toBe('ls');
+  });
+
+  test('transcript_binding_changed event round-trips with all fields', () => {
+    const msg = createTranscriptBindingChanged(
+      RID,
+      CID,
+      '/home/u/.claude/projects/-x/abc.jsonl',
+      'resume',
+    );
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'transcript_binding_changed') throw new Error('wrong type');
+    expect(round.sessionId).toBe(RID);
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.transcriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
+    expect(round.reason).toBe('resume');
+  });
+
+  test('transcript_binding_changed defaults reason to "unknown"', () => {
+    const msg = createTranscriptBindingChanged(RID, CID, '/x.jsonl');
+    expect(msg.reason).toBe('unknown');
+  });
+});


### PR DESCRIPTION
Phase 2 of epic #427. Closes #429. Depends on #431 (phase 1).

## What

Phase 1 made the daemon's PTY -> transcript binding **deterministic**. This phase makes that binding **visible** to clients and adds a daemon-side guard so an answer typed against a stale binding can never reach the wrong Claude PTY.

## Protocol additions

Files: \`packages/shared/src/protocol.ts\`, \`types.ts\`, \`index.ts\`.

- \`HelloAckMessage.claudeSessionId\` + \`.transcriptPath\` — populated on the queue-promotion path (\`cli.ts:onConnectionPromoted\`) where the daemon has a real session in hand. Initial \`hello_ack\` from \`connection.ts\` is pre-binding by design; clients learn the binding via \`session_list_response\` or this promotion ack.
- \`DiscoverableSession.claudeSessionId\` + \`.transcriptPath\` — daemon entries pulled from \`sessionStore\` + expectedTranscriptPath; external entries derived directly from the \`.jsonl\` filename.
- \`QuestionMessage.claudeSessionId\` — emitted on every question via a new lazy getter (\`sessionStore.findByRemiSessionId().claudeSessionId\`) threaded into \`MessageApiSetupDeps\`. Lazy so /resume-driven rotation is reflected without re-wiring.
- \`AnswerMessage.claudeSessionId\` + \`UserInputMessage.claudeSessionId\` — echoed back by clients so the daemon can validate.
- New \`TranscriptBindingChangedMessage\` — for runtime swaps (e.g. \`/resume\` inside the PTY). Factory exported; daemon emitter wired in phase 3 alongside the client listener so both sides ship together.

## Daemon-side stale-binding guard

\`packages/daemon/src/cli/handlers/input-events.ts\`:

\`\`\`
omitted by client (pre-#429):     accept (back-compat)
present but no daemon binding:    accept (rare race window)
present and matches bound id:     forward to PTY
present and mismatches:           refuse with ErrorMessage{code:'STALE_BINDING'}
\`\`\`

The error message includes both \`incomingClaudeSessionId\` and \`boundClaudeSessionId\` in details, so the client can rekey its UI to the new binding without a round-trip.

Plumbing: \`claudeSessionId\` optional param threaded through \`connection.ts\` -> \`websocket-server.ts\` -> \`websocket-adapter.ts\` -> \`input-events.ts\`. \`connection-adapter.ts\` interface extended.

## Tests

- **8 round-trip tests** in \`packages/shared/tests/binding-protocol.test.ts\` — covers hello_ack with binding / null / absent, question + answer + user_input echoes, transcript_binding_changed with default reason
- **4 daemon-side guard tests** in \`input-events.test.ts\` — matching id forwards, stale id is refused with correct details, legacy (no-id) client is accepted, user_input mirrors answer path

**Result:** 1929 pass / 69 skip / 0 fail across daemon+shared with \`SKIP_LLM_TESTS=1\`. Typecheck clean.

## Not in this PR (phase 3 #430)

- Client composite-key refactor (\`(connectionId, claudeSessionId)\` keying in App.tsx)
- Chat-header binding display (the "show on mobile remi which transcript" UX bit)
- Hook-bridge restart path firing \`transcript_binding_changed\` — protocol/factory in place; the daemon emitter will land with the client listener so both sides ship together

## Acceptance

- [x] Protocol carries \`claudeSessionId\` + \`transcriptPath\` end-to-end
- [x] Daemon refuses answers whose binding has rotated since the question was emitted
- [x] All existing tests pass; new tests cover round-trip + guard