### PR TITLE
Phase 1: extract QuestionPipeline (NotificationDispatcher + AutoApproveGate)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -36,12 +36,20 @@ import type { AutoApproveResult } from './types.ts';
  * mocking framework or a live LLM.
  */
 export interface AutoApproveEvaluator {
+  /**
+   * Evaluate a permission request. MUST NOT throw — return an `escalate` result
+   * instead so the gate's decision path is deterministic. A rejected Promise is
+   * tolerated (the gate's `.catch` treats it identically to `escalate`), but a
+   * synchronous throw would escape into the hook dispatch loop.
+   */
   evaluate(
     toolName: string,
     toolInput: Record<string, unknown>,
     tag?: string,
     permissionSuggestions?: readonly unknown[],
   ): Promise<AutoApproveResult>;
+  /** Abort any in-flight `evaluate`. Returns true if an abort was issued, false
+   *  if nothing was in flight (idempotent). */
   cancel(reason: string): boolean;
 }
 
@@ -52,7 +60,10 @@ export interface AutoApproveGateDeps {
   tracker: QuestionPresenceTracker;
   /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
   isInSubagentContext: () => boolean;
-  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate adds the try/catch. */
+  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate wraps
+   *  every call in a try/catch, so an implementation that throws is logged and
+   *  absorbed rather than propagated; implementations should still prefer to
+   *  handle their own errors. */
   escalate: (input: PermissionRequestHookInput) => void;
 }
 

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1,0 +1,258 @@
+/**
+ * AutoApproveGate — owns the PermissionRequest control plane for a session.
+ *
+ * Epic #453 phase 1: extracted verbatim from `cli/session-phases/hook-bridge-setup.ts`
+ * (concern 3 of that file's three braided concerns). It is the third member of the
+ * QuestionPipeline boundary, alongside `NotificationDispatcher` and the already-
+ * standalone `QuestionPresenceTracker`.
+ *
+ * Given a PermissionRequest hook event, it either:
+ *   - runs the auto-approve LLM eval and injects "1" (approve) / "3" (deny) /
+ *     a 1-based pick index into the PTY, or
+ *   - escalates the prompt to the user (the normal Question flow), or
+ *   - default-denies a subagent prompt the user cannot answer (to avoid hanging it).
+ *
+ * The two outward couplings the hook bridge used directly are injected as callbacks
+ * so the gate has no back-reference to the bridge or the hook router:
+ *   - `isInSubagentContext()` wraps `HookEventBridge.isInSubagentContext()`
+ *   - `escalate(input)` wraps `handlers.onPermissionRequest?.(input)`
+ * Both are read LIVE at each branch (never captured): the LLM eval is async, so the
+ * subagent/Task context can open or close between the hook firing and the
+ * `.then()`/`.catch()` running. Capturing would TOCTOU.
+ */
+
+import type { UUID } from '@remi/shared';
+
+import type { QuestionPresenceTracker } from '../api/question-presence-tracker.ts';
+import { log, logError } from '../cli/logger.ts';
+import type { PermissionRequestHookInput } from '../hooks/index.ts';
+import type { SessionRegistry } from '../session/index.ts';
+import type { AutoApproveResult } from './types.ts';
+
+/**
+ * Minimal seam the gate consumes. The real `AutoApproveService` satisfies it
+ * structurally; tests inject a real object literal returning real
+ * `AutoApproveResult` values, so the gate's branching is exercised without a
+ * mocking framework or a live LLM.
+ */
+export interface AutoApproveEvaluator {
+  evaluate(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    tag?: string,
+    permissionSuggestions?: readonly unknown[],
+  ): Promise<AutoApproveResult>;
+  cancel(reason: string): boolean;
+}
+
+export interface AutoApproveGateDeps {
+  /** null => no auto-approve configured; the no-AA escalate/default-deny path runs. */
+  service: AutoApproveEvaluator | null;
+  sessionRegistry: SessionRegistry;
+  tracker: QuestionPresenceTracker;
+  /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
+  isInSubagentContext: () => boolean;
+  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate adds the try/catch. */
+  escalate: (input: PermissionRequestHookInput) => void;
+}
+
+export class AutoApproveGate {
+  private readonly sessionTag: string;
+
+  constructor(
+    private readonly deps: AutoApproveGateDeps,
+    private readonly sessionId: UUID,
+  ) {
+    this.sessionTag = sessionId.slice(0, 8);
+  }
+
+  /**
+   * Cancel any in-flight auto-approve LLM eval. The bridge calls this on hook events
+   * that unambiguously confirm Claude advanced past a prompt (PreToolUse / PostToolUse /
+   * Stop / SessionEnd): the user already answered, and a stale LLM result would inject
+   * into the wrong PTY position or emit a phantom question.
+   *
+   * Deliberately NOT called on Notification events: idle_prompt can fire while a
+   * permission eval is still legitimately in flight, and auth_success /
+   * elicitation_dialog don't carry "user answered" semantics either. No-op when no
+   * service is configured.
+   */
+  cancelStale(reason: string): void {
+    if (this.deps.service === null) return;
+    if (this.deps.service.cancel(reason)) {
+      log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
+    }
+  }
+
+  /**
+   * Handle a PermissionRequest hook event: auto-approve eval + inject, or escalate.
+   * Caller is responsible for session filtering (the bridge runs initFromHookEvent
+   * + filterBySession before delegating here).
+   */
+  handlePermissionRequest(input: PermissionRequestHookInput): void {
+    const { service, isInSubagentContext } = this.deps;
+
+    // Phase 4 (#419): subagent PermissionRequest events are forwarded (not dropped).
+    // The PTY-presence model treats "what's on screen" as truth: a hot-switched
+    // subagent view that renders a permission prompt IS user-answerable, and
+    // dropping the hook here would lose the rich tool/option metadata.
+    if (this.isSubagentEvent(input)) {
+      log(
+        `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
+      );
+    }
+
+    // Auto-approve gate: evaluate before creating a Question object.
+    if (service) {
+      // Pass the raw suggestions array; AutoApproveService does its own strict-string
+      // filtering before feeding the LLM. We forward the raw shape (rather than
+      // coercing) so the multi-choice classifier can see "non-string entry" and route
+      // through escalate instead of crashing on a future permission_suggestions schema
+      // change.
+      service
+        .evaluate(
+          input.tool_name,
+          input.tool_input,
+          this.sessionTag,
+          input.permission_suggestions as readonly unknown[] | undefined,
+        )
+        .then(async (result) => {
+          if (result.decision === 'cancelled') {
+            // User already advanced past the prompt. Do not inject, do not escalate.
+            // Drop the pending hook record so its stale option labels cannot merge
+            // onto the next unrelated PTY prompt (e.g. user typed /compact, no
+            // PreToolUse fires).
+            this.deps.tracker.clearPending();
+            log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
+            return;
+          }
+          if (result.decision === 'approve') {
+            if (!(await this.inject(input, '1', 'approved'))) this.escalateToUser(input);
+            return;
+          }
+          if (result.decision === 'deny') {
+            if (!(await this.inject(input, '3', 'denied'))) this.escalateToUser(input);
+            return;
+          }
+          if (result.decision === 'pick' && result.pickIndex !== undefined) {
+            // Multi-choice pick (#399): inject the 1-based index Claude Code expects.
+            // parseMultiChoiceDecision already validated the index against options
+            // length, so out-of-range values cannot reach this branch.
+            if (
+              !(await this.inject(
+                input,
+                String(result.pickIndex),
+                `multichoice-pick-${result.pickIndex}`,
+              ))
+            ) {
+              this.escalateToUser(input);
+            }
+            return;
+          }
+          // escalate: in a subagent context, default-deny to avoid hanging the
+          // subagent (the user could not answer it anyway). Bypass the subagent PTY
+          // gate because the alternative is letting it hang forever; typing '3' into
+          // the parent PTY is the lesser evil. The approve/deny/pick branches above
+          // use the gate because they have a fallback (escalateToUser); this does not.
+          if (isInSubagentContext()) {
+            log(
+              `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
+            );
+            await this.inject(input, '3', 'subagent-escalate-default-deny', true);
+            return;
+          }
+          this.escalateToUser(input);
+        })
+        .catch(async (err) => {
+          // Last line of defense; must not leave an unhandled rejection.
+          try {
+            logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
+            if (isInSubagentContext()) {
+              await this.inject(input, '3', 'subagent-error-default-deny', true);
+              return;
+            }
+            this.escalateToUser(input);
+          } catch (inner) {
+            logError(`[AutoApprove ${this.sessionTag}] catch handler threw:`, inner);
+          }
+        });
+      return;
+    }
+
+    // No auto-approve. In a subagent context, still must not hang the subagent:
+    // default-deny rather than emit a question the user can't answer.
+    if (isInSubagentContext()) {
+      log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
+      this.inject(input, '3', 'subagent-no-aa-default-deny', true).catch((err) => {
+        logError(`[${this.sessionTag}] Failed to inject default-deny:`, err);
+      });
+      return;
+    }
+
+    this.escalateToUser(input);
+  }
+
+  /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */
+  private isSubagentEvent(input: PermissionRequestHookInput): boolean {
+    return typeof input.agent_id === 'string' && input.agent_id.length > 0;
+  }
+
+  /**
+   * Inject an answer into the PTY. Returns true on success. On failure (session
+   * missing, PTY not running, submitInput throws, subagent off-screen gate trips)
+   * it logs and returns false so callers can fall back to escalating.
+   *
+   * `value` is a 1-based numeric option index serialised as a string. Most
+   * permissions only need '1' (approve) or '3' (deny); multi-choice picks can land
+   * any index in the prompt's option range (#399).
+   *
+   * PTY-presence gate (subagent-only): a background subagent emits PermissionRequest
+   * hooks for its own tool calls, but its prompts never render on the main PTY — only
+   * a hot-switched subagent view does. Without this gate, auto-approve would type
+   * "1"/"3" into the MAIN AGENT's input every time a background subagent asked.
+   * `bypassSubagentPtyGate` is set by the default-deny paths, whose alternative is
+   * hanging the subagent indefinitely.
+   */
+  private async inject(
+    input: PermissionRequestHookInput,
+    value: string,
+    reason: string,
+    bypassSubagentPtyGate = false,
+  ): Promise<boolean> {
+    const { sessionRegistry, tracker, isInSubagentContext } = this.deps;
+    try {
+      const session = sessionRegistry.getSession(this.sessionId);
+      if (!session) {
+        logError(`[AutoApprove ${this.sessionTag}] Session not found; cannot inject "${value}"`);
+        return false;
+      }
+      const inSubagentContext = this.isSubagentEvent(input) || isInSubagentContext();
+      if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
+        log(
+          `[AutoApprove ${this.sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
+        );
+        return false;
+      }
+      await session.pty.submitInput(value);
+      log(`[AutoApprove ${this.sessionTag}] Injected "${value}" into PTY (${reason})`);
+      sessionRegistry.updateStatus(this.sessionId, value === '1' ? 'executing' : 'thinking');
+      return true;
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] inject("${value}") threw:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Safe escalation to the user. Used when inject fails or when auto-approve is off
+   * and we're in main context. Wrapped so a bridge/push failure does not leave a
+   * dangling unhandled rejection in the hook handler.
+   */
+  private escalateToUser(input: PermissionRequestHookInput): void {
+    try {
+      this.deps.escalate(input);
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
+    }
+  }
+}

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -1,4 +1,6 @@
 export { AutoApproveService, parseDecision } from './auto-approve-service.ts';
+export { AutoApproveGate } from './auto-approve-gate.ts';
+export type { AutoApproveEvaluator, AutoApproveGateDeps } from './auto-approve-gate.ts';
 export { resolveProviderUrl } from './llm-client.ts';
 export type {
   AutoApproveConfig,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -2,9 +2,8 @@
  * Wire the Claude Code hook event stream into our PTY's MessageAPI during
  * createNewSession.
  *
- * Three concerns are tangled here and kept together because they all depend
- * on the same per-session locks (claudeSessionId, mainSessionEnded,
- * hasSiblingInDir()):
+ * Two concerns live here, both depending on the same per-session locks
+ * (claudeSessionId, mainSessionEnded, hasSiblingInDir()):
  *
  *   1. **Session filtering.** Claude Code fires hook events that may belong
  *      to our PTY, a subagent inside it, or a sibling daemon's PTY in the
@@ -18,11 +17,14 @@
  *      keeps the same session id) tears down the old watcher, starts a fresh
  *      one, and emits a single session_rotated event.
  *
- *   3. **Auto-approve gate.** PermissionRequest events are intercepted
- *      before they reach the user. If auto-approve returns approve/deny we
- *      inject "1"/"3" into the PTY; otherwise (or on subagent PTY failure)
- *      we escalate to the user or default-deny to avoid hanging a subagent
- *      with no one to answer.
+ * A third concern, the **auto-approve gate**, used to be inlined here; it is now
+ * delegated to `AutoApproveGate` (#453 phase 1). The bridge does the session
+ * filtering, then routes PermissionRequest to the gate, which runs the
+ * auto-approve eval and injects "1"/"3"/pick into the PTY, escalates to the user,
+ * or default-denies a subagent prompt no one can answer. The gate is wired with
+ * the bridge's `isInSubagentContext` + the router's `onPermissionRequest` as
+ * callbacks; Pre/PostToolUse/Stop/SessionEnd call `gate.cancelStale()` to abort a
+ * stale in-flight eval once Claude has advanced past the prompt.
  *
  * The function registers 7 hookServer listeners (SessionStart, PreToolUse,
  * PostToolUse, Notification, PermissionRequest, Stop, SessionEnd) and
@@ -37,6 +39,7 @@ import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
 import type { QuestionPresenceTracker } from '../../api/question-presence-tracker.ts';
+import { AutoApproveGate } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
@@ -155,25 +158,6 @@ export function setupHookBridge(
   // reflected immediately. Issue #321: a stale `null`-once cache wedged
   // this state and permanently disabled hook-driven discovery for both
   // daemons.
-
-  /**
-   * Cancel any in-flight auto-approve LLM eval. Called on hook events that
-   * unambiguously confirm Claude advanced past a prompt: PreToolUse /
-   * PostToolUse / Stop / SessionEnd. At that point the user has already
-   * answered (probably in the local terminal) and a stale LLM result would
-   * either inject into the wrong PTY position or emit a phantom question.
-   *
-   * Deliberately NOT called on Notification events: idle_prompt can fire
-   * while a permission eval is still legitimately in flight, and
-   * auth_success / elicitation_dialog don't carry "user answered" semantics
-   * either.
-   */
-  const cancelStaleAutoApprove = (reason: string): void => {
-    if (autoApproveService === null) return;
-    if (autoApproveService.cancel(reason)) {
-      log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
-    }
-  };
 
   // ---- Helpers ------------------------------------------------------------
 
@@ -552,6 +536,21 @@ export function setupHookBridge(
 
   const handlers = hookBridge.hookHandlers();
 
+  // Auto-approve control plane (#453 phase 1): owns the PermissionRequest eval +
+  // inject + escalate + cancelStale. Constructed after the bridge + handlers so it
+  // can wrap the two outward couplings (isInSubagentContext, onPermissionRequest) as
+  // injected callbacks, read live at inject time (async TOCTOU).
+  const autoApproveGate = new AutoApproveGate(
+    {
+      service: autoApproveService,
+      sessionRegistry,
+      tracker,
+      isInSubagentContext: () => hookBridge.isInSubagentContext(),
+      escalate: (i) => handlers.onPermissionRequest?.(i),
+    },
+    sessionId,
+  );
+
   // Filter: accept events only from our own Claude. Before claudeSessionId
   // is known, block events when siblings exist (they could be from the
   // sibling's Claude).
@@ -611,14 +610,14 @@ export function setupHookBridge(
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    cancelStaleAutoApprove('PreToolUse');
+    autoApproveGate.cancelStale('PreToolUse');
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    cancelStaleAutoApprove('PostToolUse');
+    autoApproveGate.cancelStale('PostToolUse');
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
@@ -644,197 +643,17 @@ export function setupHookBridge(
   hookServer.on('PermissionRequest', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
-
-    // Phase 4 (#419): subagent PermissionRequest events (events with
-    // agent_id set, originating from Task/Agent-spawned subagents) used
-    // to be dropped at this seam. Under phase 3's PTY-presence model,
-    // "what's on screen" is the truth: a hot-switched subagent view
-    // that renders a permission prompt IS user-answerable, and dropping
-    // the hook here loses the rich tool/option metadata. Forward the
-    // event; the tracker pairs it with PTY confirmation. Auto-approve
-    // and the inSubagent default-deny safety net below still gate
-    // injection independently.
-    if (isSubagentEvent(input)) {
-      log(
-        `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
-      );
-    }
-
-    // Nested-Task context (secondary safety net for cases where
-    // agent_id is absent). Used by the auto-approve default-deny path
-    // below to avoid hanging a subagent whose only escalation route is
-    // a main-PTY prompt the user cannot see.
-    //
-    // Read live (not captured) at each branch: auto-approve evaluate()
-    // is async, so the Task context can open or close between when this
-    // listener fires and when the .then()/.catch() runs. Capturing
-    // would TOCTOU — a Task that closed mid-eval would still trigger
-    // default-deny, and a Task that opened mid-eval would escape it.
-    const sessionTag = sessionId.slice(0, 8);
-
-    // Inject an answer into the PTY. Returns true on success. On failure
-    // (session missing, PTY not running, submitInput throws, subagent
-    // off-screen gate trips) it logs and returns false so callers can
-    // fall back to escalating the prompt.
-    //
-    // Value is a 1-based numeric option index serialised as a string. Most
-    // permissions only need '1' (approve) or '3' (deny); multi-choice picks
-    // can land any index in the prompt's option range (#399).
-    //
-    // PTY-presence gate (subagent-only): a background subagent emits
-    // PermissionRequest hooks for its own tool calls, but its prompts
-    // never render on the main PTY — only a hot-switched subagent view
-    // does. Without this gate, auto-approve would type "1"/"3" into the
-    // MAIN AGENT's input every time a background subagent asked for
-    // permission.
-    //
-    // Detect subagent context two ways: (a) explicit `agent_id` on the
-    // hook event (Task tool with agent_id set), and (b)
-    // `hookBridge.isInSubagentContext()` (nested-Task tracker — the
-    // secondary safety net for legacy events without agent_id). Both
-    // are read at inject time, not captured, so the hot-switched case
-    // (PTY has rendered the subagent prompt between the hook firing
-    // and the LLM eval returning) still injects.
-    //
-    // Asymmetry: the default-deny path (subagent-escalate / subagent-
-    // error) passes `bypassSubagentPtyGate=true` to keep firing even
-    // without PTY confirmation, because the alternative is hanging the
-    // subagent indefinitely with no one to answer. That is a
-    // deliberately-different trade-off from the approve/deny/pick path,
-    // which falls through to escalateToUser when gated.
-    const inject = async (
-      value: string,
-      reason: string,
-      bypassSubagentPtyGate = false,
-    ): Promise<boolean> => {
-      try {
-        const session = sessionRegistry.getSession(sessionId);
-        if (!session) {
-          logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
-          return false;
-        }
-        const inSubagentContext = isSubagentEvent(input) || hookBridge.isInSubagentContext();
-        if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
-          log(
-            `[AutoApprove ${sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
-          );
-          return false;
-        }
-        await session.pty.submitInput(value);
-        log(`[AutoApprove ${sessionTag}] Injected "${value}" into PTY (${reason})`);
-        sessionRegistry.updateStatus(sessionId, value === '1' ? 'executing' : 'thinking');
-        return true;
-      } catch (err) {
-        logError(`[AutoApprove ${sessionTag}] inject("${value}") threw:`, err);
-        return false;
-      }
-    };
-
-    // Safe escalation to the user. Used when inject fails or when auto-approve
-    // is off and we're in main context. Wrapped so bridge/push failures don't
-    // leave the hook handler with a dangling unhandled rejection.
-    const escalateToUser = () => {
-      try {
-        handlers.onPermissionRequest?.(input);
-      } catch (err) {
-        logError(`[AutoApprove ${sessionTag}] escalateToUser threw:`, err);
-      }
-    };
-
-    // Auto-approve gate: evaluate before creating a Question object.
-    if (autoApproveService) {
-      const aaService = autoApproveService;
-      // Pass the raw suggestions array; AutoApproveService does its own
-      // strict-string filtering before feeding the LLM. We forward the
-      // raw shape (rather than coercing) so the multi-choice classifier
-      // can see "non-string entry" and route through escalate instead
-      // of crashing on a future Claude Code permission_suggestions
-      // schema change.
-      aaService
-        .evaluate(
-          input.tool_name,
-          input.tool_input,
-          sessionTag,
-          input.permission_suggestions as readonly unknown[] | undefined,
-        )
-        .then(async (result) => {
-          if (result.decision === 'cancelled') {
-            // User already advanced past the prompt (terminal answer or
-            // hook event confirmed the tool ran). Do not inject, do not
-            // escalate. Drop the pending hook record so its stale option
-            // labels cannot merge onto the next unrelated PTY prompt
-            // (e.g. user typed /compact, no PreToolUse fires).
-            tracker.clearPending();
-            log(`[AutoApprove ${sessionTag}] Decision dropped: ${result.reasoning}`);
-            return;
-          }
-          if (result.decision === 'approve') {
-            if (!(await inject('1', 'approved'))) escalateToUser();
-            return;
-          }
-          if (result.decision === 'deny') {
-            if (!(await inject('3', 'denied'))) escalateToUser();
-            return;
-          }
-          if (result.decision === 'pick' && result.pickIndex !== undefined) {
-            // Multi-choice pick (#399): inject the 1-based index Claude Code
-            // expects on the terminal. parseMultiChoiceDecision already
-            // validated the index against options length, so out-of-range
-            // values cannot reach this branch.
-            if (!(await inject(String(result.pickIndex), `multichoice-pick-${result.pickIndex}`))) {
-              escalateToUser();
-            }
-            return;
-          }
-          // escalate: in a subagent context, default-deny to avoid hanging
-          // the subagent. The user could not answer it anyway. Bypass the
-          // subagent PTY gate (`bypassSubagentPtyGate=true`) because the
-          // alternative is letting the subagent hang forever; typing '3'
-          // into the parent PTY is accepted as the lesser evil here. The
-          // approve/deny/pick branches above use the gate because they
-          // have a fallback (escalateToUser); this branch does not.
-          if (hookBridge.isInSubagentContext()) {
-            log(`[AutoApprove ${sessionTag}] Subagent context; escalate->deny to prevent hang`);
-            await inject('3', 'subagent-escalate-default-deny', true);
-            return;
-          }
-          escalateToUser();
-        })
-        .catch(async (err) => {
-          // Last line of defense; must not leave an unhandled rejection.
-          try {
-            logError(`[AutoApprove ${sessionTag}] Unexpected error:`, err);
-            if (hookBridge.isInSubagentContext()) {
-              await inject('3', 'subagent-error-default-deny', true);
-              return;
-            }
-            escalateToUser();
-          } catch (inner) {
-            logError(`[AutoApprove ${sessionTag}] catch handler threw:`, inner);
-          }
-        });
-      return;
-    }
-
-    // No auto-approve. In a subagent context, still must not hang the
-    // subagent: default-deny rather than emit a question the user can't
-    // answer. Synchronous fallback — read live for symmetry with the
-    // async branches above; no TOCTOU here but the consistent shape
-    // helps a future maintainer.
-    if (hookBridge.isInSubagentContext()) {
-      log(`[${sessionTag}] Subagent context without auto-approve; default-deny`);
-      inject('3', 'subagent-no-aa-default-deny', true).catch((err) => {
-        logError(`[${sessionTag}] Failed to inject default-deny:`, err);
-      });
-      return;
-    }
-
-    escalateToUser();
+    // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
+    // owns the PTY injection, the subagent PTY-presence gate, the default-deny
+    // safety net, and the escalate fallback; session filtering above stays here in
+    // the bridge. isInSubagentContext / onPermissionRequest are injected into the
+    // gate and read live at inject time (async TOCTOU).
+    autoApproveGate.handlePermissionRequest(input);
   });
   hookServer.on('Stop', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
-    cancelStaleAutoApprove('Stop');
+    autoApproveGate.cancelStale('Stop');
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
@@ -844,7 +663,7 @@ export function setupHookBridge(
       mainSessionEnded = true;
     }
     if (!filterBySession(input)) return;
-    cancelStaleAutoApprove('SessionEnd');
+    autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);
   });
 

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -19,22 +19,19 @@
  */
 
 import { createStructuredAgentOutput, generateId, now } from '@remi/shared';
-import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, Question, UUID } from '@remi/shared';
 
 import type { MessageAPIEvents } from '../../api/message-api.ts';
 import { MessageAPI } from '../../api/message-api.ts';
-import { sendPushTrigger } from '../../notifications/push-client.ts';
-import { PushDedup } from '../../notifications/push-dedup.ts';
+import { NotificationDispatcher } from '../../notifications/notification-dispatcher.ts';
+import type { PushConfig } from '../../notifications/notification-dispatcher.ts';
 import type { SessionRegistry } from '../../session/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import type { DeviceTokenEntry } from '../handlers/trivial-events.ts';
 import { log, logError } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
 
-export interface PushConfig {
-  signalingUrl: string;
-  pushSecret?: string | undefined;
-}
+export type { PushConfig };
 
 export interface MessageApiSetupDeps {
   sessionRegistry: SessionRegistry;
@@ -65,18 +62,6 @@ export interface MessageApiHandle {
   sendAndRecord: (message: ProtocolMessage) => void;
 }
 
-/**
- * Select the APNS notification category based on the number of question
- * options. iOS renders action buttons matching the category; watchOS mirrors
- * them automatically.
- */
-export function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
-  if (options.length === 2) return 'REMI_YN';
-  if (options.length === 3) return 'REMI_YNA';
-  if (options.length === 4) return 'REMI_MULTI';
-  return undefined;
-}
-
 export function createMessageApiForSession(
   deps: MessageApiSetupDeps,
   sessionId: UUID,
@@ -101,11 +86,13 @@ export function createMessageApiForSession(
     sessionRegistry.recordOutgoingMessage(recordId, message);
   };
 
-  // Per-session push-dedup baseline. PTY + Hook double-emit one prompt
-  // with different ids; without this, the user gets two lock-screen
-  // notifications per prompt (#409). Reset whenever status leaves
-  // 'waiting' so a fresh prompt cycle starts with a clean baseline.
-  const pushDedup = new PushDedup();
+  // APNS push for this session's questions (#453 phase 1). Owns the
+  // active-client gate, the per-prompt PushDedup baseline (#409), and the
+  // device-token fan-out; the MessageAPI callback just hands it the question.
+  const notifications = new NotificationDispatcher(
+    { sessionRegistry, deviceTokens, pushConfig },
+    sessionId,
+  );
 
   const callbacks: MessageAPIEvents = {
     onStructuredMessage: (structured) => {
@@ -141,37 +128,7 @@ export function createMessageApiForSession(
       sessionRegistry.addQuestion(questionSessionId, question);
 
       // Push only when no client is attached; attached clients see it in-app.
-      const sessionForPush = sessionRegistry.getSession(questionSessionId);
-      const hasActiveClient =
-        sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-      if (deviceTokens.size > 0 && !hasActiveClient) {
-        // Push-dedup gate (#409): suppress the PTY/Hook double-emission
-        // for one prompt cycle. Mirrors the client's richer-wins guard
-        // so phone and in-app converge on the same option set.
-        if (!pushDedup.shouldPush(question)) {
-          log(`Push suppressed by dedup for session ${questionSessionId}`);
-          return;
-        }
-        const session = sessionRegistry.getSession(sessionId);
-        const sessionName = session?.name || 'Agent';
-        const cfg = pushConfig();
-        const pushSessionId = getPrimarySessionId() ?? sessionId;
-        const pushCategory = selectPushCategory(question.options);
-        const pushOptions = question.options.map((o) => o.value);
-        for (const dt of deviceTokens.values()) {
-          sendPushTrigger(cfg.signalingUrl, dt.token, {
-            title: `${sessionName} needs input`,
-            body: question.text.slice(0, 100),
-            ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
-            sessionId: pushSessionId,
-            questionId: question.id,
-            ...(pushCategory !== undefined ? { category: pushCategory } : {}),
-            ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
-          })
-            .then(() => log(`Push notification sent for session ${pushSessionId}`))
-            .catch((err) => log(`Push notification failed: ${err}`));
-        }
-      }
+      notifications.maybePush(questionSessionId, question);
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);
@@ -180,7 +137,7 @@ export function createMessageApiForSession(
       // prompt cycle starts fresh and is not silently absorbed by a
       // stale prior push (#409).
       if (status !== 'waiting') {
-        pushDedup.reset();
+        notifications.resetDedup();
       }
       const msg: ProtocolMessage = {
         type: 'session_update',

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -90,7 +90,7 @@ export function createMessageApiForSession(
   // active-client gate, the per-prompt PushDedup baseline (#409), and the
   // device-token fan-out; the MessageAPI callback just hands it the question.
   const notifications = new NotificationDispatcher(
-    { sessionRegistry, deviceTokens, pushConfig },
+    { sessionRegistry, deviceTokens, pushConfig, getPrimarySessionId },
     sessionId,
   );
 

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -1,0 +1,113 @@
+/**
+ * NotificationDispatcher — owns APNS push for a session's questions.
+ *
+ * Epic #453 phase 1: extracted from `cli/session-phases/message-api-setup.ts`
+ * so the push concern (active-client gate + per-prompt dedup + the device-token
+ * fan-out) is a named member of the future `QuestionPipeline`, not inlined in
+ * the MessageAPI question callback.
+ *
+ * Push fires only when no client is actively viewing the session (attached
+ * clients see the question in-app over the WebSocket). The per-session
+ * PushDedup baseline suppresses the PTY+Hook double-emission of one prompt so
+ * the user does not get two lock-screen notifications per prompt (#409); it is
+ * reset whenever the agent leaves the 'waiting' state.
+ */
+
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+
+import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
+import { log } from '../cli/logger.ts';
+import { getPrimarySessionId } from '../cli/session-state.ts';
+import type { SessionRegistry } from '../session/index.ts';
+import { sendPushTrigger } from './push-client.ts';
+import { PushDedup } from './push-dedup.ts';
+
+export interface PushConfig {
+  signalingUrl: string;
+  pushSecret?: string | undefined;
+}
+
+/**
+ * Select the APNS notification category from the number of question options.
+ * iOS renders action buttons matching the category; watchOS mirrors them.
+ */
+export function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
+  if (options.length === 2) return 'REMI_YN';
+  if (options.length === 3) return 'REMI_YNA';
+  if (options.length === 4) return 'REMI_MULTI';
+  return undefined;
+}
+
+/** Signature of the APNS-relay push call; injectable so the push branch is
+ *  observable in tests without mocking a network module. */
+export type PushFn = typeof sendPushTrigger;
+
+export interface NotificationDispatcherDeps {
+  sessionRegistry: SessionRegistry;
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  /**
+   * Current push config; read on every dispatch so the caller can swap the
+   * source without re-wiring. Must be synchronous and non-throwing.
+   */
+  pushConfig: () => PushConfig;
+  /** Defaults to the real sendPushTrigger; overridden in tests. */
+  pushFn?: PushFn;
+}
+
+export class NotificationDispatcher {
+  private readonly pushDedup = new PushDedup();
+
+  constructor(
+    private readonly deps: NotificationDispatcherDeps,
+    private readonly sessionId: UUID,
+  ) {}
+
+  /**
+   * Reset the dedup baseline when the prompt cycle ends (status != 'waiting'),
+   * same lifecycle as QuestionDedup so a new prompt starts fresh (#409).
+   */
+  resetDedup(): void {
+    this.pushDedup.reset();
+  }
+
+  /**
+   * Push `question` to all registered devices, unless a client is actively
+   * attached (they see it in-app) or the dedup gate suppresses it.
+   * `questionSessionId` is the primary id the client knows (from hello_ack).
+   */
+  maybePush(questionSessionId: UUID, question: Question): void {
+    const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
+
+    const sessionForPush = sessionRegistry.getSession(questionSessionId);
+    const hasActiveClient =
+      sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
+    if (deviceTokens.size === 0 || hasActiveClient) return;
+
+    if (!this.pushDedup.shouldPush(question)) {
+      log(`Push suppressed by dedup for session ${questionSessionId}`);
+      return;
+    }
+
+    const session = sessionRegistry.getSession(this.sessionId);
+    const sessionName = session?.name || 'Agent';
+    const cfg = pushConfig();
+    const pushSessionId = getPrimarySessionId() ?? this.sessionId;
+    const pushCategory = selectPushCategory(question.options);
+    const pushOptions = question.options.map((o) => o.value);
+    const push = this.deps.pushFn ?? sendPushTrigger;
+
+    for (const dt of deviceTokens.values()) {
+      push(cfg.signalingUrl, dt.token, {
+        title: `${sessionName} needs input`,
+        body: question.text.slice(0, 100),
+        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+        sessionId: pushSessionId,
+        questionId: question.id,
+        ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+        ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+      })
+        .then(() => log(`Push notification sent for session ${pushSessionId}`))
+        .catch((err) => log(`Push notification failed: ${err}`));
+    }
+  }
+}

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -17,12 +17,16 @@ import type { Question, QuestionOption, UUID } from '@remi/shared';
 
 import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
 import { log } from '../cli/logger.ts';
-import { getPrimarySessionId } from '../cli/session-state.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import { sendPushTrigger } from './push-client.ts';
 import { PushDedup } from './push-dedup.ts';
 
 export interface PushConfig {
+  /**
+   * Signaling server base URL. Always provided by the caller; `sendPushTrigger`'s
+   * `string | undefined` first parameter is wider (it has its own fallback), but
+   * the dispatcher never passes undefined here.
+   */
   signalingUrl: string;
   pushSecret?: string | undefined;
 }
@@ -50,17 +54,28 @@ export interface NotificationDispatcherDeps {
    * source without re-wiring. Must be synchronous and non-throwing.
    */
   pushConfig: () => PushConfig;
+  /**
+   * Reads the primary session id the client knows (from hello_ack) so pushes
+   * carry the id the phone can route on. Injected (not imported) so the
+   * dispatcher has no upward dependency on cli/session-state.
+   */
+  getPrimarySessionId: () => UUID | null;
   /** Defaults to the real sendPushTrigger; overridden in tests. */
   pushFn?: PushFn;
 }
 
 export class NotificationDispatcher {
   private readonly pushDedup = new PushDedup();
+  /** Resolved once at construction: the real sendPushTrigger unless a test
+   *  injected an override. Fixed for the instance lifetime. */
+  private readonly pushFn: PushFn;
 
   constructor(
     private readonly deps: NotificationDispatcherDeps,
     private readonly sessionId: UUID,
-  ) {}
+  ) {
+    this.pushFn = deps.pushFn ?? sendPushTrigger;
+  }
 
   /**
    * Reset the dedup baseline when the prompt cycle ends (status != 'waiting'),
@@ -91,13 +106,12 @@ export class NotificationDispatcher {
     const session = sessionRegistry.getSession(this.sessionId);
     const sessionName = session?.name || 'Agent';
     const cfg = pushConfig();
-    const pushSessionId = getPrimarySessionId() ?? this.sessionId;
+    const pushSessionId = this.deps.getPrimarySessionId() ?? this.sessionId;
     const pushCategory = selectPushCategory(question.options);
     const pushOptions = question.options.map((o) => o.value);
-    const push = this.deps.pushFn ?? sendPushTrigger;
 
     for (const dt of deviceTokens.values()) {
-      push(cfg.signalingUrl, dt.token, {
+      this.pushFn(cfg.signalingUrl, dt.token, {
         title: `${sessionName} needs input`,
         body: question.text.slice(0, 100),
         ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+// Real test double for the PTY: records every submitInput so inject() is
+// observable. `throws` exercises the inject() failure -> escalate fallback.
+function fakePTY(submits: string[], opts: { throws?: boolean } = {}): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async (content: string) => {
+      submits.push(content);
+      if (opts.throws) throw new Error('test: submitInput synthetic failure');
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+// Real AutoApproveResult builders (no mock framework; plain domain objects).
+const approve: AutoApproveResult = {
+  decision: 'approve',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+const deny: AutoApproveResult = { decision: 'deny', reasoning: 't', durationMs: 0, model: 'm' };
+const escalate: AutoApproveResult = {
+  decision: 'escalate',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+const cancelled: AutoApproveResult = { decision: 'cancelled', reasoning: 't', durationMs: 0 };
+const pick = (pickIndex: number): AutoApproveResult => ({
+  decision: 'pick',
+  pickIndex,
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+});
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 20));
+
+describe('AutoApproveGate', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let cancels: string[];
+  let tracker: QuestionPresenceTracker;
+  let subagent: boolean;
+
+  function evaluator(
+    result: AutoApproveResult,
+    opts: { throws?: boolean } = {},
+  ): AutoApproveEvaluator {
+    return {
+      evaluate: async () => {
+        if (opts.throws) throw new Error('test: llm provider down');
+        return result;
+      },
+      cancel: (reason: string) => {
+        cancels.push(reason);
+        return true;
+      },
+    };
+  }
+
+  function gateWith(service: AutoApproveEvaluator | null, ptyThrows = false): AutoApproveGate {
+    // (Re)register the session with the desired PTY behavior.
+    registry.registerSession(SID, '/d', fakePTY(submits, { throws: ptyThrows }), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => subagent,
+        escalate: (i) => escalations.push(i),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    cancels = [];
+    subagent = false;
+    tracker = new QuestionPresenceTracker(() => {});
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve injects "1" and sets status executing (main context)', async () => {
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']);
+    expect(registry.getSession(SID)?.currentStatus).toBe('executing');
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('deny injects "3" and sets status thinking (main context)', async () => {
+    gateWith(evaluator(deny)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(registry.getSession(SID)?.currentStatus).toBe('thinking');
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('pick injects the 1-based index (main context)', async () => {
+    gateWith(evaluator(pick(2))).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['2']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('escalate in main context calls escalate, never injects', async () => {
+    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]?.tool_name).toBe('Bash');
+  });
+
+  test('escalate in subagent context default-denies ("3"), never escalates', async () => {
+    subagent = true;
+    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('cancelled clears the tracker pending; no inject, no escalate', async () => {
+    // Stash a pending hook so clearPending() is observable.
+    tracker.recordPendingHook({
+      id: generateId(),
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(tracker.hasPendingForTest()).toBe(true);
+
+    gateWith(evaluator(cancelled)).handlePermissionRequest(pr());
+    await flush();
+
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('subagent + no PTY presence: inject is gated; approve falls back to escalate', async () => {
+    subagent = true; // background subagent, prompt not on the main PTY
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0); // PTY-presence gate blocked the inject
+    expect(escalations).toHaveLength(1); // approve has a fallback -> escalate
+  });
+
+  test('subagent + PTY prompt visible: inject proceeds', async () => {
+    subagent = true;
+    tracker.onPTYPromptVisible({
+      id: generateId(),
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']);
+  });
+
+  test('explicit agent_id (no isInSubagentContext) also gates inject by PTY presence', async () => {
+    subagent = false; // gate must rely on input.agent_id alone
+    gateWith(evaluator(approve)).handlePermissionRequest(pr({ agent_id: 'agent-xyz' }));
+    await flush();
+    expect(submits).toHaveLength(0); // no PTY presence -> gated
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('inject failure (PTY throws) falls back to escalate (main context)', async () => {
+    gateWith(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
+    await flush();
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('eval rejection in main context escalates (the outer .catch)', async () => {
+    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('eval rejection in subagent context default-denies', async () => {
+    subagent = true;
+    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('no service + subagent: default-deny "3"', async () => {
+    subagent = true;
+    gateWith(null).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('no service + main context: escalate to user', async () => {
+    gateWith(null).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('cancelStale forwards the reason to service.cancel', () => {
+    gateWith(evaluator(approve)).cancelStale('PreToolUse');
+    expect(cancels).toEqual(['PreToolUse']);
+  });
+
+  test('cancelStale is a no-op when no service is configured', () => {
+    expect(() => gateWith(null).cancelStale('Stop')).not.toThrow();
+    expect(cancels).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -3,14 +3,12 @@ import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } fro
 import { generateId, now } from '@remi/shared';
 import type { DeviceTokenEntry } from '../../../src/cli/handlers/trivial-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
-import {
-  createMessageApiForSession,
-  selectPushCategory,
-} from '../../../src/cli/session-phases/message-api-setup.ts';
+import { createMessageApiForSession } from '../../../src/cli/session-phases/message-api-setup.ts';
 import {
   __resetSessionStateForTests,
   setPrimarySessionId,
 } from '../../../src/cli/session-state.ts';
+import { selectPushCategory } from '../../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+import type { DeviceTokenEntry } from '../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import { __resetSessionStateForTests } from '../../src/cli/session-state.ts';
+import {
+  NotificationDispatcher,
+  type PushFn,
+  selectPushCategory,
+} from '../../src/notifications/notification-dispatcher.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+const yesOpt: QuestionOption = {
+  value: 'y',
+  label: 'Yes',
+  isRecommended: true,
+  isYes: true,
+  isNo: false,
+};
+const noOpt: QuestionOption = {
+  value: 'n',
+  label: 'No',
+  isRecommended: false,
+  isYes: false,
+  isNo: true,
+};
+
+function question(id: string, options: QuestionOption[]): Question {
+  return { id: id as UUID, text: 'proceed?', options, allowsFreeText: false, isAnswered: false };
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: 'pty' as unknown as PTYSession['id'],
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+describe('selectPushCategory', () => {
+  test('maps option count to the iOS category', () => {
+    expect(selectPushCategory([yesOpt, noOpt])).toBe('REMI_YN');
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt])).toBe('REMI_YNA');
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt])).toBe('REMI_MULTI');
+    expect(selectPushCategory([yesOpt])).toBeUndefined();
+    expect(selectPushCategory([])).toBeUndefined();
+  });
+});
+
+describe('NotificationDispatcher.maybePush', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ url: string | undefined; token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (url, token, opts) => {
+    pushed.push({ url, token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    __resetSessionStateForTests();
+    await registry.shutdown();
+  });
+
+  test('pushes to every registered device when no client is attached', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    deviceTokens.set('b', { token: 'b', platform: 'ios', registeredAt: 2, connectionId: SID });
+
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed.map((p) => p.token).sort()).toEqual(['a', 'b']);
+    // The dispatcher forwards the raw signaling URL; sendPushTrigger does the
+    // wss->https normalization downstream.
+    expect(pushed[0]?.url).toBe('ws://x');
+    expect(pushed[0]?.opts['category']).toBe('REMI_YN');
+    expect(pushed[0]?.opts['options']).toEqual(['y', 'n']);
+  });
+
+  test('does NOT push when a client is attached (it sees the question in-app)', () => {
+    register(true);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed).toHaveLength(0);
+  });
+
+  test('does NOT push when no devices are registered', () => {
+    register(false);
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pushed).toHaveLength(0);
+  });
+
+  test('dedup: a second identical prompt is suppressed; resetDedup re-allows', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    const d = make();
+
+    d.maybePush(SID, question('q1', [yesOpt, noOpt]));
+    d.maybePush(SID, question('q2', [yesOpt, noOpt])); // same shape -> suppressed
+    expect(pushed).toHaveLength(1);
+
+    d.resetDedup(); // prompt cycle ended (status left 'waiting')
+    d.maybePush(SID, question('q3', [yesOpt, noOpt]));
+    expect(pushed).toHaveLength(2);
+  });
+});

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { Question, QuestionOption, UUID } from '@remi/shared';
 import type { DeviceTokenEntry } from '../../src/cli/handlers/trivial-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
-import { __resetSessionStateForTests } from '../../src/cli/session-state.ts';
 import {
   NotificationDispatcher,
   type PushFn,
@@ -74,6 +73,7 @@ describe('NotificationDispatcher.maybePush', () => {
         sessionRegistry: registry,
         deviceTokens,
         pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
         pushFn,
       },
       SID,
@@ -89,7 +89,6 @@ describe('NotificationDispatcher.maybePush', () => {
 
   afterEach(async () => {
     __resetLoggerForTests();
-    __resetSessionStateForTests();
     await registry.shutdown();
   });
 


### PR DESCRIPTION
## Summary

Phase 1 of epic #453: lift the question/push/auto-approve concern out of the two
god-files into cohesive, independently testable members — the **QuestionPipeline
boundary**. No behavior change; both extractions are verified against the existing
characterization baseline (PR #457).

Two members extracted (the third, `QuestionPresenceTracker`, was already standalone):

1. **`NotificationDispatcher`** (`src/notifications/`) — out of `message-api-setup.ts`.
   Owns the APNS concern for a session's questions: active-client gate + per-prompt
   `PushDedup` baseline (#409) + device-token fan-out. Injectable `pushFn` seam closes
   a testability gap the inline code had noted.

2. **`AutoApproveGate`** (`src/auto-approve/`) — out of `hook-bridge-setup.ts` (concern 3
   of that file's three braided concerns). Owns the `PermissionRequest` control plane:
   the auto-approve eval + `1`/`3`/pick injection, the subagent PTY-presence gate, the
   default-deny safety net, and `cancelStale`. The two outward couplings
   (`isInSubagentContext`, `onPermissionRequest`) are injected as callbacks read **live**
   at inject time — preserving the documented async TOCTOU behavior — so the gate has no
   back-reference to the bridge or the hook router. This is the inter-module contract the
   phase delivers.

`hook-bridge-setup.ts`: **854 -> 673 lines**, left with only concern 1 (session filtering)
and concern 2 (transcript discovery/rotation). Concerns are realized as composable members
wired in `setupHookBridge`, not a single wrapper class.

Closes #458
Part of epic #453

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] The 2267-line characterization suite (`hook-bridge-setup.test.ts`, 50 tests) passes
  **unchanged** — proves both extractions are behavior-preserving.
- [x] New no-mock unit tests: `auto-approve-gate.test.ts` (16 cases — every decision
  branch, PTY gate, inject-failure fallback, eval rejection, no-service path) and
  `notification-dispatcher.test.ts` (5 cases via injected `pushFn`).
- [x] 262 tests pass / 0 fail across session-phases + notifications + auto-approve units.