### PR TITLE
chore(release): 0.6.0 prep (changelog, coverage gate, checkout@v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
     name: Spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@v1.28.4
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -37,7 +37,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -48,7 +48,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -57,8 +57,17 @@ jobs:
         run: bun test --coverage --coverage-reporter=text --coverage-reporter=lcov
       - name: Check coverage threshold
         run: |
-          COVERAGE=$(bun test --coverage 2>&1 | grep "All files" | awk '{print $NF}' | tr -d '%')
+          # The "All files" row is pipe-delimited: File | % Funcs | % Lines | Uncovered.
+          # % Lines is the 3rd field. Strip ANSI colour codes first (bun colourises
+          # on a TTY) and fail loudly if parsing yields a non-number — the previous
+          # `awk '{print $NF}'` extracted the trailing "|", silently passing the gate.
+          COVERAGE=$(bun test --coverage 2>&1 | grep "All files" | head -1 \
+            | sed 's/\x1b\[[0-9;]*m//g' | awk -F'|' '{gsub(/[[:space:]]/,"",$3); print $3}' | tr -d '%')
           echo "Line coverage: ${COVERAGE}%"
+          if ! echo "$COVERAGE" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+            echo "Could not parse line coverage from bun output"
+            exit 1
+          fi
           if [ "$(echo "$COVERAGE < 60" | bc -l)" -eq 1 ]; then
             echo "Coverage ${COVERAGE}% is below 60% threshold"
             exit 1
@@ -72,7 +81,7 @@ jobs:
     # Docker-based Playwright tests are too heavy for CI.
     if: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -104,7 +113,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -152,7 +161,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Wait for npm registry propagation
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,65 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-04
+
+Redesign + a sweep of session/transcript reliability work. Changelog
+entries for 0.5.0–0.5.3 were not kept at the time; this section documents
+the headline changes since the last documented release.
+
+### Added
+- iOS/web redesign: lime design system with bundled fonts (Inter Tight /
+  JetBrains Mono), `StatusPill` + session-display helpers, redesigned
+  sessions/chat/question-card screens, connect bottom sheet, settings
+  reskin, and a generated app icon (light/dark/tinted) (#446, #448).
+- Auto-approve multi-choice handling: skip-by-default with optional
+  evaluation via an alternate model (#399); `permission_suggestions`
+  accepts object-shaped entries (#417).
+- PTY-presence question gate: questions are surfaced based on what is
+  actually visible on the PTY, with keyed multi-question routing (#415,
+  #418, #419, #441).
+- iMessage-style reply: chat input is decoupled from the answer flow so a
+  typed message is not hijacked by a pending question (#401).
+- iOS edge-swipe back gesture from chat to the session list (#411).
+- Daemon port-range scan when connecting by hostname with no port (#393).
+
+### Changed
+- Wire protocol carries `claudeSessionId` and `transcriptPath` end to end
+  (`hello_ack`, `session_list_response`, `question`,
+  `transcript_binding_changed`); the daemon refuses outbound answers with
+  `STALE_BINDING` when the client's claimed binding no longer matches.
+  New fields are optional and backward compatible (#429, #430).
+- Session rotation on `/clear` and `/resume` is announced with a single
+  atomic `session_rotated` message (replacing the former `session_reset`)
+  so the client clears, rebinds, and re-fetches the transcript in one step
+  (#443). **Upgrade note:** after updating the daemon, reconnect older
+  mobile/web clients once — a pre-0.6.0 client will not act on
+  `session_rotated` and may show a stale chat after `/clear`/`/resume`
+  until it reconnects.
+
 ### Fixed
-- Cross-daemon answer routing: two daemons running in the same cwd no
-  longer cross-route responses to each other's sessions (#427). The fix
-  has three layers of defense:
-  - Daemon pre-assigns the Claude session UUID at spawn via
-    `--session-id <uuid>` so transcript binding is deterministic; no
-    more mtime-based discovery race (#428).
-  - Wire protocol carries `claudeSessionId` and `transcriptPath` end to
-    end (`hello_ack`, `session_list_response`, `question`,
-    `transcript_binding_changed`). The daemon refuses outbound answers
-    with `STALE_BINDING` when the client's claimed binding no longer
-    matches (#429).
-  - Mobile and web chat header now shows the active port and Claude
-    session id (`:<port> · <8-char-uuid>`), tap to copy the transcript
-    path; client tracks the binding through `transcript_binding_changed`
-    and rekeys on `STALE_BINDING` (#430).
+- Cross-daemon answer routing: two daemons in the same cwd no longer
+  cross-route responses. Deterministic PTY→transcript binding via a
+  pre-assigned `--session-id <uuid>` removes the mtime discovery race
+  (#427, #428, #429, #430).
+- Transcript-watcher start reliability: a leftover daemon whose Claude
+  child has died no longer wedges a co-located session (`claudeChildPid`
+  liveness + a `remi:<port>` transcript ownership marker), and a session
+  whose fallback poll timed out before Claude wrote its transcript now
+  self-heals its watcher on the next hook event (#451, #452).
+- SessionEpoch reliability: prompt-chrome question detection, host-identity
+  connection resolver, and reconnect-mid-rotation reconcile (#435, #440,
+  #445).
+- APNS/question fixes: no duplicate push within a prompt cycle, the
+  default 3-option set never clobbers a richer pending question, and PTY
+  questions the user can answer are no longer dropped by the
+  subagent-context filter (#405, #407, #409, #413).
+- CORS headers on HTTP endpoints so the iOS Capacitor app can scan ports
+  (#403).
+- Light-mode accent contrast and connect-landing fixes (#449, #450).
 
 ### Internal
-- Auto-approve tests honor `SKIP_LLM_TESTS=1` (skip Ollama-gated suite).
+- Auto-approve tests honor `SKIP_LLM_TESTS=1` (skip the Ollama-gated suite).
 
 ## [0.4.4] - 2026-03-20
 


### PR DESCRIPTION
Release-readiness fixes for #454 (develop → main, 0.6.0). From the release review:

- **CHANGELOG**: add the `[0.6.0]` section. Includes an upgrade note: after updating the daemon, reconnect older mobile/web clients once — a pre-0.6.0 client won't act on `session_rotated` (renamed from `session_reset` in #443) and may show a stale chat after `/clear`/`/resume` until reconnect.
- **ci: restore the coverage gate** (real bug). The old `awk '{print $NF}'` extracted the trailing `|`, not the `% Lines` column, so the 60% floor was a silent no-op for the entire 0.5.x cycle. Now parses the 3rd pipe field, strips ANSI, and fails loudly on a non-numeric result. Verified against real bun 1.3.11 output.
- **ci/release: `actions/checkout` v4 → v5** ahead of the Node 20 deprecation (forced Node 24 migration 2026-06-16).

Merges into develop so #454 picks these up before the release.