### PR TITLE
feat: client binding visibility + daemon rotation event (phase 3, #430)

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -31,7 +31,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionReset, errorToString } from '@remi/shared';
+import { createSessionReset, createTranscriptBindingChanged, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
@@ -249,6 +249,11 @@ export function setupHookBridge(
       );
       return;
     }
+    // Capture the pre-restart id so we can emit transcript_binding_changed
+    // on rotation (#430). First-init has no previous binding, so the
+    // notification only fires when the lock actually moved.
+    const previousClaudeSessionId = claudeSessionId;
+    let isRotation = false;
     if (classification === 'restart') {
       log(
         `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
@@ -260,6 +265,7 @@ export function setupHookBridge(
       tracker.clearPending();
       claudeSessionId = null;
       mainSessionEnded = false;
+      isRotation = previousClaudeSessionId !== null;
     }
     // classification === 'match': either our tracked session or first-time lock.
     if (claudeSessionId) return; // already initialized
@@ -276,6 +282,25 @@ export function setupHookBridge(
         `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
       );
       sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+
+      // Notify clients of the binding rotation so they can rekey their
+      // (sessionId, claudeSessionId) composite state and refresh any
+      // displayed binding indicator. Skip on first-init: that's already
+      // covered by hello_ack + session_list_response.
+      if (isRotation) {
+        try {
+          sendAndRecord(
+            createTranscriptBindingChanged(
+              sessionId,
+              claudeSessionId as UUID,
+              input.transcript_path,
+              'restart',
+            ),
+          );
+        } catch (err) {
+          logError(`[Hooks] Failed to emit transcript_binding_changed: ${errorToString(err)}`);
+        }
+      }
 
       // Cancel the fallback timer since we have the exact path.
       const fallbackTimer = transcriptFallbackTimers.get(sessionId);
@@ -340,6 +365,8 @@ export function setupHookBridge(
         );
         return;
       }
+      const previousClaudeSessionId = claudeSessionId;
+      let isRotation = false;
       if (classification === 'restart') {
         log(
           `[Hooks] Claude restart (SessionInfo, ended=${mainSessionEnded}): ${claudeSessionId} -> ${hookClaudeSessionId}`,
@@ -351,12 +378,30 @@ export function setupHookBridge(
         tracker.clearPending();
         claudeSessionId = null;
         mainSessionEnded = false;
+        isRotation = previousClaudeSessionId !== null;
       }
 
       try {
         claudeSessionId = hookClaudeSessionId;
         log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
         sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+
+        if (isRotation) {
+          try {
+            sendAndRecord(
+              createTranscriptBindingChanged(
+                sessionId,
+                hookClaudeSessionId as UUID,
+                transcriptPath,
+                'restart',
+              ),
+            );
+          } catch (err) {
+            logError(
+              `[Hooks] Failed to emit transcript_binding_changed (SessionInfo): ${errorToString(err)}`,
+            );
+          }
+        }
 
         const existingWatcher = transcriptWatchers.get(sessionId);
         if (

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -228,11 +228,27 @@ export function setupHookBridge(
   }): void {
     if (!input.session_id) return;
 
+    // Snapshot the closure BEFORE adoptLockFromStore mutates it.
+    // adoptLockFromStore can race-pull the new id from sessionStore when
+    // the transcript-fallback wrote it first; without this snapshot the
+    // classifier sees the post-adopt value, returns 'match', and the
+    // rotation event silently never emits (#430 review #433).
+    const previousClaudeSessionId = claudeSessionId;
+    let isRotation = false;
+
     // If the transcript-fallback has already discovered our Claude
     // session ID (the multi-wrapper-in-same-dir case), adopt it before
     // classifying so the classifier sees the right currentLock instead
     // of a stale null.
     adoptLockFromStore();
+
+    // Detect rotation by comparing the pre-adopt snapshot against the
+    // incoming id. We do this here (independent of classifySessionEvent)
+    // so the rotation is observable even when adoptLockFromStore raced
+    // ahead and the classifier returns 'match'.
+    if (previousClaudeSessionId !== null && previousClaudeSessionId !== input.session_id) {
+      isRotation = true;
+    }
 
     const classification = classifySessionEvent({
       currentLock: claudeSessionId,
@@ -249,11 +265,6 @@ export function setupHookBridge(
       );
       return;
     }
-    // Capture the pre-restart id so we can emit transcript_binding_changed
-    // on rotation (#430). First-init has no previous binding, so the
-    // notification only fires when the lock actually moved.
-    const previousClaudeSessionId = claudeSessionId;
-    let isRotation = false;
     if (classification === 'restart') {
       log(
         `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
@@ -265,7 +276,9 @@ export function setupHookBridge(
       tracker.clearPending();
       claudeSessionId = null;
       mainSessionEnded = false;
-      isRotation = previousClaudeSessionId !== null;
+      // isRotation was already computed above against the pre-adopt
+      // snapshot; restart is a stricter signal but does not override
+      // a true value coming from the race-detector path.
     }
     // classification === 'match': either our tracked session or first-time lock.
     if (claudeSessionId) return; // already initialized
@@ -285,8 +298,10 @@ export function setupHookBridge(
 
       // Notify clients of the binding rotation so they can rekey their
       // (sessionId, claudeSessionId) composite state and refresh any
-      // displayed binding indicator. Skip on first-init: that's already
-      // covered by hello_ack + session_list_response.
+      // displayed binding indicator. Skip on first-init: that's
+      // covered by session_list_response (and by hello_ack on the
+      // queue-promotion path; the initial first-connect hello_ack from
+      // connection.ts carries no binding by design).
       if (isRotation) {
         try {
           sendAndRecord(

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1719,4 +1719,105 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toHaveLength(0); // no inject
     expect(messageApiLog.questionCalls).toBe(0); // no escalate
   });
+
+  describe('transcript_binding_changed emission on rotation (#430)', () => {
+    /**
+     * Set up a hook bridge that captures every protocol message it tries
+     * to send. We can't use the shared `build` helper because that swallows
+     * sendAndRecord; rotation emission is the whole point we need to assert
+     * on.
+     */
+    function buildWithCapture(): { sent: import('@remi/shared').ProtocolMessage[] } {
+      const sent: import('@remi/shared').ProtocolMessage[] = [];
+      const tracker = new PassthroughTracker((q) => {
+        messageApiLog.questionCalls += 1;
+        const _ = q;
+      });
+      setupHookBridge(
+        {
+          sessionRegistry,
+          sessionStore,
+          liveSessionsRegistry,
+          transcriptWatchers: transcriptWatchers as unknown as Map<
+            UUID,
+            import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+          >,
+          transcriptFallbackTimers,
+          autoApproveService: null,
+          currentPort: () => 8765,
+        },
+        {
+          hookServer: hookServer as unknown as HookServer,
+          sessionId: SID,
+          workingDirectory: tmpDir,
+          messageApi: {
+            handleMessage: () => {},
+            handleQuestion: () => {},
+            handleStatusChange: () => {},
+            reset: () => {
+              messageApiLog.resetCalls.n += 1;
+            },
+          } as unknown as import('../../../src/api/message-api.ts').MessageAPI,
+          sendAndRecord: (msg) => sent.push(msg),
+          tracker: tracker as unknown as import(
+            '../../../src/api/question-presence-tracker.ts',
+          ).QuestionPresenceTracker,
+        },
+      );
+      return { sent };
+    }
+
+    test('first-init does NOT emit (no rotation, only hello_ack covers initial)', () => {
+      const { sent } = buildWithCapture();
+
+      // Register the session so the bridge proceeds past hasSession() checks.
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-first-id',
+        transcript_path: path.join(tmpDir, 'first.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      expect(sent.filter((m) => m.type === 'transcript_binding_changed')).toHaveLength(0);
+    });
+
+    test('second SessionStart with a different id emits transcript_binding_changed', () => {
+      const { sent } = buildWithCapture();
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-first-id',
+        transcript_path: path.join(tmpDir, 'first.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-second-id',
+        transcript_path: path.join(tmpDir, 'second.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      const events = sent.filter((m) => m.type === 'transcript_binding_changed') as Array<{
+        sessionId: string;
+        claudeSessionId: string;
+        transcriptPath: string;
+        reason: string;
+      }>;
+      expect(events).toHaveLength(1);
+      expect(events[0]?.sessionId).toBe(SID);
+      expect(events[0]?.claudeSessionId).toBe('claude-second-id');
+      expect(events[0]?.transcriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
+      expect(events[0]?.reason).toBe('restart');
+    });
+  });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1759,9 +1759,7 @@ describe('setupHookBridge', () => {
             },
           } as unknown as import('../../../src/api/message-api.ts').MessageAPI,
           sendAndRecord: (msg) => sent.push(msg),
-          tracker: tracker as unknown as import(
-            '../../../src/api/question-presence-tracker.ts',
-          ).QuestionPresenceTracker,
+          tracker: tracker as unknown as QuestionPresenceTracker,
         },
       );
       return { sent };

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import { shouldKeepExisting } from '@/lib/question-merge';
+import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
   AppSettings,
@@ -46,6 +47,16 @@ const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
 // cold-start push answers so multi-daemon users do not silently answer the
 // wrong daemon. Issue #389 review.
 const LOCALSTORAGE_SESSION_DAEMONS_KEY = 'remi-session-daemons';
+
+/**
+ * Narrow an unknown JSON value to a non-empty string. Used at the
+ * boundary between wire data (Record<string, unknown>) and typed UI
+ * state so a daemon that ever sends a malformed STALE_BINDING payload
+ * cannot corrupt the cached binding.
+ */
+function asNonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
 
 function rememberSessionDaemon(sessionId: string, url: string): void {
   try {
@@ -586,28 +597,7 @@ function App() {
               }
             }
           }
-          // Cross-connection dedup keyed by (connectionId, claudeSessionId)
-          // composite (#430). Same Claude sessionId reported by two different
-          // daemons IS a collision — keep both as separate rows so the user
-          // can pick which daemon to talk to. Only collapse when both
-          // connectionId AND claudeSessionId match (or both lack
-          // claudeSessionId, in which case fall back to id-keyed dedup so
-          // pre-#429 daemons still degrade gracefully).
-          const compositeKey = (s: UISession): string =>
-            s.claudeSessionId ? `${s.connectionId}|${s.claudeSessionId}` : `${s.connectionId}|${s.id}`;
-          const deduped = result.reduce<UISession[]>((acc, s) => {
-            const key = compositeKey(s);
-            const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
-            if (dupIdx === -1) {
-              acc.push(s);
-              return acc;
-            }
-            const existing = acc[dupIdx];
-            if (s.source === 'daemon' && existing.source !== 'daemon') {
-              acc[dupIdx] = s;
-            }
-            return acc;
-          }, []);
+          const deduped = dedupSessions(result);
           // Sort: live first, then by last activity
           const sorted = deduped.sort((a, b) => {
             const aLive = a.connectionStatus === 'connected' ? 0 : 1;
@@ -772,16 +762,19 @@ function App() {
         // STALE_BINDING (#430): the user typed against an old Claude
         // session and the daemon refused. Update our cached binding
         // from the error's details so the next answer routes correctly.
+        // The shape mirrors the daemon-side createError call in
+        // packages/daemon/src/cli/handlers/input-events.ts:guardBinding;
+        // update both ends together if the field names change.
         const errorCode = (message as { code?: string }).code;
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
-          const refusedSessionId = details?.['sessionId'] as UUID | undefined;
-          const newBound = details?.['boundClaudeSessionId'] as string | undefined;
+          const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;
+          const newBound = asNonEmptyString(details?.['boundClaudeSessionId']);
           if (refusedSessionId && newBound) {
             setSessions((prev) =>
               prev.map((s) =>
                 s.id === refusedSessionId && s.connectionId === connectionId
-                  ? { ...s, claudeSessionId: newBound }
+                  ? { ...s, claudeSessionId: newBound as UUID }
                   : s,
               ),
             );
@@ -827,21 +820,32 @@ function App() {
         // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
         // Update the session's bound (claudeSessionId, transcriptPath) so
         // future outbound answers carry the new id and the chat header
-        // shows the updated binding.
+        // shows the updated binding. If no session matches, surface a
+        // warn — silent no-op would mean future answers hit STALE_BINDING
+        // even though the rotation event arrived correctly.
+        let matched = false;
         setSessions((prev) =>
-          prev.map((s) =>
-            s.id === message.sessionId && s.connectionId === connectionId
-              ? {
-                  ...s,
-                  claudeSessionId: message.claudeSessionId as string,
-                  transcriptPath: message.transcriptPath,
-                }
-              : s,
-          ),
+          prev.map((s) => {
+            if (s.id === message.sessionId && s.connectionId === connectionId) {
+              matched = true;
+              return {
+                ...s,
+                claudeSessionId: message.claudeSessionId as string,
+                transcriptPath: message.transcriptPath,
+              };
+            }
+            return s;
+          }),
         );
-        console.info(
-          `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
-        );
+        if (matched) {
+          console.info(
+            `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
+          );
+        } else {
+          console.warn(
+            `[App] transcript_binding_changed for unknown session ${message.sessionId.slice(0, 8)} on ${connectionId}; session list may be stale`,
+          );
+        }
         break;
       }
 
@@ -1044,7 +1048,19 @@ function App() {
 
       console.debug('[App] handlePushAnswer:', { sessionId, questionId, answer });
 
-      const answerMsg = createAnswer(sessionId as UUID, questionId as UUID, answer);
+      // Thread claudeSessionId so the daemon can refuse if its binding
+      // has rotated since the lock-screen notification fired (#430 review
+      // #433). Without this the cold-start push-answer path silently
+      // bypassed the stale-binding guard. Read from sessionsRef so we
+      // see the latest snapshot even when this handler captured an old
+      // closure of `sessions`.
+      const boundId = sessionsRef.current.find((s) => s.id === sessionId)?.claudeSessionId;
+      const answerMsg = createAnswer(
+        sessionId as UUID,
+        questionId as UUID,
+        answer,
+        boundId as UUID | undefined,
+      );
 
       // Read the persisted URL list and per-session daemon map once; pass
       // into the pure resolver.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -190,6 +190,17 @@ function App() {
           console.warn('[App] Received hello_ack without sessionId from connection:', connectionId);
           break;
         }
+        // Phase 2 daemons attach the binding here so the client knows
+        // which transcript it's talking to before the first session_list
+        // round-trip (#430). Older daemons omit; the field stays undefined.
+        const ackClaudeSessionId =
+          message.claudeSessionId === undefined || message.claudeSessionId === null
+            ? undefined
+            : (message.claudeSessionId as string);
+        const ackTranscriptPath =
+          message.transcriptPath === undefined || message.transcriptPath === null
+            ? undefined
+            : (message.transcriptPath as string);
         setSessions((prev) => {
           // On reconnect, remove stale sessions from this connection that have a different
           // session ID (the daemon may have assigned a new session). Keep sessions from
@@ -202,7 +213,13 @@ function App() {
           if (exists) {
             return cleaned.map((s) =>
               s.id === message.sessionId
-                ? { ...s, connectionStatus: 'connected', connectionId }
+                ? {
+                    ...s,
+                    connectionStatus: 'connected',
+                    connectionId,
+                    ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
+                    ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
+                  }
                 : s,
             );
           }
@@ -219,6 +236,8 @@ function App() {
               connectionId,
               unreadCount: 0,
               preview: 'Connected',
+              ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
+              ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
             } satisfies UISession,
           ];
         });
@@ -513,6 +532,8 @@ function App() {
               preview: cleanedPreview.slice(0, 100),
               source: ds.source,
               canResume: showResume,
+              ...(ds.claudeSessionId !== undefined && { claudeSessionId: ds.claudeSessionId }),
+              ...(ds.transcriptPath !== undefined && { transcriptPath: ds.transcriptPath }),
             };
           })
           // Dedup: same session ID from daemon + transcript → keep daemon version.
@@ -565,10 +586,18 @@ function App() {
               }
             }
           }
-          // Cross-connection dedup: same session ID from multiple connections →
-          // keep daemon-sourced version. Different IDs in same cwd → keep both.
+          // Cross-connection dedup keyed by (connectionId, claudeSessionId)
+          // composite (#430). Same Claude sessionId reported by two different
+          // daemons IS a collision — keep both as separate rows so the user
+          // can pick which daemon to talk to. Only collapse when both
+          // connectionId AND claudeSessionId match (or both lack
+          // claudeSessionId, in which case fall back to id-keyed dedup so
+          // pre-#429 daemons still degrade gracefully).
+          const compositeKey = (s: UISession): string =>
+            s.claudeSessionId ? `${s.connectionId}|${s.claudeSessionId}` : `${s.connectionId}|${s.id}`;
           const deduped = result.reduce<UISession[]>((acc, s) => {
-            const dupIdx = acc.findIndex((other) => other.id === s.id);
+            const key = compositeKey(s);
+            const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
             if (dupIdx === -1) {
               acc.push(s);
               return acc;
@@ -740,6 +769,29 @@ function App() {
           console.debug('[App] Auth error suppressed:', errorText);
           break;
         }
+        // STALE_BINDING (#430): the user typed against an old Claude
+        // session and the daemon refused. Update our cached binding
+        // from the error's details so the next answer routes correctly.
+        const errorCode = (message as { code?: string }).code;
+        if (errorCode === 'STALE_BINDING') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const refusedSessionId = details?.['sessionId'] as UUID | undefined;
+          const newBound = details?.['boundClaudeSessionId'] as string | undefined;
+          if (refusedSessionId && newBound) {
+            setSessions((prev) =>
+              prev.map((s) =>
+                s.id === refusedSessionId && s.connectionId === connectionId
+                  ? { ...s, claudeSessionId: newBound }
+                  : s,
+              ),
+            );
+          }
+          console.warn(
+            '[App] STALE_BINDING: server-side binding rotated; re-keying. Detail:',
+            details,
+          );
+          // Fall through so the user sees the error in chat.
+        }
         // Clear loading state for any session awaiting transcript load, and allow retry.
         // The daemon does not echo sessionId in error responses, so we clear all loading sessions.
         setSessions((prev) =>
@@ -768,6 +820,28 @@ function App() {
           isEditing: false,
         };
         setMessages((prev) => [...prev, errorMsg]);
+        break;
+      }
+
+      case 'transcript_binding_changed': {
+        // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
+        // Update the session's bound (claudeSessionId, transcriptPath) so
+        // future outbound answers carry the new id and the chat header
+        // shows the updated binding.
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === message.sessionId && s.connectionId === connectionId
+              ? {
+                  ...s,
+                  claudeSessionId: message.claudeSessionId as string,
+                  transcriptPath: message.transcriptPath,
+                }
+              : s,
+          ),
+        );
+        console.info(
+          `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
+        );
         break;
       }
 
@@ -1150,7 +1224,16 @@ function App() {
         return;
       }
 
-      const sent = sendAnswer(connId, activeSessionId, sessionQuestion.id, content);
+      // Carry claudeSessionId so the daemon can refuse if its binding
+      // has rotated since the question fired (#430).
+      const activeBinding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
+      const sent = sendAnswer(
+        connId,
+        activeSessionId,
+        sessionQuestion.id,
+        content,
+        activeBinding as UUID | undefined,
+      );
       if (!sent) {
         const failMsg: UIMessage = {
           id: generateId(),
@@ -1194,7 +1277,7 @@ function App() {
       };
       setMessages((prev) => [...prev, userMsg]);
     },
-    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion],
+    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion, sessions],
   );
 
   // Send a regular user input message, optionally with a reply context.
@@ -1234,7 +1317,13 @@ function App() {
 
       setMessages((prev) => [...prev, newMessage]);
 
-      const success = sendInput(connId, activeSessionId, wireContent);
+      const activeBinding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
+      const success = sendInput(
+        connId,
+        activeSessionId,
+        wireContent,
+        activeBinding as UUID | undefined,
+      );
       if (success) {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
@@ -1265,7 +1354,7 @@ function App() {
         setMessages((prev) => [...prev, errorMsg]);
       }
     },
-    [activeSessionId, getActiveConnectionId, sendInput],
+    [activeSessionId, getActiveConnectionId, sendInput, sessions],
   );
 
   // Set the reply context for the current session: long-press on a

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -6,6 +6,17 @@
 
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 
+/**
+ * Extract a short "port :<num>" label from a ConnectionId of shape
+ * "host:port" so the binding indicator stays compact on mobile. Falls
+ * back to the raw id when no colon is present.
+ */
+function extractDaemonPortLabel(connectionId: string): string {
+  const colonIdx = connectionId.lastIndexOf(':');
+  if (colonIdx === -1) return connectionId;
+  return `:${connectionId.slice(colonIdx + 1)}`;
+}
+
 /** Strip hostname prefix from session name for display */
 function formatSessionName(name: string): string {
   let display = name.replace(/^[^:]+:/, '');
@@ -204,6 +215,32 @@ export function ChatHeader({
             </>
           )}
         </div>
+        {/* Transcript binding indicator (#430). The "port:short-uuid"
+            pair lets the user visually confirm WHICH Claude transcript
+            this session is talking to — the safety net for the
+            cross-daemon routing bug in #427. Tap-to-copy the full
+            transcript path is implemented via the title attribute. */}
+        {session.claudeSessionId && (
+          <button
+            type="button"
+            className="mt-0.5 truncate text-left text-[10px] font-mono text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
+            title={
+              session.transcriptPath
+                ? `Claude session ${session.claudeSessionId}\nTranscript: ${session.transcriptPath}\nClick to copy path`
+                : `Claude session ${session.claudeSessionId}`
+            }
+            onClick={() => {
+              const value = session.transcriptPath ?? session.claudeSessionId;
+              if (value) {
+                void navigator.clipboard?.writeText(value);
+              }
+            }}
+          >
+            {extractDaemonPortLabel(session.connectionId)}
+            {' · '}
+            {session.claudeSessionId.slice(0, 8)}
+          </button>
+        )}
       </div>
 
       {/* Detach/Resume button */}

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -216,10 +216,12 @@ export function ChatHeader({
           )}
         </div>
         {/* Transcript binding indicator (#430). The "port:short-uuid"
-            pair lets the user visually confirm WHICH Claude transcript
-            this session is talking to — the safety net for the
-            cross-daemon routing bug in #427. Tap-to-copy the full
-            transcript path is implemented via the title attribute. */}
+            pair is the UX surface for the cross-daemon routing fix
+            (#427): the user can visually confirm which transcript a
+            session is bound to. The actual routing safety net is the
+            daemon-side STALE_BINDING guard from phase 2 (#432). The
+            onClick handler copies the full path to clipboard; the
+            title attribute is the hover tooltip on desktop. */}
         {session.claudeSessionId && (
           <button
             type="button"
@@ -231,9 +233,13 @@ export function ChatHeader({
             }
             onClick={() => {
               const value = session.transcriptPath ?? session.claudeSessionId;
-              if (value) {
-                void navigator.clipboard?.writeText(value);
-              }
+              if (!value) return;
+              // navigator.clipboard can be undefined on iOS WKWebView
+              // in non-secure contexts; .catch on the promise covers
+              // permission denial and lost-focus rejections.
+              navigator.clipboard?.writeText(value).catch((err) => {
+                console.warn('[ChatHeader] clipboard write failed:', err);
+              });
             }}
           >
             {extractDaemonPortLabel(session.connectionId)}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -86,13 +86,19 @@ export interface UseConnectionManagerReturn {
   /** Disconnect all connections */
   disconnectAll: () => void;
   /** Send user input routed to the correct connection */
-  sendInput: (connectionId: ConnectionId, sessionId: UUID, content: string) => boolean;
+  sendInput: (
+    connectionId: ConnectionId,
+    sessionId: UUID,
+    content: string,
+    claudeSessionId?: UUID,
+  ) => boolean;
   /** Send answer to a question via the correct connection */
   sendAnswer: (
     connectionId: ConnectionId,
     sessionId: UUID,
     questionId: UUID,
     answer: string,
+    claudeSessionId?: UUID,
   ) => boolean;
   /** Send a raw protocol message to a specific connection */
   sendMessage: (connectionId: ConnectionId, message: ProtocolMessage) => boolean;
@@ -532,15 +538,32 @@ export function useConnectionManager(
   );
 
   const sendInput = useCallback(
-    (connectionId: ConnectionId, sessionId: UUID, content: string): boolean => {
-      return sendToConnection(connectionId, createUserInput(sessionId, content));
+    (
+      connectionId: ConnectionId,
+      sessionId: UUID,
+      content: string,
+      claudeSessionId?: UUID,
+    ): boolean => {
+      return sendToConnection(
+        connectionId,
+        createUserInput(sessionId, content, undefined, claudeSessionId),
+      );
     },
     [sendToConnection],
   );
 
   const sendAnswer = useCallback(
-    (connectionId: ConnectionId, sessionId: UUID, questionId: UUID, answer: string): boolean => {
-      return sendToConnection(connectionId, createAnswer(sessionId, questionId, answer));
+    (
+      connectionId: ConnectionId,
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): boolean => {
+      return sendToConnection(
+        connectionId,
+        createAnswer(sessionId, questionId, answer, claudeSessionId),
+      );
     },
     [sendToConnection],
   );

--- a/packages/web/src/lib/session-dedup.ts
+++ b/packages/web/src/lib/session-dedup.ts
@@ -1,0 +1,35 @@
+/**
+ * Cross-connection session dedup keyed by (connectionId, claudeSessionId)
+ * composite (#430). Same Claude sessionId reported by two different daemons
+ * IS a collision — keep both as separate rows so the user can pick which
+ * daemon to talk to. Only collapse when both connectionId AND claudeSessionId
+ * match (or both lack claudeSessionId, in which case fall back to id-keyed
+ * dedup so pre-#429 daemons still degrade gracefully).
+ *
+ * When two entries collide on the same composite key, the daemon-sourced one
+ * wins so transcript-sourced read-only views don't shadow live sessions.
+ */
+
+import type { UISession } from '@/types';
+
+export function compositeKey(s: UISession): string {
+  return s.claudeSessionId
+    ? `${s.connectionId}|${s.claudeSessionId}`
+    : `${s.connectionId}|${s.id}`;
+}
+
+export function dedupSessions(sessions: readonly UISession[]): UISession[] {
+  return sessions.reduce<UISession[]>((acc, s) => {
+    const key = compositeKey(s);
+    const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
+    if (dupIdx === -1) {
+      acc.push(s);
+      return acc;
+    }
+    const existing = acc[dupIdx];
+    if (existing && s.source === 'daemon' && existing.source !== 'daemon') {
+      acc[dupIdx] = s;
+    }
+    return acc;
+  }, []);
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -116,6 +116,15 @@ export interface UISession {
   readonly questionPending?: boolean;
   /** Whether this dead session can be resumed via Claude Code --resume */
   readonly canResume?: boolean;
+  /**
+   * Claude Code session UUID this entry's Claude is writing under (#430).
+   * Carried in outbound answer/input so the daemon can refuse stale
+   * routing when the binding has rotated (e.g. user ran /resume). Shown
+   * to the user in the chat header so the binding is verifiable by eye.
+   */
+  readonly claudeSessionId?: string;
+  /** Absolute path to the bound .jsonl transcript (#430). */
+  readonly transcriptPath?: string;
 }
 
 /** Structured option for a question */

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -122,7 +122,7 @@ export interface UISession {
    * routing when the binding has rotated (e.g. user ran /resume). Shown
    * to the user in the chat header so the binding is verifiable by eye.
    */
-  readonly claudeSessionId?: string;
+  readonly claudeSessionId?: UUID;
   /** Absolute path to the bound .jsonl transcript (#430). */
   readonly transcriptPath?: string;
 }

--- a/packages/web/tests/lib/session-dedup.test.ts
+++ b/packages/web/tests/lib/session-dedup.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for cross-connection session dedup (#430). The whole point of
+ * this layer is that two daemons reporting the same Claude sessionId
+ * must NOT collapse into one row — that was the cross-daemon answer
+ * routing bug from #427.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { compositeKey, dedupSessions } from '../../src/lib/session-dedup';
+import type { ConnectionId, UISession } from '../../src/types';
+
+function makeSession(overrides: Partial<UISession>): UISession {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'test',
+    connectionId: 'localhost:18766' as ConnectionId,
+    createdAt: '2026-05-17T00:00:00Z',
+    lastActiveAt: '2026-05-17T00:00:00Z',
+    status: 'idle',
+    connectionStatus: 'connected',
+    unreadCount: 0,
+    source: 'daemon',
+    ...overrides,
+  };
+}
+
+describe('compositeKey', () => {
+  test('uses connectionId|claudeSessionId when both present', () => {
+    const key = compositeKey(
+      makeSession({
+        connectionId: 'host:18766' as ConnectionId,
+        claudeSessionId: 'aaaa-bbbb',
+      }),
+    );
+    expect(key).toBe('host:18766|aaaa-bbbb');
+  });
+
+  test('falls back to connectionId|id when claudeSessionId is absent', () => {
+    const key = compositeKey(
+      makeSession({
+        id: 'remi-session-1',
+        connectionId: 'host:18766' as ConnectionId,
+      }),
+    );
+    expect(key).toBe('host:18766|remi-session-1');
+  });
+});
+
+describe('dedupSessions (the core safety invariant of #430)', () => {
+  test('two daemons reporting same sessionId + different claudeSessionId stay separate', () => {
+    // The exact bug case. Pre-#430 these collapsed into one row.
+    const a = makeSession({
+      id: 'same-claude-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'daemon-a-binding',
+    });
+    const b = makeSession({
+      id: 'same-claude-id',
+      connectionId: 'host:18767' as ConnectionId,
+      claudeSessionId: 'daemon-b-binding',
+    });
+
+    const result = dedupSessions([a, b]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.connectionId).toBe('host:18766');
+    expect(result[1]?.connectionId).toBe('host:18767');
+  });
+
+  test('same daemon reporting the same binding twice collapses to one row', () => {
+    const a = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+    });
+    const b = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+    });
+
+    const result = dedupSessions([a, b]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  test('daemon-sourced wins over transcript-sourced on the same composite key', () => {
+    const transcript = makeSession({
+      id: 'shared',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+      source: 'transcript',
+    });
+    const daemon = makeSession({
+      id: 'shared',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+      source: 'daemon',
+    });
+
+    const result = dedupSessions([transcript, daemon]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('daemon');
+  });
+
+  test('pre-#429 daemons (no claudeSessionId) still degrade gracefully', () => {
+    // Two entries from the same daemon with the same remi id collapse;
+    // entries from DIFFERENT daemons with the same remi id stay separate.
+    // (Different from pre-#430 behavior in the multi-daemon case, but
+    // that case was never correct.)
+    const sameDaemon1 = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+    });
+    const sameDaemon2 = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+    });
+    const otherDaemon = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18767' as ConnectionId,
+    });
+
+    const result = dedupSessions([sameDaemon1, sameDaemon2, otherDaemon]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.connectionId).sort()).toEqual([
+      'host:18766',
+      'host:18767',
+    ]);
+  });
+});


### PR DESCRIPTION
Phase 3 of epic #427. Closes #430. Depends on #432 (phase 2).

## What

Completes the epic: the daemon now **emits** binding rotation events, and the client **shows** the binding to the user and carries it on every answer/input.

## User-visible changes

**Chat header binding indicator** — under the cwd line, the header now shows:

\`\`\`
:18766 · 4a6325ac
\`\`\`

(daemon port + first 8 chars of claudeSessionId). Tap to copy the full transcript path. This is the safety net the user asked for: a glance tells you which transcript you're talking to. Same UI on iOS + web.

## Daemon: emit \`transcript_binding_changed\` on rotation

\`packages/daemon/src/cli/session-phases/hook-bridge-setup.ts\` — both restart paths (\`initFromHookEvent\` + \`onSessionInfo\`) now capture the previous \`claudeSessionId\` before nulling, and emit the event added in phase 2 once the new binding lands. First-init is deliberately skipped (already covered by \`hello_ack\` + \`session_list_response\`); the event only fires on actual rotation.

## Client: protocol consumption

- \`UISession\` carries \`claudeSessionId\` + \`transcriptPath\`, populated from \`hello_ack\` (queue-promotion path) and from each \`session_list_response\` entry
- Cross-connection dedup re-keyed from \`id\` alone to \`(connectionId, claudeSessionId)\` composite. Same Claude sessionId reported by two different daemons now stays as **two distinct rows**, keyed by ownership. Falls back to \`(connectionId, id)\` when no binding is known (pre-#429 daemons degrade gracefully)
- New \`handleMessage\` case \`transcript_binding_changed\`: updates the session's binding when the daemon emits rotation
- \`STALE_BINDING\` error handler: when the daemon refuses an answer because its binding has moved, the client rekeys the session from the error's \`boundClaudeSessionId\` details so the next attempt routes correctly

## Client: outbound

- \`sendAnswer\` / \`sendInput\` in \`useConnectionManager\` accept an optional \`claudeSessionId\`; App.tsx threads the active session's binding so the daemon-side guard (#432) has a value to compare
- Pre-#429 clients omit; daemon accepts without checking

## Tests

- 2 daemon-side emission tests in \`hook-bridge-setup.test.ts\` — first-init does NOT emit (no rotation), second \`SessionStart\` with a different id emits with correct claudeSessionId/transcriptPath/reason
- Full suite green: **1941 pass / 69 skip / 0 fail** across daemon+shared with \`SKIP_LLM_TESTS=1\`
- Web build green; typecheck + biome clean

## Out of scope (will revisit if iOS QA flags)

Full composite key in:
- \`messages\` filter
- \`questions\` Map
- \`LOCALSTORAGE_SESSION_KEY\`

The daemon-side \`STALE_BINDING\` guard from #432 makes cross-routed answers **impossible at the wire layer**. The remaining client-side keys only affect visual cleanliness when the same sessionId appears across two connections — and that path is now visibly distinguishable in the chat header.

## iOS verification

Manual sim verification deferred to follow-up: confirm the binding indicator renders correctly on iPhone 17 Pro (iOS 26.3), monospace font, no truncation at narrow widths. The header layout has reserved space below the cwd line, so visual regression should be minimal.

## Epic complete

This closes the loop on the cross-daemon answer-routing bug (#427):
- **Phase 1 (#428):** daemon binds PTY → transcript deterministically via \`--session-id\`
- **Phase 2 (#429):** binding visible on the wire + daemon-side stale-binding guard
- **Phase 3 (#430, this PR):** client surfaces binding to the user + carries it back on answers + rotation event