### PR TITLE
Phase 2: SessionBindingStore (no-cache binding accessor)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -144,6 +144,7 @@ import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
   DEFAULT_BASE_PORT,
   DEFAULT_PORT_RANGE,
+  SessionBindingStore,
   SessionRegistry,
   SessionRegistryFile,
   SessionStore,
@@ -805,6 +806,10 @@ const transcriptDiscovery = new TranscriptDiscovery();
 const transcriptWatchers: Map<UUID, TranscriptWatcher> = new Map();
 const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new Map();
 const sessionStore = new SessionStore();
+// Single binding accessor for the whole daemon (#460 phase 2): the one typed,
+// disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
+// both resume resolvers route through it. No cache — see session-binding-store.ts.
+const bindingStore = new SessionBindingStore(sessionStore);
 
 const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
@@ -1008,15 +1013,14 @@ async function createNewSession(
       updateRemiStatus: (patch) => updateRemiStatus(patch),
       maxBulletLength: MAX_BULLET_LENGTH,
       sendMessage,
-      // Lazy read so the binding seen on each question emission is the
-      // current value — survives /resume rotation via hook-bridge's
-      // updateClaudeSessionId write into the store. Wrapped in try/catch
-      // so a transient sessions.json I/O hiccup cannot kill question
-      // emission (the dep contract is non-throwing).
+      // Lazy disk-backed read so the binding seen on each question emission is
+      // the current value — survives /resume rotation via the hook bridge's
+      // bindingStore.update write. Wrapped in try/catch so a transient
+      // sessions.json I/O hiccup cannot kill question emission (the dep
+      // contract is non-throwing).
       getClaudeSessionId: () => {
         try {
-          return (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ??
-            null) as UUID | null;
+          return (bindingStore.get(sessionId)?.claudeSessionId ?? null) as UUID | null;
         } catch (err) {
           logError(`[Binding] getClaudeSessionId lookup failed: ${errorToString(err)}`);
           return null;
@@ -1068,7 +1072,7 @@ async function createNewSession(
 
   // Persist the binding before spawn so siblings observing the store
   // during the race window see our claim immediately.
-  sessionStore.save({
+  bindingStore.preAssign({
     remiSessionId: sessionId,
     claudeSessionId: binding.claudeSessionId,
     projectPath: workingDirectory,
@@ -1083,7 +1087,7 @@ async function createNewSession(
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -1192,13 +1196,13 @@ const trivialHandlers: TrivialHandlers = createTrivialHandlers({
 
 const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
-  sessionStore,
+  bindingStore,
   send: sendToConnection,
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({
   sessionRegistry,
-  sessionStore,
+  bindingStore,
   transcriptDiscovery,
   liveSessionsRegistry,
   currentPort: () => PORT,
@@ -1211,13 +1215,14 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
-  sessionStore,
+  bindingStore,
   send: sendToConnection,
 });
 
 const resumeSessionHandlers: ResumeSessionHandlers = createResumeSessionHandlers({
   sessionRegistry,
   sessionStore,
+  bindingStore,
   transcriptDiscovery,
   createNewSession,
   send: sendToConnection,
@@ -1818,8 +1823,8 @@ if (cliDaemonMode) {
               // sessions for this connection).
               const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
               for (const remiId of [...managedIds]) {
-                const stored = sessionStore.findByRemiSessionId(remiId as UUID);
-                if (stored?.claudeSessionId) managedIds.add(stored.claudeSessionId);
+                const binding = bindingStore.get(remiId as UUID);
+                if (binding?.claudeSessionId) managedIds.add(binding.claudeSessionId);
               }
               const allSessions = [
                 ...sessionRegistry.listSessions(),

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -12,13 +12,13 @@
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   send: SendToConnection;
 }
 
@@ -44,7 +44,7 @@ export interface InputHandlerDeps {
  *     least surfaces the problem in logs while letting the user work.
  */
 function guardBinding(
-  sessionStore: SessionStore,
+  bindingStore: SessionBindingStore,
   send: SendToConnection,
   connectionId: UUID,
   sessionId: UUID,
@@ -53,9 +53,9 @@ function guardBinding(
   if (claudeSessionId === undefined) return true;
   let bound: string | undefined;
   try {
-    bound = sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? undefined;
+    bound = bindingStore.get(sessionId)?.claudeSessionId ?? undefined;
   } catch (err) {
-    logError(`[Binding] sessionStore lookup failed; accepting message: ${errorToString(err)}`);
+    logError(`[Binding] binding lookup failed; accepting message: ${errorToString(err)}`);
     return true;
   }
   if (!bound) return true;
@@ -81,7 +81,7 @@ function guardBinding(
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, sessionStore, send } = deps;
+  const { sessionRegistry, bindingStore, send } = deps;
 
   return {
     onUserInput: async (
@@ -99,7 +99,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 
@@ -140,7 +140,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -27,7 +27,7 @@ import {
 } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore, SessionRegistry, SessionStore } from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import { resolveDirectory } from '../path-resolver.ts';
@@ -48,7 +48,11 @@ export type CreateNewSessionFn = (
 
 export interface ResumeSessionHandlerDeps {
   sessionRegistry: SessionRegistry;
+  /** Full-record reads that also need projectPath (resume seed by remi id). */
   sessionStore: SessionStore;
+  /** Binding-only reverse lookup (resolve by claude session id) — routed through
+   *  the accessor so it cannot diverge from the other resume resolver. */
+  bindingStore: SessionBindingStore;
   transcriptDiscovery: TranscriptDiscovery;
   createNewSession: CreateNewSessionFn;
   send: SendToConnection;
@@ -57,7 +61,14 @@ export interface ResumeSessionHandlerDeps {
 export type ResumeSessionHandlers = ReturnType<typeof createResumeSessionHandlers>;
 
 export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
-  const { sessionRegistry, sessionStore, transcriptDiscovery, createNewSession, send } = deps;
+  const {
+    sessionRegistry,
+    sessionStore,
+    bindingStore,
+    transcriptDiscovery,
+    createNewSession,
+    send,
+  } = deps;
 
   return {
     onResumeSessionRequest: async (
@@ -120,7 +131,7 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
       }
 
       if (!claudeSessionId) {
-        const storedByClaude = sessionStore.findByClaudeSessionId(targetSessionId);
+        const storedByClaude = bindingStore.getByClaudeSessionId(targetSessionId);
         if (storedByClaude) {
           claudeSessionId = storedByClaude.claudeSessionId;
           projectPath = storedByClaude.projectPath;

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -22,14 +22,18 @@ import {
 } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SessionHandlerDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   transcriptDiscovery: TranscriptDiscovery;
   liveSessionsRegistry: SessionRegistryFile;
   /** PORT is reassigned during daemon-mode port probing; read lazily. */
@@ -46,7 +50,7 @@ export type SessionHandlers = ReturnType<typeof createSessionHandlers>;
 export function createSessionHandlers(deps: SessionHandlerDeps) {
   const {
     sessionRegistry,
-    sessionStore,
+    bindingStore,
     transcriptDiscovery,
     liveSessionsRegistry,
     currentPort,
@@ -67,10 +71,10 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       const daemonSessionsRaw = sessionRegistry.listSessions();
       const daemonSessions = daemonSessionsRaw.map((s) => {
         try {
-          const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
-          if (!stored?.claudeSessionId) return s;
-          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
-          return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+          const binding = bindingStore.get(s.sessionId as UUID);
+          if (!binding?.claudeSessionId) return s;
+          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${binding.claudeSessionId}.jsonl`;
+          return { ...s, claudeSessionId: binding.claudeSessionId, transcriptPath };
         } catch (err) {
           logError(
             `[SessionList] Failed to decorate session ${s.sessionId.slice(0, 8)}; serving raw entry: ${errorToString(err)}`,
@@ -84,9 +88,9 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
         // Also exclude by Claude session ID (JSONL filename UUID is a different namespace from remi IDs).
         for (const remiId of [...managedIds]) {
-          const stored = sessionStore.findByRemiSessionId(remiId as UUID);
-          if (stored?.claudeSessionId) {
-            managedIds.add(stored.claudeSessionId);
+          const binding = bindingStore.get(remiId as UUID);
+          if (binding?.claudeSessionId) {
+            managedIds.add(binding.claudeSessionId);
           }
         }
         const externalSessions = transcriptDiscovery.discoverSessions(managedIds);

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -87,10 +87,19 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       if (includeExternal) {
         const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
         // Also exclude by Claude session ID (JSONL filename UUID is a different namespace from remi IDs).
+        // Per-entry try/catch (mirrors the decoration loop above): a disk hiccup on
+        // one lookup must not throw out of this void handler and hang the whole
+        // session-list response — degrade to a possibly-incomplete exclude set.
         for (const remiId of [...managedIds]) {
-          const binding = bindingStore.get(remiId as UUID);
-          if (binding?.claudeSessionId) {
-            managedIds.add(binding.claudeSessionId);
+          try {
+            const binding = bindingStore.get(remiId as UUID);
+            if (binding?.claudeSessionId) {
+              managedIds.add(binding.claudeSessionId);
+            }
+          } catch (err) {
+            logError(
+              `[SessionList] binding lookup failed for ${remiId.slice(0, 8)}; external exclusion may be incomplete: ${errorToString(err)}`,
+            );
           }
         }
         const externalSessions = transcriptDiscovery.discoverSessions(managedIds);

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -15,7 +15,7 @@ import { createError, createTranscriptLoadComplete, errorToString } from '@remi/
 import type { UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
-import type { SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
   TranscriptWatcher as TranscriptWatcherType,
@@ -31,14 +31,14 @@ export interface TranscriptHandlerDeps {
   transcriptWatchers: Map<UUID, TranscriptWatcherType>;
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, sessionStore, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, bindingStore, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -63,7 +63,7 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       // rotation handler keeps current (#451), so history loads even when the
       // streaming watcher is absent rather than failing with NOT_FOUND.
       if (!filePath) {
-        const boundClaudeId = sessionStore.findByRemiSessionId(sessionId as UUID)?.claudeSessionId;
+        const boundClaudeId = bindingStore.get(sessionId as UUID)?.claudeSessionId;
         if (boundClaudeId) {
           filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
           if (filePath) {

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -63,14 +63,23 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       // rotation handler keeps current (#451), so history loads even when the
       // streaming watcher is absent rather than failing with NOT_FOUND.
       if (!filePath) {
-        const boundClaudeId = bindingStore.get(sessionId as UUID)?.claudeSessionId;
-        if (boundClaudeId) {
-          filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
-          if (filePath) {
-            log(
-              `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via store binding ${boundClaudeId.slice(0, 8)}`,
-            );
+        // A disk hiccup on the binding lookup must not throw out of this void
+        // handler (the client would hang with no response). Fail soft: log and
+        // fall through to the NOT_FOUND path below.
+        try {
+          const boundClaudeId = bindingStore.get(sessionId as UUID)?.claudeSessionId;
+          if (boundClaudeId) {
+            filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
+            if (filePath) {
+              log(
+                `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via store binding ${boundClaudeId.slice(0, 8)}`,
+              );
+            }
           }
+        } catch (err) {
+          logError(
+            `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
+          );
         }
       }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -132,7 +132,7 @@ export function setupHookBridge(
       const previous = claudeSessionId;
       claudeSessionId = storedId;
       log(
-        `[Hooks] Lock ${previous === null ? 'adopted' : 'updated'} from sessionStore: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
+        `[Hooks] Lock ${previous === null ? 'adopted' : 'updated'} from binding store: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
       );
     } catch (err) {
       logError(`[Hooks] adoptLockFromStore failed: ${errorToString(err)}`);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -45,7 +45,11 @@ import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
 import { classifySessionEvent } from '../../hooks/session-lock-classifier.ts';
 import { claudeChildLooksAlive } from '../../session/index.ts';
-import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../../session/index.ts';
 import { readTranscriptOwnerPort } from '../../transcript/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
@@ -53,7 +57,7 @@ import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
 export interface HookBridgeDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   liveSessionsRegistry: SessionRegistryFile;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -90,7 +94,7 @@ export function setupHookBridge(
 ): HookBridgeHandle {
   const {
     sessionRegistry,
-    sessionStore,
+    bindingStore,
     liveSessionsRegistry,
     transcriptWatchers,
     transcriptFallbackTimers,
@@ -120,8 +124,10 @@ export function setupHookBridge(
    */
   const adoptLockFromStore = (): void => {
     try {
-      const stored = sessionStore.findByRemiSessionId(sessionId);
-      const storedId = stored?.claudeSessionId ?? null;
+      // Disk-backed read (no cache) via the binding accessor: a sibling/fallback
+      // write is observed every call, which is what preserves the #430 re-adopt
+      // and #321 no-wedge guarantees.
+      const storedId = bindingStore.get(sessionId)?.claudeSessionId ?? null;
       if (storedId === null || storedId === claudeSessionId) return;
       const previous = claudeSessionId;
       claudeSessionId = storedId;
@@ -377,7 +383,7 @@ export function setupHookBridge(
       log(
         `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
       );
-      sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+      bindingStore.update(sessionId, claudeSessionId);
 
       // Announce the rotation as ONE atomic event so the client clears, swaps
       // the binding, and re-fetches the new transcript in a single step (#438).
@@ -489,7 +495,7 @@ export function setupHookBridge(
       try {
         claudeSessionId = hookClaudeSessionId;
         log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
-        sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+        bindingStore.update(sessionId, hookClaudeSessionId);
 
         if (isRotation) {
           try {

--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -21,13 +21,13 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionStore } from '../session/index.ts';
+import type { SessionBindingStore } from '../session/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../transcript/index.ts';
 import type { AssistantEntry } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
 
 export interface ExtractClaudeSessionIdDeps {
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
 }
 
 /**
@@ -50,7 +50,7 @@ export function extractClaudeSessionId(
   const parts = basename.split('_');
   const candidateId = parts[parts.length - 1];
   if (candidateId && candidateId.length >= 8) {
-    deps.sessionStore.updateClaudeSessionId(sessionId, candidateId);
+    deps.bindingStore.update(sessionId, candidateId);
     log(`Claude session ID: ${candidateId}`);
     return candidateId;
   }

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -13,6 +13,8 @@ export {
 
 export { SessionStore, type StoredSession } from './session-store.ts';
 
+export { SessionBindingStore, type SessionBinding } from './session-binding-store.ts';
+
 export {
   SessionRegistryFile,
   type LiveSessionEntry,

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -1,0 +1,65 @@
+/**
+ * SessionBindingStore — the single typed accessor for the durable session binding
+ * (remiUUID <-> claudeSessionId) persisted in sessions.json.
+ *
+ * Epic #453 phase 2. Today the binding is read/written from ~12 scattered sites and
+ * the two resume resolvers read it independently (and can diverge after a rotation).
+ * This facade consolidates the binding surface so every reader/writer goes through
+ * one auditable API, and gives phase-3's TranscriptBinder a single binding dependency.
+ *
+ * NO CACHE — deliberately. It delegates straight to the stateless SessionStore
+ * (fs.readFileSync on every findBy* call), so every read stays disk-fresh and the
+ * accessor is behavior-identical to today's direct SessionStore calls. The phase-2
+ * adversarial review showed a write-through in-memory copy would reintroduce #321
+ * (a cached claudeSessionId wedging classify) and break the #430 "re-adopt on
+ * rotation" characterization test, because today's cross-process freshness comes
+ * precisely from SessionStore being stateless. The cost of a readFileSync on a
+ * <100-entry JSON is microseconds; binding reads are not a hot path. (Design §3.2 v3.)
+ *
+ * Scope: the durable binding ONLY. Liveness (pid/childPid/claudeChildExited) stays in
+ * SessionRegistryFile; transcriptPath has no disk column today (a phase-3 concern).
+ */
+
+import type { UUID } from '@remi/shared';
+
+import type { SessionStore, StoredSession } from './session-store.ts';
+
+export interface SessionBinding {
+  claudeSessionId: string | null;
+}
+
+export class SessionBindingStore {
+  constructor(private readonly store: SessionStore) {}
+
+  /**
+   * Current durable binding for this Remi session, or null when no record exists.
+   * Disk-backed every call (no cache) so a sibling/rotation write is always observed
+   * (#321/#430). Returns an object iff the record exists — exactly mirroring
+   * `findByRemiSessionId(id)?.claudeSessionId`: a record present with a null binding
+   * yields `{ claudeSessionId: null }`, an absent record yields `null`. Callers that
+   * want the id keep using `?.claudeSessionId`, so the substitution is behavior-identical.
+   */
+  get(remiSessionId: UUID): SessionBinding | null {
+    const stored = this.store.findByRemiSessionId(remiSessionId);
+    return stored ? { claudeSessionId: stored.claudeSessionId } : null;
+  }
+
+  /** Reverse lookup: the full record bound to a Claude session id (disk-backed). */
+  getByClaudeSessionId(claudeSessionId: string): StoredSession | null {
+    return this.store.findByClaudeSessionId(claudeSessionId);
+  }
+
+  /**
+   * Update the durable binding on rotation / first discovery. Delegates to
+   * SessionStore.updateClaudeSessionId (a no-op when the record is absent, matching
+   * today). Together with preAssign, the ONLY claudeSessionId writer.
+   */
+  update(remiSessionId: UUID, claudeSessionId: string): void {
+    this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+  }
+
+  /** Pre-spawn deterministic assignment: persist the full session record. */
+  preAssign(session: StoredSession): void {
+    this.store.save(session);
+  }
+}

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -58,7 +58,12 @@ export class SessionBindingStore {
     this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
   }
 
-  /** Pre-spawn deterministic assignment: persist the full session record. */
+  /**
+   * Pre-spawn deterministic assignment: persist the full session record. Takes the
+   * whole StoredSession (not just the binding) because save() creates the row,
+   * including the liveness fields (pid/port/exitedAt) which are the CALLER's
+   * responsibility to populate correctly — the accessor does not own them.
+   */
   preAssign(session: StoredSession): void {
     this.store.save(session);
   }

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createInputHandlers } from '../../../src/cli/handlers/input-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 
@@ -51,6 +52,7 @@ const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 describe('createInputHandlers', () => {
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let tmpDir: string;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
@@ -59,6 +61,7 @@ describe('createInputHandlers', () => {
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-input-events-'));
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     sendCalls = [];
     send = (connectionId, message) => {
       sendCalls.push({ connectionId, message });
@@ -85,7 +88,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
 
       expect(ptyCapture.writes).toEqual(['\x1b[A']);
@@ -103,7 +106,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, 'hello world', false);
 
       expect(ptyCapture.submits).toEqual(['hello world']);
@@ -113,7 +116,7 @@ describe('createInputHandlers', () => {
     test('logs and returns when no session is attached to the connection', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       await handlers.onUserInput(
         CID,
@@ -142,7 +145,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Should not throw
       await handlers.onUserInput(CID, sessionId, 'x', true);
 
@@ -173,7 +176,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
@@ -203,7 +206,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Pass a bogus sessionId, handler should still find the session via connection
       await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
@@ -228,7 +231,7 @@ describe('createInputHandlers', () => {
       // must signal the drop back to the iOS client so the user is not left
       // wondering whether their tap landed.
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -259,7 +262,7 @@ describe('createInputHandlers', () => {
       });
 
       const stale = 'stal0000-0000-0000-0000-000000000000' as UUID;
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -301,7 +304,7 @@ describe('createInputHandlers', () => {
         agentId: 'sub-7',
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Answer the first; it should inject and be removed, the second stays.
       await handlers.onAnswer(CID, sessionId, QID, 'one');
       expect(ptyCapture.submits).toEqual(['one']);
@@ -320,7 +323,7 @@ describe('createInputHandlers', () => {
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
 
@@ -330,7 +333,7 @@ describe('createInputHandlers', () => {
 
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
 
@@ -349,7 +352,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -367,7 +370,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map([[7, 'full expanded content']])),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -413,7 +416,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y', bound);
 
       expect(capture.submits).toEqual(['y']);
@@ -432,7 +435,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y', stale);
 
       expect(capture.submits).toEqual([]);
@@ -455,7 +458,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y');
 
       expect(capture.submits).toEqual(['y']);
@@ -467,7 +470,7 @@ describe('createInputHandlers', () => {
       const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, 'ls', false, stale);
 
       expect(capture.submits).toEqual([]);
@@ -496,7 +499,7 @@ describe('createInputHandlers', () => {
         allowsFreeText: false,
         isAnswered: false,
       });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
       await handlers.onAnswer(CID, sessionId, QID, 'y', claudeId);

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createResumeSessionHandlers } from '../../../src/cli/handlers/resume-session-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
@@ -35,6 +36,7 @@ describe('createResumeSessionHandlers', () => {
   let projectsDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let transcriptDiscovery: TranscriptDiscovery;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
@@ -49,6 +51,7 @@ describe('createResumeSessionHandlers', () => {
     fs.mkdirSync(projectsDir, { recursive: true });
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
@@ -73,6 +76,7 @@ describe('createResumeSessionHandlers', () => {
     return createResumeSessionHandlers({
       sessionRegistry,
       sessionStore,
+      bindingStore,
       transcriptDiscovery,
       createNewSession,
       send,

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createSessionHandlers } from '../../../src/cli/handlers/session-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
@@ -38,6 +39,7 @@ describe('createSessionHandlers', () => {
   let tmpDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let liveSessionsRegistry: SessionRegistryFile;
   let transcriptDiscovery: TranscriptDiscovery;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
@@ -50,6 +52,7 @@ describe('createSessionHandlers', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-session-events-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     liveSessionsRegistry = new SessionRegistryFile(tmpDir);
     transcriptDiscovery = new TranscriptDiscovery({
       projectsDir: path.join(tmpDir, 'claude-projects'),
@@ -73,7 +76,7 @@ describe('createSessionHandlers', () => {
   function makeHandlers() {
     return createSessionHandlers({
       sessionRegistry,
-      sessionStore,
+      bindingStore,
       transcriptDiscovery,
       liveSessionsRegistry,
       currentPort: () => PORT,

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
 import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
@@ -43,6 +44,7 @@ describe('createTranscriptHandlers', () => {
   let transcriptDiscovery: TranscriptDiscovery;
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
   function send(connectionId: UUID, message: ProtocolMessage): boolean {
@@ -57,6 +59,7 @@ describe('createTranscriptHandlers', () => {
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
   });
@@ -70,7 +73,7 @@ describe('createTranscriptHandlers', () => {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
-      sessionStore,
+      bindingStore,
       send,
     });
   }

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -10,6 +10,7 @@ import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.
 import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
 import type { HookServer } from '../../../src/hooks/index.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
@@ -105,6 +106,7 @@ describe('setupHookBridge', () => {
   let tmpDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let liveSessionsRegistry: SessionRegistryFile;
   // Stored loosely so tests can inject a minimal fake watcher without
   // dragging in a real TranscriptWatcher instance.
@@ -118,6 +120,7 @@ describe('setupHookBridge', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-hook-bridge-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     // Live-sessions registry gets its OWN subdir so its listLive() scan does
     // not see (and delete as "invalid") the SessionStore's sessions.json that
     // shares the tmp root. Create it up front so tests that write sibling
@@ -230,7 +233,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1129,7 +1132,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1207,7 +1210,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1279,7 +1282,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1752,7 +1755,7 @@ describe('setupHookBridge', () => {
       setupHookBridge(
         {
           sessionRegistry,
-          sessionStore,
+          bindingStore,
           liveSessionsRegistry,
           transcriptWatchers: transcriptWatchers as unknown as Map<
             UUID,

--- a/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
+++ b/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
@@ -9,6 +9,7 @@ import {
   extractClaudeSessionId,
   startTranscriptWatcher,
 } from '../../src/cli/transcript-watcher-setup.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../src/session/session-store.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
@@ -25,10 +26,12 @@ function fakeMessageAPI(): MessageAPI {
 describe('transcript-watcher-setup', () => {
   let tmpDir: string;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tws-'));
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     configureLogger({ writeLog: () => {} });
     // Seed a session so updateClaudeSessionId has a row to update
     sessionStore.save({
@@ -53,7 +56,7 @@ describe('transcript-watcher-setup', () => {
       const claudeId = '11111111-2222-3333-4444-555555555555';
       const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
 
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
 
       expect(result).toBe(claudeId);
       expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(claudeId);
@@ -63,14 +66,14 @@ describe('transcript-watcher-setup', () => {
       const claudeId = '66666666-7777-8888-9999-000000000000';
       const filePath = path.join(tmpDir, `prefix_${claudeId}.jsonl`);
 
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
 
       expect(result).toBe(claudeId);
     });
 
     test('returns null and does not persist when the filename has no usable id', () => {
       const filePath = path.join(tmpDir, 'ab.jsonl'); // under 8 chars
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
       expect(result).toBeNull();
       expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBeNull();
     });

--- a/packages/daemon/tests/session/session-binding-store.test.ts
+++ b/packages/daemon/tests/session/session-binding-store.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionStore, type StoredSession } from '../../src/session/session-store.ts';
+
+function makeTmpPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binding-test-'));
+  return path.join(dir, 'sessions.json');
+}
+
+function makeSession(overrides: Partial<StoredSession> = {}): StoredSession {
+  return {
+    remiSessionId: crypto.randomUUID() as UUID,
+    claudeSessionId: null,
+    projectPath: '/tmp/project',
+    port: 18765,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+    ...overrides,
+  };
+}
+
+describe('SessionBindingStore', () => {
+  let filePath: string;
+  let store: SessionStore;
+  let binding: SessionBindingStore;
+
+  beforeEach(() => {
+    filePath = makeTmpPath();
+    store = new SessionStore(filePath);
+    binding = new SessionBindingStore(store);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('preAssign persists the full record; get reads the binding back', () => {
+    const session = makeSession({ claudeSessionId: 'claude-A' });
+    binding.preAssign(session);
+
+    expect(binding.get(session.remiSessionId)).toEqual({ claudeSessionId: 'claude-A' });
+    // Durable: a fresh accessor over a fresh store off the same file reads it.
+    const fresh = new SessionBindingStore(new SessionStore(filePath));
+    expect(fresh.get(session.remiSessionId)?.claudeSessionId).toBe('claude-A');
+  });
+
+  test('update sets the binding (rotation / first discovery)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-A' });
+    binding.preAssign(session);
+
+    binding.update(session.remiSessionId, 'claude-B');
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-B');
+    // Persisted, not just in memory.
+    expect(
+      new SessionStore(filePath).findByRemiSessionId(session.remiSessionId)?.claudeSessionId,
+    ).toBe('claude-B');
+  });
+
+  test('get mirrors findByRemiSessionId(id)?.claudeSessionId exactly', () => {
+    // absent record -> null (not an object)
+    const absent = crypto.randomUUID() as UUID;
+    expect(binding.get(absent)).toBeNull();
+
+    // present record with a null binding -> object carrying null
+    const session = makeSession({ claudeSessionId: null });
+    binding.preAssign(session);
+    expect(binding.get(session.remiSessionId)).toEqual({ claudeSessionId: null });
+    // ?.claudeSessionId yields null in both today and post-migration form
+    expect(binding.get(session.remiSessionId)?.claudeSessionId ?? null).toBe(
+      store.findByRemiSessionId(session.remiSessionId)?.claudeSessionId ?? null,
+    );
+  });
+
+  test('update on an absent record is a no-op (matches SessionStore)', () => {
+    const absent = crypto.randomUUID() as UUID;
+    binding.update(absent, 'claude-X');
+    expect(binding.get(absent)).toBeNull();
+  });
+
+  test('getByClaudeSessionId reverse-looks-up the record (or null)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-rev' });
+    binding.preAssign(session);
+
+    expect(binding.getByClaudeSessionId('claude-rev')?.remiSessionId).toBe(session.remiSessionId);
+    expect(binding.getByClaudeSessionId('nope')).toBeNull();
+  });
+
+  test('cross-process freshness: a second store handle writing the same file is seen immediately', () => {
+    // This is the load-bearing no-cache property. A sibling daemon (a DIFFERENT
+    // SessionStore handle on the same sessions.json) rotates the binding; the
+    // accessor must observe it on the very next get() with zero staleness — this
+    // is exactly what preserves #321 (no cached id wedges classify) and the #430
+    // "re-adopt on rotation" characterization test.
+    const session = makeSession({ claudeSessionId: 'claude-1' });
+    binding.preAssign(session);
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-1');
+
+    // A separate handle (simulating a sibling/fallback writer in another context)
+    // writes a new id straight to disk, NOT through `binding`.
+    const sibling = new SessionStore(filePath);
+    sibling.updateClaudeSessionId(session.remiSessionId, 'claude-2');
+
+    // No cache: the next read observes the external write.
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-2');
+  });
+
+  test('multi-rotation sequence ends on the final id (golden)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-1' });
+    binding.preAssign(session);
+    binding.update(session.remiSessionId, 'claude-2');
+    binding.update(session.remiSessionId, 'claude-3');
+
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-3');
+    expect(binding.getByClaudeSessionId('claude-3')?.remiSessionId).toBe(session.remiSessionId);
+    expect(binding.getByClaudeSessionId('claude-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of epic #453: consolidate the durable `remiUUID ↔ claudeSessionId` binding — read/written from ~12 scattered sites — behind one typed accessor, `SessionBindingStore`.

**Design correction (recorded in design §3.2 v3, issue #460).** The eng-cleared design specified a *write-through in-memory cache*. The phase-2 Understand workflow's two adversarial critics (converging) showed that cache reintroduces the epic's core bugs: `SessionStore` is **stateless** (`fs.readFileSync` on every `findBy*`), and that statelessness is what makes #321 (no cached id wedges `classify`) and the #430 "re-adopt on rotation" characterization test hold for free. A self-writes-only cache breaks that test, resurrects the #321 null-once wedge, and regresses sibling correctness. The perf win is illusory (µs on a <100-entry JSON). **Maintainer decision: no cache.**

So `SessionBindingStore` is a thin, disk-backed facade (`get` / `getByClaudeSessionId` / `update` / `preAssign`) delegating straight to `SessionStore` — **every read stays disk-fresh, so the whole phase is behavior-identical indirection** with #321/#430 preserved structurally. Its value is consolidation: one auditable binding API, both resume resolvers routed through it, and the single binding surface phase-3's `TranscriptBinder` will depend on.

### Commits
1. `b89c3d1` — add the accessor + export + 8 no-mock unit tests (incl. the load-bearing cross-process-freshness property: a second `SessionStore` handle writes the same file and `get()` observes it immediately).
2. `c157b51` — construct one instance in `cli.ts`, thread it through the hook bridge / 4 handlers / transcript-watcher, migrate every binding read/write + both resume reverse-lookups. Mixed reads (need `projectPath`) and CLI one-shots stay on the raw store.

Closes #460
Part of epic #453

## Test plan

- [x] `bun run typecheck` + `bunx biome check` clean
- [x] **50-test characterization suite (`hook-bridge-setup.test.ts`) passes UNCHANGED** — only the deps-injection point in tests updated; all assertions identical. Proves behavior preservation.
- [x] New `session-binding-store.test.ts` (8 no-mock tests): write-through, `get` mirrors `findByRemiSessionId(id)?.claudeSessionId`, never-stale cross-process read, multi-rotation golden.
- [x] **Grep-gate**: no `claudeSessionId` writer (`updateClaudeSessionId`/`save`) bypasses the accessor outside `session-store.ts` / `session-binding-store.ts`.
- [x] 688 daemon cli+session tests pass / 0 fail.

## Out of scope (tracked)
- #461 — `SessionStore.list()/doPurge()` purge-writes `sessions.json` from CLI one-shots (pre-existing latent multi-writer race; the no-cache accessor leaves it exactly as today).
- `transcriptPath` on the binding + the `TranscriptBinder` itself are phase 3.