### PR TITLE
Phase 6: delete flag-independent dead code

### DIFF
--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -6,56 +6,20 @@
  * shared `transcriptWatchers` map so other code (status refresh, cleanup,
  * fallback teardown) can find it by session id.
  *
- * `extractClaudeSessionId` is **deprecated** (post-#427/phase 1): the
- * daemon now pre-assigns the Claude session id via `resolveClaudeBinding`
- * before spawn and persists it directly to `SessionStore`, so no
- * filename-based inference is needed. The function is kept only because
- * the test suite still exercises it; remove once tests are migrated.
- *
- * Both helpers are pure over their inputs — no module-level singletons — so
- * tests can supply tmpdir-backed stores and an in-memory Map.
+ * Pure over its inputs — no module-level singletons — so tests can supply
+ * tmpdir-backed stores and an in-memory Map. (The deprecated
+ * `extractClaudeSessionId` filename-inference helper was removed in #469;
+ * the daemon pre-assigns the Claude session id via `resolveClaudeBinding`
+ * before spawn, so no runtime inference is needed.)
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionBindingStore } from '../session/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../transcript/index.ts';
 import type { AssistantEntry } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
-
-export interface ExtractClaudeSessionIdDeps {
-  bindingStore: SessionBindingStore;
-}
-
-/**
- * @deprecated Superseded by `resolveClaudeBinding` (#427/phase 1). The
- * daemon now pre-assigns the Claude session id before spawn; no
- * filename-based inference happens at runtime. Retained only for the
- * legacy test surface; not called from any production code path.
- *
- * Extracts the Claude session id from a transcript filename and persists
- * it. Returns the extracted id, or null if the filename does not expose
- * one. Filenames are plain UUIDs (`abc123-def456.jsonl`); the underscore
- * split is defensive in case a prefixed format is ever introduced.
- */
-export function extractClaudeSessionId(
-  deps: ExtractClaudeSessionIdDeps,
-  transcriptPath: string,
-  sessionId: UUID,
-): string | null {
-  const basename = path.basename(transcriptPath, '.jsonl');
-  const parts = basename.split('_');
-  const candidateId = parts[parts.length - 1];
-  if (candidateId && candidateId.length >= 8) {
-    deps.bindingStore.update(sessionId, candidateId);
-    log(`Claude session ID: ${candidateId}`);
-    return candidateId;
-  }
-  return null;
-}
 
 export interface StartTranscriptWatcherDeps {
   transcriptWatchers: Map<UUID, TranscriptWatcher>;

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -106,59 +106,6 @@ export class TranscriptDiscovery {
   }
 
   /**
-   * @deprecated Superseded by deterministic path construction in
-   * `transcript-fallback.ts:expectedTranscriptPath` (#427/phase 1). The
-   * daemon now knows the bound `.jsonl` path before Claude writes a
-   * single line; no mtime-based discovery is performed at runtime. Only
-   * the test suite still references this method.
-   *
-   * Find the most recent transcript file for a given project directory
-   * by modification time.
-   */
-  findLatestTranscript(projectPath: string): string | null {
-    const transcriptDir = this.getProjectTranscriptDir(projectPath);
-
-    if (!fs.existsSync(transcriptDir)) {
-      return null;
-    }
-
-    const files = this.listJsonlFiles(transcriptDir);
-    if (files.length === 0) {
-      return null;
-    }
-
-    // Sort by modification time, most recent first
-    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-    return files[0]?.filePath ?? null;
-  }
-
-  /**
-   * @deprecated Superseded by deterministic binding (#427/phase 1). The
-   * sibling-exclusion race this guarded against is now structurally
-   * impossible because each daemon writes its claudeSessionId into the
-   * store before spawn. Only the test suite still references this
-   * method.
-   *
-   * Find the most recent transcript for a project, skipping specific
-   * session IDs.
-   */
-  findLatestTranscriptExcluding(projectPath: string, excludeIds: Set<string>): string | null {
-    const transcriptDir = this.getProjectTranscriptDir(projectPath);
-    if (!fs.existsSync(transcriptDir)) return null;
-
-    const files = this.listJsonlFiles(transcriptDir);
-    if (files.length === 0) return null;
-
-    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-    for (const file of files) {
-      if (!excludeIds.has(file.sessionId)) {
-        return file.filePath;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Find a transcript file path by its session ID (the UUID filename without .jsonl).
    * Returns the file path if found, null otherwise.
    */

--- a/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
+++ b/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
@@ -5,12 +5,7 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import type { MessageAPI } from '../../src/api/message-api.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
-import {
-  extractClaudeSessionId,
-  startTranscriptWatcher,
-} from '../../src/cli/transcript-watcher-setup.ts';
-import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
-import { SessionStore } from '../../src/session/session-store.ts';
+import { startTranscriptWatcher } from '../../src/cli/transcript-watcher-setup.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
 const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
@@ -25,58 +20,15 @@ function fakeMessageAPI(): MessageAPI {
 
 describe('transcript-watcher-setup', () => {
   let tmpDir: string;
-  let sessionStore: SessionStore;
-  let bindingStore: SessionBindingStore;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tws-'));
-    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
-    bindingStore = new SessionBindingStore(sessionStore);
     configureLogger({ writeLog: () => {} });
-    // Seed a session so updateClaudeSessionId has a row to update
-    sessionStore.save({
-      remiSessionId: SID,
-      claudeSessionId: null,
-      projectPath: tmpDir,
-      port: 0,
-      pid: null,
-      startedAt: new Date().toISOString(),
-      exitedAt: null,
-      exitCode: null,
-    });
   });
 
   afterEach(() => {
     __resetLoggerForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  describe('extractClaudeSessionId', () => {
-    test('reads UUID from a plain filename and persists it', () => {
-      const claudeId = '11111111-2222-3333-4444-555555555555';
-      const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
-
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-
-      expect(result).toBe(claudeId);
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(claudeId);
-    });
-
-    test('accepts prefixed _UUID filenames (picks the last segment)', () => {
-      const claudeId = '66666666-7777-8888-9999-000000000000';
-      const filePath = path.join(tmpDir, `prefix_${claudeId}.jsonl`);
-
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-
-      expect(result).toBe(claudeId);
-    });
-
-    test('returns null and does not persist when the filename has no usable id', () => {
-      const filePath = path.join(tmpDir, 'ab.jsonl'); // under 8 chars
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-      expect(result).toBeNull();
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBeNull();
-    });
   });
 
   describe('startTranscriptWatcher', () => {

--- a/packages/daemon/tests/transcript-discovery.test.ts
+++ b/packages/daemon/tests/transcript-discovery.test.ts
@@ -184,26 +184,6 @@ describe('TranscriptDiscovery', () => {
     expect(sessions2[0]?.status).toBe('completed');
   });
 
-  test('findLatestTranscript returns most recent file', async () => {
-    const projectDir = makeProjectDir('/Users/test/myproject');
-
-    writeTranscript(projectDir, 'old-session', [makeUserEntry('old')]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    writeTranscript(projectDir, 'new-session', [makeUserEntry('new')]);
-
-    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
-    const latest = discovery.findLatestTranscript('/Users/test/myproject');
-
-    expect(latest).toContain('new-session.jsonl');
-  });
-
-  test('findLatestTranscript returns null for unknown project', () => {
-    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
-    const latest = discovery.findLatestTranscript('/nonexistent/project');
-
-    expect(latest).toBeNull();
-  });
-
   test('handles empty projects directory', () => {
     const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
     const sessions = discovery.discoverSessions();


### PR DESCRIPTION
## Summary

Phase 6 (scoped) of epic #453. Deletes the deprecated, genuinely-unused helpers from the design's §6 phase-6 list — the flag-INDEPENDENT subset that is safe to remove now:
- `extractClaudeSessionId` + `ExtractClaudeSessionIdDeps` — `@deprecated` since #427 (the daemon pre-assigns the Claude id via `resolveClaudeBinding`); only caller was its own test.
- `TranscriptDiscovery.findLatestTranscript` / `findLatestTranscriptExcluding` — `@deprecated` since #427; `findLatestTranscript` test-only, the `Excluding` variant had zero callers.

Pure deletion (−157 net). The flag-DEPENDENT bulk (the old `initFromHookEvent`/`onSessionInfo`/`filterBySession` paths — still the active production driver until the TranscriptBinder flag flips to drive-by-default — plus the `HookRouter` formalization) is tracked as **#470**, gated on the production shadow soak.

Closes #469
Part of epic #453

## Test plan
- [x] Grep confirms **zero** remaining callers (production + tests)
- [x] typecheck + biome clean
- [x] 136 transcript + session-phases tests pass

Verified pure-deletion of dead code (no callers; all green) — the verification is the review.