### PR TITLE
test(e2e): real-claude transcript-binding validation harness

### DIFF
--- a/tests/e2e/transcript-binding/README.md
+++ b/tests/e2e/transcript-binding/README.md
@@ -1,0 +1,65 @@
+# Transcript-binding e2e harness
+
+A **manual / semi-automated** end-to-end harness that drives **real `claude`
+sessions** under a **real remi daemon** and validates the session-binding +
+transcript-watcher subsystem (the TranscriptBinder, epic #453) against the
+historical failure modes.
+
+Unlike `tests/integration/` (Docker, cross-machine `ls`/`attach` lifecycle) and
+`tests/e2e/specs/` (Playwright web UI), this harness exercises the part that
+needs a live model: a real `claude` writing real transcripts and rotating them
+via `/clear` and `/compact`, observed from a separate client the way the phone
+would.
+
+It is **not wired into CI** — it needs an authenticated `claude` and a trusted
+working directory, and it drives a TUI with timing-sensitive input. Run it by
+hand when changing the binding/rotation code or before flipping the binder flag.
+
+## What it validates
+
+| Scenario | Failure modes | Key checks |
+|---|---|---|
+| 1. Shadow (shipping default) | fm-430, fm-438, fm-435b, GAP-6 | binding correct; **0 `[ShadowBinder] DISAGREE`** on a normal session and across a `/clear`; rotation announced once; follow-up routes to the new transcript; old transcript frozen; `/compact` does not rotate |
+| 2. Drive (the binder itself) | fm-452, fm-438, GAP-6 | binder drives the bind (shadow suppressed); `/clear` caught by the **new re-arming dir-poll** (`No-hooks rotation detected via dir poll`), rebound + watcher rearmed; no "Transcript not found"; `/compact` does not over-fire the dir-poll |
+| 3. Two daemons, same cwd | fm-427, fm-451 | distinct binds, content segregated (ALPHA↔D1, BETA↔D2), per-port `remi:<port>` markers; zombie sibling (dead claude child, live wrapper) does **not** poison the other daemon's binding |
+
+See `failure-mode-matrix.md` for the full per-mode repro + oracle reference and
+the two non-negotiable traps (assert the on-disk id actually changed; in the
+zombie variant kill the inner claude child, never the wrapper).
+
+## Prerequisites
+
+1. **A remi binary built from the branch under test:**
+   ```bash
+   bun build --compile --outfile=/tmp/remi-tb/remi packages/daemon/src/cli.ts
+   ```
+2. **An authenticated `claude`** (`claude -p "say OK" --model haiku` returns).
+3. **A claude-trusted working directory.** claude shows a one-time
+   "Do you trust the files in this folder?" dialog in a new directory, which
+   blocks an unattended session. Use a directory you have already opened claude
+   in (`hasTrustDialogAccepted: true` in `~/.claude.json`). Trust is keyed by
+   path, so an already-trusted scratch path can be recreated and reused. Do
+   **not** disable the permission framework to work around this.
+
+## Run
+
+```bash
+REMI_BIN=/tmp/remi-tb/remi \
+E2E_TRUSTED=/private/tmp/your-trusted-scratch-dir \
+  tests/e2e/transcript-binding/run.sh
+```
+
+Exit code = number of failed checks. Daemon logs and the captured client
+renders are left in the printed `E2E_STATE` dir for inspection.
+
+## How it works (notes for maintainers)
+
+- `--daemon` mode does **not** forward `claude` args, so the model is set via
+  `ANTHROPIC_MODEL=haiku` (the daemon's env is merged into the claude PTY).
+- The driver is a persistent `remi attach` whose stdin is a FIFO held open by a
+  background `sleep`; it is both the input channel and the observer (the real
+  client path). claude's composer treats the first burst as a bracketed paste,
+  so a prompt is submitted with a **separate** Enter keystroke.
+- The oracle is the daemon log: `[ShadowBinder] DISAGREE` (shadow), the
+  `[Binder] …` rotation lines (drive), and `owned by port X, not Y; ignoring`
+  (marker-based sibling/zombie defer), plus the on-disk `<id>.jsonl` files.

--- a/tests/e2e/transcript-binding/failure-mode-matrix.md
+++ b/tests/e2e/transcript-binding/failure-mode-matrix.md
@@ -1,0 +1,56 @@
+# Transcript-binding failure-mode matrix
+
+Reference for the e2e harness: each historical failure mode, how to reproduce it
+with a real `claude` under remi, and the exact PASS/FAIL oracle. Distilled from
+the epic #453 bug history (#321, #427/#428, #429/#430/#433, #438, #451, #452,
+#435) and validated against the merged binder.
+
+## The oracle
+
+The shadow binder (`REMI_TRANSCRIPT_BINDER_SHADOW=true`) computes decisions
+alongside the live old path and logs `[ShadowBinder] DISAGREE <event>: <diffs>`
+on any divergence in three fields only: durable-store **boundId**, **rotation**
+emitted-this-event, **watcherPath** (advisory). Silent on agreement. It is
+**hook-fed only** — silent when hooks are down.
+
+`[ShadowBinder] DISAGREE` is a valid pass/fail signal **only** for:
+- **fm-438** — `rotation binder=false old=true` on the duplicate-carrying event (binder dedups the old path's double-emit).
+- **fm-430** — `rotation binder=true old=false` on the `/clear` SessionStart when the store raced ahead of the hook.
+- **fm-451** — `boundId binder=<new> old=<old>` when the old path defers on a false-live zombie sibling and the binder rebinds.
+
+It is **silent-by-design / not a bug** for fm-321 (no field captures admit-vs-drop), fm-427 (`watcherPath` is advisory; deterministic binding already agrees), and **structurally blind** for fm-452 (the dir-poll is disabled in shadow). Those are **drive-mode** validations.
+
+## Two non-negotiable traps
+
+1. **Assert the on-disk `<id>.jsonl` actually changed (B ≠ A) before scoring.** A
+   reused/`/compact` session id makes `isRotation` false and the classifier
+   short-circuits to `match` (`session-lock-classifier.ts`) — the code under
+   test never runs and the test passes for the wrong reason.
+2. **In any zombie variant, kill the inner `claude` child PID only, never the
+   remi wrapper.** `pkill remi` self-reaps the sibling and the wedge never forms
+   (vacuous). The zombie is: live remi pid + dead `claudeChildPid`.
+
+## Per-mode summary
+
+| Mode | Symptom (pre-epic) | Trigger | Oracle | Flag |
+|---|---|---|---|---|
+| **fm-321** sibling hook-lock cached | a daemon goes permanently deaf to its own claude with a sibling in the dir; killing the sibling never recovers it | two daemons same cwd; kill sibling; permission in survivor | drive: survivor processes its own PermissionRequest after sibling dies (shadow silent here) | drive |
+| **fm-427** cross-bind | daemon-B answers a question claude-A asked; "messages not from this session" | two daemons same cwd, fresh bindings | each binds its own `<uuid>.jsonl`; content segregated; co-located events classify `foreign` | both |
+| **fm-430** binding drift / STALE_BINDING | after `/clear`, second client stuck on old id, no `session_rotated` | single daemon; `/clear` (store pre-assigns new id before SessionStart) | shadow: `DISAGREE SessionStart rotation binder=true old=false`; drive: one `session_rotated`, binding updates | both |
+| **fm-438** double-emit | chat clears/reloads twice; or a stale re-emit re-binds to the dead id → STALE_BINDING | `/clear`, or kill+resume (store-race ordering), or A→B→A re-resume | exactly one rotation per A→B; shadow `DISAGREE rotation binder=false old=true` on the duplicate event | both |
+| **fm-451** zombie poisons sibling-defer | long session returns "Transcript for session not found" after `/clear`; log floods `Dropped foreign` | two daemons same cwd; kill one's inner claude child; `/clear` the other | victim rebinds + streams; `owned by port X, not Y; ignoring`; no "not found" | both |
+| **fm-452** no-hooks / slow-flush wedge | `/clear` with hooks down → locked-but-unwatched → "Transcript for session not found" | single daemon, hooks down; `/clear`; follow-up | drive: `[Binder] No-hooks rotation detected via dir poll`, watcher rearmed | **drive only** |
+| **fm-435** (a/c/d) false-positive questions, multi-question, fails-to-connect | phantom question cards; one question slot; retries a dead port | numbered-list prompt; concurrent subagent+main permission; occupy default port then attach | flag-independent (epic #435 phases 1/2/4); binder must be **inert** (no `[Binder]`/`[ShadowBinder]` lines) | off |
+
+## Minimal run order
+
+1. Two daemons, same cwd, **shadow** — fm-427 race + fm-451 zombie shadow leg.
+2. Two daemons, same cwd, **drive** — fm-427 + fm-451 + fm-321 recovery end-to-end.
+3. Single daemon, hooks up, **shadow**, one long session — fm-430 + fm-438 + A→B→A + `/compact` negative.
+4. Single daemon, hooks up, **drive**, one long session — the same, end-to-end + the positive binding invariant + the newly-wired dropped hooks.
+5. Single daemon, hooks **down**, **drive** — fm-452 (the only run exercising the dir-poll; highest value, lowest redundancy).
+6. Single daemon, binder **off** — fm-435 a/c/d (binder must be inert).
+
+`run.sh` implements a practical subset (shadow + drive single-daemon, and the
+two-daemon cross-bind/zombie). The hooks-down (5) and binder-off (6) legs are
+documented here for manual execution.

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Transcript-binding e2e harness primitives.
+#
+# Drives REAL `claude` sessions under a real remi daemon and observes binding,
+# rotation, and persistence the way a remi client (the phone) would. This is a
+# MANUAL / semi-automated harness: it needs a real authenticated `claude` and a
+# trusted working directory. It is NOT wired into CI (see README.md).
+#
+# Source this in a scenario script. Required env (see README):
+#   REMI_BIN       path to the remi binary to test (built from the branch)
+#   E2E_TRUSTED    a claude-trusted working dir (hasTrustDialogAccepted=true)
+# Optional:
+#   E2E_STATE      scratch dir for logs/pids/fifos (default: mktemp -d)
+
+set -uo pipefail
+
+REMI_BIN="${REMI_BIN:?set REMI_BIN to the remi binary under test}"
+E2E_TRUSTED="${E2E_TRUSTED:?set E2E_TRUSTED to a claude-trusted working dir}"
+E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tbe2e-XXXXXX")}"
+mkdir -p "$E2E_STATE"
+
+# Strip ANSI/OSC so logs and renders are greppable.
+deansi() { sed -E 's/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\x1b\][0-9;]*\x07//g; s/\r//g'; }
+
+# start_daemon NAME CWD PORT MODE(shadow|drive|off)
+# Launches a daemon with ANTHROPIC_MODEL=haiku (claude --model is not forwarded
+# by --daemon, but the daemon's env is, and claude honours ANTHROPIC_MODEL).
+start_daemon() {
+  local name=$1 cwd=$2 port=$3 mode=$4
+  local log="$E2E_STATE/$name.log"
+  rm -f "$log"
+  local sh=false dr=false
+  case "$mode" in
+    shadow) sh=true ;;
+    drive)  dr=true ;;
+    off)    : ;;
+  esac
+  cat > "$E2E_STATE/launch-$name.sh" <<LAUNCH
+#!/usr/bin/env bash
+cd "$cwd"
+exec "$REMI_BIN" --daemon --bind 127.0.0.1 --port $port --no-auth --no-relay --no-mdns
+LAUNCH
+  chmod +x "$E2E_STATE/launch-$name.sh"
+  ANTHROPIC_MODEL=haiku \
+  REMI_TRANSCRIPT_BINDER_SHADOW=$sh \
+  REMI_TRANSCRIPT_BINDER_ENABLED=$dr \
+    nohup bash "$E2E_STATE/launch-$name.sh" > "$log" 2>&1 &
+  echo "$!" > "$E2E_STATE/$name.pid"
+  echo "$port" > "$E2E_STATE/$name.port"
+  echo "daemon[$name] pid=$(cat "$E2E_STATE/$name.pid") port=$port mode=$mode log=$log"
+}
+
+wait_ready() {
+  local name=$1 secs=${2:-20}
+  local log="$E2E_STATE/$name.log"
+  local i
+  for ((i = 0; i < secs; i++)); do
+    grep -q "Remi daemon ready" "$log" 2>/dev/null && return 0
+    kill -0 "$(cat "$E2E_STATE/$name.pid")" 2>/dev/null || { echo "daemon[$name] DIED"; tail -8 "$log"; return 1; }
+    sleep 1
+  done
+  echo "daemon[$name] not ready in ${secs}s"; tail -8 "$log"; return 1
+}
+
+# Session id/name as `remi ls` reports it (one daemon = one session).
+session_id() {
+  "$REMI_BIN" ls --host 127.0.0.1 --port "$1" 2>/dev/null | deansi \
+    | grep -iE 'active|idle|orphan|starting|available' | awk '{print $1}' | head -1
+}
+
+# attach_start NAME PORT SESSION
+# Persistent FIFO-driven `remi attach` acting as BOTH input driver and observer
+# (this is literally how a remi client drives claude). A holder keeps the FIFO
+# write-end open so the attach never sees EOF across multiple sends.
+attach_start() {
+  local name=$1 port=$2 session=$3
+  local fifo="$E2E_STATE/$name.fifo" render="$E2E_STATE/$name.render"
+  rm -f "$fifo" "$render"; mkfifo "$fifo"
+  nohup sleep 100000 > "$fifo" 2>/dev/null &
+  echo "$!" > "$E2E_STATE/$name.holder.pid"
+  nohup "$REMI_BIN" attach "$session" --host 127.0.0.1 --port "$port" < "$fifo" > "$render" 2>&1 &
+  echo "$!" > "$E2E_STATE/$name.attach.pid"
+}
+
+# Type text then submit with a SEPARATE Enter. claude's composer treats the
+# initial burst as a bracketed paste, so an inline \r is NOT a submit; the
+# standalone Enter (a distinct write) is what submits.
+prompt() {
+  local name=$1; shift
+  printf '%s' "$*" > "$E2E_STATE/$name.fifo"
+  sleep 0.5
+  printf '\r' > "$E2E_STATE/$name.fifo"
+}
+enter() { printf '\r' > "$E2E_STATE/$1.fifo"; }
+
+attach_stop() {
+  local name=$1
+  kill "$(cat "$E2E_STATE/$name.attach.pid" 2>/dev/null)" 2>/dev/null
+  kill "$(cat "$E2E_STATE/$name.holder.pid" 2>/dev/null)" 2>/dev/null
+}
+
+stop_daemon() {
+  local name=$1
+  kill -TERM "$(cat "$E2E_STATE/$name.pid" 2>/dev/null)" 2>/dev/null
+  local i
+  for ((i = 0; i < 8; i++)); do kill -0 "$(cat "$E2E_STATE/$name.pid" 2>/dev/null)" 2>/dev/null || break; sleep 0.5; done
+  pkill -f "remi:$(cat "$E2E_STATE/$name.port" 2>/dev/null)" 2>/dev/null || true
+}
+
+# claude encodes the cwd into the transcript dir: / -> -
+tdir_for() { echo "$HOME/.claude/projects/$(echo "$1" | sed 's#/#-#g')"; }
+
+# Newest transcript in CWD carrying THIS daemon's `remi:<port>` head marker.
+# Prints "<claudeId> <path>"; non-zero if none.
+bound_transcript() {
+  local cwd=$1 port=$2 td f
+  td=$(tdir_for "$cwd")
+  # Newest-first by mtime; filenames are controlled `<uuid>.jsonl` (no spaces).
+  # shellcheck disable=SC2045
+  for f in $(ls -t "$td"/*.jsonl 2>/dev/null); do
+    if head -c 4000 "$f" 2>/dev/null | grep -q "remi:$port"; then
+      echo "$(basename "$f" .jsonl) $f"; return 0
+    fi
+  done
+  return 1
+}
+
+# Wait until a daemon binds a transcript with >= MINLINES lines. Prints id.
+wait_bound() {
+  local cwd=$1 port=$2 minlines=${3:-8} secs=${4:-100} i bt cid f
+  for ((i = 0; i < secs; i += 2)); do
+    if bt=$(bound_transcript "$cwd" "$port" 2>/dev/null); then
+      cid=$(echo "$bt" | awk '{print $1}'); f=$(echo "$bt" | awk '{print $2}')
+      [ "$(wc -l < "$f" 2>/dev/null || echo 0)" -ge "$minlines" ] && { echo "$cid"; return 0; }
+    fi
+    sleep 2
+  done
+  return 1
+}

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -16,7 +16,7 @@ set -uo pipefail
 
 REMI_BIN="${REMI_BIN:?set REMI_BIN to the remi binary under test}"
 E2E_TRUSTED="${E2E_TRUSTED:?set E2E_TRUSTED to a claude-trusted working dir}"
-E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tbe2e-XXXXXX")}"
+E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tb-e2e-XXXXXX")}"
 mkdir -p "$E2E_STATE"
 
 # Strip ANSI/OSC so logs and renders are greppable.

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -125,6 +125,17 @@ bound_transcript() {
   return 1
 }
 
+# Wait until a log line matching PATTERN (grep -E) appears, or time out.
+wait_log() {
+  local name=$1 pattern=$2 secs=${3:-20} i
+  local log="$E2E_STATE/$name.log"
+  for ((i = 0; i < secs; i++)); do
+    grep -qE "$pattern" "$log" 2>/dev/null && return 0
+    sleep 1
+  done
+  return 1
+}
+
 # Wait until a daemon binds a transcript with >= MINLINES lines. Prints id.
 wait_bound() {
   local cwd=$1 port=$2 minlines=${3:-8} secs=${4:-100} i bt cid f

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -11,6 +11,14 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$HERE/lib.sh"
 
+# reset_cwd deletes this dir's transcript history AND its .claude (trust+hooks).
+# Refuse to run unless E2E_TRUSTED is a throwaway temp path, so a wrong value
+# can never delete a real project's history/config.
+case "$E2E_TRUSTED" in
+  /tmp/* | /private/tmp/* | /var/folders/*) ;;
+  *) echo "ABORT: E2E_TRUSTED must be under a temp dir (/tmp, /private/tmp, /var/folders); got: $E2E_TRUSTED"; exit 1 ;;
+esac
+
 PASS=0; FAIL=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
@@ -62,7 +70,6 @@ echo "### Scenario 2: DRIVE (the binder itself) — bind + /clear via dir-poll +
 # ---------------------------------------------------------------------------
 reset_cwd
 start_daemon s2 "$CWD" 18812 drive; wait_ready s2 || exit 1
-check "drive: shadow suppressed when enabled" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
 SID=$(session_id 18812); attach_start s2 18812 "$SID"; sleep 2
 prompt s2 "$EXPLORE"
 A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
@@ -79,6 +86,9 @@ check "drive: no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_ST
 rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s2.log")
 prompt s2 "/compact"; sleep 12
 check "drive: /compact did NOT over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s2.log') -eq $rc ]"
+# Checked after events have flowed (a bind + a real rotation), so a leaked
+# shadow comparison would have had its chance to log.
+check "drive: shadow suppressed throughout (no [ShadowBinder] lines)" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
 attach_stop s2; stop_daemon s2
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -17,7 +17,13 @@ bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 check(){ if eval "$2"; then ok "$1"; else bad "$1 ($2)"; fi; }
 
 CWD="$E2E_TRUSTED"
-reset_cwd() { rm -rf "$CWD/.claude" 2>/dev/null; }
+# Isolate each scenario: drop the daemon hook config AND the transcript history
+# for this cwd, so a prior run's same-port transcripts cannot contaminate the
+# dir-poll. E2E_TRUSTED MUST be a throwaway scratch dir (see README).
+reset_cwd() {
+  rm -rf "$CWD/.claude" 2>/dev/null
+  rm -f "$(tdir_for "$CWD")"/*.jsonl 2>/dev/null
+}
 
 EXPLORE="Read README.md or list the files here, then give a 2-sentence summary. Read-only, do not modify anything."
 
@@ -32,10 +38,11 @@ A=$(wait_bound "$CWD" 18811 8 100) || { bad "shadow: initial bind"; A=""; }
 [ -n "$A" ] && ok "shadow: claude bound (honoured pre-assigned --session-id): $A"
 check "shadow: 0 DISAGREE on a normal session" "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
 
-prompt s1 "/clear"; sleep 6
+prompt s1 "/clear"
+wait_log s1 "restart detected" 25   # the new transcript file appears slightly before the daemon logs the rotation
 B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
 check "shadow: /clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
-check "shadow: rotation announced exactly once"     "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
+check "shadow: rotation announced exactly once (old path drives)" "[ \$(grep -c '\[Hooks\] Claude restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
 check "shadow: still 0 DISAGREE after /clear"        "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
 
 Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
@@ -61,7 +68,8 @@ prompt s2 "$EXPLORE"
 A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
 check "drive: binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s2.log'"
 
-prompt s2 "/clear"; sleep 6
+prompt s2 "/clear"
+wait_log s2 "DirPollRotation|restart detected" 25
 B2=$(bound_transcript "$CWD" 18812 2>/dev/null | awk '{print $1}')
 check "drive: /clear rotated (B != A)" "[ -n '$B2' ] && [ '$B2' != '$A2' ]"
 check "drive: new dir-poll detected the rotation (#452 machinery)" "grep -q 'No-hooks rotation detected via dir poll' '$E2E_STATE/s2.log'"
@@ -95,7 +103,9 @@ check "two-daemon: each binds its own port marker" "head -c 4000 '$F1' | grep -q
 CC=$(pgrep -f "claude .*remi:18813" | head -1)
 kill -9 "$CC" 2>/dev/null
 check "zombie: D1 daemon wrapper still alive (false-live sibling)" "kill -0 \$(cat '$E2E_STATE/d1.pid') 2>/dev/null"
-prompt d2 "/clear"; sleep 6; prompt d2 "Say the word GAMMA."
+prompt d2 "/clear"
+wait_log d2 "owned by port 18813, not 18814|DirPollRotation|restart detected" 25
+prompt d2 "Say the word GAMMA."
 C2B=$(bound_transcript "$CWD" 18814 2>/dev/null | awk '{print $1}')
 check "zombie: D2 rebound despite the zombie sibling" "[ -n '$C2B' ] && [ '$C2B' != '$C2' ]"
 check "zombie: D2 ignored the foreign/zombie transcript by marker" "grep -q 'owned by port 18813, not 18814; ignoring' '$E2E_STATE/d2.log'"

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Transcript-binding e2e runner. Executes the validated failure-mode scenarios
+# against a real claude + real daemon and prints PASS/FAIL per check.
+#
+#   REMI_BIN=/path/to/remi E2E_TRUSTED=/private/tmp/remi-tb-e2e ./run.sh
+#
+# See README.md for prerequisites (trusted dir, real claude auth) and what each
+# scenario validates. Exit code = number of failed checks.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$HERE/lib.sh"
+
+PASS=0; FAIL=0
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+check(){ if eval "$2"; then ok "$1"; else bad "$1 ($2)"; fi; }
+
+CWD="$E2E_TRUSTED"
+reset_cwd() { rm -rf "$CWD/.claude" 2>/dev/null; }
+
+EXPLORE="Read README.md or list the files here, then give a 2-sentence summary. Read-only, do not modify anything."
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 1: SHADOW (shipping default) — bind + /clear rotation + /compact"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon s1 "$CWD" 18811 shadow; wait_ready s1 || exit 1
+SID=$(session_id 18811); attach_start s1 18811 "$SID"; sleep 2
+prompt s1 "$EXPLORE"
+A=$(wait_bound "$CWD" 18811 8 100) || { bad "shadow: initial bind"; A=""; }
+[ -n "$A" ] && ok "shadow: claude bound (honoured pre-assigned --session-id): $A"
+check "shadow: 0 DISAGREE on a normal session" "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+
+prompt s1 "/clear"; sleep 6
+B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
+check "shadow: /clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
+check "shadow: rotation announced exactly once"     "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
+check "shadow: still 0 DISAGREE after /clear"        "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+
+Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
+bb=$(wc -l < "$Bf" 2>/dev/null || echo 0); ab=$(wc -l < "$Af" 2>/dev/null || echo 0)
+prompt s1 "Say the word DELTA."
+for i in $(seq 1 20); do [ "$(wc -l < "$Bf" 2>/dev/null||echo 0)" -gt "$bb" ] && break; sleep 2; done
+check "shadow: follow-up landed in rotated session B" "[ \$(grep -c DELTA '$Bf' 2>/dev/null) -ge 1 ]"
+check "shadow: old session A stayed frozen"           "[ \$(wc -l < '$Af' 2>/dev/null) -eq $ab ]"
+
+rb=$(grep -c 'restart detected' "$E2E_STATE/s1.log")
+prompt s1 "/compact"; sleep 12
+check "shadow: /compact did NOT rotate (no new restart)" "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq $rb ]"
+attach_stop s1; stop_daemon s1
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 2: DRIVE (the binder itself) — bind + /clear via dir-poll + /compact"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon s2 "$CWD" 18812 drive; wait_ready s2 || exit 1
+check "drive: shadow suppressed when enabled" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
+SID=$(session_id 18812); attach_start s2 18812 "$SID"; sleep 2
+prompt s2 "$EXPLORE"
+A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
+check "drive: binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s2.log'"
+
+prompt s2 "/clear"; sleep 6
+B2=$(bound_transcript "$CWD" 18812 2>/dev/null | awk '{print $1}')
+check "drive: /clear rotated (B != A)" "[ -n '$B2' ] && [ '$B2' != '$A2' ]"
+check "drive: new dir-poll detected the rotation (#452 machinery)" "grep -q 'No-hooks rotation detected via dir poll' '$E2E_STATE/s2.log'"
+check "drive: rebound + rearmed watcher on B" "grep -q 'Transcript from DirPollRotation' '$E2E_STATE/s2.log'"
+check "drive: no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_STATE/s2.log') -eq 0 ]"
+
+rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s2.log")
+prompt s2 "/compact"; sleep 12
+check "drive: /compact did NOT over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s2.log') -eq $rc ]"
+attach_stop s2; stop_daemon s2
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 3: TWO daemons, same cwd — cross-bind (fm-427) + zombie (fm-451)"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon d1 "$CWD" 18813 drive; wait_ready d1 || exit 1
+sleep 2   # stagger so the two daemons do not collide writing ~/.remi/sessions.json
+start_daemon d2 "$CWD" 18814 drive; wait_ready d2 || exit 1
+S1=$(session_id 18813); S2=$(session_id 18814)
+attach_start d1 18813 "$S1"; attach_start d2 18814 "$S2"; sleep 2
+prompt d1 "Say the word ALPHA."
+prompt d2 "Say the word BETA."
+C1=$(wait_bound "$CWD" 18813 8 100); C2=$(wait_bound "$CWD" 18814 8 100)
+check "two-daemon: distinct binds (no cross-bind)" "[ -n '$C1' ] && [ -n '$C2' ] && [ '$C1' != '$C2' ]"
+F1=$(tdir_for "$CWD")/$C1.jsonl; F2=$(tdir_for "$CWD")/$C2.jsonl
+check "two-daemon: ALPHA only in D1's transcript" "[ \$(grep -c ALPHA '$F1' 2>/dev/null) -ge 1 ] && [ \$(grep -c BETA '$F1' 2>/dev/null) -eq 0 ]"
+check "two-daemon: BETA only in D2's transcript"  "[ \$(grep -c BETA '$F2' 2>/dev/null) -ge 1 ] && [ \$(grep -c ALPHA '$F2' 2>/dev/null) -eq 0 ]"
+check "two-daemon: each binds its own port marker" "head -c 4000 '$F1' | grep -q 'remi:18813' && head -c 4000 '$F2' | grep -q 'remi:18814'"
+
+# fm-451 zombie: kill D1's INNER claude child only (wrapper stays alive).
+CC=$(pgrep -f "claude .*remi:18813" | head -1)
+kill -9 "$CC" 2>/dev/null
+check "zombie: D1 daemon wrapper still alive (false-live sibling)" "kill -0 \$(cat '$E2E_STATE/d1.pid') 2>/dev/null"
+prompt d2 "/clear"; sleep 6; prompt d2 "Say the word GAMMA."
+C2B=$(bound_transcript "$CWD" 18814 2>/dev/null | awk '{print $1}')
+check "zombie: D2 rebound despite the zombie sibling" "[ -n '$C2B' ] && [ '$C2B' != '$C2' ]"
+check "zombie: D2 ignored the foreign/zombie transcript by marker" "grep -q 'owned by port 18813, not 18814; ignoring' '$E2E_STATE/d2.log'"
+check "zombie: no Transcript-not-found wedge in D2" "[ \$(grep -ci 'not found' '$E2E_STATE/d2.log') -eq 0 ]"
+attach_stop d1; attach_stop d2; stop_daemon d1; stop_daemon d2
+
+echo
+echo "==================== RESULT: $PASS passed, $FAIL failed ===================="
+echo "logs + renders: $E2E_STATE"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Adds `tests/e2e/transcript-binding/` — a **manual / semi-automated** harness that drives **real `claude` sessions** under a **real remi daemon** to validate the session-binding + transcript-watcher subsystem (epic #453) against the historical failure modes. This is the harness used in the post-merge e2e validation of the epic.

It complements the existing test layers (it is **not** wired into CI — it needs an authenticated `claude` and a trusted working dir, and drives a TUI):
- `tests/e2e/specs/` — Playwright web UI
- `tests/integration/` — Docker, cross-machine `ls`/`attach` lifecycle
- `tests/e2e/transcript-binding/` (this) — real claude writing/rotating transcripts, observed from a separate client

## Contents

- `lib.sh` — primitives: `start_daemon` (shadow/drive/off, `ANTHROPIC_MODEL=haiku`), a persistent FIFO-backed `remi attach` driver/observer, `bound_transcript` (marker-based), assertions.
- `run.sh` — scenario runner with PASS/FAIL per check:
  1. **Shadow** (shipping default): bind correctness, **0 `[ShadowBinder] DISAGREE`** on a normal session and across `/clear`, single rotation, follow-up routing, `/compact` negative control.
  2. **Drive** (the binder): binder-driven bind, `/clear` caught by the **new re-arming dir-poll** (fm-452), rebind + watcher rearm, `/compact` no over-fire.
  3. **Two daemons, same cwd**: no cross-bind (fm-427) + content segregation, and the **zombie** sibling defer (fm-451, kill the inner claude child only).
- `README.md` — prerequisites, how to run, maintainer notes.
- `failure-mode-matrix.md` — per-mode repro + oracle reference, the oracle-validity table, and the two non-negotiable traps.

## Test plan

- `bash -n` clean; `shellcheck -S warning` clean (one intentional, annotated `SC2045`).
- Test-only addition (no production code); no impact on the build, typecheck, or coverage gate.
- The harness itself was run end-to-end against the merged `develop` while authoring this PR.