### PR TITLE
feat(web): reimagined UI redesign (sessions, chat, connect)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,8 @@
         "@capacitor/network": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/status-bar": "^8.0.1",
+        "@fontsource-variable/inter-tight": "^5.2.7",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@remi/shared": "workspace:*",
         "@tailwindcss/vite": "^4.1.18",
         "clsx": "^2.1.1",
@@ -265,6 +267,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource-variable/inter-tight": ["@fontsource-variable/inter-tight@5.2.7", "", {}, "sha512-uU0qW9vlzVQQv8GVrhn8SlNl2A44C0CE9IC6N9P0D9mwhmJcg8UF/fxvmdRayDPlMAnYqxlXtYENDIeZyVvxkg=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
 
     "@grammyjs/types": ["@grammyjs/types@3.23.0", "", {}, "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.5.3-dev.4",
+  "version": "0.5.3-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.5.3-dev.4'; // REMI_COMPILED_VERSION
+      return '0.5.3-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.5.3-dev.4'; // REMI_COMPILED_VERSION
+    return '0.5.3-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,8 @@
     "@capacitor/network": "^8.0.1",
     "@capacitor/push-notifications": "^8.0.3",
     "@capacitor/status-bar": "^8.0.1",
+    "@fontsource-variable/inter-tight": "^5.2.7",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
     "konsta": "^5.0.6",

--- a/packages/web/src/components/StatusPill.tsx
+++ b/packages/web/src/components/StatusPill.tsx
@@ -1,0 +1,98 @@
+/**
+ * StatusPill component.
+ *
+ * Renders one of five session states (asking / working / idle / connecting /
+ * offline). Kept framework-light with inline styles so the exact palette from
+ * the design system is honored regardless of Tailwind purge. State derivation
+ * + name splitting live in `@/lib/session-display`.
+ */
+
+import type { PillState } from '@/lib/session-display';
+
+interface PillConfig {
+  readonly label: string;
+  readonly dot: string;
+  readonly fg: string;
+  readonly bg: string;
+  readonly pulse: boolean;
+}
+
+const PILL: Record<PillState, PillConfig> = {
+  asking: {
+    label: 'Needs you',
+    dot: 'var(--color-primary)',
+    fg: 'var(--color-primary)',
+    bg: 'var(--color-accent-soft)',
+    pulse: false,
+  },
+  working: {
+    label: 'Working',
+    dot: 'var(--color-text-secondary)',
+    fg: 'var(--color-text-secondary)',
+    bg: 'var(--color-surface-elevated)',
+    pulse: true,
+  },
+  connecting: {
+    label: 'Connecting',
+    dot: 'var(--color-warning)',
+    fg: 'var(--color-warning)',
+    bg: 'transparent',
+    pulse: true,
+  },
+  offline: {
+    label: 'Offline',
+    dot: 'var(--color-error)',
+    fg: 'var(--color-error)',
+    bg: 'transparent',
+    pulse: false,
+  },
+  idle: {
+    label: 'Idle',
+    dot: 'var(--color-text-muted)',
+    fg: 'var(--color-text-muted)',
+    bg: 'transparent',
+    pulse: false,
+  },
+};
+
+export function StatusPill({
+  state,
+  className,
+}: {
+  readonly state: PillState;
+  readonly className?: string;
+}) {
+  const c = PILL[state];
+  return (
+    <span
+      className={className}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '3px 9px 3px 8px',
+        borderRadius: 999,
+        background: c.bg,
+        color: c.fg,
+        fontSize: 11,
+        fontWeight: 600,
+        lineHeight: 1,
+        height: 20,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 99,
+          background: c.dot,
+          // currentColor drives the pulse-dot box-shadow ring.
+          color: c.dot,
+          animation: c.pulse ? 'pulse-dot 1.6s ease-out infinite' : undefined,
+        }}
+      />
+      {c.label}
+    </span>
+  );
+}

--- a/packages/web/src/components/StatusPill.tsx
+++ b/packages/web/src/components/StatusPill.tsx
@@ -11,6 +11,8 @@ import type { PillState } from '@/lib/session-display';
 
 interface PillConfig {
   readonly label: string;
+  // `dot` and `fg` are separate fields (currently always equal) so a future
+  // design can tint the dot independently of the label text.
   readonly dot: string;
   readonly fg: string;
   readonly bg: string;

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -1,55 +1,35 @@
 /**
  * ChatHeader component.
  *
- * Displays session info, status, and actions.
+ * Blurred top bar for the chat screen: back, optional sessions switcher,
+ * host/project + branch + a status pill, plus a detach button and a "more"
+ * dropdown (copy / export / detach / clear).
  */
 
-import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
+import { StatusPill } from '@/components/StatusPill';
+import { sessionPillState, splitSessionName } from '@/lib/session-display';
+import type { UISession } from '@/types';
+import { clsx } from 'clsx';
+import {
+  ChevronLeft,
+  Copy,
+  FileText,
+  Layers,
+  LogOut,
+  MoreVertical,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-/**
- * Extract a short "port :<num>" label from a ConnectionId of shape
- * "host:port" so the binding indicator stays compact on mobile. Falls
- * back to the raw id when no colon is present.
- */
+/** "host:port" -> ":port" for the compact binding indicator. */
 function extractDaemonPortLabel(connectionId: string): string {
   const colonIdx = connectionId.lastIndexOf(':');
   if (colonIdx === -1) return connectionId;
   return `:${connectionId.slice(colonIdx + 1)}`;
 }
 
-/** Strip hostname prefix from session name for display */
-function formatSessionName(name: string): string {
-  let display = name.replace(/^[^:]+:/, '');
-  const slashIdx = display.indexOf('/');
-  if (slashIdx >= 0 && display.length > slashIdx + 16) {
-    display = `${display.slice(0, slashIdx + 16)}...`;
-  }
-  return display || name;
-}
-import { clsx } from 'clsx';
-import {
-  AlertCircle,
-  ArrowLeft,
-  Brain,
-  Clock,
-  Copy,
-  FileText,
-  Layers,
-  Loader2,
-  LogOut,
-  MoreVertical,
-  Terminal,
-  Trash2,
-  Wifi,
-  WifiOff,
-} from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ViewMode } from './ChatView';
-
 interface ChatHeaderProps {
   readonly session: UISession;
-  readonly viewMode?: ViewMode;
-  readonly onViewModeChange?: (mode: ViewMode) => void;
   readonly onBack?: () => void;
   readonly onOpenSessions?: () => void;
   readonly sessionCount?: number;
@@ -59,68 +39,6 @@ interface ChatHeaderProps {
   readonly onExportText?: () => void;
   readonly onDetach?: () => void;
   readonly className?: string;
-}
-
-/** Connection status indicator */
-function ConnectionIndicator({
-  status,
-}: {
-  readonly status: ConnectionStatus;
-}) {
-  switch (status) {
-    case 'connected':
-      return <Wifi className="size-4 text-[var(--color-success)]" />;
-    case 'connecting':
-    case 'reconnecting':
-      return <Loader2 className="size-4 animate-spin text-[var(--color-warning)]" />;
-    case 'error':
-    case 'unreachable':
-      return <AlertCircle className="size-4 text-[var(--color-error)]" />;
-    case 'disconnected':
-    default:
-      return <WifiOff className="size-4 text-[var(--color-text-muted)]" />;
-  }
-}
-
-/** Agent status indicator */
-function AgentStatusIndicator({ status }: { readonly status: AgentStatus }) {
-  const statusConfig = {
-    idle: {
-      icon: Clock,
-      label: 'Idle',
-      color: 'text-[var(--color-text-muted)]',
-    },
-    thinking: {
-      icon: Brain,
-      label: 'Thinking...',
-      color: 'text-[var(--color-warning)]',
-    },
-    executing: {
-      icon: Terminal,
-      label: 'Executing...',
-      color: 'text-[var(--color-primary)]',
-    },
-    waiting: {
-      icon: Clock,
-      label: 'Waiting for input',
-      color: 'text-[var(--color-success)]',
-    },
-  };
-
-  const config = statusConfig[status];
-  const Icon = config.icon;
-
-  return (
-    <div className={clsx('flex items-center gap-1 text-xs', config.color)}>
-      <Icon
-        className={clsx(
-          'size-3',
-          (status === 'thinking' || status === 'executing') && 'animate-pulse',
-        )}
-      />
-      <span>{config.label}</span>
-    </div>
-  );
 }
 
 export function ChatHeader({
@@ -137,24 +55,21 @@ export function ChatHeader({
 }: ChatHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-
+  const { host, project, branch } = splitSessionName(session);
+  const state = sessionPillState(session);
   const hasMenuActions = onCopyConversation || onClearMessages || onExportText || onDetach;
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
-  // Close menu on outside click
   useEffect(() => {
     if (!menuOpen) return;
     const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        closeMenu();
-      }
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) closeMenu();
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [menuOpen, closeMenu]);
 
-  // Close menu on Escape key
   useEffect(() => {
     if (!menuOpen) return;
     const handler = (e: KeyboardEvent) => {
@@ -167,66 +82,58 @@ export function ChatHeader({
   return (
     <header
       className={clsx(
-        'flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3',
-        'safe-area-top',
+        'safe-area-top sticky top-0 z-10 flex items-center gap-1.5 border-b border-[var(--color-border)] px-3 pb-2.5',
+        'bg-[var(--color-surface)]/90 backdrop-blur-xl',
         className,
       )}
     >
-      {/* Back button */}
       {onBack && (
         <button
+          type="button"
           onClick={onBack}
-          className="shrink-0 rounded-full p-2 text-[var(--color-primary)] transition-colors hover:bg-[var(--color-surface-light)]"
+          className="inline-flex size-9 shrink-0 items-center justify-center rounded-[10px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-light)]"
           aria-label="Go back"
         >
-          <ArrowLeft className="size-5" />
+          <ChevronLeft className="size-[22px]" />
         </button>
       )}
 
-      {/* Sessions button */}
       {onOpenSessions && sessionCount > 1 && (
         <button
+          type="button"
           onClick={onOpenSessions}
-          className="relative rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+          className="relative inline-flex size-9 shrink-0 items-center justify-center rounded-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
           aria-label="Open sessions"
         >
           <Layers className="size-5" />
           {totalUnread > 0 && (
-            <span className="absolute -right-0.5 -top-0.5 flex min-w-[1rem] items-center justify-center rounded-full bg-[var(--color-primary)] px-1 text-[9px] font-bold leading-4 text-white">
+            <span
+              className="absolute -right-0.5 -top-0.5 inline-flex min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold leading-4"
+              style={{ background: 'var(--color-primary)', color: 'var(--color-accent-ink)' }}
+            >
               {totalUnread > 9 ? '9+' : totalUnread}
             </span>
           )}
         </button>
       )}
 
-      {/* Session info */}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <h1 className="truncate font-medium text-[var(--color-text)]">
-            {formatSessionName(session.name || 'Claude Session')}
-          </h1>
-          <ConnectionIndicator status={session.connectionStatus} />
+      {/* Session identity */}
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-mono text-[11px] text-[var(--color-text-muted)]">
+          {host}
+          <span>/</span>
+          {project}
         </div>
-        <div className="flex items-center gap-2">
-          <AgentStatusIndicator status={session.status} />
-          {session.cwd && (
-            <>
-              <span className="text-[var(--color-text-muted)]">|</span>
-              <span className="truncate text-xs text-[var(--color-text-muted)]">{session.cwd}</span>
-            </>
-          )}
+        <div className="mt-px flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-base font-bold tracking-tight text-[var(--color-text)]">
+            {branch || project}
+          </span>
+          <StatusPill state={state} className="shrink-0" />
         </div>
-        {/* Transcript binding indicator (#430). The "port:short-uuid"
-            pair is the UX surface for the cross-daemon routing fix
-            (#427): the user can visually confirm which transcript a
-            session is bound to. The actual routing safety net is the
-            daemon-side STALE_BINDING guard from phase 2 (#432). The
-            onClick handler copies the full path to clipboard; the
-            title attribute is the hover tooltip on desktop. */}
         {session.claudeSessionId && (
           <button
             type="button"
-            className="mt-0.5 truncate text-left text-[10px] font-mono text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
+            className="mt-0.5 max-w-full truncate text-left font-mono text-[10px] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-secondary)]"
             title={
               session.transcriptPath
                 ? `Claude session ${session.claudeSessionId}\nTranscript: ${session.transcriptPath}\nClick to copy path`
@@ -235,9 +142,6 @@ export function ChatHeader({
             onClick={() => {
               const value = session.transcriptPath ?? session.claudeSessionId;
               if (!value) return;
-              // navigator.clipboard can be undefined on iOS WKWebView
-              // in non-secure contexts; .catch on the promise covers
-              // permission denial and lost-focus rejections.
               navigator.clipboard?.writeText(value).catch((err) => {
                 console.warn('[ChatHeader] clipboard write failed:', err);
               });
@@ -250,83 +154,77 @@ export function ChatHeader({
         )}
       </div>
 
-      {/* Detach/Resume button */}
       {onDetach && (
         <button
+          type="button"
           onClick={onDetach}
-          className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-warning)]"
+          className="inline-flex size-9 shrink-0 items-center justify-center rounded-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-warning)]"
           aria-label="Detach session"
           title="Detach session"
         >
-          <LogOut className="size-4" />
+          <LogOut className="size-[18px]" />
         </button>
       )}
 
-      {/* More button with dropdown */}
       {hasMenuActions && (
         <div className="relative" ref={menuRef}>
           <button
+            type="button"
             onClick={() => setMenuOpen(!menuOpen)}
-            className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+            className="inline-flex size-9 shrink-0 items-center justify-center rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface-light)] text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-elevated)]"
             aria-label="More options"
           >
             <MoreVertical className="size-5" />
           </button>
 
           {menuOpen && (
-            <div className="absolute right-0 top-full z-40 mt-1 w-48 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-elevated)] py-1 shadow-lg">
+            <div className="absolute right-0 top-full z-40 mt-1 w-48 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-elevated)] py-1 shadow-lg">
               {onCopyConversation && (
-                <button
+                <MenuItem
+                  icon={<Copy className="size-4 text-[var(--color-text-muted)]" />}
+                  label="Copy conversation"
                   onClick={() => {
                     onCopyConversation();
                     closeMenu();
                   }}
-                  className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-light)]"
-                >
-                  <Copy className="size-4 text-[var(--color-text-muted)]" />
-                  Copy conversation
-                </button>
+                />
               )}
               {onExportText && (
-                <button
+                <MenuItem
+                  icon={<FileText className="size-4 text-[var(--color-text-muted)]" />}
+                  label="Export as text"
                   onClick={() => {
                     onExportText();
                     closeMenu();
                   }}
-                  className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-light)]"
-                >
-                  <FileText className="size-4 text-[var(--color-text-muted)]" />
-                  Export as text
-                </button>
+                />
               )}
               {onDetach && (
                 <>
                   <div className="my-1 h-px bg-[var(--color-border)]" />
-                  <button
+                  <MenuItem
+                    icon={<LogOut className="size-4" />}
+                    label="Detach session"
+                    tone="warning"
                     onClick={() => {
                       onDetach();
                       closeMenu();
                     }}
-                    className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-warning)] transition-colors hover:bg-[var(--color-surface-light)]"
-                  >
-                    <LogOut className="size-4" />
-                    Detach session
-                  </button>
+                  />
                 </>
               )}
               {onClearMessages && (
                 <>
                   <div className="my-1 h-px bg-[var(--color-border)]" />
-                  <button
+                  <MenuItem
+                    icon={<Trash2 className="size-4" />}
+                    label="Clear messages"
+                    tone="error"
                     onClick={() => {
                       onClearMessages();
                       closeMenu();
                     }}
-                    className="flex w-full items-center gap-3 px-4 py-2 text-sm text-[var(--color-error)] transition-colors hover:bg-[var(--color-surface-light)]"
-                  >
-                    <Trash2 className="size-4" />
-                    Clear messages
-                  </button>
+                  />
                 </>
               )}
             </div>
@@ -334,5 +232,33 @@ export function ChatHeader({
         </div>
       )}
     </header>
+  );
+}
+
+function MenuItem({
+  icon,
+  label,
+  onClick,
+  tone = 'default',
+}: {
+  readonly icon: React.ReactNode;
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly tone?: 'default' | 'warning' | 'error';
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'flex w-full items-center gap-3 px-4 py-2 text-sm transition-colors hover:bg-[var(--color-surface-light)]',
+        tone === 'default' && 'text-[var(--color-text)]',
+        tone === 'warning' && 'text-[var(--color-warning)]',
+        tone === 'error' && 'text-[var(--color-error)]',
+      )}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -142,6 +142,9 @@ export function ChatHeader({
             onClick={() => {
               const value = session.transcriptPath ?? session.claudeSessionId;
               if (!value) return;
+              // navigator.clipboard can be undefined in iOS WKWebView
+              // non-secure contexts; permission denial and lost-focus
+              // rejections also land in this catch. Best-effort copy.
               navigator.clipboard?.writeText(value).catch((err) => {
                 console.warn('[ChatHeader] clipboard write failed:', err);
               });

--- a/packages/web/src/components/chat/ChatMessage.tsx
+++ b/packages/web/src/components/chat/ChatMessage.tsx
@@ -194,7 +194,7 @@ const userMarkdownComponents = {
     }
     return (
       <code
-        className="rounded px-1.5 py-0.5 text-[0.85em] font-[family-name:--font-mono] bg-white/15"
+        className="rounded px-1.5 py-0.5 text-[0.85em] font-[family-name:--font-mono] bg-[var(--color-surface)]/10"
         {...props}
       >
         {children}

--- a/packages/web/src/components/chat/ChatMessage.tsx
+++ b/packages/web/src/components/chat/ChatMessage.tsx
@@ -194,7 +194,7 @@ const userMarkdownComponents = {
     }
     return (
       <code
-        className="rounded px-1.5 py-0.5 text-[0.85em] font-[family-name:--font-mono] bg-[var(--color-surface)]/10"
+        className="rounded px-1.5 py-0.5 text-[0.85em] font-[family-name:--font-mono] bg-[var(--color-surface)]/20"
         {...props}
       >
         {children}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -1,8 +1,8 @@
 /**
  * ChatView component.
  *
- * Main chat interface combining header, messages, and input.
- * Supports two view modes: compact (plain text) and chat (parsed markdown/code).
+ * Main chat interface combining header, messages, and input. Always renders in
+ * the rich chat mode (markdown, tool grouping, pinned question stack).
  */
 
 import { useEdgeSwipeBack } from '@/hooks/useEdgeSwipeBack';
@@ -88,17 +88,14 @@ export function ChatView({
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
   const isConnected = session.connectionStatus === 'connected';
 
-  // In chat mode, render a stack of QuestionCards (main + any subagent prompts,
-  // #437). In compact mode, fall back to the InputArea's quick responses for
-  // the primary (first) prompt. A pending card needs a live connection; an
-  // already-answered card stays briefly regardless.
+  // Render a stack of QuestionCards (main + any subagent prompts, #437) pinned
+  // at the top of the chat. A pending card needs a live connection; an
+  // already-answered card stays briefly regardless. primaryQuestion routes the
+  // InputArea's answer callback (the bottom input itself never shows the
+  // quick-response chips now -- the pinned card owns answering).
   const questionList = questions ?? [];
   const primaryQuestion = questionList[0] ?? null;
-  const chatCards =
-    viewMode === 'chat'
-      ? questionList.filter((q) => q.answeredWith != null || isConnected)
-      : [];
-  const inputQuestion = viewMode === 'chat' ? null : primaryQuestion;
+  const chatCards = questionList.filter((q) => q.answeredWith != null || isConnected);
 
   // iOS edge-swipe back (#411): rightward swipe from the left edge pops
   // the chat back to the session list. Mirrors the native iOS gesture.
@@ -160,7 +157,7 @@ export function ChatView({
           if (primaryQuestion) onAnswer(primaryQuestion, answer);
         }}
         onCancel={onCancel}
-        question={inputQuestion}
+        question={null}
         isAgentBusy={isAgentBusy}
         disabled={!isConnected}
         replyContext={replyContext ?? null}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -81,7 +81,9 @@ export function ChatView({
   showTimestamps = true,
   className,
 }: ChatViewProps) {
-  const [viewMode, setViewMode] = useState<ViewMode>('chat');
+  // The redesigned chat always uses the rich "chat" rendering (markdown, tool
+  // grouping, pinned question cards). The legacy compact toggle was removed.
+  const [viewMode] = useState<ViewMode>('chat');
   const { isVisible: keyboardVisible, height: keyboardHeight } = useKeyboard();
   const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
   const isConnected = session.connectionStatus === 'connected';
@@ -119,8 +121,6 @@ export function ChatView({
     >
       <ChatHeader
         session={session}
-        viewMode={viewMode}
-        onViewModeChange={setViewMode}
         onBack={onBack}
         onOpenSessions={onOpenSessions}
         sessionCount={sessionCount}
@@ -130,6 +130,17 @@ export function ChatView({
         onExportText={onExportText}
         onDetach={onDetach}
       />
+
+      {/* Pinned question stack -- the headline interaction. One card per
+          concurrent prompt (main + any subagent prompts, #437). Kept above
+          the scroll so the answer is always reachable without scrolling. */}
+      {chatCards.length > 0 && (
+        <div className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)] pb-1">
+          {chatCards.map((q) => (
+            <QuestionCard key={q.id} question={q} onAnswer={(answer) => onAnswer(q, answer)} />
+          ))}
+        </div>
+      )}
 
       <MessageList
         messages={messages}
@@ -142,15 +153,6 @@ export function ChatView({
         keyboardVisible={keyboardVisible}
         showTimestamps={showTimestamps}
       />
-
-      {/* Question stack in chat mode (one card per concurrent prompt) */}
-      {chatCards.length > 0 && (
-        <div className="border-t border-[var(--color-border)] px-3 py-2 space-y-2">
-          {chatCards.map((q) => (
-            <QuestionCard key={q.id} question={q} onAnswer={(answer) => onAnswer(q, answer)} />
-          ))}
-        </div>
-      )}
 
       <InputArea
         onSend={onSend}

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -65,7 +65,7 @@ function QuickResponse({
         variant === 'default' &&
           'bg-[var(--color-surface-elevated)] text-[var(--color-text)] hover:bg-[var(--color-surface-light)]',
         variant === 'primary' &&
-          'bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-dark)]',
+          'bg-[var(--color-primary)] text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)]',
         variant === 'danger' &&
           'bg-[var(--color-error)]/10 text-[var(--color-error)] hover:bg-[var(--color-error)]/20',
       )}
@@ -315,10 +315,10 @@ export function InputArea({
             disabled={disabled}
             rows={1}
             className={clsx(
-              'w-full resize-none rounded-2xl bg-[var(--color-surface-light)] px-4 py-2.5',
+              'w-full resize-none rounded-[20px] border border-[var(--color-border)] bg-[var(--color-surface-light)] px-4 py-2.5',
               'text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-muted)]',
               'outline-none transition-colors',
-              'focus:ring-2 focus:ring-[var(--color-primary)]/50',
+              'focus:ring-2 focus:ring-[var(--color-primary)]/40',
               disabled && 'cursor-not-allowed opacity-50',
             )}
           />
@@ -329,10 +329,10 @@ export function InputArea({
           onClick={handleSend}
           disabled={disabled || !value.trim()}
           className={clsx(
-            'rounded-full p-2.5 transition-all',
+            'flex size-10 shrink-0 items-center justify-center rounded-full transition-all',
             value.trim()
-              ? 'bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-dark)] active:scale-95'
-              : 'text-[var(--color-text-muted)]',
+              ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)] active:scale-95'
+              : 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)]',
             disabled && 'cursor-not-allowed opacity-50',
           )}
           aria-label="Send message"

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -375,7 +375,7 @@ export function MessageBubble({
             <span
               className={clsx(
                 'text-[10px]',
-                isUser ? 'text-[var(--color-surface)]/55' : 'text-[var(--color-text-muted)]',
+                isUser ? 'text-[var(--color-surface)]/70' : 'text-[var(--color-text-muted)]',
               )}
             >
               {formatTime(message.timestamp)}

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -302,13 +302,6 @@ export function MessageBubble({
     );
   }
 
-  // Sender label for enhanced chat mode
-  let senderLabel: string | null = null;
-  if (enhanced) {
-    if (isUser) senderLabel = 'You';
-    else if (!isSystem) senderLabel = 'Claude';
-  }
-
   return (
     <div
       className={clsx('flex w-full animate-[slide-up]', isUser ? 'justify-end' : 'justify-start')}
@@ -321,8 +314,10 @@ export function MessageBubble({
           'shadow-sm border',
           // Width: wider in enhanced mode for better code block display
           enhanced ? 'max-w-[95%]' : 'max-w-[85%]',
-          // Bubble colors
-          isUser && 'bg-[var(--color-bubble-user)] text-white border-[var(--color-bubble-user)]',
+          // Bubble colors -- user is a light "ink" pill with dark text; the
+          // dark/light surface color flips with the theme so contrast holds.
+          isUser &&
+            'bg-[var(--color-bubble-user)] text-[var(--color-surface)] border-[var(--color-bubble-user)]',
           !isUser && !isSystem && 'bg-[var(--color-bubble-assistant)] border-[var(--color-border)]',
           isSystem &&
             'bg-[var(--color-bubble-system)] text-[var(--color-text-secondary)] border-[var(--color-border)]',
@@ -341,13 +336,6 @@ export function MessageBubble({
           isReplyable && 'pointer-coarse:select-none touch-manipulation',
         )}
       >
-        {/* Sender label in enhanced mode */}
-        {senderLabel && (
-          <div className="mb-1 text-[11px] font-semibold text-[var(--color-text-muted)]">
-            {senderLabel}
-          </div>
-        )}
-
         {/* Tool indicator (compact mode only; enhanced mode uses ToolUseCard) */}
         {!enhanced && message.tool && (
           <div className="mb-1 flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
@@ -357,7 +345,7 @@ export function MessageBubble({
         )}
 
         {/* Message content */}
-        <div className={clsx(isUser ? 'text-white' : 'text-[var(--color-text)]')}>
+        <div className={clsx(isUser ? 'text-[var(--color-surface)]' : 'text-[var(--color-text)]')}>
           <MessageContent
             message={message}
             enhanced={enhanced}
@@ -387,7 +375,7 @@ export function MessageBubble({
             <span
               className={clsx(
                 'text-[10px]',
-                isUser ? 'text-white/70' : 'text-[var(--color-text-muted)]',
+                isUser ? 'text-[var(--color-surface)]/55' : 'text-[var(--color-text-muted)]',
               )}
             >
               {formatTime(message.timestamp)}

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -1,14 +1,17 @@
 /**
  * QuestionCard component.
  *
- * Renders interactive question cards based on question type.
- * Supports yes/no, multi-option, numbered selection, and free text.
- * Designed for mobile with large tap targets (min 44px).
+ * The headline interaction of the chat screen: a pinned permission / question
+ * card. Renders a labeled header (with elapsed time), the prompt, an optional
+ * mono detail block, and large tap-friendly option rows with key badges and
+ * hints (Allow once / Remember for session / Cancel). Free-text questions get
+ * an inline input.
  */
 
+import { formatRelativeTime } from '@/lib/format-time';
 import type { UIQuestion, UIQuestionOption } from '@/types';
 import { clsx } from 'clsx';
-import { Check, ChevronRight, MessageSquare, Send } from 'lucide-react';
+import { Check, Send } from 'lucide-react';
 import { type KeyboardEvent, useCallback, useState } from 'react';
 
 interface QuestionCardProps {
@@ -17,14 +20,13 @@ interface QuestionCardProps {
   readonly className?: string;
 }
 
-/** Resolve the display label for an option value in the answered state */
+/** Resolve the display label for an answered value. */
 function resolveAnswerLabel(question: UIQuestion, answer: string): string {
   if (question.structuredOptions) {
     const match = question.structuredOptions.find((o) => o.value === answer);
     if (match) return match.label;
   }
   if (question.options) {
-    // For numbered questions, the answer is the index (1-based)
     const idx = Number.parseInt(answer, 10);
     if (!Number.isNaN(idx) && idx >= 1 && idx <= question.options.length) {
       return question.options[idx - 1];
@@ -33,202 +35,133 @@ function resolveAnswerLabel(question: UIQuestion, answer: string): string {
   return answer;
 }
 
-/** Get display label for an option. Uses the label from the daemon directly. */
-function getOptionDisplayLabel(option: UIQuestionOption): string {
-  return option.label;
+type OptionKind = 'primary' | 'danger' | 'default';
+
+interface RenderOption {
+  readonly key: string;
+  readonly badge: string;
+  readonly label: string;
+  readonly hint?: string;
+  readonly kind: OptionKind;
 }
 
-/** Determine button variant based on option semantics */
-function getOptionVariant(option: UIQuestionOption): 'primary' | 'danger' | 'warning' | 'default' {
+/** Hint text shown to the right of permission-style options. */
+function optionHint(option: UIQuestionOption): string | undefined {
+  if (/always/i.test(option.label)) return 'Remember for session';
+  if (option.isYes) return 'Allow once';
+  if (option.isNo) return 'Cancel';
+  return undefined;
+}
+
+function optionKind(option: UIQuestionOption): OptionKind {
   if (option.isYes || option.isRecommended) return 'primary';
   if (option.isNo) return 'danger';
-  const lower = option.value.toLowerCase();
-  if (lower === 'q' || lower === 'quit') return 'warning';
   return 'default';
 }
 
-/** Large tap-friendly button for option selection */
-function OptionButton({
-  label,
-  variant = 'default',
-  onClick,
-  disabled,
-}: {
-  readonly label: string;
-  readonly variant?: 'primary' | 'danger' | 'warning' | 'default';
-  readonly onClick: () => void;
-  readonly disabled?: boolean;
-}) {
+/** Flatten any question shape into a uniform option list for rendering. */
+function buildOptions(question: UIQuestion): RenderOption[] {
+  if (question.structuredOptions && question.structuredOptions.length > 0) {
+    return question.structuredOptions.map((o) => ({
+      key: o.value,
+      badge: o.value.slice(0, 2).toUpperCase(),
+      label: o.label,
+      hint: optionHint(o),
+      kind: optionKind(o),
+    }));
+  }
+  if (question.type === 'yes_no') {
+    return [
+      { key: 'y', badge: 'Y', label: 'Yes', hint: 'Allow once', kind: 'primary' },
+      { key: 'n', badge: 'N', label: 'No', hint: 'Cancel', kind: 'danger' },
+    ];
+  }
+  if (question.options && question.options.length > 0) {
+    return question.options.map((label, i) => ({
+      key: String(i + 1),
+      badge: String(i + 1),
+      label,
+      kind: 'default' as const,
+    }));
+  }
+  return [];
+}
+
+/** A single option row. */
+function OptionRow({ option, onAnswer }: { readonly option: RenderOption; readonly onAnswer: (v: string) => void }) {
+  const { kind } = option;
   return (
     <button
       type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={clsx(
-        'flex min-h-[44px] min-w-[44px] items-center justify-center',
-        'rounded-xl px-6 py-3 text-sm font-semibold',
-        'transition-all duration-150 active:scale-[0.97]',
-        'shadow-sm border',
-        disabled && 'pointer-events-none opacity-40',
-        variant === 'primary' && [
-          'bg-[var(--color-primary)] text-white border-[var(--color-primary)]',
-          'hover:bg-[var(--color-primary-dark)]',
-        ],
-        variant === 'danger' && [
-          'bg-[var(--color-error)]/10 text-[var(--color-error)] border-[var(--color-error)]/20',
-          'hover:bg-[var(--color-error)]/20',
-        ],
-        variant === 'warning' && [
-          'bg-[var(--color-warning)]/10 text-[var(--color-warning)] border-[var(--color-warning)]/20',
-          'hover:bg-[var(--color-warning)]/20',
-        ],
-        variant === 'default' && [
-          'bg-[var(--color-surface-elevated)] text-[var(--color-text)] border-[var(--color-border)]',
-          'hover:bg-[var(--color-surface-light)]',
-        ],
-      )}
+      onClick={() => onAnswer(option.key)}
+      className="flex min-h-[44px] items-center gap-2.5 rounded-[10px] px-3 py-2.5 text-left transition-transform active:scale-[0.99]"
+      style={{
+        background:
+          kind === 'primary'
+            ? 'var(--color-primary)'
+            : kind === 'danger'
+              ? 'transparent'
+              : 'var(--color-surface-elevated)',
+        color: kind === 'primary' ? 'var(--color-accent-ink)' : 'var(--color-text)',
+        border: kind === 'danger' ? '1px solid var(--color-border)' : 'none',
+      }}
     >
-      {label}
+      <span
+        className="inline-flex size-[22px] shrink-0 items-center justify-center rounded-md font-mono text-[11px] font-bold"
+        style={{
+          background:
+            kind === 'primary'
+              ? 'color-mix(in srgb, var(--color-accent-ink) 14%, transparent)'
+              : kind === 'danger'
+                ? 'var(--color-surface-elevated)'
+                : 'var(--color-surface)',
+          opacity: 0.95,
+        }}
+      >
+        {option.badge}
+      </span>
+      <span className="text-sm font-semibold">{option.label}</span>
+      {option.hint && (
+        <span className="ml-auto text-[11px] opacity-70">{option.hint}</span>
+      )}
     </button>
   );
 }
 
-/** Yes/No card with two large buttons */
-function YesNoCard({
-  question,
-  onAnswer,
-}: {
-  readonly question: UIQuestion;
-  readonly onAnswer: (answer: string) => void;
-}) {
-  const yesOption = question.structuredOptions?.find((o) => o.isYes);
-  const noOption = question.structuredOptions?.find((o) => o.isNo);
-
-  return (
-    <div className="flex gap-3">
-      <OptionButton
-        label="Yes"
-        variant="primary"
-        onClick={() => onAnswer(yesOption?.value ?? 'yes')}
-      />
-      <OptionButton label="No" variant="danger" onClick={() => onAnswer(noOption?.value ?? 'no')} />
-    </div>
-  );
-}
-
-/** Multi-option card (yes/no + extra options like all/quit) */
-function MultiOptionCard({
-  question,
-  onAnswer,
-}: {
-  readonly question: UIQuestion;
-  readonly onAnswer: (answer: string) => void;
-}) {
-  const options = question.structuredOptions ?? [];
-
-  return (
-    <div className="flex flex-wrap gap-2">
-      {options.map((option) => (
-        <OptionButton
-          key={option.value}
-          label={getOptionDisplayLabel(option)}
-          variant={getOptionVariant(option)}
-          onClick={() => onAnswer(option.value)}
-        />
-      ))}
-    </div>
-  );
-}
-
-/** Numbered selection card with tap targets */
-function NumberedCard({
-  question,
-  onAnswer,
-}: {
-  readonly question: UIQuestion;
-  readonly onAnswer: (answer: string) => void;
-}) {
-  const options = question.options ?? [];
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      {options.map((option, index) => (
-        <button
-          type="button"
-          key={`opt-${index + 1}-${option}`}
-          onClick={() => onAnswer(String(index + 1))}
-          className={clsx(
-            'flex min-h-[44px] items-center gap-3 rounded-xl px-4 py-3',
-            'bg-[var(--color-surface-elevated)] border border-[var(--color-border)]',
-            'text-left text-sm text-[var(--color-text)]',
-            'transition-all duration-150 active:scale-[0.98]',
-            'hover:bg-[var(--color-surface-light)] hover:border-[var(--color-primary)]/30',
-          )}
-        >
-          <span
-            className={clsx(
-              'flex size-7 shrink-0 items-center justify-center rounded-full',
-              'bg-[var(--color-primary)]/10 text-xs font-bold text-[var(--color-primary)]',
-            )}
-          >
-            {index + 1}
-          </span>
-          <span className="flex-1">{option}</span>
-          <ChevronRight className="size-4 shrink-0 text-[var(--color-text-muted)]" />
-        </button>
-      ))}
-    </div>
-  );
-}
-
-/** Free text input card */
-function FreeTextCard({
-  onAnswer,
-}: {
-  readonly onAnswer: (answer: string) => void;
-}) {
+/** Free text input row. */
+function FreeTextRow({ onAnswer }: { readonly onAnswer: (v: string) => void }) {
   const [value, setValue] = useState('');
-
-  const handleSubmit = useCallback(() => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
-    onAnswer(trimmed);
+  const submit = useCallback(() => {
+    const t = value.trim();
+    if (!t) return;
+    onAnswer(t);
     setValue('');
   }, [value, onAnswer]);
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      handleSubmit();
+      submit();
     }
   };
-
   return (
     <div className="flex items-center gap-2">
       <input
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
+        onKeyDown={onKey}
         placeholder="Type your response..."
-        className={clsx(
-          'min-h-[44px] flex-1 rounded-xl border border-[var(--color-border)]',
-          'bg-[var(--color-surface-elevated)] px-4 py-2.5 text-sm text-[var(--color-text)]',
-          'placeholder:text-[var(--color-text-muted)]',
-          'outline-none focus:ring-2 focus:ring-[var(--color-primary)]/50',
-        )}
+        className="min-h-[44px] flex-1 rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2.5 text-sm text-[var(--color-text)] outline-none placeholder:text-[var(--color-text-muted)] focus:ring-2 focus:ring-[var(--color-primary)]/40"
       />
       <button
         type="button"
-        onClick={handleSubmit}
+        onClick={submit}
         disabled={!value.trim()}
-        className={clsx(
-          'flex size-[44px] items-center justify-center rounded-xl',
-          'transition-all duration-150 active:scale-95',
-          value.trim()
-            ? 'bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-dark)]'
-            : 'bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]',
-        )}
+        className="flex size-[44px] items-center justify-center rounded-[10px] transition-transform active:scale-95"
+        style={{
+          background: value.trim() ? 'var(--color-primary)' : 'var(--color-surface-elevated)',
+          color: value.trim() ? 'var(--color-accent-ink)' : 'var(--color-text-muted)',
+        }}
         aria-label="Send response"
       >
         <Send className="size-5" />
@@ -237,76 +170,83 @@ function FreeTextCard({
   );
 }
 
-/** Answered state: collapsed card showing the selected answer */
-function AnsweredCard({
-  question,
-}: {
-  readonly question: UIQuestion;
-}) {
-  const answerLabel = resolveAnswerLabel(question, question.answeredWith ?? '');
-
-  return (
-    <div
-      className={clsx(
-        'flex items-center gap-2 rounded-xl px-4 py-2.5',
-        'bg-[var(--color-success)]/10 border border-[var(--color-success)]/20',
-        'text-sm text-[var(--color-text-secondary)]',
-        'animate-[fade-in_200ms_ease-out]',
-      )}
-    >
-      <Check className="size-4 shrink-0 text-[var(--color-success)]" />
-      <span>
-        Answered: <span className="font-medium text-[var(--color-text)]">{answerLabel}</span>
-      </span>
-    </div>
-  );
-}
-
-/** Render the appropriate answer UI based on question type and state */
-function AnswerArea({
-  question,
-  isAnswered,
-  onAnswer,
-}: {
-  readonly question: UIQuestion;
-  readonly isAnswered: boolean;
-  readonly onAnswer: (answer: string) => void;
-}) {
-  if (isAnswered) return <AnsweredCard question={question} />;
-
-  switch (question.type) {
-    case 'yes_no':
-      return <YesNoCard question={question} onAnswer={onAnswer} />;
-    case 'multi_option':
-      return <MultiOptionCard question={question} onAnswer={onAnswer} />;
-    case 'numbered':
-      return <NumberedCard question={question} onAnswer={onAnswer} />;
-    default:
-      return <FreeTextCard onAnswer={onAnswer} />;
-  }
-}
-
 export function QuestionCard({ question, onAnswer, className }: QuestionCardProps) {
   const isAnswered = question.answeredWith != null;
+  const options = buildOptions(question);
+  const isPermission = options.some((o) => o.kind === 'primary' || o.kind === 'danger');
+  const headerLabel = isPermission ? 'Permission request' : 'Question';
+
+  if (isAnswered) {
+    return (
+      <div
+        className={clsx(
+          'mx-3.5 my-2 flex items-center gap-2 rounded-2xl border px-4 py-2.5 text-sm',
+          'animate-[fade-in_200ms_ease-out]',
+          className,
+        )}
+        style={{
+          background: 'color-mix(in srgb, var(--color-success) 10%, transparent)',
+          borderColor: 'color-mix(in srgb, var(--color-success) 25%, transparent)',
+          color: 'var(--color-text-secondary)',
+        }}
+      >
+        <Check className="size-4 shrink-0 text-[var(--color-success)]" />
+        <span>
+          Answered:{' '}
+          <span className="font-medium text-[var(--color-text)]">
+            {resolveAnswerLabel(question, question.answeredWith ?? '')}
+          </span>
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div
-      className={clsx(
-        'rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)]',
-        'shadow-md p-4',
-        'animate-[slide-up_200ms_ease-out]',
-        isAnswered && 'opacity-75',
-        className,
-      )}
+      className={clsx('mx-3.5 my-2 overflow-hidden rounded-[18px]', className)}
+      style={{
+        background: 'var(--color-surface-light)',
+        border: '1px solid color-mix(in srgb, var(--color-primary) 33%, transparent)',
+        boxShadow:
+          '0 0 0 4px color-mix(in srgb, var(--color-primary) 7%, transparent), 0 12px 32px -16px color-mix(in srgb, var(--color-primary) 33%, transparent)',
+        animation: 'slide-up 200ms ease-out',
+      }}
     >
-      {/* Question prompt */}
-      <div className="mb-3 flex items-start gap-2">
-        <MessageSquare className="mt-0.5 size-4 shrink-0 text-[var(--color-primary)]" />
-        <p className="text-sm font-medium text-[var(--color-text)]">{question.prompt}</p>
+      {/* Header */}
+      <div
+        className="flex items-center gap-2 px-3.5 py-2.5"
+        style={{
+          background: 'var(--color-accent-soft)',
+          borderBottom: '1px solid color-mix(in srgb, var(--color-primary) 13%, transparent)',
+        }}
+      >
+        <span
+          className="size-1.5 rounded-full bg-[var(--color-primary)]"
+          style={{ color: 'var(--color-primary)', animation: 'pulse-dot 1.4s ease-out infinite' }}
+        />
+        <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--color-primary)]">
+          {headerLabel}
+        </span>
+        <span className="ml-auto font-mono text-[11px] text-[var(--color-text-secondary)]">
+          {formatRelativeTime(question.timestamp)}
+        </span>
       </div>
 
-      {/* Answer area */}
-      <AnswerArea question={question} isAnswered={isAnswered} onAnswer={onAnswer} />
+      {/* Prompt */}
+      <div className="px-4 pb-1.5 pt-3.5">
+        <p className="break-anywhere text-[15px] font-medium leading-snug text-[var(--color-text)]">
+          {question.prompt}
+        </p>
+      </div>
+
+      {/* Options / free text */}
+      <div className="flex flex-col gap-1.5 px-3 pb-3 pt-2.5">
+        {options.length > 0 ? (
+          options.map((o) => <OptionRow key={o.key} option={o} onAnswer={onAnswer} />)
+        ) : (
+          <FreeTextRow onAnswer={onAnswer} />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -2,10 +2,9 @@
  * QuestionCard component.
  *
  * The headline interaction of the chat screen: a pinned permission / question
- * card. Renders a labeled header (with elapsed time), the prompt, an optional
- * mono detail block, and large tap-friendly option rows with key badges and
- * hints (Allow once / Remember for session / Cancel). Free-text questions get
- * an inline input.
+ * card. Renders a labeled header (with elapsed time), the prompt, and large
+ * tap-friendly option rows with key badges and hints (Allow once / Remember
+ * for session / Cancel). Free-text questions get an inline input.
  */
 
 import { formatRelativeTime } from '@/lib/format-time';
@@ -111,7 +110,7 @@ function OptionRow({ option, onAnswer }: { readonly option: RenderOption; readon
         style={{
           background:
             kind === 'primary'
-              ? 'color-mix(in srgb, var(--color-accent-ink) 14%, transparent)'
+              ? 'var(--color-accent-ink-14)'
               : kind === 'danger'
                 ? 'var(--color-surface-elevated)'
                 : 'var(--color-surface)',
@@ -185,8 +184,8 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
           className,
         )}
         style={{
-          background: 'color-mix(in srgb, var(--color-success) 10%, transparent)',
-          borderColor: 'color-mix(in srgb, var(--color-success) 25%, transparent)',
+          background: 'var(--color-success-soft)',
+          borderColor: 'var(--color-success-line)',
           color: 'var(--color-text-secondary)',
         }}
       >
@@ -206,9 +205,8 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
       className={clsx('mx-3.5 my-2 overflow-hidden rounded-[18px]', className)}
       style={{
         background: 'var(--color-surface-light)',
-        border: '1px solid color-mix(in srgb, var(--color-primary) 33%, transparent)',
-        boxShadow:
-          '0 0 0 4px color-mix(in srgb, var(--color-primary) 7%, transparent), 0 12px 32px -16px color-mix(in srgb, var(--color-primary) 33%, transparent)',
+        border: '1px solid var(--color-accent-33)',
+        boxShadow: '0 0 0 4px var(--color-accent-7), 0 12px 32px -16px var(--color-accent-33)',
         animation: 'slide-up 200ms ease-out',
       }}
     >
@@ -217,7 +215,7 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
         className="flex items-center gap-2 px-3.5 py-2.5"
         style={{
           background: 'var(--color-accent-soft)',
-          borderBottom: '1px solid color-mix(in srgb, var(--color-primary) 13%, transparent)',
+          borderBottom: '1px solid var(--color-accent-13)',
         }}
       >
         <span

--- a/packages/web/src/components/chat/ToolUseCard.tsx
+++ b/packages/web/src/components/chat/ToolUseCard.tsx
@@ -52,7 +52,7 @@ export function ToolUseCard({ toolName, content, defaultExpanded = false }: Tool
   return (
     <div
       className={clsx(
-        'rounded-lg border border-[var(--color-border)] overflow-hidden',
+        'overflow-hidden rounded-xl border border-[var(--color-border)] font-mono',
         'bg-[var(--color-surface-light)] transition-colors',
       )}
     >
@@ -70,8 +70,8 @@ export function ToolUseCard({ toolName, content, defaultExpanded = false }: Tool
         ) : (
           <ChevronRight className="size-3.5 shrink-0 text-[var(--color-text-muted)]" />
         )}
-        <ToolIcon name={toolName} className="size-3.5 shrink-0 text-[var(--color-primary)]" />
-        <span className="text-xs font-medium text-[var(--color-text-secondary)]">{toolName}</span>
+        <ToolIcon name={toolName} className="size-3.5 shrink-0 text-[var(--color-text-muted)]" />
+        <span className="text-xs font-semibold text-[var(--color-text)]">{toolName}</span>
         {!expanded && summary && (
           <span className="truncate text-xs text-[var(--color-text-muted)]">{summary}</span>
         )}

--- a/packages/web/src/components/session/ConnectModal.tsx
+++ b/packages/web/src/components/session/ConnectModal.tsx
@@ -184,7 +184,7 @@ function PassphraseView({
         type="submit"
         disabled={!passphrase || isSubmitting}
         className={clsx(
-          'flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
+          'flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-[var(--color-accent-ink)] transition-colors',
           passphrase && !isSubmitting
             ? 'bg-[var(--color-primary)] hover:bg-[var(--color-primary-dark)]'
             : 'cursor-not-allowed bg-[var(--color-primary)]/50',
@@ -291,12 +291,13 @@ export function ConnectModal({
     return (
       <div
         data-testid="connect-modal-backdrop"
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        className="fixed inset-0 z-50 flex items-end justify-center bg-black/60"
         style={backdropStyle}
       >
-        <div className="w-full max-w-md rounded-2xl bg-[var(--color-surface)] shadow-xl border border-[var(--color-border)]">
+        <div className="w-full max-w-md rounded-t-[28px] border border-[var(--color-border)] bg-[var(--color-surface)] pb-[max(env(safe-area-inset-bottom),12px)] shadow-2xl animate-[sheet-up_260ms_cubic-bezier(.2,.8,.2,1)]">
+          <div className="mx-auto mb-1 mt-3 h-1 w-9 rounded-full bg-[var(--color-border)]" />
           <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
-            <h2 className="text-lg font-semibold text-[var(--color-text)]">Authenticate</h2>
+            <h2 className="text-lg font-bold tracking-tight text-[var(--color-text)]">Authenticate</h2>
             <button
               onClick={() => {
                 setPreflightPending(null);
@@ -420,20 +421,14 @@ export function ConnectModal({
   return (
     <div
       data-testid="connect-modal-backdrop"
-      className={clsx(
-        'fixed inset-0 z-50 flex justify-center bg-black/60 p-4',
-        // When the keyboard is open, anchor the modal to the top of the
-        // remaining visible area (paired with backdropStyle's padding-bottom
-        // equal to the keyboard height) so the input never sits behind the
-        // keyboard on short screens.
-        keyboard.isVisible ? 'items-start pt-8' : 'items-center',
-      )}
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60"
       style={backdropStyle}
     >
-      <div className="w-full max-w-md max-h-[85vh] overflow-y-auto rounded-2xl bg-[var(--color-surface)] shadow-xl border border-[var(--color-border)]">
+      <div className="max-h-[88vh] w-full max-w-md overflow-y-auto rounded-t-[28px] border border-[var(--color-border)] bg-[var(--color-surface)] pb-[max(env(safe-area-inset-bottom),12px)] shadow-2xl animate-[sheet-up_260ms_cubic-bezier(.2,.8,.2,1)]">
+        <div className="mx-auto mb-1 mt-3 h-1 w-9 rounded-full bg-[var(--color-border)]" />
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
-          <h2 className="text-lg font-semibold text-[var(--color-text)]">Connect</h2>
+        <div className="flex items-center justify-between px-5 pb-3 pt-1">
+          <h2 className="text-[22px] font-bold tracking-tight text-[var(--color-text)]">Connect</h2>
           <button
             onClick={onClose}
             className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
@@ -452,7 +447,7 @@ export function ConnectModal({
               className={clsx(
                 'flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-colors',
                 mode === 'local'
-                  ? 'bg-[var(--color-primary)] text-white'
+                  ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)]'
                   : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text)]',
               )}
             >
@@ -465,7 +460,7 @@ export function ConnectModal({
                 className={clsx(
                   'flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-colors',
                   mode === 'remote'
-                    ? 'bg-[var(--color-primary)] text-white'
+                    ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)]'
                     : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text)]',
                 )}
               >
@@ -605,7 +600,7 @@ export function ConnectModal({
               isScanning
             }
             className={clsx(
-              'flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-white transition-colors',
+              'flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium text-[var(--color-accent-ink)] transition-colors',
               canConnect &&
                 !isConnecting &&
                 !isAuthenticating &&

--- a/packages/web/src/components/session/RecentProjects.tsx
+++ b/packages/web/src/components/session/RecentProjects.tsx
@@ -97,7 +97,7 @@ export function RecentProjects({ directories, onStartSession }: RecentProjectsPr
             }
           }}
           disabled={!customPath.trim()}
-          className="rounded bg-[var(--color-primary)] px-2 py-1 text-xs text-white disabled:opacity-50"
+          className="rounded bg-[var(--color-primary)] px-2 py-1 text-xs text-[var(--color-accent-ink)] disabled:opacity-50"
         >
           Start
         </button>

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -1,30 +1,17 @@
 /**
  * SessionCard component.
  *
- * Displays a session preview in the session list.
+ * A single session row in the session list. Shows host/project, the branch,
+ * a status pill, a two-line preview, and the time + unread badge. Sessions
+ * that need the user (a pending question) get a lime attention stripe.
  */
 
-// Status icons are rendered via StatusDot, not used directly
+import { StatusPill } from '@/components/StatusPill';
 import { formatRelativeTime } from '@/lib/format-time';
-import type { AgentStatus, ConnectionStatus, UISession } from '@/types';
-import type { ConnectionId } from '@/types';
+import { sessionPillState, splitSessionName } from '@/lib/session-display';
+import type { ConnectionId, UISession } from '@/types';
 import { clsx } from 'clsx';
-import { Link2, Link2Off, MessageCircleQuestion, RotateCcw } from 'lucide-react';
-
-/** Strip hostname prefix and truncate branch for display.
- *  "yahyas-mcm:remi/develop" -> "remi/develop"
- *  "remi/very-long-branch-name-here" -> "remi/very-long..."
- */
-function formatSessionName(name: string): string {
-  // Strip hostname: prefix (everything before the first colon that's followed by non-digit)
-  let display = name.replace(/^[^:]+:/, '');
-  // Truncate branch part if too long (keep folder, limit branch to 10 chars)
-  const slashIdx = display.indexOf('/');
-  if (slashIdx >= 0 && display.length > slashIdx + 11) {
-    display = `${display.slice(0, slashIdx + 11)}...`;
-  }
-  return display || name;
-}
+import { GitBranch, Link2Off, RotateCcw } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
@@ -33,38 +20,8 @@ interface SessionCardProps {
   readonly onResume?: ((sessionId: string) => void) | undefined;
   readonly onDisconnect?: ((connectionId: ConnectionId) => void) | undefined;
   readonly isResuming?: boolean;
-}
-
-/** Status dot with color and animation */
-function StatusDot({
-  connectionStatus,
-  agentStatus,
-}: {
-  readonly connectionStatus: ConnectionStatus;
-  readonly agentStatus: AgentStatus;
-}) {
-  // Connection status takes priority
-  if (connectionStatus === 'error' || connectionStatus === 'unreachable') {
-    return <span className="size-2.5 rounded-full bg-[var(--color-error)]" />;
-  }
-  if (connectionStatus === 'disconnected') {
-    return <span className="size-2.5 rounded-full bg-[var(--color-text-muted)]" />;
-  }
-  if (connectionStatus === 'connecting' || connectionStatus === 'reconnecting') {
-    return <span className="size-2.5 animate-pulse rounded-full bg-[var(--color-warning)]" />;
-  }
-
-  // Agent status when connected
-  switch (agentStatus) {
-    case 'thinking':
-    case 'executing':
-      return <span className="size-2.5 animate-pulse rounded-full bg-[var(--color-primary)]" />;
-    case 'waiting':
-      return <span className="size-2.5 rounded-full bg-[var(--color-success)]" />;
-    case 'idle':
-    default:
-      return <span className="size-2.5 rounded-full bg-[var(--color-text-muted)]" />;
-  }
+  /** When true, the bottom hairline divider is omitted (last row in a group). */
+  readonly last?: boolean;
 }
 
 export function SessionCard({
@@ -74,32 +31,70 @@ export function SessionCard({
   onResume,
   onDisconnect,
   isResuming,
+  last = false,
 }: SessionCardProps) {
-  const showResume = onResume && session.canResume && session.connectionStatus === 'disconnected';
-
+  const { host, project, branch } = splitSessionName(session);
+  const state = sessionPillState(session);
+  const isAsking = state === 'asking';
   const isConnected = session.connectionStatus === 'connected';
+  const showResume = onResume && session.canResume && session.connectionStatus === 'disconnected';
+  const preview = session.preview || getStatusText(state);
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={clsx(
-        'w-full rounded-xl p-3 text-left transition-colors',
-        'hover:bg-[var(--color-surface-light)]',
-        isActive && 'bg-[var(--color-surface-light)] ring-1 ring-[var(--color-primary)]/30',
+        'relative flex w-full items-start gap-3 py-3.5 pl-[22px] pr-[18px] text-left',
+        'transition-colors active:bg-[var(--color-surface-light)]',
+        isActive && 'bg-[var(--color-surface-light)]',
+        !last && 'border-b border-[var(--color-border)]',
       )}
     >
-      {/* Title line: status dot, name, disconnect */}
-      <div className="flex items-center gap-2">
-        <StatusDot connectionStatus={session.connectionStatus} agentStatus={session.status} />
-        <h3 className="flex-1 truncate font-medium text-[var(--color-text)]">
-          {formatSessionName(session.name || 'Claude Session')}
-        </h3>
-        {/* Question and unread badges */}
-        {session.questionPending && (
-          <MessageCircleQuestion className="size-4 shrink-0 text-[var(--color-warning)]" />
-        )}
+      {/* Attention stripe for sessions that need the user */}
+      {isAsking && (
+        <span className="absolute inset-y-3.5 left-0 w-[3px] rounded-sm bg-[var(--color-primary)]" />
+      )}
+
+      <div className="min-w-0 flex-1">
+        {/* host / project */}
+        <div className="mb-1 flex items-center gap-2">
+          <span className="truncate font-mono text-xs text-[var(--color-text-secondary)]">
+            {host}
+            <span className="text-[var(--color-text-muted)]">/</span>
+            {project}
+          </span>
+        </div>
+
+        {/* branch + status pill */}
+        <div className="mb-1.5 flex min-w-0 items-center gap-2">
+          <GitBranch className="size-3 shrink-0 text-[var(--color-text-muted)]" />
+          <span className="truncate font-mono text-[13px] font-medium text-[var(--color-text)]">
+            {branch || project}
+          </span>
+          <StatusPill state={state} className="shrink-0" />
+        </div>
+
+        {/* preview (two lines) */}
+        <div className="line-clamp-2 text-[13px] leading-snug text-[var(--color-text-secondary)]">
+          {isAsking && <span className="font-semibold text-[var(--color-primary)]">· </span>}
+          {preview}
+        </div>
+      </div>
+
+      {/* right column: time + unread + per-row actions */}
+      <div className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
+        <span className="text-[11px] tabular-nums text-[var(--color-text-muted)]">
+          {formatRelativeTime(session.lastActiveAt)}
+        </span>
         {session.unreadCount > 0 && (
-          <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-medium text-white">
+          <span
+            className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-[5px] text-[11px] font-bold"
+            style={{
+              background: isAsking ? 'var(--color-primary)' : 'var(--color-surface-elevated)',
+              color: isAsking ? 'var(--color-accent-ink)' : 'var(--color-text)',
+            }}
+          >
             {session.unreadCount > 9 ? '9+' : session.unreadCount}
           </span>
         )}
@@ -110,7 +105,7 @@ export function SessionCard({
               e.stopPropagation();
               onDisconnect(session.connectionId);
             }}
-            className="shrink-0 rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
+            className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
             aria-label="Disconnect"
           >
             <Link2Off className="size-3.5" />
@@ -125,60 +120,32 @@ export function SessionCard({
             }}
             disabled={isResuming}
             className={clsx(
-              'shrink-0 rounded-full p-1 transition-colors',
+              'rounded-full p-1 transition-colors',
               isResuming
-                ? 'text-[var(--color-text-muted)] cursor-wait'
-                : 'text-[var(--color-primary)] hover:bg-[var(--color-primary)]/10',
+                ? 'cursor-wait text-[var(--color-text-muted)]'
+                : 'text-[var(--color-primary)] hover:bg-[var(--color-accent-soft)]',
             )}
             aria-label="Resume"
           >
-            {isResuming ? (
-              <RotateCcw className="size-3.5 animate-spin" />
-            ) : (
-              <Link2 className="size-3.5" />
-            )}
+            <RotateCcw className={clsx('size-3.5', isResuming && 'animate-spin')} />
           </button>
         )}
       </div>
-
-      {/* Preview line: status/preview + timestamp */}
-      <div className="mt-1 flex items-center gap-2 pl-4.5">
-        <p
-          className={clsx(
-            'flex-1 truncate text-sm',
-            session.questionPending
-              ? 'font-medium text-[var(--color-warning)]'
-              : 'text-[var(--color-text-secondary)]',
-          )}
-        >
-          {session.questionPending
-            ? 'Needs your input'
-            : session.preview || getStatusText(session.status)}
-        </p>
-        <span className="shrink-0 text-xs text-[var(--color-text-muted)]">
-          {formatRelativeTime(session.lastActiveAt)}
-        </span>
-      </div>
-
-      {/* CWD if available */}
-      {session.cwd && (
-        <p className="mt-0.5 truncate pl-4.5 text-xs text-[var(--color-text-muted)]">
-          {session.cwd}
-        </p>
-      )}
     </button>
   );
 }
 
-function getStatusText(status: AgentStatus): string {
-  switch (status) {
-    case 'thinking':
-      return 'Thinking...';
-    case 'executing':
-      return 'Executing...';
-    case 'waiting':
-      return 'Waiting for input';
-    case 'idle':
+/** Fallback preview text when the session has no last-output preview. */
+function getStatusText(state: ReturnType<typeof sessionPillState>): string {
+  switch (state) {
+    case 'asking':
+      return 'Waiting for your answer';
+    case 'working':
+      return 'Working...';
+    case 'connecting':
+      return 'Connecting...';
+    case 'offline':
+      return 'Disconnected. Reattach to resume.';
     default:
       return 'Idle';
   }

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -3,7 +3,7 @@
  *
  * A single session row in the session list. Shows host/project, the branch,
  * a status pill, a two-line preview, and the time + unread badge. Sessions
- * that need the user (a pending question) get a lime attention stripe.
+ * that need the user (a pending question) get an accent attention stripe.
  */
 
 import { StatusPill } from '@/components/StatusPill';
@@ -146,7 +146,7 @@ function getStatusText(state: ReturnType<typeof sessionPillState>): string {
       return 'Connecting...';
     case 'offline':
       return 'Disconnected. Reattach to resume.';
-    default:
+    case 'idle':
       return 'Idle';
   }
 }

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -1,23 +1,28 @@
 /**
  * SessionList component.
  *
- * Active sessions from connected daemons shown at top.
- * "Recent" expander for historical sessions below.
- * Connection controls: connect, disconnect per machine, disconnect all.
+ * The "Sessions" screen: a brand + connection-status header, an attention
+ * banner when agents need the user, status filter chips, then the rows.
+ * Active sessions (live daemon) are shown first; transcript-only sessions
+ * live under a collapsible "Recent" group.
  */
 
+import { type PillState, sessionPillState } from '@/lib/session-display';
 import type { ConnectionId, ConnectionState, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
 import {
   AlertTriangle,
+  Bell,
   ChevronDown,
   ChevronRight,
   Link2,
   Link2Off,
   Loader2,
-  MessageSquarePlus,
+  Plus,
   Settings,
+  Wifi,
+  WifiOff,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SessionCard } from './SessionCard';
@@ -40,6 +45,15 @@ interface SessionListProps {
   readonly className?: string;
 }
 
+type FilterId = 'all' | 'asking' | 'working' | 'idle';
+
+/** Map a pill state to the filter bucket it belongs to. */
+function filterBucket(state: PillState): FilterId {
+  if (state === 'asking') return 'asking';
+  if (state === 'working') return 'working';
+  return 'idle';
+}
+
 export function SessionList({
   sessions,
   activeSessionId,
@@ -56,6 +70,7 @@ export function SessionList({
   className,
 }: SessionListProps) {
   const [showRecent, setShowRecent] = useState(false);
+  const [filter, setFilter] = useState<FilterId>('all');
 
   // Active = sessions owned by a running daemon (has a live port behind it).
   // Recent = transcript-discovered sessions with no live daemon.
@@ -63,131 +78,250 @@ export function SessionList({
     const active: UISession[] = [];
     const recent: UISession[] = [];
     for (const session of sessions) {
-      if (session.source === 'daemon') {
-        active.push(session);
-      } else {
-        recent.push(session);
-      }
+      if (session.source === 'daemon') active.push(session);
+      else recent.push(session);
     }
     return { activeSessions: active, recentSessions: recent };
   }, [sessions]);
 
+  // Per-bucket counts drive the chip badges + attention banner.
+  const counts = useMemo(() => {
+    const c = { all: activeSessions.length, asking: 0, working: 0, idle: 0 };
+    for (const s of activeSessions) c[filterBucket(sessionPillState(s))]++;
+    return c;
+  }, [activeSessions]);
+
+  const filteredActive = useMemo(
+    () =>
+      filter === 'all'
+        ? activeSessions
+        : activeSessions.filter((s) => filterBucket(sessionPillState(s)) === filter),
+    [activeSessions, filter],
+  );
+
+  const askingCount = counts.asking;
   const hasConnections = connections.length > 0;
-  // Derive display name from first connection (hostname without port)
-  const hostLabel = hasConnections ? connections[0].connectionId.replace(/:\d+$/, '') : null;
+  const anyConnected = connections.some((c) => c.status === 'connected');
+  const anyConnecting = connections.some(
+    (c) => c.status === 'connecting' || c.status === 'reconnecting' || c.status === 'authenticating',
+  );
+
+  const problemConnections = connections.filter(
+    (c) => c.status === 'error' || c.status === 'reconnecting' || c.status === 'unreachable',
+  );
+
+  const goToFirstAsking = () => {
+    const first = activeSessions.find((s) => sessionPillState(s) === 'asking');
+    if (first) onSelectSession(first.id);
+  };
 
   return (
     <div className={clsx('flex h-full flex-col bg-[var(--color-surface)]', className)}>
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3 safe-area-top">
+      <header className="safe-area-top px-[18px] pb-2 pt-3">
+        {/* Brand + connection status */}
         <div className="flex items-center gap-2">
-          <h1 className="text-lg font-semibold text-[var(--color-text)]">Remi</h1>
-          {hostLabel && (
-            <span className="text-sm text-[var(--color-text-muted)]">on {hostLabel}</span>
+          <span className="inline-flex size-[22px] items-center justify-center rounded-[7px] bg-[var(--color-primary)] text-[13px] font-extrabold tracking-tight text-[var(--color-accent-ink)]">
+            r
+          </span>
+          <span className="text-sm font-semibold tracking-tight text-[var(--color-text-secondary)]">
+            remi
+          </span>
+          <span className="ml-1 inline-flex items-center gap-1.5 font-mono text-[11px] text-[var(--color-text-muted)]">
+            {anyConnected ? (
+              <Wifi className="size-3 text-[var(--color-success)]" />
+            ) : anyConnecting ? (
+              <Loader2 className="size-3 animate-spin text-[var(--color-warning)]" />
+            ) : (
+              <WifiOff className="size-3 text-[var(--color-text-muted)]" />
+            )}
+            {hasConnections
+              ? `local · ${connections.length} host${connections.length > 1 ? 's' : ''}`
+              : 'not connected'}
+          </span>
+          {hasConnections && (
+            <button
+              type="button"
+              onClick={onDisconnectAll}
+              className="ml-auto rounded-full p-1.5 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-error)]"
+              aria-label="Disconnect all"
+            >
+              <Link2Off className="size-4" />
+            </button>
           )}
         </div>
-        <div className="flex items-center gap-1">
-          {hasConnections ? (
+
+        {/* Title + actions */}
+        <div className="mt-1 flex items-end justify-between">
+          <h1 className="text-[30px] font-bold leading-none tracking-[-0.04em] text-[var(--color-text)]">
+            Sessions
+          </h1>
+          <div className="flex items-center gap-2">
+            {onSettings && (
+              <button
+                type="button"
+                onClick={onSettings}
+                className="inline-flex size-[38px] items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-light)] text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-elevated)]"
+                aria-label="Settings"
+              >
+                <Settings className="size-[18px]" />
+              </button>
+            )}
             <button
-              onClick={onDisconnectAll}
-              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-error)]"
-              aria-label="Disconnect"
+              type="button"
+              onClick={() => {
+                if (hasConnections && onNewSession) {
+                  // Directory selection is preserved here; the richer
+                  // new-session sheet (command + options) is a follow-up that
+                  // needs daemon-side support.
+                  const dir = window.prompt('Project directory (leave empty for home):');
+                  if (dir !== null) onNewSession(dir || undefined);
+                } else {
+                  onConnect();
+                }
+              }}
+              className="inline-flex size-[38px] items-center justify-center rounded-xl bg-[var(--color-primary)] text-[var(--color-accent-ink)] transition-transform active:scale-95"
+              style={{ boxShadow: '0 4px 18px -6px var(--color-primary)' }}
+              aria-label={hasConnections ? 'New session' : 'Connect'}
             >
-              <Link2Off className="size-5" />
+              <Plus className="size-5" />
             </button>
-          ) : (
-            <button
-              onClick={onConnect}
-              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-              aria-label="Connect"
-            >
-              <Link2 className="size-5" />
-            </button>
-          )}
-          {onSettings && (
-            <button
-              onClick={onSettings}
-              className="rounded-full p-2 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
-              aria-label="Settings"
-            >
-              <Settings className="size-5" />
-            </button>
-          )}
+          </div>
         </div>
       </header>
 
-      {/* Connection status banners */}
-      {hasConnections &&
-        connections.some(
-          (c) => c.status === 'error' || c.status === 'reconnecting' || c.status === 'unreachable',
-        ) && (
-          <div className="border-b border-[var(--color-border)] px-3 py-2 space-y-1">
-            {connections
-              .filter(
-                (c) =>
-                  c.status === 'error' ||
-                  c.status === 'reconnecting' ||
-                  c.status === 'unreachable',
-              )
-              .map((c) => (
-                <div
-                  key={c.connectionId}
+      {/* Connection problem banners */}
+      {problemConnections.length > 0 && (
+        <div className="space-y-1 px-3 pb-2">
+          {problemConnections.map((c) => (
+            <div
+              key={c.connectionId}
+              className={clsx(
+                'flex items-center gap-2 rounded-lg px-3 py-2 text-xs',
+                c.status === 'reconnecting'
+                  ? 'bg-[var(--color-warning)]/10 text-[var(--color-warning)]'
+                  : 'bg-[var(--color-error)]/10 text-[var(--color-error)]',
+              )}
+            >
+              {c.status === 'reconnecting' ? (
+                <Loader2 className="size-3.5 shrink-0 animate-spin" />
+              ) : (
+                <AlertTriangle className="size-3.5 shrink-0" />
+              )}
+              <span className="truncate">
+                {c.status === 'reconnecting'
+                  ? `Reconnecting to ${c.connectionId}...`
+                  : c.status === 'unreachable'
+                    ? `No daemon found at ${c.connectionId.replace(/:\d+$/, '')}`
+                    : c.error || `Connection error: ${c.connectionId}`}
+              </span>
+              {c.status === 'unreachable' && onReconnect && (
+                <button
+                  type="button"
+                  onClick={() => onReconnect(c.connectionId)}
+                  className="ml-auto shrink-0 rounded-md bg-[var(--color-error)]/15 px-2 py-0.5 font-medium hover:bg-[var(--color-error)]/25"
+                >
+                  Retry
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {hasConnections && (
+        <>
+          {/* Attention banner */}
+          {askingCount > 0 && (
+            <button
+              type="button"
+              onClick={goToFirstAsking}
+              className="mx-4 mb-3 mt-3 flex items-center gap-3 rounded-2xl px-3.5 py-3 text-left"
+              style={{
+                background: 'var(--color-accent-soft)',
+                border: '1px solid color-mix(in srgb, var(--color-primary) 20%, transparent)',
+              }}
+            >
+              <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-[var(--color-accent-ink)]">
+                <Bell className="size-3.5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-semibold text-[var(--color-text)]">
+                  {askingCount} agent{askingCount > 1 ? 's' : ''} need{askingCount > 1 ? '' : 's'} you
+                </div>
+                <div className="mt-px text-xs text-[var(--color-text-secondary)]">
+                  Tap to answer · Y / N / A
+                </div>
+              </div>
+              <ChevronRight className="size-4 shrink-0 text-[var(--color-text-muted)]" />
+            </button>
+          )}
+
+          {/* Filter chips */}
+          <div className={clsx('no-scrollbar flex gap-1.5 overflow-x-auto px-4 pb-3', askingCount === 0 && 'pt-3')}>
+            {([
+              { id: 'all', label: 'All' },
+              { id: 'asking', label: 'Needs you' },
+              { id: 'working', label: 'Working' },
+              { id: 'idle', label: 'Idle' },
+            ] as const).map((chip) => {
+              const active = filter === chip.id;
+              const count = counts[chip.id];
+              return (
+                <button
+                  key={chip.id}
+                  type="button"
+                  onClick={() => setFilter(chip.id)}
                   className={clsx(
-                    'flex items-center gap-2 rounded-lg px-3 py-2 text-xs',
-                    c.status === 'reconnecting'
-                      ? 'bg-[var(--color-warning,#f59e0b)]/10 text-[var(--color-warning,#f59e0b)]'
-                      : 'bg-[var(--color-error)]/10 text-[var(--color-error)]',
+                    'inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-[7px] text-[13px] font-semibold transition-colors',
+                    active
+                      ? 'bg-[var(--color-text)] text-[var(--color-surface)]'
+                      : 'border border-[var(--color-border)] bg-[var(--color-surface-light)] text-[var(--color-text-secondary)]',
                   )}
                 >
-                  {c.status === 'reconnecting' ? (
-                    <Loader2 className="size-3.5 shrink-0 animate-spin" />
-                  ) : (
-                    <AlertTriangle className="size-3.5 shrink-0" />
-                  )}
-                  <span className="truncate">
-                    {c.status === 'reconnecting'
-                      ? `Reconnecting to ${c.connectionId}...`
-                      : c.status === 'unreachable'
-                        ? `No daemon found at ${c.connectionId.replace(/:\d+$/, '')}`
-                        : c.error || `Connection error: ${c.connectionId}`}
-                  </span>
-                  {c.status === 'unreachable' && onReconnect && (
-                    <button
-                      type="button"
-                      onClick={() => onReconnect(c.connectionId)}
-                      className="ml-auto shrink-0 rounded-md bg-[var(--color-error)]/15 px-2 py-0.5 font-medium hover:bg-[var(--color-error)]/25"
+                  {chip.label}
+                  {chip.id === 'asking' && count > 0 && (
+                    <span
+                      className="inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold"
+                      style={{
+                        background: active ? 'var(--color-surface)' : 'var(--color-primary)',
+                        color: active ? 'var(--color-primary)' : 'var(--color-accent-ink)',
+                      }}
                     >
-                      Retry
-                    </button>
+                      {count}
+                    </span>
                   )}
-                </div>
-              ))}
+                </button>
+              );
+            })}
           </div>
-        )}
+        </>
+      )}
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto safe-area-bottom">
+      <div className="safe-area-bottom flex-1 overflow-y-auto">
         {!hasConnections ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center">
             <div className="mb-4 rounded-full bg-[var(--color-surface-light)] p-4">
               <Link2 className="size-8 text-[var(--color-text-muted)]" />
             </div>
-            <h2 className="mb-1 font-medium text-[var(--color-text)]">Connect to your machine</h2>
+            <h2 className="mb-1 font-semibold text-[var(--color-text)]">Connect to your machine</h2>
             <p className="mb-5 text-sm text-[var(--color-text-secondary)]">
               Enter your hostname or IP to see active Claude sessions
             </p>
             <button
+              type="button"
               onClick={onConnect}
-              className="flex items-center gap-2 rounded-full bg-[var(--color-primary)] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-dark)]"
+              className="flex items-center gap-2 rounded-full bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--color-accent-ink)] transition-transform active:scale-95"
             >
               <Link2 className="size-4" />
               Connect
             </button>
           </div>
         ) : (
-          <div className="p-2 space-y-1">
+          <>
             {/* Active sessions */}
-            {activeSessions.map((session) => (
+            {filteredActive.map((session, i) => (
               <SessionCard
                 key={session.id}
                 session={session}
@@ -196,40 +330,23 @@ export function SessionList({
                 onResume={onResumeSession}
                 onDisconnect={onDisconnect}
                 isResuming={resumingSessionId === session.id}
+                last={i === filteredActive.length - 1 && recentSessions.length === 0}
               />
             ))}
 
-            {activeSessions.length === 0 && (
-              <p className="px-3 py-4 text-center text-sm text-[var(--color-text-muted)]">
-                No active sessions
+            {filteredActive.length === 0 && (
+              <p className="px-4 py-10 text-center text-sm text-[var(--color-text-muted)]">
+                {filter === 'all' ? 'No active sessions' : `Nothing ${filter === 'asking' ? 'needs you' : filter}`}
               </p>
             )}
 
-            {/* New Session button */}
-            {onNewSession && (
-              <button
-                onClick={() => {
-                  const dir = prompt('Project directory (leave empty for home):');
-                  onNewSession(dir || undefined);
-                }}
-                className={clsx(
-                  'flex w-full items-center gap-3 rounded-xl px-4 py-3 mt-1',
-                  'border border-dashed border-[var(--color-border)]',
-                  'text-sm text-[var(--color-text-secondary)]',
-                  'transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]',
-                )}
-              >
-                <MessageSquarePlus className="size-5" />
-                New Session
-              </button>
-            )}
-
-            {/* Recent sessions */}
-            {recentSessions.length > 0 && (
-              <div className="mt-2 pt-2 border-t border-[var(--color-border)]">
+            {/* Recent (transcript-only) sessions */}
+            {filter === 'all' && recentSessions.length > 0 && (
+              <div className="border-t border-[var(--color-border)]">
                 <button
+                  type="button"
                   onClick={() => setShowRecent(!showRecent)}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-[var(--color-text-muted)]"
+                  className="flex w-full items-center gap-2 px-[22px] py-3 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]"
                 >
                   {showRecent ? (
                     <ChevronDown className="size-3.5" />
@@ -238,23 +355,21 @@ export function SessionList({
                   )}
                   Recent ({recentSessions.length})
                 </button>
-                {showRecent && (
-                  <div className="space-y-1">
-                    {recentSessions.map((session) => (
-                      <SessionCard
-                        key={session.id}
-                        session={session}
-                        isActive={session.id === activeSessionId}
-                        onClick={() => onSelectSession(session.id)}
-                        onResume={onResumeSession}
-                        isResuming={resumingSessionId === session.id}
-                      />
-                    ))}
-                  </div>
-                )}
+                {showRecent &&
+                  recentSessions.map((session, i) => (
+                    <SessionCard
+                      key={session.id}
+                      session={session}
+                      isActive={session.id === activeSessionId}
+                      onClick={() => onSelectSession(session.id)}
+                      onResume={onResumeSession}
+                      isResuming={resumingSessionId === session.id}
+                      last={i === recentSessions.length - 1}
+                    />
+                  ))}
               </div>
             )}
-          </div>
+          </>
         )}
       </div>
     </div>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -47,8 +47,10 @@ interface SessionListProps {
 
 type FilterId = 'all' | 'asking' | 'working' | 'idle';
 
-/** Map a pill state to the filter bucket it belongs to. */
-function filterBucket(state: PillState): FilterId {
+/** Map a pill state to the filter bucket it belongs to. `connecting` and
+ *  `offline` fold into `idle` on purpose: they are all non-interactive from
+ *  the user's point of view and don't warrant their own chip on a phone. */
+function filterBucket(state: PillState): 'asking' | 'working' | 'idle' {
   if (state === 'asking') return 'asking';
   if (state === 'working') return 'working';
   return 'idle';
@@ -172,8 +174,8 @@ export function SessionList({
               onClick={() => {
                 if (hasConnections && onNewSession) {
                   // Directory selection is preserved here; the richer
-                  // new-session sheet (command + options) is a follow-up that
-                  // needs daemon-side support.
+                  // new-session sheet (command + options) is tracked in #447
+                  // and needs daemon-side support.
                   const dir = window.prompt('Project directory (leave empty for home):');
                   if (dir !== null) onNewSession(dir || undefined);
                 } else {
@@ -239,7 +241,7 @@ export function SessionList({
               className="mx-4 mb-3 mt-3 flex items-center gap-3 rounded-2xl px-3.5 py-3 text-left"
               style={{
                 background: 'var(--color-accent-soft)',
-                border: '1px solid color-mix(in srgb, var(--color-primary) 20%, transparent)',
+                border: '1px solid var(--color-accent-20)',
               }}
             >
               <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-[var(--color-accent-ink)]">

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -44,7 +44,7 @@ function ThemeButton({
       className={clsx(
         'flex flex-1 flex-col items-center gap-1.5 rounded-lg p-3 text-xs transition-colors',
         active
-          ? 'bg-[var(--color-primary)] text-white'
+          ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)]'
           : 'bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-elevated)]',
       )}
     >
@@ -246,7 +246,7 @@ function IdentitySection() {
                   setShowGenerate(true);
                   setShowImport(false);
                 }}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-white hover:bg-[var(--color-primary-dark)]"
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)]"
               >
                 <Key className="size-3.5" />
                 Generate
@@ -299,7 +299,7 @@ function IdentitySection() {
                 <button
                   type="submit"
                   disabled={generating}
-                  className="flex-1 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-white hover:bg-[var(--color-primary-dark)] disabled:opacity-50"
+                  className="flex-1 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)] disabled:opacity-50"
                 >
                   {generating ? 'Generating...' : 'Create Identity'}
                 </button>
@@ -332,7 +332,7 @@ function IdentitySection() {
                 <button
                   type="submit"
                   disabled={!importJson.trim()}
-                  className="flex-1 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-white hover:bg-[var(--color-primary-dark)] disabled:opacity-50"
+                  className="flex-1 rounded-lg bg-[var(--color-primary)] py-2 text-xs text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)] disabled:opacity-50"
                 >
                   Import
                 </button>
@@ -435,7 +435,7 @@ export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPan
                   className={clsx(
                     'flex-1 rounded-lg py-2 text-sm capitalize transition-colors',
                     settings.fontSize === size
-                      ? 'bg-[var(--color-primary)] text-white'
+                      ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)]'
                       : 'bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-elevated)]',
                   )}
                 >

--- a/packages/web/src/fontsource.d.ts
+++ b/packages/web/src/fontsource.d.ts
@@ -1,0 +1,4 @@
+// Fontsource packages ship CSS that is imported for side effects only
+// (they register @font-face rules). They have no TS types, so declare the
+// bare specifiers as side-effect modules.
+declare module '@fontsource-variable/*';

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -124,6 +124,16 @@
   --color-success: #7dd87a;
   --color-warning: #f5b341;
   --color-error: #ff5d5d;
+  /* Pre-mixed success tints (literal rgba, not color-mix) so they render on
+     iOS 15 WebView where color-mix() is unsupported (Safari < 16.2). */
+  --color-success-soft: rgba(125, 216, 122, 0.1);
+  --color-success-line: rgba(125, 216, 122, 0.25);
+  /* Pre-mixed lime accent tints, same iOS-15 reason. */
+  --color-accent-7: rgba(201, 235, 74, 0.07);
+  --color-accent-13: rgba(201, 235, 74, 0.13);
+  --color-accent-20: rgba(201, 235, 74, 0.2);
+  --color-accent-33: rgba(201, 235, 74, 0.33);
+  --color-accent-ink-14: rgba(26, 28, 10, 0.14);
 
   /* Message bubbles -- light "ink" pill for the user, warm elevation for the agent */
   --color-bubble-user: #f4efe4;
@@ -214,8 +224,9 @@
   }
 }
 
-/* Expanding ring used by "working" status dots. currentColor lets the ring
-   inherit whatever color the dot is tinted. */
+/* Expanding ring used by active-state status dots (working, connecting, and
+   the question-card header). currentColor lets the ring inherit whatever color
+   the dot is tinted. */
 @keyframes pulse-dot {
   0% {
     box-shadow: 0 0 0 0 currentColor;
@@ -251,6 +262,9 @@ html[data-theme="light"] {
   --color-status-sent: #5a564e;
   --color-status-delivered: #4a8f47;
   --color-status-read: #6f8a1f;
+  /* Success tints recomputed for the lighter-foliage light-mode success. */
+  --color-success-soft: rgba(74, 143, 71, 0.1);
+  --color-success-line: rgba(74, 143, 71, 0.25);
 }
 
 /* Base styles */
@@ -320,7 +334,7 @@ body.keyboard-open .safe-area-bottom {
   background-color: var(--color-text-muted);
 }
 
-/* Hide scrollbars inside horizontal scroll regions (chips, recents) */
+/* Hide scrollbars inside horizontal scroll regions (the filter-chips row) */
 .no-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1,128 +1,140 @@
 @import "tailwindcss";
 
-/* Theme colors as @property so bare references work in Safari/WKWebView */
+/* Theme colors as @property so bare references work in Safari/WKWebView.
+   Initial values mirror the dark (default) theme. */
 @property --color-primary {
   syntax: "<color>";
   inherits: true;
-  initial-value: #0d9490;
+  initial-value: #c9eb4a;
 }
 @property --color-primary-dark {
   syntax: "<color>";
   inherits: true;
-  initial-value: #0b7f7a;
+  initial-value: #b9db3a;
+}
+@property --color-accent-ink {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #1a1c0a;
 }
 @property --color-surface {
   syntax: "<color>";
   inherits: true;
-  initial-value: #1a1d21;
+  initial-value: #0e0e0c;
 }
 @property --color-surface-light {
   syntax: "<color>";
   inherits: true;
-  initial-value: #242830;
+  initial-value: #171614;
 }
 @property --color-surface-elevated {
   syntax: "<color>";
   inherits: true;
-  initial-value: #2e323a;
+  initial-value: #211f1b;
 }
 @property --color-text {
   syntax: "<color>";
   inherits: true;
-  initial-value: #f0f2f5;
+  initial-value: #f4efe4;
 }
 @property --color-text-secondary {
   syntax: "<color>";
   inherits: true;
-  initial-value: #9ca3af;
+  initial-value: #a09a8d;
 }
 @property --color-text-muted {
   syntax: "<color>";
   inherits: true;
-  initial-value: #6b7280;
+  initial-value: #66625a;
 }
 @property --color-border {
   syntax: "<color>";
   inherits: true;
-  initial-value: #343840;
+  initial-value: #2a2924;
 }
 @property --color-success {
   syntax: "<color>";
   inherits: true;
-  initial-value: #34d399;
+  initial-value: #7dd87a;
 }
 @property --color-warning {
   syntax: "<color>";
   inherits: true;
-  initial-value: #f59e0b;
+  initial-value: #f5b341;
 }
 @property --color-error {
   syntax: "<color>";
   inherits: true;
-  initial-value: #ef4444;
+  initial-value: #ff5d5d;
 }
 @property --color-bubble-user {
   syntax: "<color>";
   inherits: true;
-  initial-value: #0d9490;
+  initial-value: #f4efe4;
 }
 @property --color-bubble-assistant {
   syntax: "<color>";
   inherits: true;
-  initial-value: #2e323a;
+  initial-value: #171614;
 }
 @property --color-bubble-system {
   syntax: "<color>";
   inherits: true;
-  initial-value: #1e3a5f;
+  initial-value: #211f1b;
 }
 @property --color-status-sending {
   syntax: "<color>";
   inherits: true;
-  initial-value: #9ca3af;
+  initial-value: #66625a;
 }
 @property --color-status-sent {
   syntax: "<color>";
   inherits: true;
-  initial-value: #38bdf8;
+  initial-value: #a09a8d;
 }
 @property --color-status-delivered {
   syntax: "<color>";
   inherits: true;
-  initial-value: #34d399;
+  initial-value: #7dd87a;
 }
 @property --color-status-read {
   syntax: "<color>";
   inherits: true;
-  initial-value: #0d9490;
+  initial-value: #c9eb4a;
 }
 
 /* Theme variables */
 @theme {
-  /* Dark mode -- warm dark grays (Telegram-inspired, not pure black) */
-  --color-primary: #0d9490;
-  --color-primary-dark: #0b7f7a;
-  --color-surface: #1a1d21;
-  --color-surface-light: #242830;
-  --color-surface-elevated: #2e323a;
-  --color-text: #f0f2f5;
-  --color-text-secondary: #9ca3af;
-  --color-text-muted: #6b7280;
-  --color-border: #343840;
-  --color-success: #34d399;
-  --color-warning: #f59e0b;
-  --color-error: #ef4444;
+  /* Dark mode -- warm near-black neutrals with a lime accent.
+     "Sovereign Intelligence. Built for the skeptical." */
+  --color-primary: #c9eb4a;
+  --color-primary-dark: #b9db3a;
+  /* Ink color for text/icons sitting ON the lime accent (never white). */
+  --color-accent-ink: #1a1c0a;
+  /* Soft accent wash for attention surfaces (banners, pills, glows). */
+  --color-accent-soft: rgba(201, 235, 74, 0.1);
 
-  /* Message bubbles -- teal for user, warm gray for assistant */
-  --color-bubble-user: #0d9490;
-  --color-bubble-assistant: #2e323a;
-  --color-bubble-system: #1e3a5f;
+  --color-surface: #0e0e0c;
+  --color-surface-light: #171614;
+  --color-surface-elevated: #211f1b;
+  --color-text: #f4efe4;
+  --color-text-secondary: #a09a8d;
+  --color-text-muted: #66625a;
+  --color-border: #2a2924;
+  --color-success: #7dd87a;
+  --color-warning: #f5b341;
+  --color-error: #ff5d5d;
+
+  /* Message bubbles -- light "ink" pill for the user, warm elevation for the agent */
+  --color-bubble-user: #f4efe4;
+  --color-bubble-assistant: #171614;
+  --color-bubble-system: #211f1b;
 
   /* Delivery status */
-  --color-status-sending: #9ca3af;
-  --color-status-sent: #38bdf8;
-  --color-status-delivered: #34d399;
-  --color-status-read: #0d9490;
+  --color-status-sending: #66625a;
+  --color-status-sent: #a09a8d;
+  --color-status-delivered: #7dd87a;
+  --color-status-read: #c9eb4a;
 
   /* Spacing */
   --spacing-safe-top: env(safe-area-inset-top, 0px);
@@ -130,9 +142,10 @@
   --spacing-safe-left: env(safe-area-inset-left, 0px);
   --spacing-safe-right: env(safe-area-inset-right, 0px);
 
-  /* Typography */
-  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+  /* Typography -- Inter Tight for UI/display, JetBrains Mono for code + hosts */
+  --font-sans: "Inter Tight Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  --font-mono: "JetBrains Mono Variable", ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
 
   /* Border radius */
   --radius-sm: 0.375rem;
@@ -150,6 +163,7 @@
   --animate-fade-in: fade-in 0.2s ease-out;
   --animate-slide-up: slide-up 0.3s ease-out;
   --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  --animate-pulse-dot: pulse-dot 1.6s ease-out infinite;
 }
 
 @keyframes fade-in {
@@ -181,6 +195,15 @@
   }
 }
 
+@keyframes sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -191,19 +214,43 @@
   }
 }
 
-/* Light mode -- soft warm whites, vibrant teal accent */
+/* Expanding ring used by "working" status dots. currentColor lets the ring
+   inherit whatever color the dot is tinted. */
+@keyframes pulse-dot {
+  0% {
+    box-shadow: 0 0 0 0 currentColor;
+  }
+  70% {
+    box-shadow: 0 0 0 5px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+/* Light mode -- warm paper whites, same lime accent */
 html[data-theme="light"] {
-  --color-primary: #0ea5a1;
-  --color-primary-dark: #0d9490;
-  --color-surface: #f7f8fa;
-  --color-surface-light: #eef0f4;
-  --color-surface-elevated: #e4e7ec;
-  --color-text: #1a1d21;
-  --color-text-secondary: #4b5563;
-  --color-text-muted: #6b7280;
-  --color-border: #d1d5db;
-  --color-bubble-assistant: #e4e7ec;
-  --color-bubble-system: #dbeafe;
+  --color-primary: #c9eb4a;
+  --color-primary-dark: #b9db3a;
+  --color-accent-ink: #1a1c0a;
+  --color-accent-soft: rgba(159, 191, 38, 0.16);
+  --color-surface: #f6f3ec;
+  --color-surface-light: #ffffff;
+  --color-surface-elevated: #ede8dc;
+  --color-text: #1a1816;
+  --color-text-secondary: #5a564e;
+  --color-text-muted: #8c887d;
+  --color-border: #e1dccf;
+  --color-success: #4a8f47;
+  --color-warning: #c98415;
+  --color-error: #c63838;
+  --color-bubble-user: #1a1816;
+  --color-bubble-assistant: #ffffff;
+  --color-bubble-system: #ede8dc;
+  --color-status-sending: #8c887d;
+  --color-status-sent: #5a564e;
+  --color-status-delivered: #4a8f47;
+  --color-status-read: #6f8a1f;
 }
 
 /* Base styles */
@@ -273,6 +320,16 @@ body.keyboard-open .safe-area-bottom {
   background-color: var(--color-text-muted);
 }
 
+/* Hide scrollbars inside horizontal scroll regions (chips, recents) */
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
 /* Code block styling */
 pre,
 code {
@@ -293,10 +350,10 @@ pre {
   word-break: break-word;
 }
 
-/* Selection styling */
+/* Selection styling -- accent ink on lime, never white */
 ::selection {
   background-color: var(--color-primary);
-  color: white;
+  color: var(--color-accent-ink);
 }
 
 /* Focus visible for accessibility */

--- a/packages/web/src/lib/format-time.ts
+++ b/packages/web/src/lib/format-time.ts
@@ -5,6 +5,12 @@
 /** Format a timestamp as a human-readable relative time string. */
 export function formatRelativeTime(timestamp: string): string {
   const date = new Date(timestamp);
+  // A timestamp that fails to parse would otherwise render the literal
+  // "Invalid Date" with no signal; surface it instead of shipping it to the UI.
+  if (Number.isNaN(date.getTime())) {
+    console.warn('[formatRelativeTime] invalid timestamp:', timestamp);
+    return '—';
+  }
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffMins = Math.floor(diffMs / 60000);

--- a/packages/web/src/lib/session-display.ts
+++ b/packages/web/src/lib/session-display.ts
@@ -26,9 +26,17 @@ export function sessionPillState(
       return 'connecting';
     case 'disconnected':
       return 'idle';
-    default:
-      break;
+    case 'connected':
+      break; // fall through to the agent-status checks below
+    default: {
+      // Exhaustiveness guard: a new ConnectionStatus must be handled above or
+      // this line fails to compile.
+      const _exhaustive: never = session.connectionStatus;
+      void _exhaustive;
+    }
   }
+  // A pending question always wins. Note: the 'waiting' AgentStatus has no
+  // distinct pill and intentionally collapses to 'idle'.
   if (session.questionPending) return 'asking';
   if (session.status === 'thinking' || session.status === 'executing') return 'working';
   return 'idle';
@@ -38,11 +46,12 @@ export function sessionPillState(
  * Split a session's display name into host / project / branch parts.
  * Session names are shaped "<host>:<project>/<branch...>" (host optional);
  * when no explicit host prefix is present we fall back to the connection's
- * hostname (the port stripped off).
+ * hostname (the port stripped off). `branch` is null when the name has no
+ * branch component (callers fall back to the project as the headline).
  */
 export function splitSessionName(
   session: Pick<UISession, 'name' | 'connectionId'>,
-): { host: string; project: string; branch: string } {
+): { host: string; project: string; branch: string | null } {
   const raw = session.name || '';
   let host = session.connectionId.replace(/:\d+$/, '');
   let rest = raw;
@@ -54,6 +63,6 @@ export function splitSessionName(
   }
   const slash = rest.indexOf('/');
   const project = (slash >= 0 ? rest.slice(0, slash) : rest) || 'session';
-  const branch = slash >= 0 ? rest.slice(slash + 1) : '';
+  const branch = slash >= 0 ? rest.slice(slash + 1) : null;
   return { host, project, branch };
 }

--- a/packages/web/src/lib/session-display.ts
+++ b/packages/web/src/lib/session-display.ts
@@ -1,0 +1,59 @@
+/**
+ * Session display helpers.
+ *
+ * The single source of truth for (a) how a session's connection + agent state
+ * maps to a visual "pill" state, and (b) how a session name splits into
+ * host / project / branch for the redesigned rows and chat header.
+ */
+
+import type { UISession } from '@/types';
+
+/** Visual state for a session, derived from connection + agent status. */
+export type PillState = 'asking' | 'working' | 'idle' | 'connecting' | 'offline';
+
+/** Derive the pill state. Connection status wins over agent status; a pending
+ *  question always surfaces as "Needs you". */
+export function sessionPillState(
+  session: Pick<UISession, 'connectionStatus' | 'status' | 'questionPending'>,
+): PillState {
+  switch (session.connectionStatus) {
+    case 'error':
+    case 'unreachable':
+      return 'offline';
+    case 'connecting':
+    case 'reconnecting':
+    case 'authenticating':
+      return 'connecting';
+    case 'disconnected':
+      return 'idle';
+    default:
+      break;
+  }
+  if (session.questionPending) return 'asking';
+  if (session.status === 'thinking' || session.status === 'executing') return 'working';
+  return 'idle';
+}
+
+/**
+ * Split a session's display name into host / project / branch parts.
+ * Session names are shaped "<host>:<project>/<branch...>" (host optional);
+ * when no explicit host prefix is present we fall back to the connection's
+ * hostname (the port stripped off).
+ */
+export function splitSessionName(
+  session: Pick<UISession, 'name' | 'connectionId'>,
+): { host: string; project: string; branch: string } {
+  const raw = session.name || '';
+  let host = session.connectionId.replace(/:\d+$/, '');
+  let rest = raw;
+  const colon = raw.indexOf(':');
+  // Only treat a leading "host:" as a host when it isn't part of a path.
+  if (colon > 0 && !raw.slice(0, colon).includes('/')) {
+    host = raw.slice(0, colon);
+    rest = raw.slice(colon + 1);
+  }
+  const slash = rest.indexOf('/');
+  const project = (slash >= 0 ? rest.slice(0, slash) : rest) || 'session';
+  const branch = slash >= 0 ? rest.slice(slash + 1) : '';
+  return { host, project, branch };
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,10 @@ import { Network } from '@capacitor/network';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+// Bundled variable fonts (offline-first; no CDN). Inter Tight for UI/display,
+// JetBrains Mono for code, hosts, and technical labels.
+import '@fontsource-variable/inter-tight';
+import '@fontsource-variable/jetbrains-mono';
 import './index.css';
 import App from './App.tsx';
 import { initNotifications } from './lib/notifications';

--- a/packages/web/tests/lib/session-display.test.ts
+++ b/packages/web/tests/lib/session-display.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for session-display helpers. Pure functions; no mocks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { sessionPillState, splitSessionName } from '../../src/lib/session-display';
+import type { ConnectionId } from '../../src/types';
+
+const cid = (s: string): ConnectionId => s as unknown as ConnectionId;
+
+describe('splitSessionName', () => {
+  test('full "host:project/branch" splits all three parts', () => {
+    expect(
+      splitSessionName({ name: 'macbook:remi/feat/notif-sheet', connectionId: cid('macbook:18924') }),
+    ).toEqual({ host: 'macbook', project: 'remi', branch: 'feat/notif-sheet' });
+  });
+
+  test('no host prefix falls back to the connectionId hostname (port stripped)', () => {
+    expect(splitSessionName({ name: 'remi/develop', connectionId: cid('localhost:18765') })).toEqual({
+      host: 'localhost',
+      project: 'remi',
+      branch: 'develop',
+    });
+  });
+
+  test('a colon after a slash is NOT treated as a host prefix', () => {
+    // "project/sub:extra" -- the colon belongs to the path, not a host.
+    expect(splitSessionName({ name: 'project/sub:extra', connectionId: cid('beelink:18924') })).toEqual({
+      host: 'beelink',
+      project: 'project',
+      branch: 'sub:extra',
+    });
+  });
+
+  test('no slash yields a null branch (project becomes the headline)', () => {
+    expect(splitSessionName({ name: 'host:soloproject', connectionId: cid('host:1') })).toEqual({
+      host: 'host',
+      project: 'soloproject',
+      branch: null,
+    });
+  });
+
+  test('empty name falls back to "session" project and connectionId host', () => {
+    expect(splitSessionName({ name: '', connectionId: cid('192.168.1.4:19924') })).toEqual({
+      host: '192.168.1.4',
+      project: 'session',
+      branch: null,
+    });
+  });
+
+  test('deep branch path keeps every component after the first slash', () => {
+    expect(
+      splitSessionName({ name: 'host:repo/feature/issue-447/phase2', connectionId: cid('host:1') }),
+    ).toEqual({ host: 'host', project: 'repo', branch: 'feature/issue-447/phase2' });
+  });
+});
+
+describe('sessionPillState', () => {
+  test('error connection is offline regardless of agent status or question', () => {
+    expect(
+      sessionPillState({ connectionStatus: 'error', status: 'thinking', questionPending: true }),
+    ).toBe('offline');
+    expect(sessionPillState({ connectionStatus: 'unreachable', status: 'idle' })).toBe('offline');
+  });
+
+  test('connection status wins: disconnected with a stale question is idle, not asking', () => {
+    expect(
+      sessionPillState({ connectionStatus: 'disconnected', status: 'idle', questionPending: true }),
+    ).toBe('idle');
+  });
+
+  test('connecting / reconnecting / authenticating all map to connecting', () => {
+    expect(sessionPillState({ connectionStatus: 'connecting', status: 'idle' })).toBe('connecting');
+    expect(sessionPillState({ connectionStatus: 'reconnecting', status: 'idle' })).toBe('connecting');
+    expect(sessionPillState({ connectionStatus: 'authenticating', status: 'idle' })).toBe('connecting');
+  });
+
+  test('connected + pending question is asking', () => {
+    expect(
+      sessionPillState({ connectionStatus: 'connected', status: 'idle', questionPending: true }),
+    ).toBe('asking');
+  });
+
+  test('connected + thinking/executing is working', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'thinking' })).toBe('working');
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'executing' })).toBe('working');
+  });
+
+  test('connected + idle (or waiting) is idle', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'idle' })).toBe('idle');
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'waiting' })).toBe('idle');
+  });
+});


### PR DESCRIPTION
## Summary

Reimagined the Remi web/iOS UI to the new design language: warm near-black neutrals with a single lime accent, Inter Tight + JetBrains Mono, and a more information-rich layout. Visual migration only; all wiring (WebSocket, sessions, questions, auth, connection manager) is preserved.

The pixel spec is the self-contained prototype in `prototypes/redesign/` (kept local, not committed).

## What changed

- **Design foundation** (`index.css`): warm palette + lime `--color-primary`; new `--color-accent-ink` (dark text on lime, never white) and `--color-accent-soft` tokens; `data-theme="light"` variant; `pulse-dot`/`sheet-up` animations. Fonts bundled offline via `@fontsource-variable/inter-tight` + `jetbrains-mono` (no CDN).
- **Single source of truth** for session state: `lib/session-display.ts` (`sessionPillState`, `splitSessionName`) + `components/StatusPill.tsx`.
- **Sessions**: brand chip + live connection status, "N agents need you" attention banner, status filter chips, rich rows (host/project mono, branch + git icon, status pill, 2-line preview, attention stripe, unread badge).
- **Chat**: blurred header (host/project + branch + pill + menu), the permission/question card pinned at the top with Y/N/A key-badges + hints, light "ink" user bubbles, mono tool cards, lime composer.
- **Connect** reworked as a bottom sheet (grab handle, lime CTA). **Settings** + every `text-white`-on-lime fixed to dark ink.

## Verification

- Sessions / Chat / Connect / Settings checked in-browser (dark + light) against the prototype.
- `tsc -b` clean; ESLint clean on changed files.
- Real `vite build` succeeds; fonts ship as local woff2 (offline confirmed).

## Deferred (needs daemon API)

- The prototype's full "New session" sheet (host picker + command quick-picks + options toggles). The header "+" keeps directory selection via prompt for now.
- `MessageList` keeps its "N tool calls" collapse (intentional mobile-noise feature) rather than per-tool cards.

## Notes

- Pre-existing `react-hooks/set-state-in-effect` in `InputArea` draft-rehydration effect left untouched (not in scope; web ESLint is not in the CI gate).
