### PR TITLE
Phase 4: wire the 4 dropped hook events

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -26,10 +26,14 @@
  * callbacks; Pre/PostToolUse/Stop/SessionEnd call `gate.cancelStale()` to abort a
  * stale in-flight eval once Claude has advanced past the prompt.
  *
- * The function registers 7 hookServer listeners (SessionStart, PreToolUse,
- * PostToolUse, Notification, PermissionRequest, Stop, SessionEnd) and
- * returns void. It runs once per session at createNewSession time, only
- * when a hookServer is configured.
+ * This listener block IS the per-session hook router (admit-then-fan-out); a
+ * formal HookRouter class is deferred until the shadow/drive dual path is
+ * deleted (the `driveBinder ? … : oldPath` ternaries collapse first). The
+ * function registers 11 hookServer listeners — the original 7 (SessionStart,
+ * PreToolUse, PostToolUse, Notification, PermissionRequest, Stop, SessionEnd)
+ * plus the 4 wired in phase 4 (StopFailure, PostToolUseFailure, SubagentStart,
+ * SubagentStop) — and returns void. It runs once per session at
+ * createNewSession time, only when a hookServer is configured.
  */
 
 import * as fs from 'node:fs';
@@ -1009,6 +1013,62 @@ export function setupHookBridge(
     if (!filterBySession(input)) return;
     autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);
+  });
+
+  // ---- The 4 previously-dropped events (#453 phase 4) -----------------------
+  // These were registered with Claude Code (REMI_REGISTERED_HOOK_EVENTS) but had
+  // NO listener here, so they reached only (absent) dynamic listeners — a silent
+  // no-op. Wired now, each following the same admit-then-fan-out template as the
+  // tool listeners (drive the binder first so admits() sees an up-to-date lock,
+  // then the per-event policy). The bridge handlers already exist + are tested.
+
+  hookServer.on('StopFailure', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('StopFailure', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // Question event: a failed Stop hook leaves the agent in an unknown state, so
+    // the bridge emits a "Retry?" card via onQuestion. Like PermissionRequest it
+    // is NOT agent_id-dropped — PTY-presence gating happens downstream in the
+    // tracker (#419).
+    handlers.onStopFailure?.(input);
+  });
+
+  hookServer.on('PostToolUseFailure', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('PostToolUseFailure', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // Status event: a subagent's tool failure must not flip MAIN's status, so
+    // drop on agent_id — the same split policy as Pre/PostToolUse (#419).
+    if (isSubagentEvent(input)) return;
+    handlers.onPostToolUseFailure?.(input);
+  });
+
+  // SubagentStart/SubagentStop are subagent-LIFECYCLE events: they ALWAYS carry
+  // agent_id by definition, so the isSubagentEvent drop would discard them
+  // entirely. The whole point is to surface subagent activity as a status
+  // breadcrumb, so gate them with admits() ONLY (the sibling defer + session
+  // scoping still apply via session_id) — a deliberate divergence from the
+  // Pre/PostToolUse agent_id drop (#453 phase 4).
+  hookServer.on('SubagentStart', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('SubagentStart', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    handlers.onSubagentStart?.(input);
+  });
+
+  hookServer.on('SubagentStop', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('SubagentStop', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    handlers.onSubagentStop?.(input);
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -262,7 +262,7 @@ describe('setupHookBridge', () => {
     return { tracker };
   }
 
-  test('registers listeners for all 7 hook events', () => {
+  test('registers listeners for all 11 hook events', () => {
     build();
     const events = new Set(hookServer.listeners.keys());
     expect(events).toEqual(
@@ -274,8 +274,87 @@ describe('setupHookBridge', () => {
         'PermissionRequest',
         'Stop',
         'SessionEnd',
+        // Wired in phase 4 (#453).
+        'StopFailure',
+        'PostToolUseFailure',
+        'SubagentStart',
+        'SubagentStop',
       ]),
     );
+  });
+
+  describe('phase 4 (#453): the 4 previously-dropped events', () => {
+    /** Fire a SessionStart so the bridge locks onto `id` (admit gate then passes). */
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('StopFailure emits a "Retry?" question + waiting status (no agent_id drop)', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('StopFailure', { session_id: 'claude-A', error_type: 'timeout' });
+      expect(messageApiLog.questionCalls).toBeGreaterThanOrEqual(1);
+      expect(messageApiLog.statusCalls).toContain('waiting');
+    });
+
+    test('StopFailure for a FOREIGN session_id is dropped by the admit gate', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('StopFailure', { session_id: 'claude-OTHER', error_type: 'timeout' });
+      expect(messageApiLog.questionCalls).toBe(0);
+    });
+
+    test('PostToolUseFailure sets executing status (main); a subagent failure is dropped', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-A',
+        tool_name: 'Bash',
+        error: 'exit 1',
+      });
+      expect(messageApiLog.statusCalls).toEqual(['executing']);
+
+      // A subagent's tool failure (agent_id set) must NOT flip main's status.
+      messageApiLog.statusCalls.length = 0;
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-A',
+        agent_id: 'sub-1',
+        tool_name: 'Bash',
+        error: 'exit 1',
+      });
+      expect(messageApiLog.statusCalls).toEqual([]);
+    });
+
+    test('SubagentStart/Stop set the status breadcrumb (admit-gated, NOT agent_id-dropped)', () => {
+      build();
+      lock('claude-A');
+      // SubagentStart/Stop ALWAYS carry agent_id; they must NOT be dropped.
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-A',
+        agent_id: 'sub-1',
+        agent_type: 'code-architect',
+      });
+      expect(messageApiLog.statusCalls).toEqual(['executing']);
+
+      messageApiLog.statusCalls.length = 0;
+      hookServer.fire('SubagentStop', { session_id: 'claude-A', agent_id: 'sub-1' });
+      expect(messageApiLog.statusCalls).toEqual(['thinking']);
+    });
+
+    test('SubagentStart for a FOREIGN session_id is dropped by the admit gate', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-OTHER',
+        agent_id: 'sub-1',
+        agent_type: 'task',
+      });
+      expect(messageApiLog.statusCalls).toEqual([]);
+    });
   });
 
   test('does not throw when autoApproveService is null (common case)', () => {


### PR DESCRIPTION
## Summary

Phase 4 of epic #453. The hook fan-out in `setupHookBridge` already IS the per-session router (admit-then-fan-out); a formal `HookRouter` class is deferred until the shadow/drive dual path is deleted (the `driveBinder ? … : oldPath` ternaries collapse first) — formalizing now would churn the riskiest file right after the phase-3 binder for no behavior change.

Wires the **4 events that were registered with Claude Code but had no listener** (a silent no-op — their `HookEventBridge` handlers already existed, just unreachable):
- `StopFailure` → "Retry?" question card (no `agent_id` drop)
- `PostToolUseFailure` → "<tool> failed" status (`agent_id`-dropped — a subagent's failure must not flip main's status)
- `SubagentStart`/`SubagentStop` → status breadcrumb (`subagent:<type>` / `thinking`), admit-only (NOT `agent_id`-dropped, since these events are *defined* by `agent_id`)

Each follows the existing listener template exactly (binder-drives-first → admit gate → per-event policy).

Closes #465
Part of epic #453

## Test plan
- [x] typecheck + biome clean
- [x] Characterization suite unchanged except the listener-count test (7→11, the proof the wiring landed)
- [x] 5 new tests: each event's fan-out + the admit gate (foreign session_id dropped) + the `agent_id` split policy
- [x] Shadow differential + drive-mode + transcript suites unaffected (44 pass); 163 tests total