### PR TITLE
Phase 5: Adapter Gap A — eliminate relay/telegram silent message drops

### DIFF
--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -12,15 +12,20 @@ import { generateId, now } from '@remi/shared';
 import type {
   AgentOutputMessage,
   AgentStatus,
+  DaemonUpdateAvailableMessage,
   EditMessage,
   ErrorMessage,
   HelloAckMessage,
+  KillSessionResponseMessage,
   Message,
   ProtocolMessage,
   Question,
   QuestionMessage,
   ReplayBatchMessage,
+  ResumeSessionResponseMessage,
+  SessionHistoryResponseMessage,
   SessionListResponseMessage,
+  SessionRotatedMessage,
   SessionUpdateMessage,
   StructuredAgentOutputMessage,
   TranscriptContentMessage,
@@ -440,15 +445,108 @@ export class TelegramAdapter implements ConnectionAdapter {
         return true;
       }
 
-      // Messages that don't need Telegram rendering
+      case 'kill_session_response': {
+        const kill = message as KillSessionResponseMessage;
+        const killSession = this.getSession(connectionId);
+        if (killSession && this.bot) {
+          const text = kill.success
+            ? 'Session stopped.'
+            : `Session stop failed: ${kill.error ?? 'unknown error'}`;
+          this.bot.api
+            .sendMessage(killSession.chatId, text, {
+              message_thread_id: killSession.topicId,
+            })
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'resume_session_response': {
+        const resume = message as ResumeSessionResponseMessage;
+        const resumeSession = this.getSession(connectionId);
+        if (resumeSession && this.bot) {
+          const text = resume.success
+            ? `Resumed session ${resume.sessionId ?? '(unknown id)'}.`
+            : `Resume failed: ${resume.error ?? 'unknown error'}`;
+          this.bot.api
+            .sendMessage(resumeSession.chatId, text, {
+              message_thread_id: resumeSession.topicId,
+            })
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'session_rotated': {
+        const rotated = message as SessionRotatedMessage;
+        const rotatedSession = this.getSession(connectionId);
+        if (rotatedSession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              rotatedSession.chatId,
+              `Session restarted (${rotated.reason}). New Claude session id: ${rotated.newClaudeSessionId}`,
+              { message_thread_id: rotatedSession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'daemon_update_available': {
+        const update = message as DaemonUpdateAvailableMessage;
+        const updateSession = this.getSession(connectionId);
+        if (updateSession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              updateSession.chatId,
+              `A newer remi is on disk. Restart this session to pick up the update (current: ${update.currentVersion}).`,
+              { message_thread_id: updateSession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'session_history_response': {
+        const history = message as SessionHistoryResponseMessage;
+        const historySession = this.getSession(connectionId);
+        if (historySession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              historySession.chatId,
+              `History: ${history.directories.length} recent directories. Open the app for detail.`,
+              { message_thread_id: historySession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      // Messages that don't need Telegram rendering.
+      // N/A on Telegram: no PTY/attach/wire-auth; content surfaces via other branches.
       case 'create_session_response':
       case 'ping':
       case 'pong':
       case 'ack':
       case 'bullet_expand_response':
+      case 'detach_session_ack':
+      case 'raw_pty_output':
+      case 'auth_challenge':
+      case 'auth_result':
         return true;
 
       default:
+        console.warn(`TelegramAdapter: unhandled outbound message type "${message.type}"`);
         return false;
     }
   }

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -14,7 +14,13 @@
  *   peer-connected -> auth_challenge -> auth_response -> auth_result -> onConnect
  */
 
-import { createAgentOutput, createAuthResult, createQuestion, generateId } from '@remi/shared';
+import {
+  createAgentOutput,
+  createAuthResult,
+  createError,
+  createQuestion,
+  generateId,
+} from '@remi/shared';
 import type {
   AgentStatus,
   AuthResponseMessage,
@@ -332,11 +338,56 @@ export class RelayAdapter implements ConnectionAdapter {
         }
         this.events.onTerminalResize?.(connectionId, msg['cols'], msg['rows']);
         break;
+      case 'kill_session_request':
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid kill_session_request payload: missing sessionId or id');
+          return;
+        }
+        this.events.onKillSessionRequest?.(connectionId, msg['sessionId'], msg['id']);
+        break;
+      case 'detach_session':
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid detach_session payload: missing sessionId or id');
+          return;
+        }
+        this.events.onDetachSession?.(connectionId, msg['sessionId'], msg['id']);
+        break;
+      case 'session_history_request': {
+        if (typeof msg['id'] !== 'string') {
+          console.warn('Invalid session_history_request payload: missing id');
+          return;
+        }
+        const limit = typeof msg['limit'] === 'number' ? msg['limit'] : undefined;
+        this.events.onSessionHistoryRequest?.(connectionId, msg['id'], limit);
+        break;
+      }
+      case 'register_device_token':
+        if (typeof msg['token'] !== 'string') {
+          console.warn('Invalid register_device_token payload: missing token');
+          return;
+        }
+        if (msg['platform'] !== 'ios' && msg['platform'] !== 'android') {
+          console.warn('Invalid register_device_token payload: platform must be ios or android');
+          return;
+        }
+        this.events.onRegisterDeviceToken?.(connectionId, msg['token'], msg['platform']);
+        break;
+      case 'ping':
+        // Liveness ping needs no reply over relay.
+        break;
       case 'hello':
         // Hello is handled at connection level, not message level
         break;
       default:
         console.warn(`Unknown relay message type: ${msg['type']}`);
+        this.client?.sendRelay(
+          JSON.stringify(
+            createError(
+              'UNSUPPORTED',
+              `Message type '${String(msg['type'])}' is not supported over relay`,
+            ),
+          ),
+        );
     }
   }
 

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -22,6 +22,21 @@ function makeAdapter(events: object): RelayAdapter {
   return adapter;
 }
 
+/**
+ * Inject a fake SignalingClient whose `sendRelay` records every payload.
+ * routeMessage's default (rejection) branch routes through `this.client?.sendRelay`,
+ * which is the same seam the real adapter uses for challenges/auth results.
+ */
+function attachSendRelaySpy(adapter: RelayAdapter): string[] {
+  const sent: string[] = [];
+  (adapter as unknown as { client: { sendRelay: (p: string) => void } }).client = {
+    sendRelay: (payload: string) => {
+      sent.push(payload);
+    },
+  };
+  return sent;
+}
+
 function callRoute(adapter: RelayAdapter, msg: Record<string, unknown>): void {
   (adapter as unknown as { routeMessage: (m: Record<string, unknown>) => void }).routeMessage(msg);
 }
@@ -127,5 +142,123 @@ describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+});
+
+describe('relay-adapter routeMessage no-longer-silently-drops requests (#453 phase 5)', () => {
+  const RID = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+  test('kill_session_request dispatches onKillSessionRequest with sessionId + requestId', () => {
+    const calls: Array<{ connectionId: UUID; sessionId: UUID; requestId: UUID }> = [];
+    const adapter = makeAdapter({
+      onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
+        calls.push({ connectionId, sessionId, requestId });
+      },
+    });
+
+    callRoute(adapter, { type: 'kill_session_request', sessionId: SID, id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.sessionId).toBe(SID);
+    expect(calls[0]?.requestId).toBe(RID);
+  });
+
+  test('detach_session dispatches onDetachSession with sessionId + requestId', () => {
+    const calls: Array<{ connectionId: UUID; sessionId: UUID; requestId: UUID }> = [];
+    const adapter = makeAdapter({
+      onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
+        calls.push({ connectionId, sessionId, requestId });
+      },
+    });
+
+    callRoute(adapter, { type: 'detach_session', sessionId: SID, id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.sessionId).toBe(SID);
+    expect(calls[0]?.requestId).toBe(RID);
+  });
+
+  test('session_history_request dispatches onSessionHistoryRequest with requestId + limit', () => {
+    const calls: Array<{ connectionId: UUID; requestId: UUID; limit: number | undefined }> = [];
+    const adapter = makeAdapter({
+      onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {
+        calls.push({ connectionId, requestId, limit });
+      },
+    });
+
+    callRoute(adapter, { type: 'session_history_request', id: RID, limit: 5 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.requestId).toBe(RID);
+    expect(calls[0]?.limit).toBe(5);
+  });
+
+  test('session_history_request without limit forwards undefined', () => {
+    const calls: Array<{ limit: number | undefined }> = [];
+    const adapter = makeAdapter({
+      onSessionHistoryRequest: (_c: UUID, _r: UUID, limit: number | undefined) => {
+        calls.push({ limit });
+      },
+    });
+
+    callRoute(adapter, { type: 'session_history_request', id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.limit).toBeUndefined();
+  });
+
+  test('register_device_token with valid platform dispatches onRegisterDeviceToken', () => {
+    const calls: Array<{ connectionId: UUID; token: string; platform: 'ios' | 'android' }> = [];
+    const adapter = makeAdapter({
+      onRegisterDeviceToken: (connectionId: UUID, token: string, platform: 'ios' | 'android') => {
+        calls.push({ connectionId, token, platform });
+      },
+    });
+
+    callRoute(adapter, { type: 'register_device_token', token: 'abc123', platform: 'ios' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.token).toBe('abc123');
+    expect(calls[0]?.platform).toBe('ios');
+  });
+
+  test('register_device_token with invalid platform is NOT dispatched', () => {
+    const calls: Array<{ token: string }> = [];
+    const adapter = makeAdapter({
+      onRegisterDeviceToken: (_c: UUID, token: string) => {
+        calls.push({ token });
+      },
+    });
+
+    callRoute(adapter, { type: 'register_device_token', token: 'abc123', platform: 'windows' });
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test('unknown type now rejects via sendRelay with error + UNSUPPORTED (no silent drop)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'bogus_request', id: RID });
+
+    expect(sent).toHaveLength(1);
+    const parsed = JSON.parse(sent[0] as string);
+    expect(parsed.type).toBe('error');
+    expect(parsed.code).toBe('UNSUPPORTED');
+    expect(typeof parsed.message).toBe('string');
+    expect(parsed.message).toContain('bogus_request');
+  });
+
+  test('ping is an explicit no-op: no rejection emitted', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'ping', id: RID });
+
+    expect(sent).toHaveLength(0);
   });
 });

--- a/packages/daemon/tests/telegram-adapter.test.ts
+++ b/packages/daemon/tests/telegram-adapter.test.ts
@@ -6,19 +6,25 @@
  * the adapter object directly.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import type {
   AgentOutputMessage,
+  DaemonUpdateAvailableMessage,
   ErrorMessage,
   HelloAckMessage,
+  KillSessionResponseMessage,
   ProtocolMessage,
   QuestionMessage,
   ReplayBatchMessage,
+  ResumeSessionResponseMessage,
+  SessionHistoryResponseMessage,
   SessionListResponseMessage,
+  SessionRotatedMessage,
   SessionUpdateMessage,
   StructuredAgentOutputMessage,
   TranscriptContentMessage,
   TranscriptLoadCompleteMessage,
+  UUID,
 } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { AdapterEvents } from '../src/adapters/connection-adapter.ts';
@@ -36,6 +42,58 @@ function createAdapter(events: Partial<AdapterEvents> = {}): TelegramAdapter {
 }
 
 const unknownConnectionId = generateId();
+
+/** Minimal grammY bot/api stub with a sendMessage spy. */
+interface SendMessageSpy {
+  (chatId: number, text: string, opts?: unknown): Promise<{ message_id: number }>;
+  mock: { calls: unknown[][] };
+}
+
+/**
+ * Register a session on the adapter with a stubbed bot so render cases that
+ * call `bot.api.sendMessage` can be observed. Reaches into private fields the
+ * same way the production code populates them in handleStart().
+ */
+function withBoundSession(events: Partial<AdapterEvents> = {}): {
+  adapter: TelegramAdapter;
+  connectionId: UUID;
+  sendMessage: SendMessageSpy;
+} {
+  const adapter = createAdapter(events);
+  const sendMessage = mock(async () => ({ message_id: 1 })) as unknown as SendMessageSpy;
+
+  const internal = adapter as unknown as {
+    bot: { api: { sendMessage: SendMessageSpy } };
+    sessions: Map<string, Record<string, unknown>>;
+    connectionToSession: Map<UUID, string>;
+  };
+
+  internal.bot = { api: { sendMessage } };
+
+  const connectionId = generateId();
+  const chatId = 100;
+  const topicId = 200;
+  const sessionKey = `${chatId}:${topicId}`;
+
+  internal.sessions.set(sessionKey, {
+    connectionId,
+    sessionId: generateId(),
+    chatId,
+    topicId,
+    workingDirectory: '/tmp',
+    machineName: 'test-machine',
+    topicName: 'test-topic',
+    sessionNumber: 1,
+    startedAt: now(),
+    currentMessageId: undefined,
+    streamBuffer: '',
+    lastSentContent: '',
+    paused: false,
+  });
+  internal.connectionToSession.set(connectionId, sessionKey);
+
+  return { adapter, connectionId, sendMessage };
+}
 
 describe('TelegramAdapter constructor defaults', () => {
   test('connectionCount is 0 before any sessions', () => {
@@ -308,14 +366,157 @@ describe('sendRaw routing', () => {
     expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
   });
 
-  test('unknown type returns false', () => {
+  test('unknown type returns false and emits a warn', () => {
     const adapter = createAdapter();
     const msg = {
       type: 'totally_unknown_type',
       id: generateId(),
       timestamp: now(),
     } as unknown as ProtocolMessage;
-    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+
+    const originalWarn = console.warn;
+    const warnSpy = mock((..._args: unknown[]) => {});
+    console.warn = warnSpy as unknown as typeof console.warn;
+    try {
+      expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnSpy.mock.calls.length).toBe(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('totally_unknown_type');
+  });
+
+  test('detach_session_ack returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'detach_session_ack',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      success: true,
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('raw_pty_output returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'raw_pty_output',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      data: 'YmFzZTY0',
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('auth_challenge returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'auth_challenge',
+      id: generateId(),
+      timestamp: now(),
+      challenge: 'abc',
+      serverFingerprint: 'fp',
+      serverPublicKey: 'pk',
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('auth_result returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'auth_result',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+});
+
+describe('sendRaw render cases with a bound session', () => {
+  test('kill_session_response (success) sends a "Session stopped" line', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: KillSessionResponseMessage = {
+      type: 'kill_session_response',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('Session stopped');
+  });
+
+  test('resume_session_response (success) sends a "Resumed session" line with the id', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const resumedId = generateId();
+    const msg: ResumeSessionResponseMessage = {
+      type: 'resume_session_response',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+      sessionId: resumedId,
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    const text = String(sendMessage.mock.calls[0]?.[1]);
+    expect(text).toContain('Resumed session');
+    expect(text).toContain(resumedId);
+  });
+
+  test('session_rotated sends a "Session restarted" line with the new claude id', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const newClaudeId = generateId();
+    const msg: SessionRotatedMessage = {
+      type: 'session_rotated',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      newClaudeSessionId: newClaudeId,
+      newTranscriptPath: '/tmp/new.jsonl',
+      reason: 'clear',
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    const text = String(sendMessage.mock.calls[0]?.[1]);
+    expect(text).toContain('Session restarted');
+    expect(text).toContain(newClaudeId);
+  });
+
+  test('daemon_update_available sends a line with the new version', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: DaemonUpdateAvailableMessage = {
+      type: 'daemon_update_available',
+      id: generateId(),
+      timestamp: now(),
+      currentVersion: '0.9.9',
+      binaryPath: '/opt/homebrew/bin/remi',
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('0.9.9');
+  });
+
+  test('session_history_response sends a best-effort summary line', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: SessionHistoryResponseMessage = {
+      type: 'session_history_response',
+      id: generateId(),
+      timestamp: now(),
+      directories: [
+        { directory: '/a', lastUsed: now(), sessionCount: 2, displayName: 'a' },
+        { directory: '/b', lastUsed: now(), sessionCount: 1, displayName: 'b' },
+      ],
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('2');
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 5 of epic #453. The `AdapterRegistry` broadcast target is non-uniform — capability must be *declared*, never implied by falling through. This eliminates the silent message drops in the relay + telegram adapters.

**Relay** (`8566077`): wired the 4 inbound client requests that fell through `routeMessage`'s default (mirroring the WebSocket path whose `onX` events already existed) — `kill_session_request`, `detach_session`, `session_history_request`, and **`register_device_token`** (the high-value fix: **APNS push for off-LAN relay clients never armed before** because the token never reached the daemon over relay). `ping` is an explicit no-op; the default now returns a structured `createError('UNSUPPORTED')` to the client. No silent drop survives.

**Telegram** (`f3ac9f7`): every outbound type is now classified — real one-line renders for `kill_session_response`/`resume_session_response`/`session_rotated`/`daemon_update_available`/`session_history_response`, explicit `return true` no-ops for the structurally-N/A types (`detach_session_ack`/`raw_pty_output`/`auth_challenge`/`auth_result`, which were `default: return false`), and a loud `console.warn` default for any genuinely-new type.

WebSocket (the reference) + the registry need no change. Gaps B/C (`ConnectionManager` rename, resume-resolver decoupling) are deferred — no behavior change.

Closes #467
Part of epic #453

## Test plan
- [x] typecheck + biome clean
- [x] 51 adapter tests pass (relay-binding 12 + telegram 31 + relay-auth regression 8; 17 new)
- [x] Strictly additive — no already-handled type changed; field names verified against `protocol.ts`

Reviewed by 2 adversarial reviewers (sonnet): no silent drop remains, no regression, no mid-switch throw, field names correct — both clean PASS.