### PR TITLE
fix(daemon): per-process tmp path for sessions.json write (#461)

### DIFF
--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -79,9 +79,25 @@ export class SessionStore {
   private write(sessions: StoredSession[]): void {
     this.ensureDir();
     const data: SessionsFile = { version: 1, sessions };
-    const tmpPath = `${this.filePath}.tmp`;
+    // Per-writer-unique tmp path. A fixed `${filePath}.tmp` shared across
+    // processes is a multi-writer race (#461): when two daemons in the same
+    // ~/.remi write concurrently, both target the same tmp file and whichever
+    // renames second hits ENOENT because the first already moved it away.
+    // The pid scopes the tmp per process; the synchronous write+rename
+    // serialize within a process, so the pid alone makes collisions impossible.
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
     fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-    fs.renameSync(tmpPath, this.filePath);
+    try {
+      fs.renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      // Don't leave our tmp file behind if the rename fails.
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        // best-effort cleanup; surface the original error
+      }
+      throw err;
+    }
   }
 
   /** Save or update a session record. Trims to MAX_SESSIONS. */

--- a/packages/daemon/tests/session/session-store-concurrency.test.ts
+++ b/packages/daemon/tests/session/session-store-concurrency.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Regression test for #461: two daemons sharing one ~/.remi raced on a fixed
+ * `sessions.json.tmp` path — whichever process renamed second hit ENOENT
+ * because the other had already moved the shared tmp away. The fix scopes the
+ * tmp file per process (`sessions.json.<pid>.tmp`), so concurrent writers can
+ * never collide. This drives REAL concurrent subprocesses (no mocks): on the
+ * pre-fix code some workers crash with ENOENT; with the fix all exit cleanly.
+ */
+describe('SessionStore multi-process concurrency (#461)', () => {
+  let filePath: string;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-store-conc-'));
+    filePath = path.join(dir, 'sessions.json');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('concurrent writers never crash on the tmp-rename race', async () => {
+    const worker = path.join(import.meta.dir, 'store-concurrency-worker.ts');
+    const WORKERS = 6;
+    const ITERATIONS = 60;
+
+    const procs = Array.from({ length: WORKERS }, () =>
+      Bun.spawn(['bun', worker, filePath, String(ITERATIONS)], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }),
+    );
+
+    const results = await Promise.all(
+      procs.map(async (proc, i) => ({ i, code: await proc.exited, proc })),
+    );
+
+    // Surface the first crashing worker's stderr for a useful failure message.
+    for (const { i, code, proc } of results) {
+      if (code !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`worker ${i} exited with code ${code}: ${stderr.trim()}`);
+      }
+    }
+    expect(results.every((r) => r.code === 0)).toBe(true);
+
+    // The final file must be intact and valid (no torn write).
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw) as { version: number; sessions: unknown[] };
+    expect(data.version).toBe(1);
+    expect(Array.isArray(data.sessions)).toBe(true);
+    expect(data.sessions.length).toBeGreaterThan(0);
+
+    // Every writer completes its rename, so no per-process tmp files linger.
+    const leftovers = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  }, 30000);
+});

--- a/packages/daemon/tests/session/store-concurrency-worker.ts
+++ b/packages/daemon/tests/session/store-concurrency-worker.ts
@@ -1,0 +1,34 @@
+// Worker process for session-store-concurrency.test.ts. NOT a test file
+// (its name does not match the bun test glob). It hammers a shared
+// sessions.json via SessionStore.save() so the test can exercise the
+// multi-writer tmp-rename race (#461) with REAL concurrent processes.
+//
+// Usage: bun store-concurrency-worker.ts <sessionsFilePath> <iterations>
+import type { UUID } from '@remi/shared';
+import { SessionStore } from '../../src/session/session-store.ts';
+
+const filePath = process.argv[2];
+const iterations = Number(process.argv[3]) || 50;
+
+if (!filePath) {
+  process.stderr.write('worker: missing sessions file path\n');
+  process.exit(2);
+}
+
+const store = new SessionStore(filePath);
+const workerTag = crypto.randomUUID();
+
+for (let i = 0; i < iterations; i++) {
+  store.save({
+    remiSessionId: crypto.randomUUID() as UUID,
+    claudeSessionId: `claude-${workerTag}-${i}`,
+    projectPath: '/tmp/concurrency-project',
+    port: 18000 + (i % 200),
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

Fixes the multi-writer race in `SessionStore.write()` (#461). The atomic write used a **fixed, shared** tmp path (`sessions.json.tmp`), so two daemons in the same `~/.remi` writing concurrently both targeted the same tmp file — whichever called `renameSync` second hit `ENOENT` because the first had already moved the shared tmp away, crashing a daemon at startup:

```
Failed to create session: ENOENT: no such file or directory,
rename '/Users/.../.remi/sessions.json.tmp' -> '/Users/.../.remi/sessions.json'
```

The fix scopes the tmp file per process (`sessions.json.<pid>.tmp`) and removes the tmp on rename failure. The pid makes the tmp path collision-free across processes; the synchronous write+rename serialize within a process.

Surfaced concretely during the post-merge e2e validation of epic #453 (two daemons started within ~ms of each other in the same cwd). Pre-existing and independent of the binder flag.

## Test plan

- New **real multi-process** test `session-store-concurrency.test.ts` (no mocks): spawns 6 subprocesses each doing 60 `save()`s against one shared file.
  - On the **pre-fix** code it fails with the exact `ENOENT … rename 'sessions.json.tmp'`.
  - On the **fix** it passes; asserts a valid final file and no leftover `.tmp` files.
- `bun run typecheck` clean; `bunx biome check` clean; existing `session-store` suite (47 tests) green.

Closes #461