### PR TITLE
Phase 2: Keyed question collection (multi-question routing)

### DIFF
--- a/packages/daemon/src/adapters/adapter-registry.ts
+++ b/packages/daemon/src/adapters/adapter-registry.ts
@@ -196,7 +196,7 @@ export class AdapterRegistry {
   /**
    * Send a question to a specific connection.
    */
-  sendQuestion(connectionId: UUID, question: Question, sessionId?: UUID): boolean {
+  sendQuestion(connectionId: UUID, question: Question, sessionId: UUID): boolean {
     const adapterType = this.connectionToAdapter.get(connectionId);
     if (!adapterType) {
       return false;

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -169,7 +169,7 @@ export interface ConnectionAdapter {
    * The adapter is responsible for formatting appropriately
    * (e.g., inline keyboard for Telegram).
    */
-  sendQuestion(connectionId: UUID, question: Question, sessionId?: UUID): boolean;
+  sendQuestion(connectionId: UUID, question: Question, sessionId: UUID): boolean;
 
   /**
    * Send a status update to a specific connection.

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -263,7 +263,7 @@ export class TelegramAdapter implements ConnectionAdapter {
     return true;
   }
 
-  sendQuestion(connectionId: UUID, question: Question, _sessionId?: UUID): boolean {
+  sendQuestion(connectionId: UUID, question: Question, _sessionId: UUID): boolean {
     const sessionKey = this.connectionToSession.get(connectionId);
     if (!sessionKey) {
       return false;
@@ -326,7 +326,11 @@ export class TelegramAdapter implements ConnectionAdapter {
       }
 
       case 'question':
-        return this.sendQuestion(connectionId, (message as QuestionMessage).question);
+        return this.sendQuestion(
+          connectionId,
+          (message as QuestionMessage).question,
+          (message as QuestionMessage).sessionId,
+        );
 
       case 'session_update':
         return this.sendStatus(connectionId, (message as SessionUpdateMessage).session.status);

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -202,7 +202,7 @@ export class WebSocketAdapter implements ConnectionAdapter {
     return this.server.sendTo(connectionId, protocolMessage);
   }
 
-  sendQuestion(connectionId: UUID, question: Question, sessionId?: UUID): boolean {
+  sendQuestion(connectionId: UUID, question: Question, sessionId: UUID): boolean {
     if (!this.server) {
       return false;
     }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -20,9 +20,13 @@
  *     user's terminal RIGHT NOW. Push immediately, merging hook metadata
  *     if a pending hook record matches (real option labels, agent_id, etc.).
  *   - Status transitions OUT of `'waiting'` (`onStatusChange`) clear any
- *     pending hook record. The user advanced past the prompt — auto-
+ *     pending hook records. The user advanced past the prompt — auto-
  *     approve handled it silently, or the subagent stayed in the
  *     background, or the user answered in-terminal. No push needed.
+ *
+ * Pending hook records are keyed by agent (`agentId` or `'main'`), so two
+ * concurrent agents (main + a subagent, #419) keep separate records and a
+ * later subagent hook cannot clobber the main agent's option labels (#425).
  *
  * Upstream context (anthropics/claude-code #23983): subagent / Agent-Teams
  * permission requests do not fire PermissionRequest hooks at all. The PTY
@@ -40,14 +44,18 @@ import type { AgentStatus, Question } from '@remi/shared';
  */
 export type PushQuestion = (question: Question) => void;
 
+/** Pending-hook map key: the prompt's agent, or 'main' for the primary agent. */
+function agentKey(question: Question): string {
+  return question.agentId ?? 'main';
+}
+
 export class QuestionPresenceTracker {
-  /** The last hook-derived question we have not yet paired with PTY
-   *  confirmation or cleared via status. At most one is held at a time:
-   *  if a second hook arrives before the first paired/cleared, the newer
-   *  one wins — Claude only renders one prompt on screen at a time, and
-   *  the second hook is the more accurate description of the prompt the
-   *  user will see. */
-  private pending: Question | null = null;
+  /** Hook-derived questions not yet paired with PTY confirmation or cleared,
+   *  keyed by agent. At most one per agent: a second hook for the SAME agent
+   *  (e.g. PermissionRequest then Notification for one prompt) replaces the
+   *  first, but different agents keep separate entries. Insertion order is
+   *  preserved so the PTY-pairing fallback can pick the most recent. */
+  private pending = new Map<string, Question>();
 
   /** True while a permission prompt is on the main PTY. Set by
    *  `onPTYPromptVisible`; reset by `onStatusChange` out of `'waiting'`
@@ -63,54 +71,63 @@ export class QuestionPresenceTracker {
 
   /**
    * Hook fired (PermissionRequest or Notification(permission_prompt)).
-   * Stash the question; do NOT push yet. Push happens when PTY confirms
-   * the prompt is visible, or never if status moves past 'waiting' first.
+   * Stash the question by agent; do NOT push yet. Push happens when PTY
+   * confirms the prompt is visible, or never if status moves past 'waiting'
+   * first.
    *
-   * Replacement policy: the newer hook wins. This is correct for the
-   * same-prompt double-fire case (PermissionRequest then Notification
-   * for the same prompt) but is a known weak spot for concurrent
-   * subagents (phase 4, #419) — if two different agents have prompts
-   * in flight, the second silently overwrites the first. The PTY
-   * presence gate still prevents the wrong push from firing for an
-   * off-screen agent; what is lost is option-label accuracy when the
-   * on-screen agent's hook arrived earlier. An agent_id-aware tracker
-   * would fix this structurally; tracked as a follow-up.
+   * Replacement policy: per agent, the newer hook wins (correct for the
+   * same-prompt double-fire: PermissionRequest then Notification). Different
+   * agents no longer overwrite each other (#425).
    */
   recordPendingHook(question: Question): void {
-    if (this.pending !== null) {
+    const key = agentKey(question);
+    if (this.pending.has(key)) {
       console.debug(
-        `[QuestionPresenceTracker] Overwriting pending hook (old="${this.pending.text.slice(0, 60)}", new="${question.text.slice(0, 60)}")`,
+        `[QuestionPresenceTracker] Replacing pending hook for agent "${key}" (old="${this.pending.get(key)?.text.slice(0, 50)}", new="${question.text.slice(0, 50)}")`,
       );
     }
-    this.pending = question;
+    // Re-insert so this agent's entry is the most recent (matters for the
+    // PTY-pairing fallback below).
+    this.pending.delete(key);
+    this.pending.set(key, question);
   }
 
   /**
-   * PTY parser saw a prompt on screen. Push immediately. If we have a
-   * recent hook record, merge: PTY contributes `id` / `text` /
-   * `allowsFreeText` / `isAnswered` (it reflects the screen) and the
-   * hook contributes `options` (it knows real labels like
-   * ['Yes', 'Always', 'No'] while PTY usually has numbered fallbacks).
+   * PTY parser saw a prompt on screen. Push immediately. Pair with a hook
+   * record for option labels / agent_id: prefer the same agent, else fall
+   * back to the most-recent pending hook (PTY output does not reliably name
+   * the agent — #425). When paired, the hook contributes `options` and
+   * `agentId` (so the client keys the prompt to the right agent) while PTY
+   * contributes `id` / `text` / `allowsFreeText` / `isAnswered` (it reflects
+   * the screen). The consumed hook entry is removed.
    *
-   * When the merge fires, `ptyQuestion.options` is intentionally
-   * discarded — the hook record is the authoritative source for option
-   * labels. A future PTY-side options parser would not change this
-   * unless we promote PTY options past the hook (see merge rule).
-   *
-   * Pending is cleared BEFORE the push so a re-entrant call to this
-   * method (push sink fires synchronous side effects that loop back
-   * here) cannot re-merge the same hook record. Push errors are caught
-   * and logged but not rethrown — the next PTY emit for the same prompt
-   * (re-render) will retry the push WITHOUT the hook merge, falling
-   * back to PTY's numbered options. That degraded UX is still preferable
-   * to the daemon crashing on a network blip during APNS fan-out.
+   * Pending is mutated BEFORE the push so a re-entrant call cannot re-merge
+   * the same record. Push errors are caught and logged but not rethrown — the
+   * next PTY emit for the same prompt retries WITHOUT the hook merge (PTY's
+   * numbered options), which beats crashing on a network blip during APNS.
    */
   onPTYPromptVisible(ptyQuestion: Question): void {
+    const key = agentKey(ptyQuestion);
+    let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
+    if (recordKey === undefined && this.pending.size > 0) {
+      // Most-recent pending hook (Map preserves insertion order).
+      const keys = [...this.pending.keys()];
+      recordKey = keys[keys.length - 1];
+    }
+    const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
+    if (recordKey !== undefined) {
+      this.pending.delete(recordKey);
+    }
+
     const merged: Question =
-      this.pending && this.pending.options.length > 0
-        ? { ...ptyQuestion, options: [...this.pending.options] }
+      hookRecord && hookRecord.options.length > 0
+        ? {
+            ...ptyQuestion,
+            options: [...hookRecord.options],
+            agentId: ptyQuestion.agentId ?? hookRecord.agentId,
+          }
         : ptyQuestion;
-    this.pending = null;
+
     this.ptyShowingQuestion = true;
     try {
       this.push(merged);
@@ -123,28 +140,25 @@ export class QuestionPresenceTracker {
 
   /**
    * Status transition observed. When status leaves 'waiting', the user
-   * advanced past whatever prompt was up: drop any pending hook record
-   * so it cannot push later (Claude is busy executing, the prompt is
-   * gone from screen, the iOS card would be stale).
+   * advanced past whatever prompts were up: drop all pending hook records
+   * so they cannot push later (Claude is busy executing, the prompts are
+   * gone from screen, the iOS cards would be stale).
    */
   onStatusChange(status: AgentStatus): void {
     if (status !== 'waiting') {
-      this.pending = null;
+      this.pending.clear();
       this.ptyShowingQuestion = false;
     }
   }
 
   /**
-   * Drop any pending hook record without firing a push, and clear the
-   * PTY-presence flag. Used by the auto-approve cancelled branch where
-   * Claude has advanced past the prompt without a status transition we
-   * can observe — leaving the pending in place would merge stale option
-   * labels onto the NEXT unrelated prompt, and leaving `ptyShowingQuestion`
-   * set would let the inject gate pass for a subagent prompt that arrives
-   * after the screen is already past the previous prompt.
+   * Drop all pending hook records without firing a push, and clear the
+   * PTY-presence flag. Used by the auto-approve cancelled branch and on
+   * Claude restart (where the dying session's prompts must not merge stale
+   * labels onto the new session's first prompt).
    */
   clearPending(): void {
-    this.pending = null;
+    this.pending.clear();
     this.ptyShowingQuestion = false;
   }
 
@@ -161,11 +175,15 @@ export class QuestionPresenceTracker {
   }
 
   /**
-   * Test-only inspection of the pending state. Exposed so the unit test
-   * suite can assert state-machine invariants without resorting to
-   * mocking the push sink.
+   * Test-only inspection of pending state. Exposed so the unit test suite
+   * can assert state-machine invariants without mocking the push sink.
    */
   hasPendingForTest(): boolean {
-    return this.pending !== null;
+    return this.pending.size > 0;
+  }
+
+  /** Test-only: number of distinct agents with a pending hook record. */
+  pendingCountForTest(): number {
+    return this.pending.size;
   }
 }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -34,6 +34,7 @@
  * record) is therefore a first-class case here, not a fallback.
  */
 
+import { MAIN_AGENT_ID } from '@remi/shared';
 import type { AgentStatus, Question } from '@remi/shared';
 
 /**
@@ -44,9 +45,9 @@ import type { AgentStatus, Question } from '@remi/shared';
  */
 export type PushQuestion = (question: Question) => void;
 
-/** Pending-hook map key: the prompt's agent, or 'main' for the primary agent. */
+/** Pending-hook map key: the prompt's agent, or MAIN_AGENT_ID for the primary. */
 function agentKey(question: Question): string {
-  return question.agentId ?? 'main';
+  return question.agentId ?? MAIN_AGENT_ID;
 }
 
 export class QuestionPresenceTracker {
@@ -110,9 +111,15 @@ export class QuestionPresenceTracker {
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
     if (recordKey === undefined && this.pending.size > 0) {
-      // Most-recent pending hook (Map preserves insertion order).
+      // Most-recent pending hook (Map preserves insertion order). The PTY did
+      // not name an agent we have a record for, so this may attach the wrong
+      // agent's option labels (#425). Log it so the misattribution is
+      // observable rather than silent.
       const keys = [...this.pending.keys()];
       recordKey = keys[keys.length - 1];
+      console.warn(
+        `[QuestionPresenceTracker] PTY prompt (agent "${key}") has no matching hook; pairing most-recent "${recordKey}" of [${keys.join(', ')}] — option labels may be misattributed`,
+      );
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -146,28 +146,31 @@ export function createInputHandlers(deps: InputHandlerDeps) {
 
       // Drop stale answers. APNS tokens persist across disconnect (#286), so a
       // delayed lock-screen tap can deliver an answer for a question that has
-      // since been auto-approved or replaced. Without this guard, the digit
-      // would inject into whatever Claude prompt is currently live. Surface
-      // the drop to the client so the iOS user gets a "not delivered" signal
-      // instead of silent failure.
-      const active = session.currentQuestion;
-      if (active === null || active.id !== questionId) {
+      // since been auto-approved or resolved. Membership in the pending set
+      // (not equality with a single slot) is the check, so answering one of
+      // several concurrent prompts (main + subagent, #419) never invalidates
+      // the others. Surface the drop so the iOS user gets a "not delivered"
+      // signal instead of silent failure.
+      const active = sessionRegistry.getQuestion(session.sessionId, questionId);
+      if (active === null) {
+        const pendingIds = [...session.currentQuestions.keys()];
         log(
-          `Ignoring stale answer: questionId ${questionId} does not match active ${active?.id ?? 'none'}`,
+          `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
         );
         send(
           connectionId,
           createError('STALE_ANSWER', 'The question this answer was for is no longer active', {
             sessionId,
             questionId,
-            activeQuestionId: active?.id ?? null,
+            pendingQuestionIds: pendingIds,
           }),
         );
         return;
       }
 
       await session.pty.submitInput(answer);
-      sessionRegistry.updateQuestion(session.sessionId, null);
+      // Remove only the answered question; sibling prompts remain answerable.
+      sessionRegistry.removeQuestion(session.sessionId, questionId);
     },
 
     onBulletExpandRequest: (

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -275,8 +275,10 @@ export function setupHookBridge(
       teardownWatcher('claude_restarted', 'restart');
       // Drop any hook record stashed before /clear or /compact: the new
       // Claude session's first PTY prompt must not merge stale option
-      // labels from the dying session.
+      // labels from the dying session. Also drop the pending-question
+      // collection so answers to the dead session's prompts are refused.
       tracker.clearPending();
+      sessionRegistry.clearQuestions(sessionId);
       claudeSessionId = null;
       mainSessionEnded = false;
       // isRotation was already computed above against the pre-adopt
@@ -391,9 +393,11 @@ export function setupHookBridge(
         );
         teardownWatcher('claude_restarted', 'restart-sessioninfo');
         // Mirror the initFromHookEvent restart branch: drop any hook
-        // record so the new session's first PTY prompt cannot merge
-        // stale options from the dying session.
+        // record and the pending-question collection so the new session's
+        // first PTY prompt cannot merge stale options, and stale answers
+        // are refused.
         tracker.clearPending();
+        sessionRegistry.clearQuestions(sessionId);
         claudeSessionId = null;
         mainSessionEnded = false;
         isRotation = previousClaudeSessionId !== null;

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -138,7 +138,7 @@ export function createMessageApiForSession(
         ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
-      sessionRegistry.updateQuestion(questionSessionId, question);
+      sessionRegistry.addQuestion(questionSessionId, question);
 
       // Push only when no client is attached; attached clients see it in-app.
       const sessionForPush = sessionRegistry.getSession(questionSessionId);

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -144,6 +144,7 @@ export class HookEventBridge {
         options: [...DEFAULT_PERMISSION_OPTIONS],
         allowsFreeText: false,
         isAnswered: false,
+        agentId: input.agent_id,
       };
       this.events.onQuestion(question);
       this.events.onStatusChange('waiting');
@@ -225,6 +226,7 @@ export class HookEventBridge {
       options,
       allowsFreeText: false,
       isAnswered: false,
+      agentId: input.agent_id,
     });
     this.events.onStatusChange('waiting');
   }
@@ -255,6 +257,7 @@ export class HookEventBridge {
       ],
       allowsFreeText: false,
       isAnswered: false,
+      agentId: input.agent_id,
     };
     this.events.onQuestion(question);
     this.events.onStatusChange('waiting');

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -355,7 +355,7 @@ export class RelayAdapter implements ConnectionAdapter {
     return this.sendRaw(connectionId, createAgentOutput(message));
   }
 
-  sendQuestion(connectionId: UUID, question: Question, sessionId?: UUID): boolean {
+  sendQuestion(connectionId: UUID, question: Question, sessionId: UUID): boolean {
     return this.sendRaw(connectionId, createQuestion(question, sessionId));
   }
 

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -453,7 +453,14 @@ export class SessionRegistry {
     while (map.size > MAX_PENDING_QUESTIONS) {
       const oldest = map.keys().next().value;
       if (oldest === undefined) break;
+      const evicted = map.get(oldest);
       map.delete(oldest);
+      // Log: an evicted prompt may have an outstanding APNS push whose answer
+      // will now be refused as STALE_ANSWER. Should be unreachable in normal
+      // use (cap is generous); a hit signals a runaway prompt loop.
+      console.warn(
+        `[SessionRegistry] pending-question cap (${MAX_PENDING_QUESTIONS}) exceeded; evicted oldest id=${oldest} text="${evicted?.text.slice(0, 60) ?? ''}"`,
+      );
     }
     this.session.lastActivityAt = now();
   }
@@ -466,7 +473,10 @@ export class SessionRegistry {
     }
   }
 
-  /** Drop all pending questions (status left 'waiting', or session restart). */
+  /** Drop all pending questions on Claude session restart (/clear, /resume).
+   *  Status-leaving-'waiting' is handled by QuestionPresenceTracker and the
+   *  client; this covers the restart path only, so answers to the dying
+   *  session's prompts are refused. */
   clearQuestions(sessionId: UUID): void {
     if (this.session !== null && this.session.sessionId === sessionId) {
       this.session.currentQuestions.clear();

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -24,6 +24,11 @@ import type { MessageAPI } from '../api/message-api.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
 import { generateSessionName } from './session-name.ts';
 
+/** Upper bound on concurrently-pending questions per session. Real prompts are
+ *  few (main + a handful of subagents); the cap is a backstop against a runaway
+ *  prompt loop growing the map unbounded. Oldest is evicted first. */
+const MAX_PENDING_QUESTIONS = 8;
+
 /** Configuration for SessionRegistry */
 export interface SessionRegistryConfig {
   /** How long orphaned sessions stay alive (ms). Default: 5 minutes */
@@ -42,8 +47,8 @@ export interface AttachResult {
   readonly replayMessages: readonly ProtocolMessage[];
   /** Current agent status */
   readonly currentStatus: AgentStatus;
-  /** Current pending question (if any) */
-  readonly currentQuestion: Question | null;
+  /** Currently pending questions (multiple can be in flight: main + subagent). */
+  readonly currentQuestions: readonly Question[];
   /** Next bullet ID for continuation */
   readonly nextBulletId: number;
   /** Error message if attachment failed */
@@ -98,8 +103,10 @@ export interface ManagedSession {
 
   /** Current agent status */
   currentStatus: AgentStatus;
-  /** Current pending question */
-  currentQuestion: Question | null;
+  /** Currently pending questions, keyed by questionId. Multiple can be in
+   *  flight at once (e.g. main agent + a subagent since #419), so an answer to
+   *  one must not invalidate the others. Bounded by MAX_PENDING_QUESTIONS. */
+  currentQuestions: Map<UUID, Question>;
 
   /** Whether this session is owned by the local process (wrapper mode).
    * Locally-owned sessions are never killed by orphan timeout. */
@@ -171,7 +178,7 @@ export class SessionRegistry {
       messageHistory: [],
       lastDeliveredIndex: -1,
       currentStatus: 'idle',
-      currentQuestion: null,
+      currentQuestions: new Map(),
       locallyOwned,
       explicitlyDetached: false,
     };
@@ -245,7 +252,7 @@ export class SessionRegistry {
         isResume: false,
         replayMessages: [],
         currentStatus: 'idle',
-        currentQuestion: null,
+        currentQuestions: [],
         nextBulletId: 1,
         error: 'Session not found',
       };
@@ -268,7 +275,7 @@ export class SessionRegistry {
         isResume: true,
         replayMessages,
         currentStatus: this.session.currentStatus,
-        currentQuestion: this.session.currentQuestion,
+        currentQuestions: [...this.session.currentQuestions.values()],
         nextBulletId: this.session.messageApi.bulletCount + 1,
       };
     }
@@ -306,7 +313,7 @@ export class SessionRegistry {
       isResume,
       replayMessages,
       currentStatus: this.session.currentStatus,
-      currentQuestion: this.session.currentQuestion,
+      currentQuestions: [...this.session.currentQuestions.values()],
       nextBulletId: this.session.messageApi.bulletCount + 1,
     };
   }
@@ -433,13 +440,44 @@ export class SessionRegistry {
   }
 
   /**
-   * Update current question (from hook events).
+   * Register a pending question. Multiple can coexist (main + subagent); each
+   * is tracked by its own id so answering one never invalidates another.
+   * Bounded by MAX_PENDING_QUESTIONS (oldest evicted first) so a runaway
+   * prompt loop cannot grow the map without limit.
    */
-  updateQuestion(sessionId: UUID, question: Question | null): void {
+  addQuestion(sessionId: UUID, question: Question): void {
+    if (this.session === null || this.session.sessionId !== sessionId) return;
+    const map = this.session.currentQuestions;
+    map.delete(question.id); // re-insert so a refreshed question is "newest"
+    map.set(question.id, question);
+    while (map.size > MAX_PENDING_QUESTIONS) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+    }
+    this.session.lastActivityAt = now();
+  }
+
+  /** Remove one answered/resolved question by id. */
+  removeQuestion(sessionId: UUID, questionId: UUID): void {
     if (this.session !== null && this.session.sessionId === sessionId) {
-      this.session.currentQuestion = question;
+      this.session.currentQuestions.delete(questionId);
       this.session.lastActivityAt = now();
     }
+  }
+
+  /** Drop all pending questions (status left 'waiting', or session restart). */
+  clearQuestions(sessionId: UUID): void {
+    if (this.session !== null && this.session.sessionId === sessionId) {
+      this.session.currentQuestions.clear();
+      this.session.lastActivityAt = now();
+    }
+  }
+
+  /** Look up a pending question by id (null if not awaitable). */
+  getQuestion(sessionId: UUID, questionId: UUID): Question | null {
+    if (this.session === null || this.session.sessionId !== sessionId) return null;
+    return this.session.currentQuestions.get(questionId) ?? null;
   }
 
   /**

--- a/packages/daemon/tests/adapter-registry.test.ts
+++ b/packages/daemon/tests/adapter-registry.test.ts
@@ -327,7 +327,7 @@ describe('AdapterRegistry', () => {
         ],
       };
 
-      const result = registry.sendQuestion(connId, question);
+      const result = registry.sendQuestion(connId, question, generateId());
       expect(result).toBe(true);
       expect(adapter.sentQuestions.length).toBe(1);
     });
@@ -342,7 +342,7 @@ describe('AdapterRegistry', () => {
         options: [],
       };
 
-      expect(registry.sendQuestion(generateId(), question)).toBe(false);
+      expect(registry.sendQuestion(generateId(), question, generateId())).toBe(false);
     });
 
     test('sendStatus routes to correct adapter', () => {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -295,7 +295,7 @@ describe('runAttachClient', () => {
           if (msg.type === 'hello') {
             ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
             setTimeout(() => {
-              ws.send(serialize(createQuestion(question)));
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
             }, 50);
             setTimeout(() => ws.close(), 200);
           }

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -275,6 +275,48 @@ describe('createInputHandlers', () => {
       expect(errMsg.details?.pendingQuestionIds).toContain(QID);
     });
 
+    test('two concurrent questions: answering one leaves the other answerable (#437)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      const q2 = 'q2000000-0000-0000-0000-000000000000' as UUID;
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'main?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+      sessionRegistry.addQuestion(sessionId, {
+        id: q2,
+        text: 'subagent?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+        agentId: 'sub-7',
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      // Answer the first; it should inject and be removed, the second stays.
+      await handlers.onAnswer(CID, sessionId, QID, 'one');
+      expect(ptyCapture.submits).toEqual(['one']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+      const after1 = sessionRegistry.getSession(sessionId)?.currentQuestions;
+      expect(after1?.has(QID)).toBe(false);
+      expect(after1?.has(q2)).toBe(true);
+
+      // Answer the second; no STALE_ANSWER, injected and removed.
+      await handlers.onAnswer(CID, sessionId, q2, 'two');
+      expect(ptyCapture.submits).toEqual(['one', 'two']);
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -162,7 +162,7 @@ describe('createInputHandlers', () => {
         fakePTY(ptyCapture),
         fakeMessageAPI(new Map()),
       );
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'yes?',
         options: [
@@ -177,7 +177,7 @@ describe('createInputHandlers', () => {
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
-      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
     test('falls back to connection lookup when sessionId is unknown', async () => {
@@ -192,7 +192,7 @@ describe('createInputHandlers', () => {
       sessionRegistry.attachConnection(sessionId, CID);
       // Pre-seed a question so we can assert the fallback path clears it on
       // the REAL session's id, not on the bogus arg it was handed.
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'proceed?',
         options: [
@@ -209,7 +209,7 @@ describe('createInputHandlers', () => {
 
       expect(ptyCapture.submits).toEqual(['hello']);
       // Question must be cleared on the real session id, not the bogus one.
-      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
     test('drops answer when no question is pending (stale APNS push answer)', async () => {
@@ -232,7 +232,7 @@ describe('createInputHandlers', () => {
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
-      expect(sessionRegistry.getSession(sessionId)?.currentQuestion).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
       const errors = sendCalls.filter((c) => c.message.type === 'error');
       expect(errors).toHaveLength(1);
       expect((errors[0]?.message as unknown as { code: string }).code).toBe('STALE_ANSWER');
@@ -247,7 +247,7 @@ describe('createInputHandlers', () => {
         fakePTY(ptyCapture),
         fakeMessageAPI(new Map()),
       );
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'current?',
         options: [
@@ -263,16 +263,16 @@ describe('createInputHandlers', () => {
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
-      // Active question stays in place; only the matching answer should clear it.
-      expect(sessionRegistry.getSession(sessionId)?.currentQuestion?.id).toBe(QID);
+      // Active question stays pending; only the matching answer removes it.
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.has(QID)).toBe(true);
       const errors = sendCalls.filter((c) => c.message.type === 'error');
       expect(errors).toHaveLength(1);
       const errMsg = errors[0]?.message as unknown as {
         code: string;
-        details?: { activeQuestionId: string | null };
+        details?: { pendingQuestionIds: string[] };
       };
       expect(errMsg.code).toBe('STALE_ANSWER');
-      expect(errMsg.details?.activeQuestionId).toBe(QID);
+      expect(errMsg.details?.pendingQuestionIds).toContain(QID);
     });
 
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
@@ -363,7 +363,7 @@ describe('createInputHandlers', () => {
     test('answer with matching claudeSessionId is forwarded', async () => {
       const bound = '11111111-2222-3333-4444-555555555555' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'go?',
         options: [{ value: 'y', label: 'Y', isRecommended: true, isYes: true, isNo: false }],
@@ -382,7 +382,7 @@ describe('createInputHandlers', () => {
       const bound = '11111111-2222-3333-4444-555555555555' as UUID;
       const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'go?',
         options: [],
@@ -405,7 +405,7 @@ describe('createInputHandlers', () => {
     test('answer without claudeSessionId (legacy client) is accepted', async () => {
       const bound = '11111111-2222-3333-4444-555555555555' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'go?',
         options: [],
@@ -447,7 +447,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
       // Deliberately do NOT call sessionStore.save here.
-      sessionRegistry.updateQuestion(sessionId, {
+      sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'go?',
         options: [],

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -147,7 +147,8 @@ describe('createMessageApiForSession', () => {
 
     const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
     expect(questionMsgs).toHaveLength(1);
-    expect(sessionRegistry.getSession(sessionId)?.currentQuestion?.text).toBe('proceed?');
+    const pending = [...(sessionRegistry.getSession(sessionId)?.currentQuestions.values() ?? [])];
+    expect(pending[0]?.text).toBe('proceed?');
   });
 
   test('onQuestion does NOT push when a client is attached', () => {

--- a/packages/daemon/tests/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/question-presence-tracker.test.ts
@@ -12,7 +12,11 @@ function opt(label: string, value: string): QuestionOption {
   return { label, value, isRecommended: false, isYes: false, isNo: false };
 }
 
-function question(opts: { text?: string; agentId?: string; options?: QuestionOption[] }): Question {
+function question(opts: {
+  text?: string;
+  agentId?: string | undefined;
+  options?: QuestionOption[];
+}): Question {
   return {
     id: generateId(),
     text: opts.text ?? 'Allow?',
@@ -89,6 +93,22 @@ describe('QuestionPresenceTracker per-agent pending', () => {
     tracker.onStatusChange('thinking');
     expect(tracker.pendingCountForTest()).toBe(0);
     expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+  });
+
+  test('a throwing push consumes the hook but leaves presence set, so a retry re-pushes', () => {
+    let calls = 0;
+    const tracker = new QuestionPresenceTracker(() => {
+      calls++;
+      if (calls === 1) throw new Error('network blip');
+    });
+    tracker.recordPendingHook(question({ agentId: undefined, options: [opt('Yes', 'y')] }));
+    tracker.onPTYPromptVisible(question({ agentId: undefined }));
+    // hook consumed, presence set, error swallowed (not rethrown).
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+    // A re-render emits again; the second push (no hook to merge) succeeds.
+    tracker.onPTYPromptVisible(question({ agentId: undefined }));
+    expect(calls).toBe(2);
   });
 
   test('clearPending drops all records and presence', () => {

--- a/packages/daemon/tests/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/question-presence-tracker.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for QuestionPresenceTracker per-agent pending map (#425/#437). No mocks:
+ * a real push sink captures emitted questions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import { QuestionPresenceTracker } from '../src/api/question-presence-tracker.ts';
+
+function opt(label: string, value: string): QuestionOption {
+  return { label, value, isRecommended: false, isYes: false, isNo: false };
+}
+
+function question(opts: { text?: string; agentId?: string; options?: QuestionOption[] }): Question {
+  return {
+    id: generateId(),
+    text: opts.text ?? 'Allow?',
+    options: opts.options ?? [],
+    allowsFreeText: false,
+    isAnswered: false,
+    agentId: opts.agentId,
+  };
+}
+
+function makeTracker() {
+  const pushed: Question[] = [];
+  const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+  return { tracker, pushed };
+}
+
+describe('QuestionPresenceTracker per-agent pending', () => {
+  test('hooks for two agents keep separate pending entries', () => {
+    const { tracker } = makeTracker();
+    tracker.recordPendingHook(question({ agentId: undefined, text: 'main?' }));
+    tracker.recordPendingHook(question({ agentId: 'sub-7', text: 'sub?' }));
+    expect(tracker.pendingCountForTest()).toBe(2);
+  });
+
+  test('a second hook for the SAME agent replaces (one slot per agent)', () => {
+    const { tracker } = makeTracker();
+    tracker.recordPendingHook(question({ agentId: 'sub-7', text: 'first' }));
+    tracker.recordPendingHook(question({ agentId: 'sub-7', text: 'second' }));
+    expect(tracker.pendingCountForTest()).toBe(1);
+  });
+
+  test('PTY visible pairs the same agent, merges its options, leaves others pending', () => {
+    const { tracker, pushed } = makeTracker();
+    tracker.recordPendingHook(
+      question({ agentId: undefined, options: [opt('Yes', '1'), opt('No', '2')] }),
+    );
+    tracker.recordPendingHook(question({ agentId: 'sub-7', options: [opt('A', '1')] }));
+
+    // PTY prompt for the main agent (numbered fallback options).
+    tracker.onPTYPromptVisible(question({ agentId: undefined, options: [opt('1', '1')] }));
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.options.map((o) => o.label)).toEqual(['Yes', 'No']); // hook labels win
+    // main consumed; sub-7 still pending.
+    expect(tracker.pendingCountForTest()).toBe(1);
+    expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+  });
+
+  test('PTY-only prompt (no hook) is pushed as-is', () => {
+    const { tracker, pushed } = makeTracker();
+    const q = question({ agentId: undefined, options: [opt('1', '1'), opt('2', '2')] });
+    tracker.onPTYPromptVisible(q);
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.id).toBe(q.id);
+  });
+
+  test('most-recent fallback when PTY agent has no matching hook (#425 caveat)', () => {
+    const { tracker, pushed } = makeTracker();
+    tracker.recordPendingHook(
+      question({ agentId: 'sub-7', options: [opt('Allow', '1'), opt('Deny', '2')] }),
+    );
+    // PTY prompt arrives without an agent id; no 'main' entry, so it pairs the
+    // most-recent pending hook (sub-7) and adopts its labels + agentId.
+    tracker.onPTYPromptVisible(question({ agentId: undefined, options: [] }));
+    expect(pushed[0]?.options.map((o) => o.label)).toEqual(['Allow', 'Deny']);
+    expect(pushed[0]?.agentId).toBe('sub-7');
+  });
+
+  test('status leaving waiting clears all pending and presence', () => {
+    const { tracker } = makeTracker();
+    tracker.recordPendingHook(question({ agentId: 'sub-7' }));
+    tracker.onPTYPromptVisible(question({ agentId: undefined }));
+    expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+    tracker.onStatusChange('thinking');
+    expect(tracker.pendingCountForTest()).toBe(0);
+    expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+  });
+
+  test('clearPending drops all records and presence', () => {
+    const { tracker } = makeTracker();
+    tracker.recordPendingHook(question({ agentId: undefined }));
+    tracker.recordPendingHook(question({ agentId: 'sub-7' }));
+    tracker.clearPending();
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+  });
+});

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -78,6 +78,84 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('pending questions (#437)', () => {
+    const mkQuestion = (id: string, agentId?: string) => ({
+      id: id as ReturnType<typeof generateId>,
+      text: `${id}?`,
+      options: [],
+      allowsFreeText: true,
+      isAnswered: false,
+      ...(agentId !== undefined && { agentId }),
+    });
+
+    test('add/remove keep concurrent questions independent', () => {
+      const sid = generateId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      const q1 = generateId();
+      const q2 = generateId();
+      registry.addQuestion(sid, mkQuestion(q1));
+      registry.addQuestion(sid, mkQuestion(q2, 'sub-7'));
+      expect(registry.getSession(sid)?.currentQuestions.size).toBe(2);
+
+      registry.removeQuestion(sid, q1);
+      expect(registry.getQuestion(sid, q1)).toBeNull();
+      expect(registry.getQuestion(sid, q2)?.text).toBe(`${q2}?`);
+    });
+
+    test('clearQuestions drops all', () => {
+      const sid = generateId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.addQuestion(sid, mkQuestion(generateId()));
+      registry.addQuestion(sid, mkQuestion(generateId()));
+      registry.clearQuestions(sid);
+      expect(registry.getSession(sid)?.currentQuestions.size).toBe(0);
+    });
+
+    test('evicts the OLDEST when MAX_PENDING_QUESTIONS exceeded', () => {
+      const sid = generateId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      const ids: string[] = [];
+      for (let i = 0; i < 9; i++) {
+        const id = generateId();
+        ids.push(id);
+        registry.addQuestion(sid, mkQuestion(id));
+      }
+      const map = registry.getSession(sid)?.currentQuestions;
+      expect(map?.size).toBe(8); // capped
+      expect(registry.getQuestion(sid, ids[0] as string)).toBeNull(); // oldest gone
+      expect(registry.getQuestion(sid, ids[8] as string)?.text).toBe(`${ids[8]}?`); // newest kept
+    });
+
+    test('re-adding an existing id refreshes it to newest (survives eviction)', () => {
+      const sid = generateId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      const ids: string[] = [];
+      for (let i = 0; i < 8; i++) {
+        const id = generateId();
+        ids.push(id);
+        registry.addQuestion(sid, mkQuestion(id));
+      }
+      // Refresh the oldest, then add one more: the refreshed one must survive
+      // and the now-oldest (ids[1]) must be evicted.
+      registry.addQuestion(sid, mkQuestion(ids[0] as string));
+      registry.addQuestion(sid, mkQuestion(generateId()));
+      expect(registry.getQuestion(sid, ids[0] as string)).not.toBeNull();
+      expect(registry.getQuestion(sid, ids[1] as string)).toBeNull();
+    });
+
+    test('attachConnection result replays all pending questions', () => {
+      const sid = generateId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      const q1 = generateId();
+      const q2 = generateId();
+      registry.addQuestion(sid, mkQuestion(q1));
+      registry.addQuestion(sid, mkQuestion(q2, 'sub-7'));
+
+      const result = registry.attachConnection(sid, generateId());
+      expect(result.currentQuestions.map((q) => q.id)).toEqual([q1, q2]);
+    });
+  });
+
   describe('attachConnection()', () => {
     test('attaches connection to session', () => {
       const sessionId = generateId();

--- a/packages/daemon/tests/telegram-adapter.test.ts
+++ b/packages/daemon/tests/telegram-adapter.test.ts
@@ -74,13 +74,17 @@ describe('sendMessage with unknown connection', () => {
 describe('sendQuestion with unknown connection', () => {
   test('returns false for unknown connectionId', () => {
     const adapter = createAdapter();
-    const result = adapter.sendQuestion(unknownConnectionId, {
-      id: generateId(),
-      text: 'Allow?',
-      options: [],
-      allowsFreeText: false,
-      isAnswered: false,
-    });
+    const result = adapter.sendQuestion(
+      unknownConnectionId,
+      {
+        id: generateId(),
+        text: 'Allow?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      },
+      generateId(),
+    );
     expect(result).toBe(false);
   });
 });
@@ -142,6 +146,7 @@ describe('sendRaw routing', () => {
       type: 'question',
       id: generateId(),
       timestamp: now(),
+      sessionId: generateId(),
       question: {
         id: generateId(),
         text: 'Allow?',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,7 +31,7 @@ export type {
   DiscoverableSession,
 } from './types.ts';
 
-export { ok, err, isOk, isErr } from './types.ts';
+export { ok, err, isOk, isErr, MAIN_AGENT_ID } from './types.ts';
 
 // Permission/question defaults shared by daemon and client (#396)
 export {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -215,8 +215,11 @@ export interface QuestionMessage {
   readonly id: UUID;
   readonly timestamp: Timestamp;
   readonly question: Question;
-  /** Session that owns this question */
-  readonly sessionId?: UUID | undefined;
+  /** Remi session that owns this question. Mandatory (#437): the client routes
+   *  and keys questions by it and must never fall back to "the active session",
+   *  which cross-contaminates when multiple sessions/agents have prompts. The
+   *  owning agent is carried inside `question.agentId`. */
+  readonly sessionId: UUID;
   /**
    * Claude Code session UUID the question came from. The answer carrying
    * this id back lets the daemon reject the write if the binding has
@@ -934,7 +937,7 @@ export function createError(
  */
 export function createQuestion(
   question: Question,
-  sessionId?: UUID,
+  sessionId: UUID,
   claudeSessionId?: UUID,
 ): QuestionMessage {
   return {
@@ -942,7 +945,7 @@ export function createQuestion(
     id: generateId(),
     timestamp: now(),
     question,
-    ...(sessionId !== undefined && { sessionId }),
+    sessionId,
     ...(claudeSessionId !== undefined && { claudeSessionId }),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -149,12 +149,19 @@ export interface Question {
 
   /**
    * The Claude agent this prompt belongs to: the hook `agent_id` for a
-   * subagent, or undefined ('main') for the primary agent. Keys the
-   * pending-question collection so a main-agent prompt and a concurrent
-   * subagent prompt (#419) coexist instead of overwriting each other (#425).
+   * subagent, or undefined (MAIN_AGENT_ID) for the primary agent. Used as the
+   * key in QuestionPresenceTracker's pending map and as part of the composite
+   * key (`${sessionId}#${agentId}`) in the web client's collection, so a
+   * main-agent prompt and a concurrent subagent prompt (#419) coexist instead
+   * of overwriting each other (#425). The daemon SessionRegistry keys by
+   * question id, so concurrency there holds regardless of this field.
    */
   readonly agentId?: string | undefined;
 }
+
+/** Sentinel agent key for the primary (main) agent, whose questions carry no
+ *  `agentId`. Normalize `agentId ?? MAIN_AGENT_ID` when building collection keys. */
+export const MAIN_AGENT_ID = 'main';
 
 /**
  * Option for a question (e.g., Yes/No, numbered choices).
@@ -194,9 +201,6 @@ export interface Session {
 
   /** Current agent status */
   status: AgentStatus;
-
-  /** Current pending question (if any) */
-  pendingQuestion?: Question | undefined;
 
   /** Is session still active */
   isActive: boolean;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -146,6 +146,14 @@ export interface Question {
 
   /** The answer that was given (if answered) */
   answer?: string | undefined;
+
+  /**
+   * The Claude agent this prompt belongs to: the hook `agent_id` for a
+   * subagent, or undefined ('main') for the primary agent. Keys the
+   * pending-question collection so a main-agent prompt and a concurrent
+   * subagent prompt (#419) coexist instead of overwriting each other (#425).
+   */
+  readonly agentId?: string | undefined;
 }
 
 /**

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -525,7 +525,7 @@ describe('Message factory functions', () => {
         ],
       };
 
-      const msg = createQuestion(question);
+      const msg = createQuestion(question, generateId());
       expect(msg.type).toBe('question');
       expect(msg.question).toBe(question);
       expect(msg.question.text).toBe('Do you want to continue?');
@@ -548,18 +548,19 @@ describe('Message factory functions', () => {
       expect(msg.sessionId).toBe(sid);
     });
 
-    test('creates question message without sessionId when omitted', () => {
+    test('carries the agentId from the question payload', () => {
       const question: Question = {
         id: generateId(),
         text: 'Continue?',
         allowsFreeText: false,
         isAnswered: false,
         options: [],
+        agentId: 'subagent-7',
       };
 
-      const msg = createQuestion(question);
+      const msg = createQuestion(question, generateId());
       expect(msg.type).toBe('question');
-      expect(msg.sessionId).toBeUndefined();
+      expect(msg.question.agentId).toBe('subagent-7');
     });
   });
 

--- a/packages/shared/tests/types.test.ts
+++ b/packages/shared/tests/types.test.ts
@@ -294,27 +294,5 @@ describe('Type structures', () => {
       expect(session.isActive).toBe(false);
       expect(session.endedAt).toBe('2026-01-10T01:00:00.000Z');
     });
-
-    test('session can have pending question', () => {
-      const question: Question = {
-        id: 'q-123',
-        text: 'Proceed?',
-        options: [],
-        allowsFreeText: true,
-        isAnswered: false,
-      };
-
-      const session: Session = {
-        id: 'session-123',
-        name: 'claude-code-project',
-        startedAt: '2026-01-10T00:00:00.000Z',
-        status: 'waiting',
-        isActive: true,
-        pendingQuestion: question,
-      };
-
-      expect(session.pendingQuestion?.id).toBe('q-123');
-      expect(session.status).toBe('waiting');
-    });
   });
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -169,6 +169,7 @@ function App() {
   const resumingSessionRef = useRef<string | null>(null);
   const loadedTranscriptsRef = useRef<Set<string>>(new Set());
   const messagesRef = useRef(messages);
+  const questionsRef = useRef(questions);
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
@@ -396,9 +397,18 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === sessionData.id ? { ...s, status: sessionData.status } : s)),
         );
-        // If status moved from 'waiting' to something else, the question was answered elsewhere
+        // If status moved from 'waiting', the MAIN agent's prompt resolved
+        // (auto-approved, answered in terminal, etc.). Session status tracks
+        // the main agent only (subagent events don't change it), so clear just
+        // the main-agent slot — a concurrent subagent prompt must survive.
         if (sessionData.status !== 'waiting') {
-          setQuestions((prev) => clearSessionQuestions(prev, sessionData.id));
+          setQuestions((prev) => {
+            const key = questionKey(sessionData.id);
+            if (!prev.has(key)) return prev;
+            const next = new Map(prev);
+            next.delete(key);
+            return next;
+          });
         }
         break;
       }
@@ -897,6 +907,10 @@ function App() {
   }, [messages]);
 
   useEffect(() => {
+    questionsRef.current = questions;
+  }, [questions]);
+
+  useEffect(() => {
     replyContextsRef.current = replyContexts;
   }, [replyContexts]);
 
@@ -1257,7 +1271,9 @@ function App() {
   const handleAnswer = useCallback(
     (question: UIQuestion, content: string) => {
       const sid = question.sessionId;
-      const connId = getActiveConnectionId();
+      // Route by the question's OWN session connection (in a multi-daemon
+      // stack it may differ from the active session), not "whatever is active".
+      const connId = sessionsRef.current.find((s) => s.id === sid)?.connectionId ?? getActiveConnectionId();
       if (!connId) {
         const systemMsg: UIMessage = {
           id: generateId(),
@@ -1275,7 +1291,7 @@ function App() {
       // Carry claudeSessionId so the daemon can refuse if its binding
       // has rotated since the question fired (#430). Route by the question's
       // OWN session/id so answering one of several stacked prompts is precise.
-      const binding = sessions.find((s) => s.id === sid)?.claudeSessionId;
+      const binding = sessionsRef.current.find((s) => s.id === sid)?.claudeSessionId;
       const sent = sendAnswer(connId, sid, question.id, content, binding as UUID | undefined);
       if (!sent) {
         const failMsg: UIMessage = {
@@ -1309,8 +1325,10 @@ function App() {
           return next;
         });
       }, 1500);
-      // Keep the session flagged while other prompts remain unanswered.
-      const stillPending = getSessionQuestions(questions, sid).some(
+      // Keep the session flagged while OTHER prompts remain unanswered. Read
+      // the ref (latest committed map) rather than the closure so the badge
+      // can't get stuck after the dep snapshot goes stale.
+      const stillPending = getSessionQuestions(questionsRef.current, sid).some(
         (q) => q.id !== question.id && q.answeredWith === undefined,
       );
       setSessions((prev) =>
@@ -1328,7 +1346,7 @@ function App() {
       };
       setMessages((prev) => [...prev, userMsg]);
     },
-    [getActiveConnectionId, sendAnswer, sessions, questions],
+    [getActiveConnectionId, sendAnswer],
   );
 
   // Send a regular user input message, optionally with a reply context.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -14,6 +14,11 @@ import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
+import {
+  clearSessionQuestions,
+  getSessionQuestions,
+  questionKey,
+} from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
@@ -147,7 +152,9 @@ function App() {
   const [sessions, setSessions] = useState<UISession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<UUID | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
-  const [questions, setQuestions] = useState<Map<UUID, UIQuestion>>(new Map());
+  // Keyed by `${sessionId}#${agentId}` so concurrent main + subagent prompts
+  // coexist; see lib/question-collection (#437).
+  const [questions, setQuestions] = useState<Map<string, UIQuestion>>(new Map());
   // Reply context per session: when set, the InputArea shows a quoted-message
   // banner and outgoing user input is wrapped in a markdown blockquote so
   // Claude Code receives the quoted context (#401).
@@ -269,12 +276,7 @@ function App() {
             setActiveSessionId(message.sessionId);
             if (oldActive) {
               setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
-              setQuestions((prev) => {
-                if (!prev.has(oldActive)) return prev;
-                const next = new Map(prev);
-                next.delete(oldActive);
-                return next;
-              });
+              setQuestions((prev) => clearSessionQuestions(prev, oldActive));
             }
           }
         }
@@ -396,12 +398,7 @@ function App() {
         );
         // If status moved from 'waiting' to something else, the question was answered elsewhere
         if (sessionData.status !== 'waiting') {
-          setQuestions((prev) => {
-            if (!prev.has(sessionData.id)) return prev;
-            const next = new Map(prev);
-            next.delete(sessionData.id);
-            return next;
-          });
+          setQuestions((prev) => clearSessionQuestions(prev, sessionData.id));
         }
         break;
       }
@@ -411,12 +408,7 @@ function App() {
         const resetSessionId = message.sessionId;
         if (resetSessionId) {
           setMessages((prev) => prev.filter((m) => m.sessionId !== resetSessionId));
-          setQuestions((prev) => {
-            if (!prev.has(resetSessionId)) return prev;
-            const next = new Map(prev);
-            next.delete(resetSessionId);
-            return next;
-          });
+          setQuestions((prev) => clearSessionQuestions(prev, resetSessionId));
         }
         break;
       }
@@ -454,8 +446,15 @@ function App() {
           isRecommended: o.isRecommended || undefined,
         }));
 
-        // Use sessionId from the message when available; fall back to active session
-        const questionSessionId = message.sessionId ?? activeSessionIdRef.current ?? ('' as UUID);
+        // sessionId is mandatory on the wire now (#437); never fall back to
+        // the active session (that cross-contaminated when another session or
+        // agent had a prompt). Drop a malformed message rather than misroute.
+        const questionSessionId = message.sessionId;
+        if (!questionSessionId) {
+          console.warn('[App] Dropping question with no sessionId');
+          break;
+        }
+        const questionAgentId = q.agentId;
         const uiQuestion: UIQuestion = {
           id: q.id,
           sessionId: questionSessionId,
@@ -464,21 +463,22 @@ function App() {
           options: q.options.length > 0 ? q.options.map((o) => o.label) : undefined,
           structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
           timestamp: new Date().toISOString(),
+          agentId: questionAgentId,
         };
+        const key = questionKey(questionSessionId, questionAgentId);
         setQuestions((prev) => {
-          // Richer-wins guard (#396). The daemon emits two questions for
-          // one prompt cycle (HookEventBridge default 3-set + PTY-parsed
-          // multi-choice with full sentences); their ids differ so the
-          // session-keyed map otherwise lets the second arrival overwrite
-          // the first regardless of richness. Keeping the richer pending
-          // question here prevents the "multi-choice flickers, then
-          // collapses to Yes/Yes-always/No" symptom users reported.
-          const existing = prev.get(questionSessionId);
+          // Richer-wins guard (#396), scoped to this agent's slot. The daemon
+          // emits two questions for one prompt cycle (HookEventBridge default
+          // 3-set + PTY-parsed multi-choice with full sentences); their ids
+          // differ so a same-key second arrival would otherwise overwrite the
+          // first regardless of richness. A DIFFERENT agent's prompt has a
+          // different key and so coexists rather than clobbering (#419/#425).
+          const existing = prev.get(key);
           if (existing && shouldKeepExisting(existing, uiQuestion)) {
             return prev;
           }
           const next = new Map(prev);
-          next.set(questionSessionId, uiQuestion);
+          next.set(key, uiQuestion);
           return next;
         });
 
@@ -783,13 +783,19 @@ function App() {
             // Without this the QuestionCard stays collapsed showing
             // the rejected answer and the user has no retry path.
             setQuestions((prev) => {
-              const stale = prev.get(refusedSessionId);
-              if (!stale || stale.answeredWith === undefined) return prev;
+              // Un-answer any optimistically-collapsed question for the refused
+              // session (across agents) so the user can retry (#434 review).
+              let changed = false;
               const next = new Map(prev);
-              const restored = { ...stale };
-              delete (restored as { answeredWith?: string }).answeredWith;
-              next.set(refusedSessionId, restored);
-              return next;
+              for (const [key, q] of prev) {
+                if (q.sessionId === refusedSessionId && q.answeredWith !== undefined) {
+                  const restored = { ...q };
+                  delete (restored as { answeredWith?: string }).answeredWith;
+                  next.set(key, restored);
+                  changed = true;
+                }
+              }
+              return changed ? next : prev;
             });
           }
           console.warn(
@@ -1211,7 +1217,9 @@ function App() {
       })()
     : undefined;
   const sessionMessages = messages.filter((m) => m.sessionId === activeSessionId);
-  const sessionQuestion = activeSessionId ? (questions.get(activeSessionId) ?? null) : null;
+  // All pending prompts for the active session (main + any subagents), oldest
+  // first; rendered as a stack of cards (#437).
+  const sessionQuestions = activeSessionId ? getSessionQuestions(questions, activeSessionId) : [];
 
   const handleSelectSession = useCallback(
     (id: UUID) => {
@@ -1247,13 +1255,13 @@ function App() {
   // (#401): the user can ask the agent a fresh question without it
   // being treated as an answer to a stale prompt.
   const handleAnswer = useCallback(
-    (content: string) => {
-      if (!activeSessionId || !sessionQuestion) return;
+    (question: UIQuestion, content: string) => {
+      const sid = question.sessionId;
       const connId = getActiveConnectionId();
       if (!connId) {
         const systemMsg: UIMessage = {
           id: generateId(),
-          sessionId: activeSessionId,
+          sessionId: sid,
           sender: 'system',
           content: 'Cannot send: not connected to daemon',
           timestamp: new Date().toISOString(),
@@ -1265,19 +1273,14 @@ function App() {
       }
 
       // Carry claudeSessionId so the daemon can refuse if its binding
-      // has rotated since the question fired (#430).
-      const activeBinding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
-      const sent = sendAnswer(
-        connId,
-        activeSessionId,
-        sessionQuestion.id,
-        content,
-        activeBinding as UUID | undefined,
-      );
+      // has rotated since the question fired (#430). Route by the question's
+      // OWN session/id so answering one of several stacked prompts is precise.
+      const binding = sessions.find((s) => s.id === sid)?.claudeSessionId;
+      const sent = sendAnswer(connId, sid, question.id, content, binding as UUID | undefined);
       if (!sent) {
         const failMsg: UIMessage = {
           id: generateId(),
-          sessionId: activeSessionId,
+          sessionId: sid,
           connectionId: connId,
           sender: 'system',
           content: 'Failed to send answer: connection unavailable. Try again.',
@@ -1288,26 +1291,34 @@ function App() {
         setMessages((prev) => [...prev, failMsg]);
         return;
       }
-      // Mark question as answered (card shows collapsed state briefly)
+      const key = questionKey(sid, question.agentId);
+      // Mark this question answered (card shows collapsed state briefly), then
+      // remove it; sibling prompts for the session stay in the stack.
       setQuestions((prev) => {
+        const existing = prev.get(key);
+        if (!existing) return prev;
         const next = new Map(prev);
-        next.set(activeSessionId, { ...sessionQuestion, answeredWith: content });
+        next.set(key, { ...existing, answeredWith: content });
         return next;
       });
       setTimeout(() => {
         setQuestions((prev) => {
-          if (!prev.has(activeSessionId)) return prev;
+          if (!prev.has(key)) return prev;
           const next = new Map(prev);
-          next.delete(activeSessionId);
+          next.delete(key);
           return next;
         });
       }, 1500);
+      // Keep the session flagged while other prompts remain unanswered.
+      const stillPending = getSessionQuestions(questions, sid).some(
+        (q) => q.id !== question.id && q.answeredWith === undefined,
+      );
       setSessions((prev) =>
-        prev.map((s) => (s.id === activeSessionId ? { ...s, questionPending: false } : s)),
+        prev.map((s) => (s.id === sid ? { ...s, questionPending: stillPending } : s)),
       );
       const userMsg: UIMessage = {
         id: generateId(),
-        sessionId: activeSessionId,
+        sessionId: sid,
         sender: 'user',
         content,
         timestamp: new Date().toISOString(),
@@ -1317,7 +1328,7 @@ function App() {
       };
       setMessages((prev) => [...prev, userMsg]);
     },
-    [activeSessionId, getActiveConnectionId, sendAnswer, sessionQuestion, sessions],
+    [getActiveConnectionId, sendAnswer, sessions, questions],
   );
 
   // Send a regular user input message, optionally with a reply context.
@@ -1648,7 +1659,7 @@ function App() {
     <ChatView
       session={activeSession}
       messages={sessionMessages}
-      question={sessionQuestion}
+      questions={sessionQuestions}
       error={error}
       onSend={handleSend}
       onAnswer={handleAnswer}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -32,8 +32,8 @@ interface ChatViewProps {
   readonly onSend: (message: string) => void;
   /** Answer a specific pending question. Routes through sendAnswer keyed by the
    *  question itself; decoupled from onSend so the bottom InputArea no longer
-   *  hijacks input when a question is pending (#401). Required: a missing
-   *  handler would silently route answers through onSend and re-create the bug. */
+   *  hijacks input when a question is pending (#401). Non-optional so the
+   *  decoupling can't be accidentally dropped back onto onSend. */
   readonly onAnswer: (question: UIQuestion, answer: string) => void;
   /** Long-press on a message bubble fires this with the message; consumer
    *  records it as the active reply context for the session (#401). */

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -23,16 +23,18 @@ export type ViewMode = 'compact' | 'chat';
 interface ChatViewProps {
   readonly session: UISession;
   readonly messages: readonly UIMessage[];
-  readonly question?: UIQuestion | null;
+  /** Pending prompts for this session, oldest first. Multiple can be in flight
+   *  (main agent + a subagent, #419/#437); rendered as a stack of cards. */
+  readonly questions?: readonly UIQuestion[];
   readonly error?: string | null;
   /** Send a regular user input message. Reply context (when set) is wrapped
    *  into a markdown blockquote inside this callback's caller (#401). */
   readonly onSend: (message: string) => void;
-  /** Answer the active question. Routes through sendAnswer; decoupled from
-   *  onSend so the bottom InputArea no longer hijacks input when a question
-   *  is pending (#401). Required: a missing handler would silently route
-   *  answers through onSend and re-create the bug. */
-  readonly onAnswer: (answer: string) => void;
+  /** Answer a specific pending question. Routes through sendAnswer keyed by the
+   *  question itself; decoupled from onSend so the bottom InputArea no longer
+   *  hijacks input when a question is pending (#401). Required: a missing
+   *  handler would silently route answers through onSend and re-create the bug. */
+  readonly onAnswer: (question: UIQuestion, answer: string) => void;
   /** Long-press on a message bubble fires this with the message; consumer
    *  records it as the active reply context for the session (#401). */
   readonly onReply?: (message: UIMessage) => void;
@@ -58,7 +60,7 @@ interface ChatViewProps {
 export function ChatView({
   session,
   messages,
-  question,
+  questions,
   error,
   onSend,
   onAnswer,
@@ -84,13 +86,17 @@ export function ChatView({
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
   const isConnected = session.connectionStatus === 'connected';
 
-  // In chat mode, show QuestionCard for active questions (not free_text with no options).
-  // In compact mode, fall back to the InputArea's built-in quick responses.
-  const showQuestionCard = viewMode === 'chat' && question && !question.answeredWith && isConnected;
-  const showAnsweredCard = viewMode === 'chat' && question?.answeredWith != null;
-
-  // Hide InputArea's quick responses when QuestionCard is handling the question
-  const inputQuestion = viewMode === 'chat' ? null : question;
+  // In chat mode, render a stack of QuestionCards (main + any subagent prompts,
+  // #437). In compact mode, fall back to the InputArea's quick responses for
+  // the primary (first) prompt. A pending card needs a live connection; an
+  // already-answered card stays briefly regardless.
+  const questionList = questions ?? [];
+  const primaryQuestion = questionList[0] ?? null;
+  const chatCards =
+    viewMode === 'chat'
+      ? questionList.filter((q) => q.answeredWith != null || isConnected)
+      : [];
+  const inputQuestion = viewMode === 'chat' ? null : primaryQuestion;
 
   // iOS edge-swipe back (#411): rightward swipe from the left edge pops
   // the chat back to the session list. Mirrors the native iOS gesture.
@@ -137,16 +143,20 @@ export function ChatView({
         showTimestamps={showTimestamps}
       />
 
-      {/* Question card in chat mode */}
-      {(showQuestionCard || showAnsweredCard) && question && (
-        <div className="border-t border-[var(--color-border)] px-3 py-2">
-          <QuestionCard question={question} onAnswer={onAnswer} />
+      {/* Question stack in chat mode (one card per concurrent prompt) */}
+      {chatCards.length > 0 && (
+        <div className="border-t border-[var(--color-border)] px-3 py-2 space-y-2">
+          {chatCards.map((q) => (
+            <QuestionCard key={q.id} question={q} onAnswer={(answer) => onAnswer(q, answer)} />
+          ))}
         </div>
       )}
 
       <InputArea
         onSend={onSend}
-        onAnswer={onAnswer}
+        onAnswer={(answer) => {
+          if (primaryQuestion) onAnswer(primaryQuestion, answer);
+        }}
         onCancel={onCancel}
         question={inputQuestion}
         isAgentBusy={isAgentBusy}

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -7,11 +7,12 @@
  * collapses via the richer-wins guard. Pure functions, unit-tested directly.
  */
 
+import { MAIN_AGENT_ID } from '@remi/shared';
 import type { UIQuestion } from '@/types';
 
-/** Composite map key: a session's prompt, scoped to its agent ('main' default). */
+/** Composite map key: a session's prompt, scoped to its agent (main default). */
 export function questionKey(sessionId: string, agentId?: string | undefined): string {
-  return `${sessionId}#${agentId ?? 'main'}`;
+  return `${sessionId}#${agentId ?? MAIN_AGENT_ID}`;
 }
 
 /** All pending questions belonging to a session, in insertion order. */

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -1,0 +1,57 @@
+/**
+ * Helpers for the client's pending-question collection (#437).
+ *
+ * Questions are keyed by `${sessionId}#${agentId}` so a main-agent prompt and a
+ * concurrent subagent prompt (#419) coexist in one map instead of overwriting
+ * each other, while a hook+PTY double-emit for ONE prompt (same agent) still
+ * collapses via the richer-wins guard. Pure functions, unit-tested directly.
+ */
+
+import type { UIQuestion } from '@/types';
+
+/** Composite map key: a session's prompt, scoped to its agent ('main' default). */
+export function questionKey(sessionId: string, agentId?: string | undefined): string {
+  return `${sessionId}#${agentId ?? 'main'}`;
+}
+
+/** All pending questions belonging to a session, in insertion order. */
+export function getSessionQuestions(
+  questions: ReadonlyMap<string, UIQuestion>,
+  sessionId: string,
+): UIQuestion[] {
+  const out: UIQuestion[] = [];
+  for (const q of questions.values()) {
+    if (q.sessionId === sessionId) out.push(q);
+  }
+  return out;
+}
+
+/** Whether a session has any pending question. */
+export function hasSessionQuestion(
+  questions: ReadonlyMap<string, UIQuestion>,
+  sessionId: string,
+): boolean {
+  for (const q of questions.values()) {
+    if (q.sessionId === sessionId) return true;
+  }
+  return false;
+}
+
+/**
+ * Return a map with all of a session's questions removed. Returns the SAME
+ * reference when nothing matched, so callers keep React's no-op-update
+ * optimization (`setQuestions(prev => clearSessionQuestions(prev, id))`).
+ */
+export function clearSessionQuestions(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+): Map<string, UIQuestion> {
+  const keys: string[] = [];
+  for (const [key, q] of questions) {
+    if (q.sessionId === sessionId) keys.push(key);
+  }
+  if (keys.length === 0) return questions;
+  const next = new Map(questions);
+  for (const key of keys) next.delete(key);
+  return next;
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -151,6 +151,9 @@ export interface UIQuestion {
   readonly timestamp: Timestamp;
   /** The answer that was selected (set after answering) */
   readonly answeredWith?: string;
+  /** The Claude agent this prompt belongs to ('main' default). Keys the
+   *  collection so a main + subagent prompt coexist rather than overwrite. */
+  readonly agentId?: string;
 }
 
 /** App settings */

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the client's composite-key question collection (#437). Pure
+ * functions; no mocks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  clearSessionQuestions,
+  getSessionQuestions,
+  hasSessionQuestion,
+  questionKey,
+} from '../../src/lib/question-collection';
+import type { UIQuestion } from '../../src/types';
+
+function q(sessionId: string, agentId: string | undefined, id: string): UIQuestion {
+  return {
+    id: id as UIQuestion['id'],
+    sessionId: sessionId as UIQuestion['sessionId'],
+    type: 'yes_no',
+    prompt: `${id}?`,
+    timestamp: '2026-05-29T00:00:00.000Z',
+    agentId,
+  };
+}
+
+function build(...items: UIQuestion[]): Map<string, UIQuestion> {
+  const m = new Map<string, UIQuestion>();
+  for (const item of items) m.set(questionKey(item.sessionId, item.agentId), item);
+  return m;
+}
+
+describe('questionKey', () => {
+  test('defaults agent to main', () => {
+    expect(questionKey('s1')).toBe('s1#main');
+    expect(questionKey('s1', undefined)).toBe('s1#main');
+  });
+  test('scopes by agent', () => {
+    expect(questionKey('s1', 'sub-7')).toBe('s1#sub-7');
+  });
+  test('main and a subagent get distinct keys for the same session', () => {
+    expect(questionKey('s1')).not.toBe(questionKey('s1', 'sub-7'));
+  });
+});
+
+describe('getSessionQuestions', () => {
+  test('returns all questions for a session across agents, in insertion order', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'), q('s2', undefined, 'c'));
+    const got = getSessionQuestions(map, 's1');
+    expect(got.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+  test('empty for an unknown session', () => {
+    expect(getSessionQuestions(build(q('s1', undefined, 'a')), 's2')).toEqual([]);
+  });
+});
+
+describe('hasSessionQuestion', () => {
+  test('true when any agent has a prompt for the session', () => {
+    expect(hasSessionQuestion(build(q('s1', 'sub-7', 'a')), 's1')).toBe(true);
+  });
+  test('false otherwise', () => {
+    expect(hasSessionQuestion(build(q('s1', undefined, 'a')), 's2')).toBe(false);
+  });
+});
+
+describe('clearSessionQuestions', () => {
+  test('removes all of a session, keeps others', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'), q('s2', undefined, 'c'));
+    const next = clearSessionQuestions(map, 's1');
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['c']);
+  });
+  test('returns the same reference when nothing matched (no-op update)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(clearSessionQuestions(map, 's2')).toBe(map);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the SessionEpoch reliability epic (#435). Replaces the single-slot question state at every layer so concurrent prompts (main agent + a subagent, #419) coexist, each is individually answerable, and answering one never drops the others as `STALE_ANSWER`. Daemon + web ship together (the protocol break below).

### Daemon
- `SessionRegistry`: `currentQuestion` scalar → `currentQuestions: Map<questionId, Question>` (bounded by `MAX_PENDING_QUESTIONS`); `add`/`remove`/`clear`/`get`. Restart teardown clears the collection.
- `onAnswer` validates **membership** and removes only the answered question; `STALE_ANSWER` only when the id isn't pending.
- `QuestionPresenceTracker.pending` → `Map` keyed by agent (`agentId||'main'`), so concurrent agents keep separate hook records; PTY pairing prefers the same agent, else most-recent (the #425 caveat: PTY output can't always name the agent). Hook bridge stamps `agentId` on emitted questions.

### Protocol (coordinated break; no shims)
- `Question` gains `agentId`; `QuestionMessage.sessionId` is now **mandatory** (client must never fall back to the active session). `createQuestion` + the `ConnectionAdapter.sendQuestion` signature require `sessionId`.

### Web
- `questions` map keyed by `${sessionId}#${agentId||main}` (`lib/question-collection.ts`); richer-wins still collapses a hook+PTY pair for one agent (#396), but different agents coexist.
- Removed the active-session attribution fallback (drop a question with no `sessionId` rather than misroute).
- `ChatView` renders a **stack** of `QuestionCard`s; `handleAnswer` routes by the specific question's own session/id and keeps the session flagged while siblings remain.

Closes #437. Subsumes #425; addresses #396 #401 #409 #377. Part of epic #435.

## Validation (real, no mocks)
- `question-collection` helpers; `QuestionPresenceTracker` per-agent pending + pairing + #425 most-recent fallback; daemon two-concurrent-questions (answer one → the other stays answerable, no STALE_ANSWER).
- Full suite green: **162 web, 1575 daemon (excl. auto-approve), 215 shared**. `tsc -b` clean (root + web); `biome` clean (one pre-existing `prefixMatches` warning, unrelated).

## Test plan
- [x] daemon + shared + web suites
- [x] typecheck (root + web), biome
- [ ] Live: drive a session with a main-agent permission prompt AND a subagent prompt concurrently; confirm both render in the stack and are independently answerable, and the first answer isn't dropped.

## Notes / out of scope
- #425 caveat (documented + tested): a PTY-only prompt can't always be attributed to a specific subagent; two simultaneous hook-less subagent prompts may still share the `main` slot. Bounded and rare; the PTY-presence gate still prevents off-screen pushes.
- Keeps discrete `question`/`answer` wire messages; folding this collection into the `SessionEpoch` object is Phase 4 (#439).