### PR TITLE
Phase 3: Atomic session_rotated on /clear|/resume + client transcript re-fetch

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -14,8 +14,9 @@
  *   2. **Transcript discovery via hooks.** Most events carry
  *      `transcript_path`; when present (and not shadowed by a sibling), we
  *      can start the watcher immediately instead of waiting for the
- *      2s mtime poll. A restart (/clear /compact /resume) tears down the
- *      old watcher and starts a fresh one.
+ *      2s mtime poll. A rotation (/clear or /resume — NOT /compact, which
+ *      keeps the same session id) tears down the old watcher, starts a fresh
+ *      one, and emits a single session_rotated event.
  *
  *   3. **Auto-approve gate.** PermissionRequest events are intercepted
  *      before they reach the user. If auto-approve returns approve/deny we
@@ -235,6 +236,7 @@ export function setupHookBridge(
     // rotation event silently never emits (#430 review #433).
     const previousClaudeSessionId = claudeSessionId;
     let isRotation = false;
+    let rotationAnnounced = false;
 
     // If the transcript-fallback has already discovered our Claude
     // session ID (the multi-wrapper-in-same-dir case), adopt it before
@@ -276,6 +278,28 @@ export function setupHookBridge(
       // collection so answers to the dead session's prompts are refused.
       tracker.clearPending();
       sessionRegistry.clearQuestions(sessionId);
+      // Announce the rotation NOW, before the sibling / no-transcript_path
+      // guards below can early-return. teardownWatcher already reset the
+      // client's view, so the client must learn of the rotation (clear +
+      // rebind + re-fetch) even when we can't (re)start the watcher yet — the
+      // sibling guard only defers WATCHER setup, not this notification. The
+      // flag suppresses the duplicate emit in the adopt block.
+      if (isRotation && input.transcript_path) {
+        try {
+          sendAndRecord(
+            createSessionRotated(
+              sessionId,
+              input.session_id as UUID,
+              input.transcript_path,
+              'restart',
+              previousClaudeSessionId ?? undefined,
+            ),
+          );
+          rotationAnnounced = true;
+        } catch (err) {
+          logError(`[Hooks] Failed to emit session_rotated (restart): ${errorToString(err)}`);
+        }
+      }
       claudeSessionId = null;
       mainSessionEnded = false;
       // isRotation was already computed above against the pre-adopt
@@ -301,8 +325,11 @@ export function setupHookBridge(
       // Announce the rotation as ONE atomic event so the client clears, swaps
       // the binding, and re-fetches the new transcript in a single step (#438).
       // Skip on first-init (not a rotation): that's covered by
-      // session_list_response / the queue-promotion hello_ack.
-      if (isRotation) {
+      // session_list_response / the queue-promotion hello_ack. Also skip if the
+      // restart branch already announced it (the common path); this covers the
+      // race-detector case where isRotation is true without a 'restart'
+      // classification (adoptLockFromStore got ahead of us).
+      if (isRotation && !rotationAnnounced) {
         try {
           sendAndRecord(
             createSessionRotated(

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -31,7 +31,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionReset, createTranscriptBindingChanged, errorToString } from '@remi/shared';
+import { createSessionRotated, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
@@ -202,12 +202,14 @@ export function setupHookBridge(
   };
 
   /**
-   * Safely tear down an existing transcript watcher, reset messages, and
-   * notify clients. Errors from stop() and sendAndRecord() are swallowed so
-   * they never prevent the new watcher from being created. Shared by
-   * initFromHookEvent and onSessionInfo.
+   * Safely tear down an existing transcript watcher and reset message state.
+   * Errors from stop() are swallowed so they never prevent the new watcher
+   * from being created. Does NOT emit a wire message: a rotation is announced
+   * by a single atomic `session_rotated` from the adopt path (#438), so the
+   * client clears + rebinds + re-fetches in one step rather than reacting to a
+   * separate reset. Shared by initFromHookEvent and onSessionInfo.
    */
-  function teardownWatcher(reason: string, label: string): void {
+  function teardownWatcher(label: string): void {
     const watcher = transcriptWatchers.get(sessionId);
     if (!watcher) return;
     transcriptWatchers.delete(sessionId); // Remove FIRST to unblock the new watcher.
@@ -217,11 +219,6 @@ export function setupHookBridge(
       logError(`[Hooks] Failed to stop watcher (${label}): ${errorToString(stopErr)}`);
     }
     messageApi.reset();
-    try {
-      sendAndRecord(createSessionReset(sessionId, reason));
-    } catch (sendErr) {
-      logError(`[Hooks] Failed to send ${reason} for ${sessionId}: ${errorToString(sendErr)}`);
-    }
   }
 
   function initFromHookEvent(input: {
@@ -272,7 +269,7 @@ export function setupHookBridge(
       log(
         `[Hooks] Claude restart detected (ended=${mainSessionEnded}): ${claudeSessionId} -> ${input.session_id}`,
       );
-      teardownWatcher('claude_restarted', 'restart');
+      teardownWatcher('restart');
       // Drop any hook record stashed before /clear or /compact: the new
       // Claude session's first PTY prompt must not merge stale option
       // labels from the dying session. Also drop the pending-question
@@ -301,24 +298,23 @@ export function setupHookBridge(
       );
       sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
 
-      // Notify clients of the binding rotation so they can rekey their
-      // (sessionId, claudeSessionId) composite state and refresh any
-      // displayed binding indicator. Skip on first-init: that's
-      // covered by session_list_response (and by hello_ack on the
-      // queue-promotion path; the initial first-connect hello_ack from
-      // connection.ts carries no binding by design).
+      // Announce the rotation as ONE atomic event so the client clears, swaps
+      // the binding, and re-fetches the new transcript in a single step (#438).
+      // Skip on first-init (not a rotation): that's covered by
+      // session_list_response / the queue-promotion hello_ack.
       if (isRotation) {
         try {
           sendAndRecord(
-            createTranscriptBindingChanged(
+            createSessionRotated(
               sessionId,
               claudeSessionId as UUID,
               input.transcript_path,
               'restart',
+              previousClaudeSessionId ?? undefined,
             ),
           );
         } catch (err) {
-          logError(`[Hooks] Failed to emit transcript_binding_changed: ${errorToString(err)}`);
+          logError(`[Hooks] Failed to emit session_rotated: ${errorToString(err)}`);
         }
       }
 
@@ -339,7 +335,7 @@ export function setupHookBridge(
         log(
           `[Hooks] Replacing stale watcher: ${existingWatcher.filePath} -> ${input.transcript_path}`,
         );
-        teardownWatcher('transcript_changed', 'stale-replace');
+        teardownWatcher('stale-replace');
       }
 
       if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {
@@ -391,7 +387,7 @@ export function setupHookBridge(
         log(
           `[Hooks] Claude restart (SessionInfo, ended=${mainSessionEnded}): ${claudeSessionId} -> ${hookClaudeSessionId}`,
         );
-        teardownWatcher('claude_restarted', 'restart-sessioninfo');
+        teardownWatcher('restart-sessioninfo');
         // Mirror the initFromHookEvent restart branch: drop any hook
         // record and the pending-question collection so the new session's
         // first PTY prompt cannot merge stale options, and stale answers
@@ -411,17 +407,16 @@ export function setupHookBridge(
         if (isRotation) {
           try {
             sendAndRecord(
-              createTranscriptBindingChanged(
+              createSessionRotated(
                 sessionId,
                 hookClaudeSessionId as UUID,
                 transcriptPath,
                 'restart',
+                previousClaudeSessionId ?? undefined,
               ),
             );
           } catch (err) {
-            logError(
-              `[Hooks] Failed to emit transcript_binding_changed (SessionInfo): ${errorToString(err)}`,
-            );
+            logError(`[Hooks] Failed to emit session_rotated (SessionInfo): ${errorToString(err)}`);
           }
         }
 
@@ -433,7 +428,7 @@ export function setupHookBridge(
           log(
             `[Hooks] Replacing stale watcher (SessionInfo): ${existingWatcher.filePath} -> ${transcriptPath}`,
           );
-          teardownWatcher('transcript_changed', 'stale-replace-sessioninfo');
+          teardownWatcher('stale-replace-sessioninfo');
         }
 
         if (!transcriptWatchers.has(sessionId) && sessionRegistry.hasSession(sessionId)) {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1720,7 +1720,7 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.questionCalls).toBe(0); // no escalate
   });
 
-  describe('transcript_binding_changed emission on rotation (#430)', () => {
+  describe('session_rotated emission on rotation (#430 #438)', () => {
     /**
      * Set up a hook bridge that captures every protocol message it tries
      * to send. We can't use the shared `build` helper because that swallows

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1782,10 +1782,10 @@ describe('setupHookBridge', () => {
         hook_event_name: 'SessionStart',
       });
 
-      expect(sent.filter((m) => m.type === 'transcript_binding_changed')).toHaveLength(0);
+      expect(sent.filter((m) => m.type === 'session_rotated')).toHaveLength(0);
     });
 
-    test('second SessionStart with a different id emits transcript_binding_changed', () => {
+    test('second SessionStart with a different id emits one session_rotated', () => {
       const { sent } = buildWithCapture();
       sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
         handleMessage: () => {},
@@ -1805,16 +1805,18 @@ describe('setupHookBridge', () => {
         hook_event_name: 'SessionStart',
       });
 
-      const events = sent.filter((m) => m.type === 'transcript_binding_changed') as Array<{
+      const events = sent.filter((m) => m.type === 'session_rotated') as Array<{
         sessionId: string;
-        claudeSessionId: string;
-        transcriptPath: string;
+        oldClaudeSessionId?: string;
+        newClaudeSessionId: string;
+        newTranscriptPath: string;
         reason: string;
       }>;
       expect(events).toHaveLength(1);
       expect(events[0]?.sessionId).toBe(SID);
-      expect(events[0]?.claudeSessionId).toBe('claude-second-id');
-      expect(events[0]?.transcriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
+      expect(events[0]?.oldClaudeSessionId).toBe('claude-first-id');
+      expect(events[0]?.newClaudeSessionId).toBe('claude-second-id');
+      expect(events[0]?.newTranscriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
       expect(events[0]?.reason).toBe('restart');
     });
   });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -85,9 +85,8 @@ export type {
   DetachSessionMessage,
   DetachSessionAckMessage,
   RegisterDeviceTokenMessage,
-  SessionResetMessage,
   DaemonUpdateAvailableMessage,
-  TranscriptBindingChangedMessage,
+  SessionRotatedMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -133,9 +132,8 @@ export {
   createDetachSession,
   createDetachSessionAck,
   createRegisterDeviceToken,
-  createSessionReset,
   createDaemonUpdateAvailable,
-  createTranscriptBindingChanged,
+  createSessionRotated,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -342,9 +342,10 @@ export interface SessionListResponseMessage {
  *
  * Replaces the former non-atomic pair `session_reset` + `transcript_binding_
  * changed`. On receipt, a client that owns this session clears its messages
- * and pending questions, swaps the binding to the new (claudeSessionId,
- * transcriptPath), re-fetches the new transcript, and un-stales any pending
- * question so the next answer carries the new id (no STALE_BINDING).
+ * AND all pending questions for the session (answers to the old session's
+ * prompts would be refused as STALE_BINDING anyway), swaps the binding to the
+ * new (claudeSessionId, transcriptPath), and re-fetches the new transcript so
+ * the next answer carries the new id.
  */
 export interface SessionRotatedMessage {
   readonly type: 'session_rotated';
@@ -1408,7 +1409,9 @@ export function createDaemonUpdateAvailable(
 /**
  * Create an atomic session-rotated notification (#438): the PTY's bound Claude
  * session rotated to a new transcript (`/clear` or `/resume`). Replaces the
- * former session_reset + transcript_binding_changed pair.
+ * former session_reset + transcript_binding_changed pair. `reason` is `'clear'`
+ * / `'resume'` when the triggering command is known; the hook-detection path
+ * currently can't distinguish them and passes `'restart'`.
  */
 export function createSessionRotated(
   sessionId: UUID,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -99,9 +99,8 @@ export type ProtocolMessage =
   | DetachSessionMessage
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
-  | SessionResetMessage
   | DaemonUpdateAvailableMessage
-  | TranscriptBindingChangedMessage;
+  | SessionRotatedMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -336,23 +335,31 @@ export interface SessionListResponseMessage {
 }
 
 /**
- * Notifies the client that the PTY's bound Claude session has changed,
- * e.g. user ran /resume or /clear inside the PTY (#429). Clients should
- * rekey UI state by the new (sessionId, claudeSessionId) tuple and update
- * any displayed binding indicator.
+ * One atomic rotation event (#438): the PTY's bound Claude session rotated —
+ * the user ran `/clear` or `/resume` inside the PTY, starting a NEW transcript
+ * under a new Claude session id. (`/compact` does NOT rotate — it keeps the
+ * same id and appends in place — so it never produces this message.)
+ *
+ * Replaces the former non-atomic pair `session_reset` + `transcript_binding_
+ * changed`. On receipt, a client that owns this session clears its messages
+ * and pending questions, swaps the binding to the new (claudeSessionId,
+ * transcriptPath), re-fetches the new transcript, and un-stales any pending
+ * question so the next answer carries the new id (no STALE_BINDING).
  */
-export interface TranscriptBindingChangedMessage {
-  readonly type: 'transcript_binding_changed';
+export interface SessionRotatedMessage {
+  readonly type: 'session_rotated';
   readonly id: UUID;
   readonly timestamp: Timestamp;
-  /** Remi session id whose binding rotated. */
+  /** Remi session id whose Claude binding rotated (unchanged across rotation). */
   readonly sessionId: UUID;
+  /** Claude session id before the rotation, if known. */
+  readonly oldClaudeSessionId?: UUID | undefined;
   /** The new Claude session id Claude is now writing under. */
-  readonly claudeSessionId: UUID;
+  readonly newClaudeSessionId: UUID;
   /** Absolute path to the new transcript .jsonl. */
-  readonly transcriptPath: string;
-  /** Diagnostic: 'restart' for /clear|/compact, 'resume' for /resume, 'unknown' otherwise. */
-  readonly reason: 'restart' | 'resume' | 'unknown';
+  readonly newTranscriptPath: string;
+  /** Diagnostic: what triggered the rotation. */
+  readonly reason: 'clear' | 'resume' | 'restart';
 }
 
 /** Token usage information from a transcript entry */
@@ -618,17 +625,6 @@ export interface DaemonUpdateAvailableMessage {
   readonly binaryPath: string;
 }
 
-/** Notification that a Claude session restarted within the same Remi session */
-export interface SessionResetMessage {
-  readonly type: 'session_reset';
-  readonly id: UUID;
-  readonly timestamp: Timestamp;
-  /** Remi session ID that was reset */
-  readonly sessionId: UUID;
-  /** Reason for the reset */
-  readonly reason: string;
-}
-
 /** A recent project directory aggregated from session history */
 export interface RecentDirectory {
   /** Absolute path */
@@ -738,8 +734,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'detach_session_ack',
     'register_device_token',
     'daemon_update_available',
-    'session_reset',
-    'transcript_binding_changed',
+    'session_rotated',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1411,35 +1406,25 @@ export function createDaemonUpdateAvailable(
 }
 
 /**
- * Create a session reset notification (Claude restarted within the same Remi session).
+ * Create an atomic session-rotated notification (#438): the PTY's bound Claude
+ * session rotated to a new transcript (`/clear` or `/resume`). Replaces the
+ * former session_reset + transcript_binding_changed pair.
  */
-export function createSessionReset(sessionId: UUID, reason: string): SessionResetMessage {
-  return {
-    type: 'session_reset',
-    id: generateId(),
-    timestamp: now(),
-    sessionId,
-    reason,
-  };
-}
-
-/**
- * Create a transcript-binding-changed notification (PTY's bound Claude
- * session UUID rotated, e.g. /resume, /clear).
- */
-export function createTranscriptBindingChanged(
+export function createSessionRotated(
   sessionId: UUID,
-  claudeSessionId: UUID,
-  transcriptPath: string,
-  reason: 'restart' | 'resume' | 'unknown' = 'unknown',
-): TranscriptBindingChangedMessage {
+  newClaudeSessionId: UUID,
+  newTranscriptPath: string,
+  reason: 'clear' | 'resume' | 'restart' = 'restart',
+  oldClaudeSessionId?: UUID,
+): SessionRotatedMessage {
   return {
-    type: 'transcript_binding_changed',
+    type: 'session_rotated',
     id: generateId(),
     timestamp: now(),
     sessionId,
-    claudeSessionId,
-    transcriptPath,
+    ...(oldClaudeSessionId !== undefined && { oldClaudeSessionId }),
+    newClaudeSessionId,
+    newTranscriptPath,
     reason,
   };
 }

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -10,7 +10,7 @@ import {
   createAnswer,
   createHelloAck,
   createQuestion,
-  createTranscriptBindingChanged,
+  createSessionRotated,
   createUserInput,
   deserialize,
   serialize,
@@ -80,23 +80,27 @@ describe('binding fields on the wire (#429)', () => {
     expect(round.content).toBe('ls');
   });
 
-  test('transcript_binding_changed event round-trips with all fields', () => {
-    const msg = createTranscriptBindingChanged(
+  test('session_rotated event round-trips with all fields', () => {
+    const OLD = 'claude00-0000-0000-0000-00000000000a' as UUID;
+    const msg = createSessionRotated(
       RID,
       CID,
       '/home/u/.claude/projects/-x/abc.jsonl',
       'resume',
+      OLD,
     );
     const round = deserialize(serialize(msg));
-    if (round?.type !== 'transcript_binding_changed') throw new Error('wrong type');
+    if (round?.type !== 'session_rotated') throw new Error('wrong type');
     expect(round.sessionId).toBe(RID);
-    expect(round.claudeSessionId).toBe(CID);
-    expect(round.transcriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
+    expect(round.newClaudeSessionId).toBe(CID);
+    expect(round.oldClaudeSessionId).toBe(OLD);
+    expect(round.newTranscriptPath).toBe('/home/u/.claude/projects/-x/abc.jsonl');
     expect(round.reason).toBe('resume');
   });
 
-  test('transcript_binding_changed defaults reason to "unknown"', () => {
-    const msg = createTranscriptBindingChanged(RID, CID, '/x.jsonl');
-    expect(msg.reason).toBe('unknown');
+  test('session_rotated defaults reason to "restart" and omits old id when absent', () => {
+    const msg = createSessionRotated(RID, CID, '/x.jsonl');
+    expect(msg.reason).toBe('restart');
+    expect('oldClaudeSessionId' in msg).toBe(false);
   });
 });

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -103,4 +103,10 @@ describe('binding fields on the wire (#429)', () => {
     expect(msg.reason).toBe('restart');
     expect('oldClaudeSessionId' in msg).toBe(false);
   });
+
+  test('session_rotated round-trips reason "clear"', () => {
+    const round = deserialize(serialize(createSessionRotated(RID, CID, '/x.jsonl', 'clear')));
+    if (round?.type !== 'session_rotated') throw new Error('wrong type');
+    expect(round.reason).toBe('clear');
+  });
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -413,13 +413,35 @@ function App() {
         break;
       }
 
-      case 'session_reset': {
-        // Claude restarted in the same directory; clear old messages and questions
-        const resetSessionId = message.sessionId;
-        if (resetSessionId) {
-          setMessages((prev) => prev.filter((m) => m.sessionId !== resetSessionId));
-          setQuestions((prev) => clearSessionQuestions(prev, resetSessionId));
-        }
+      case 'session_rotated': {
+        // Atomic rotation (#438): /clear or /resume started a NEW transcript
+        // under a new Claude session id (NOT /compact, which keeps the same
+        // id). Only applies to a session THIS connection owns. Clear the stale
+        // messages + questions, swap the binding, and clear loadedTranscriptsRef
+        // so the new transcript re-fetches — otherwise the old chat lingers and
+        // the next answer is refused as STALE_BINDING ("not from this session").
+        const rotatedId = message.sessionId;
+        const owns = sessionsRef.current.some(
+          (s) => s.id === rotatedId && s.connectionId === connectionId,
+        );
+        if (!owns) break; // sibling connection's session, or none: not ours.
+        setMessages((prev) => prev.filter((m) => m.sessionId !== rotatedId));
+        setQuestions((prev) => clearSessionQuestions(prev, rotatedId));
+        loadedTranscriptsRef.current.delete(rotatedId);
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === rotatedId && s.connectionId === connectionId
+              ? {
+                  ...s,
+                  claudeSessionId: message.newClaudeSessionId as string,
+                  transcriptPath: message.newTranscriptPath,
+                }
+              : s,
+          ),
+        );
+        console.info(
+          `[App] session_rotated ${rotatedId.slice(0, 8)} on ${connectionId}: claude=${message.newClaudeSessionId.slice(0, 8)} reason=${message.reason}`,
+        );
         break;
       }
 
@@ -842,49 +864,6 @@ function App() {
           isEditing: false,
         };
         setMessages((prev) => [...prev, errorMsg]);
-        break;
-      }
-
-      case 'transcript_binding_changed': {
-        // Daemon-side rotation (/clear, /compact, /resume inside the PTY).
-        // Update the session's bound (claudeSessionId, transcriptPath) so
-        // future outbound answers carry the new id and the chat header
-        // shows the updated binding.
-        //
-        // Daemon-side broadcast (registry.broadcast) fans this event to
-        // every connection on this adapter, but a connection only "owns"
-        // sessions it created. Sessions are stored with their owning
-        // connectionId, so a session belonging to a SIBLING connection
-        // (or none at all) is correctly filtered out here. We
-        // intentionally don't warn in that case: it's not an error, just
-        // an event that doesn't apply to this connection's state.
-        // Only warn if a session matches the id on THIS connection but
-        // the binding is unexpectedly absent.
-        let matched = false;
-        let sessionExistedOnThisConnection = false;
-        setSessions((prev) =>
-          prev.map((s) => {
-            if (s.id === message.sessionId && s.connectionId === connectionId) {
-              sessionExistedOnThisConnection = true;
-              matched = true;
-              return {
-                ...s,
-                claudeSessionId: message.claudeSessionId as string,
-                transcriptPath: message.transcriptPath,
-              };
-            }
-            return s;
-          }),
-        );
-        if (matched) {
-          console.info(
-            `[App] Binding rotated for session ${message.sessionId.slice(0, 8)} on ${connectionId}: claude=${(message.claudeSessionId as string).slice(0, 8)} reason=${message.reason}`,
-          );
-        } else if (sessionExistedOnThisConnection) {
-          console.warn(
-            `[App] transcript_binding_changed: session ${message.sessionId.slice(0, 8)} on ${connectionId} could not be updated; session list may be stale`,
-          );
-        }
         break;
       }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -424,7 +424,16 @@ function App() {
         const owns = sessionsRef.current.some(
           (s) => s.id === rotatedId && s.connectionId === connectionId,
         );
-        if (!owns) break; // sibling connection's session, or none: not ours.
+        if (!owns) {
+          // Usually a sibling connection's session (not ours) — expected and
+          // benign. The rare exception is a rotation arriving in the same tick
+          // as the session's hello_ack, before sessionsRef commits; log so that
+          // case is diagnosable rather than a silent dropped rotation.
+          console.warn(
+            `[App] session_rotated for ${rotatedId.slice(0, 8)} not owned by ${connectionId} (sibling, or hello_ack not yet committed)`,
+          );
+          break;
+        }
         setMessages((prev) => prev.filter((m) => m.sessionId !== rotatedId));
         setQuestions((prev) => clearSessionQuestions(prev, rotatedId));
         loadedTranscriptsRef.current.delete(rotatedId);


### PR DESCRIPTION
## Summary

Phase 3 of the SessionEpoch reliability epic (#435). Fixes the "messages not from this session" experience after `/clear` (and `/resume`): the daemon now emits ONE atomic rotation event and the client re-fetches the new transcript instead of lingering on the old one.

Validated (real Claude Code 2.1.156): `/clear` and `/resume` rotate the `session_id` and start a new `<uuid>.jsonl`; `/compact` does NOT (same id, in-place append), so it must — and does — emit nothing.

### Protocol
- Add `SessionRotatedMessage { sessionId, oldClaudeSessionId?, newClaudeSessionId, newTranscriptPath, reason }` + `createSessionRotated`. **Remove** `SessionResetMessage` + `TranscriptBindingChangedMessage` (factories, union, validTypes, exports). One atomic message replaces the former non-atomic pair.

### Daemon
- `hook-bridge-setup`: `teardownWatcher` now only stops the watcher + resets messages (no wire message); the adopt-on-rotation path emits ONE `session_rotated` with old+new ids and the new path.

### Web
- `App.tsx`: one `session_rotated` handler replaces the `session_reset` + `transcript_binding_changed` handlers. For a session this connection owns it clears messages + questions, swaps the binding, and **clears `loadedTranscriptsRef`** so the NEW transcript re-fetches (fixes the lingering old chat and the STALE_BINDING-on-next-answer that read as "not from this session").

Part of #438. (The remaining **no-hooks** path — a re-arming transcript-dir detector — is deferred to #442 with rationale; it targets an unconfirmed deployment class and is the riskiest piece, so it ships as its own reviewed change. The hooks-installed common case this PR fixes is what users hit.)

## Validation (real, no mocks)
- `session_rotated` round-trip (old/new ids, new path, reason). Hook-bridge emits exactly one `session_rotated` on a new-id SessionStart (old+new), none on first-init.
- Full suite green: **162 web, 1581 daemon (excl. auto-approve), 214 shared**. `tsc -b` clean (root + web); `biome` clean (pre-existing `prefixMatches` warning only).

## Test plan
- [x] shared/daemon/web suites, typecheck, biome
- [ ] Live (PTY harness): `/clear` with hooks ON → exactly one `session_rotated`, chat re-fetches the NEW transcript, next answer not STALE_BINDING; `/compact` → no rotation event, chat continues. Hooks-OFF `/clear` rotation is the deferred #442.

## Notes
- Minor: the stale-watcher-replace-on-first-init edge (a no-hooks fallback claiming a wrong file before the hook arrives) no longer sends a client reset (teardownWatcher is silent now). Rare; the authoritative watcher re-streams correct data, and a true rotation still emits `session_rotated`.