### PR TITLE
Phase 4: reconnect-mid-rotation reconcile (#439)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
   questionKey,
 } from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
+import { bindingRotated } from '@/lib/session-binding';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
@@ -202,6 +203,16 @@ function App() {
 
   // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
   const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
+    // Drop a session's now-orphaned chat so its (new) transcript re-fetches.
+    // Shared by session_rotated (live rotation) and hello_ack
+    // (reconnect-mid-rotation, #439): both clear stale messages + questions and
+    // forget the loaded-transcript marker so the load gate re-pulls history.
+    const clearSessionForRebind = (sid: string) => {
+      setMessages((prev) => prev.filter((m) => m.sessionId !== sid));
+      setQuestions((prev) => clearSessionQuestions(prev, sid));
+      loadedTranscriptsRef.current.delete(sid);
+    };
+
     switch (message.type) {
       case 'hello_ack': {
         // The attached session from this daemon. Additional sessions may arrive via session_list_response.
@@ -220,6 +231,13 @@ function App() {
           message.transcriptPath === undefined || message.transcriptPath === null
             ? undefined
             : (message.transcriptPath as string);
+        // Capture the binding we held BEFORE this ack so we can detect a
+        // rotation that happened while we were disconnected (#439). If Claude
+        // rotated (/clear, /resume) while away, the remi session id is
+        // unchanged but its claudeSessionId differs from the one we last saw.
+        const prevClaudeSessionId = sessionsRef.current.find(
+          (s) => s.id === message.sessionId && s.connectionId === connectionId,
+        )?.claudeSessionId;
         setSessions((prev) => {
           // On reconnect, remove stale sessions from this connection that have a different
           // session ID (the daemon may have assigned a new session). Keep sessions from
@@ -260,6 +278,13 @@ function App() {
             } satisfies UISession,
           ];
         });
+        // Reconnect-mid-rotation: the binding changed while we were away, so the
+        // chat on screen belongs to the OLD Claude session. Reconcile exactly
+        // like a live session_rotated, clear it so the new transcript loads
+        // (the setSessions above already swapped the binding) (#439).
+        if (bindingRotated(prevClaudeSessionId, ackClaudeSessionId)) {
+          clearSessionForRebind(message.sessionId);
+        }
         localStorage.setItem(LOCALSTORAGE_SESSION_KEY, message.sessionId);
 
         // Pin sessionId -> daemon URL so cold-start push answers route to the
@@ -434,9 +459,7 @@ function App() {
           );
           break;
         }
-        setMessages((prev) => prev.filter((m) => m.sessionId !== rotatedId));
-        setQuestions((prev) => clearSessionQuestions(prev, rotatedId));
-        loadedTranscriptsRef.current.delete(rotatedId);
+        clearSessionForRebind(rotatedId);
         setSessions((prev) =>
           prev.map((s) =>
             s.id === rotatedId && s.connectionId === connectionId

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -235,9 +235,18 @@ function App() {
         // rotation that happened while we were disconnected (#439). If Claude
         // rotated (/clear, /resume) while away, the remi session id is
         // unchanged but its claudeSessionId differs from the one we last saw.
+        // This read must precede the setSessions enqueue below, which is what
+        // overwrites the binding.
         const prevClaudeSessionId = sessionsRef.current.find(
           (s) => s.id === message.sessionId && s.connectionId === connectionId,
         )?.claudeSessionId;
+        // Reconnect-mid-rotation: the binding changed while we were away, so the
+        // chat on screen belongs to the OLD Claude session. Clear it first, then
+        // let the setSessions below swap the binding. Same effect as a live
+        // session_rotated, which also clears before swapping (#439).
+        if (bindingRotated(prevClaudeSessionId, ackClaudeSessionId)) {
+          clearSessionForRebind(message.sessionId);
+        }
         setSessions((prev) => {
           // On reconnect, remove stale sessions from this connection that have a different
           // session ID (the daemon may have assigned a new session). Keep sessions from
@@ -278,13 +287,6 @@ function App() {
             } satisfies UISession,
           ];
         });
-        // Reconnect-mid-rotation: the binding changed while we were away, so the
-        // chat on screen belongs to the OLD Claude session. Reconcile exactly
-        // like a live session_rotated, clear it so the new transcript loads
-        // (the setSessions above already swapped the binding) (#439).
-        if (bindingRotated(prevClaudeSessionId, ackClaudeSessionId)) {
-          clearSessionForRebind(message.sessionId);
-        }
         localStorage.setItem(LOCALSTORAGE_SESSION_KEY, message.sessionId);
 
         // Pin sessionId -> daemon URL so cold-start push answers route to the

--- a/packages/web/src/lib/session-binding.ts
+++ b/packages/web/src/lib/session-binding.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for reconciling the client's view of a session's Claude binding.
+ *
+ * A `/clear` or `/resume` rotates Claude's session id; while the client is
+ * connected this arrives as a `session_rotated` event. But if the client was
+ * DISCONNECTED when it happened, it misses that broadcast — and learns the new
+ * binding only from the `hello_ack` on reconnect. This helper detects that
+ * "binding changed while we were away" case so the chat can re-fetch the new
+ * transcript instead of lingering on the old one (#439).
+ */
+
+/**
+ * True when a reconnect's `hello_ack` reveals the Claude binding rotated while
+ * the client was away, so the session's stale chat must be cleared and
+ * re-fetched. False on first-connect (no prior binding — nothing stale), on a
+ * steady reconnect (same id), and when the ack omits the binding (older daemon
+ * — nothing to reconcile against).
+ */
+export function bindingRotated(
+  prevClaudeSessionId: string | undefined,
+  ackClaudeSessionId: string | undefined,
+): boolean {
+  return (
+    prevClaudeSessionId !== undefined &&
+    ackClaudeSessionId !== undefined &&
+    prevClaudeSessionId !== ackClaudeSessionId
+  );
+}

--- a/packages/web/src/lib/session-binding.ts
+++ b/packages/web/src/lib/session-binding.ts
@@ -1,20 +1,21 @@
 /**
  * Helpers for reconciling the client's view of a session's Claude binding.
  *
- * A `/clear` or `/resume` rotates Claude's session id; while the client is
- * connected this arrives as a `session_rotated` event. But if the client was
- * DISCONNECTED when it happened, it misses that broadcast — and learns the new
- * binding only from the `hello_ack` on reconnect. This helper detects that
- * "binding changed while we were away" case so the chat can re-fetch the new
- * transcript instead of lingering on the old one (#439).
+ * A `/clear` or `/resume` rotates Claude's session id (but not `/compact`,
+ * which keeps the same id); while the client is connected this arrives as a
+ * `session_rotated` event. But if the client was DISCONNECTED when it happened,
+ * it misses that broadcast and learns the new binding only from the `hello_ack`
+ * on reconnect. This helper detects that "binding changed while we were away"
+ * case so the chat can re-fetch the new transcript instead of lingering on the
+ * old one (#439).
  */
 
 /**
  * True when a reconnect's `hello_ack` reveals the Claude binding rotated while
  * the client was away, so the session's stale chat must be cleared and
- * re-fetched. False on first-connect (no prior binding — nothing stale), on a
- * steady reconnect (same id), and when the ack omits the binding (older daemon
- * — nothing to reconcile against).
+ * re-fetched. False on first-connect (no prior binding, nothing stale), on a
+ * steady reconnect (same id), and when the ack omits the binding (older daemon,
+ * nothing to reconcile against).
  */
 export function bindingRotated(
   prevClaudeSessionId: string | undefined,

--- a/packages/web/tests/lib/session-binding.test.ts
+++ b/packages/web/tests/lib/session-binding.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for bindingRotated (#439). Pure function; no mocks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { bindingRotated } from '../../src/lib/session-binding';
+
+describe('bindingRotated', () => {
+  test('true when a prior binding existed and the ack differs (rotated while away)', () => {
+    expect(bindingRotated('claude-old', 'claude-new')).toBe(true);
+  });
+
+  test('false on first-connect (no prior binding)', () => {
+    expect(bindingRotated(undefined, 'claude-new')).toBe(false);
+  });
+
+  test('false on a steady reconnect (same id)', () => {
+    expect(bindingRotated('claude-same', 'claude-same')).toBe(false);
+  });
+
+  test('false when the ack omits the binding (older daemon)', () => {
+    expect(bindingRotated('claude-old', undefined)).toBe(false);
+  });
+
+  test('false when neither side has a binding', () => {
+    expect(bindingRotated(undefined, undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Final phase of the SessionEpoch reliability epic (#435). Targeted hardening for the one residual gap left after Phases 1-3: if Claude rotates its session (`/clear`, `/resume`) while a client is **disconnected**, that client misses the live `session_rotated` broadcast. On reconnect the `hello_ack` already updated the session's binding (`claudeSessionId` / `transcriptPath`), so the next answer wouldn't be refused with STALE_BINDING, but the stale messages and `loadedTranscriptsRef` were never cleared, so the chat kept showing the OLD transcript and never re-fetched the new one.

Now a reconnect that observes a changed binding self-heals exactly like a live `session_rotated`.

## Changes

- New pure helper `packages/web/src/lib/session-binding.ts` (`bindingRotated`): true only when a prior binding existed and the ack's `claudeSessionId` is present and differs. False on first-connect (nothing stale), steady reconnect (same id), and older daemons that omit the binding.
- `App.tsx` `hello_ack` handler: captures the pre-ack `claudeSessionId` before `setSessions`, and after the binding swap clears the session's chat (messages + questions + `loadedTranscriptsRef`) when `bindingRotated` is true so the new transcript re-fetches.
- Factored the shared "clear a session for rebind" path into one local `clearSessionForRebind(sid)` used by both `session_rotated` (live) and the new `hello_ack` branch, so the two cannot drift.
- Daemon: confirmed `session_list_response` already populates the live session's `claudeSessionId` / `transcriptPath` (`cli.ts` 1653-1660); no change needed.

## Descoped (no follow-up)

The full SessionEpoch object refactor (epoch integer, one-owner module, `(connectionId, epoch)` re-keying) was descoped as YAGNI: the `claudeSessionId`-based binding + `guardBinding` already deliver the correctness, and re-architecting the most-tested daemon module carried high regression risk for no user payoff.

## Test plan

- [x] New `tests/lib/session-binding.test.ts`: 5 cases for `bindingRotated` (rotated-while-away true; first-connect, steady-reconnect, ack-absent, neither-present all false). No mocks.
- [x] Full web suite: 156 pass, 0 fail.
- [x] `bunx biome check` clean on all changed files.
- [x] `bun run typecheck` exit 0 (shared + daemon + web + signaling).

Closes #439
Part of epic #435