### PR TITLE
fix(web): legible accent text in light mode

### DIFF
--- a/packages/web/src/components/StatusPill.tsx
+++ b/packages/web/src/components/StatusPill.tsx
@@ -23,7 +23,7 @@ const PILL: Record<PillState, PillConfig> = {
   asking: {
     label: 'Needs you',
     dot: 'var(--color-primary)',
-    fg: 'var(--color-primary)',
+    fg: 'var(--color-accent-text)',
     bg: 'var(--color-accent-soft)',
     pulse: false,
   },

--- a/packages/web/src/components/chat/ChatMessage.tsx
+++ b/packages/web/src/components/chat/ChatMessage.tsx
@@ -117,7 +117,7 @@ const markdownComponents = {
   a: ({ children, href, ...props }: React.ComponentProps<'a'>) => (
     <a
       href={href}
-      className="text-[var(--color-primary)] underline underline-offset-2"
+      className="text-[var(--color-accent-text)] underline underline-offset-2"
       target="_blank"
       rel="noopener noreferrer"
       {...props}
@@ -167,9 +167,9 @@ const markdownComponents = {
     return (
       <code
         className={clsx(
-          'rounded px-1.5 py-0.5 text-[0.85em]',
+          'rounded px-1.5 py-0.5 text-[0.85em] font-medium',
           'font-[family-name:--font-mono]',
-          'bg-[var(--color-surface-light)] text-[var(--color-primary)]',
+          'bg-[var(--color-surface-elevated)] text-[var(--color-accent-text)]',
         )}
         {...props}
       >

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -90,7 +90,7 @@ function BulletItem({
           disabled={bullet.isExpanding}
           className={clsx(
             'mt-1 flex items-center gap-1 text-xs',
-            'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)]',
+            'text-[var(--color-accent-text)] hover:opacity-80',
             'transition-colors duration-150',
             bullet.isExpanding && 'opacity-50 cursor-wait',
           )}

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -222,7 +222,7 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
           className="size-1.5 rounded-full bg-[var(--color-primary)]"
           style={{ color: 'var(--color-primary)', animation: 'pulse-dot 1.4s ease-out infinite' }}
         />
-        <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--color-primary)]">
+        <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--color-accent-text)]">
           {headerLabel}
         </span>
         <span className="ml-auto font-mono text-[11px] text-[var(--color-text-secondary)]">

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -77,7 +77,7 @@ export function SessionCard({
 
         {/* preview (two lines) */}
         <div className="line-clamp-2 text-[13px] leading-snug text-[var(--color-text-secondary)]">
-          {isAsking && <span className="font-semibold text-[var(--color-primary)]">· </span>}
+          {isAsking && <span className="font-semibold text-[var(--color-accent-text)]">· </span>}
           {preview}
         </div>
       </div>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -287,7 +287,7 @@ export function SessionList({
                       className="inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold"
                       style={{
                         background: active ? 'var(--color-surface)' : 'var(--color-primary)',
-                        color: active ? 'var(--color-primary)' : 'var(--color-accent-ink)',
+                        color: active ? 'var(--color-accent-text)' : 'var(--color-accent-ink)',
                       }}
                     >
                       {count}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -113,6 +113,9 @@
   --color-accent-ink: #1a1c0a;
   /* Soft accent wash for attention surfaces (banners, pills, glows). */
   --color-accent-soft: rgba(201, 235, 74, 0.1);
+  /* Lime as TEXT. Legible on dark surfaces; the light theme overrides this to a
+     darker olive-lime because bright lime text fails contrast on light bg. */
+  --color-accent-text: #c9eb4a;
 
   --color-surface: #0e0e0c;
   --color-surface-light: #171614;
@@ -245,6 +248,9 @@ html[data-theme="light"] {
   --color-primary-dark: #b9db3a;
   --color-accent-ink: #1a1c0a;
   --color-accent-soft: rgba(159, 191, 38, 0.16);
+  /* Darker olive-lime so accent text (inline code, links, labels) stays legible
+     on the light paper surfaces (~5:1 on white, ~4.8:1 on the elevated chip). */
+  --color-accent-text: #4f6b07;
   --color-surface: #f6f3ec;
   --color-surface-light: #ffffff;
   --color-surface-elevated: #ede8dc;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -17,6 +17,11 @@
   inherits: true;
   initial-value: #1a1c0a;
 }
+@property --color-accent-text {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #c9eb4a;
+}
 @property --color-surface {
   syntax: "<color>";
   inherits: true;


### PR DESCRIPTION
The lime accent (#c9eb4a) is great on dark surfaces but fails contrast as **text** on the light theme — inline code, links, the PERMISSION REQUEST label, and the Needs-you pill were washed out.

New theme-aware `--color-accent-text` token: lime in dark mode (unchanged), a darker olive-lime `#4f6b07` (~5:1 on white, ~4.8:1 on the elevated chip) in light. Inline code additionally gets a visible elevated-chip background + medium weight. Icons keep the brand lime.

Verified in both themes; built/installed on a physical iPhone 15 Pro Max.