### PR TITLE
Epic: deterministic PTY->transcript binding (closes #427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Remi are documented here.
 
+## [Unreleased]
+
+### Fixed
+- Cross-daemon answer routing: two daemons running in the same cwd no
+  longer cross-route responses to each other's sessions (#427). The fix
+  has three layers of defense:
+  - Daemon pre-assigns the Claude session UUID at spawn via
+    `--session-id <uuid>` so transcript binding is deterministic; no
+    more mtime-based discovery race (#428).
+  - Wire protocol carries `claudeSessionId` and `transcriptPath` end to
+    end (`hello_ack`, `session_list_response`, `question`,
+    `transcript_binding_changed`). The daemon refuses outbound answers
+    with `STALE_BINDING` when the client's claimed binding no longer
+    matches (#429).
+  - Mobile and web chat header now shows the active port and Claude
+    session id (`:<port> · <8-char-uuid>`), tap to copy the transcript
+    path; client tracks the binding through `transcript_binding_changed`
+    and rekeys on `STALE_BINDING` (#430).
+
+### Internal
+- Auto-approve tests honor `SKIP_LLM_TESTS=1` (skip Ollama-gated suite).
+
 ## [0.4.4] - 2026-03-20
 
 ### Added

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -64,10 +64,22 @@ export interface AdapterEvents {
   onDisconnect: (connectionId: UUID, reason: string) => void;
 
   /** User input received */
-  onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (
+    connectionId: UUID,
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Answer to question received */
-  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -110,12 +110,12 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (connectionId, sessionId, content, raw) => {
-        this.events.onUserInput?.(connectionId, sessionId, content, raw);
+      onUserInput: (connectionId, sessionId, content, raw, claudeSessionId) => {
+        this.events.onUserInput?.(connectionId, sessionId, content, raw, claudeSessionId);
       },
 
-      onAnswer: (connectionId, sessionId, questionId, answer) => {
-        this.events.onAnswer?.(connectionId, sessionId, questionId, answer);
+      onAnswer: (connectionId, sessionId, questionId, answer, claudeSessionId) => {
+        this.events.onAnswer?.(connectionId, sessionId, questionId, answer, claudeSessionId);
       },
 
       onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1088,12 +1088,23 @@ async function createNewSession(
     messageApi,
     locallyOwned,
   );
-  await ptySession.start();
+
+  // If the spawn or any post-spawn wiring throws, mark the pre-saved
+  // store entry as exited so sibling daemons reading the store don't
+  // see a phantom "live" session with our claudeSessionId reserved.
+  // Without this, the failed-spawn entry stays exitedAt=null and the
+  // pid-aliveness self-heal in SessionStore only fires after our
+  // daemon process itself exits.
+  try {
+    await ptySession.start();
+  } catch (err) {
+    sessionStore.markExited(sessionId, null);
+    throw err;
+  }
 
   startTranscriptFallback(
     {
       sessionRegistry,
-      sessionStore,
       transcriptDiscovery,
       transcriptWatchers,
       transcriptFallbackTimers,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1010,9 +1010,18 @@ async function createNewSession(
       sendMessage,
       // Lazy read so the binding seen on each question emission is the
       // current value — survives /resume rotation via hook-bridge's
-      // updateClaudeSessionId write into the store.
-      getClaudeSessionId: () =>
-        (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? null) as UUID | null,
+      // updateClaudeSessionId write into the store. Wrapped in try/catch
+      // so a transient sessions.json I/O hiccup cannot kill question
+      // emission (the dep contract is non-throwing).
+      getClaudeSessionId: () => {
+        try {
+          return (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ??
+            null) as UUID | null;
+        } catch (err) {
+          logError(`[Binding] getClaudeSessionId lookup failed: ${errorToString(err)}`);
+          return null;
+        }
+      },
     },
     sessionId,
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -105,6 +105,7 @@ import { QuestionPresenceTracker } from './api/question-presence-tracker.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
+import { resolveClaudeBinding } from './cli/claude-binding.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
@@ -1028,6 +1029,30 @@ async function createNewSession(
     },
   );
 
+  // Deterministic PTY -> transcript binding (#427). Resolve the
+  // claudeSessionId Claude will write under BEFORE spawning, so sibling
+  // daemons in the same cwd cannot race-claim each other's transcripts
+  // through mtime-based discovery.
+  const binding = resolveClaudeBinding(extraArgs, {
+    displayName: `remi:${remiStatus.wsPort}`,
+  });
+  log(
+    `[Binding] claude=${binding.claudeSessionId.slice(0, 8)} source=${binding.source} for remi=${sessionId.slice(0, 8)}`,
+  );
+
+  // Persist the binding before spawn so siblings observing the store
+  // during the race window see our claim immediately.
+  sessionStore.save({
+    remiSessionId: sessionId,
+    claudeSessionId: binding.claudeSessionId,
+    projectPath: workingDirectory,
+    port: PORT,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
   if (hookServer) {
     setupHookBridge(
       {
@@ -1052,7 +1077,7 @@ async function createNewSession(
       sendMessage,
       cleanup,
     },
-    { sessionId, workingDirectory, extraArgs, passThrough },
+    { sessionId, workingDirectory, extraArgs: binding.args, passThrough },
   );
 
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
@@ -1065,17 +1090,6 @@ async function createNewSession(
   );
   await ptySession.start();
 
-  sessionStore.save({
-    remiSessionId: sessionId,
-    claudeSessionId: null,
-    projectPath: workingDirectory,
-    port: PORT,
-    pid: process.pid,
-    startedAt: new Date().toISOString(),
-    exitedAt: null,
-    exitCode: null,
-  });
-
   startTranscriptFallback(
     {
       sessionRegistry,
@@ -1086,6 +1100,7 @@ async function createNewSession(
     },
     sessionId,
     workingDirectory,
+    binding.claudeSessionId,
     messageApi,
     sendAndRecord,
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -842,13 +842,25 @@ const sessionRegistry = new SessionRegistry(
     },
     onConnectionPromoted: (sessionId, connectionId, result) => {
       log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
+      const stored = sessionStore.findByRemiSessionId(sessionId);
+      const claudeId = stored?.claudeSessionId ?? null;
+      const projPath = stored?.projectPath ?? null;
+      const tpath =
+        claudeId && projPath
+          ? `${transcriptDiscovery.getProjectTranscriptDir(projPath)}/${claudeId}.jsonl`
+          : null;
       const sent = registry.sendRaw(
         connectionId,
-        createHelloAck('1.0.0', sessionId, {
-          isResume: result.replayMessages.length > 0,
-          replayCount: result.replayMessages.length,
-          nextBulletId: result.nextBulletId,
-        }),
+        createHelloAck(
+          '1.0.0',
+          sessionId,
+          {
+            isResume: result.replayMessages.length > 0,
+            replayCount: result.replayMessages.length,
+            nextBulletId: result.nextBulletId,
+          },
+          { claudeSessionId: claudeId, transcriptPath: tpath },
+        ),
       );
       if (!sent) {
         log(`Promoted connection ${connectionId} is unreachable; detaching`);
@@ -996,6 +1008,11 @@ async function createNewSession(
       updateRemiStatus: (patch) => updateRemiStatus(patch),
       maxBulletLength: MAX_BULLET_LENGTH,
       sendMessage,
+      // Lazy read so the binding seen on each question emission is the
+      // current value — survives /resume rotation via hook-bridge's
+      // updateClaudeSessionId write into the store.
+      getClaudeSessionId: () =>
+        (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? null) as UUID | null,
     },
     sessionId,
   );
@@ -1150,6 +1167,7 @@ const trivialHandlers: TrivialHandlers = createTrivialHandlers({
 
 const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
+  sessionStore,
   send: sendToConnection,
 });
 

--- a/packages/daemon/src/cli/claude-binding.ts
+++ b/packages/daemon/src/cli/claude-binding.ts
@@ -29,8 +29,14 @@ import { randomUUID } from 'node:crypto';
 export interface ClaudeBindingResult {
   /** The session id Claude will use; either pre-existing in args or freshly minted. */
   readonly claudeSessionId: string;
-  /** The args to pass to `Bun.spawn`. Equal to input args plus any injection. */
-  readonly args: string[];
+  /**
+   * The args to pass to `Bun.spawn`. Equal to input args plus any injection.
+   * Invariant by source: `fresh` and `user-resume-fork` always contain an
+   * injected `--session-id <claudeSessionId>` pair; `user-session-id` and
+   * `user-resume` never inject because the binding is already in the user's
+   * args (or, in the resume case, implicit in `--resume`).
+   */
+  readonly args: readonly string[];
   /** How the binding was determined; useful for diagnostics + tests. */
   readonly source: 'user-session-id' | 'user-resume' | 'user-resume-fork' | 'fresh';
 }

--- a/packages/daemon/src/cli/claude-binding.ts
+++ b/packages/daemon/src/cli/claude-binding.ts
@@ -1,0 +1,116 @@
+/**
+ * Resolve the deterministic Claude session-id binding for a PTY spawn.
+ *
+ * The daemon needs to know which transcript .jsonl the spawned `claude` will
+ * write to before Claude has written its first line. Otherwise sibling daemons
+ * sharing a cwd race through `findLatestTranscript` (newest-by-mtime) and can
+ * adopt each other's transcripts — leading to cross-daemon answer routing
+ * (#427).
+ *
+ * Resolution order:
+ *   1. User passed `--session-id <uuid>` explicitly: respect it.
+ *   2. User passed `--resume <uuid>` without `--fork-session`: Claude reuses
+ *      that session id, so it's also our binding.
+ *   3. User passed `--resume <uuid> --fork-session`: Claude creates a NEW
+ *      session id; pre-assign one and inject `--session-id` so we know it.
+ *   4. Otherwise (fresh spawn): pre-assign and inject `--session-id`.
+ *
+ * Cases (2) and (3) can be combined: when `--resume` is present we inject
+ * `--session-id` only if `--fork-session` is also there, because Claude with
+ * `--resume <X>` alone preserves X.
+ *
+ * The function is pure and returns the augmented args. It does not touch the
+ * store; the caller is responsible for persisting `claudeSessionId` to
+ * `sessionStore` BEFORE `Bun.spawn` so siblings see it on first race tick.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+export interface ClaudeBindingResult {
+  /** The session id Claude will use; either pre-existing in args or freshly minted. */
+  readonly claudeSessionId: string;
+  /** The args to pass to `Bun.spawn`. Equal to input args plus any injection. */
+  readonly args: string[];
+  /** How the binding was determined; useful for diagnostics + tests. */
+  readonly source: 'user-session-id' | 'user-resume' | 'user-resume-fork' | 'fresh';
+}
+
+const SESSION_ID_FLAGS = new Set(['--session-id']);
+const RESUME_FLAGS = new Set(['-r', '--resume']);
+const FORK_FLAGS = new Set(['--fork-session']);
+const NAME_FLAGS = new Set(['-n', '--name']);
+
+/**
+ * Find a flag's value in an argv list. Supports both `--flag value` and
+ * `--flag=value` shapes. Returns undefined if absent or if the flag has no
+ * following value.
+ */
+function findFlagValue(args: readonly string[], flagSet: ReadonlySet<string>): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg) continue;
+    if (flagSet.has(arg)) {
+      const next = args[i + 1];
+      if (next && !next.startsWith('-')) return next;
+      continue;
+    }
+    const eq = arg.indexOf('=');
+    if (eq > 0 && flagSet.has(arg.slice(0, eq))) {
+      return arg.slice(eq + 1);
+    }
+  }
+  return undefined;
+}
+
+/** True if any of the bare flags (no value expected) is present. */
+function hasBareFlag(args: readonly string[], flagSet: ReadonlySet<string>): boolean {
+  return args.some((a) => flagSet.has(a));
+}
+
+function isUuidLike(value: string | undefined): value is string {
+  if (!value) return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+/**
+ * Resolve the claudeSessionId we will lock for this PTY and return augmented
+ * spawn args. `displayName` is appended via `-n` only when the user did not
+ * already set one, so an operator peeking at the PTY (or at /resume picker)
+ * can tell which daemon owns this session.
+ */
+export function resolveClaudeBinding(
+  extraArgs: readonly string[],
+  options: { readonly displayName?: string } = {},
+): ClaudeBindingResult {
+  const args = [...extraArgs];
+
+  const existingSessionId = findFlagValue(args, SESSION_ID_FLAGS);
+  const resumeId = findFlagValue(args, RESUME_FLAGS);
+  const isFork = hasBareFlag(args, FORK_FLAGS);
+  const hasName = hasBareFlag(args, NAME_FLAGS);
+
+  let claudeSessionId: string;
+  let source: ClaudeBindingResult['source'];
+
+  if (isUuidLike(existingSessionId)) {
+    claudeSessionId = existingSessionId;
+    source = 'user-session-id';
+  } else if (isUuidLike(resumeId) && !isFork) {
+    claudeSessionId = resumeId;
+    source = 'user-resume';
+  } else if (isUuidLike(resumeId) && isFork) {
+    claudeSessionId = randomUUID();
+    args.push('--session-id', claudeSessionId);
+    source = 'user-resume-fork';
+  } else {
+    claudeSessionId = randomUUID();
+    args.push('--session-id', claudeSessionId);
+    source = 'fresh';
+  }
+
+  if (!hasName && options.displayName) {
+    args.push('-n', options.displayName);
+  }
+
+  return { claudeSessionId, args, source };
+}

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -13,7 +13,7 @@ import { createBulletExpandResponse, createError, errorToString } from '@remi/sh
 import type { UUID } from '@remi/shared';
 
 import type { SessionRegistry, SessionStore } from '../../session/index.ts';
-import { log } from '../logger.ts';
+import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
@@ -32,13 +32,16 @@ export interface InputHandlerDeps {
  *     accept the message unconditionally. The client cannot have known
  *     the binding to check against.
  *   - If the client sent it but no daemon binding is recorded yet
- *     (extreme race: input received before transcript-fallback wrote
- *     the id), accept rather than refuse. The pre-spawn save in
- *     createNewSession makes this branch rare.
+ *     (extreme race: message arrived before the pre-spawn save in
+ *     cli.ts:createNewSession completed), accept rather than refuse.
  *   - If both are present and differ, the user typed against an old
  *     view (e.g. /resume rotated the binding between question and
  *     answer); refuse and emit STALE_BINDING with both ids so the
  *     client can rekey its UI.
+ *   - If the sessionStore lookup throws (I/O error on the sessions
+ *     file): fail-open with a logError. Refusing on a transient store
+ *     hiccup would silently swallow legitimate input; accepting at
+ *     least surfaces the problem in logs while letting the user work.
  */
 function guardBinding(
   sessionStore: SessionStore,
@@ -48,8 +51,13 @@ function guardBinding(
   claudeSessionId: UUID | undefined,
 ): boolean {
   if (claudeSessionId === undefined) return true;
-  const stored = sessionStore.findByRemiSessionId(sessionId);
-  const bound = stored?.claudeSessionId;
+  let bound: string | undefined;
+  try {
+    bound = sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? undefined;
+  } catch (err) {
+    logError(`[Binding] sessionStore lookup failed; accepting message: ${errorToString(err)}`);
+    return true;
+  }
   if (!bound) return true;
   if (bound === claudeSessionId) return true;
   log(

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -12,32 +12,86 @@
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry } from '../../session/index.ts';
+import type { SessionRegistry, SessionStore } from '../../session/index.ts';
 import { log } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
+  sessionStore: SessionStore;
   send: SendToConnection;
+}
+
+/**
+ * Compare an incoming message's claudeSessionId against the daemon's
+ * current binding for the target remi session (#429). Returns true when
+ * the message is safe to forward to the PTY, false when stale.
+ *
+ * Stale-binding semantics:
+ *   - If the client did not send claudeSessionId (pre-#429 client),
+ *     accept the message unconditionally. The client cannot have known
+ *     the binding to check against.
+ *   - If the client sent it but no daemon binding is recorded yet
+ *     (extreme race: input received before transcript-fallback wrote
+ *     the id), accept rather than refuse. The pre-spawn save in
+ *     createNewSession makes this branch rare.
+ *   - If both are present and differ, the user typed against an old
+ *     view (e.g. /resume rotated the binding between question and
+ *     answer); refuse and emit STALE_BINDING with both ids so the
+ *     client can rekey its UI.
+ */
+function guardBinding(
+  sessionStore: SessionStore,
+  send: SendToConnection,
+  connectionId: UUID,
+  sessionId: UUID,
+  claudeSessionId: UUID | undefined,
+): boolean {
+  if (claudeSessionId === undefined) return true;
+  const stored = sessionStore.findByRemiSessionId(sessionId);
+  const bound = stored?.claudeSessionId;
+  if (!bound) return true;
+  if (bound === claudeSessionId) return true;
+  log(
+    `[Binding] STALE_BINDING refused for session ${sessionId.slice(0, 8)}: incoming=${claudeSessionId.slice(0, 8)} bound=${bound.slice(0, 8)}`,
+  );
+  send(
+    connectionId,
+    createError(
+      'STALE_BINDING',
+      'The Claude session this message was for has rotated; the binding has moved',
+      {
+        sessionId,
+        incomingClaudeSessionId: claudeSessionId,
+        boundClaudeSessionId: bound,
+      },
+    ),
+  );
+  return false;
 }
 
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, send } = deps;
+  const { sessionRegistry, sessionStore, send } = deps;
 
   return {
     onUserInput: async (
       connectionId: UUID,
-      _sessionId: UUID,
+      sessionId: UUID,
       content: string,
       raw?: boolean,
+      claudeSessionId?: UUID,
     ): Promise<void> => {
       log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
 
       const session = sessionRegistry.getSessionForConnection(connectionId);
       if (!session) {
         log(`No session found for connection ${connectionId}`);
+        return;
+      }
+
+      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 
@@ -60,6 +114,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       sessionId: UUID,
       questionId: UUID,
       answer: string,
+      claudeSessionId?: UUID,
     ): Promise<void> => {
       log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
 
@@ -74,6 +129,10 @@ export function createInputHandlers(deps: InputHandlerDeps) {
           connectionId,
           createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
         );
+        return;
+      }
+
+      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -56,7 +56,17 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
 
   return {
     onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean): void => {
-      const daemonSessions = sessionRegistry.listSessions();
+      // Decorate daemon-sourced sessions with their pre-assigned Claude
+      // binding (#429). transcriptPath is derived from the same encoding
+      // rule transcript-discovery uses, so the client can show "you are
+      // talking to port X / claude <short-uuid>" without round-tripping.
+      const daemonSessionsRaw = sessionRegistry.listSessions();
+      const daemonSessions = daemonSessionsRaw.map((s) => {
+        const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
+        if (!stored?.claudeSessionId) return s;
+        const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
+        return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+      });
       let allSessions = [...daemonSessions];
 
       if (includeExternal) {

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -18,12 +18,13 @@ import {
   createError,
   createKillSessionResponse,
   createSessionListResponse,
+  errorToString,
 } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
-import { log } from '../logger.ts';
+import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SessionHandlerDeps {
@@ -60,12 +61,22 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       // binding (#429). transcriptPath is derived from the same encoding
       // rule transcript-discovery uses, so the client can show "you are
       // talking to port X / claude <short-uuid>" without round-tripping.
+      // A failed lookup on any one entry must not nuke the entire list
+      // response — the connection would hang waiting for a reply. Fall
+      // back to the undecorated entry on per-entry failure.
       const daemonSessionsRaw = sessionRegistry.listSessions();
       const daemonSessions = daemonSessionsRaw.map((s) => {
-        const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
-        if (!stored?.claudeSessionId) return s;
-        const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
-        return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+        try {
+          const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
+          if (!stored?.claudeSessionId) return s;
+          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
+          return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+        } catch (err) {
+          logError(
+            `[SessionList] Failed to decorate session ${s.sessionId.slice(0, 8)}; serving raw entry: ${errorToString(err)}`,
+          );
+          return s;
+        }
       });
       let allSessions = [...daemonSessions];
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -100,22 +100,17 @@ export function setupHookBridge(
   let claudeSessionId: string | null = null;
 
   /**
-   * When `hasSiblingInDir()` is true (multiple Remi wrappers in the same
-   * project directory) the hook-event-based locking path defers to the
-   * filesystem fallback in transcript-fallback.ts, which discovers our
-   * own Claude session ID by looking at `~/.claude/projects/<dir>/` and
-   * excluding sibling-claimed transcripts. The fallback writes the
-   * discovered id to `sessionStore.updateClaudeSessionId(...)` — but
-   * the hook-bridge's `claudeSessionId` closure was never updated from
-   * the store, so `filterBySession` kept reading null and dropped every
-   * hook for the entire session lifetime. This helper closes that gap:
-   * each hook event re-reads the store and adopts the discovered id when
-   * it differs from the closure (initial adopt, or rotation after a
-   * /clear in the multi-wrapper case where hooks were never authoritative).
-   * Log only on change to avoid spam on steady-state hooks. Wrapped in
-   * try/catch so an EMFILE / permission flake on the sessions file does
-   * not propagate into the hook dispatch loop; on failure we leave the
-   * closure untouched (the existing sibling-guard path remains active).
+   * Adopt the canonical claudeSessionId from `sessionStore`. After phase 1
+   * (#427), `cli.ts:createNewSession` pre-writes the binding to the store
+   * BEFORE Bun.spawn, so the value is authoritative the moment the bridge
+   * starts receiving hook events — no inference from filesystem mtime,
+   * no risk of latching a sibling daemon's id. The same call also covers
+   * subsequent rotations: if a hook-driven restart (/clear, /resume) flips
+   * the closure to null and writes a new id to the store, the next event
+   * re-adopts the new value. Logs only on change to avoid spam on
+   * steady-state hooks. Wrapped in try/catch so an EMFILE / permission
+   * flake on the sessions file does not propagate into the hook dispatch
+   * loop; on failure we leave the closure untouched.
    */
   const adoptLockFromStore = (): void => {
     try {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -31,7 +31,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionReset, errorToString } from '@remi/shared';
+import { createSessionReset, createTranscriptBindingChanged, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
@@ -249,6 +249,11 @@ export function setupHookBridge(
       );
       return;
     }
+    // Capture the pre-restart id so we can emit transcript_binding_changed
+    // on rotation (#430). First-init has no previous binding, so the
+    // notification only fires when the lock actually moved.
+    const previousClaudeSessionId = claudeSessionId;
+    let isRotation = false;
     if (classification === 'restart') {
       log(
         `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
@@ -260,6 +265,7 @@ export function setupHookBridge(
       tracker.clearPending();
       claudeSessionId = null;
       mainSessionEnded = false;
+      isRotation = previousClaudeSessionId !== null;
     }
     // classification === 'match': either our tracked session or first-time lock.
     if (claudeSessionId) return; // already initialized
@@ -276,6 +282,25 @@ export function setupHookBridge(
         `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
       );
       sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+
+      // Notify clients of the binding rotation so they can rekey their
+      // (sessionId, claudeSessionId) composite state and refresh any
+      // displayed binding indicator. Skip on first-init: that's already
+      // covered by hello_ack + session_list_response.
+      if (isRotation) {
+        try {
+          sendAndRecord(
+            createTranscriptBindingChanged(
+              sessionId,
+              claudeSessionId as UUID,
+              input.transcript_path,
+              'restart',
+            ),
+          );
+        } catch (err) {
+          logError(`[Hooks] Failed to emit transcript_binding_changed: ${errorToString(err)}`);
+        }
+      }
 
       // Cancel the fallback timer since we have the exact path.
       const fallbackTimer = transcriptFallbackTimers.get(sessionId);
@@ -340,6 +365,8 @@ export function setupHookBridge(
         );
         return;
       }
+      const previousClaudeSessionId = claudeSessionId;
+      let isRotation = false;
       if (classification === 'restart') {
         log(
           `[Hooks] Claude restart (SessionInfo, ended=${mainSessionEnded}): ${claudeSessionId} -> ${hookClaudeSessionId}`,
@@ -351,12 +378,30 @@ export function setupHookBridge(
         tracker.clearPending();
         claudeSessionId = null;
         mainSessionEnded = false;
+        isRotation = previousClaudeSessionId !== null;
       }
 
       try {
         claudeSessionId = hookClaudeSessionId;
         log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
         sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+
+        if (isRotation) {
+          try {
+            sendAndRecord(
+              createTranscriptBindingChanged(
+                sessionId,
+                hookClaudeSessionId as UUID,
+                transcriptPath,
+                'restart',
+              ),
+            );
+          } catch (err) {
+            logError(
+              `[Hooks] Failed to emit transcript_binding_changed (SessionInfo): ${errorToString(err)}`,
+            );
+          }
+        }
 
         const existingWatcher = transcriptWatchers.get(sessionId);
         if (

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -140,15 +140,18 @@ export function setupHookBridge(
 
   // Extract transcript info from hook events. Most Claude Code hook events
   // include session_id and transcript_path. When present, the first event
-  // gives us the transcript path, bypassing the slower mtime fallback.
+  // gives us the transcript path immediately, bypassing the deterministic-
+  // path fallback poll in transcript-fallback.ts.
   //
   // GUARD: when sibling daemons serve the same directory, all Claudes POST
   // to all hook URLs (shared settings.local.json), so a sibling's event may
   // arrive before our own Claude fires. Skip hook-based discovery and let
-  // the mtime fallback handle it. Re-evaluated per event so a sibling dying
-  // (or a fresh sibling appearing) is reflected immediately. Issue #321:
-  // a stale `null`-once cache wedged this state and permanently disabled
-  // hook-driven discovery for both daemons.
+  // the deterministic-path fallback handle it (post-#427 the fallback waits
+  // for our pre-assigned UUID rather than racing on mtime). Re-evaluated
+  // per event so a sibling dying (or a fresh sibling appearing) is
+  // reflected immediately. Issue #321: a stale `null`-once cache wedged
+  // this state and permanently disabled hook-driven discovery for both
+  // daemons.
 
   /**
    * Cancel any in-flight auto-approve LLM eval. Called on hook events that

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -228,11 +228,27 @@ export function setupHookBridge(
   }): void {
     if (!input.session_id) return;
 
+    // Snapshot the closure BEFORE adoptLockFromStore mutates it.
+    // adoptLockFromStore can race-pull the new id from sessionStore when
+    // the transcript-fallback wrote it first; without this snapshot the
+    // classifier sees the post-adopt value, returns 'match', and the
+    // rotation event silently never emits (#430 review #433).
+    const previousClaudeSessionId = claudeSessionId;
+    let isRotation = false;
+
     // If the transcript-fallback has already discovered our Claude
     // session ID (the multi-wrapper-in-same-dir case), adopt it before
     // classifying so the classifier sees the right currentLock instead
     // of a stale null.
     adoptLockFromStore();
+
+    // Detect rotation by comparing the pre-adopt snapshot against the
+    // incoming id. We do this here (independent of classifySessionEvent)
+    // so the rotation is observable even when adoptLockFromStore raced
+    // ahead and the classifier returns 'match'.
+    if (previousClaudeSessionId !== null && previousClaudeSessionId !== input.session_id) {
+      isRotation = true;
+    }
 
     const classification = classifySessionEvent({
       currentLock: claudeSessionId,
@@ -249,11 +265,6 @@ export function setupHookBridge(
       );
       return;
     }
-    // Capture the pre-restart id so we can emit transcript_binding_changed
-    // on rotation (#430). First-init has no previous binding, so the
-    // notification only fires when the lock actually moved.
-    const previousClaudeSessionId = claudeSessionId;
-    let isRotation = false;
     if (classification === 'restart') {
       log(
         `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
@@ -265,7 +276,9 @@ export function setupHookBridge(
       tracker.clearPending();
       claudeSessionId = null;
       mainSessionEnded = false;
-      isRotation = previousClaudeSessionId !== null;
+      // isRotation was already computed above against the pre-adopt
+      // snapshot; restart is a stricter signal but does not override
+      // a true value coming from the race-detector path.
     }
     // classification === 'match': either our tracked session or first-time lock.
     if (claudeSessionId) return; // already initialized
@@ -285,8 +298,10 @@ export function setupHookBridge(
 
       // Notify clients of the binding rotation so they can rekey their
       // (sessionId, claudeSessionId) composite state and refresh any
-      // displayed binding indicator. Skip on first-init: that's already
-      // covered by hello_ack + session_list_response.
+      // displayed binding indicator. Skip on first-init: that's
+      // covered by session_list_response (and by hello_ack on the
+      // queue-promotion path; the initial first-connect hello_ack from
+      // connection.ts carries no binding by design).
       if (isRotation) {
         try {
           sendAndRecord(

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -51,9 +51,11 @@ export interface MessageApiSetupDeps {
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
   /**
    * Returns the current Claude session UUID this PTY is bound to (#429).
-   * Called on every question emission; returns null if no binding is known
-   * (the daemon's pre-spawn save always sets one, so null is rare). Same
-   * synchronous/non-throwing contract as pushConfig.
+   * Called on every question emission; returns null if no binding is
+   * recorded for this session (the normal spawn path sets one pre-spawn,
+   * so null is rare in production). Same synchronous/non-throwing
+   * contract as pushConfig — implementations must absorb their own I/O
+   * errors rather than throwing into the emission path.
    */
   getClaudeSessionId?: () => UUID | null;
 }

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -49,6 +49,13 @@ export interface MessageApiSetupDeps {
   updateRemiStatus: (patch: { sessionStatus: AgentStatus }) => void;
   maxBulletLength: number;
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
+  /**
+   * Returns the current Claude session UUID this PTY is bound to (#429).
+   * Called on every question emission; returns null if no binding is known
+   * (the daemon's pre-spawn save always sets one, so null is rare). Same
+   * synchronous/non-throwing contract as pushConfig.
+   */
+  getClaudeSessionId?: () => UUID | null;
 }
 
 export interface MessageApiHandle {
@@ -80,6 +87,7 @@ export function createMessageApiForSession(
     updateRemiStatus,
     maxBulletLength,
     sendMessage,
+    getClaudeSessionId,
   } = deps;
 
   const sendAndRecord = (message: ProtocolMessage): void => {
@@ -118,12 +126,14 @@ export function createMessageApiForSession(
     onQuestion: (question: Question) => {
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
+      const claudeSessionId = getClaudeSessionId?.() ?? undefined;
       const msg: ProtocolMessage = {
         type: 'question',
         id: generateId(),
         timestamp: now(),
         question,
         sessionId: questionSessionId,
+        ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
       sessionRegistry.updateQuestion(questionSessionId, question);

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -1,15 +1,20 @@
 /**
  * Transcript-watcher fallback poll for the hook-miss case.
  *
- * Normally the Claude Code hook event stream tells us the exact transcript
- * path (SessionStart carries `transcript_path`). When sibling daemons share
- * the same project directory, hook events are intentionally skipped because
- * all Claudes POST to all hook URLs and we can't tell which one we own.
- * This poll becomes the primary discovery path in that case.
+ * Since #427 / phase 1, the daemon pre-assigns a `claudeSessionId` and passes
+ * `--session-id <uuid>` to `claude` so Claude writes to a known path. This
+ * poll waits for that exact file to appear under
+ * `~/.claude/projects/<encoded-cwd>/<claudeSessionId>.jsonl` and then starts
+ * the watcher. No mtime sort, no sibling exclusion, no inference.
  *
- * Every 2 seconds, look for a transcript file whose mtime is recent or is
- * newer than the PTY startup. If found, start the watcher and cancel the
- * poll. Give up after 30 seconds and log the reason.
+ * Normally the Claude Code hook event stream tells us the exact transcript
+ * path (SessionStart carries `transcript_path`), in which case the hook
+ * bridge starts the watcher and this poll self-cancels on the next tick. The
+ * poll is the primary path only when hook events are unavailable (e.g.
+ * settings.local.json absent, hook server disabled, or in the sibling-in-dir
+ * case where the bridge defers to filesystem ground-truth).
+ *
+ * Poll every 2 seconds. Give up after 30 seconds and log the reason.
  */
 
 import * as fs from 'node:fs';
@@ -21,11 +26,10 @@ import type { SessionRegistry, SessionStore } from '../session/index.ts';
 import type { TranscriptDiscovery } from '../transcript/index.ts';
 import type { TranscriptWatcher } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
-import { extractClaudeSessionId, startTranscriptWatcher } from './transcript-watcher-setup.ts';
+import { startTranscriptWatcher } from './transcript-watcher-setup.ts';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_POLL_TIMEOUT_MS = 30000;
-const RECENT_THRESHOLD_MS = 5 * 60 * 1000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
@@ -40,20 +44,34 @@ export interface TranscriptFallbackDeps {
 }
 
 /**
- * Start polling for a transcript path to watch. Registers the interval in
- * `transcriptFallbackTimers` so cleanup can cancel it; the poll self-clears
- * on success, on session loss, or after the timeout.
+ * Build the deterministic transcript path Claude will write to for a given
+ * (projectPath, claudeSessionId) pair. Exposed so callers (and tests) can
+ * agree on the same encoding rule as Claude Code itself.
+ */
+export function expectedTranscriptPath(
+  transcriptDiscovery: TranscriptDiscovery,
+  projectPath: string,
+  claudeSessionId: string,
+): string {
+  return `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`;
+}
+
+/**
+ * Start polling for the pre-assigned transcript path to appear. Registers
+ * the interval in `transcriptFallbackTimers` so cleanup can cancel it; the
+ * poll self-clears on success, on session loss, or after the timeout.
  */
 export function startTranscriptFallback(
   deps: TranscriptFallbackDeps,
   sessionId: UUID,
   workingDirectory: string,
+  claudeSessionId: string,
   messageApi: MessageAPI,
   sendAndRecord: (message: ProtocolMessage) => void,
 ): void {
   const {
     sessionRegistry,
-    sessionStore,
+    sessionStore: _sessionStore,
     transcriptDiscovery,
     transcriptWatchers,
     transcriptFallbackTimers,
@@ -61,18 +79,18 @@ export function startTranscriptFallback(
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
   } = deps;
 
-  const startupTime = Date.now();
+  // SessionStore writes happen pre-spawn in cli.ts; this poll only consumes
+  // the binding it was given. Kept in the interface so future recovery
+  // paths (e.g. /resume swap re-binding) can persist updates without
+  // having to thread a second dep object.
+  void _sessionStore;
 
-  const attachWatcher = (transcriptPath: string): void => {
-    startTranscriptWatcher(
-      { transcriptWatchers },
-      sessionId,
-      transcriptPath,
-      messageApi,
-      sendAndRecord,
-    );
-    extractClaudeSessionId({ sessionStore }, transcriptPath, sessionId);
-  };
+  const startupTime = Date.now();
+  const expectedPath = expectedTranscriptPath(
+    transcriptDiscovery,
+    workingDirectory,
+    claudeSessionId,
+  );
 
   const stopPoll = (): void => {
     clearInterval(fallbackInterval);
@@ -89,61 +107,30 @@ export function startTranscriptFallback(
       return;
     }
 
-    // Exclude transcripts already claimed by sibling daemons (their
-    // claudeSessionId is stored in sessions.json) to avoid double-watching.
-    const siblingClaudeIds = new Set<string>();
-    for (const entry of sessionStore.list()) {
-      if (entry.remiSessionId !== sessionId && entry.claudeSessionId && !entry.exitedAt) {
-        siblingClaudeIds.add(entry.claudeSessionId);
-      }
-    }
-    const transcriptPath =
-      siblingClaudeIds.size > 0
-        ? transcriptDiscovery.findLatestTranscriptExcluding(workingDirectory, siblingClaudeIds)
-        : transcriptDiscovery.findLatestTranscript(workingDirectory);
-
-    if (transcriptPath) {
+    if (fs.existsSync(expectedPath)) {
       try {
-        const stat = fs.statSync(transcriptPath);
-        if (stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS) {
-          stopPoll();
-          log(`[Hooks] Found new transcript via fallback: ${transcriptPath}`);
-          attachWatcher(transcriptPath);
-          return;
-        }
+        stopPoll();
+        log(
+          `[Fallback] Bound transcript appeared: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)})`,
+        );
+        startTranscriptWatcher(
+          { transcriptWatchers },
+          sessionId,
+          expectedPath,
+          messageApi,
+          sendAndRecord,
+        );
       } catch (err) {
-        log(`[Hooks] Fallback stat failed for ${transcriptPath}: ${errorToString(err)}`);
+        logError(`[Fallback] Failed to start watcher for ${expectedPath}: ${errorToString(err)}`);
       }
+      return;
     }
 
-    // Timeout branch. Still accept the transcript if it became recent
-    // during the final interval, otherwise log and give up.
     if (Date.now() - startupTime > pollTimeoutMs) {
       stopPoll();
-      if (transcriptPath) {
-        try {
-          const stat = fs.statSync(transcriptPath);
-          const isRecent =
-            stat.mtimeMs >= startupTime || Date.now() - stat.mtimeMs < RECENT_THRESHOLD_MS;
-          if (isRecent) {
-            log('[Hooks] Transcript fallback: found recent transcript on final check.');
-            attachWatcher(transcriptPath);
-            return;
-          }
-
-          logError(
-            `[Hooks] Transcript fallback timed out without a fresh transcript. Skipping stale file: ${transcriptPath}`,
-          );
-          return;
-        } catch {
-          logError(
-            '[Hooks] Transcript fallback timed out and transcript stat failed on final check.',
-          );
-          return;
-        }
-      }
-
-      logError('[Hooks] Transcript fallback timed out without any transcript file.');
+      logError(
+        `[Fallback] Timed out waiting for transcript: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude may have failed to start, or wrote to an unexpected path.`,
+      );
     }
   }, pollIntervalMs);
 

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -22,7 +22,7 @@ import { errorToString } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionRegistry, SessionStore } from '../session/index.ts';
+import type { SessionRegistry } from '../session/index.ts';
 import type { TranscriptDiscovery } from '../transcript/index.ts';
 import type { TranscriptWatcher } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
@@ -33,7 +33,6 @@ const DEFAULT_POLL_TIMEOUT_MS = 30000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
   transcriptDiscovery: TranscriptDiscovery;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -71,19 +70,12 @@ export function startTranscriptFallback(
 ): void {
   const {
     sessionRegistry,
-    sessionStore: _sessionStore,
     transcriptDiscovery,
     transcriptWatchers,
     transcriptFallbackTimers,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
   } = deps;
-
-  // SessionStore writes happen pre-spawn in cli.ts; this poll only consumes
-  // the binding it was given. Kept in the interface so future recovery
-  // paths (e.g. /resume swap re-binding) can persist updates without
-  // having to thread a second dep object.
-  void _sessionStore;
 
   const startupTime = Date.now();
   const expectedPath = expectedTranscriptPath(
@@ -108,8 +100,11 @@ export function startTranscriptFallback(
     }
 
     if (fs.existsSync(expectedPath)) {
+      // Do NOT stopPoll before the watcher is wired. A throw inside
+      // startTranscriptWatcher (e.g. transient EMFILE on the watcher's
+      // openSync) used to kill the poll while leaving the session
+      // unwatched — silent failure with no retry.
       try {
-        stopPoll();
         log(
           `[Fallback] Bound transcript appeared: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)})`,
         );
@@ -120,8 +115,12 @@ export function startTranscriptFallback(
           messageApi,
           sendAndRecord,
         );
+        stopPoll();
       } catch (err) {
-        logError(`[Fallback] Failed to start watcher for ${expectedPath}: ${errorToString(err)}`);
+        logError(
+          `[Fallback] Failed to start watcher for ${expectedPath}; will retry: ${errorToString(err)}`,
+        );
+        // Fall through without stopping the poll so the next tick retries.
       }
       return;
     }

--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -1,12 +1,16 @@
 /**
- * Transcript-watcher helpers used during session creation and during the
- * hook-miss fallback poll.
+ * Transcript-watcher helper used during session creation.
  *
- * `extractClaudeSessionId` reads the Claude session id out of a transcript
- * filename and persists it in the local SessionStore. `startTranscriptWatcher`
- * wires a `TranscriptMessageBridge` + `TranscriptWatcher` for the given file
- * and registers the watcher in the shared `transcriptWatchers` map so other
- * code (status refresh, cleanup, fallback teardown) can find it by session id.
+ * `startTranscriptWatcher` wires a `TranscriptMessageBridge` +
+ * `TranscriptWatcher` for the given file and registers the watcher in the
+ * shared `transcriptWatchers` map so other code (status refresh, cleanup,
+ * fallback teardown) can find it by session id.
+ *
+ * `extractClaudeSessionId` is **deprecated** (post-#427/phase 1): the
+ * daemon now pre-assigns the Claude session id via `resolveClaudeBinding`
+ * before spawn and persists it directly to `SessionStore`, so no
+ * filename-based inference is needed. The function is kept only because
+ * the test suite still exercises it; remove once tests are migrated.
  *
  * Both helpers are pure over their inputs — no module-level singletons — so
  * tests can supply tmpdir-backed stores and an in-memory Map.
@@ -27,11 +31,15 @@ export interface ExtractClaudeSessionIdDeps {
 }
 
 /**
- * Extract the Claude session id from a transcript filename and persist it.
- * Returns the extracted id, or null if the filename does not expose one.
+ * @deprecated Superseded by `resolveClaudeBinding` (#427/phase 1). The
+ * daemon now pre-assigns the Claude session id before spawn; no
+ * filename-based inference happens at runtime. Retained only for the
+ * legacy test surface; not called from any production code path.
  *
- * Transcript filenames are plain UUIDs (`abc123-def456.jsonl`). The
- * underscore split is defensive in case a prefixed format is ever introduced.
+ * Extracts the Claude session id from a transcript filename and persists
+ * it. Returns the extracted id, or null if the filename does not expose
+ * one. Filenames are plain UUIDs (`abc123-def456.jsonl`); the underscore
+ * split is defensive in case a prefixed format is ever introduced.
  */
 export function extractClaudeSessionId(
   deps: ExtractClaudeSessionIdDeps,

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -241,30 +241,38 @@ export class RelayAdapter implements ConnectionAdapter {
     if (!this.clientConnectionId) return;
     const connectionId = this.clientConnectionId;
     switch (msg['type']) {
-      case 'user_input':
+      case 'user_input': {
         if (typeof msg['content'] !== 'string' || typeof msg['sessionId'] !== 'string') {
           console.warn('Invalid user_input payload: missing content or sessionId');
           return;
         }
+        const claudeId =
+          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
         this.events.onUserInput?.(
           connectionId,
           msg['sessionId'],
           msg['content'],
           msg['raw'] === true,
+          claudeId,
         );
         break;
-      case 'answer':
+      }
+      case 'answer': {
         if (typeof msg['questionId'] !== 'string' || typeof msg['answer'] !== 'string') {
           console.warn('Invalid answer payload: missing questionId or answer');
           return;
         }
+        const claudeId =
+          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
         this.events.onAnswer?.(
           connectionId,
           typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '',
           msg['questionId'],
           msg['answer'],
+          claudeId,
         );
         break;
+      }
       case 'session_list_request':
         if (typeof msg['id'] !== 'string') {
           console.warn('Invalid session_list_request payload: missing id');

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -60,10 +60,10 @@ export interface ConnectionEvents {
   onDisconnect: (reason: string) => void;
 
   /** User input received */
-  onUserInput: (sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (sessionId: UUID, content: string, raw?: boolean, claudeSessionId?: UUID) => void;
 
   /** Answer to question received */
-  onAnswer: (sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (sessionId: UUID, questionId: UUID, answer: string, claudeSessionId?: UUID) => void;
 
   /** Bullet expand request received */
   onBulletExpandRequest: (sessionId: UUID, bulletId: number, requestId: UUID) => void;
@@ -405,7 +405,12 @@ export class Connection {
     this.sendAck(message.id, 'delivered');
 
     // Notify
-    this.events.onUserInput?.(message.sessionId, message.content, message.raw);
+    this.events.onUserInput?.(
+      message.sessionId,
+      message.content,
+      message.raw,
+      message.claudeSessionId,
+    );
   }
 
   private handleAnswer(message: AnswerMessage): void {
@@ -418,7 +423,12 @@ export class Connection {
     this.sendAck(message.id, 'delivered');
 
     // Notify
-    this.events.onAnswer?.(message.sessionId, message.questionId, message.answer);
+    this.events.onAnswer?.(
+      message.sessionId,
+      message.questionId,
+      message.answer,
+      message.claudeSessionId,
+    );
   }
 
   private handleBulletExpandRequest(message: BulletExpandRequestMessage): void {

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -43,10 +43,22 @@ export interface ServerEvents {
   onClientDisconnect: (connectionId: UUID, reason: string) => void;
 
   /** User input from client */
-  onUserInput: (connectionId: UUID, sessionId: UUID, content: string, raw?: boolean) => void;
+  onUserInput: (
+    connectionId: UUID,
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Answer from client */
-  onAnswer: (connectionId: UUID, sessionId: UUID, questionId: UUID, answer: string) => void;
+  onAnswer: (
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => void;
 
   /** Bullet expand request from client */
   onBulletExpandRequest: (
@@ -338,12 +350,18 @@ export class WebSocketServer {
         this.events.onClientDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (sessionId, content, raw) => {
-        this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw);
+      onUserInput: (sessionId, content, raw, claudeSessionId) => {
+        this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw, claudeSessionId);
       },
 
-      onAnswer: (sessionId, questionId, answer) => {
-        this.events.onAnswer?.(ws.data.connectionId, sessionId, questionId, answer);
+      onAnswer: (sessionId, questionId, answer, claudeSessionId) => {
+        this.events.onAnswer?.(
+          ws.data.connectionId,
+          sessionId,
+          questionId,
+          answer,
+          claudeSessionId,
+        );
       },
 
       onBulletExpandRequest: (sessionId, bulletId, requestId) => {

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -106,8 +106,14 @@ export class TranscriptDiscovery {
   }
 
   /**
-   * Find the most recent transcript file for a given project directory.
-   * Useful for connecting a daemon-managed session to its transcript.
+   * @deprecated Superseded by deterministic path construction in
+   * `transcript-fallback.ts:expectedTranscriptPath` (#427/phase 1). The
+   * daemon now knows the bound `.jsonl` path before Claude writes a
+   * single line; no mtime-based discovery is performed at runtime. Only
+   * the test suite still references this method.
+   *
+   * Find the most recent transcript file for a given project directory
+   * by modification time.
    */
   findLatestTranscript(projectPath: string): string | null {
     const transcriptDir = this.getProjectTranscriptDir(projectPath);
@@ -127,8 +133,14 @@ export class TranscriptDiscovery {
   }
 
   /**
-   * Find the most recent transcript for a project, skipping specific session IDs.
-   * Used when sibling daemons in the same directory have already claimed transcripts.
+   * @deprecated Superseded by deterministic binding (#427/phase 1). The
+   * sibling-exclusion race this guarded against is now structurally
+   * impossible because each daemon writes its claudeSessionId into the
+   * store before spawn. Only the test suite still references this
+   * method.
+   *
+   * Find the most recent transcript for a project, skipping specific
+   * session IDs.
    */
   findLatestTranscriptExcluding(projectPath: string, excludeIds: Set<string>): string | null {
     const transcriptDir = this.getProjectTranscriptDir(projectPath);

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -271,6 +271,10 @@ export class TranscriptDiscovery {
       source: 'transcript',
       canAttach: false, // External sessions can't be attached to via daemon
       canResume: status !== 'active', // Only offer resume for idle/completed sessions, not actively running ones
+      // For external entries the filename UUID IS the Claude session id;
+      // path comes from the same disk scan.
+      claudeSessionId: file.sessionId,
+      transcriptPath: file.filePath,
     };
   }
 

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -16,6 +16,10 @@ import { applyEnvOverrides, loadConfig } from '../../src/config/config.ts';
  */
 
 async function isOllamaAvailable(): Promise<boolean> {
+  // SKIP_LLM_TESTS=1 lets a developer pin GPU-heavy LLM tests off without
+  // killing the local Ollama daemon (which they may want running for other
+  // workflows). Honored by every Ollama-gated test in this directory.
+  if (process.env['SKIP_LLM_TESTS'] === '1') return false;
   try {
     const res = await fetch('http://localhost:11434/api/tags', {
       signal: AbortSignal.timeout(2000),

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -31,6 +31,10 @@ import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 
 async function isOllamaAvailable(): Promise<boolean> {
+  // SKIP_LLM_TESTS=1 lets a developer pin GPU-heavy LLM tests off without
+  // killing the local Ollama daemon (which they may want running for other
+  // workflows). Honored by every Ollama-gated test in this directory.
+  if (process.env['SKIP_LLM_TESTS'] === '1') return false;
   try {
     const res = await fetch('http://localhost:11434/api/tags', {
       signal: AbortSignal.timeout(2000),

--- a/packages/daemon/tests/cli/claude-binding.test.ts
+++ b/packages/daemon/tests/cli/claude-binding.test.ts
@@ -36,6 +36,28 @@ describe('resolveClaudeBinding', () => {
     expect(claudeSessionId).toBe(id);
   });
 
+  test('user-provided --resume=<uuid> (equals form) is respected', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding([`--resume=${id}`]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+    expect(args).not.toContain('--session-id');
+  });
+
+  test('malformed --session-id=uuid=foo (second = in value) falls back to fresh', () => {
+    // Documents safe-degradation behavior: isUuidLike rejects the trailing
+    // garbage, so we mint a fresh id and inject our own --session-id rather
+    // than trusting a malformed value.
+    const malformed = '--session-id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee=foo';
+    const { source, claudeSessionId, args } = resolveClaudeBinding([malformed]);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+    // The user's malformed arg is preserved verbatim AND our fresh --session-id
+    // is injected; Claude will reject one of them or honor the last.
+    expect(args[0]).toBe(malformed);
+    expect(args).toContain('--session-id');
+  });
+
   test('--resume alone: binding equals the resumed id', () => {
     const id = '11111111-2222-3333-4444-555555555555';
     const { claudeSessionId, args, source } = resolveClaudeBinding(['--resume', id]);

--- a/packages/daemon/tests/cli/claude-binding.test.ts
+++ b/packages/daemon/tests/cli/claude-binding.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveClaudeBinding } from '../../src/cli/claude-binding.ts';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('resolveClaudeBinding', () => {
+  test('fresh spawn: mints a UUID and injects --session-id', () => {
+    const { claudeSessionId, args, source } = resolveClaudeBinding([]);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+    expect(args).toContain('--session-id');
+    expect(args[args.indexOf('--session-id') + 1]).toBe(claudeSessionId);
+  });
+
+  test('two fresh spawns get distinct ids', () => {
+    const a = resolveClaudeBinding([]);
+    const b = resolveClaudeBinding([]);
+    expect(a.claudeSessionId).not.toBe(b.claudeSessionId);
+  });
+
+  test('user-provided --session-id is respected (no fresh mint)', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const { claudeSessionId, args, source } = resolveClaudeBinding(['--session-id', id]);
+    expect(source).toBe('user-session-id');
+    expect(claudeSessionId).toBe(id);
+    // Should NOT have duplicated the flag.
+    const occurrences = args.filter((a) => a === '--session-id').length;
+    expect(occurrences).toBe(1);
+  });
+
+  test('user-provided --session-id= (equals form) is respected', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const { claudeSessionId, source } = resolveClaudeBinding([`--session-id=${id}`]);
+    expect(source).toBe('user-session-id');
+    expect(claudeSessionId).toBe(id);
+  });
+
+  test('--resume alone: binding equals the resumed id', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding(['--resume', id]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+    // No injected --session-id because claude --resume preserves the id.
+    expect(args).not.toContain('--session-id');
+  });
+
+  test('--resume -r short form', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, source } = resolveClaudeBinding(['-r', id]);
+    expect(source).toBe('user-resume');
+    expect(claudeSessionId).toBe(id);
+  });
+
+  test('--resume with --fork-session: mints a fresh id and injects --session-id', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    const { claudeSessionId, args, source } = resolveClaudeBinding([
+      '--resume',
+      id,
+      '--fork-session',
+    ]);
+    expect(source).toBe('user-resume-fork');
+    expect(claudeSessionId).not.toBe(id);
+    expect(args).toContain('--session-id');
+    // Resume is still passed through so claude knows what to fork from.
+    expect(args).toContain('--resume');
+    expect(args).toContain('--fork-session');
+  });
+
+  test('appends -n displayName when not already present', () => {
+    const { args } = resolveClaudeBinding([], { displayName: 'remi:19920' });
+    expect(args).toContain('-n');
+    expect(args[args.indexOf('-n') + 1]).toBe('remi:19920');
+  });
+
+  test('respects user-provided -n / --name (no override)', () => {
+    const a = resolveClaudeBinding(['-n', 'my-session'], { displayName: 'remi:19920' });
+    expect(a.args.filter((x) => x === '-n').length).toBe(1);
+    expect(a.args[a.args.indexOf('-n') + 1]).toBe('my-session');
+
+    const b = resolveClaudeBinding(['--name', 'my-session'], { displayName: 'remi:19920' });
+    expect(b.args).not.toContain('-n');
+    expect(b.args.filter((x) => x === '--name').length).toBe(1);
+  });
+
+  test('ignores non-UUID values in --session-id and falls back to fresh', () => {
+    const { source, claudeSessionId } = resolveClaudeBinding(['--session-id', 'not-a-uuid']);
+    expect(source).toBe('fresh');
+    expect(UUID_RE.test(claudeSessionId)).toBe(true);
+  });
+
+  test('preserves the original arg order plus appended injections', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const input = ['--model', 'sonnet', '--session-id', id, '--add-dir', '/tmp'];
+    const { args } = resolveClaudeBinding(input);
+    // First five args must match input verbatim (no rewriting of user flags).
+    for (let i = 0; i < input.length; i++) {
+      expect(args[i]).toBe(input[i] as string);
+    }
+  });
+
+  test('does not mutate the input array', () => {
+    const input: string[] = [];
+    resolveClaudeBinding(input, { displayName: 'remi:19920' });
+    expect(input.length).toBe(0);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -432,5 +432,35 @@ describe('createInputHandlers', () => {
       expect(capture.writes).toEqual([]);
       expect(sendCalls.filter((c) => c.message.type === 'error').length).toBe(1);
     });
+
+    test('client-sent claudeSessionId but no daemon binding yet: accept (race window)', async () => {
+      // Pre-spawn save in production makes this rare, but the contract
+      // is fail-open for the race window. Construct it by registering
+      // a session without saving the store entry.
+      const capture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(capture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+      // Deliberately do NOT call sessionStore.save here.
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+
+      const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
+      await handlers.onAnswer(CID, sessionId, QID, 'y', claudeId);
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
   });
 });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
@@ -6,6 +9,7 @@ import { createInputHandlers } from '../../../src/cli/handlers/input-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
 
 /**
  * Minimal PTY/MessageAPI fakes, loosely inspired by the cast-through-unknown
@@ -46,11 +50,15 @@ const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 
 describe('createInputHandlers', () => {
   let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let tmpDir: string;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
 
   beforeEach(() => {
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-input-events-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     sendCalls = [];
     send = (connectionId, message) => {
       sendCalls.push({ connectionId, message });
@@ -62,6 +70,7 @@ describe('createInputHandlers', () => {
   afterEach(async () => {
     __resetLoggerForTests();
     await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   describe('onUserInput', () => {
@@ -76,7 +85,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
 
       expect(ptyCapture.writes).toEqual(['\x1b[A']);
@@ -94,7 +103,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onUserInput(CID, sessionId, 'hello world', false);
 
       expect(ptyCapture.submits).toEqual(['hello world']);
@@ -104,7 +113,7 @@ describe('createInputHandlers', () => {
     test('logs and returns when no session is attached to the connection', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       await handlers.onUserInput(
         CID,
@@ -133,7 +142,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       // Should not throw
       await handlers.onUserInput(CID, sessionId, 'x', true);
 
@@ -164,7 +173,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
@@ -194,7 +203,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       // Pass a bogus sessionId, handler should still find the session via connection
       await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
@@ -219,7 +228,7 @@ describe('createInputHandlers', () => {
       // must signal the drop back to the iOS client so the user is not left
       // wondering whether their tap landed.
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -250,7 +259,7 @@ describe('createInputHandlers', () => {
       });
 
       const stale = 'stal0000-0000-0000-0000-000000000000' as UUID;
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -269,7 +278,7 @@ describe('createInputHandlers', () => {
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
 
@@ -279,7 +288,7 @@ describe('createInputHandlers', () => {
 
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
 
       handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
 
@@ -298,7 +307,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -316,11 +325,112 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map([[7, 'full expanded content']])),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, send });
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
 
       expect(sendCalls).toHaveLength(1);
       expect(sendCalls[0]?.message.type).toBe('bullet_expand_response');
+    });
+  });
+
+  describe('STALE_BINDING guard (#429)', () => {
+    function registerSessionWithBinding(claudeId: string): {
+      sessionId: UUID;
+      capture: { writes: string[]; submits: string[] };
+    } {
+      const capture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(capture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.attachConnection(sessionId, CID);
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: claudeId,
+        projectPath: '/test/dir',
+        port: 0,
+        pid: 0,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      return { sessionId, capture };
+    }
+
+    test('answer with matching claudeSessionId is forwarded', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [{ value: 'y', label: 'Y', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y', bound);
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('answer with stale claudeSessionId is refused with STALE_BINDING', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y', stale);
+
+      expect(capture.submits).toEqual([]);
+      const errs = sendCalls.filter((c) => c.message.type === 'error');
+      expect(errs).toHaveLength(1);
+      const err = errs[0]?.message as { code?: string; details?: Record<string, unknown> };
+      expect(err.code).toBe('STALE_BINDING');
+      expect(err.details?.['boundClaudeSessionId']).toBe(bound);
+      expect(err.details?.['incomingClaudeSessionId']).toBe(stale);
+    });
+
+    test('answer without claudeSessionId (legacy client) is accepted', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+      sessionRegistry.updateQuestion(sessionId, {
+        id: QID,
+        text: 'go?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(capture.submits).toEqual(['y']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('user_input with stale claudeSessionId is refused', async () => {
+      const bound = '11111111-2222-3333-4444-555555555555' as UUID;
+      const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      const { sessionId, capture } = registerSessionWithBinding(bound);
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      await handlers.onUserInput(CID, sessionId, 'ls', false, stale);
+
+      expect(capture.submits).toEqual([]);
+      expect(capture.writes).toEqual([]);
+      expect(sendCalls.filter((c) => c.message.type === 'error').length).toBe(1);
     });
   });
 });

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -103,6 +103,50 @@ describe('createSessionHandlers', () => {
       expect(msg.sessions).toHaveLength(1);
     });
 
+    test('decorates daemon sessions with claudeSessionId + transcriptPath (#429)', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      const claudeId = '11111111-2222-3333-4444-555555555555';
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: claudeId,
+        projectPath: '/test/dir',
+        port: PORT,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      const msg = sendCalls[0]?.message as unknown as {
+        sessions: Array<{
+          sessionId: string;
+          claudeSessionId?: string;
+          transcriptPath?: string;
+        }>;
+      };
+      expect(msg.sessions).toHaveLength(1);
+      expect(msg.sessions[0]?.claudeSessionId).toBe(claudeId);
+      expect(msg.sessions[0]?.transcriptPath).toContain(`/${claudeId}.jsonl`);
+    });
+
+    test('falls back to undecorated entry when sessionStore lookup misses', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      // Deliberately do NOT call sessionStore.save.
+
+      makeHandlers().onSessionListRequest(CID, REQ, false);
+
+      const msg = sendCalls[0]?.message as unknown as {
+        sessions: Array<{ claudeSessionId?: string; transcriptPath?: string }>;
+      };
+      expect(msg.sessions).toHaveLength(1);
+      expect(msg.sessions[0]?.claudeSessionId).toBeUndefined();
+      expect(msg.sessions[0]?.transcriptPath).toBeUndefined();
+    });
+
     test('omits the current daemon port from daemonPorts', () => {
       // Register one session entry for a DIFFERENT port alongside ours.
       liveSessionsRegistry.register({

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1719,4 +1719,105 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toHaveLength(0); // no inject
     expect(messageApiLog.questionCalls).toBe(0); // no escalate
   });
+
+  describe('transcript_binding_changed emission on rotation (#430)', () => {
+    /**
+     * Set up a hook bridge that captures every protocol message it tries
+     * to send. We can't use the shared `build` helper because that swallows
+     * sendAndRecord; rotation emission is the whole point we need to assert
+     * on.
+     */
+    function buildWithCapture(): { sent: import('@remi/shared').ProtocolMessage[] } {
+      const sent: import('@remi/shared').ProtocolMessage[] = [];
+      const tracker = new PassthroughTracker((q) => {
+        messageApiLog.questionCalls += 1;
+        const _ = q;
+      });
+      setupHookBridge(
+        {
+          sessionRegistry,
+          sessionStore,
+          liveSessionsRegistry,
+          transcriptWatchers: transcriptWatchers as unknown as Map<
+            UUID,
+            import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+          >,
+          transcriptFallbackTimers,
+          autoApproveService: null,
+          currentPort: () => 8765,
+        },
+        {
+          hookServer: hookServer as unknown as HookServer,
+          sessionId: SID,
+          workingDirectory: tmpDir,
+          messageApi: {
+            handleMessage: () => {},
+            handleQuestion: () => {},
+            handleStatusChange: () => {},
+            reset: () => {
+              messageApiLog.resetCalls.n += 1;
+            },
+          } as unknown as import('../../../src/api/message-api.ts').MessageAPI,
+          sendAndRecord: (msg) => sent.push(msg),
+          tracker: tracker as unknown as import(
+            '../../../src/api/question-presence-tracker.ts',
+          ).QuestionPresenceTracker,
+        },
+      );
+      return { sent };
+    }
+
+    test('first-init does NOT emit (no rotation, only hello_ack covers initial)', () => {
+      const { sent } = buildWithCapture();
+
+      // Register the session so the bridge proceeds past hasSession() checks.
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-first-id',
+        transcript_path: path.join(tmpDir, 'first.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      expect(sent.filter((m) => m.type === 'transcript_binding_changed')).toHaveLength(0);
+    });
+
+    test('second SessionStart with a different id emits transcript_binding_changed', () => {
+      const { sent } = buildWithCapture();
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-first-id',
+        transcript_path: path.join(tmpDir, 'first.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-second-id',
+        transcript_path: path.join(tmpDir, 'second.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      const events = sent.filter((m) => m.type === 'transcript_binding_changed') as Array<{
+        sessionId: string;
+        claudeSessionId: string;
+        transcriptPath: string;
+        reason: string;
+      }>;
+      expect(events).toHaveLength(1);
+      expect(events[0]?.sessionId).toBe(SID);
+      expect(events[0]?.claudeSessionId).toBe('claude-second-id');
+      expect(events[0]?.transcriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
+      expect(events[0]?.reason).toBe('restart');
+    });
+  });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1759,9 +1759,7 @@ describe('setupHookBridge', () => {
             },
           } as unknown as import('../../../src/api/message-api.ts').MessageAPI,
           sendAndRecord: (msg) => sent.push(msg),
-          tracker: tracker as unknown as import(
-            '../../../src/api/question-presence-tracker.ts',
-          ).QuestionPresenceTracker,
+          tracker: tracker as unknown as QuestionPresenceTracker,
         },
       );
       return { sent };

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -326,4 +326,92 @@ describe('createMessageApiForSession', () => {
     expect(updates.length).toBeGreaterThanOrEqual(1);
     expect((updates[0]?.message as { isUpdate: boolean }).isUpdate).toBe(true);
   });
+
+  describe('getClaudeSessionId on questions (#429)', () => {
+    function buildWithBinding(sessionId: UUID, get: () => UUID | null) {
+      return createMessageApiForSession(
+        {
+          sessionRegistry,
+          transcriptWatchers,
+          deviceTokens,
+          pushConfig: () => ({ signalingUrl: 'ws://fake-signaling' }),
+          updateRemiStatus: (patch) => statusPatches.push(patch),
+          maxBulletLength: 4000,
+          sendMessage: (sid, message) => {
+            sendCalls.push({ sessionId: sid, message });
+          },
+          getClaudeSessionId: get,
+        },
+        sessionId,
+      );
+    }
+
+    test('question carries claudeSessionId returned by the lazy getter', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
+      const { messageApi } = buildWithBinding(sessionId, () => claudeId);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+      const q = sendCalls.find((c) => c.message.type === 'question');
+      expect(q).toBeDefined();
+      expect((q?.message as { claudeSessionId?: string }).claudeSessionId).toBe(claudeId);
+    });
+
+    test('getter rotation: second question reflects the new binding', () => {
+      // Simulates /resume rotation between two question emissions —
+      // the lazy getter must re-read on each emission, not capture once.
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const before = '11111111-2222-3333-4444-555555555555' as UUID;
+      const after = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
+      let current: UUID = before;
+      const { messageApi } = buildWithBinding(sessionId, () => current);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+      // Force a status reset so questionDedup doesn't suppress the
+      // second emission.
+      messageApi.handleStatusChange('idle');
+      current = after;
+      messageApi.handleQuestion(
+        questionWith([
+          { ...yesOpt, value: 'y2', label: 'Y2' },
+          { ...noOpt, value: 'n2', label: 'N2' },
+        ]),
+      );
+
+      const questions = sendCalls
+        .filter((c) => c.message.type === 'question')
+        .map((c) => (c.message as { claudeSessionId?: string }).claudeSessionId);
+      expect(questions).toEqual([before, after]);
+    });
+
+    test('getter returning null omits claudeSessionId from the wire message', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+      setPrimarySessionId(sessionId);
+      const { messageApi } = buildWithBinding(sessionId, () => null);
+
+      messageApi.handleQuestion(questionWith([yesOpt, noOpt]));
+
+      const q = sendCalls.find((c) => c.message.type === 'question');
+      expect(q).toBeDefined();
+      expect('claudeSessionId' in (q?.message ?? {})).toBe(false);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/transcript-fallback.test.ts
+++ b/packages/daemon/tests/cli/transcript-fallback.test.ts
@@ -9,7 +9,6 @@ import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts'
 import { startTranscriptFallback } from '../../src/cli/transcript-fallback.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../src/session/session-registry.ts';
-import { SessionStore } from '../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
@@ -39,7 +38,6 @@ describe('startTranscriptFallback', () => {
   let projectsDir: string;
   let projectPath: string;
   let sessionRegistry: SessionRegistry;
-  let sessionStore: SessionStore;
   let transcriptDiscovery: TranscriptDiscovery;
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -52,7 +50,6 @@ describe('startTranscriptFallback', () => {
     fs.mkdirSync(projectsDir, { recursive: true });
     fs.mkdirSync(projectPath, { recursive: true });
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
-    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     transcriptFallbackTimers = new Map();
@@ -98,7 +95,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -123,7 +119,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -149,7 +144,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -183,7 +177,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -224,7 +217,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -251,7 +243,6 @@ describe('startTranscriptFallback', () => {
     startTranscriptFallback(
       {
         sessionRegistry,
-        sessionStore,
         transcriptDiscovery,
         transcriptWatchers,
         transcriptFallbackTimers,

--- a/packages/daemon/tests/cli/transcript-fallback.test.ts
+++ b/packages/daemon/tests/cli/transcript-fallback.test.ts
@@ -89,6 +89,9 @@ describe('startTranscriptFallback', () => {
 
   const sendAndRecord = (_: ProtocolMessage) => {};
 
+  const KNOWN_CLAUDE_ID = '11111111-2222-3333-4444-555555555555';
+  const OTHER_CLAUDE_ID = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+
   test('registers a timer in transcriptFallbackTimers', () => {
     const sid = registerSession();
 
@@ -104,6 +107,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -128,6 +132,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -153,6 +158,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -162,18 +168,17 @@ describe('startTranscriptFallback', () => {
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
   });
 
-  test('attaches a watcher when a fresh transcript appears on disk', async () => {
+  test('attaches a watcher when the bound transcript appears on disk', async () => {
     const sid = registerSession();
-    const claudeId = '11111111-2222-3333-4444-555555555555';
     const entry = {
       type: 'user',
       uuid: 'u1',
-      sessionId: claudeId,
+      sessionId: KNOWN_CLAUDE_ID,
       cwd: projectPath,
       timestamp: new Date().toISOString(),
       message: { role: 'user', content: 'hi' },
     };
-    writeTranscript(claudeId, [entry]);
+    writeTranscript(KNOWN_CLAUDE_ID, [entry]);
 
     startTranscriptFallback(
       {
@@ -187,6 +192,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -201,7 +207,44 @@ describe('startTranscriptFallback', () => {
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
   });
 
-  test('times out when no transcript ever appears', async () => {
+  test('ignores a sibling daemons transcript with a different UUID', async () => {
+    // Race scenario: a sibling daemon's claude wrote its transcript first.
+    // The new fallback waits for OUR pre-bound id, not "newest in the dir".
+    const sid = registerSession();
+    const entry = {
+      type: 'user',
+      uuid: 'u1',
+      sessionId: OTHER_CLAUDE_ID,
+      cwd: projectPath,
+      timestamp: new Date().toISOString(),
+      message: { role: 'user', content: 'hi' },
+    };
+    writeTranscript(OTHER_CLAUDE_ID, [entry]);
+
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 150,
+      },
+      sid,
+      projectPath,
+      KNOWN_CLAUDE_ID,
+      fakeMessageAPI(),
+      sendAndRecord,
+    );
+
+    await sleep(200);
+
+    expect(transcriptWatchers.has(sid)).toBe(false);
+    expect(transcriptFallbackTimers.has(sid)).toBe(false);
+  });
+
+  test('times out when the bound transcript never appears', async () => {
     // No transcript on disk.
     const sid = registerSession();
 
@@ -217,6 +260,7 @@ describe('startTranscriptFallback', () => {
       },
       sid,
       projectPath,
+      KNOWN_CLAUDE_ID,
       fakeMessageAPI(),
       sendAndRecord,
     );
@@ -226,10 +270,6 @@ describe('startTranscriptFallback', () => {
 
     expect(transcriptFallbackTimers.has(sid)).toBe(false);
     expect(transcriptWatchers.has(sid)).toBe(false);
-    expect(
-      logs.some((m) =>
-        m.includes('[error] [Hooks] Transcript fallback timed out without any transcript file'),
-      ),
-    ).toBe(true);
+    expect(logs.some((m) => m.includes('[Fallback] Timed out waiting for transcript'))).toBe(true);
   });
 });

--- a/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
+++ b/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration test for #427/#428: two daemons in the SAME cwd must never
+ * cross-bind each other's Claude transcripts.
+ *
+ * Exercises the actual binding chain — resolveClaudeBinding, SessionStore,
+ * and startTranscriptFallback wired together the same way createNewSession
+ * wires them in cli.ts. Does not mock Bun.spawn: instead we simulate two
+ * "claude" processes by writing the .jsonl files each binding expects.
+ *
+ * Pre-fix this scenario was the silent killer behind cross-daemon answer
+ * routing: both daemons' fallbacks called findLatestTranscript and grabbed
+ * whichever .jsonl had the freshest mtime, regardless of which Claude wrote
+ * it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { resolveClaudeBinding } from '../../src/cli/claude-binding.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import {
+  expectedTranscriptPath,
+  startTranscriptFallback,
+} from '../../src/cli/transcript-fallback.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Model one daemon's state — its own sessionStore, its own watchers map,
+ * its own transcript-fallback timer map. In production each daemon is a
+ * separate process; here we keep them isolated within one test process by
+ * giving each its own state bundle.
+ */
+interface DaemonFixture {
+  readonly label: string;
+  readonly remiSessionId: UUID;
+  readonly sessionStore: SessionStore;
+  readonly sessionRegistry: SessionRegistry;
+  readonly transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  readonly transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  claudeSessionId?: string;
+}
+
+describe('two daemons in the same cwd never cross-bind (#427)', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+  let projectPath: string;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let logs: string[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-cross-bind-'));
+    projectsDir = path.join(tmpDir, 'claude-projects');
+    projectPath = path.join(tmpDir, 'shared-project');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.mkdirSync(projectPath, { recursive: true });
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+    logs = [];
+    configureLogger({ writeLog: (m) => logs.push(m) });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDaemon(label: string): DaemonFixture {
+    const sessionStore = new SessionStore(path.join(tmpDir, `sessions-${label}.json`));
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const remiSessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(remiSessionId, projectPath, fakePTY(), fakeMessageAPI());
+    return {
+      label,
+      remiSessionId,
+      sessionStore,
+      sessionRegistry,
+      transcriptWatchers: new Map(),
+      transcriptFallbackTimers: new Map(),
+    };
+  }
+
+  /**
+   * Simulate the create-session flow up to (but not including) Bun.spawn:
+   * resolve a binding, persist to store, and start the fallback poll.
+   * Mirrors the order in cli.ts:createNewSession.
+   */
+  function startDaemonBinding(d: DaemonFixture): void {
+    const binding = resolveClaudeBinding([], { displayName: `remi:${d.label}` });
+    d.claudeSessionId = binding.claudeSessionId;
+    d.sessionStore.save({
+      remiSessionId: d.remiSessionId,
+      claudeSessionId: binding.claudeSessionId,
+      projectPath,
+      port: 0,
+      pid: 0,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+    startTranscriptFallback(
+      {
+        sessionRegistry: d.sessionRegistry,
+        sessionStore: d.sessionStore,
+        transcriptDiscovery,
+        transcriptWatchers: d.transcriptWatchers,
+        transcriptFallbackTimers: d.transcriptFallbackTimers,
+        pollIntervalMs: 20,
+        pollTimeoutMs: 2000,
+      },
+      d.remiSessionId,
+      projectPath,
+      binding.claudeSessionId,
+      fakeMessageAPI(),
+      (_: ProtocolMessage) => {},
+    );
+  }
+
+  /** Write a fake transcript .jsonl to disk as if Claude had just started. */
+  function writeClaudeTranscript(claudeId: string): string {
+    const encodedDir = path.join(projectsDir, projectPath.replace(/\//g, '-'));
+    fs.mkdirSync(encodedDir, { recursive: true });
+    const filePath = path.join(encodedDir, `${claudeId}.jsonl`);
+    fs.writeFileSync(
+      filePath,
+      `${JSON.stringify({
+        type: 'user',
+        uuid: generateId(),
+        sessionId: claudeId,
+        cwd: projectPath,
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'boot' },
+      })}\n`,
+    );
+    return filePath;
+  }
+
+  async function shutdownAll(daemons: DaemonFixture[]): Promise<void> {
+    for (const d of daemons) {
+      for (const t of d.transcriptFallbackTimers.values()) clearInterval(t);
+      d.transcriptFallbackTimers.clear();
+      for (const w of d.transcriptWatchers.values()) w.stop();
+      d.transcriptWatchers.clear();
+      await d.sessionRegistry.shutdown();
+    }
+  }
+
+  test('two daemons race-binding produce distinct claudeSessionIds', () => {
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    // Race: bindings resolved + saved synchronously back-to-back, like two
+    // daemons booting at the same instant.
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    expect(a.claudeSessionId).toBeDefined();
+    expect(b.claudeSessionId).toBeDefined();
+    expect(a.claudeSessionId).not.toBe(b.claudeSessionId);
+
+    // Each store has its OWN entry; no leakage across daemon stores.
+    const storedA = a.sessionStore.findByRemiSessionId(a.remiSessionId);
+    const storedB = b.sessionStore.findByRemiSessionId(b.remiSessionId);
+    expect(storedA?.claudeSessionId).toBe(a.claudeSessionId!);
+    expect(storedB?.claudeSessionId).toBe(b.claudeSessionId!);
+
+    return shutdownAll([a, b]);
+  });
+
+  test('each daemon binds its OWN transcript even when both files exist', async () => {
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    // Both "claudes" write their transcripts concurrently. Daemon B's
+    // file lands FIRST so pre-fix code (newest-mtime sort) would have
+    // pointed daemon A at B's file.
+    const bPath = writeClaudeTranscript(b.claudeSessionId!);
+    await sleep(15);
+    const aPath = writeClaudeTranscript(a.claudeSessionId!);
+
+    // Wait for both fallbacks to bind.
+    for (let i = 0; i < 50; i++) {
+      if (a.transcriptWatchers.has(a.remiSessionId) && b.transcriptWatchers.has(b.remiSessionId)) {
+        break;
+      }
+      await sleep(30);
+    }
+
+    const watcherA = a.transcriptWatchers.get(a.remiSessionId);
+    const watcherB = b.transcriptWatchers.get(b.remiSessionId);
+
+    expect(watcherA).toBeDefined();
+    expect(watcherB).toBeDefined();
+    expect(watcherA!.filePath).toBe(aPath);
+    expect(watcherB!.filePath).toBe(bPath);
+    expect(watcherA!.filePath).not.toBe(watcherB!.filePath);
+
+    return shutdownAll([a, b]);
+  });
+
+  test('daemon ignores sibling-only transcripts even if its own never appears', async () => {
+    // Mirror the cruel case: daemon A is alive but its claude crashed
+    // before writing any transcript; daemon B's transcript is present.
+    // Pre-fix, A would have adopted B's file. Now, A times out cleanly.
+    const a = makeDaemon('A');
+    const b = makeDaemon('B');
+
+    startDaemonBinding(a);
+    startDaemonBinding(b);
+
+    writeClaudeTranscript(b.claudeSessionId!);
+    // Deliberately DO NOT write A's transcript.
+
+    // Wait past A's fallback timeout (configured 2000ms in startDaemonBinding).
+    await sleep(2200);
+
+    expect(a.transcriptWatchers.has(a.remiSessionId)).toBe(false);
+    // A timed out cleanly with a typed error log, not by adopting B's file.
+    expect(logs.some((m) => m.includes('[Fallback] Timed out waiting for transcript'))).toBe(true);
+
+    // B should be bound correctly to its own file.
+    await sleep(50);
+    const watcherB = b.transcriptWatchers.get(b.remiSessionId);
+    expect(watcherB?.filePath).toBe(
+      expectedTranscriptPath(transcriptDiscovery, projectPath, b.claudeSessionId!),
+    );
+
+    return shutdownAll([a, b]);
+  });
+
+  test('expected paths derived from binding match what fallback waits for', () => {
+    // Defense-in-depth: the path the fallback polls for must equal the
+    // path the .jsonl filename derives from the bound UUID. If these
+    // ever drift (e.g. someone changes the encoding rule on one side
+    // only), this test fires immediately.
+    const a = makeDaemon('A');
+    startDaemonBinding(a);
+    const derived = expectedTranscriptPath(transcriptDiscovery, projectPath, a.claudeSessionId!);
+    const expectedDir = transcriptDiscovery.getProjectTranscriptDir(projectPath);
+    expect(derived.startsWith(expectedDir)).toBe(true);
+    expect(derived.endsWith(`${a.claudeSessionId!}.jsonl`)).toBe(true);
+    return shutdownAll([a]);
+  });
+});

--- a/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
+++ b/packages/daemon/tests/integration/same-cwd-no-cross-binding.test.ts
@@ -8,9 +8,8 @@
  * "claude" processes by writing the .jsonl files each binding expects.
  *
  * Pre-fix this scenario was the silent killer behind cross-daemon answer
- * routing: both daemons' fallbacks called findLatestTranscript and grabbed
- * whichever .jsonl had the freshest mtime, regardless of which Claude wrote
- * it.
+ * routing: both daemons' fallbacks sorted the project directory by mtime
+ * and grabbed the newest .jsonl regardless of which Claude wrote it.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -131,7 +130,6 @@ describe('two daemons in the same cwd never cross-bind (#427)', () => {
     startTranscriptFallback(
       {
         sessionRegistry: d.sessionRegistry,
-        sessionStore: d.sessionStore,
         transcriptDiscovery,
         transcriptWatchers: d.transcriptWatchers,
         transcriptFallbackTimers: d.transcriptFallbackTimers,

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Verifies the relay adapter's routeMessage forwards `claudeSessionId`
+ * to onUserInput / onAnswer (#429). Pre-fix the field was silently
+ * dropped, so relay-mode clients bypassed the daemon's stale-binding
+ * guard entirely.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
+import { RelayAdapter } from '../src/remote/relay-adapter.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
+const SID = 'sess0000-0000-0000-0000-000000000000' as UUID;
+const QID = 'ques0000-0000-0000-0000-000000000000' as UUID;
+const CSID = '11111111-2222-3333-4444-555555555555';
+
+function makeAdapter(events: object): RelayAdapter {
+  const adapter = new RelayAdapter({ signalingUrl: 'wss://ignored.example.com' }, events);
+  // routeMessage is private and needs clientConnectionId; this matches
+  // the assignment that happens in the real auth flow.
+  (adapter as unknown as { clientConnectionId: UUID }).clientConnectionId = CID;
+  return adapter;
+}
+
+function callRoute(adapter: RelayAdapter, msg: Record<string, unknown>): void {
+  (adapter as unknown as { routeMessage: (m: Record<string, unknown>) => void }).routeMessage(msg);
+}
+
+describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
+  test('user_input with claudeSessionId is forwarded as the 5th arg', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+      raw: false,
+      claudeSessionId: CSID,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBe(CSID);
+  });
+
+  test('user_input without claudeSessionId forwards undefined (back-compat)', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+
+  test('answer with claudeSessionId is forwarded as the 5th arg', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onAnswer: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _questionId: UUID,
+        _answer: string,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: 'y',
+      claudeSessionId: CSID,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBe(CSID);
+  });
+
+  test('non-string claudeSessionId is dropped to undefined (defensive)', () => {
+    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onAnswer: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _questionId: UUID,
+        _answer: string,
+        claudeSessionId?: string,
+      ) => {
+        calls.push({ claudeSessionId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: 'y',
+      claudeSessionId: 42,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -84,6 +84,7 @@ export type {
   RegisterDeviceTokenMessage,
   SessionResetMessage,
   DaemonUpdateAvailableMessage,
+  TranscriptBindingChangedMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -131,6 +132,7 @@ export {
   createRegisterDeviceToken,
   createSessionReset,
   createDaemonUpdateAvailable,
+  createTranscriptBindingChanged,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -100,7 +100,8 @@ export type ProtocolMessage =
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
   | SessionResetMessage
-  | DaemonUpdateAvailableMessage;
+  | DaemonUpdateAvailableMessage
+  | TranscriptBindingChangedMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -126,6 +127,22 @@ export interface HelloAckMessage {
   readonly timestamp: Timestamp;
   readonly serverVersion: string;
   readonly sessionId: UUID;
+  /**
+   * Claude Code session UUID this daemon's PTY is bound to (#427/#429).
+   * Always populated post-phase-1 because the daemon pre-assigns the id
+   * before spawning Claude. Null only when this hello_ack predates a
+   * resolved binding (e.g. resume-attaching to a session whose lock was
+   * lost across a daemon crash). Clients should key sessions by
+   * (connectionId, claudeSessionId) to keep two daemons in the same cwd
+   * from cross-contaminating.
+   */
+  readonly claudeSessionId?: UUID | null | undefined;
+  /**
+   * Absolute path to the .jsonl transcript file Claude writes to.
+   * Pre-assigned alongside claudeSessionId; the file may not yet exist on
+   * disk when this ack is sent. Null when claudeSessionId is null.
+   */
+  readonly transcriptPath?: string | null | undefined;
   /** Whether this is a resumed session */
   readonly isResume?: boolean | undefined;
   /** Number of messages to be replayed (if resume) */
@@ -163,6 +180,15 @@ export interface UserInputMessage {
   readonly content: string;
   /** When true, content is raw terminal bytes (no Enter appended) */
   readonly raw?: boolean;
+  /**
+   * Claude Code session UUID the client believed it was talking to when
+   * the user typed this. Daemon rejects with code='stale_binding' when
+   * present and != current binding (e.g. the PTY swapped to another
+   * session via /resume between the user typing and the message
+   * landing). Omitted by pre-#429 clients; daemon accepts without
+   * checking in that case.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Acknowledgment */
@@ -192,6 +218,13 @@ export interface QuestionMessage {
   readonly question: Question;
   /** Session that owns this question */
   readonly sessionId?: UUID | undefined;
+  /**
+   * Claude Code session UUID the question came from. The answer carrying
+   * this id back lets the daemon reject the write if the binding has
+   * moved (e.g. user ran /resume between the question firing and their
+   * tap). Populated when the daemon has a binding; omitted otherwise.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Answer to a question */
@@ -202,6 +235,12 @@ export interface AnswerMessage {
   readonly sessionId: UUID;
   readonly questionId: UUID;
   readonly answer: string;
+  /**
+   * Echoes the claudeSessionId from the QuestionMessage. Daemon refuses
+   * with code='stale_binding' when present and != current binding.
+   * Omitted by pre-#429 clients.
+   */
+  readonly claudeSessionId?: UUID | undefined;
 }
 
 /** Session state update */
@@ -292,6 +331,26 @@ export interface SessionListResponseMessage {
   readonly requestId: UUID;
   /** Other daemon ports on this machine (for auto-connect) */
   readonly daemonPorts?: readonly number[];
+}
+
+/**
+ * Notifies the client that the PTY's bound Claude session has changed,
+ * e.g. user ran /resume or /clear inside the PTY (#429). Clients should
+ * rekey UI state by the new (sessionId, claudeSessionId) tuple and update
+ * any displayed binding indicator.
+ */
+export interface TranscriptBindingChangedMessage {
+  readonly type: 'transcript_binding_changed';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session id whose binding rotated. */
+  readonly sessionId: UUID;
+  /** The new Claude session id Claude is now writing under. */
+  readonly claudeSessionId: UUID;
+  /** Absolute path to the new transcript .jsonl. */
+  readonly transcriptPath: string;
+  /** Diagnostic: 'restart' for /clear|/compact, 'resume' for /resume, 'unknown' otherwise. */
+  readonly reason: 'restart' | 'resume' | 'unknown';
 }
 
 /** Token usage information from a transcript entry */
@@ -678,6 +737,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'register_device_token',
     'daemon_update_available',
     'session_reset',
+    'transcript_binding_changed',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -727,6 +787,7 @@ export function createHelloAck(
   serverVersion: string,
   sessionId: UUID,
   resumeInfo?: { isResume: boolean; replayCount: number; nextBulletId: number },
+  binding?: { claudeSessionId: UUID | null; transcriptPath: string | null },
 ): HelloAckMessage {
   return {
     type: 'hello_ack',
@@ -738,6 +799,10 @@ export function createHelloAck(
       isResume: resumeInfo.isResume,
       replayCount: resumeInfo.replayCount,
       nextBulletId: resumeInfo.nextBulletId,
+    }),
+    ...(binding && {
+      claudeSessionId: binding.claudeSessionId,
+      transcriptPath: binding.transcriptPath,
     }),
   };
 }
@@ -775,7 +840,12 @@ export function createStructuredAgentOutput(
 /**
  * Create a user input message.
  */
-export function createUserInput(sessionId: UUID, content: string, raw?: boolean): UserInputMessage {
+export function createUserInput(
+  sessionId: UUID,
+  content: string,
+  raw?: boolean,
+  claudeSessionId?: UUID,
+): UserInputMessage {
   return {
     type: 'user_input',
     id: generateId(),
@@ -783,6 +853,7 @@ export function createUserInput(sessionId: UUID, content: string, raw?: boolean)
     sessionId,
     content,
     ...(raw && { raw }),
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
@@ -862,20 +933,30 @@ export function createError(
 /**
  * Create a question message.
  */
-export function createQuestion(question: Question, sessionId?: UUID): QuestionMessage {
+export function createQuestion(
+  question: Question,
+  sessionId?: UUID,
+  claudeSessionId?: UUID,
+): QuestionMessage {
   return {
     type: 'question',
     id: generateId(),
     timestamp: now(),
     question,
     ...(sessionId !== undefined && { sessionId }),
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
 /**
  * Create an answer message for a question.
  */
-export function createAnswer(sessionId: UUID, questionId: UUID, answer: string): AnswerMessage {
+export function createAnswer(
+  sessionId: UUID,
+  questionId: UUID,
+  answer: string,
+  claudeSessionId?: UUID,
+): AnswerMessage {
   return {
     type: 'answer',
     id: generateId(),
@@ -883,6 +964,7 @@ export function createAnswer(sessionId: UUID, questionId: UUID, answer: string):
     sessionId,
     questionId,
     answer,
+    ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }
 
@@ -1335,6 +1417,27 @@ export function createSessionReset(sessionId: UUID, reason: string): SessionRese
     id: generateId(),
     timestamp: now(),
     sessionId,
+    reason,
+  };
+}
+
+/**
+ * Create a transcript-binding-changed notification (PTY's bound Claude
+ * session UUID rotated, e.g. /resume, /clear).
+ */
+export function createTranscriptBindingChanged(
+  sessionId: UUID,
+  claudeSessionId: UUID,
+  transcriptPath: string,
+  reason: 'restart' | 'resume' | 'unknown' = 'unknown',
+): TranscriptBindingChangedMessage {
+  return {
+    type: 'transcript_binding_changed',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    claudeSessionId,
+    transcriptPath,
     reason,
   };
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -130,19 +130,18 @@ export interface HelloAckMessage {
   /**
    * Claude Code session UUID this daemon's PTY is bound to (#427/#429).
    * Always populated post-phase-1 because the daemon pre-assigns the id
-   * before spawning Claude. Null only when this hello_ack predates a
-   * resolved binding (e.g. resume-attaching to a session whose lock was
-   * lost across a daemon crash). Clients should key sessions by
-   * (connectionId, claudeSessionId) to keep two daemons in the same cwd
-   * from cross-contaminating.
+   * before spawning Claude. Null only on the promotion path when the
+   * store lookup misses (crashed daemon, store cleared). Clients should
+   * key sessions by (connectionId, claudeSessionId) to keep two daemons
+   * in the same cwd from cross-contaminating.
    */
-  readonly claudeSessionId?: UUID | null | undefined;
+  readonly claudeSessionId?: UUID | null;
   /**
    * Absolute path to the .jsonl transcript file Claude writes to.
    * Pre-assigned alongside claudeSessionId; the file may not yet exist on
    * disk when this ack is sent. Null when claudeSessionId is null.
    */
-  readonly transcriptPath?: string | null | undefined;
+  readonly transcriptPath?: string | null;
   /** Whether this is a resumed session */
   readonly isResume?: boolean | undefined;
   /** Number of messages to be replayed (if resume) */
@@ -182,7 +181,7 @@ export interface UserInputMessage {
   readonly raw?: boolean;
   /**
    * Claude Code session UUID the client believed it was talking to when
-   * the user typed this. Daemon rejects with code='stale_binding' when
+   * the user typed this. Daemon rejects with code='STALE_BINDING' when
    * present and != current binding (e.g. the PTY swapped to another
    * session via /resume between the user typing and the message
    * landing). Omitted by pre-#429 clients; daemon accepts without
@@ -237,7 +236,7 @@ export interface AnswerMessage {
   readonly answer: string;
   /**
    * Echoes the claudeSessionId from the QuestionMessage. Daemon refuses
-   * with code='stale_binding' when present and != current binding.
+   * with code='STALE_BINDING' when present and != current binding.
    * Omitted by pre-#429 clients.
    */
   readonly claudeSessionId?: UUID | undefined;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -287,15 +287,16 @@ export interface DiscoverableSession {
    * Claude Code session UUID this entry's Claude is bound to (#427/#429).
    * For daemon-sourced entries, this is the pre-assigned binding from
    * SessionStore. For transcript-sourced entries it equals sessionId.
-   * Optional because legacy/edge cases (daemon entry whose Claude was
-   * spawned before #428) may have no recorded binding.
+   * Optional because the SessionStore lookup may miss on the daemon-list
+   * path (e.g. a daemon entry whose sessions.json record was lost across
+   * a crash before the client requested the list).
    */
   readonly claudeSessionId?: string | undefined;
 
   /**
    * Absolute path to the .jsonl transcript Claude writes to. Populated
-   * for all entries where it can be derived; omitted only when the entry
-   * predates #428's binding model and no transcript file was discovered.
+   * for all entries where the binding is known. Omitted in the same
+   * lookup-miss case described above.
    */
   readonly transcriptPath?: string | undefined;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -283,6 +283,22 @@ export interface DiscoverableSession {
   /** Whether this dead session can be resumed via Claude Code --resume */
   readonly canResume: boolean;
 
+  /**
+   * Claude Code session UUID this entry's Claude is bound to (#427/#429).
+   * For daemon-sourced entries, this is the pre-assigned binding from
+   * SessionStore. For transcript-sourced entries it equals sessionId.
+   * Optional because legacy/edge cases (daemon entry whose Claude was
+   * spawned before #428) may have no recorded binding.
+   */
+  readonly claudeSessionId?: string | undefined;
+
+  /**
+   * Absolute path to the .jsonl transcript Claude writes to. Populated
+   * for all entries where it can be derived; omitted only when the entry
+   * predates #428's binding model and no transcript file was discovered.
+   */
+  readonly transcriptPath?: string | undefined;
+
   /** WebSocket port of the daemon hosting this session (for auto-connect) */
   readonly wsPort?: number;
 

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -53,7 +53,7 @@ describe('binding fields on the wire (#429)', () => {
 
   test('question carries claudeSessionId when provided', () => {
     const msg = createQuestion(
-      { id: QID, text: 'continue?', options: [], freeText: false },
+      { id: QID, text: 'continue?', options: [], allowsFreeText: false, isAnswered: false },
       RID,
       CID,
     );

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Round-trip tests for the binding-aware protocol additions in phase 2
+ * (#429). Each new field should survive serialize → deserialize without
+ * loss so client and daemon agree on the same wire shape.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '../src/index.ts';
+import {
+  createAnswer,
+  createHelloAck,
+  createQuestion,
+  createTranscriptBindingChanged,
+  createUserInput,
+  deserialize,
+  serialize,
+} from '../src/index.ts';
+
+const RID = 'remi0000-0000-0000-0000-000000000001' as UUID;
+const CID = 'claude00-0000-0000-0000-000000000002' as UUID;
+const QID = 'ques0000-0000-0000-0000-000000000003' as UUID;
+
+describe('binding fields on the wire (#429)', () => {
+  test('hello_ack carries claudeSessionId + transcriptPath when binding present', () => {
+    const msg = createHelloAck('1.0.0', RID, undefined, {
+      claudeSessionId: CID,
+      transcriptPath: '/home/u/.claude/projects/-x/abc.jsonl',
+    });
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.transcriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
+  });
+
+  test('hello_ack with null binding (no resolved id yet)', () => {
+    const msg = createHelloAck('1.0.0', RID, undefined, {
+      claudeSessionId: null,
+      transcriptPath: null,
+    });
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBeNull();
+    expect(round.transcriptPath).toBeNull();
+  });
+
+  test('hello_ack without binding arg omits the fields (back-compat)', () => {
+    const msg = createHelloAck('1.0.0', RID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'hello_ack') throw new Error('wrong type');
+    expect('claudeSessionId' in round).toBe(false);
+    expect('transcriptPath' in round).toBe(false);
+  });
+
+  test('question carries claudeSessionId when provided', () => {
+    const msg = createQuestion(
+      { id: QID, text: 'continue?', options: [], freeText: false },
+      RID,
+      CID,
+    );
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'question') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.sessionId).toBe(RID);
+  });
+
+  test('answer carries claudeSessionId echo when provided', () => {
+    const msg = createAnswer(RID, QID, 'y', CID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'answer') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.questionId).toBe(QID);
+    expect(round.answer).toBe('y');
+  });
+
+  test('user_input carries claudeSessionId when provided', () => {
+    const msg = createUserInput(RID, 'ls', false, CID);
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'user_input') throw new Error('wrong type');
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.content).toBe('ls');
+  });
+
+  test('transcript_binding_changed event round-trips with all fields', () => {
+    const msg = createTranscriptBindingChanged(
+      RID,
+      CID,
+      '/home/u/.claude/projects/-x/abc.jsonl',
+      'resume',
+    );
+    const round = deserialize(serialize(msg));
+    if (round?.type !== 'transcript_binding_changed') throw new Error('wrong type');
+    expect(round.sessionId).toBe(RID);
+    expect(round.claudeSessionId).toBe(CID);
+    expect(round.transcriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
+    expect(round.reason).toBe('resume');
+  });
+
+  test('transcript_binding_changed defaults reason to "unknown"', () => {
+    const msg = createTranscriptBindingChanged(RID, CID, '/x.jsonl');
+    expect(msg.reason).toBe('unknown');
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import { shouldKeepExisting } from '@/lib/question-merge';
+import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
   AppSettings,
@@ -46,6 +47,16 @@ const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
 // cold-start push answers so multi-daemon users do not silently answer the
 // wrong daemon. Issue #389 review.
 const LOCALSTORAGE_SESSION_DAEMONS_KEY = 'remi-session-daemons';
+
+/**
+ * Narrow an unknown JSON value to a non-empty string. Used at the
+ * boundary between wire data (Record<string, unknown>) and typed UI
+ * state so a daemon that ever sends a malformed STALE_BINDING payload
+ * cannot corrupt the cached binding.
+ */
+function asNonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
 
 function rememberSessionDaemon(sessionId: string, url: string): void {
   try {
@@ -586,28 +597,7 @@ function App() {
               }
             }
           }
-          // Cross-connection dedup keyed by (connectionId, claudeSessionId)
-          // composite (#430). Same Claude sessionId reported by two different
-          // daemons IS a collision — keep both as separate rows so the user
-          // can pick which daemon to talk to. Only collapse when both
-          // connectionId AND claudeSessionId match (or both lack
-          // claudeSessionId, in which case fall back to id-keyed dedup so
-          // pre-#429 daemons still degrade gracefully).
-          const compositeKey = (s: UISession): string =>
-            s.claudeSessionId ? `${s.connectionId}|${s.claudeSessionId}` : `${s.connectionId}|${s.id}`;
-          const deduped = result.reduce<UISession[]>((acc, s) => {
-            const key = compositeKey(s);
-            const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
-            if (dupIdx === -1) {
-              acc.push(s);
-              return acc;
-            }
-            const existing = acc[dupIdx];
-            if (s.source === 'daemon' && existing.source !== 'daemon') {
-              acc[dupIdx] = s;
-            }
-            return acc;
-          }, []);
+          const deduped = dedupSessions(result);
           // Sort: live first, then by last activity
           const sorted = deduped.sort((a, b) => {
             const aLive = a.connectionStatus === 'connected' ? 0 : 1;
@@ -772,16 +762,19 @@ function App() {
         // STALE_BINDING (#430): the user typed against an old Claude
         // session and the daemon refused. Update our cached binding
         // from the error's details so the next answer routes correctly.
+        // The shape mirrors the daemon-side createError call in
+        // packages/daemon/src/cli/handlers/input-events.ts:guardBinding;
+        // update both ends together if the field names change.
         const errorCode = (message as { code?: string }).code;
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
-          const refusedSessionId = details?.['sessionId'] as UUID | undefined;
-          const newBound = details?.['boundClaudeSessionId'] as string | undefined;
+          const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;
+          const newBound = asNonEmptyString(details?.['boundClaudeSessionId']);
           if (refusedSessionId && newBound) {
             setSessions((prev) =>
               prev.map((s) =>
                 s.id === refusedSessionId && s.connectionId === connectionId
-                  ? { ...s, claudeSessionId: newBound }
+                  ? { ...s, claudeSessionId: newBound as UUID }
                   : s,
               ),
             );
@@ -827,21 +820,32 @@ function App() {
         // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
         // Update the session's bound (claudeSessionId, transcriptPath) so
         // future outbound answers carry the new id and the chat header
-        // shows the updated binding.
+        // shows the updated binding. If no session matches, surface a
+        // warn — silent no-op would mean future answers hit STALE_BINDING
+        // even though the rotation event arrived correctly.
+        let matched = false;
         setSessions((prev) =>
-          prev.map((s) =>
-            s.id === message.sessionId && s.connectionId === connectionId
-              ? {
-                  ...s,
-                  claudeSessionId: message.claudeSessionId as string,
-                  transcriptPath: message.transcriptPath,
-                }
-              : s,
-          ),
+          prev.map((s) => {
+            if (s.id === message.sessionId && s.connectionId === connectionId) {
+              matched = true;
+              return {
+                ...s,
+                claudeSessionId: message.claudeSessionId as string,
+                transcriptPath: message.transcriptPath,
+              };
+            }
+            return s;
+          }),
         );
-        console.info(
-          `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
-        );
+        if (matched) {
+          console.info(
+            `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
+          );
+        } else {
+          console.warn(
+            `[App] transcript_binding_changed for unknown session ${message.sessionId.slice(0, 8)} on ${connectionId}; session list may be stale`,
+          );
+        }
         break;
       }
 
@@ -1044,7 +1048,19 @@ function App() {
 
       console.debug('[App] handlePushAnswer:', { sessionId, questionId, answer });
 
-      const answerMsg = createAnswer(sessionId as UUID, questionId as UUID, answer);
+      // Thread claudeSessionId so the daemon can refuse if its binding
+      // has rotated since the lock-screen notification fired (#430 review
+      // #433). Without this the cold-start push-answer path silently
+      // bypassed the stale-binding guard. Read from sessionsRef so we
+      // see the latest snapshot even when this handler captured an old
+      // closure of `sessions`.
+      const boundId = sessionsRef.current.find((s) => s.id === sessionId)?.claudeSessionId;
+      const answerMsg = createAnswer(
+        sessionId as UUID,
+        questionId as UUID,
+        answer,
+        boundId as UUID | undefined,
+      );
 
       // Read the persisted URL list and per-session daemon map once; pass
       // into the pure resolver.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -190,6 +190,17 @@ function App() {
           console.warn('[App] Received hello_ack without sessionId from connection:', connectionId);
           break;
         }
+        // Phase 2 daemons attach the binding here so the client knows
+        // which transcript it's talking to before the first session_list
+        // round-trip (#430). Older daemons omit; the field stays undefined.
+        const ackClaudeSessionId =
+          message.claudeSessionId === undefined || message.claudeSessionId === null
+            ? undefined
+            : (message.claudeSessionId as string);
+        const ackTranscriptPath =
+          message.transcriptPath === undefined || message.transcriptPath === null
+            ? undefined
+            : (message.transcriptPath as string);
         setSessions((prev) => {
           // On reconnect, remove stale sessions from this connection that have a different
           // session ID (the daemon may have assigned a new session). Keep sessions from
@@ -202,7 +213,13 @@ function App() {
           if (exists) {
             return cleaned.map((s) =>
               s.id === message.sessionId
-                ? { ...s, connectionStatus: 'connected', connectionId }
+                ? {
+                    ...s,
+                    connectionStatus: 'connected',
+                    connectionId,
+                    ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
+                    ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
+                  }
                 : s,
             );
           }
@@ -219,6 +236,8 @@ function App() {
               connectionId,
               unreadCount: 0,
               preview: 'Connected',
+              ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
+              ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
             } satisfies UISession,
           ];
         });
@@ -513,6 +532,8 @@ function App() {
               preview: cleanedPreview.slice(0, 100),
               source: ds.source,
               canResume: showResume,
+              ...(ds.claudeSessionId !== undefined && { claudeSessionId: ds.claudeSessionId }),
+              ...(ds.transcriptPath !== undefined && { transcriptPath: ds.transcriptPath }),
             };
           })
           // Dedup: same session ID from daemon + transcript → keep daemon version.
@@ -565,10 +586,18 @@ function App() {
               }
             }
           }
-          // Cross-connection dedup: same session ID from multiple connections →
-          // keep daemon-sourced version. Different IDs in same cwd → keep both.
+          // Cross-connection dedup keyed by (connectionId, claudeSessionId)
+          // composite (#430). Same Claude sessionId reported by two different
+          // daemons IS a collision — keep both as separate rows so the user
+          // can pick which daemon to talk to. Only collapse when both
+          // connectionId AND claudeSessionId match (or both lack
+          // claudeSessionId, in which case fall back to id-keyed dedup so
+          // pre-#429 daemons still degrade gracefully).
+          const compositeKey = (s: UISession): string =>
+            s.claudeSessionId ? `${s.connectionId}|${s.claudeSessionId}` : `${s.connectionId}|${s.id}`;
           const deduped = result.reduce<UISession[]>((acc, s) => {
-            const dupIdx = acc.findIndex((other) => other.id === s.id);
+            const key = compositeKey(s);
+            const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
             if (dupIdx === -1) {
               acc.push(s);
               return acc;
@@ -740,6 +769,29 @@ function App() {
           console.debug('[App] Auth error suppressed:', errorText);
           break;
         }
+        // STALE_BINDING (#430): the user typed against an old Claude
+        // session and the daemon refused. Update our cached binding
+        // from the error's details so the next answer routes correctly.
+        const errorCode = (message as { code?: string }).code;
+        if (errorCode === 'STALE_BINDING') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const refusedSessionId = details?.['sessionId'] as UUID | undefined;
+          const newBound = details?.['boundClaudeSessionId'] as string | undefined;
+          if (refusedSessionId && newBound) {
+            setSessions((prev) =>
+              prev.map((s) =>
+                s.id === refusedSessionId && s.connectionId === connectionId
+                  ? { ...s, claudeSessionId: newBound }
+                  : s,
+              ),
+            );
+          }
+          console.warn(
+            '[App] STALE_BINDING: server-side binding rotated; re-keying. Detail:',
+            details,
+          );
+          // Fall through so the user sees the error in chat.
+        }
         // Clear loading state for any session awaiting transcript load, and allow retry.
         // The daemon does not echo sessionId in error responses, so we clear all loading sessions.
         setSessions((prev) =>
@@ -768,6 +820,28 @@ function App() {
           isEditing: false,
         };
         setMessages((prev) => [...prev, errorMsg]);
+        break;
+      }
+
+      case 'transcript_binding_changed': {
+        // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
+        // Update the session's bound (claudeSessionId, transcriptPath) so
+        // future outbound answers carry the new id and the chat header
+        // shows the updated binding.
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === message.sessionId && s.connectionId === connectionId
+              ? {
+                  ...s,
+                  claudeSessionId: message.claudeSessionId as string,
+                  transcriptPath: message.transcriptPath,
+                }
+              : s,
+          ),
+        );
+        console.info(
+          `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
+        );
         break;
       }
 
@@ -1150,7 +1224,16 @@ function App() {
         return;
       }
 
-      const sent = sendAnswer(connId, activeSessionId, sessionQuestion.id, content);
+      // Carry claudeSessionId so the daemon can refuse if its binding
+      // has rotated since the question fired (#430).
+      const activeBinding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
+      const sent = sendAnswer(
+        connId,
+        activeSessionId,
+        sessionQuestion.id,
+        content,
+        activeBinding as UUID | undefined,
+      );
       if (!sent) {
         const failMsg: UIMessage = {
           id: generateId(),
@@ -1194,7 +1277,7 @@ function App() {
       };
       setMessages((prev) => [...prev, userMsg]);
     },
-    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion],
+    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion, sessions],
   );
 
   // Send a regular user input message, optionally with a reply context.
@@ -1234,7 +1317,13 @@ function App() {
 
       setMessages((prev) => [...prev, newMessage]);
 
-      const success = sendInput(connId, activeSessionId, wireContent);
+      const activeBinding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
+      const success = sendInput(
+        connId,
+        activeSessionId,
+        wireContent,
+        activeBinding as UUID | undefined,
+      );
       if (success) {
         setMessages((prev) =>
           prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
@@ -1265,7 +1354,7 @@ function App() {
         setMessages((prev) => [...prev, errorMsg]);
       }
     },
-    [activeSessionId, getActiveConnectionId, sendInput],
+    [activeSessionId, getActiveConnectionId, sendInput, sessions],
   );
 
   // Set the reply context for the current session: long-press on a

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -778,6 +778,19 @@ function App() {
                   : s,
               ),
             );
+            // Un-answer the optimistically-collapsed question so the
+            // user can retry against the new binding (#434 review).
+            // Without this the QuestionCard stays collapsed showing
+            // the rejected answer and the user has no retry path.
+            setQuestions((prev) => {
+              const stale = prev.get(refusedSessionId);
+              if (!stale || stale.answeredWith === undefined) return prev;
+              const next = new Map(prev);
+              const restored = { ...stale };
+              delete (restored as { answeredWith?: string }).answeredWith;
+              next.set(refusedSessionId, restored);
+              return next;
+            });
           }
           console.warn(
             '[App] STALE_BINDING: server-side binding rotated; re-keying. Detail:',
@@ -820,13 +833,23 @@ function App() {
         // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
         // Update the session's bound (claudeSessionId, transcriptPath) so
         // future outbound answers carry the new id and the chat header
-        // shows the updated binding. If no session matches, surface a
-        // warn — silent no-op would mean future answers hit STALE_BINDING
-        // even though the rotation event arrived correctly.
+        // shows the updated binding.
+        //
+        // Daemon-side broadcast (registry.broadcast) fans this event to
+        // every connection on this adapter, but a connection only "owns"
+        // sessions it created. Sessions are stored with their owning
+        // connectionId, so a session belonging to a SIBLING connection
+        // (or none at all) is correctly filtered out here. We
+        // intentionally don't warn in that case: it's not an error, just
+        // an event that doesn't apply to this connection's state.
+        // Only warn if a session matches the id on THIS connection but
+        // the binding is unexpectedly absent.
         let matched = false;
+        let sessionExistedOnThisConnection = false;
         setSessions((prev) =>
           prev.map((s) => {
             if (s.id === message.sessionId && s.connectionId === connectionId) {
+              sessionExistedOnThisConnection = true;
               matched = true;
               return {
                 ...s,
@@ -841,9 +864,9 @@ function App() {
           console.info(
             `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
           );
-        } else {
+        } else if (sessionExistedOnThisConnection) {
           console.warn(
-            `[App] transcript_binding_changed for unknown session ${message.sessionId.slice(0, 8)} on ${connectionId}; session list may be stale`,
+            `[App] transcript_binding_changed: session ${message.sessionId.slice(0, 8)} on ${connectionId} could not be updated; session list may be stale`,
           );
         }
         break;

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -6,6 +6,17 @@
 
 import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
 
+/**
+ * Extract a short "port :<num>" label from a ConnectionId of shape
+ * "host:port" so the binding indicator stays compact on mobile. Falls
+ * back to the raw id when no colon is present.
+ */
+function extractDaemonPortLabel(connectionId: string): string {
+  const colonIdx = connectionId.lastIndexOf(':');
+  if (colonIdx === -1) return connectionId;
+  return `:${connectionId.slice(colonIdx + 1)}`;
+}
+
 /** Strip hostname prefix from session name for display */
 function formatSessionName(name: string): string {
   let display = name.replace(/^[^:]+:/, '');
@@ -204,6 +215,32 @@ export function ChatHeader({
             </>
           )}
         </div>
+        {/* Transcript binding indicator (#430). The "port:short-uuid"
+            pair lets the user visually confirm WHICH Claude transcript
+            this session is talking to — the safety net for the
+            cross-daemon routing bug in #427. Tap-to-copy the full
+            transcript path is implemented via the title attribute. */}
+        {session.claudeSessionId && (
+          <button
+            type="button"
+            className="mt-0.5 truncate text-left text-[10px] font-mono text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
+            title={
+              session.transcriptPath
+                ? `Claude session ${session.claudeSessionId}\nTranscript: ${session.transcriptPath}\nClick to copy path`
+                : `Claude session ${session.claudeSessionId}`
+            }
+            onClick={() => {
+              const value = session.transcriptPath ?? session.claudeSessionId;
+              if (value) {
+                void navigator.clipboard?.writeText(value);
+              }
+            }}
+          >
+            {extractDaemonPortLabel(session.connectionId)}
+            {' · '}
+            {session.claudeSessionId.slice(0, 8)}
+          </button>
+        )}
       </div>
 
       {/* Detach/Resume button */}

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -216,10 +216,12 @@ export function ChatHeader({
           )}
         </div>
         {/* Transcript binding indicator (#430). The "port:short-uuid"
-            pair lets the user visually confirm WHICH Claude transcript
-            this session is talking to — the safety net for the
-            cross-daemon routing bug in #427. Tap-to-copy the full
-            transcript path is implemented via the title attribute. */}
+            pair is the UX surface for the cross-daemon routing fix
+            (#427): the user can visually confirm which transcript a
+            session is bound to. The actual routing safety net is the
+            daemon-side STALE_BINDING guard from phase 2 (#432). The
+            onClick handler copies the full path to clipboard; the
+            title attribute is the hover tooltip on desktop. */}
         {session.claudeSessionId && (
           <button
             type="button"
@@ -231,9 +233,13 @@ export function ChatHeader({
             }
             onClick={() => {
               const value = session.transcriptPath ?? session.claudeSessionId;
-              if (value) {
-                void navigator.clipboard?.writeText(value);
-              }
+              if (!value) return;
+              // navigator.clipboard can be undefined on iOS WKWebView
+              // in non-secure contexts; .catch on the promise covers
+              // permission denial and lost-focus rejections.
+              navigator.clipboard?.writeText(value).catch((err) => {
+                console.warn('[ChatHeader] clipboard write failed:', err);
+              });
             }}
           >
             {extractDaemonPortLabel(session.connectionId)}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -86,13 +86,19 @@ export interface UseConnectionManagerReturn {
   /** Disconnect all connections */
   disconnectAll: () => void;
   /** Send user input routed to the correct connection */
-  sendInput: (connectionId: ConnectionId, sessionId: UUID, content: string) => boolean;
+  sendInput: (
+    connectionId: ConnectionId,
+    sessionId: UUID,
+    content: string,
+    claudeSessionId?: UUID,
+  ) => boolean;
   /** Send answer to a question via the correct connection */
   sendAnswer: (
     connectionId: ConnectionId,
     sessionId: UUID,
     questionId: UUID,
     answer: string,
+    claudeSessionId?: UUID,
   ) => boolean;
   /** Send a raw protocol message to a specific connection */
   sendMessage: (connectionId: ConnectionId, message: ProtocolMessage) => boolean;
@@ -532,15 +538,32 @@ export function useConnectionManager(
   );
 
   const sendInput = useCallback(
-    (connectionId: ConnectionId, sessionId: UUID, content: string): boolean => {
-      return sendToConnection(connectionId, createUserInput(sessionId, content));
+    (
+      connectionId: ConnectionId,
+      sessionId: UUID,
+      content: string,
+      claudeSessionId?: UUID,
+    ): boolean => {
+      return sendToConnection(
+        connectionId,
+        createUserInput(sessionId, content, undefined, claudeSessionId),
+      );
     },
     [sendToConnection],
   );
 
   const sendAnswer = useCallback(
-    (connectionId: ConnectionId, sessionId: UUID, questionId: UUID, answer: string): boolean => {
-      return sendToConnection(connectionId, createAnswer(sessionId, questionId, answer));
+    (
+      connectionId: ConnectionId,
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): boolean => {
+      return sendToConnection(
+        connectionId,
+        createAnswer(sessionId, questionId, answer, claudeSessionId),
+      );
     },
     [sendToConnection],
   );

--- a/packages/web/src/lib/session-dedup.ts
+++ b/packages/web/src/lib/session-dedup.ts
@@ -1,0 +1,35 @@
+/**
+ * Cross-connection session dedup keyed by (connectionId, claudeSessionId)
+ * composite (#430). Same Claude sessionId reported by two different daemons
+ * IS a collision — keep both as separate rows so the user can pick which
+ * daemon to talk to. Only collapse when both connectionId AND claudeSessionId
+ * match (or both lack claudeSessionId, in which case fall back to id-keyed
+ * dedup so pre-#429 daemons still degrade gracefully).
+ *
+ * When two entries collide on the same composite key, the daemon-sourced one
+ * wins so transcript-sourced read-only views don't shadow live sessions.
+ */
+
+import type { UISession } from '@/types';
+
+export function compositeKey(s: UISession): string {
+  return s.claudeSessionId
+    ? `${s.connectionId}|${s.claudeSessionId}`
+    : `${s.connectionId}|${s.id}`;
+}
+
+export function dedupSessions(sessions: readonly UISession[]): UISession[] {
+  return sessions.reduce<UISession[]>((acc, s) => {
+    const key = compositeKey(s);
+    const dupIdx = acc.findIndex((other) => compositeKey(other) === key);
+    if (dupIdx === -1) {
+      acc.push(s);
+      return acc;
+    }
+    const existing = acc[dupIdx];
+    if (existing && s.source === 'daemon' && existing.source !== 'daemon') {
+      acc[dupIdx] = s;
+    }
+    return acc;
+  }, []);
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -116,6 +116,15 @@ export interface UISession {
   readonly questionPending?: boolean;
   /** Whether this dead session can be resumed via Claude Code --resume */
   readonly canResume?: boolean;
+  /**
+   * Claude Code session UUID this entry's Claude is writing under (#430).
+   * Carried in outbound answer/input so the daemon can refuse stale
+   * routing when the binding has rotated (e.g. user ran /resume). Shown
+   * to the user in the chat header so the binding is verifiable by eye.
+   */
+  readonly claudeSessionId?: string;
+  /** Absolute path to the bound .jsonl transcript (#430). */
+  readonly transcriptPath?: string;
 }
 
 /** Structured option for a question */

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -122,7 +122,7 @@ export interface UISession {
    * routing when the binding has rotated (e.g. user ran /resume). Shown
    * to the user in the chat header so the binding is verifiable by eye.
    */
-  readonly claudeSessionId?: string;
+  readonly claudeSessionId?: UUID;
   /** Absolute path to the bound .jsonl transcript (#430). */
   readonly transcriptPath?: string;
 }

--- a/packages/web/tests/lib/session-dedup.test.ts
+++ b/packages/web/tests/lib/session-dedup.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for cross-connection session dedup (#430). The whole point of
+ * this layer is that two daemons reporting the same Claude sessionId
+ * must NOT collapse into one row — that was the cross-daemon answer
+ * routing bug from #427.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { compositeKey, dedupSessions } from '../../src/lib/session-dedup';
+import type { ConnectionId, UISession } from '../../src/types';
+
+function makeSession(overrides: Partial<UISession>): UISession {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'test',
+    connectionId: 'localhost:18766' as ConnectionId,
+    createdAt: '2026-05-17T00:00:00Z',
+    lastActiveAt: '2026-05-17T00:00:00Z',
+    status: 'idle',
+    connectionStatus: 'connected',
+    unreadCount: 0,
+    source: 'daemon',
+    ...overrides,
+  };
+}
+
+describe('compositeKey', () => {
+  test('uses connectionId|claudeSessionId when both present', () => {
+    const key = compositeKey(
+      makeSession({
+        connectionId: 'host:18766' as ConnectionId,
+        claudeSessionId: 'aaaa-bbbb',
+      }),
+    );
+    expect(key).toBe('host:18766|aaaa-bbbb');
+  });
+
+  test('falls back to connectionId|id when claudeSessionId is absent', () => {
+    const key = compositeKey(
+      makeSession({
+        id: 'remi-session-1',
+        connectionId: 'host:18766' as ConnectionId,
+      }),
+    );
+    expect(key).toBe('host:18766|remi-session-1');
+  });
+});
+
+describe('dedupSessions (the core safety invariant of #430)', () => {
+  test('two daemons reporting same sessionId + different claudeSessionId stay separate', () => {
+    // The exact bug case. Pre-#430 these collapsed into one row.
+    const a = makeSession({
+      id: 'same-claude-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'daemon-a-binding',
+    });
+    const b = makeSession({
+      id: 'same-claude-id',
+      connectionId: 'host:18767' as ConnectionId,
+      claudeSessionId: 'daemon-b-binding',
+    });
+
+    const result = dedupSessions([a, b]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.connectionId).toBe('host:18766');
+    expect(result[1]?.connectionId).toBe('host:18767');
+  });
+
+  test('same daemon reporting the same binding twice collapses to one row', () => {
+    const a = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+    });
+    const b = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+    });
+
+    const result = dedupSessions([a, b]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  test('daemon-sourced wins over transcript-sourced on the same composite key', () => {
+    const transcript = makeSession({
+      id: 'shared',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+      source: 'transcript',
+    });
+    const daemon = makeSession({
+      id: 'shared',
+      connectionId: 'host:18766' as ConnectionId,
+      claudeSessionId: 'same-binding',
+      source: 'daemon',
+    });
+
+    const result = dedupSessions([transcript, daemon]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('daemon');
+  });
+
+  test('pre-#429 daemons (no claudeSessionId) still degrade gracefully', () => {
+    // Two entries from the same daemon with the same remi id collapse;
+    // entries from DIFFERENT daemons with the same remi id stay separate.
+    // (Different from pre-#430 behavior in the multi-daemon case, but
+    // that case was never correct.)
+    const sameDaemon1 = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+    });
+    const sameDaemon2 = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18766' as ConnectionId,
+    });
+    const otherDaemon = makeSession({
+      id: 'same-id',
+      connectionId: 'host:18767' as ConnectionId,
+    });
+
+    const result = dedupSessions([sameDaemon1, sameDaemon2, otherDaemon]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.connectionId).sort()).toEqual([
+      'host:18766',
+      'host:18767',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #427. Lands the cross-daemon answer-routing fix end-to-end.

## What shipped

Three phases merged in order:

- **#431 (phase 1, daemon):** deterministic PTY->transcript binding. Daemon pre-assigns a UUID at spawn and passes \`--session-id <uuid>\` to \`claude\` so it knows exactly which \`.jsonl\` belongs to its PTY before Claude writes a single line. Replaces the previous mtime-based discovery race.
- **#432 (phase 2, protocol + guard):** \`claudeSessionId\` + \`transcriptPath\` on the wire (\`hello_ack\`, \`session_list_response\`, \`question\`). \`AnswerMessage\` + \`UserInputMessage\` echo \`claudeSessionId\` so the daemon can refuse with \`STALE_BINDING\` when its current binding has rotated. New \`transcript_binding_changed\` event for runtime swaps.
- **#433 (phase 3, daemon emission + client surface):** hook-bridge emits \`transcript_binding_changed\` on rotation (\`/clear\`, \`/compact\`, \`/resume\`). Client \`UISession\` carries the binding, populated from \`hello_ack\` and \`session_list_response\`. Cross-connection dedup re-keyed by \`(connectionId, claudeSessionId)\` composite. New chat-header indicator shows \`:<port> · <8-char-uuid>\` (tap to copy full transcript path). Outbound answer/input thread the binding so the daemon-side guard fires. \`STALE_BINDING\` error handler rekeys the session.

## Defenses in depth

The original bug (two daemons in the same cwd cross-routing answers) now has **three independent layers**:

1. **Daemon can't read the wrong transcript** (phase 1): deterministic path, no race.
2. **Daemon refuses cross-routed answers** (phase 2): \`STALE_BINDING\` at the wire layer.
3. **User can see the binding** (phase 3): chat-header surface, visible isolation between daemons.

## Test surface

Across the three phases:
- Daemon: 4 integration tests for two-daemon same-cwd isolation, 11 unit tests for \`resolveClaudeBinding\`, 5 fallback tests, 2 hook-bridge rotation-emission tests, 4 stale-binding guard tests, 4 relay-adapter forwarding tests, more
- Shared: 8 protocol round-trip tests for the new fields
- Web: 6 session-dedup composite-key tests covering the core safety invariant

**Final state:** 2079 pass / 69 skip (LLM-gated, opted out via \`SKIP_LLM_TESTS=1\`) / 0 fail across daemon + shared + web. Typecheck and biome clean.

## Out of scope (deferred)

- Full composite keying in \`messages\` filter + \`questions\` Map + \`LOCALSTORAGE_SESSION_KEY\`. The daemon-side \`STALE_BINDING\` guard makes wire-level cross-routing impossible; remaining client-side keys only affect visual cleanliness when the same sessionId appears across two connections, and that case is now visibly distinguished in the chat header.
- iOS sim visual QA of the binding header.
- Dead code cleanup: \`extractClaudeSessionId\` and \`findLatestTranscriptExcluding\` are still defined but no longer called from any spawn path.
- Pre-existing empty catch in \`session-store.ts:163\`.

## Per-PR review trails

Each phase went through the multi-agent review and addressed all findings:
- #431: PR comment thread covers the deferred-binding cleanup, integration test, race-window unit tests
- #432: stale_binding error code mismatch, relay-adapter forwarding gap, three I/O silent-failure paths
- #433: \`adoptLockFromStore\` race fix, cold-start push-answer binding bypass fix, clipboard \`.catch\`, UUID type alignment

This epic-to-develop PR is the final review gate before the fix lands on the integration branch.