### PR TITLE
fix: land on session list on fresh connect + warm launch bg

### DIFF
--- a/packages/web/capacitor.config.ts
+++ b/packages/web/capacitor.config.ts
@@ -12,7 +12,7 @@ const config: CapacitorConfig = {
     contentInset: 'automatic',
     preferredContentMode: 'mobile',
     overrideUserAgent: 'Remi/1.0 iOS',
-    backgroundColor: '#1a1d21',
+    backgroundColor: '#0e0e0c',
     scrollEnabled: false,
   },
   android: {
@@ -24,7 +24,7 @@ const config: CapacitorConfig = {
   plugins: {
     StatusBar: {
       style: 'dark',
-      backgroundColor: '#1a1d21',
+      backgroundColor: '#0e0e0c',
     },
     Keyboard: {
       resize: 'none',

--- a/packages/web/ios/App/App/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/packages/web/ios/App/App/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -4,9 +4,27 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.102",
-          "green": "0.114",
-          "blue": "0.129",
+          "red": "0.965",
+          "green": "0.953",
+          "blue": "0.925",
+          "alpha": "1.000"
+        }
+      },
+      "idiom": "universal"
+    },
+    {
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.055",
+          "green": "0.055",
+          "blue": "0.047",
           "alpha": "1.000"
         }
       },

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -295,11 +295,16 @@ function App() {
         const conn = connectionsRef.current.find((c) => c.connectionId === connectionId);
         if (conn?.url) rememberSessionDaemon(message.sessionId, conn.url);
 
-        // Auto-switch to new session when same connection restarts
+        // Reconnect-mid-rotation only: if the chat the user is CURRENTLY
+        // viewing belongs to this connection and the daemon came back with a
+        // new session id, follow it into the new session. A fresh connect (no
+        // chat open) must NOT bypass the session list -- land on the list so
+        // the user picks a session. Notification deep-links navigate via their
+        // own `push-notification-tap` handler, not here.
         const oldActive = activeSessionIdRef.current;
         if (oldActive !== message.sessionId) {
           const oldSession = sessionsRef.current.find((s) => s.id === oldActive);
-          const shouldSwitch = !oldActive || oldSession?.connectionId === connectionId;
+          const shouldSwitch = !!oldActive && oldSession?.connectionId === connectionId;
           if (shouldSwitch) {
             setActiveSessionId(message.sessionId);
             if (oldActive) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -304,13 +304,13 @@ function App() {
         const oldActive = activeSessionIdRef.current;
         if (oldActive !== message.sessionId) {
           const oldSession = sessionsRef.current.find((s) => s.id === oldActive);
-          const shouldSwitch = !!oldActive && oldSession?.connectionId === connectionId;
-          if (shouldSwitch) {
+          // `oldActive &&` both gates on a chat being open (so a fresh connect
+          // stays on the list) and narrows oldActive to non-null for the
+          // cleanup below.
+          if (oldActive && oldSession?.connectionId === connectionId) {
             setActiveSessionId(message.sessionId);
-            if (oldActive) {
-              setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
-              setQuestions((prev) => clearSessionQuestions(prev, oldActive));
-            }
+            setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
+            setQuestions((prev) => clearSessionQuestions(prev, oldActive));
           }
         }
         break;


### PR DESCRIPTION
Two post-redesign fixes.

## Connect lands on the session list (not chat)
On a fresh connect (e.g. connecting to a host without a specific session, or opening the app cold), the `hello_ack` handler was auto-selecting the daemon's directly-attached session and jumping straight into chat, bypassing the session list. It now only follows a session into chat for **reconnect-mid-rotation** (the chat you're already viewing belongs to this connection and the daemon came back with a new session id). Notification deep-links are unaffected — they navigate via the separate `push-notification-tap` handler.

## Warm launch background
The native launch flashed the old cool gray `#1a1d21`. `LaunchBackground` is now a theme-aware color set (#f6f3ec light / #0e0e0c dark), and the Capacitor webview + status-bar background colors move to `#0e0e0c`, so launch matches the redesign.

Built (Debug, signed) and installed on a physical iPhone 15 Pro Max.