### PR TITLE
fix(daemon): make transcript-watcher start reliable (#451 + fallback-timeout)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1098,6 +1098,7 @@ async function createNewSession(
     {
       sessionRegistry,
       sessionStore,
+      liveSessionsRegistry,
       outputProcessor,
       wsPort: remiStatus.wsPort,
       sendMessage,
@@ -1126,6 +1127,15 @@ async function createNewSession(
   } catch (err) {
     sessionStore.markExited(sessionId, null);
     throw err;
+  }
+
+  // Record the spawned Claude child pid in the live-sessions entry now that the
+  // PTY is up. Co-located daemons use it to tell a live sibling from a zombie
+  // (daemon process alive, its Claude long dead) so a leftover daemon can no
+  // longer permanently wedge our rotation handling (#451).
+  const claudeChildPid = ptySession.childPid;
+  if (claudeChildPid !== null) {
+    liveSessionsRegistry.setClaudeChildPid(sessionId, claudeChildPid);
   }
 
   startTranscriptFallback(
@@ -1195,6 +1205,7 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
+  sessionStore,
   send: sendToConnection,
 });
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1136,6 +1136,12 @@ async function createNewSession(
   const claudeChildPid = ptySession.childPid;
   if (claudeChildPid !== null) {
     liveSessionsRegistry.setClaudeChildPid(sessionId, claudeChildPid);
+  } else {
+    // Unreachable after a successful start() (the child pid is assigned
+    // synchronously by the spawn). Log rather than silently skip: without the
+    // pid the entry stays "unknown" and peers keep treating this live session
+    // as a zombie's sibling, re-opening the wedge this fix closes (#451).
+    logError(`[live-sessions] No Claude child pid after PTY start for session ${sessionId}`);
   }
 
   startTranscriptFallback(

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -15,6 +15,7 @@ import { createError, createTranscriptLoadComplete, errorToString } from '@remi/
 import type { UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
+import type { SessionStore } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
   TranscriptWatcher as TranscriptWatcherType,
@@ -28,13 +29,16 @@ export interface TranscriptHandlerDeps {
   transcriptDiscovery: TranscriptDiscovery;
   /** Live watchers keyed by Remi session ID (for Remi-UUID fallback resolution). */
   transcriptWatchers: Map<UUID, TranscriptWatcherType>;
+  /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
+   *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
+  sessionStore: SessionStore;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, sessionStore, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -51,6 +55,22 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
         if (activeWatcher) {
           filePath = activeWatcher.filePath;
           log(`[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via active watcher`);
+        }
+      }
+
+      // Last resort: no live watcher (e.g. a session wedged or torn down mid
+      // rotation). Resolve through the authoritative store binding, which the
+      // rotation handler keeps current (#451), so history loads even when the
+      // streaming watcher is absent rather than failing with NOT_FOUND.
+      if (!filePath) {
+        const boundClaudeId = sessionStore.findByRemiSessionId(sessionId as UUID)?.claudeSessionId;
+        if (boundClaudeId) {
+          filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
+          if (filePath) {
+            log(
+              `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via store binding ${boundClaudeId.slice(0, 8)}`,
+            );
+          }
         }
       }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -241,6 +241,36 @@ export function setupHookBridge(
     messageApi.reset();
   }
 
+  /**
+   * Start the transcript watcher for our own session if one is not already
+   * running. Self-heals the case where the lock was adopted from the store
+   * (so first-init never ran) but no watcher exists because the fallback poll
+   * gave up after its 30s window — common when Claude writes its first
+   * transcript line late on an idle start (observed across many sessions:
+   * "[Fallback] Timed out ..."). Only called for events whose session_id
+   * matches our lock (classification 'match'), i.e. our own Claude's events,
+   * whose transcript_path is therefore ours.
+   */
+  function ensureWatcher(transcriptPath: string | undefined): void {
+    if (!transcriptPath) return;
+    if (transcriptWatchers.has(sessionId)) return;
+    if (!sessionRegistry.hasSession(sessionId)) return;
+    // We have the exact path now; cancel any lingering fallback poll.
+    const fallbackTimer = transcriptFallbackTimers.get(sessionId);
+    if (fallbackTimer) {
+      clearInterval(fallbackTimer);
+      transcriptFallbackTimers.delete(sessionId);
+    }
+    log(`[Hooks] Ensuring watcher (self-heal) for ${sessionId.slice(0, 8)}: ${transcriptPath}`);
+    startTranscriptWatcher(
+      { transcriptWatchers },
+      sessionId,
+      transcriptPath,
+      messageApi,
+      sendAndRecord,
+    );
+  }
+
   function initFromHookEvent(input: {
     session_id?: string;
     transcript_path?: string;
@@ -326,7 +356,16 @@ export function setupHookBridge(
       // a true value coming from the race-detector path.
     }
     // classification === 'match': either our tracked session or first-time lock.
-    if (claudeSessionId) return; // already initialized
+    if (claudeSessionId) {
+      // Lock already held (typically adopted from the store before first-init
+      // ran). This event is from our own Claude (session_id matches our lock),
+      // so its transcript_path is ours — make sure a watcher is running. Without
+      // this, a session whose fallback poll timed out before Claude wrote its
+      // transcript stays locked-but-unwatched: no live stream and
+      // transcript_load returns NOT_FOUND.
+      ensureWatcher(input.transcript_path);
+      return;
+    }
     if (!input.transcript_path) return;
 
     if (hasSiblingInDir() && !ownsTranscript(input.transcript_path)) {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -41,7 +41,9 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
 import { classifySessionEvent } from '../../hooks/session-lock-classifier.ts';
+import { claudeChildLooksAlive } from '../../session/index.ts';
 import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import { readTranscriptOwnerPort } from '../../transcript/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
@@ -192,15 +194,32 @@ export function setupHookBridge(
       );
       return true;
     }
-    return liveSessionsRegistry
-      .listLive()
-      .some(
-        (e) =>
-          e.projectPath === workingDirectory &&
-          e.sessionId !== sessionId &&
-          e.wsPort !== currentPort(),
-      );
+    return liveSessionsRegistry.listLive().some(
+      (e) =>
+        e.projectPath === workingDirectory &&
+        e.sessionId !== sessionId &&
+        e.wsPort !== currentPort() &&
+        // A daemon whose process is alive but whose Claude child has died
+        // (a zombie) must not count as a sibling: it posts no hook events,
+        // yet its lingering registry entry would otherwise permanently
+        // defer our rotation handling (#451). Legacy entries with no
+        // recorded child pid stay fail-safe "live".
+        claudeChildLooksAlive(e),
+    );
   };
+
+  /**
+   * Whether the transcript named by a hook event was written by OUR claude.
+   * Each daemon spawns `claude -n remi:<wsPort>`, so the transcript head's
+   * `custom-title` marker carries the owning port — content the owning daemon
+   * caused Claude to write. When a genuine sibling shares the directory, this
+   * is what lets us adopt our OWN rotation without latching onto the sibling's
+   * (its transcript carries the sibling's port). Returns false when the marker
+   * is absent (older Claude/remi, or a user-supplied `-n`), in which case the
+   * caller falls back to the sibling-guard default.
+   */
+  const ownsTranscript = (transcriptPath: string | undefined): boolean =>
+    typeof transcriptPath === 'string' && readTranscriptOwnerPort(transcriptPath) === currentPort();
 
   /**
    * Safely tear down an existing transcript watcher and reset message state.
@@ -310,8 +329,12 @@ export function setupHookBridge(
     if (claudeSessionId) return; // already initialized
     if (!input.transcript_path) return;
 
-    if (hasSiblingInDir()) {
-      // Cannot trust which Claude sent this event; defer to fallback.
+    if (hasSiblingInDir() && !ownsTranscript(input.transcript_path)) {
+      // A sibling shares the directory and the transcript's port marker does
+      // not prove this event is ours — cannot trust which Claude sent it;
+      // defer to the deterministic-path fallback. When the marker DOES match
+      // our port (the common rotation case, #451) we fall through and adopt,
+      // so an in-process rotation is not wedged by the sibling guard.
       return;
     }
 
@@ -391,8 +414,11 @@ export function setupHookBridge(
       tracker.recordPendingHook(question);
     },
     onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
-      // Guard: skip if sibling daemons share this directory (event may be from sibling's Claude).
-      if (hasSiblingInDir()) return;
+      // Guard: skip if sibling daemons share this directory AND the transcript's
+      // port marker does not prove this SessionStart is ours (#451). When the
+      // marker matches our port we proceed so our own rotation rebinds even
+      // with a genuine sibling co-located.
+      if (hasSiblingInDir() && !ownsTranscript(transcriptPath)) return;
 
       // Use the same classifier as initFromHookEvent so both paths share
       // one rule for distinguishing foreign (subagent/sibling) from restart.
@@ -514,7 +540,13 @@ export function setupHookBridge(
       !isSubagentEvent(input) &&
       claudeSessionId &&
       input.session_id &&
-      input.session_id !== claudeSessionId
+      input.session_id !== claudeSessionId &&
+      // Only treat this as OUR lifecycle transition when there is no genuine
+      // sibling, or the new transcript's port marker proves it is ours (#451).
+      // Otherwise a sibling's SessionStart, fanned out via the shared
+      // settings.local.json hook URLs, would wrongly flip mainSessionEnded and
+      // make us tear down our own (still-live) session.
+      (!hasSiblingInDir() || ownsTranscript(input.transcript_path))
     ) {
       log(
         `[Hooks] Main lifecycle transition (source=${input.source ?? 'unknown'}): ${claudeSessionId} -> ${input.session_id}`,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -252,9 +252,20 @@ export function setupHookBridge(
    * whose transcript_path is therefore ours.
    */
   function ensureWatcher(transcriptPath: string | undefined): void {
-    if (!transcriptPath) return;
+    // Steady-state no-op: a watcher is already running. Checked first so a
+    // healthy session never logs the "no path" warning below.
     if (transcriptWatchers.has(sessionId)) return;
     if (!sessionRegistry.hasSession(sessionId)) return;
+    if (!transcriptPath) {
+      // We need a watcher (none running) but this match event carried no path,
+      // so we can't self-heal on it. Normally the next event supplies one; log
+      // so a SYSTEMATIC absence (e.g. a changed hook payload) is visible rather
+      // than an invisible locked-but-unwatched wedge.
+      logError(
+        `[Hooks] ensureWatcher: match event without transcript_path for ${sessionId.slice(0, 8)}; watcher still missing`,
+      );
+      return;
+    }
     // We have the exact path now; cancel any lingering fallback poll.
     const fallbackTimer = transcriptFallbackTimers.get(sessionId);
     if (fallbackTimer) {

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -24,7 +24,7 @@ import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { OutputProcessor } from '../../parser/output-processor.ts';
 import { PTYSession } from '../../pty/index.ts';
-import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
 import {
   getPtyStdoutFd,
@@ -36,6 +36,12 @@ import {
 export interface PtySessionSetupDeps {
   sessionRegistry: SessionRegistry;
   sessionStore: SessionStore;
+  /**
+   * Live-sessions registry. On PTY exit the daemon may keep running (daemon
+   * mode), so we mark this session's Claude child exited in its registry
+   * entry; co-located daemons then stop treating us as a live sibling (#451).
+   */
+  liveSessionsRegistry: SessionRegistryFile;
   outputProcessor: OutputProcessor;
   /** Value passed to PTYSession.env as REMI_PORT so hooks can report back. */
   wsPort: number;
@@ -75,7 +81,15 @@ export function createPtySessionForSession(
   deps: Readonly<PtySessionSetupDeps>,
   args: Readonly<PtySessionSetupArgs>,
 ): PTYSession {
-  const { sessionRegistry, sessionStore, outputProcessor, wsPort, sendMessage, cleanup } = deps;
+  const {
+    sessionRegistry,
+    sessionStore,
+    liveSessionsRegistry,
+    outputProcessor,
+    wsPort,
+    sendMessage,
+    cleanup,
+  } = deps;
   const { sessionId, workingDirectory, extraArgs, passThrough } = args;
 
   if (!Number.isInteger(wsPort) || wsPort <= 0) {
@@ -146,6 +160,14 @@ export function createPtySessionForSession(
         log(`PTY ${ptySession.id} exited with code ${code}`);
         sessionRegistry.handlePTYExit(sessionId);
         sessionStore.markExited(sessionId, code);
+        // The daemon process can outlive its Claude child (daemon mode). Record
+        // the child as dead so co-located daemons stop counting us as a live
+        // sibling and their rotation handling is not wedged (#451). Best-effort.
+        try {
+          liveSessionsRegistry.markClaudeChildExited(sessionId);
+        } catch (err) {
+          logError(`[live-sessions] markClaudeChildExited failed: ${errorToString(err)}`);
+        }
 
         if (passThrough) {
           cleanup()

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -16,6 +16,7 @@ export { SessionStore, type StoredSession } from './session-store.ts';
 export {
   SessionRegistryFile,
   type LiveSessionEntry,
+  claudeChildLooksAlive,
   DEFAULT_BASE_PORT,
   DEFAULT_PORT_RANGE,
 } from './session-registry-file.ts';

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -136,7 +136,13 @@ export class SessionRegistryFile {
     try {
       const raw = fs.readFileSync(filePath, 'utf-8');
       const data: unknown = JSON.parse(raw);
-      if (!isValidEntry(data)) return;
+      if (!isValidEntry(data)) {
+        // The on-disk entry is malformed (e.g. a torn write). Skipping the
+        // patch silently would disable the zombie guard for this session with
+        // no trace; surface it (listLive will reap the bad entry separately).
+        console.error(`[live-sessions] Cannot patch ${sessionId}: existing entry is invalid`);
+        return;
+      }
       this.register({ ...data, ...patch });
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -27,6 +27,34 @@ export interface LiveSessionEntry {
   readonly projectPath: string;
   readonly name: string;
   readonly startedAt: string;
+  /**
+   * OS pid of the spawned `claude` child, recorded once the PTY starts.
+   * Absent on legacy entries and during the pre-spawn registration window.
+   * Lets co-located daemons tell a live sibling from a zombie (daemon
+   * process alive, its Claude long dead) — see {@link claudeChildLooksAlive}.
+   */
+  readonly claudeChildPid?: number;
+  /**
+   * Set true when the Claude child exits while the daemon keeps running.
+   * Distinguishes "known dead" (recycle-proof: never reconsidered live even
+   * if the OS reassigns the old pid) from "unknown" (field absent ⇒ treated
+   * as live, the fail-safe for legacy entries).
+   */
+  readonly claudeChildExited?: boolean;
+}
+
+/**
+ * Whether a registry entry's Claude child should be treated as a live sibling.
+ *
+ * Fail-safe by design: an entry with no recorded child pid (legacy writer, or
+ * the pre-spawn window) counts as live so we never drop a guard we cannot
+ * disprove. A child explicitly marked exited is permanently dead (pid-reuse
+ * proof); otherwise we probe the recorded pid.
+ */
+export function claudeChildLooksAlive(entry: LiveSessionEntry): boolean {
+  if (entry.claudeChildExited === true) return false;
+  if (entry.claudeChildPid === undefined) return true;
+  return isProcessAlive(entry.claudeChildPid);
 }
 
 /** Default port range for auto-selection (single source of truth in @remi/shared). */
@@ -37,6 +65,12 @@ export const DEFAULT_PORT_RANGE = DAEMON_PORT_RANGE;
 function isValidEntry(data: unknown): data is LiveSessionEntry {
   if (typeof data !== 'object' || data === null) return false;
   const obj = data as Record<string, unknown>;
+  const childPid = obj['claudeChildPid'];
+  const childPidOk =
+    childPid === undefined ||
+    (typeof childPid === 'number' && Number.isInteger(childPid) && childPid > 0);
+  const childExited = obj['claudeChildExited'];
+  const childExitedOk = childExited === undefined || typeof childExited === 'boolean';
   return (
     typeof obj['sessionId'] === 'string' &&
     obj['sessionId'].length > 0 &&
@@ -44,7 +78,9 @@ function isValidEntry(data: unknown): data is LiveSessionEntry {
     obj['pid'] > 0 &&
     typeof obj['wsPort'] === 'number' &&
     obj['wsPort'] > 0 &&
-    obj['wsPort'] <= 65535
+    obj['wsPort'] <= 65535 &&
+    childPidOk &&
+    childExitedOk
   );
 }
 
@@ -87,6 +123,41 @@ export class SessionRegistryFile {
         console.error(`[live-sessions] Failed to unregister ${sessionId}: ${errorToString(err)}`);
       }
     }
+  }
+
+  /**
+   * Merge fields into an existing entry, preserving everything else (notably
+   * startedAt). No-op if the entry is gone. Best-effort: enumeration/parse
+   * failures are swallowed so a registry hiccup never propagates into the
+   * spawn or PTY-exit path.
+   */
+  private patchEntry(sessionId: string, patch: Partial<LiveSessionEntry>): void {
+    const filePath = path.join(this.dir, `${sessionId}.json`);
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const data: unknown = JSON.parse(raw);
+      if (!isValidEntry(data)) return;
+      this.register({ ...data, ...patch });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return; // entry already gone
+      console.error(`[live-sessions] Failed to patch ${sessionId}: ${errorToString(err)}`);
+    }
+  }
+
+  /** Record the Claude child pid once the PTY has spawned. */
+  setClaudeChildPid(sessionId: string, claudeChildPid: number): void {
+    this.patchEntry(sessionId, { claudeChildPid, claudeChildExited: false });
+  }
+
+  /**
+   * Mark the Claude child as exited while keeping the daemon entry (the
+   * daemon process is still alive and must remain discoverable for
+   * `remi ls`/attach/resume). Recycle-proof: the entry is never reconsidered
+   * a live sibling regardless of pid reassignment.
+   */
+  markClaudeChildExited(sessionId: string): void {
+    this.patchEntry(sessionId, { claudeChildExited: true });
   }
 
   /**

--- a/packages/daemon/src/transcript/index.ts
+++ b/packages/daemon/src/transcript/index.ts
@@ -8,6 +8,7 @@
 export { TranscriptWatcher } from './transcript-watcher.ts';
 export { TranscriptDiscovery } from './transcript-discovery.ts';
 export { TranscriptMessageBridge } from './transcript-message-bridge.ts';
+export { readTranscriptOwnerPort } from './transcript-owner.ts';
 export type { TranscriptDiscoveryConfig } from './transcript-discovery.ts';
 export type {
   TranscriptMessageBridgeConfig,

--- a/packages/daemon/src/transcript/transcript-owner.ts
+++ b/packages/daemon/src/transcript/transcript-owner.ts
@@ -68,7 +68,15 @@ export function readTranscriptOwnerPort(transcriptPath: string): number | null {
       }
     }
     return null;
-  } catch {
+  } catch (err) {
+    // Fail safe: a missing/unflushed file (ENOENT) is routine during the
+    // fallback window, so callers treat null as "no marker". But a non-routine
+    // I/O error (EMFILE, ENOMEM, EACCES) is worth surfacing so an operator can
+    // see why ownership checks are coming up empty.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== undefined && code !== 'ENOENT') {
+      console.error(`[transcript-owner] Failed to read ${transcriptPath}: ${code}`);
+    }
     return null;
   } finally {
     if (fd !== null) {

--- a/packages/daemon/src/transcript/transcript-owner.ts
+++ b/packages/daemon/src/transcript/transcript-owner.ts
@@ -1,0 +1,90 @@
+/**
+ * Read the Remi ownership marker from a Claude Code transcript.
+ *
+ * Each daemon spawns `claude` with `-n remi:<wsPort>` (see
+ * `cli/claude-binding.ts` + `cli.ts` `displayName`). Claude records that name
+ * at the head of every transcript it writes as a `custom-title` entry:
+ *
+ *   {"type":"custom-title","customTitle":"remi:18767","sessionId":"..."}
+ *
+ * Because two daemons sharing a project directory both receive each other's
+ * hook events (shared `.claude/settings.local.json` fan-out), the incoming
+ * `session_id` alone cannot tell us which daemon's Claude wrote a transcript.
+ * The port baked into `customTitle` can: it is content the OWNING daemon
+ * caused Claude to write. We use it to prove a rotation is ours before
+ * adopting it, even when a genuine sibling daemon is present.
+ *
+ * READ-ONLY: never modifies the transcript. Returns null when the marker is
+ * absent (e.g. the user supplied their own `-n`, or an older Claude/remi),
+ * in which case callers fall back to the sibling-guard default.
+ */
+
+import * as fs from 'node:fs';
+
+/** Only the first few lines can hold the head marker; cap the read. */
+const HEAD_BYTES = 8192;
+
+interface CustomTitleEntry {
+  type?: string;
+  customTitle?: string;
+}
+
+/**
+ * Return the remi wsPort encoded in the transcript's `custom-title` head
+ * marker, or null if the file is unreadable or carries no `remi:<port>` title.
+ */
+export function readTranscriptOwnerPort(transcriptPath: string): number | null {
+  let fd: number | null = null;
+  try {
+    const stat = fs.statSync(transcriptPath);
+    const readSize = Math.min(stat.size, HEAD_BYTES);
+    if (readSize === 0) return null;
+
+    const buffer = Buffer.alloc(readSize);
+    fd = fs.openSync(transcriptPath, 'r');
+    fs.readSync(fd, buffer, 0, readSize, 0);
+    fs.closeSync(fd);
+    fd = null;
+
+    const lines = buffer.toString('utf-8').split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      // The marker is at the very head; bail out once real conversation
+      // entries start so we never scan a large transcript line-by-line.
+      let entry: CustomTitleEntry;
+      try {
+        entry = JSON.parse(trimmed) as CustomTitleEntry;
+      } catch {
+        continue;
+      }
+      if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') {
+        const port = parseRemiPort(entry.customTitle);
+        if (port !== null) return port;
+      }
+      if (entry.type === 'user' || entry.type === 'assistant') {
+        // Past the header region without a remi marker; stop early.
+        return null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Parse `remi:<port>` into the numeric port, or null if it isn't that shape. */
+function parseRemiPort(customTitle: string): number | null {
+  const match = /^remi:(\d{1,5})$/.exec(customTitle);
+  if (!match) return null;
+  const port = Number(match[1]);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+}

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
 import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
 
@@ -41,6 +42,7 @@ describe('createTranscriptHandlers', () => {
   let projectsDir: string;
   let transcriptDiscovery: TranscriptDiscovery;
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let sessionStore: SessionStore;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
   function send(connectionId: UUID, message: ProtocolMessage): boolean {
@@ -54,6 +56,7 @@ describe('createTranscriptHandlers', () => {
     fs.mkdirSync(projectsDir, { recursive: true });
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
   });
@@ -64,7 +67,12 @@ describe('createTranscriptHandlers', () => {
   });
 
   function makeHandlers() {
-    return createTranscriptHandlers({ transcriptDiscovery, transcriptWatchers, send });
+    return createTranscriptHandlers({
+      transcriptDiscovery,
+      transcriptWatchers,
+      sessionStore,
+      send,
+    });
   }
 
   function writeTranscript(claudeSessionId: string, entries: object[]): string {
@@ -124,6 +132,46 @@ describe('createTranscriptHandlers', () => {
     expect(complete).toBeDefined();
     // Requesting connection matches the ack receiver.
     expect(complete?.connectionId).toBe(CID);
+  });
+
+  test('falls back to the store binding when a Remi UUID has no active watcher (#451)', async () => {
+    // A wedged/rotated session: no live watcher, but the store knows the
+    // current Claude session id. The handler must resolve via the binding
+    // instead of returning NOT_FOUND.
+    const claudeSessionId = '44444444-4444-4444-4444-444444444444';
+    writeTranscript(claudeSessionId, [
+      {
+        type: 'user',
+        uuid: 'u1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'history please' },
+      },
+    ]);
+
+    const remiUuid = '55555555-5555-5555-5555-555555555555' as UUID;
+    sessionStore.save({
+      remiSessionId: remiUuid,
+      claudeSessionId,
+      projectPath: '/Users/test/project',
+      port: 18767,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
+    });
+
+    // No watcher registered for remiUuid.
+    makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+
+    expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+      false,
+    );
   });
 
   test('falls back to the active watcher when the id is a Remi UUID', async () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -118,7 +118,12 @@ describe('setupHookBridge', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-hook-bridge-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
-    liveSessionsRegistry = new SessionRegistryFile(tmpDir);
+    // Live-sessions registry gets its OWN subdir so its listLive() scan does
+    // not see (and delete as "invalid") the SessionStore's sessions.json that
+    // shares the tmp root. Create it up front so tests that write sibling
+    // entries directly into dirPath don't need their own mkdir.
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
     transcriptWatchers = new Map();
     transcriptFallbackTimers = new Map();
     hookServer = new RecordingHookServer();
@@ -1818,6 +1823,174 @@ describe('setupHookBridge', () => {
       expect(events[0]?.newClaudeSessionId).toBe('claude-second-id');
       expect(events[0]?.newTranscriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
       expect(events[0]?.reason).toBe('restart');
+    });
+  });
+
+  describe('child-liveness + port-ownership rotation (#451)', () => {
+    /** Write a co-located sibling registry entry. `child` controls how its
+     *  Claude liveness is recorded: alive pid, a dead pid, or none (legacy). */
+    function writeSibling(
+      name: string,
+      child: { claudeChildPid?: number; claudeChildExited?: boolean } = {},
+    ): void {
+      fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, name),
+        JSON.stringify({
+          sessionId: `sib-${name}`,
+          pid: process.pid, // sibling DAEMON is alive
+          wsPort: 18999,
+          hookPort: 18001,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+          ...child,
+        }),
+      );
+    }
+
+    /** Write a transcript whose head optionally carries the remi:<port> marker. */
+    function writeTranscript(claudeId: string, ownerPort: number | null): string {
+      const p = path.join(tmpDir, `${claudeId}.jsonl`);
+      const head =
+        ownerPort !== null
+          ? `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${ownerPort}` })}\n`
+          : '';
+      fs.writeFileSync(
+        p,
+        `${head}${JSON.stringify({
+          type: 'user',
+          uuid: 'u1',
+          sessionId: claudeId,
+          message: { role: 'user', content: 'hi' },
+        })}\n`,
+      );
+      return p;
+    }
+
+    /** Pre-seed the store binding so the first event adopts the lock. */
+    function seedLock(claudeId: string): void {
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: claudeId,
+        projectPath: tmpDir,
+        port: 8765, // matches the harness currentPort()
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    function stopWatchers(): void {
+      for (const w of transcriptWatchers.values()) {
+        try {
+          w.stop();
+        } catch {
+          /* best effort */
+        }
+      }
+    }
+
+    const CLAUDE_A = 'aaaaaaaa-1111-1111-1111-111111111111';
+    const CLAUDE_B = 'bbbbbbbb-2222-2222-2222-222222222222';
+
+    test('zombie sibling (dead Claude child) no longer wedges our rotation', async () => {
+      // The exact bug: a leftover daemon (process alive, Claude dead) shares
+      // the dir. Pre-fix it permanently deferred rotation handling. The
+      // rotated transcript here carries NO port marker, proving the zombie is
+      // fully ignored rather than relying on the ownership signal.
+      const deadProc = Bun.spawn(['true'], { stdout: 'ignore', stderr: 'ignore' });
+      await deadProc.exited;
+      writeSibling('zombie.json', { claudeChildPid: deadProc.pid });
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, null);
+      const pathB = writeTranscript(CLAUDE_B, null);
+
+      build();
+      // Event 1: establish lock=CLAUDE_A from the store.
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+      // Event 2: in-process rotation to CLAUDE_B.
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_B,
+        transcript_path: pathB,
+        hook_event_name: 'SessionStart',
+      });
+
+      try {
+        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
+        expect(transcriptWatchers.has(SID)).toBe(true);
+      } finally {
+        stopWatchers();
+      }
+    });
+
+    test('genuine live sibling: our own rotation adopts via the remi:<port> marker', async () => {
+      // A real second daemon (live Claude child) shares the dir. Our rotation
+      // must still rebind because the new transcript carries OUR port marker.
+      writeSibling('live.json', { claudeChildPid: process.pid }); // alive
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, 8765);
+      const pathB = writeTranscript(CLAUDE_B, 8765); // ours
+
+      build();
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_B,
+        transcript_path: pathB,
+        hook_event_name: 'SessionStart',
+      });
+
+      try {
+        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
+        expect(transcriptWatchers.has(SID)).toBe(true);
+      } finally {
+        stopWatchers();
+      }
+    });
+
+    test("genuine live sibling: the SIBLING's rotation is NOT adopted (no latching)", () => {
+      // Mirror of the above, but the rotating transcript carries the SIBLING's
+      // port. We must not overwrite our binding or start a watcher on it.
+      writeSibling('live2.json', { claudeChildPid: process.pid });
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, 8765);
+      const siblingId = 'cccccccc-3333-3333-3333-333333333333';
+      const pathSib = writeTranscript(siblingId, 18999); // sibling's port
+
+      build();
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: siblingId,
+        transcript_path: pathSib,
+        hook_event_name: 'SessionStart',
+      });
+
+      try {
+        // Binding unchanged: the sibling's rotation never overwrote ours.
+        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_A);
+        // If a watcher exists it must be on OUR transcript, never latched onto
+        // the sibling's path.
+        const watched = transcriptWatchers.get(SID)?.filePath;
+        if (watched !== undefined) {
+          expect(watched).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
+          expect(watched).not.toBe(pathSib);
+        }
+      } finally {
+        stopWatchers();
+      }
     });
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2051,5 +2051,33 @@ describe('setupHookBridge', () => {
         stopWatchers();
       }
     });
+
+    test('self-heals the watcher when locked-from-store but the fallback gave up', () => {
+      // The osa case: single daemon, no sibling. The lock is adopted from the
+      // store (deterministic pre-spawn binding), but no watcher exists because
+      // the 30s fallback poll timed out before Claude wrote its first transcript
+      // line. The next hook event from our own Claude must start the watcher
+      // (no port marker needed: the session_id match is proof of ownership).
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, null);
+
+      build();
+      // No fallback ran in this harness, so we start with no watcher.
+      expect(transcriptWatchers.has(SID)).toBe(false);
+
+      hookServer.fire('PreToolUse', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        hook_event_name: 'PreToolUse',
+      });
+
+      try {
+        expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
+      } finally {
+        stopWatchers();
+      }
+    });
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1981,13 +1981,72 @@ describe('setupHookBridge', () => {
       try {
         // Binding unchanged: the sibling's rotation never overwrote ours.
         expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_A);
-        // If a watcher exists it must be on OUR transcript, never latched onto
-        // the sibling's path.
-        const watched = transcriptWatchers.get(SID)?.filePath;
-        if (watched !== undefined) {
-          expect(watched).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
-          expect(watched).not.toBe(pathSib);
-        }
+        // Our watcher (started for CLAUDE_A on event 1) is still intact and was
+        // never torn down or re-pointed at the sibling's transcript.
+        expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
+        expect(transcriptWatchers.get(SID)?.filePath).not.toBe(pathSib);
+      } finally {
+        stopWatchers();
+      }
+    });
+
+    test('live sibling + rotation with NO port marker is not adopted', () => {
+      // Guards the &&-not-|| shape of the ownership check: with a live sibling
+      // present and a rotated transcript carrying no remi:<port> marker, we
+      // cannot prove ownership, so we must defer rather than latch.
+      writeSibling('live-nomarker.json', { claudeChildPid: process.pid });
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, 8765); // ours, lets event 1 lock cleanly
+      const pathB = writeTranscript(CLAUDE_B, null); // rotation, unmarked
+
+      build();
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_B,
+        transcript_path: pathB,
+        hook_event_name: 'SessionStart',
+      });
+
+      try {
+        // Unproven rotation deferred: binding stays, watcher stays on CLAUDE_A.
+        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_A);
+        expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
+      } finally {
+        stopWatchers();
+      }
+    });
+
+    test('sibling explicitly flagged claudeChildExited is ignored (recycle-proof)', () => {
+      // The recycle-proof tombstone path: an entry that went alive -> exited via
+      // markClaudeChildExited must not count as a sibling even though its pid is
+      // alive. Rotation proceeds with no port marker, as in the zombie case.
+      writeSibling('flagged-exited.json', {
+        claudeChildPid: process.pid, // alive pid...
+        claudeChildExited: true, // ...but explicitly tombstoned
+      });
+      seedLock(CLAUDE_A);
+      writeTranscript(CLAUDE_A, null);
+      const pathB = writeTranscript(CLAUDE_B, null);
+
+      build();
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_A,
+        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: CLAUDE_B,
+        transcript_path: pathB,
+        hook_event_name: 'SessionStart',
+      });
+
+      try {
+        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
+        expect(transcriptWatchers.has(SID)).toBe(true);
       } finally {
         stopWatchers();
       }

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -131,4 +131,71 @@ describe('createPtySessionForSession', () => {
     const b = build(false);
     expect(a.id).not.toBe(b.id);
   });
+
+  // Real-PTY wiring for #451 Part 2: when the Claude child exits, onExit must
+  // mark the live-sessions entry's child as exited so co-located daemons stop
+  // counting us as a live sibling. Drives a genuine PTY by putting a fake,
+  // immediately-exiting `claude` on PATH (no mocks).
+  test('onExit marks the live-sessions child as exited (#451 Part 2)', async () => {
+    const fakeBin = path.join(tmpDir, 'bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    const fakeClaude = path.join(fakeBin, 'claude');
+    fs.writeFileSync(fakeClaude, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(fakeClaude, 0o755);
+
+    // Pre-register the live-sessions entry with a (currently alive) child pid,
+    // mirroring the post-spawn setClaudeChildPid state.
+    liveSessionsRegistry.register({
+      sessionId: SID,
+      pid: process.pid,
+      wsPort: 9999,
+      hookPort: 9998,
+      projectPath: tmpDir,
+      name: 'pty-exit-test',
+      startedAt: new Date().toISOString(),
+      claudeChildPid: process.pid,
+    });
+
+    const pty = createPtySessionForSession(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        outputProcessor,
+        wsPort: 9999,
+        sendMessage: (sid, message) => sendCalls.push({ sessionId: sid, message }),
+        cleanup: async () => {},
+      },
+      { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: false },
+    );
+    // Register so handlePTYExit in onExit resolves the session.
+    sessionRegistry.registerSession(SID, tmpDir, pty, {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+      reset: () => {},
+    } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+    const originalPath = process.env['PATH'];
+    process.env['PATH'] = `${fakeBin}:${originalPath ?? ''}`;
+    try {
+      await pty.start();
+      // Wait for the fake claude to exit and onExit to fire.
+      const deadline = Date.now() + 4000;
+      while (Date.now() < deadline) {
+        const entry = liveSessionsRegistry.findBySessionId(SID);
+        if (entry?.claudeChildExited === true) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(liveSessionsRegistry.findBySessionId(SID)?.claudeChildExited).toBe(true);
+    } finally {
+      // Restore PATH (originalPath is effectively always defined in practice).
+      process.env['PATH'] = originalPath ?? '';
+      try {
+        await pty.close();
+      } catch {
+        /* already exited */
+      }
+    }
+  });
 });

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/cli/session-phases/pty-session-setup.ts';
 import { __resetWrapperStateForTests } from '../../../src/cli/wrapper-state.ts';
 import { OutputProcessor } from '../../../src/parser/output-processor.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 
@@ -51,6 +52,7 @@ describe('createPtySessionForSession', () => {
   let tmpDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let liveSessionsRegistry: SessionRegistryFile;
   let outputProcessor: OutputProcessor;
   let sendCalls: Array<{ sessionId: UUID; message: ProtocolMessage }>;
 
@@ -58,6 +60,7 @@ describe('createPtySessionForSession', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-pty-setup-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
     outputProcessor = new OutputProcessor(
       { sessionId: SID, streamStatusOnly: true },
       { onMessage: () => {}, onQuestion: () => {}, onStatusChange: () => {} },
@@ -78,6 +81,7 @@ describe('createPtySessionForSession', () => {
       {
         sessionRegistry,
         sessionStore,
+        liveSessionsRegistry,
         outputProcessor,
         wsPort: 9999,
         sendMessage: (sid, message) => sendCalls.push({ sessionId: sid, message }),
@@ -106,6 +110,7 @@ describe('createPtySessionForSession', () => {
         {
           sessionRegistry,
           sessionStore,
+          liveSessionsRegistry,
           outputProcessor,
           wsPort: 0,
           sendMessage: () => {},

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -6,7 +6,15 @@ import {
   DEFAULT_BASE_PORT,
   type LiveSessionEntry,
   SessionRegistryFile,
+  claudeChildLooksAlive,
 } from '../src/session/session-registry-file.ts';
+
+/** Spawn a trivial process and await its exit to obtain a really-dead pid. */
+async function deadChildPid(): Promise<number> {
+  const proc = Bun.spawn(['true'], { stdout: 'ignore', stderr: 'ignore' });
+  await proc.exited;
+  return proc.pid;
+}
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-registry-test-'));
@@ -268,5 +276,81 @@ describe('SessionRegistryFile', () => {
     const live = registry.listLive();
     expect(live).toHaveLength(1);
     expect(live[0]!.wsPort).toBe(18770);
+  });
+
+  // ---- Claude-child liveness (#451) ---------------------------------------
+
+  describe('Claude child liveness', () => {
+    test('claudeChildPid round-trips through register/list', () => {
+      registry.register(makeEntry({ sessionId: 's', claudeChildPid: 4242 }));
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.claudeChildPid).toBe(4242);
+    });
+
+    test('legacy entry without the field parses and is treated as live', () => {
+      // listLive keeps it (daemon pid alive); the liveness helper fail-safes.
+      registry.register(makeEntry({ sessionId: 'legacy' }));
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.claudeChildPid).toBeUndefined();
+      expect(claudeChildLooksAlive(live[0]!)).toBe(true);
+    });
+
+    test('listLive still keeps an entry whose daemon is alive but child is dead', async () => {
+      // The whole point of #451: daemon-pid liveness is unchanged, so the
+      // entry survives; the per-entry helper is what flips it to not-a-sibling.
+      const childPid = await deadChildPid();
+      registry.register(makeEntry({ sessionId: 'zombie', claudeChildPid: childPid }));
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(claudeChildLooksAlive(live[0]!)).toBe(false);
+    });
+
+    test('setClaudeChildPid preserves other fields (notably startedAt)', () => {
+      const entry = makeEntry({ sessionId: 's', wsPort: 18767 });
+      registry.register(entry);
+      registry.setClaudeChildPid('s', 5150);
+      const live = registry.listLive();
+      expect(live[0]!.claudeChildPid).toBe(5150);
+      expect(live[0]!.claudeChildExited).toBe(false);
+      expect(live[0]!.startedAt).toBe(entry.startedAt);
+      expect(live[0]!.wsPort).toBe(18767);
+    });
+
+    test('markClaudeChildExited keeps the entry but flags it not-alive (recycle-proof)', () => {
+      // Use the CURRENT pid as the child pid: still alive, but the explicit
+      // exited flag must override the pid probe so reuse cannot resurrect it.
+      registry.register(makeEntry({ sessionId: 's', claudeChildPid: process.pid }));
+      registry.markClaudeChildExited('s');
+      const live = registry.listLive();
+      expect(live).toHaveLength(1); // entry retained for ls/attach/resume
+      expect(live[0]!.claudeChildExited).toBe(true);
+      expect(claudeChildLooksAlive(live[0]!)).toBe(false);
+    });
+
+    test('patch methods are a no-op for a missing entry', () => {
+      registry.setClaudeChildPid('ghost', 1);
+      registry.markClaudeChildExited('ghost');
+      expect(registry.listLive()).toHaveLength(0);
+    });
+
+    test('an entry with an invalid claudeChildPid is rejected by listLive', () => {
+      const filePath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ ...makeEntry({ sessionId: 'bad' }), claudeChildPid: -3 }),
+      );
+      // Invalid entries are removed on read.
+      expect(registry.listLive()).toHaveLength(0);
+    });
+
+    test('claudeChildLooksAlive: live pid → true, undefined → true, exited → false', () => {
+      expect(claudeChildLooksAlive(makeEntry({ claudeChildPid: process.pid }))).toBe(true);
+      expect(claudeChildLooksAlive(makeEntry())).toBe(true);
+      expect(
+        claudeChildLooksAlive(makeEntry({ claudeChildPid: process.pid, claudeChildExited: true })),
+      ).toBe(false);
+    });
   });
 });

--- a/packages/daemon/tests/transcript/transcript-owner.test.ts
+++ b/packages/daemon/tests/transcript/transcript-owner.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readTranscriptOwnerPort } from '../../src/transcript/transcript-owner.ts';
+
+describe('readTranscriptOwnerPort', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-owner-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLines(name: string, lines: object[]): string {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join('\n'));
+    return filePath;
+  }
+
+  test('returns the wsPort from a remi custom-title head marker', () => {
+    const file = writeLines('a.jsonl', [
+      { type: 'custom-title', customTitle: 'remi:18767', sessionId: 'x' },
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+    ]);
+    expect(readTranscriptOwnerPort(file)).toBe(18767);
+  });
+
+  test('returns null when the title is a user-supplied name (not remi:<port>)', () => {
+    const file = writeLines('b.jsonl', [
+      { type: 'custom-title', customTitle: 'my project', sessionId: 'x' },
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+    ]);
+    expect(readTranscriptOwnerPort(file)).toBeNull();
+  });
+
+  test('returns null when there is no custom-title head marker', () => {
+    const file = writeLines('c.jsonl', [
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'assistant', message: { role: 'assistant', content: [] } },
+    ]);
+    expect(readTranscriptOwnerPort(file)).toBeNull();
+  });
+
+  test('stops early once conversation entries begin (no marker)', () => {
+    // A custom-title appearing AFTER real conversation must not be picked up;
+    // the marker is only ever at the head.
+    const file = writeLines('d.jsonl', [
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'custom-title', customTitle: 'remi:19999', sessionId: 'x' },
+    ]);
+    expect(readTranscriptOwnerPort(file)).toBeNull();
+  });
+
+  test('returns null for a missing file', () => {
+    expect(readTranscriptOwnerPort(path.join(tmpDir, 'nope.jsonl'))).toBeNull();
+  });
+
+  test('returns null for an empty file', () => {
+    const file = path.join(tmpDir, 'empty.jsonl');
+    fs.writeFileSync(file, '');
+    expect(readTranscriptOwnerPort(file)).toBeNull();
+  });
+
+  test('tolerates a leading blank/garbage line before the marker', () => {
+    const file = path.join(tmpDir, 'e.jsonl');
+    fs.writeFileSync(
+      file,
+      `\nnot json\n${JSON.stringify({ type: 'custom-title', customTitle: 'remi:18770' })}\n`,
+    );
+    expect(readTranscriptOwnerPort(file)).toBe(18770);
+  });
+
+  test('rejects an out-of-range port', () => {
+    const file = writeLines('f.jsonl', [{ type: 'custom-title', customTitle: 'remi:99999999' }]);
+    expect(readTranscriptOwnerPort(file)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #451.

## Problem

A long-running session (real case: nemar-cli on port 18767) permanently returned **"Transcript for session <id> not found"** on the phone, and live streaming silently stopped. Captured from `~/.remi/remi.log`:

```
[Hooks] Claude restart detected (ended=true): 31c98a5a -> 9092310f
[Hooks] Lock adopted from sessionStore: claude=31c98a5a          <- lock snaps back to the dead id
... 5738x Dropped foreign ... incoming=9092310f
...  558x Dropped foreign ... incoming=4532b590
Transcript for session b7f8d9af-... not found
```

## Root cause

Two compounding defects:

1. **`listLive()` staleness is daemon-pid granular, but the question is Claude-child granular.** `LiveSessionEntry` stored only the daemon pid; a leftover daemon whose process is alive but whose Claude child died (a *zombie*) still counted as a live sibling, so `hasSiblingInDir()` returned a false TRUE forever. Nothing reaps it (daemon-mode `onExit` never touched the registry).
2. **The sibling guard short-circuits rotation's store update.** On an in-process rotation (`/clear`/`/compact`), the restart branch tore down the watcher and nulled the lock, then hit `if (hasSiblingInDir()) return;` *before* `updateClaudeSessionId(...)` and `startTranscriptWatcher(...)`. The store stayed pinned to the dead id, `adoptLockFromStore()` re-seeded it every event, real events dropped as `foreign`, and with no watcher `transcript_load` returned NOT_FOUND.

## Fix

| Part | Change |
|---|---|
| 1 | Record `claudeChildPid` in `LiveSessionEntry`; `hasSiblingInDir()` ignores siblings whose Claude child is dead. Legacy entries (no field) stay fail-safe "live". |
| 2 | On PTY exit, mark the child exited (recycle-proof) while keeping the daemon entry for `ls`/attach/resume. |
| 3 | Adopt our own rotation even with a genuine sibling present, gated on the transcript head's `remi:<port>` ownership marker matching our port. |
| 4 | Gate the SessionStart pre-empt on the same marker so a sibling's SessionStart can't force a bogus restart on us. |
| 5 | `transcript_load` falls back to the authoritative store binding before NOT_FOUND. |

**Ownership disambiguator:** every transcript head carries `{"type":"custom-title","customTitle":"remi:<port>"}` (written from `displayName: remi:${wsPort}`), verified on disk across all rotated transcripts. A genuine sibling's transcript carries the sibling's port, so its rotation can never overwrite our binding.

## Avoids regressing

The #321/#430 sibling-latching protections: legacy entries stay fail-safe, and the store-write on rotation is gated on the port marker matching ours. The classifier `foreign`-drop remains the second line of defense.

## Testing

- `bun test` across session/cli/transcript suites: **836 pass, 0 fail**.
- New unit tests: ownership-marker reader (`transcript-owner`), child-liveness registry (round-trip, dead-child, recycle-proof exit, legacy tolerance), and hook-bridge rotation cases (zombie ignored, live-sibling own-rotation adopted via marker, sibling rotation NOT latched), plus the `transcript_load` store-binding fallback.
- `bun run typecheck` clean; `bunx biome check` clean (one pre-existing `noNonNullAssertion` warning in `findByName`, unchanged by this PR).

## Residual / follow-ups (not blocking)

- `SessionStore.write()` is unlocked tmp+rename (pre-existing); Part 3 slightly increases concurrent-write frequency in the multi-daemon case. Candidate follow-up: per-pid tmp path + CAS.
- A pre-fix zombie from an old binary (entry without `claudeChildPid`) still fail-safes to "live" until its daemon dies; new zombies self-heal via Part 2.
