### PR TITLE
Phase 3: TranscriptBinder (state machine + #452 dir-watch), behind a flag in shadow mode

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -454,9 +454,11 @@ const liveSessionsRegistry = new SessionRegistryFile();
 // would split sessions across the old/new code paths, which share the
 // transcriptWatchers map. SIGUSR1 / config reload is a no-op for these; an
 // instant flip-back means a daemon restart (design §3.1 v4 #9). Default OFF.
-const binderShadow = remiConfig.features.transcript_binder_shadow;
 const binderEnabled = remiConfig.features.transcript_binder_enabled;
-void binderEnabled; // commit 4 wires the DRIVE path; commit 3 is shadow-only.
+// Drive mode and shadow mode are mutually exclusive: enabled wins. When the
+// binder DRIVES, running the shadow alongside it would be meaningless (and would
+// double-construct the binder), so the shadow is suppressed whenever drive is on.
+const binderShadow = remiConfig.features.transcript_binder_shadow && !binderEnabled;
 
 // Handle 'ls' subcommand: query live sessions from running daemon(s)
 if (cliSubcommand === 'ls') {
@@ -814,6 +816,12 @@ const _ptyManager = new PTYManager();
 const transcriptDiscovery = new TranscriptDiscovery();
 const transcriptWatchers: Map<UUID, TranscriptWatcher> = new Map();
 const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new Map();
+// Per-session drive-mode TranscriptBinder teardown hooks (#453 phase 3, commit
+// 5). The shared transcriptWatchers/transcriptFallbackTimers cleanup below stops
+// the binder's watcher + fallback timer, but NOT its #452 rotation dir-poll
+// interval (it lives inside the binder); close() reaches all three. Empty when
+// transcript_binder_enabled is off (no binder is ever constructed).
+const binderClosers: Map<UUID, () => void> = new Map();
 const sessionStore = new SessionStore();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
@@ -1093,7 +1101,7 @@ async function createNewSession(
   });
 
   if (hookServer) {
-    setupHookBridge(
+    const hookBridgeHandle = setupHookBridge(
       {
         sessionRegistry,
         bindingStore,
@@ -1103,10 +1111,15 @@ async function createNewSession(
         autoApproveService,
         currentPort: () => PORT,
         shadowBinder: binderShadow,
+        binderEnabled,
         transcriptDiscovery,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
+    // In drive mode the binder owns the fallback poll + #452 dir-watch (armed by
+    // its start() inside setupHookBridge); record its teardown so cleanup()
+    // reaches the rotation dir-poll interval the shared maps below cannot.
+    if (binderEnabled) binderClosers.set(sessionId, hookBridgeHandle.closeBinder);
   }
 
   const ptySession = createPtySessionForSession(
@@ -1159,19 +1172,24 @@ async function createNewSession(
     logError(`[live-sessions] No Claude child pid after PTY start for session ${sessionId}`);
   }
 
-  startTranscriptFallback(
-    {
-      sessionRegistry,
-      transcriptDiscovery,
-      transcriptWatchers,
-      transcriptFallbackTimers,
-    },
-    sessionId,
-    workingDirectory,
-    binding.claudeSessionId,
-    messageApi,
-    sendAndRecord,
-  );
+  // In drive mode the TranscriptBinder's start() (inside setupHookBridge) already
+  // armed BOTH the fallback poll and the #452 rotation dir-watch; arming it again
+  // here would double-arm the same fallback timer. Only the old path needs this.
+  if (!binderEnabled) {
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+      },
+      sessionId,
+      workingDirectory,
+      binding.claudeSessionId,
+      messageApi,
+      sendAndRecord,
+    );
+  }
 
   return ptySession;
 }
@@ -1478,6 +1496,13 @@ async function cleanup(): Promise<void> {
     mdnsPublisher = null;
   }
 
+  // Drive-mode binders own a rotation dir-poll interval the shared maps below do
+  // not reach; close() tears down its watcher + fallback timer + dir-poll. No-op
+  // map when transcript_binder_enabled is off.
+  for (const closeBinder of binderClosers.values()) {
+    closeBinder();
+  }
+  binderClosers.clear();
   for (const watcher of transcriptWatchers.values()) {
     watcher.stop();
   }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -449,6 +449,15 @@ if (
 // Instantiated early so subcommand handlers (ls, attach, kill) can use it.
 const liveSessionsRegistry = new SessionRegistryFile();
 
+// Experimental TranscriptBinder flags (#453 phase 3). Snapshotted into immutable
+// module-level consts at boot and NEVER re-read per session: a mid-process flip
+// would split sessions across the old/new code paths, which share the
+// transcriptWatchers map. SIGUSR1 / config reload is a no-op for these; an
+// instant flip-back means a daemon restart (design §3.1 v4 #9). Default OFF.
+const binderShadow = remiConfig.features.transcript_binder_shadow;
+const binderEnabled = remiConfig.features.transcript_binder_enabled;
+void binderEnabled; // commit 4 wires the DRIVE path; commit 3 is shadow-only.
+
 // Handle 'ls' subcommand: query live sessions from running daemon(s)
 if (cliSubcommand === 'ls') {
   const { runLsCommand } = await import('./cli/cmd-ls.ts');
@@ -1093,6 +1102,8 @@ async function createNewSession(
         transcriptFallbackTimers,
         autoApproveService,
         currentPort: () => PORT,
+        shadowBinder: binderShadow,
+        transcriptDiscovery,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -843,6 +843,11 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionClosed: (sessionId, reason) => {
       log(`Session closed: ${sessionId} (reason: ${reason})`);
+      // Tear down the drive-mode binder (rotation dir-poll + fallback timer) at
+      // session close, not just at process cleanup — else the poll interval leaks
+      // for the rest of the daemon's life across resumes (#463 phase 3 review).
+      binderClosers.get(sessionId)?.();
+      binderClosers.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -76,9 +76,24 @@ export interface HookBridgeDeps {
    */
   shadowBinder?: boolean;
   /**
-   * Required by the shadow `TranscriptBinder` constructor (its `start()` reads
-   * it). Shadow never calls `start()`, but the dep is part of the binder's
-   * construction contract. Optional so non-shadow callers/tests are unaffected.
+   * #453 phase 3, commit 5 (DRIVE MODE). When true, a single drive-mode
+   * `TranscriptBinder` per session OWNS the binding/watcher/rotation control
+   * plane: each hook listener routes to `binder.onHookEvent` /
+   * `binder.admits` / `binder.preemptOnSessionStart` / `binder.onSessionEnd`
+   * INSTEAD of the old `initFromHookEvent` / `onSessionInfo` / `filterBySession`
+   * bodies, and `binder.start()` arms the fallback poll + #452 dir-watch. The
+   * binder's decisions are already proven equivalent to the old path by the
+   * shadow differential harness (commit 3); this flag lets it DRIVE. Mutually
+   * exclusive with `shadowBinder` (enabled wins; the caller never sets both).
+   * Default OFF (undefined) — flag-off path is byte-identical to pre-commit.
+   * Requires `transcriptDiscovery` (the binder's `start()` reads it).
+   */
+  binderEnabled?: boolean;
+  /**
+   * Required by the `TranscriptBinder` constructor (its `start()` reads it).
+   * Shadow never calls `start()`, but drive mode does; the dep is part of the
+   * binder's construction contract. Optional so callers/tests that use neither
+   * binder mode are unaffected.
    */
   transcriptDiscovery?: TranscriptDiscovery;
 }
@@ -103,6 +118,15 @@ export interface HookBridgeHandle {
    *  alternate question sources (e.g. PTY parser) so subagent prompts are
    *  not surfaced to the user. */
   bridge: HookEventBridge;
+  /**
+   * Tear down the drive-mode `TranscriptBinder` for this session (its watcher,
+   * fallback timer, and the #452 rotation dir-poll). No-op when binderEnabled is
+   * off (no binder was constructed). The caller must invoke this on session
+   * teardown so the binder's rotation dir-poll interval — which the shared
+   * `transcriptWatchers` / `transcriptFallbackTimers` cleanup in cli.ts does NOT
+   * reach — never outlives the session.
+   */
+  closeBinder: () => void;
 }
 
 export function setupHookBridge(
@@ -118,6 +142,7 @@ export function setupHookBridge(
     autoApproveService,
     currentPort,
     shadowBinder,
+    binderEnabled,
     transcriptDiscovery,
   } = deps;
   const {
@@ -494,6 +519,12 @@ export function setupHookBridge(
       tracker.recordPendingHook(question);
     },
     onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
+      // DRIVE: the binder's onHookEvent (fired from the SessionStart listener)
+      // already subsumes this SessionInfo bind/rotation; skip the old body so we
+      // never double-bind or double-emit. The bridge still fires this callback
+      // (status/subagent tracking lives on handlers.onSessionStart), but the
+      // binding control plane is the binder's alone.
+      if (binderEnabled) return;
       // Guard: skip if sibling daemons share this directory AND the transcript's
       // port marker does not prove this SessionStart is ours (#451). When the
       // marker matches our port we proceed so our own rotation rebinds even
@@ -689,6 +720,71 @@ export function setupHookBridge(
     );
   }
 
+  // ---- Drive TranscriptBinder (#453 phase 3, commit 5) --------------------
+  //
+  // ONE drive-mode binder per session, constructed only when binderEnabled is on
+  // (mutually exclusive with shadowBinder; the caller never sets both). It OWNS
+  // the binding/watcher/rotation control plane: the hook listeners below route to
+  // its `onHookEvent` / `admits` / `preemptOnSessionStart` / `onSessionEnd`
+  // INSTEAD of the old `initFromHookEvent` / `onSessionInfo` / `filterBySession`
+  // bodies. Wired with the REAL effect deps (the same `sendAndRecord`,
+  // `bindingStore`, `messageApi` the old path used) and the REAL rotation side
+  // effect (clear the presence tracker's pending record + sessionRegistry
+  // questions, exactly the old restart branch's
+  // `tracker.clearPending(); sessionRegistry.clearQuestions(sessionId)`).
+  //
+  // `start()` arms BOTH the existing fallback poll (Case A: our pre-assigned file
+  // appears) AND the #452 re-arming dir-watch (Case B: a no-hooks rotation), so
+  // in drive mode the cli.ts-level `startTranscriptFallback` is NOT also called
+  // (the caller skips it to avoid double-arming). The pre-assigned claudeSessionId
+  // is the binding cli.ts wrote to the store before spawn (#427); read it here.
+  const driveBinder: TranscriptBinder | null =
+    binderEnabled && transcriptDiscovery
+      ? new TranscriptBinder(
+          {
+            sessionRegistry,
+            bindingStore,
+            liveSessionsRegistry,
+            transcriptWatchers,
+            transcriptFallbackTimers,
+            transcriptDiscovery,
+            messageApi,
+            sendAndRecord: rawSendAndRecord,
+            currentPort,
+            onRotation: () => {
+              // The old restart branch's injected side effects: drop any hook
+              // record stashed before the rotation so the new session's first
+              // PTY prompt cannot merge stale option labels, and drop the
+              // pending-question collection so stale answers are refused.
+              tracker.clearPending();
+              sessionRegistry.clearQuestions(sessionId);
+            },
+          },
+          { sessionId, workingDirectory },
+          'drive',
+        )
+      : null;
+
+  if (binderEnabled && !transcriptDiscovery) {
+    logError(
+      `[Binder] binderEnabled=true but no transcriptDiscovery dep supplied for ${sessionId.slice(0, 8)}; drive mode disabled`,
+    );
+  }
+
+  if (driveBinder) {
+    // Arm the fallback poll + #452 dir-watch on the pre-assigned id (the binding
+    // cli.ts wrote to the store before Bun.spawn). On a fresh store read this is
+    // the deterministic claude id Claude will write under.
+    const preAssignedClaudeId = bindingStore.get(sessionId)?.claudeSessionId ?? null;
+    if (preAssignedClaudeId) {
+      driveBinder.start(preAssignedClaudeId);
+    } else {
+      logError(
+        `[Binder] No pre-assigned claudeSessionId for ${sessionId.slice(0, 8)}; fallback poll + dir-watch not armed`,
+      );
+    }
+  }
+
   /**
    * Capture the old path's observable control-plane outcome from LIVE state,
    * read right after the old-path listener body ran. `boundId` is a disk-fresh
@@ -776,6 +872,16 @@ export function setupHookBridge(
 
   hookServer.on('SessionStart', (input) => {
     shadowEnterEvent(); // reset rotation tap + snapshot store (shadow-only)
+    if (driveBinder) {
+      // DRIVE: the binder owns the pre-empt + bind. Mirror the old listener
+      // order — pre-empt (flip its own mainSessionEnded) BEFORE onHookEvent.
+      // The old closure pre-empt + initFromHookEvent below are skipped; the
+      // bridge's onSessionInfo body is also skipped (binder subsumes it).
+      driveBinder.preemptOnSessionStart(input);
+      driveBinder.onHookEvent(input);
+      handlers.onSessionStart?.(input);
+      return;
+    }
     // Pre-empt the classifier into 'restart' on any session_id rotation while
     // our PTY is alive, regardless of `source` (Claude Code rotates session_id
     // through flows that omit source or carry undocumented values; the narrow
@@ -813,34 +919,39 @@ export function setupHookBridge(
 
   hookServer.on('PreToolUse', (input) => {
     shadowEnterEvent();
-    initFromHookEvent(input);
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
     shadowDecide('PreToolUse', input);
-    if (!filterBySession(input)) return;
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PreToolUse');
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
     shadowEnterEvent();
-    initFromHookEvent(input);
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
     shadowDecide('PostToolUse', input);
-    if (!filterBySession(input)) return;
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PostToolUse');
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
     shadowEnterEvent();
-    initFromHookEvent(input);
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
     shadowDecide('Notification', input);
-    if (!filterBySession(input)) return;
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // SessionEnd already cleared status to 'idle'; a late
     // Notification(permission_prompt) for the dying session would
     // re-populate tracker.pending and a final PTY echo could fire a
     // spurious push the user cannot answer. Gate at the listener
     // boundary; restart resets mainSessionEnded so legitimate
-    // post-restart notifications still pass.
-    if (mainSessionEnded) {
+    // post-restart notifications still pass. In drive mode the binder owns
+    // mainSessionEnded (and resets it on restart via rotate()), so read it
+    // there as the single source of truth; the closure flag is the old path's.
+    if (driveBinder ? driveBinder.isMainEnded() : mainSessionEnded) {
       log(`[Hooks] Dropped post-SessionEnd Notification: type=${input.notification_type}`);
       return;
     }
@@ -853,9 +964,10 @@ export function setupHookBridge(
   });
   hookServer.on('PermissionRequest', (input) => {
     shadowEnterEvent();
-    initFromHookEvent(input);
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
     shadowDecide('PermissionRequest', input);
-    if (!filterBySession(input)) return;
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
     // owns the PTY injection, the subagent PTY-presence gate, the default-deny
     // safety net, and the escalate fallback; session filtering above stays here in
@@ -865,14 +977,26 @@ export function setupHookBridge(
   });
   hookServer.on('Stop', (input) => {
     shadowEnterEvent();
-    initFromHookEvent(input);
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
     shadowDecide('Stop', input);
-    if (!filterBySession(input)) return;
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     autoApproveGate.cancelStale('Stop');
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
     shadowEnterEvent();
+    if (driveBinder) {
+      // DRIVE: the binder owns mainSessionEnded on id-match (and resets it on
+      // restart via rotate()). The post-SessionEnd Notification drop reads
+      // driveBinder.isMainEnded() directly, so there is no closure flag to keep
+      // in sync here — the binder is the single source of truth.
+      driveBinder.onSessionEnd(input);
+      if (!driveBinder.admits(input)) return;
+      autoApproveGate.cancelStale('SessionEnd');
+      handlers.onSessionEnd?.(input);
+      return;
+    }
     // Only mark our main as ended when the session_id matches what we locked.
     // Foreign SessionEnds (subagents, siblings) must not unlock our tracking.
     if (input.session_id && claudeSessionId && input.session_id === claudeSessionId) {
@@ -889,5 +1013,8 @@ export function setupHookBridge(
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);
 
-  return { bridge: hookBridge };
+  return {
+    bridge: hookBridge,
+    closeBinder: () => driveBinder?.close(),
+  };
 }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -50,8 +50,10 @@ import type {
   SessionRegistry,
   SessionRegistryFile,
 } from '../../session/index.ts';
-import { readTranscriptOwnerPort } from '../../transcript/index.ts';
+import { TranscriptBinder, readTranscriptOwnerPort } from '../../transcript/index.ts';
+import type { BinderDecision, BinderHookEvent } from '../../transcript/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
+import type { TranscriptDiscovery } from '../../transcript/transcript-discovery.ts';
 import { log, logError } from '../logger.ts';
 import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
@@ -64,6 +66,21 @@ export interface HookBridgeDeps {
   autoApproveService: AutoApproveService | null;
   /** PORT is reassigned during daemon-mode port probing; read lazily. */
   currentPort: () => number;
+  /**
+   * #453 phase 3, commit 3 (SHADOW MODE). When true, a compute-only
+   * `TranscriptBinder` runs alongside the old initFromHookEvent/onSessionInfo
+   * path and logs control-plane disagreements. It is constructed with no-op
+   * effect deps (no send, no store write, no watcher start, no rotation
+   * callback) so it is PROVABLY side-effect-free; the old path stays the sole
+   * driver. Default OFF (undefined) — zero behavior change when unset.
+   */
+  shadowBinder?: boolean;
+  /**
+   * Required by the shadow `TranscriptBinder` constructor (its `start()` reads
+   * it). Shadow never calls `start()`, but the dep is part of the binder's
+   * construction contract. Optional so non-shadow callers/tests are unaffected.
+   */
+  transcriptDiscovery?: TranscriptDiscovery;
 }
 
 export interface HookBridgeArgs {
@@ -100,8 +117,31 @@ export function setupHookBridge(
     transcriptFallbackTimers,
     autoApproveService,
     currentPort,
+    shadowBinder,
+    transcriptDiscovery,
   } = deps;
-  const { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker } = args;
+  const {
+    hookServer,
+    sessionId,
+    workingDirectory,
+    messageApi,
+    sendAndRecord: rawSendAndRecord,
+    tracker,
+  } = args;
+
+  // ---- Shadow-mode plumbing (#453 phase 3, commit 3) ----------------------
+  // When shadowBinder is OFF (the default), `sendAndRecord` and the binding
+  // writer below are the untouched originals: ZERO behavior change. When ON,
+  // sendAndRecord is wrapped in a forwarding tap that records (per old-path
+  // event) whether a session_rotated crossed the wire, then forwards EVERY
+  // message untouched. The tap never alters or drops a message.
+  let oldPathRotationEmitted = false;
+  const sendAndRecord = shadowBinder
+    ? (message: ProtocolMessage): void => {
+        if (message.type === 'session_rotated') oldPathRotationEmitted = true;
+        rawSendAndRecord(message);
+      }
+    : rawSendAndRecord;
 
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
@@ -582,7 +622,160 @@ export function setupHookBridge(
   const isSubagentEvent = (input: { agent_id?: string }): boolean =>
     typeof input.agent_id === 'string' && input.agent_id.length > 0;
 
+  // ---- Shadow TranscriptBinder (#453 phase 3, commit 3) -------------------
+  //
+  // ONE compute-only binder per session, constructed only when shadowBinder is
+  // on. It is provably side-effect-free:
+  //   - `sendAndRecord: () => {}`  -> cannot emit (no session_rotated on the wire).
+  //   - `bindingStore` wrapped read-only: `update()` is a no-op; `get(ourSession)`
+  //     returns the PER-EVENT snapshot (the store as it stood before the old path
+  //     ran) so the old path's same-event write cannot leak into the shadow's
+  //     adoptLockFromStore and race the classifier; foreign ids delegate through.
+  //   - `messageApi` no-op: `reset()` does nothing (the binder calls it on teardown).
+  //   - `onRotation: () => {}` -> no presence-tracker / question side effects.
+  //   - `start()` is a no-op in 'shadow' mode (no fs.watch, no fallback timer),
+  //     and we never call it anyway.
+  //
+  // After each old-path listener body runs, the same input is fed to the shadow
+  // binder mirroring the old listener order (preemptOnSessionStart + decide for
+  // SessionStart; decide for the events that call initFromHookEvent; onSessionEnd
+  // for SessionEnd), then we compare the binder's decision against the old path's
+  // observable outcome captured live from state.
+
+  // The real store's binding for OUR session as it stood at the START of the
+  // current event (captured before the old path runs). The shadow reads THIS,
+  // not the live store, so the old path's same-event write does not leak into
+  // the shadow's adoptLockFromStore and race the classifier into 'match' when
+  // the old path saw 'restart' (the #430/#433 snapshot invariant). For other
+  // sessions the wrapper delegates straight through (the binder only ever reads
+  // its own sessionId via get(), so this is exact).
+  let oldPathStoreSnapshot: ReturnType<SessionBindingStore['get']> = null;
+
+  const shadow: TranscriptBinder | null =
+    shadowBinder && transcriptDiscovery
+      ? new TranscriptBinder(
+          {
+            sessionRegistry,
+            // Read-only wrapper: get() delegates to the real store but, for our
+            // own session, returns the per-event entry snapshot taken before the
+            // old path mutated it (so the shadow adopts the same value the old
+            // path's adoptLockFromStore saw, not the old path's just-written id).
+            // update() is a no-op — the shadow must never write the binding.
+            bindingStore: {
+              get: (id: UUID) => (id === sessionId ? oldPathStoreSnapshot : bindingStore.get(id)),
+              getByClaudeSessionId: (id: string) => bindingStore.getByClaudeSessionId(id),
+              update: () => {},
+              preAssign: () => {},
+            } as unknown as SessionBindingStore,
+            liveSessionsRegistry,
+            transcriptWatchers,
+            transcriptFallbackTimers,
+            transcriptDiscovery,
+            // No-op MessageAPI: only reset() is reachable from the binder, and it
+            // must do nothing in shadow.
+            messageApi: { reset: () => {} } as unknown as MessageAPI,
+            sendAndRecord: () => {},
+            currentPort,
+            onRotation: () => {},
+          },
+          { sessionId, workingDirectory },
+          'shadow',
+        )
+      : null;
+
+  if (shadowBinder && !transcriptDiscovery) {
+    logError(
+      `[ShadowBinder] shadowBinder=true but no transcriptDiscovery dep supplied for ${sessionId.slice(0, 8)}; shadow comparison disabled`,
+    );
+  }
+
+  /**
+   * Capture the old path's observable control-plane outcome from LIVE state,
+   * read right after the old-path listener body ran. `boundId` is a disk-fresh
+   * read of the binding the old path may have written; `watcherPath` is the
+   * path of the watcher the old path may have (re)started; `rotationEmitted` is
+   * the per-event flag set by the sendAndRecord tap above.
+   */
+  const observeOldState = (): {
+    boundId: string | null;
+    watcherPath: string | null;
+    rotationEmitted: boolean;
+  } => ({
+    boundId: bindingStore.get(sessionId)?.claudeSessionId ?? null,
+    watcherPath: transcriptWatchers.get(sessionId)?.filePath ?? null,
+    rotationEmitted: oldPathRotationEmitted,
+  });
+
+  /**
+   * Emit a single structured DISAGREE line ONLY when the binder's decision and
+   * the old path's observed outcome diverge on a LOAD-BEARING control-plane
+   * field: the DURABLE store binding after the event, or whether a rotation was
+   * emitted. watcherPath is compared path-normalized but is advisory (the binder
+   * reports intent, the old path reports the live watcher). Silent on agreement.
+   *
+   * The compared "bound id" is the DURABLE store binding, not the binder's
+   * in-memory lock. The two diverge intentionally on a path-less restart: the
+   * old path NULLs its in-closure lock but does NOT write the store (no path to
+   * rebind on), so the store keeps the prior id; the binder likewise drops its
+   * in-memory `currentBoundId` to null WITHOUT writing the store. So the binder's
+   * store-after = `boundIdAfter` when it (re)bound this event, else the prior
+   * snapshot (it wrote nothing). That reconstruction matches the old path's
+   * post-event store exactly — which is the #430/#433 invariant we are pinning.
+   */
+  const compareAndLog = (
+    eventName: string,
+    input: BinderHookEvent,
+    decision: BinderDecision,
+    old: { boundId: string | null; watcherPath: string | null; rotationEmitted: boolean },
+  ): void => {
+    const diffs: string[] = [];
+    // The binder writes the store only when it (re)binds (boundIdAfter non-null);
+    // otherwise it leaves the durable binding untouched at its pre-event value.
+    const binderStoreAfter = decision.boundIdAfter ?? oldPathStoreSnapshot?.claudeSessionId ?? null;
+    if (binderStoreAfter !== old.boundId) {
+      diffs.push(`boundId binder=${binderStoreAfter ?? 'null'} old=${old.boundId ?? 'null'}`);
+    }
+    if (decision.wouldEmitRotation !== old.rotationEmitted) {
+      diffs.push(`rotation binder=${decision.wouldEmitRotation} old=${old.rotationEmitted}`);
+    }
+    const binderWatcher = decision.watcherPath ? path.resolve(decision.watcherPath) : null;
+    const oldWatcher = old.watcherPath ? path.resolve(old.watcherPath) : null;
+    if (decision.wouldStartWatcher && binderWatcher !== oldWatcher) {
+      diffs.push(`watcherPath binder=${binderWatcher ?? 'null'} old=${oldWatcher ?? 'null'}`);
+    }
+    if (diffs.length > 0) {
+      logError(
+        `[ShadowBinder] DISAGREE ${eventName}: ${diffs.join('; ')} (class=${decision.classification} incoming=${input.session_id?.slice(0, 8) ?? 'none'})`,
+      );
+    }
+  };
+
+  /**
+   * Run at the TOP of every listener (before the old path executes). Resets the
+   * per-event rotation tap and snapshots the real store's current binding for
+   * our session so the shadow's read reflects the pre-event truth. No-op when
+   * shadow is off.
+   */
+  const shadowEnterEvent = (): void => {
+    if (!shadow) return;
+    oldPathRotationEmitted = false;
+    oldPathStoreSnapshot = bindingStore.get(sessionId);
+  };
+
+  /**
+   * Feed an event that went through the `initFromHookEvent` old path to the
+   * shadow binder via `decide()`, then compare. `shadowEnterEvent` must have run
+   * at handler entry; here we just read the captured outcome. Called at the END
+   * of each old-path listener body.
+   */
+  const shadowDecide = (eventName: string, input: BinderHookEvent): void => {
+    if (!shadow) return;
+    const decision = shadow.decide(input);
+    compareAndLog(eventName, input, decision, observeOldState());
+  };
+
   hookServer.on('SessionStart', (input) => {
+    shadowEnterEvent(); // reset rotation tap + snapshot store (shadow-only)
     // Pre-empt the classifier into 'restart' on any session_id rotation while
     // our PTY is alive, regardless of `source` (Claude Code rotates session_id
     // through flows that omit source or carry undocumented values; the narrow
@@ -610,24 +803,36 @@ export function setupHookBridge(
     }
     initFromHookEvent(input);
     handlers.onSessionStart?.(input);
+    // Shadow: mirror the old listener order — pre-empt BEFORE decide so the
+    // binder flips its own mainSessionEnded exactly like the closure above did.
+    if (shadow) {
+      shadow.preemptOnSessionStart(input);
+      shadowDecide('SessionStart', input);
+    }
   });
 
   hookServer.on('PreToolUse', (input) => {
+    shadowEnterEvent();
     initFromHookEvent(input);
+    shadowDecide('PreToolUse', input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PreToolUse');
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
+    shadowEnterEvent();
     initFromHookEvent(input);
+    shadowDecide('PostToolUse', input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PostToolUse');
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
+    shadowEnterEvent();
     initFromHookEvent(input);
+    shadowDecide('Notification', input);
     if (!filterBySession(input)) return;
     // SessionEnd already cleared status to 'idle'; a late
     // Notification(permission_prompt) for the dying session would
@@ -647,7 +852,9 @@ export function setupHookBridge(
     handlers.onNotification?.(input);
   });
   hookServer.on('PermissionRequest', (input) => {
+    shadowEnterEvent();
     initFromHookEvent(input);
+    shadowDecide('PermissionRequest', input);
     if (!filterBySession(input)) return;
     // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
     // owns the PTY injection, the subagent PTY-presence gate, the default-deny
@@ -657,17 +864,24 @@ export function setupHookBridge(
     autoApproveGate.handlePermissionRequest(input);
   });
   hookServer.on('Stop', (input) => {
+    shadowEnterEvent();
     initFromHookEvent(input);
+    shadowDecide('Stop', input);
     if (!filterBySession(input)) return;
     autoApproveGate.cancelStale('Stop');
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
+    shadowEnterEvent();
     // Only mark our main as ended when the session_id matches what we locked.
     // Foreign SessionEnds (subagents, siblings) must not unlock our tracking.
     if (input.session_id && claudeSessionId && input.session_id === claudeSessionId) {
       mainSessionEnded = true;
     }
+    // Shadow: SessionEnd does NOT run initFromHookEvent/decide; it only flips
+    // mainSessionEnded on id-match. Mirror with onSessionEnd (no decide, no
+    // compare — there is no binding/rotation outcome to diff on this event).
+    shadow?.onSessionEnd(input);
     if (!filterBySession(input)) return;
     autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -49,6 +49,21 @@ export interface TelegramConfig {
   readonly authorized_user_ids: readonly number[];
 }
 
+/**
+ * Experimental feature flags (epic #453). Default OFF. Snapshotted into a const at
+ * daemon boot and treated as immutable for the process lifetime — never re-read per
+ * session (a mid-process flip would split sessions across the old/new code paths,
+ * which share the transcriptWatchers map).
+ */
+export interface FeaturesConfig {
+  /** Phase 3: run the TranscriptBinder in compute-only shadow mode alongside the old
+   *  path and log decision disagreements. No side effects; observation only. */
+  readonly transcript_binder_shadow: boolean;
+  /** Phase 3: the TranscriptBinder DRIVES the session-binding/watcher/rotation; the
+   *  old initFromHookEvent/onSessionInfo path is skipped. */
+  readonly transcript_binder_enabled: boolean;
+}
+
 /** Complete Remi configuration */
 export interface RemiConfig {
   readonly daemon: DaemonConfig;
@@ -57,6 +72,7 @@ export interface RemiConfig {
   readonly display: DisplayConfig;
   readonly telegram: TelegramConfig;
   readonly auto_approve: AutoApproveConfig;
+  readonly features: FeaturesConfig;
 }
 
 /** Built-in defaults used when no config file or CLI flags are provided */
@@ -98,6 +114,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     multichoice: 'skip',
     multichoice_model: '',
   },
+  features: {
+    transcript_binder_shadow: false,
+    transcript_binder_enabled: false,
+  },
 };
 
 /**
@@ -129,6 +149,10 @@ function deepMerge(base: RemiConfig, partial: Record<string, unknown>): RemiConf
     auto_approve: mergeSection(
       base.auto_approve,
       partial['auto_approve'] as Record<string, unknown> | undefined,
+    ),
+    features: mergeSection(
+      base.features,
+      partial['features'] as Record<string, unknown> | undefined,
     ),
   };
 }
@@ -346,6 +370,19 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       env['REMI_AUTO_APPROVE_MULTICHOICE_MODEL'];
   }
 
+  // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
+  const features = { ...config.features };
+  if (env['REMI_TRANSCRIPT_BINDER_SHADOW'] === 'true') {
+    (features as { transcript_binder_shadow: boolean }).transcript_binder_shadow = true;
+  } else if (env['REMI_TRANSCRIPT_BINDER_SHADOW'] === 'false') {
+    (features as { transcript_binder_shadow: boolean }).transcript_binder_shadow = false;
+  }
+  if (env['REMI_TRANSCRIPT_BINDER_ENABLED'] === 'true') {
+    (features as { transcript_binder_enabled: boolean }).transcript_binder_enabled = true;
+  } else if (env['REMI_TRANSCRIPT_BINDER_ENABLED'] === 'false') {
+    (features as { transcript_binder_enabled: boolean }).transcript_binder_enabled = false;
+  }
+
   return {
     ...config,
     daemon,
@@ -353,6 +390,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     display,
     telegram,
     auto_approve,
+    features,
   };
 }
 
@@ -490,6 +528,11 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  instructions = ${instrDisplay}`);
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
+  lines.push('');
+  lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
+  lines.push('[features]');
+  lines.push(`  transcript_binder_shadow = ${config.features.transcript_binder_shadow}`);
+  lines.push(`  transcript_binder_enabled = ${config.features.transcript_binder_enabled}`);
 
   return lines.join('\n');
 }

--- a/packages/daemon/src/transcript/index.ts
+++ b/packages/daemon/src/transcript/index.ts
@@ -9,6 +9,14 @@ export { TranscriptWatcher } from './transcript-watcher.ts';
 export { TranscriptDiscovery } from './transcript-discovery.ts';
 export { TranscriptMessageBridge } from './transcript-message-bridge.ts';
 export { readTranscriptOwnerPort } from './transcript-owner.ts';
+export { TranscriptBinder } from './transcript-binder.ts';
+export type {
+  BinderDecision,
+  BinderHookEvent,
+  BinderMode,
+  TranscriptBinderArgs,
+  TranscriptBinderDeps,
+} from './transcript-binder.ts';
 export type { TranscriptDiscoveryConfig } from './transcript-discovery.ts';
 export type {
   TranscriptMessageBridgeConfig,

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -802,6 +802,17 @@ export class TranscriptBinder {
    * can drive a deterministic tick without waiting on the interval.
    */
   rotationPollTick(): void {
+    // A throw escaping the setInterval callback permanently kills the timer with
+    // no log or recovery. The inner fs reads have their own catches; this is the
+    // backstop for an unexpected throw (sessionRegistry/currentPort/etc.).
+    try {
+      this.rotationPollTickInner();
+    } catch (err) {
+      logError(`[Binder] rotation poll tick failed unexpectedly: ${errorToString(err)}`);
+    }
+  }
+
+  private rotationPollTickInner(): void {
     if (this.mode === 'shadow') return;
     // Session gone -> the lifecycle owner will close() us; do nothing meanwhile.
     if (!this.deps.sessionRegistry.hasSession(this.sessionId)) return;

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -1,0 +1,676 @@
+/**
+ * TranscriptBinder — the single owner of one Remi session's binding state,
+ * transcript watcher, and Claude-restart rotation (epic #453, phase 3).
+ *
+ * This is a BEHAVIOR-PRESERVING extraction of the logic previously scattered
+ * across `cli/session-phases/hook-bridge-setup.ts` (`initFromHookEvent`,
+ * `onSessionInfo`, `teardownWatcher`, `ensureWatcher`, the SessionStart
+ * pre-empt, the SessionEnd id-match, `hasSiblingInDir`, `ownsTranscript`,
+ * `adoptLockFromStore`) plus the fallback poll arming previously done in
+ * `cli.ts`. The state machine reproduces the hook-bridge logic EXACTLY; the
+ * phase-0 characterization suite (`tests/cli/session-phases/hook-bridge-setup.test.ts`)
+ * is the contract this class must satisfy.
+ *
+ * Two entry points, with a strict ownership split:
+ *
+ *   - `decide(event)` is PURE — it runs the snapshot -> adopt -> rotation ->
+ *     classify pipeline and returns a `BinderDecision` describing what the
+ *     DRIVE path WOULD do, WITHOUT any external effect (no store write, no
+ *     watcher start, no send, no teardown). It MAY advance the binder's OWN
+ *     state fields so successive `decide()` calls track rotations the same
+ *     way the live path does. This is the shadow-mode tap (design §3.1 v4 #8).
+ *
+ *   - `onHookEvent(event)` is the DRIVE path = decide-equivalent ordering plus
+ *     the side effects, and the SINGLE caller of `rotate()`. Ordering mirrors
+ *     `initFromHookEvent` to the line: snapshot -> adopt -> classify ->
+ *     foreign/defer return -> restart funnels through `rotate()` -> the
+ *     `if (currentBoundId) { ensureWatching; return }` tripwire (BEFORE the
+ *     first-adopt emit, so the store-raced case stays zero-emit, #430) ->
+ *     first-adopt: bindingStore.update + ensureWatching + (isRotation &&
+ *     !announced) emitRotated.
+ *
+ * All rotation emits go through `emitRotated`, which is idempotent on
+ * `lastAnnouncedRotationId` (design §3.1 v4 #2) so an A->B->A re-resume emits
+ * A->B, B->A, and never a duplicate A->B.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createSessionRotated, errorToString } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { MessageAPI } from '../api/message-api.ts';
+import { log, logError } from '../cli/logger.ts';
+import { startTranscriptFallback } from '../cli/transcript-fallback.ts';
+import { startTranscriptWatcher } from '../cli/transcript-watcher-setup.ts';
+import { classifySessionEvent } from '../hooks/session-lock-classifier.ts';
+import type { SessionEventClass } from '../hooks/session-lock-classifier.ts';
+import { claudeChildLooksAlive } from '../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../session/index.ts';
+import type { TranscriptDiscovery } from './transcript-discovery.ts';
+import { readTranscriptOwnerPort } from './transcript-owner.ts';
+import type { TranscriptWatcher } from './transcript-watcher.ts';
+
+/** A hook event as the binder consumes it (the subset it reads). */
+export interface BinderHookEvent {
+  readonly session_id?: string;
+  readonly transcript_path?: string;
+  readonly hook_event_name?: string;
+  /** Subagent/team events carry agent_id; used by the SessionStart pre-empt. */
+  readonly agent_id?: string;
+}
+
+/**
+ * The pure result of `decide(event)`. Describes what the DRIVE path WOULD do
+ * for this event, with no external effect performed.
+ */
+export interface BinderDecision {
+  /** Three-way classification + the sibling-defer gate as a 4th outcome. */
+  readonly classification: 'match' | 'foreign' | 'restart' | 'defer';
+  /** Whether the drive path would emit a session_rotated for this event. */
+  readonly wouldEmitRotation: boolean;
+  /** Whether the drive path would (re)start a transcript watcher. */
+  readonly wouldStartWatcher: boolean;
+  /** The path the watcher would be (re)started on, when known. */
+  readonly watcherPath: string | null;
+  /** The bound claude session id AFTER this event is processed. */
+  readonly boundIdAfter: string | null;
+}
+
+/** Construction mode (immutable for the binder lifetime; design §3.1 v4 #9). */
+export type BinderMode = 'shadow' | 'drive';
+
+export interface TranscriptBinderDeps {
+  sessionRegistry: SessionRegistry;
+  bindingStore: SessionBindingStore;
+  liveSessionsRegistry: SessionRegistryFile;
+  transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  transcriptDiscovery: TranscriptDiscovery;
+  messageApi: MessageAPI;
+  sendAndRecord: (message: ProtocolMessage) => void;
+  /** PORT is reassigned during daemon-mode port probing; read lazily. */
+  currentPort: () => number;
+  /**
+   * Injected rotation side effects that live OUTSIDE the binder's concern
+   * (clear the presence tracker's pending record + sessionRegistry questions).
+   * Called from `rotate()` only, matching the old restart branch's
+   * `tracker.clearPending(); sessionRegistry.clearQuestions()`.
+   */
+  onRotation: () => void;
+}
+
+export interface TranscriptBinderArgs {
+  sessionId: UUID;
+  workingDirectory: string;
+}
+
+export class TranscriptBinder {
+  // --- Owned binding state (the OWN pre-adopt copy is the snapshot source) ---
+  /** Our currently-bound Claude session id, or null before first adopt. */
+  private currentBoundId: string | null = null;
+  /** Set when main explicitly ended (SessionEnd id-match) or the SessionStart
+   *  pre-empt fired; makes the classifier treat the next id as 'restart'. */
+  private mainSessionEnded = false;
+  /** Idempotency scalar: the last id we announced a rotation for. */
+  private lastAnnouncedRotationId: string | null = null;
+  /** Last transcript path we (re)started a watcher on; for snapshot(). */
+  private lastTranscriptPath: string | null = null;
+
+  private readonly deps: TranscriptBinderDeps;
+  private readonly sessionId: UUID;
+  private readonly workingDirectory: string;
+  private readonly mode: BinderMode;
+
+  constructor(deps: TranscriptBinderDeps, args: TranscriptBinderArgs, mode: BinderMode) {
+    this.deps = deps;
+    this.sessionId = args.sessionId;
+    this.workingDirectory = args.workingDirectory;
+    this.mode = mode;
+  }
+
+  // =========================================================================
+  // PURE decision path (shadow tap). NO external effects.
+  // =========================================================================
+
+  /**
+   * Compute the decision for an event WITHOUT performing any side effect.
+   * Mirrors `onHookEvent` ordering but performs nothing external: no
+   * bindingStore.update, no watcher start, no sendAndRecord, no teardown.
+   * It MAY advance the binder's own state fields (currentBoundId,
+   * mainSessionEnded, lastAnnouncedRotationId) so successive decide() calls
+   * track rotations identically to the drive path.
+   *
+   * MODE CONTRACT: a `'shadow'` instance receives ONLY `decide()`; a `'drive'`
+   * instance receives ONLY `onHookEvent()`. They mutate the same fields, so
+   * mixing them on one instance would let one advance `lastAnnouncedRotationId`
+   * and silently suppress the other's emit. The shadow harness (commit 3)
+   * constructs a dedicated shadow instance for this reason. (Tests may call both
+   * on one drive instance purely to inspect intermediate state.)
+   */
+  decide(event: BinderHookEvent): BinderDecision {
+    const inert: BinderDecision = {
+      classification: 'defer',
+      wouldEmitRotation: false,
+      wouldStartWatcher: false,
+      watcherPath: null,
+      boundIdAfter: this.currentBoundId,
+    };
+    if (!event.session_id) return inert;
+
+    // 1) Snapshot BEFORE adopt (preserves the #430/#433 invariant).
+    const previous = this.currentBoundId;
+
+    // 2) Adopt from the disk-backed binding store (a read, never a write).
+    this.adoptLockFromStore();
+
+    // 3) Rotation is decided against the pre-adopt snapshot, never the store.
+    const isRotation = previous !== null && previous !== event.session_id;
+
+    // 4) Classify.
+    const classification = this.classify(event.session_id);
+
+    if (classification === 'foreign') {
+      return {
+        classification: 'foreign',
+        wouldEmitRotation: false,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Restart PROLOGUE (pure mirror of rotate()): announce (idempotent +
+    // path-guarded), NULL the lock, reset mainSessionEnded — then FALL THROUGH to
+    // the tripwire + first-adopt gate below, so a restart with a live sibling and
+    // an unproven transcript defers (#451) instead of binding, and a path-less
+    // restart leaves the lock null (no rebind), exactly as the old code does.
+    let rotationAnnounced = false;
+    if (classification === 'restart') {
+      if (
+        isRotation &&
+        !!event.transcript_path &&
+        event.session_id !== this.lastAnnouncedRotationId
+      ) {
+        this.lastAnnouncedRotationId = event.session_id;
+        rotationAnnounced = true;
+      }
+      this.currentBoundId = null;
+      this.mainSessionEnded = false;
+    }
+
+    // Tripwire: a lock is already held (match, or store-raced) -> ensureWatching
+    // path, no emit, no store write. The store-raced zero-emit case (#430).
+    if (this.currentBoundId) {
+      return {
+        classification,
+        wouldEmitRotation: false,
+        // ensureWatching only starts when none running AND a path is present;
+        // for a pure decision we report intent on path presence.
+        wouldStartWatcher: !!event.transcript_path,
+        watcherPath: event.transcript_path ?? null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // First adopt. No path -> nothing to bind (a path-less restart lands here
+    // with the lock null; the prologue may already have announced).
+    if (!event.transcript_path) {
+      return {
+        classification,
+        wouldEmitRotation: rotationAnnounced,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Sibling-defer gate (separate from classify): a co-located sibling and the
+    // marker does not prove ownership -> defer (no bind, no watcher). A restart
+    // that already announced still reports the emit.
+    if (this.hasSiblingInDir() && !this.ownsTranscript(event.transcript_path)) {
+      return {
+        classification: 'defer',
+        wouldEmitRotation: rotationAnnounced,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Adopt: bind the new id, maybe announce the rotation (unless the prologue
+    // already did).
+    const wouldEmit =
+      isRotation && !rotationAnnounced && event.session_id !== this.lastAnnouncedRotationId;
+    if (wouldEmit) {
+      this.lastAnnouncedRotationId = event.session_id;
+    }
+    this.currentBoundId = event.session_id;
+    this.lastTranscriptPath = event.transcript_path;
+    return {
+      classification,
+      wouldEmitRotation: wouldEmit || rotationAnnounced,
+      wouldStartWatcher: true,
+      watcherPath: event.transcript_path,
+      boundIdAfter: this.currentBoundId,
+    };
+  }
+
+  // =========================================================================
+  // DRIVE path. decide + side effects. SINGLE caller of rotate().
+  // =========================================================================
+
+  /**
+   * The drive entry point. Reproduces `initFromHookEvent` exactly: snapshot,
+   * adopt, classify, foreign/defer return, restart via `rotate()`, the
+   * tripwire BEFORE the first-adopt emit, then first-adopt
+   * (bindingStore.update + ensureWatching + rotation announce).
+   */
+  onHookEvent(event: BinderHookEvent): void {
+    if (!event.session_id) return;
+
+    // 1) Snapshot BEFORE adopt.
+    const previous = this.currentBoundId;
+
+    // 2) Adopt from the store.
+    this.adoptLockFromStore();
+
+    // 3) Rotation against the pre-adopt snapshot.
+    const isRotation = previous !== null && previous !== event.session_id;
+
+    // 4) Classify.
+    const classification = this.classify(event.session_id);
+
+    if (classification === 'foreign') {
+      log(
+        `[Binder] Dropped foreign ${event.hook_event_name ?? 'event'}: lock=${this.currentBoundId?.slice(0, 8)} incoming=${event.session_id.slice(0, 8)}`,
+      );
+      return;
+    }
+
+    let rotationAnnounced = false;
+    if (classification === 'restart') {
+      log(
+        `[Binder] Claude restart detected (ended=${this.mainSessionEnded}): ${this.currentBoundId} -> ${event.session_id}`,
+      );
+      // The single rotation funnel. Performs teardown -> onRotation ->
+      // emitRotated (path-guarded) -> bindingStore.update -> currentBoundId=new
+      // -> mainSessionEnded=false. emitRotated only fires when a path is
+      // present and isRotation holds.
+      rotationAnnounced = this.rotate(
+        event.session_id,
+        event.transcript_path,
+        previous,
+        isRotation,
+      );
+    }
+
+    // classification === 'match' (or restart fell through with the new lock).
+    // Tripwire: lock already held -> ensure a watcher, return BEFORE the
+    // first-adopt emit so the store-raced case stays zero-emit (#430).
+    if (this.currentBoundId) {
+      this.ensureWatching(event.transcript_path, 'match');
+      return;
+    }
+
+    // First adopt path.
+    if (!event.transcript_path) return;
+
+    if (this.hasSiblingInDir() && !this.ownsTranscript(event.transcript_path)) {
+      // Defer to the fallback poll: cannot prove this event is ours.
+      return;
+    }
+
+    try {
+      this.currentBoundId = event.session_id;
+      this.lastTranscriptPath = event.transcript_path;
+      log(
+        `[Binder] Transcript from ${event.hook_event_name ?? 'hook'}: claude=${this.currentBoundId}, transcript=${event.transcript_path}`,
+      );
+      this.deps.bindingStore.update(this.sessionId, this.currentBoundId);
+
+      // Announce the rotation as ONE atomic event. Skip on first-init (not a
+      // rotation) and skip if rotate() already announced it.
+      if (isRotation && !rotationAnnounced) {
+        this.emitRotated(event.session_id, event.transcript_path, previous);
+      }
+
+      this.startOrReplaceWatcher(event.transcript_path);
+    } catch (err) {
+      logError(`[Binder] onHookEvent failed for session ${this.sessionId}: ${errorToString(err)}`);
+      this.currentBoundId = null; // Reset so the fallback can take over.
+    }
+  }
+
+  // =========================================================================
+  // Classification.
+  // =========================================================================
+
+  /**
+   * Wraps `classifySessionEvent` with the binder's live inputs. The
+   * sibling-defer gate is applied SEPARATELY in onHookEvent/decide (it gates
+   * the first-adopt only), matching the old code where classify never knew
+   * about siblings.
+   */
+  private classify(incomingSessionId: string): SessionEventClass {
+    return classifySessionEvent({
+      currentLock: this.currentBoundId,
+      incomingSessionId,
+      mainPtyRunning: this.deps.sessionRegistry.getSession(this.sessionId)?.pty.isRunning ?? false,
+      mainSessionEnded: this.mainSessionEnded,
+    });
+  }
+
+  // =========================================================================
+  // SessionStart pre-empt + SessionEnd id-match.
+  // =========================================================================
+
+  /**
+   * The SessionStart pre-empt (old `hook-bridge-setup.ts:585-610`). On any
+   * in-process session_id rotation while our PTY is alive, flip
+   * mainSessionEnded=true so the classifier returns 'restart'. Gated by the
+   * subagent check + the sibling/ownership guard. Must be called by the
+   * driver BEFORE onHookEvent for SessionStart, mirroring the old order.
+   */
+  preemptOnSessionStart(event: BinderHookEvent): void {
+    if (
+      !this.isSubagentEvent(event) &&
+      this.currentBoundId &&
+      event.session_id &&
+      event.session_id !== this.currentBoundId &&
+      (!this.hasSiblingInDir() || this.ownsTranscript(event.transcript_path))
+    ) {
+      log(`[Binder] Main lifecycle transition: ${this.currentBoundId} -> ${event.session_id}`);
+      this.mainSessionEnded = true;
+    }
+  }
+
+  /**
+   * SessionEnd handler (old `hook-bridge-setup.ts:665-670`). Mark main ended
+   * ONLY when the session_id matches our lock — foreign SessionEnds (subagents,
+   * siblings) must not unlock our tracking. THIS WAS MISSING in v2; without it
+   * clean-exit restarts drop.
+   */
+  onSessionEnd(event: BinderHookEvent): void {
+    if (event.session_id && this.currentBoundId && event.session_id === this.currentBoundId) {
+      this.mainSessionEnded = true;
+    }
+  }
+
+  // =========================================================================
+  // Watcher lifecycle.
+  // =========================================================================
+
+  /**
+   * Idempotent watcher ensure (subsumes old `ensureWatcher` + the init start).
+   * No-op if a watcher exists; else cancel the fallback timer, replace a
+   * stale-path watcher, and start. Only called for 'match' events (our own
+   * Claude), whose transcript_path is therefore ours.
+   */
+  ensureWatching(transcriptPath: string | undefined, _source: string): void {
+    // Steady-state no-op: a watcher is already running.
+    if (this.deps.transcriptWatchers.has(this.sessionId)) return;
+    if (!this.deps.sessionRegistry.hasSession(this.sessionId)) return;
+    if (!transcriptPath) {
+      logError(
+        `[Binder] ensureWatching: match event without transcript_path for ${this.sessionId.slice(0, 8)}; watcher still missing`,
+      );
+      return;
+    }
+    this.cancelFallbackTimer();
+    log(
+      `[Binder] Ensuring watcher (self-heal) for ${this.sessionId.slice(0, 8)}: ${transcriptPath}`,
+    );
+    this.lastTranscriptPath = transcriptPath;
+    startTranscriptWatcher(
+      { transcriptWatchers: this.deps.transcriptWatchers },
+      this.sessionId,
+      transcriptPath,
+      this.deps.messageApi,
+      this.deps.sendAndRecord,
+    );
+  }
+
+  /**
+   * First-adopt watcher start with the stale-path replace (old
+   * initFromHookEvent tail). Cancels the fallback timer, replaces a watcher
+   * pointed at a different file, then starts if none running.
+   */
+  private startOrReplaceWatcher(transcriptPath: string): void {
+    this.cancelFallbackTimer();
+
+    const existingWatcher = this.deps.transcriptWatchers.get(this.sessionId);
+    if (
+      existingWatcher &&
+      path.resolve(existingWatcher.filePath) !== path.resolve(transcriptPath)
+    ) {
+      log(`[Binder] Replacing stale watcher: ${existingWatcher.filePath} -> ${transcriptPath}`);
+      this.teardownWatcher('stale-replace');
+    }
+
+    if (
+      !this.deps.transcriptWatchers.has(this.sessionId) &&
+      this.deps.sessionRegistry.hasSession(this.sessionId)
+    ) {
+      this.lastTranscriptPath = transcriptPath;
+      startTranscriptWatcher(
+        { transcriptWatchers: this.deps.transcriptWatchers },
+        this.sessionId,
+        transcriptPath,
+        this.deps.messageApi,
+        this.deps.sendAndRecord,
+      );
+    }
+  }
+
+  /**
+   * Tear down the existing watcher + reset message state. Errors from stop()
+   * are swallowed. Does NOT emit a wire message (the rotation is announced
+   * atomically via emitRotated, #438). Mirrors old `teardownWatcher`.
+   */
+  private teardownWatcher(label: string): void {
+    const watcher = this.deps.transcriptWatchers.get(this.sessionId);
+    if (!watcher) return;
+    this.deps.transcriptWatchers.delete(this.sessionId); // Remove FIRST.
+    try {
+      watcher.stop();
+    } catch (stopErr) {
+      logError(`[Binder] Failed to stop watcher (${label}): ${errorToString(stopErr)}`);
+    }
+    this.deps.messageApi.reset();
+  }
+
+  private cancelFallbackTimer(): void {
+    const fallbackTimer = this.deps.transcriptFallbackTimers.get(this.sessionId);
+    if (fallbackTimer) {
+      clearInterval(fallbackTimer);
+      this.deps.transcriptFallbackTimers.delete(this.sessionId);
+    }
+  }
+
+  // =========================================================================
+  // Rotation funnel + idempotent emit.
+  // =========================================================================
+
+  /**
+   * Restart PROLOGUE (#438 ordering) — mirrors `initFromHookEvent`'s restart
+   * branch EXACTLY: teardownWatcher -> onRotation() -> emitRotated (idempotent,
+   * path-guarded) -> NULL the lock -> reset mainSessionEnded. It deliberately
+   * does NOT bind the new id or write the store: `onHookEvent` falls through to
+   * the first-adopt path, so the sibling-defer / ownership gate (#451) still
+   * applies before any watcher start or store write, AND a path-less restart
+   * leaves the lock null (no rebind) — both matching the old code (`:353` nulls
+   * the lock; `:370` returns before the store write on a path-less restart).
+   * Returns whether the rotation was announced so the first-adopt emit is
+   * suppressed.
+   */
+  private rotate(
+    newId: string,
+    newPath: string | undefined,
+    previousId: string | null,
+    isRotation: boolean,
+  ): boolean {
+    this.teardownWatcher('restart');
+    // Injected: clear presence-tracker pending + sessionRegistry questions.
+    this.deps.onRotation();
+    // Announce (idempotent + path-guarded). A path-less restart emits nothing.
+    let announced = false;
+    if (isRotation && newPath) {
+      announced = this.emitRotated(newId, newPath, previousId);
+    }
+    this.currentBoundId = null;
+    this.mainSessionEnded = false;
+    return announced;
+  }
+
+  /**
+   * Idempotent rotation announce. ALL emit sites go through this. Emits only
+   * when a path is present and newId !== lastAnnouncedRotationId, so an
+   * A->B->A re-resume emits A->B, B->A, and never a duplicate A->B. Returns
+   * whether it emitted.
+   */
+  private emitRotated(
+    newId: string,
+    transcriptPath: string | undefined,
+    prev: string | null,
+  ): boolean {
+    if (!transcriptPath) return false;
+    if (newId === this.lastAnnouncedRotationId) return false;
+    try {
+      this.deps.sendAndRecord(
+        createSessionRotated(
+          this.sessionId,
+          newId as UUID,
+          transcriptPath,
+          'restart',
+          (prev ?? undefined) as UUID | undefined,
+        ),
+      );
+      this.lastAnnouncedRotationId = newId;
+      return true;
+    } catch (err) {
+      logError(`[Binder] Failed to emit session_rotated: ${errorToString(err)}`);
+      return false;
+    }
+  }
+
+  // =========================================================================
+  // Adopt + ownership/sibling helpers (ported verbatim from hook-bridge).
+  // =========================================================================
+
+  /**
+   * Adopt the canonical claudeSessionId from the disk-backed binding store.
+   * Disk-fresh every call (no cache) so a sibling/fallback write is observed
+   * (#321/#430). On change only; wrapped in try/catch so an EMFILE flake on
+   * the sessions file does not propagate into the dispatch loop.
+   */
+  private adoptLockFromStore(): void {
+    try {
+      const storedId = this.deps.bindingStore.get(this.sessionId)?.claudeSessionId ?? null;
+      if (storedId === null || storedId === this.currentBoundId) return;
+      const previous = this.currentBoundId;
+      this.currentBoundId = storedId;
+      log(
+        `[Binder] Lock ${previous === null ? 'adopted' : 'updated'} from binding store: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
+      );
+    } catch (err) {
+      logError(`[Binder] adoptLockFromStore failed: ${errorToString(err)}`);
+    }
+  }
+
+  /**
+   * Whether a co-located sibling daemon (live Claude child) serves the same
+   * directory. Ported verbatim from `hook-bridge-setup.ts:hasSiblingInDir`.
+   */
+  private hasSiblingInDir(): boolean {
+    try {
+      // Probe the dir ourselves so an enumeration failure flips to the safe
+      // default of "sibling present" (PR #358).
+      fs.readdirSync(this.deps.liveSessionsRegistry.dirPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return false; // first daemon
+      logError(
+        `[Binder] Could not enumerate live-sessions; assuming sibling present: ${errorToString(err)}`,
+      );
+      return true;
+    }
+    return this.deps.liveSessionsRegistry.listLive().some(
+      (e) =>
+        e.projectPath === this.workingDirectory &&
+        e.sessionId !== this.sessionId &&
+        e.wsPort !== this.deps.currentPort() &&
+        // A zombie (daemon alive, Claude dead) must not count as a sibling
+        // (#451). Legacy entries with no recorded child pid stay fail-safe live.
+        claudeChildLooksAlive(e),
+    );
+  }
+
+  /**
+   * Whether the transcript named by an event was written by OUR Claude (the
+   * remi:<port> head marker matches our port). Ported verbatim from
+   * `hook-bridge-setup.ts:ownsTranscript`.
+   */
+  private ownsTranscript(transcriptPath: string | undefined): boolean {
+    return (
+      typeof transcriptPath === 'string' &&
+      readTranscriptOwnerPort(transcriptPath) === this.deps.currentPort()
+    );
+  }
+
+  /** Subagent/team events carry agent_id. */
+  private isSubagentEvent(event: BinderHookEvent): boolean {
+    return typeof event.agent_id === 'string' && event.agent_id.length > 0;
+  }
+
+  // =========================================================================
+  // Lifecycle: start / close / snapshot.
+  // =========================================================================
+
+  /**
+   * Arm the transcript discovery. In SHADOW mode this is a NO-OP (no fs.watch,
+   * no fallback timer — the binder is provably side-effect-free, design §3.1
+   * v4 #8). In DRIVE mode it arms the existing fallback poll only.
+   *
+   * TODO(#453 commit 4): add the re-arming directory watcher (the #452
+   * no-hooks-rotation fix) here. That is a separate commit; this seam stays
+   * fallback-poll-only for now.
+   */
+  start(claudeId: string): void {
+    if (this.mode === 'shadow') return;
+    startTranscriptFallback(
+      {
+        sessionRegistry: this.deps.sessionRegistry,
+        transcriptDiscovery: this.deps.transcriptDiscovery,
+        transcriptWatchers: this.deps.transcriptWatchers,
+        transcriptFallbackTimers: this.deps.transcriptFallbackTimers,
+      },
+      this.sessionId,
+      this.workingDirectory,
+      claudeId,
+      this.deps.messageApi,
+      this.deps.sendAndRecord,
+    );
+  }
+
+  /**
+   * Single teardown owner: clears the watcher AND the fallback/dir-watch timer
+   * (fixes the transcriptFallbackTimers leak at cli.ts:822-829).
+   */
+  close(): void {
+    this.teardownWatcher('close');
+    this.cancelFallbackTimer();
+  }
+
+  /** Current binding for callers that stamp outgoing messages. */
+  snapshot(): { claudeSessionId: string | null; transcriptPath: string | null } {
+    return {
+      claudeSessionId: this.currentBoundId,
+      transcriptPath: this.lastTranscriptPath,
+    };
+  }
+}

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -468,6 +468,19 @@ export class TranscriptBinder {
     }
   }
 
+  /**
+   * Session filter (DRIVE-mode replacement for the old `filterBySession`,
+   * `hook-bridge-setup.ts:603-607`). Accept events only from our own Claude.
+   * Before the lock is known, block events when a live sibling exists (they
+   * could be from the sibling's Claude). Ported line-for-line: adopt the
+   * disk-fresh lock first, then gate on it (or the sibling guard). Pure read
+   * (the adopt is a store read, never a write); no rotation, no watcher.
+   */
+  admits(event: BinderHookEvent): boolean {
+    this.adoptLockFromStore();
+    return this.currentBoundId ? event.session_id === this.currentBoundId : !this.hasSiblingInDir();
+  }
+
   // =========================================================================
   // Watcher lifecycle.
   // =========================================================================
@@ -911,5 +924,18 @@ export class TranscriptBinder {
       claudeSessionId: this.currentBoundId,
       transcriptPath: this.lastTranscriptPath,
     };
+  }
+
+  /**
+   * Whether our main session has ended (SessionEnd id-match fired and no
+   * subsequent restart reset it). Read by the bridge's post-SessionEnd
+   * Notification drop so that gate reads the binder's single source of truth in
+   * drive mode rather than a duplicated closure flag (the closure
+   * `mainSessionEnded` is reset on restart by `rotate()`; mirroring that reset
+   * outside the binder would be fragile). The Notification-drop gate itself is
+   * a question-pipeline concern that moves onto the binder in phase 4.
+   */
+  isMainEnded(): boolean {
+    return this.mainSessionEnded;
   }
 }

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -55,6 +55,27 @@ import type { TranscriptDiscovery } from './transcript-discovery.ts';
 import { readTranscriptOwnerPort } from './transcript-owner.ts';
 import type { TranscriptWatcher } from './transcript-watcher.ts';
 
+/**
+ * Re-stat cadence for the #452 no-hooks rotation detector. 1500ms is a
+ * deliberate middle: fast enough that a no-hooks rotation surfaces within
+ * ~1.5–3s (comparable to the existing 2s fallback poll), slow enough that
+ * readdir+stat on a ~tens-of-files dir is negligible CPU.
+ */
+const ROTATION_POLL_INTERVAL_MS = 1500;
+/**
+ * How long a NEW `.jsonl` may sit with an unreadable `remi:<port>` head marker
+ * before we stop re-polling it. The marker-ready guard: an empty/unflushed file
+ * reads `null` and is re-polled (it may still be flushing), never classified on
+ * the empty edge. We discriminate "still flushing" from "settled non-remi file"
+ * by the file's mtime AGE, not a tick count — so a slow-flushing OWN transcript
+ * (or a transient EMFILE read) is NEVER permanently dropped within this window
+ * (that permanent drop would be the exact #452 wedge: the kept fallback poll
+ * only ever waits for the INITIAL transcript, not a rotated id). Only a file
+ * settled-and-markerless for longer than this is recorded as seen. 10s is far
+ * beyond Claude's synchronous create-to-marker gap.
+ */
+const MARKER_SETTLE_MS = 10_000;
+
 /** A hook event as the binder consumes it (the subset it reads). */
 export interface BinderHookEvent {
   readonly session_id?: string;
@@ -109,6 +130,14 @@ export interface TranscriptBinderArgs {
   workingDirectory: string;
 }
 
+/** Test-only overrides for the rotation dir-poll cadence. */
+export interface TranscriptBinderTuning {
+  /** Rotation re-stat cadence (ms). Defaults to ROTATION_POLL_INTERVAL_MS. */
+  rotationPollIntervalMs?: number;
+  /** Marker-settle window (ms). Defaults to MARKER_SETTLE_MS. */
+  markerSettleMs?: number;
+}
+
 export class TranscriptBinder {
   // --- Owned binding state (the OWN pre-adopt copy is the snapshot source) ---
   /** Our currently-bound Claude session id, or null before first adopt. */
@@ -121,16 +150,54 @@ export class TranscriptBinder {
   /** Last transcript path we (re)started a watcher on; for snapshot(). */
   private lastTranscriptPath: string | null = null;
 
+  // --- Re-arming rotation dir-poll (#452, drive-mode only) ---
+  /**
+   * The periodic dir RE-STAT interval handle; null when unarmed (shadow mode,
+   * pre-start, post-close). Distinct from `deps.transcriptFallbackTimers` —
+   * this is the rotation detector, NOT the first-bind fallback poll.
+   */
+  private rotationPollTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * The project transcript dir we re-stat. Resolved once at start() so the poll
+   * never recomputes the lossy path encoding per tick; null when unarmed.
+   */
+  private rotationPollDir: string | null = null;
+  /**
+   * Every Claude session id we have ALREADY considered for rotation — fed,
+   * bound, announced, or proven-foreign. A candidate in this set is never
+   * re-fed, so each rotation fires `onHookEvent` exactly once even though the
+   * poll re-stats the dir every tick. Seeded with the initial claudeId at
+   * start(); cleared by close().
+   */
+  private readonly seenRotationIds: Set<string> = new Set();
+  /** Test override for the poll cadence; defaults to ROTATION_POLL_INTERVAL_MS. */
+  private rotationPollIntervalMs: number = ROTATION_POLL_INTERVAL_MS;
+  /** Marker-settle window (ms): a new candidate whose `remi:<port>` marker is not
+   *  yet readable is re-polled until its file has been settled-and-markerless for
+   *  this long (by mtime), then recorded as seen. Test-overridable. */
+  private markerSettleMs: number = MARKER_SETTLE_MS;
+
   private readonly deps: TranscriptBinderDeps;
   private readonly sessionId: UUID;
   private readonly workingDirectory: string;
   private readonly mode: BinderMode;
 
-  constructor(deps: TranscriptBinderDeps, args: TranscriptBinderArgs, mode: BinderMode) {
+  constructor(
+    deps: TranscriptBinderDeps,
+    args: TranscriptBinderArgs,
+    mode: BinderMode,
+    tuning?: TranscriptBinderTuning,
+  ) {
     this.deps = deps;
     this.sessionId = args.sessionId;
     this.workingDirectory = args.workingDirectory;
     this.mode = mode;
+    if (tuning?.rotationPollIntervalMs !== undefined) {
+      this.rotationPollIntervalMs = tuning.rotationPollIntervalMs;
+    }
+    if (tuning?.markerSettleMs !== undefined) {
+      this.markerSettleMs = tuning.markerSettleMs;
+    }
   }
 
   // =========================================================================
@@ -632,13 +699,14 @@ export class TranscriptBinder {
   // =========================================================================
 
   /**
-   * Arm the transcript discovery. In SHADOW mode this is a NO-OP (no fs.watch,
+   * Arm the transcript discovery. In SHADOW mode this is a NO-OP (no dir-poll,
    * no fallback timer — the binder is provably side-effect-free, design §3.1
-   * v4 #8). In DRIVE mode it arms the existing fallback poll only.
+   * v4 #8). In DRIVE mode it arms BOTH:
    *
-   * TODO(#453 commit 4): add the re-arming directory watcher (the #452
-   * no-hooks-rotation fix) here. That is a separate commit; this seam stays
-   * fallback-poll-only for now.
+   *   - the existing fallback poll (Case A: our pre-assigned file appears), the
+   *     safety net the #452 critic mandated — KEPT, unchanged;
+   *   - the re-arming rotation dir-poll (Case B: a NEW Claude id with NO hook
+   *     event — the hooks-down / no-hooks rotation the #452 dir-watcher targets).
    */
   start(claudeId: string): void {
     if (this.mode === 'shadow') return;
@@ -655,15 +723,186 @@ export class TranscriptBinder {
       this.deps.messageApi,
       this.deps.sendAndRecord,
     );
+    this.armRotationPoll(claudeId);
   }
 
   /**
-   * Single teardown owner: clears the watcher AND the fallback/dir-watch timer
-   * (fixes the transcriptFallbackTimers leak at cli.ts:822-829).
+   * Single teardown owner: clears the watcher, the fallback timer, AND the
+   * rotation dir-poll (fixes the transcriptFallbackTimers leak at
+   * cli.ts:822-829 and ensures the dir-poll never outlives the binder).
    */
   close(): void {
     this.teardownWatcher('close');
     this.cancelFallbackTimer();
+    this.cancelRotationPoll();
+  }
+
+  // =========================================================================
+  // Re-arming rotation dir-poll (#452 no-hooks rotation). Drive-mode only.
+  //
+  // ROBUSTNESS: a level-triggered RE-STAT poll over SETTLED state, not an
+  // edge-triggered fs.watch. The empty-file edge that wedged #452 is
+  // structurally absent — the poll observes the new `.jsonl` only at quantized
+  // ticks, by which point Claude has flushed the `remi:<port>` head marker. The
+  // marker-ready guard re-polls a not-yet-flushed candidate (RECENT by mtime),
+  // only seen-setting a settled-and-markerless file so a slow flush is never
+  // permanently dropped (#452); the seen-set is the exactly-once gate; the
+  // marker == currentPort check is
+  // the sibling gate. NON-EMITTING: every detection routes through the single
+  // funnel onHookEvent(); we never call rotate()/emitRotated directly.
+  // =========================================================================
+
+  /**
+   * Arm the periodic dir RE-STAT poll. Idempotent (no-op if already armed, so
+   * the post-rotation re-arm — which is a no-op by construction here — is safe).
+   * Seeds `seenRotationIds` with the initial claudeId so our own first
+   * transcript is never mistaken for a rotation. Resolves the dir ONCE.
+   */
+  private armRotationPoll(initialClaudeId: string): void {
+    if (this.mode === 'shadow') return;
+    if (this.rotationPollTimer !== null) return; // already armed
+    this.rotationPollDir = this.deps.transcriptDiscovery.getProjectTranscriptDir(
+      this.workingDirectory,
+    );
+    this.seenRotationIds.add(initialClaudeId);
+    this.rotationPollTimer = setInterval(
+      () => this.rotationPollTick(),
+      this.rotationPollIntervalMs,
+    );
+  }
+
+  private cancelRotationPoll(): void {
+    if (this.rotationPollTimer !== null) {
+      clearInterval(this.rotationPollTimer);
+      this.rotationPollTimer = null;
+    }
+    this.rotationPollDir = null;
+    this.seenRotationIds.clear();
+  }
+
+  /**
+   * One rotation-poll tick. Re-stats the project transcript dir, finds a NEW
+   * Claude session id (not our current bind, not previously seen), verifies the
+   * `remi:<port>` head marker proves it is OURS, and — only then — synthesizes a
+   * hook-shaped event into the SINGLE funnel `onHookEvent()`. NEVER calls
+   * `rotate()` / `emitRotated()` directly. Exposed (package-private) so a test
+   * can drive a deterministic tick without waiting on the interval.
+   */
+  rotationPollTick(): void {
+    if (this.mode === 'shadow') return;
+    // Session gone -> the lifecycle owner will close() us; do nothing meanwhile.
+    if (!this.deps.sessionRegistry.hasSession(this.sessionId)) return;
+    if (this.rotationPollDir === null) return;
+
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.rotationPollDir);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // ENOENT is routine before Claude first writes the project dir; stay quiet.
+      if (code !== undefined && code !== 'ENOENT') {
+        logError(`[Binder] rotation poll readdir failed: ${errorToString(err)}`);
+      }
+      return;
+    }
+
+    for (const name of entries) {
+      if (!name.endsWith('.jsonl')) continue;
+      const candidateId = name.slice(0, -'.jsonl'.length);
+
+      // (a) EXACTLY-ONCE + non-duplication gate. Skip our current bind, the last
+      //     id we announced, and anything already considered. Re-read the lock
+      //     disk-fresh so a hook/fallback bind we already absorbed is excluded.
+      this.adoptLockFromStore();
+      if (candidateId === this.currentBoundId) continue;
+      if (candidateId === this.lastAnnouncedRotationId) continue;
+      if (this.seenRotationIds.has(candidateId)) continue;
+
+      const candidatePath = path.join(this.rotationPollDir, name);
+
+      // (b) MARKER-READY GUARD. Unlike fs.watch's instant rename edge, by the
+      //     time a tick observes the file Claude has almost always flushed the
+      //     head marker. We still bounded-re-poll: a null read (empty/unflushed
+      //     OR markerless) gives the candidate a few more ticks rather than
+      //     classifying on an unproven edge.
+      const ownerPort = readTranscriptOwnerPort(candidatePath);
+
+      if (ownerPort === null) {
+        // Null marker = empty/unflushed (mid-create), a non-remi session that
+        // will never carry our marker, OR a transient read error. Do NOT
+        // permanently drop on a tick count — a slow-flushing OWN transcript (or a
+        // transient EMFILE) would then silently never rotate (the #452 wedge).
+        // Keep re-polling RECENT files (still flushing); only stop touching a
+        // file once it has been settled-and-markerless (by mtime) beyond the
+        // grace window — a genuine non-remi/sibling file we'll never own.
+        let ageMs = 0;
+        try {
+          ageMs = Date.now() - fs.statSync(candidatePath).mtimeMs;
+        } catch {
+          ageMs = 0; // raced a delete/rename -> treat as recent, re-poll.
+        }
+        if (ageMs > this.markerSettleMs) {
+          this.seenRotationIds.add(candidateId);
+        }
+        continue;
+      }
+
+      // (c) SIBLING-MARKER GATE. The marker is readable AND must be OURS. A
+      //     sibling daemon's fresh transcript carries the sibling's port; it
+      //     must NOT rotate us. Mark seen so we never re-read it.
+      if (ownerPort !== this.deps.currentPort()) {
+        this.seenRotationIds.add(candidateId);
+        log(
+          `[Binder] rotation poll: ${candidateId.slice(0, 8)} owned by port ${ownerPort}, not ${this.deps.currentPort()}; ignoring`,
+        );
+        continue;
+      }
+
+      // (d) OURS + NEW. Mark seen BEFORE feeding so a re-entrant readdir on the
+      //     next tick (or a throw) can never double-feed.
+      this.seenRotationIds.add(candidateId);
+      this.feedSyntheticRotation(candidateId, candidatePath);
+
+      // One rotation per tick is enough; the next new id (if any) is picked up
+      // next tick. Bounding to one keeps the tick cheap and avoids feeding two
+      // synthetic restarts in a single synchronous frame.
+      return;
+    }
+  }
+
+  /**
+   * NON-EMITTING FEEDER: synthesizes a hook-shaped event and routes it through
+   * the SINGLE funnel `onHookEvent()`. Never calls `rotate()` / `emitRotated()`.
+   * The no-hooks case means NO SessionStart fired to flip `mainSessionEnded`, so
+   * we mirror `preemptOnSessionStart` first (gated identically) to make
+   * `classify()` return 'restart' rather than 'foreign' while our PTY is alive.
+   * Ownership is already proven (marker == our port), so the sibling guard
+   * inside the pre-empt is satisfied. After the funnel runs, re-arm (a no-op by
+   * construction for the dir-poll, but keeps the lifecycle explicit).
+   */
+  private feedSyntheticRotation(candidateId: string, candidatePath: string): void {
+    if (this.mode === 'shadow') return;
+    log(
+      `[Binder] No-hooks rotation detected via dir poll: ${this.currentBoundId?.slice(0, 8) ?? 'none'} -> ${candidateId.slice(0, 8)} (${candidatePath})`,
+    );
+    const synthetic: BinderHookEvent = {
+      session_id: candidateId,
+      transcript_path: candidatePath,
+      hook_event_name: 'DirPollRotation', // sentinel; not a real CC hook
+    };
+    try {
+      // Flip mainSessionEnded so a different id with a live PTY classifies as a
+      // restart, not foreign — the SessionStart that would normally do this
+      // never arrived (the hooks-down premise of #452).
+      this.preemptOnSessionStart(synthetic);
+      this.onHookEvent(synthetic);
+    } catch (err) {
+      logError(`[Binder] synthetic rotation funnel failed: ${errorToString(err)}`);
+    }
+    // Re-arm for the NEXT rotation. The interval keeps running, so this is a
+    // no-op in the common case; it only re-creates the timer if a prior
+    // teardown nulled it (defensive, keeps the lifecycle symmetric).
+    this.armRotationPoll(candidateId);
   }
 
   /** Current binding for callers that stamp outgoing messages. */

--- a/packages/daemon/src/transcript/transcript-owner.ts
+++ b/packages/daemon/src/transcript/transcript-owner.ts
@@ -21,6 +21,8 @@
 
 import * as fs from 'node:fs';
 
+import { logError } from '../cli/logger.ts';
+
 /** Only the first few lines can hold the head marker; cap the read. */
 const HEAD_BYTES = 8192;
 
@@ -75,7 +77,7 @@ export function readTranscriptOwnerPort(transcriptPath: string): number | null {
     // see why ownership checks are coming up empty.
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== undefined && code !== 'ENOENT') {
-      console.error(`[transcript-owner] Failed to read ${transcriptPath}: ${code}`);
+      logError(`[transcript-owner] Failed to read ${transcriptPath}: ${code}`);
     }
     return null;
   } finally {

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Differential (shadow-mode) test for the TranscriptBinder — epic #453 phase 3,
+ * commit 3.
+ *
+ * Drives `setupHookBridge` with `shadowBinder=true` through the same
+ * RecordingHookServer harness the characterization suite uses, replaying the
+ * four MANDATORY event streams from the design doc (§3.1 v4 #10):
+ *
+ *   (a) SessionEnd-then-restart  (SessionStart A, SessionEnd A, SessionStart B)
+ *   (b) A -> B -> A re-resume
+ *   (c) path-less restart        (SessionStart B without transcript_path)
+ *   (d) foreign-subagent-after-rotation (agent_id event right after a rotation)
+ *
+ * Two assertions per stream:
+ *   1. ZERO `[ShadowBinder] DISAGREE` lines: the shadow binder's load-bearing
+ *      control-plane decision (bound id after, would-emit-rotation, watcher
+ *      path) matches the old path's observed outcome on every event.
+ *   2. ZERO shadow side effects: running the SAME stream with the shadow OFF
+ *      (baseline) vs ON produces byte-identical observable output — same
+ *      session_rotated messages on the wire, same final store binding, same
+ *      final watcher path. The shadow cannot emit, write the store, or start a
+ *      watcher, so the two runs must be indistinguishable.
+ *
+ * NO MOCKS: real SessionStore / SessionBindingStore / SessionRegistry /
+ * TranscriptWatcher over a tmpdir; a fake PTY (the only seam, matching the
+ * characterization suite).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
+import type { HookServer } from '../../../src/hooks/index.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/index.ts';
+import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+/** Recording HookServer: capture `.on()` registrations, fire them directly. */
+class RecordingHookServer {
+  readonly listeners = new Map<string, (input: unknown) => void>();
+  on(event: string, listener: (input: unknown) => void): () => void {
+    this.listeners.set(event, listener);
+    return () => this.listeners.delete(event);
+  }
+  fire(event: string, input: unknown): void {
+    const fn = this.listeners.get(event);
+    if (!fn) throw new Error(`No listener registered for ${event}`);
+    fn(input);
+  }
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+/** Minimal no-op MessageAPI — the bridge calls reset() on rotation. */
+function noopMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+
+/** One replay step: the hook event name + the raw input payload. */
+interface Step {
+  event: string;
+  input: Record<string, unknown>;
+}
+
+/** Observable output of running a stream (for the side-effect-free diff). */
+interface RunResult {
+  /** Every session_rotated message that crossed the wire, in order. */
+  rotations: Array<{ newClaudeSessionId: string; oldClaudeSessionId?: string | undefined }>;
+  /** The durable binding after the whole stream ran. */
+  finalBoundId: string | null;
+  /** The final watcher's filePath (path-resolved), or null. */
+  finalWatcherPath: string | null;
+  /** Captured DISAGREE lines (only ever non-empty in the shadow-on run). */
+  disagreements: string[];
+}
+
+describe('TranscriptBinder differential (shadow mode)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-diff-'));
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build one isolated bridge + its backing state, replay `steps`, and return
+   * the observable outcome. Each run gets a FRESH SessionStore/Registry/watcher
+   * map under its own subdir so the shadow-on and shadow-off runs cannot share
+   * state. The shadow binder writes nothing, so the two runs must match.
+   */
+  async function runStream(
+    steps: Step[],
+    shadowBinder: boolean,
+    txBase: string,
+  ): Promise<RunResult> {
+    // Isolated per-run state dir (store + live-sessions) so the baseline and
+    // shadow runs never share persisted state; transcript paths resolve against
+    // the SHARED `txBase` so both runs produce identical absolute watcher paths.
+    const stateDir = fs.mkdtempSync(path.join(tmpDir, 'state-'));
+    const disagreements: string[] = [];
+    configureLogger({
+      writeLog: (msg: string) => {
+        if (msg.includes('[ShadowBinder] DISAGREE')) disagreements.push(msg);
+      },
+    });
+
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const sessionStore = new SessionStore(path.join(stateDir, 'sessions.json'));
+    const bindingStore = new SessionBindingStore(sessionStore);
+    const liveSessionsRegistry = new SessionRegistryFile(path.join(stateDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    const transcriptWatchers = new Map<UUID, TranscriptWatcher>();
+    const transcriptFallbackTimers = new Map<UUID, ReturnType<typeof setInterval>>();
+    const transcriptDiscovery = new TranscriptDiscovery();
+    const hookServer = new RecordingHookServer();
+    const messageApi = noopMessageAPI();
+    const tracker = new QuestionPresenceTracker(() => {});
+
+    sessionRegistry.registerSession(SID, txBase, fakePTY(), messageApi);
+
+    // Mirror production cli.ts: the deterministic pre-spawn binding is written
+    // to the store BEFORE the bridge sees any hook event. Without this record
+    // SessionStore.updateClaudeSessionId is a no-op (it never creates a row),
+    // so bindingStore.get() would always read null and the binding can never be
+    // observed. Pre-assign the FIRST event's claude session id, exactly as
+    // resolveClaudeBinding + bindingStore.preAssign do at spawn time.
+    const firstClaudeId = steps[0]?.input['session_id'] as string | undefined;
+    if (firstClaudeId) {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: firstClaudeId,
+        projectPath: txBase,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    const rotations: RunResult['rotations'] = [];
+    const sendAndRecord = (message: ProtocolMessage): void => {
+      if (message.type === 'session_rotated') {
+        rotations.push({
+          newClaudeSessionId: message.newClaudeSessionId as string,
+          oldClaudeSessionId: message.oldClaudeSessionId as string | undefined,
+        });
+      }
+    };
+
+    setupHookBridge(
+      {
+        sessionRegistry,
+        bindingStore,
+        liveSessionsRegistry,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        autoApproveService: null,
+        currentPort: () => 8765,
+        shadowBinder,
+        transcriptDiscovery,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: txBase,
+        messageApi,
+        sendAndRecord,
+        tracker,
+      },
+    );
+
+    // Resolve relative transcript paths against this run's dir so the two runs
+    // produce identical absolute paths for the diff.
+    for (const step of steps) {
+      const input: Record<string, unknown> = { ...step.input };
+      if (typeof input['transcript_path'] === 'string') {
+        const abs = path.join(txBase, input['transcript_path'] as string);
+        // Create the (empty) transcript file so the real TranscriptWatcher's
+        // waitForFile resolves immediately instead of leaving a 1s poll alive
+        // across runs (a harness flake under rapid back-to-back invocation). No
+        // sibling in these streams, so the absent head marker never gates
+        // ownsTranscript; both baseline and shadow runs share txBase so they see
+        // identical files.
+        if (!fs.existsSync(abs)) fs.writeFileSync(abs, '');
+        input['transcript_path'] = abs;
+      }
+      hookServer.fire(step.event, input);
+    }
+
+    const finalWatcher = transcriptWatchers.get(SID);
+    const result: RunResult = {
+      rotations,
+      finalBoundId: bindingStore.get(SID)?.claudeSessionId ?? null,
+      finalWatcherPath: finalWatcher ? path.resolve(finalWatcher.filePath) : null,
+      disagreements,
+    };
+
+    // Cleanup: stop any real watchers this run started (fs.watch + 1s poll).
+    for (const w of transcriptWatchers.values()) {
+      try {
+        w.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    await sessionRegistry.shutdown();
+    return result;
+  }
+
+  /**
+   * Replay a stream with the shadow OFF and ON, assert ZERO disagreements and
+   * that the two runs are observationally identical (the shadow added no side
+   * effect). Returns the shadow-on result for any stream-specific assertions.
+   */
+  async function assertNoDivergence(name: string, steps: Step[]): Promise<RunResult> {
+    // Shared transcript base so both runs resolve identical absolute paths; each
+    // run still gets its own isolated state dir inside runStream.
+    const txBase = fs.mkdtempSync(path.join(tmpDir, 'tx-'));
+    const baseline = await runStream(steps, /* shadowBinder */ false, txBase);
+    const shadow = await runStream(steps, /* shadowBinder */ true, txBase);
+
+    // 1) The shadow binder logged no control-plane disagreement.
+    expect(shadow.disagreements, `${name}: shadow DISAGREE lines`).toEqual([]);
+    // The baseline run never constructs a shadow, so it cannot disagree.
+    expect(baseline.disagreements).toEqual([]);
+
+    // 2) Side-effect-free: shadow-on output is identical to shadow-off output.
+    expect(shadow.rotations, `${name}: rotations on wire`).toEqual(baseline.rotations);
+    expect(shadow.finalBoundId, `${name}: final bound id`).toBe(baseline.finalBoundId);
+    expect(shadow.finalWatcherPath, `${name}: final watcher path`).toBe(baseline.finalWatcherPath);
+
+    return shadow;
+  }
+
+  test('(a) SessionEnd-then-restart: SessionStart A, SessionEnd A, SessionStart B', async () => {
+    const result = await assertNoDivergence('end-then-restart', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'logout' } },
+      { event: 'SessionStart', input: { session_id: 'claude-B', transcript_path: 'b.jsonl' } },
+    ]);
+
+    // Exactly one rotation (A -> B); final lock is B.
+    expect(result.rotations.length).toBe(1);
+    expect(result.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(result.rotations[0]?.oldClaudeSessionId).toBe('claude-A');
+    expect(result.finalBoundId).toBe('claude-B');
+    expect(result.finalWatcherPath?.endsWith(`${path.sep}b.jsonl`)).toBe(true);
+  });
+
+  test('(b) A -> B -> A re-resume', async () => {
+    // /clear from A to B, then /resume back to A. The idempotent emit guard
+    // must produce A->B, B->A and never a duplicate; the shadow must agree.
+    const result = await assertNoDivergence('a-b-a', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-A', transcript_path: 'a.jsonl', source: 'resume' },
+      },
+    ]);
+
+    expect(result.rotations.length).toBe(2);
+    expect(result.rotations.map((r) => r.newClaudeSessionId)).toEqual(['claude-B', 'claude-A']);
+    expect(result.finalBoundId).toBe('claude-A');
+  });
+
+  test('(c) path-less restart emits nothing for the path-less event', async () => {
+    // SessionStart B with NO transcript_path. The old path nulls the lock but
+    // does not emit (the :337 path guard); the shadow must match (zero emit,
+    // lock null after the path-less event), then a follow-up event with a path
+    // rebinds and emits the rotation.
+    const result = await assertNoDivergence('path-less-restart', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'logout' } },
+      // Path-less restart: nulls the lock, emits nothing.
+      { event: 'SessionStart', input: { session_id: 'claude-B' } },
+    ]);
+
+    // No rotation crossed the wire (B carried no path on its SessionStart).
+    expect(result.rotations.length).toBe(0);
+  });
+
+  test('(d) foreign subagent event (agent_id set) immediately after a rotation', async () => {
+    // After A -> B rotates, a subagent event arrives with a DISTINCT session_id
+    // (and agent_id) while the PTY is still running. It must classify FOREIGN
+    // (different id, PTY running, mainSessionEnded reset to false by the rotate)
+    // -> no new bind, no rotation, lock stays B. The distinct id is essential:
+    // reusing B short-circuits the classifier to 'match' BEFORE mainSessionEnded
+    // is read, so it would NOT exercise the v4 #5 reset (the reviewer proved
+    // deleting the reset still passed the same-id form). With a distinct id this
+    // stream genuinely depends on rotate() resetting mainSessionEnded.
+    const result = await assertNoDivergence('foreign-after-rotation', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      // Foreign subagent event right after the rotation: agent_id set, DISTINCT
+      // session_id so it reaches the mainPtyRunning && !mainSessionEnded branch.
+      {
+        event: 'PostToolUse',
+        input: {
+          session_id: 'claude-foreign-sub',
+          agent_id: 'subagent-xyz',
+          agent_type: 'task',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+          transcript_path: 'b.jsonl',
+        },
+      },
+    ]);
+
+    // Exactly one rotation (A -> B); the foreign subagent event adds nothing.
+    expect(result.rotations.length).toBe(1);
+    expect(result.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(result.finalBoundId).toBe('claude-B');
+  });
+});

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Drive-mode test for the TranscriptBinder — epic #453 phase 3, commit 5.
+ *
+ * The shadow differential test (transcript-binder-differential.test.ts) proves
+ * the binder's DECISIONS are equivalent to the old path. THIS test proves that
+ * when `binderEnabled=true` the binder actually DRIVES — applies those decisions
+ * (emits session_rotated on the wire, writes the durable store binding, starts
+ * the watcher) — producing the SAME observable output the OLD path produces with
+ * `binderEnabled=false`.
+ *
+ * Method: replay the same event streams through `setupHookBridge` twice over a
+ * SHARED transcript base — once with the OLD path (binderEnabled=false) and once
+ * with the binder DRIVING (binderEnabled=true) — and assert the two runs are
+ * observationally identical:
+ *   - the same session_rotated messages on the wire (in order),
+ *   - the same final durable store binding,
+ *   - the same final watcher path (proves the watcher started on the same file).
+ *
+ * Streams (mirroring the differential corpus, plus a sibling-defer case):
+ *   (a) normal first-bind + a /clear rotation (A -> B),
+ *   (b) A -> B -> A re-resume (idempotent emit guard),
+ *   (c) sibling-defer: a live co-located sibling owns the dir and the incoming
+ *       event's transcript carries the sibling's port marker -> both paths
+ *       defer (no bind, no watcher, no rotation).
+ *
+ * NO MOCKS: real SessionStore / SessionBindingStore / SessionRegistry /
+ * SessionRegistryFile / TranscriptWatcher over a tmpdir; a fake PTY (the only
+ * seam, matching the characterization + differential suites).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
+import type { HookServer } from '../../../src/hooks/index.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/index.ts';
+import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+/** Recording HookServer: capture `.on()` registrations, fire them directly. */
+class RecordingHookServer {
+  readonly listeners = new Map<string, (input: unknown) => void>();
+  on(event: string, listener: (input: unknown) => void): () => void {
+    this.listeners.set(event, listener);
+    return () => this.listeners.delete(event);
+  }
+  fire(event: string, input: unknown): void {
+    const fn = this.listeners.get(event);
+    if (!fn) throw new Error(`No listener registered for ${event}`);
+    fn(input);
+  }
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+/** Minimal no-op MessageAPI — the bridge calls reset() on rotation. */
+function noopMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+const PORT = 8765;
+
+/** One replay step: the hook event name + the raw input payload. */
+interface Step {
+  event: string;
+  input: Record<string, unknown>;
+}
+
+/** Optional per-run injection of a live sibling into the live-sessions dir. */
+interface SiblingSpec {
+  /** Sibling's wsPort (must differ from PORT so it counts as a sibling). */
+  wsPort: number;
+  /** A live pid so claudeChildLooksAlive() treats it as a live sibling. */
+  claudeChildPid: number;
+}
+
+interface RunOptions {
+  sibling?: SiblingSpec;
+  /**
+   * Skip the pre-spawn binding write. The sibling-defer case needs the lock
+   * UNBOUND (no stored binding to adopt) so the first-adopt sibling/ownership
+   * gate — not the already-bound tripwire — is what defers.
+   */
+  skipPreAssign?: boolean;
+}
+
+/** Observable output of running a stream (for the drive-vs-old diff). */
+interface RunResult {
+  /** Every session_rotated message that crossed the wire, in order. */
+  rotations: Array<{ newClaudeSessionId: string; oldClaudeSessionId?: string | undefined }>;
+  /** The durable binding after the whole stream ran. */
+  finalBoundId: string | null;
+  /** The final watcher's filePath (path-resolved), or null. */
+  finalWatcherPath: string | null;
+  /** Any unexpected error lines (should always be empty). */
+  errors: string[];
+}
+
+describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-drive-'));
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build one isolated bridge + its backing state, replay `steps`, and return
+   * the observable outcome. Each run gets a FRESH SessionStore/Registry/watcher
+   * map under its own subdir so the old-path and drive runs cannot share state.
+   * Transcript paths resolve against the SHARED `txBase` so both runs produce
+   * identical absolute watcher paths. When `binderEnabled` is true the binder
+   * DRIVES; the returned handle's closeBinder() is called in cleanup so the
+   * binder's fallback poll + #452 rotation dir-poll never outlive the run.
+   */
+  async function runStream(
+    steps: Step[],
+    binderEnabled: boolean,
+    txBase: string,
+    options: RunOptions = {},
+  ): Promise<RunResult> {
+    const { sibling, skipPreAssign } = options;
+    const stateDir = fs.mkdtempSync(path.join(tmpDir, 'state-'));
+    const errors: string[] = [];
+    configureLogger({
+      writeLog: (msg: string) => {
+        // Surface only genuine failure lines; the binder/old path log routine
+        // [Hooks]/[Binder] info lines that are not errors.
+        if (msg.includes('failed') || msg.includes('Failed')) errors.push(msg);
+      },
+    });
+
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const sessionStore = new SessionStore(path.join(stateDir, 'sessions.json'));
+    const bindingStore = new SessionBindingStore(sessionStore);
+    const liveSessionsRegistry = new SessionRegistryFile(path.join(stateDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    const transcriptWatchers = new Map<UUID, TranscriptWatcher>();
+    const transcriptFallbackTimers = new Map<UUID, ReturnType<typeof setInterval>>();
+    const transcriptDiscovery = new TranscriptDiscovery();
+    const hookServer = new RecordingHookServer();
+    const messageApi = noopMessageAPI();
+    const tracker = new QuestionPresenceTracker(() => {});
+
+    sessionRegistry.registerSession(SID, txBase, fakePTY(), messageApi);
+
+    // Mirror production cli.ts: the deterministic pre-spawn binding is written to
+    // the store BEFORE the bridge sees any hook event (and BEFORE binder.start(),
+    // which reads it for the fallback/dir-watch arm).
+    const firstClaudeId = steps[0]?.input['session_id'] as string | undefined;
+    if (firstClaudeId && !skipPreAssign) {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: firstClaudeId,
+        projectPath: txBase,
+        port: PORT,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    // Optional: register a LIVE co-located sibling so hasSiblingInDir() returns
+    // true for both paths (the sibling-defer case). Written as a raw registry
+    // file (matching the #451 tests): projectPath equals our workingDirectory,
+    // wsPort differs from PORT, and a live claudeChildPid keeps it from being
+    // treated as a zombie.
+    if (sibling) {
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sibling.json'),
+        JSON.stringify({
+          sessionId: 'sib-drive-test',
+          pid: process.pid, // sibling DAEMON is alive
+          wsPort: sibling.wsPort,
+          hookPort: sibling.wsPort + 1,
+          projectPath: txBase,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+          claudeChildPid: sibling.claudeChildPid,
+        }),
+      );
+    }
+
+    const rotations: RunResult['rotations'] = [];
+    const sendAndRecord = (message: ProtocolMessage): void => {
+      if (message.type === 'session_rotated') {
+        rotations.push({
+          newClaudeSessionId: message.newClaudeSessionId as string,
+          oldClaudeSessionId: message.oldClaudeSessionId as string | undefined,
+        });
+      }
+    };
+
+    const handle = setupHookBridge(
+      {
+        sessionRegistry,
+        bindingStore,
+        liveSessionsRegistry,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        autoApproveService: null,
+        currentPort: () => PORT,
+        binderEnabled,
+        transcriptDiscovery,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: txBase,
+        messageApi,
+        sendAndRecord,
+        tracker,
+      },
+    );
+
+    // Resolve relative transcript paths against this run's dir so the two runs
+    // produce identical absolute paths for the diff.
+    for (const step of steps) {
+      const input: Record<string, unknown> = { ...step.input };
+      if (typeof input['transcript_path'] === 'string') {
+        const abs = path.join(txBase, input['transcript_path'] as string);
+        // Create the (empty) transcript file so the real TranscriptWatcher's
+        // waitForFile resolves immediately instead of leaving a 1s poll alive.
+        if (!fs.existsSync(abs)) fs.writeFileSync(abs, '');
+        input['transcript_path'] = abs;
+      }
+      hookServer.fire(step.event, input);
+    }
+
+    const finalWatcher = transcriptWatchers.get(SID);
+    const result: RunResult = {
+      rotations,
+      finalBoundId: bindingStore.get(SID)?.claudeSessionId ?? null,
+      finalWatcherPath: finalWatcher ? path.resolve(finalWatcher.filePath) : null,
+      errors,
+    };
+
+    // Cleanup: close the binder (drive mode only — no-op when off) so its
+    // fallback poll + #452 rotation dir-poll intervals are cleared, then stop any
+    // watchers + remaining fallback timers this run started.
+    handle.closeBinder();
+    for (const w of transcriptWatchers.values()) {
+      try {
+        w.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    for (const t of transcriptFallbackTimers.values()) clearInterval(t);
+    await sessionRegistry.shutdown();
+    return result;
+  }
+
+  /**
+   * Replay a stream through the OLD path and the DRIVING binder and assert the
+   * two runs are observationally identical. Returns the drive result for any
+   * stream-specific assertions.
+   */
+  async function assertDriveMatchesOld(
+    name: string,
+    steps: Step[],
+    options: RunOptions = {},
+  ): Promise<RunResult> {
+    const txBase = fs.mkdtempSync(path.join(tmpDir, 'tx-'));
+    const old = await runStream(steps, /* binderEnabled */ false, txBase, options);
+    const drive = await runStream(steps, /* binderEnabled */ true, txBase, options);
+
+    expect(old.errors, `${name}: old-path errors`).toEqual([]);
+    expect(drive.errors, `${name}: drive errors`).toEqual([]);
+
+    expect(drive.rotations, `${name}: rotations on wire`).toEqual(old.rotations);
+    expect(drive.finalBoundId, `${name}: final bound id`).toBe(old.finalBoundId);
+    expect(drive.finalWatcherPath, `${name}: final watcher path`).toBe(old.finalWatcherPath);
+
+    return drive;
+  }
+
+  test('(a) normal first-bind + /clear rotation A -> B', async () => {
+    const drive = await assertDriveMatchesOld('first-bind-rotation', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+    ]);
+
+    // The binder DROVE: exactly one rotation A -> B reached the wire, the store
+    // is bound to B, and the watcher started on b.jsonl.
+    expect(drive.rotations.length).toBe(1);
+    expect(drive.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(drive.rotations[0]?.oldClaudeSessionId).toBe('claude-A');
+    expect(drive.finalBoundId).toBe('claude-B');
+    expect(drive.finalWatcherPath?.endsWith(`${path.sep}b.jsonl`)).toBe(true);
+  });
+
+  test('(b) A -> B -> A re-resume (idempotent emit)', async () => {
+    const drive = await assertDriveMatchesOld('a-b-a', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-A', transcript_path: 'a.jsonl', source: 'resume' },
+      },
+    ]);
+
+    // The binder DROVE A->B then B->A and never a duplicate; final lock is A.
+    expect(drive.rotations.map((r) => r.newClaudeSessionId)).toEqual(['claude-B', 'claude-A']);
+    expect(drive.finalBoundId).toBe('claude-A');
+  });
+
+  test('(c) sibling-defer: live sibling owns the dir, incoming marker is not ours', async () => {
+    // A live co-located sibling shares the directory. The pre-assigned binding is
+    // never written by a hook here (we start at the UNBOUND state and the first
+    // event's transcript carries no remi:<port> head marker proving ownership),
+    // so admits()/initFromHookEvent both defer: no bind, no watcher, no rotation.
+    // The empty transcript file the harness writes carries no marker, so
+    // ownsTranscript() is false for both paths -> both defer identically.
+    const drive = await assertDriveMatchesOld(
+      'sibling-defer',
+      [
+        // Use PreToolUse (not SessionStart) so the SessionStart pre-empt does not
+        // fire; this exercises the first-adopt sibling/ownership gate directly.
+        {
+          event: 'PreToolUse',
+          input: {
+            session_id: 'claude-X',
+            transcript_path: 'x.jsonl',
+            tool_name: 'Bash',
+            tool_input: { command: 'ls' },
+          },
+        },
+      ],
+      {
+        // Lock must stay UNBOUND so the first-adopt sibling/ownership gate (not
+        // the already-bound tripwire) is what defers; the empty x.jsonl carries
+        // no remi:<port> marker so ownsTranscript() is false for both paths.
+        skipPreAssign: true,
+        sibling: { wsPort: 9999, claudeChildPid: process.pid },
+      },
+    );
+
+    // Both paths deferred: nothing bound, nothing emitted, no watcher.
+    expect(drive.rotations.length).toBe(0);
+    expect(drive.finalWatcherPath).toBe(null);
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -140,6 +140,30 @@ describe('applyEnvOverrides', () => {
     expect(config.display.max_bullet_length).toBe(100);
   });
 
+  test('transcript-binder feature flags default OFF', () => {
+    expect(DEFAULT_CONFIG.features.transcript_binder_shadow).toBe(false);
+    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_shadow).toBe(true);
+    expect(config.features.transcript_binder_enabled).toBe(false);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_ENABLED=true enables drive', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'true';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_enabled).toBe(true);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_SHADOW=false keeps shadow off', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'false';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_shadow).toBe(false);
+  });
+
   test('TELEGRAM_BOT_TOKEN enables telegram', () => {
     process.env['TELEGRAM_BOT_TOKEN'] = 'test-token-123';
     const config = applyEnvOverrides(DEFAULT_CONFIG);

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1,0 +1,688 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import {
+  type BinderHookEvent,
+  TranscriptBinder,
+  type TranscriptBinderDeps,
+} from '../../src/transcript/transcript-binder.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+/**
+ * No-mock unit tests for TranscriptBinder. Real SessionRegistry / SessionStore /
+ * SessionBindingStore / SessionRegistryFile on tmp files; a fakePTY capturing
+ * submits; sendAndRecord captured into an array. The binder must reproduce the
+ * hook-bridge-setup.ts behavior the phase-0 characterization suite pins.
+ */
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+
+/** PTYSession fake: isRunning toggles via the closure so tests can "exit" it. */
+function fakePTY(submits: string[], state: { running: boolean }): PTYSession {
+  return {
+    id: generateId(),
+    get isRunning() {
+      return state.running;
+    },
+    write: () => {},
+    submitInput: async (content: string) => {
+      submits.push(content);
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+interface MessageApiLog {
+  resetCalls: number;
+}
+
+function fakeMessageAPI(logRef: MessageApiLog): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {
+      logRef.resetCalls += 1;
+    },
+  } as unknown as MessageAPI;
+}
+
+describe('TranscriptBinder', () => {
+  let tmpDir: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  let sent: ProtocolMessage[];
+  let ptySubmits: string[];
+  let ptyState: { running: boolean };
+  let messageApiLog: MessageApiLog;
+  let messageApi: MessageAPI;
+  let rotationCallbacks: number;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-'));
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    // Point Claude's transcript-dir encoding at our tmp root so the fallback
+    // poll's expectedTranscriptPath stays inside tmp (no real ~/.claude touch).
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir: tmpDir });
+    transcriptWatchers = new Map();
+    transcriptFallbackTimers = new Map();
+    sent = [];
+    ptySubmits = [];
+    ptyState = { running: true };
+    messageApiLog = { resetCalls: 0 };
+    messageApi = fakeMessageAPI(messageApiLog);
+    rotationCallbacks = 0;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    for (const w of transcriptWatchers.values()) {
+      try {
+        (w as unknown as { stop: () => void }).stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    for (const t of transcriptFallbackTimers.values()) clearInterval(t);
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function registerSession(): void {
+    sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits, ptyState), messageApi);
+  }
+
+  function deps(): TranscriptBinderDeps {
+    return {
+      sessionRegistry,
+      bindingStore,
+      liveSessionsRegistry,
+      transcriptWatchers,
+      transcriptFallbackTimers,
+      transcriptDiscovery,
+      messageApi,
+      sendAndRecord: (m) => sent.push(m),
+      currentPort: () => 8765,
+      onRotation: () => {
+        rotationCallbacks += 1;
+      },
+    };
+  }
+
+  function makeBinder(mode: 'shadow' | 'drive' = 'drive'): TranscriptBinder {
+    return new TranscriptBinder(deps(), { sessionId: SID, workingDirectory: tmpDir }, mode);
+  }
+
+  /** Insert a fake watcher into the map so teardown/stale-replace has a target. */
+  function seedWatcher(filePath: string, stopCalls: number[]): void {
+    transcriptWatchers.set(SID, {
+      filePath,
+      stop: () => stopCalls.push(1),
+    } as unknown as TranscriptWatcher);
+  }
+
+  function rotations(): Array<{
+    old: string | undefined;
+    new: string;
+    path: string;
+    reason: string;
+  }> {
+    return sent
+      .filter((m) => m.type === 'session_rotated')
+      .map((m) => {
+        const r = m as unknown as {
+          oldClaudeSessionId?: string;
+          newClaudeSessionId: string;
+          newTranscriptPath: string;
+          reason: string;
+        };
+        return {
+          old: r.oldClaudeSessionId,
+          new: r.newClaudeSessionId,
+          path: r.newTranscriptPath,
+          reason: r.reason,
+        };
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // classify: 3-way + defer
+  // -------------------------------------------------------------------------
+
+  describe('classification (3-way + defer)', () => {
+    test('match: first event with no lock locks and starts a watcher', () => {
+      registerSession();
+      const binder = makeBinder();
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+        hook_event_name: 'SessionStart',
+      };
+      const decision = binder.decide(ev);
+      expect(decision.classification).toBe('match');
+      // Re-run via the drive path (fresh binder so state is clean).
+      const driver = makeBinder();
+      driver.onHookEvent(ev);
+      expect(transcriptWatchers.has(SID)).toBe(true);
+      expect(driver.snapshot().claudeSessionId).toBe('claude-A');
+      // First-init is not a rotation: no emit.
+      expect(rotations()).toHaveLength(0);
+    });
+
+    test('foreign: a different session_id while our PTY is alive is dropped', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Lock on A.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      const before = transcriptWatchers.get(SID)?.filePath;
+      // A sibling/subagent id arrives while PTY runs.
+      const d = binder.decide({
+        session_id: 'claude-FOREIGN',
+        transcript_path: path.join(tmpDir, 'f.jsonl'),
+      });
+      expect(d.classification).toBe('foreign');
+      binder.onHookEvent({
+        session_id: 'claude-FOREIGN',
+        transcript_path: path.join(tmpDir, 'f.jsonl'),
+      });
+      // Binding + watcher unchanged.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(before);
+    });
+
+    test('restart: a different session_id after PTY exited classifies restart', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      // PTY exits -> main is gone.
+      ptyState.running = false;
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+    });
+
+    test('defer: sibling present + no ownership marker defers first-adopt (no lock, no watcher)', () => {
+      registerSession();
+      // Live sibling in the same dir.
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sib.json'),
+        JSON.stringify({
+          sessionId: 'sib-1',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18001,
+          projectPath: tmpDir,
+          name: 'sib',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const binder = makeBinder();
+      // Transcript carries no remi:<port> marker -> ownership unproven.
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      };
+      const d = binder.decide(ev);
+      expect(d.classification).toBe('defer');
+      binder.onHookEvent(ev);
+      expect(binder.snapshot().claudeSessionId).toBeNull();
+      expect(transcriptWatchers.has(SID)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // rotation ordering
+  // -------------------------------------------------------------------------
+
+  describe('rotation ordering (#438)', () => {
+    test('rotate() ordering: teardown -> onRotation -> emit -> store update -> bind', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      // First event adopts A from the store + starts a watcher.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      const resetsBefore = messageApiLog.resetCalls;
+
+      // PTY exits so the next different id classifies restart.
+      ptyState.running = false;
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      // teardown stopped the old watcher + reset messageApi.
+      expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+      expect(messageApiLog.resetCalls).toBeGreaterThan(resetsBefore);
+      // onRotation injected callback fired.
+      expect(rotationCallbacks).toBeGreaterThanOrEqual(1);
+      // exactly one session_rotated, store + lock advanced to B.
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: path.join(tmpDir, 'b.jsonl'), reason: 'restart' },
+      ]);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-B');
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+    });
+
+    test('path-less restart emits NOTHING and resets the lock without rebinding', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      ptyState.running = false;
+      // Restart event without a transcript_path: the old code nulls the lock and
+      // returns BEFORE the store write (initFromHookEvent :353 then :370). The
+      // binder must match: no emit, lock null, store unchanged at claude-A.
+      binder.onHookEvent({ session_id: 'claude-B' });
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBeNull();
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A');
+    });
+
+    test('#451: restart with a live sibling + unmarked transcript defers (no watcher, no store write)', () => {
+      // The blocker the rotation reviewer caught: a genuine `restart`
+      // classification (PTY exited) with a co-located live sibling and a
+      // transcript that carries NO remi:<port> marker must DEFER — emit the
+      // rotation (old emits before the guard) but NOT start a watcher or rebind
+      // the store, leaving the fallback poll to adopt. The old code reaches the
+      // sibling-defer gate because the restart branch nulls the lock first.
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A');
+
+      // Seed a live sibling in the same project dir (different port + alive pid).
+      const sibFile = path.join(liveSessionsRegistry.dirPath, 'sibling.json');
+      fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+      fs.writeFileSync(
+        sibFile,
+        JSON.stringify({
+          sessionId: 'sibling-session',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18000,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+
+      ptyState.running = false; // PTY exited -> a different id classifies 'restart'
+      // The rotated transcript (b.jsonl) has NO custom-title marker -> ownership
+      // unproven -> with a live sibling present, defer.
+      fs.writeFileSync(path.join(tmpDir, 'b.jsonl'), '{"type":"user"}\n');
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      // Emitted the rotation (old emits before the guard), but DEFERRED the bind:
+      expect(rotations()).toHaveLength(1);
+      expect(binder.snapshot().claudeSessionId).toBeNull(); // lock not latched to the sibling's id
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A'); // store not rebound
+      expect(transcriptWatchers.has(SID)).toBe(false); // no watcher started on the unproven transcript
+    });
+
+    test('golden master: multi-rotation control-plane sequence + final binding', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-1',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      const t1 = path.join(tmpDir, 'm1.jsonl');
+      const t2 = path.join(tmpDir, 'm2.jsonl');
+      const t3 = path.join(tmpDir, 'm3.jsonl');
+
+      // Mirror the hook-bridge driver: SessionStart pre-empt then onHookEvent.
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-1', t1);
+      fire('claude-2', t2);
+      fire('claude-3', t3);
+
+      expect(rotations()).toEqual([
+        { old: 'claude-1', new: 'claude-2', path: t2, reason: 'restart' },
+        { old: 'claude-2', new: 'claude-3', path: t3, reason: 'restart' },
+      ]);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-3');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // emitRotated idempotency
+  // -------------------------------------------------------------------------
+
+  describe('emitRotated idempotency (#438 scalar gate)', () => {
+    test('re-emit of the same id does not duplicate the rotation', () => {
+      registerSession();
+      const binder = makeBinder();
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-A', path.join(tmpDir, 'a.jsonl'));
+      fire('claude-B', path.join(tmpDir, 'b.jsonl'));
+      // A duplicate SessionStart for B (e.g. coalesced replay): same id, must
+      // not re-emit. preempt is a no-op (same id), onHookEvent classifies match.
+      fire('claude-B', path.join(tmpDir, 'b.jsonl'));
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: path.join(tmpDir, 'b.jsonl'), reason: 'restart' },
+      ]);
+    });
+
+    test('A->B->A re-resume emits A->B, B->A, and NOT a duplicate A->B', () => {
+      registerSession();
+      const binder = makeBinder();
+      const aPath = path.join(tmpDir, 'a.jsonl');
+      const bPath = path.join(tmpDir, 'b.jsonl');
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-A', aPath); // first-init, no emit
+      fire('claude-B', bPath); // A->B
+      fire('claude-A', aPath); // B->A re-resume
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: bPath, reason: 'restart' },
+        { old: 'claude-B', new: 'claude-A', path: aPath, reason: 'restart' },
+      ]);
+      // The scalar gate now holds A; a coalesced replay of A must NOT re-emit.
+      fire('claude-A', aPath);
+      expect(rotations()).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // store-raced zero-emit (#430)
+  // -------------------------------------------------------------------------
+
+  describe('store-raced zero-emit (#430 tripwire)', () => {
+    test('store already at the new id: 0 session_rotated but binding advances', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Lock on A.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+
+      // Fallback races the store to B before the SessionStart for B.
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-B',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      // SessionStart for B arrives; adopt pulls B -> classify 'match' ->
+      // tripwire (currentBoundId set) -> ensureWatching -> return BEFORE emit.
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      expect(rotations()).toHaveLength(0);
+      // But the binding DID advance to B.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onSessionEnd
+  // -------------------------------------------------------------------------
+
+  describe('onSessionEnd sets mainSessionEnded', () => {
+    test('matching id: a subsequent different-id event classifies restart not foreign (PTY still running)', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(ptyState.running).toBe(true);
+
+      // SessionEnd for our locked id -> mainSessionEnded = true.
+      binder.onSessionEnd({ session_id: 'claude-A' });
+
+      // PTY is STILL running, but because mainSessionEnded is set, the next
+      // different id is a restart (clean-exit restart), not foreign.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+    });
+
+    test('foreign id: SessionEnd for a non-matching id does NOT set the flag', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+
+      // SessionEnd from a sibling/subagent (different id) must not unlock us.
+      binder.onSessionEnd({ session_id: 'claude-OTHER' });
+
+      // PTY running + flag NOT set -> a different id is still foreign.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('foreign');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // close()
+  // -------------------------------------------------------------------------
+
+  describe('close()', () => {
+    test('clears the watcher AND the fallback timer', () => {
+      registerSession();
+      const binder = makeBinder();
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      const timer = setInterval(() => {}, 100000);
+      transcriptFallbackTimers.set(SID, timer);
+
+      binder.close();
+
+      expect(stopCalls.length).toBe(1);
+      expect(transcriptWatchers.has(SID)).toBe(false);
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // decide() purity
+  // -------------------------------------------------------------------------
+
+  describe('decide() purity', () => {
+    test('decide performs NO external effect (no send, no store write, no watcher)', () => {
+      registerSession();
+      const binder = makeBinder();
+      const storeBefore = sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null;
+
+      // A restart-shaped scenario (which on the drive path WOULD emit + write).
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      // Snapshot external state after the legitimate drive call.
+      const sentAfterDrive = sent.length;
+      const watcherAfterDrive = transcriptWatchers.has(SID);
+      const rotCbAfterDrive = rotationCallbacks;
+      const resetsAfterDrive = messageApiLog.resetCalls;
+      // Clear the binding store write the drive path made, to detect a fresh one.
+      const storeAfterDrive = sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null;
+
+      ptyState.running = false;
+      // Now call decide() for a rotation. It must NOT send, write, or start.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+      expect(d.wouldEmitRotation).toBe(true);
+      expect(d.wouldStartWatcher).toBe(true);
+      expect(d.boundIdAfter).toBe('claude-B');
+
+      // No NEW external effect from decide().
+      expect(sent.length).toBe(sentAfterDrive); // no send
+      expect(transcriptWatchers.has(SID)).toBe(watcherAfterDrive); // no watcher change
+      expect(rotationCallbacks).toBe(rotCbAfterDrive); // onRotation not called
+      expect(messageApiLog.resetCalls).toBe(resetsAfterDrive); // no teardown/reset
+      // Store still holds the drive-path value, NOT a decide() write to B.
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null).toBe(storeAfterDrive);
+      expect(storeBefore).toBeNull();
+    });
+
+    test('decide advances internal state so successive calls track rotations', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Pure decisions only.
+      const d1 = binder.decide({
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      });
+      expect(d1.classification).toBe('match');
+      expect(d1.boundIdAfter).toBe('claude-A');
+      expect(d1.wouldEmitRotation).toBe(false); // first-init
+
+      ptyState.running = false;
+      const d2 = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d2.classification).toBe('restart');
+      expect(d2.boundIdAfter).toBe('claude-B');
+      expect(d2.wouldEmitRotation).toBe(true);
+
+      // Re-decide the same B (coalesced replay): scalar gate suppresses emit.
+      const d3 = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d3.wouldEmitRotation).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // start() shadow vs drive
+  // -------------------------------------------------------------------------
+
+  describe('start() mode behavior', () => {
+    test('shadow mode start() is a no-op (no fallback timer)', () => {
+      registerSession();
+      const binder = makeBinder('shadow');
+      binder.start('claude-A');
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+
+    test('drive mode start() arms the fallback poll', () => {
+      registerSession();
+      const binder = makeBinder('drive');
+      binder.start('claude-A');
+      expect(transcriptFallbackTimers.has(SID)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ensureWatching idempotency + self-heal
+  // -------------------------------------------------------------------------
+
+  describe('ensureWatching', () => {
+    test('idempotent: no-op when a watcher already exists', () => {
+      registerSession();
+      const binder = makeBinder();
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      binder.ensureWatching(path.join(tmpDir, 'b.jsonl'), 'match');
+      // Existing watcher untouched (still the seeded one, never stopped).
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, 'a.jsonl'));
+      expect(stopCalls.length).toBe(0);
+    });
+
+    test('self-heal: locked-from-store but watcher gone -> next match event starts it', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      expect(transcriptWatchers.has(SID)).toBe(false);
+      // A match event from our own Claude with a path self-heals the watcher.
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+        hook_event_name: 'PreToolUse',
+      });
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, 'a.jsonl'));
+    });
+
+    test('cancels the fallback timer when it starts a watcher', () => {
+      registerSession();
+      const binder = makeBinder();
+      const timer = setInterval(() => {}, 100000);
+      transcriptFallbackTimers.set(SID, timer);
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+  });
+});

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -641,6 +641,247 @@ describe('TranscriptBinder', () => {
   // ensureWatching idempotency + self-heal
   // -------------------------------------------------------------------------
 
+  // -------------------------------------------------------------------------
+  // Re-arming rotation dir-poll (#452 no-hooks rotation)
+  // -------------------------------------------------------------------------
+
+  describe('rotation dir-poll (#452 no-hooks rotation)', () => {
+    /** The dir the rotation poll re-stats (Claude's encoded project dir). */
+    function rotationDir(): string {
+      return transcriptDiscovery.getProjectTranscriptDir(tmpDir);
+    }
+
+    /** Write a transcript file. With `port` it carries a remi:<port> marker. */
+    function writeTranscript(claudeId: string, port?: number): string {
+      const dir = rotationDir();
+      fs.mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, `${claudeId}.jsonl`);
+      const head =
+        port === undefined
+          ? '{"type":"user","message":{"role":"user","content":"hi"}}\n'
+          : `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${port}`, sessionId: claudeId })}\n`;
+      fs.writeFileSync(filePath, head);
+      return filePath;
+    }
+
+    /** A binder with a fast poll cadence for deterministic tests. */
+    function makeDriveBinder(): TranscriptBinder {
+      return new TranscriptBinder(deps(), { sessionId: SID, workingDirectory: tmpDir }, 'drive', {
+        rotationPollIntervalMs: 20,
+      });
+    }
+
+    test('marker-ready: empty new .jsonl does NOT rotate; once the remi marker is written it DOES', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      // Lock on A first (our current bind).
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.start('claude-A');
+
+      // A NEW rotation file appears EMPTY (the #452 empty-file edge): the marker
+      // is not yet flushed. A poll tick must NOT classify it as a rotation.
+      const dir = rotationDir();
+      const newPath = path.join(dir, 'claude-B.jsonl');
+      fs.writeFileSync(newPath, ''); // zero bytes -> readTranscriptOwnerPort === null
+      ptyState.running = false; // PTY exited so a different id would classify restart
+
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A'); // unchanged
+
+      // Now Claude flushes the head marker (our port). The next tick rotates.
+      fs.writeFileSync(
+        newPath,
+        `${JSON.stringify({ type: 'custom-title', customTitle: 'remi:8765', sessionId: 'claude-B' })}\n`,
+      );
+      binder.rotationPollTick();
+
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: newPath, reason: 'restart' },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('exactly-once: repeated ticks seeing the same new file rotate only once', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A fully-flushed rotation file (marker present) appears.
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+
+      // Drive several ticks; the file persists on disk and is re-listed each time.
+      binder.rotationPollTick();
+      binder.rotationPollTick();
+      binder.rotationPollTick();
+
+      // Despite the poll re-stat'ing the same file every tick, exactly ONE
+      // session_rotated crossed the wire (lastAnnouncedRotationId + seen-set).
+      expect(rotations()).toEqual([
+        {
+          old: 'claude-A',
+          new: 'claude-B',
+          path: path.join(rotationDir(), 'claude-B.jsonl'),
+          reason: 'restart',
+        },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('sibling gate: a new .jsonl carrying a DIFFERENT port marker does NOT rotate us', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A sibling daemon (port 19999) writes its own fresh transcript into the
+      // SHARED project dir. Its marker proves it is the sibling's, not ours.
+      writeTranscript('claude-SIB', 19999);
+      ptyState.running = false;
+
+      binder.rotationPollTick();
+      binder.rotationPollTick(); // a 2nd tick must not change the verdict
+
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A'); // not rotated
+      binder.close();
+    });
+
+    test('markerless RECENT file is re-polled (never rotates), never permanently dropped', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A markerless transcript (non-remi / user `-n`). It never proves
+      // ownership -> never rotated. Because it stays RECENT it is re-polled
+      // (not seen-set), so a later-appearing marker is NOT permanently lost.
+      writeTranscript('claude-NOMARK'); // no port -> no remi marker
+      ptyState.running = false;
+
+      for (let i = 0; i < 8; i++) binder.rotationPollTick();
+
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.close();
+    });
+
+    test('#452: a SLOW-FLUSH rotation (marker appears after many empty ticks) is NOT dropped', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // The rotated file is created EMPTY and stays empty across MANY ticks (more
+      // than the old hard cap of 4) — the slow-flush / transient-EMFILE case the
+      // old tick-cap permanently dropped. The dir-poll must keep re-polling.
+      const dir = rotationDir();
+      const newPath = path.join(dir, 'claude-B.jsonl');
+      fs.writeFileSync(newPath, '');
+      ptyState.running = false;
+      for (let i = 0; i < 10; i++) binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0); // no false rotation on the empty edge
+
+      // Claude finally flushes the head marker. Because the candidate was never
+      // permanently dropped, the next tick rotates it (the #452 fix).
+      fs.writeFileSync(
+        newPath,
+        `${JSON.stringify({ type: 'custom-title', customTitle: 'remi:8765', sessionId: 'claude-B' })}\n`,
+      );
+      binder.rotationPollTick();
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: newPath, reason: 'restart' },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('markerless SETTLED file (mtime past the grace window) is recorded seen', () => {
+      registerSession();
+      // Short settle window so the test is fast + deterministic.
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: tmpDir },
+        'drive',
+        { rotationPollIntervalMs: 20, markerSettleMs: 50 },
+      );
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A markerless file whose mtime is already well past the settle window: a
+      // genuine settled non-remi file we will never own. It is recorded seen so
+      // the poll stops re-reading it (bounds the re-stat cost).
+      const stale = writeTranscript('claude-NOMARK');
+      const old = new Date(Date.now() - 60_000);
+      fs.utimesSync(stale, old, old);
+      ptyState.running = false;
+
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.close();
+    });
+
+    test('close() clears the dir-poll (no leaked timer/handle after close)', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.start('claude-A');
+      // Drive-mode start armed BOTH the fallback poll and the rotation poll.
+      expect(transcriptFallbackTimers.has(SID)).toBe(true);
+
+      binder.close();
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+
+      // After close, a new fully-marked rotation file must NOT rotate: the poll
+      // is torn down, and a late manual tick is inert (mode-guard / dir null).
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+    });
+
+    test('shadow mode arms NO dir-poll', () => {
+      registerSession();
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: tmpDir },
+        'shadow',
+        { rotationPollIntervalMs: 20 },
+      );
+      binder.start('claude-A');
+      // No fallback timer (shadow start is a no-op) AND a manual tick is inert.
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+    });
+  });
+
   describe('ensureWatching', () => {
     test('idempotent: no-op when a watcher already exists', () => {
       registerSession();


### PR DESCRIPTION
## Summary

Phase 3 of epic #453 — the riskiest. Consolidates session-filtering + transcript discovery/watcher/rotation/ownership (previously scattered across `hook-bridge-setup.ts`, `transcript-fallback.ts`, `transcript-watcher-setup.ts`) into ONE per-session `TranscriptBinder` state machine, and adds the #452 re-arming directory watcher for the no-hooks-rotation case.

**Shipped behind a feature flag, default OFF, so merging is behavior-identical** — the old path drives until the flag flips. The design was corrected to v4 after the Understand workflow's 3 adversarial critics proved the naive design would reintroduce #438/#452 and leak shadow side effects.

### Commits
1. `4c840cb` — `[features]` flag (`REMI_TRANSCRIPT_BINDER_SHADOW`/`_ENABLED`), default OFF, immutable-at-boot.
2. `5203c63` — `TranscriptBinder` core (`decide`/`onHookEvent`/`classify`/`rotate`/`emitRotated`/`ensureWatching`/`preemptOnSessionStart`/`onSessionEnd`/`close`/`snapshot`). Review caught a real **#451 sibling-defer regression** (rotate bound before the tripwire) — fixed (restart prologue nulls the lock, falls through to the gated first-adopt).
3. `1a11e0d` — shadow mode (provably side-effect-free) + the differential harness over the 4 mandatory streams. Fault-injection proved the corpus catches a broken `mainSessionEnded` reset.
4. `34dda58` — #452 re-arming dir-watch: a **marker-ready non-emitting feeder** (periodic re-stat poll chosen via an options pass; routes through the single `onHookEvent` funnel). Review caught a **slow-flush permanent-drop wedge** (the #452 class reborn) — fixed with mtime-based settling + a load-bearing regression test.
5. `9961e7a` — drive-mode wiring (`binder.admits()`; routes `setupHookBridge` to the binder when enabled; flag OFF = byte-identical). Reviewer ran 7 additional drive-vs-old streams — all match.

Every commit was implemented + **double-adversarially-reviewed** via workflow; three real regressions were caught before merge.

Closes #463
Part of epic #453

## Test plan

- [x] `bun run typecheck` + `bunx biome check` clean
- [x] **50-test characterization suite (`hook-bridge-setup.test.ts`) byte-for-byte UNCHANGED + green** (flag off = old path drives)
- [x] `TranscriptBinder` unit tests (29: classify/rotation/emit-once/A→B→A/store-raced/onSessionEnd/close/decide-purity + the #452 dir-watch: marker-ready, exactly-once, sibling gate, slow-flush-not-dropped, settled-file, shadow-no-op)
- [x] Differential harness (shadow): the 4 mandatory streams, shadow-OFF vs shadow-ON byte-identical + zero DISAGREE
- [x] Drive-mode test: binder-drives output == old-path output (first-bind+/clear, A→B→A, sibling-defer)
- [x] ~1249 daemon tests pass (excl. auto-approve LLM)

## Notes
- Flag stays OFF on merge. The flip-to-drive (after a shadow soak proves DISAGREE is absent in production) is a separate, gated step.
- Deleting the old `initFromHookEvent`/`onSessionInfo`/fallback paths = phase 6.
- Design v4 corrections recorded in `.context/refactor-453-design.md` §3.1.