### PR TITLE
Release 0.6.1: TranscriptBinder (dormant), sessions.json race fix, e2e harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-05
+
+### Changed
+- Internal: the session-binding + transcript-watcher subsystem is unified
+  into a single `TranscriptBinder` (epic #453). Ships **behind a feature
+  flag, default off** (`transcript_binder_shadow` / `transcript_binder_enabled`)
+  — no behavior change in the default configuration, verified at runtime
+  against the old path. Includes a re-arming directory poll for no-hooks
+  rotations, an extracted `QuestionPipeline` (notification dispatch +
+  auto-approve gate), a no-cache `SessionBindingStore`, the four
+  previously-unwired hook events (StopFailure, PostToolUseFailure,
+  SubagentStart/Stop), and relay/telegram adapter silent-drop fixes
+  (#459, #462, #464, #466, #468, #471, #472).
+
+### Fixed
+- `sessions.json` write now uses a per-process temp path, fixing a
+  multi-writer race where two daemons starting in the same `~/.remi` could
+  crash one on the atomic rename (#461).
+
+### Internal
+- Added a manual real-Claude e2e harness for the transcript-binding
+  subsystem under `tests/e2e/transcript-binding/` (not wired into CI) (#475).
+
 ## [0.6.0] - 2026-06-04
 
 Redesign + a sweep of session/transcript reliability work. Changelog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.0",
+  "version": "0.6.1-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -12,15 +12,20 @@ import { generateId, now } from '@remi/shared';
 import type {
   AgentOutputMessage,
   AgentStatus,
+  DaemonUpdateAvailableMessage,
   EditMessage,
   ErrorMessage,
   HelloAckMessage,
+  KillSessionResponseMessage,
   Message,
   ProtocolMessage,
   Question,
   QuestionMessage,
   ReplayBatchMessage,
+  ResumeSessionResponseMessage,
+  SessionHistoryResponseMessage,
   SessionListResponseMessage,
+  SessionRotatedMessage,
   SessionUpdateMessage,
   StructuredAgentOutputMessage,
   TranscriptContentMessage,
@@ -440,15 +445,108 @@ export class TelegramAdapter implements ConnectionAdapter {
         return true;
       }
 
-      // Messages that don't need Telegram rendering
+      case 'kill_session_response': {
+        const kill = message as KillSessionResponseMessage;
+        const killSession = this.getSession(connectionId);
+        if (killSession && this.bot) {
+          const text = kill.success
+            ? 'Session stopped.'
+            : `Session stop failed: ${kill.error ?? 'unknown error'}`;
+          this.bot.api
+            .sendMessage(killSession.chatId, text, {
+              message_thread_id: killSession.topicId,
+            })
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'resume_session_response': {
+        const resume = message as ResumeSessionResponseMessage;
+        const resumeSession = this.getSession(connectionId);
+        if (resumeSession && this.bot) {
+          const text = resume.success
+            ? `Resumed session ${resume.sessionId ?? '(unknown id)'}.`
+            : `Resume failed: ${resume.error ?? 'unknown error'}`;
+          this.bot.api
+            .sendMessage(resumeSession.chatId, text, {
+              message_thread_id: resumeSession.topicId,
+            })
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'session_rotated': {
+        const rotated = message as SessionRotatedMessage;
+        const rotatedSession = this.getSession(connectionId);
+        if (rotatedSession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              rotatedSession.chatId,
+              `Session restarted (${rotated.reason}). New Claude session id: ${rotated.newClaudeSessionId}`,
+              { message_thread_id: rotatedSession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'daemon_update_available': {
+        const update = message as DaemonUpdateAvailableMessage;
+        const updateSession = this.getSession(connectionId);
+        if (updateSession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              updateSession.chatId,
+              `A newer remi is on disk. Restart this session to pick up the update (current: ${update.currentVersion}).`,
+              { message_thread_id: updateSession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      case 'session_history_response': {
+        const history = message as SessionHistoryResponseMessage;
+        const historySession = this.getSession(connectionId);
+        if (historySession && this.bot) {
+          this.bot.api
+            .sendMessage(
+              historySession.chatId,
+              `History: ${history.directories.length} recent directories. Open the app for detail.`,
+              { message_thread_id: historySession.topicId },
+            )
+            .catch(() => {
+              /* ignore send errors */
+            });
+        }
+        return true;
+      }
+
+      // Messages that don't need Telegram rendering.
+      // N/A on Telegram: no PTY/attach/wire-auth; content surfaces via other branches.
       case 'create_session_response':
       case 'ping':
       case 'pong':
       case 'ack':
       case 'bullet_expand_response':
+      case 'detach_session_ack':
+      case 'raw_pty_output':
+      case 'auth_challenge':
+      case 'auth_result':
         return true;
 
       default:
+        console.warn(`TelegramAdapter: unhandled outbound message type "${message.type}"`);
         return false;
     }
   }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1,0 +1,269 @@
+/**
+ * AutoApproveGate — owns the PermissionRequest control plane for a session.
+ *
+ * Epic #453 phase 1: extracted verbatim from `cli/session-phases/hook-bridge-setup.ts`
+ * (concern 3 of that file's three braided concerns). It is the third member of the
+ * QuestionPipeline boundary, alongside `NotificationDispatcher` and the already-
+ * standalone `QuestionPresenceTracker`.
+ *
+ * Given a PermissionRequest hook event, it either:
+ *   - runs the auto-approve LLM eval and injects "1" (approve) / "3" (deny) /
+ *     a 1-based pick index into the PTY, or
+ *   - escalates the prompt to the user (the normal Question flow), or
+ *   - default-denies a subagent prompt the user cannot answer (to avoid hanging it).
+ *
+ * The two outward couplings the hook bridge used directly are injected as callbacks
+ * so the gate has no back-reference to the bridge or the hook router:
+ *   - `isInSubagentContext()` wraps `HookEventBridge.isInSubagentContext()`
+ *   - `escalate(input)` wraps `handlers.onPermissionRequest?.(input)`
+ * Both are read LIVE at each branch (never captured): the LLM eval is async, so the
+ * subagent/Task context can open or close between the hook firing and the
+ * `.then()`/`.catch()` running. Capturing would TOCTOU.
+ */
+
+import type { UUID } from '@remi/shared';
+
+import type { QuestionPresenceTracker } from '../api/question-presence-tracker.ts';
+import { log, logError } from '../cli/logger.ts';
+import type { PermissionRequestHookInput } from '../hooks/index.ts';
+import type { SessionRegistry } from '../session/index.ts';
+import type { AutoApproveResult } from './types.ts';
+
+/**
+ * Minimal seam the gate consumes. The real `AutoApproveService` satisfies it
+ * structurally; tests inject a real object literal returning real
+ * `AutoApproveResult` values, so the gate's branching is exercised without a
+ * mocking framework or a live LLM.
+ */
+export interface AutoApproveEvaluator {
+  /**
+   * Evaluate a permission request. MUST NOT throw — return an `escalate` result
+   * instead so the gate's decision path is deterministic. A rejected Promise is
+   * tolerated (the gate's `.catch` treats it identically to `escalate`), but a
+   * synchronous throw would escape into the hook dispatch loop.
+   */
+  evaluate(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    tag?: string,
+    permissionSuggestions?: readonly unknown[],
+  ): Promise<AutoApproveResult>;
+  /** Abort any in-flight `evaluate`. Returns true if an abort was issued, false
+   *  if nothing was in flight (idempotent). */
+  cancel(reason: string): boolean;
+}
+
+export interface AutoApproveGateDeps {
+  /** null => no auto-approve configured; the no-AA escalate/default-deny path runs. */
+  service: AutoApproveEvaluator | null;
+  sessionRegistry: SessionRegistry;
+  tracker: QuestionPresenceTracker;
+  /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
+  isInSubagentContext: () => boolean;
+  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate wraps
+   *  every call in a try/catch, so an implementation that throws is logged and
+   *  absorbed rather than propagated; implementations should still prefer to
+   *  handle their own errors. */
+  escalate: (input: PermissionRequestHookInput) => void;
+}
+
+export class AutoApproveGate {
+  private readonly sessionTag: string;
+
+  constructor(
+    private readonly deps: AutoApproveGateDeps,
+    private readonly sessionId: UUID,
+  ) {
+    this.sessionTag = sessionId.slice(0, 8);
+  }
+
+  /**
+   * Cancel any in-flight auto-approve LLM eval. The bridge calls this on hook events
+   * that unambiguously confirm Claude advanced past a prompt (PreToolUse / PostToolUse /
+   * Stop / SessionEnd): the user already answered, and a stale LLM result would inject
+   * into the wrong PTY position or emit a phantom question.
+   *
+   * Deliberately NOT called on Notification events: idle_prompt can fire while a
+   * permission eval is still legitimately in flight, and auth_success /
+   * elicitation_dialog don't carry "user answered" semantics either. No-op when no
+   * service is configured.
+   */
+  cancelStale(reason: string): void {
+    if (this.deps.service === null) return;
+    if (this.deps.service.cancel(reason)) {
+      log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
+    }
+  }
+
+  /**
+   * Handle a PermissionRequest hook event: auto-approve eval + inject, or escalate.
+   * Caller is responsible for session filtering (the bridge runs initFromHookEvent
+   * + filterBySession before delegating here).
+   */
+  handlePermissionRequest(input: PermissionRequestHookInput): void {
+    const { service, isInSubagentContext } = this.deps;
+
+    // Phase 4 (#419): subagent PermissionRequest events are forwarded (not dropped).
+    // The PTY-presence model treats "what's on screen" as truth: a hot-switched
+    // subagent view that renders a permission prompt IS user-answerable, and
+    // dropping the hook here would lose the rich tool/option metadata.
+    if (this.isSubagentEvent(input)) {
+      log(
+        `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
+      );
+    }
+
+    // Auto-approve gate: evaluate before creating a Question object.
+    if (service) {
+      // Pass the raw suggestions array; AutoApproveService does its own strict-string
+      // filtering before feeding the LLM. We forward the raw shape (rather than
+      // coercing) so the multi-choice classifier can see "non-string entry" and route
+      // through escalate instead of crashing on a future permission_suggestions schema
+      // change.
+      service
+        .evaluate(
+          input.tool_name,
+          input.tool_input,
+          this.sessionTag,
+          input.permission_suggestions as readonly unknown[] | undefined,
+        )
+        .then(async (result) => {
+          if (result.decision === 'cancelled') {
+            // User already advanced past the prompt. Do not inject, do not escalate.
+            // Drop the pending hook record so its stale option labels cannot merge
+            // onto the next unrelated PTY prompt (e.g. user typed /compact, no
+            // PreToolUse fires).
+            this.deps.tracker.clearPending();
+            log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
+            return;
+          }
+          if (result.decision === 'approve') {
+            if (!(await this.inject(input, '1', 'approved'))) this.escalateToUser(input);
+            return;
+          }
+          if (result.decision === 'deny') {
+            if (!(await this.inject(input, '3', 'denied'))) this.escalateToUser(input);
+            return;
+          }
+          if (result.decision === 'pick' && result.pickIndex !== undefined) {
+            // Multi-choice pick (#399): inject the 1-based index Claude Code expects.
+            // parseMultiChoiceDecision already validated the index against options
+            // length, so out-of-range values cannot reach this branch.
+            if (
+              !(await this.inject(
+                input,
+                String(result.pickIndex),
+                `multichoice-pick-${result.pickIndex}`,
+              ))
+            ) {
+              this.escalateToUser(input);
+            }
+            return;
+          }
+          // escalate: in a subagent context, default-deny to avoid hanging the
+          // subagent (the user could not answer it anyway). Bypass the subagent PTY
+          // gate because the alternative is letting it hang forever; typing '3' into
+          // the parent PTY is the lesser evil. The approve/deny/pick branches above
+          // use the gate because they have a fallback (escalateToUser); this does not.
+          if (isInSubagentContext()) {
+            log(
+              `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
+            );
+            await this.inject(input, '3', 'subagent-escalate-default-deny', true);
+            return;
+          }
+          this.escalateToUser(input);
+        })
+        .catch(async (err) => {
+          // Last line of defense; must not leave an unhandled rejection.
+          try {
+            logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
+            if (isInSubagentContext()) {
+              await this.inject(input, '3', 'subagent-error-default-deny', true);
+              return;
+            }
+            this.escalateToUser(input);
+          } catch (inner) {
+            logError(`[AutoApprove ${this.sessionTag}] catch handler threw:`, inner);
+          }
+        });
+      return;
+    }
+
+    // No auto-approve. In a subagent context, still must not hang the subagent:
+    // default-deny rather than emit a question the user can't answer.
+    if (isInSubagentContext()) {
+      log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
+      this.inject(input, '3', 'subagent-no-aa-default-deny', true).catch((err) => {
+        logError(`[${this.sessionTag}] Failed to inject default-deny:`, err);
+      });
+      return;
+    }
+
+    this.escalateToUser(input);
+  }
+
+  /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */
+  private isSubagentEvent(input: PermissionRequestHookInput): boolean {
+    return typeof input.agent_id === 'string' && input.agent_id.length > 0;
+  }
+
+  /**
+   * Inject an answer into the PTY. Returns true on success. On failure (session
+   * missing, PTY not running, submitInput throws, subagent off-screen gate trips)
+   * it logs and returns false so callers can fall back to escalating.
+   *
+   * `value` is a 1-based numeric option index serialised as a string. Most
+   * permissions only need '1' (approve) or '3' (deny); multi-choice picks can land
+   * any index in the prompt's option range (#399).
+   *
+   * PTY-presence gate (subagent-only): a background subagent emits PermissionRequest
+   * hooks for its own tool calls, but its prompts never render on the main PTY — only
+   * a hot-switched subagent view does. Without this gate, auto-approve would type
+   * "1"/"3" into the MAIN AGENT's input every time a background subagent asked.
+   * `bypassSubagentPtyGate` is set by the default-deny paths, whose alternative is
+   * hanging the subagent indefinitely.
+   */
+  private async inject(
+    input: PermissionRequestHookInput,
+    value: string,
+    reason: string,
+    bypassSubagentPtyGate = false,
+  ): Promise<boolean> {
+    const { sessionRegistry, tracker, isInSubagentContext } = this.deps;
+    try {
+      const session = sessionRegistry.getSession(this.sessionId);
+      if (!session) {
+        logError(`[AutoApprove ${this.sessionTag}] Session not found; cannot inject "${value}"`);
+        return false;
+      }
+      const inSubagentContext = this.isSubagentEvent(input) || isInSubagentContext();
+      if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
+        log(
+          `[AutoApprove ${this.sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
+        );
+        return false;
+      }
+      await session.pty.submitInput(value);
+      log(`[AutoApprove ${this.sessionTag}] Injected "${value}" into PTY (${reason})`);
+      sessionRegistry.updateStatus(this.sessionId, value === '1' ? 'executing' : 'thinking');
+      return true;
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] inject("${value}") threw:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Safe escalation to the user. Used when inject fails or when auto-approve is off
+   * and we're in main context. Wrapped so a bridge/push failure does not leave a
+   * dangling unhandled rejection in the hook handler.
+   */
+  private escalateToUser(input: PermissionRequestHookInput): void {
+    try {
+      this.deps.escalate(input);
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
+    }
+  }
+}

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -1,4 +1,6 @@
 export { AutoApproveService, parseDecision } from './auto-approve-service.ts';
+export { AutoApproveGate } from './auto-approve-gate.ts';
+export type { AutoApproveEvaluator, AutoApproveGateDeps } from './auto-approve-gate.ts';
 export { resolveProviderUrl } from './llm-client.ts';
 export type {
   AutoApproveConfig,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.0'; // REMI_COMPILED_VERSION
+      return '0.6.1-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.0'; // REMI_COMPILED_VERSION
+    return '0.6.1-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -449,6 +449,17 @@ if (
 // Instantiated early so subcommand handlers (ls, attach, kill) can use it.
 const liveSessionsRegistry = new SessionRegistryFile();
 
+// Experimental TranscriptBinder flags (#453 phase 3). Snapshotted into immutable
+// module-level consts at boot and NEVER re-read per session: a mid-process flip
+// would split sessions across the old/new code paths, which share the
+// transcriptWatchers map. SIGUSR1 / config reload is a no-op for these; an
+// instant flip-back means a daemon restart (design §3.1 v4 #9). Default OFF.
+const binderEnabled = remiConfig.features.transcript_binder_enabled;
+// Drive mode and shadow mode are mutually exclusive: enabled wins. When the
+// binder DRIVES, running the shadow alongside it would be meaningless (and would
+// double-construct the binder), so the shadow is suppressed whenever drive is on.
+const binderShadow = remiConfig.features.transcript_binder_shadow && !binderEnabled;
+
 // Handle 'ls' subcommand: query live sessions from running daemon(s)
 if (cliSubcommand === 'ls') {
   const { runLsCommand } = await import('./cli/cmd-ls.ts');
@@ -805,6 +816,12 @@ const _ptyManager = new PTYManager();
 const transcriptDiscovery = new TranscriptDiscovery();
 const transcriptWatchers: Map<UUID, TranscriptWatcher> = new Map();
 const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new Map();
+// Per-session drive-mode TranscriptBinder teardown hooks (#453 phase 3, commit
+// 5). The shared transcriptWatchers/transcriptFallbackTimers cleanup below stops
+// the binder's watcher + fallback timer, but NOT its #452 rotation dir-poll
+// interval (it lives inside the binder); close() reaches all three. Empty when
+// transcript_binder_enabled is off (no binder is ever constructed).
+const binderClosers: Map<UUID, () => void> = new Map();
 const sessionStore = new SessionStore();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
@@ -826,6 +843,11 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionClosed: (sessionId, reason) => {
       log(`Session closed: ${sessionId} (reason: ${reason})`);
+      // Tear down the drive-mode binder (rotation dir-poll + fallback timer) at
+      // session close, not just at process cleanup — else the poll interval leaks
+      // for the rest of the daemon's life across resumes (#463 phase 3 review).
+      binderClosers.get(sessionId)?.();
+      binderClosers.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();
@@ -1084,7 +1106,7 @@ async function createNewSession(
   });
 
   if (hookServer) {
-    setupHookBridge(
+    const hookBridgeHandle = setupHookBridge(
       {
         sessionRegistry,
         bindingStore,
@@ -1093,9 +1115,16 @@ async function createNewSession(
         transcriptFallbackTimers,
         autoApproveService,
         currentPort: () => PORT,
+        shadowBinder: binderShadow,
+        binderEnabled,
+        transcriptDiscovery,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
+    // In drive mode the binder owns the fallback poll + #452 dir-watch (armed by
+    // its start() inside setupHookBridge); record its teardown so cleanup()
+    // reaches the rotation dir-poll interval the shared maps below cannot.
+    if (binderEnabled) binderClosers.set(sessionId, hookBridgeHandle.closeBinder);
   }
 
   const ptySession = createPtySessionForSession(
@@ -1148,19 +1177,24 @@ async function createNewSession(
     logError(`[live-sessions] No Claude child pid after PTY start for session ${sessionId}`);
   }
 
-  startTranscriptFallback(
-    {
-      sessionRegistry,
-      transcriptDiscovery,
-      transcriptWatchers,
-      transcriptFallbackTimers,
-    },
-    sessionId,
-    workingDirectory,
-    binding.claudeSessionId,
-    messageApi,
-    sendAndRecord,
-  );
+  // In drive mode the TranscriptBinder's start() (inside setupHookBridge) already
+  // armed BOTH the fallback poll and the #452 rotation dir-watch; arming it again
+  // here would double-arm the same fallback timer. Only the old path needs this.
+  if (!binderEnabled) {
+    startTranscriptFallback(
+      {
+        sessionRegistry,
+        transcriptDiscovery,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+      },
+      sessionId,
+      workingDirectory,
+      binding.claudeSessionId,
+      messageApi,
+      sendAndRecord,
+    );
+  }
 
   return ptySession;
 }
@@ -1467,6 +1501,13 @@ async function cleanup(): Promise<void> {
     mdnsPublisher = null;
   }
 
+  // Drive-mode binders own a rotation dir-poll interval the shared maps below do
+  // not reach; close() tears down its watcher + fallback timer + dir-poll. No-op
+  // map when transcript_binder_enabled is off.
+  for (const closeBinder of binderClosers.values()) {
+    closeBinder();
+  }
+  binderClosers.clear();
   for (const watcher of transcriptWatchers.values()) {
     watcher.stop();
   }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -144,6 +144,7 @@ import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
   DEFAULT_BASE_PORT,
   DEFAULT_PORT_RANGE,
+  SessionBindingStore,
   SessionRegistry,
   SessionRegistryFile,
   SessionStore,
@@ -805,6 +806,10 @@ const transcriptDiscovery = new TranscriptDiscovery();
 const transcriptWatchers: Map<UUID, TranscriptWatcher> = new Map();
 const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new Map();
 const sessionStore = new SessionStore();
+// Single binding accessor for the whole daemon (#460 phase 2): the one typed,
+// disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
+// both resume resolvers route through it. No cache — see session-binding-store.ts.
+const bindingStore = new SessionBindingStore(sessionStore);
 
 const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
@@ -1008,15 +1013,14 @@ async function createNewSession(
       updateRemiStatus: (patch) => updateRemiStatus(patch),
       maxBulletLength: MAX_BULLET_LENGTH,
       sendMessage,
-      // Lazy read so the binding seen on each question emission is the
-      // current value — survives /resume rotation via hook-bridge's
-      // updateClaudeSessionId write into the store. Wrapped in try/catch
-      // so a transient sessions.json I/O hiccup cannot kill question
-      // emission (the dep contract is non-throwing).
+      // Lazy disk-backed read so the binding seen on each question emission is
+      // the current value — survives /resume rotation via the hook bridge's
+      // bindingStore.update write. Wrapped in try/catch so a transient
+      // sessions.json I/O hiccup cannot kill question emission (the dep
+      // contract is non-throwing).
       getClaudeSessionId: () => {
         try {
-          return (sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ??
-            null) as UUID | null;
+          return (bindingStore.get(sessionId)?.claudeSessionId ?? null) as UUID | null;
         } catch (err) {
           logError(`[Binding] getClaudeSessionId lookup failed: ${errorToString(err)}`);
           return null;
@@ -1068,7 +1072,7 @@ async function createNewSession(
 
   // Persist the binding before spawn so siblings observing the store
   // during the race window see our claim immediately.
-  sessionStore.save({
+  bindingStore.preAssign({
     remiSessionId: sessionId,
     claudeSessionId: binding.claudeSessionId,
     projectPath: workingDirectory,
@@ -1083,7 +1087,7 @@ async function createNewSession(
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers,
         transcriptFallbackTimers,
@@ -1192,13 +1196,13 @@ const trivialHandlers: TrivialHandlers = createTrivialHandlers({
 
 const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
-  sessionStore,
+  bindingStore,
   send: sendToConnection,
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({
   sessionRegistry,
-  sessionStore,
+  bindingStore,
   transcriptDiscovery,
   liveSessionsRegistry,
   currentPort: () => PORT,
@@ -1211,13 +1215,14 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
-  sessionStore,
+  bindingStore,
   send: sendToConnection,
 });
 
 const resumeSessionHandlers: ResumeSessionHandlers = createResumeSessionHandlers({
   sessionRegistry,
   sessionStore,
+  bindingStore,
   transcriptDiscovery,
   createNewSession,
   send: sendToConnection,
@@ -1818,8 +1823,8 @@ if (cliDaemonMode) {
               // sessions for this connection).
               const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
               for (const remiId of [...managedIds]) {
-                const stored = sessionStore.findByRemiSessionId(remiId as UUID);
-                if (stored?.claudeSessionId) managedIds.add(stored.claudeSessionId);
+                const binding = bindingStore.get(remiId as UUID);
+                if (binding?.claudeSessionId) managedIds.add(binding.claudeSessionId);
               }
               const allSessions = [
                 ...sessionRegistry.listSessions(),

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -12,13 +12,13 @@
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   send: SendToConnection;
 }
 
@@ -44,7 +44,7 @@ export interface InputHandlerDeps {
  *     least surfaces the problem in logs while letting the user work.
  */
 function guardBinding(
-  sessionStore: SessionStore,
+  bindingStore: SessionBindingStore,
   send: SendToConnection,
   connectionId: UUID,
   sessionId: UUID,
@@ -53,9 +53,9 @@ function guardBinding(
   if (claudeSessionId === undefined) return true;
   let bound: string | undefined;
   try {
-    bound = sessionStore.findByRemiSessionId(sessionId)?.claudeSessionId ?? undefined;
+    bound = bindingStore.get(sessionId)?.claudeSessionId ?? undefined;
   } catch (err) {
-    logError(`[Binding] sessionStore lookup failed; accepting message: ${errorToString(err)}`);
+    logError(`[Binding] binding lookup failed; accepting message: ${errorToString(err)}`);
     return true;
   }
   if (!bound) return true;
@@ -81,7 +81,7 @@ function guardBinding(
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, sessionStore, send } = deps;
+  const { sessionRegistry, bindingStore, send } = deps;
 
   return {
     onUserInput: async (
@@ -99,7 +99,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 
@@ -140,7 +140,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      if (!guardBinding(sessionStore, send, connectionId, sessionId, claudeSessionId)) {
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
         return;
       }
 

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -27,7 +27,7 @@ import {
 } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore, SessionRegistry, SessionStore } from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import { resolveDirectory } from '../path-resolver.ts';
@@ -48,7 +48,11 @@ export type CreateNewSessionFn = (
 
 export interface ResumeSessionHandlerDeps {
   sessionRegistry: SessionRegistry;
+  /** Full-record reads that also need projectPath (resume seed by remi id). */
   sessionStore: SessionStore;
+  /** Binding-only reverse lookup (resolve by claude session id) — routed through
+   *  the accessor so it cannot diverge from the other resume resolver. */
+  bindingStore: SessionBindingStore;
   transcriptDiscovery: TranscriptDiscovery;
   createNewSession: CreateNewSessionFn;
   send: SendToConnection;
@@ -57,7 +61,14 @@ export interface ResumeSessionHandlerDeps {
 export type ResumeSessionHandlers = ReturnType<typeof createResumeSessionHandlers>;
 
 export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
-  const { sessionRegistry, sessionStore, transcriptDiscovery, createNewSession, send } = deps;
+  const {
+    sessionRegistry,
+    sessionStore,
+    bindingStore,
+    transcriptDiscovery,
+    createNewSession,
+    send,
+  } = deps;
 
   return {
     onResumeSessionRequest: async (
@@ -120,7 +131,7 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
       }
 
       if (!claudeSessionId) {
-        const storedByClaude = sessionStore.findByClaudeSessionId(targetSessionId);
+        const storedByClaude = bindingStore.getByClaudeSessionId(targetSessionId);
         if (storedByClaude) {
           claudeSessionId = storedByClaude.claudeSessionId;
           projectPath = storedByClaude.projectPath;

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -22,14 +22,18 @@ import {
 } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
-import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../../session/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SessionHandlerDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   transcriptDiscovery: TranscriptDiscovery;
   liveSessionsRegistry: SessionRegistryFile;
   /** PORT is reassigned during daemon-mode port probing; read lazily. */
@@ -46,7 +50,7 @@ export type SessionHandlers = ReturnType<typeof createSessionHandlers>;
 export function createSessionHandlers(deps: SessionHandlerDeps) {
   const {
     sessionRegistry,
-    sessionStore,
+    bindingStore,
     transcriptDiscovery,
     liveSessionsRegistry,
     currentPort,
@@ -67,10 +71,10 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       const daemonSessionsRaw = sessionRegistry.listSessions();
       const daemonSessions = daemonSessionsRaw.map((s) => {
         try {
-          const stored = sessionStore.findByRemiSessionId(s.sessionId as UUID);
-          if (!stored?.claudeSessionId) return s;
-          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${stored.claudeSessionId}.jsonl`;
-          return { ...s, claudeSessionId: stored.claudeSessionId, transcriptPath };
+          const binding = bindingStore.get(s.sessionId as UUID);
+          if (!binding?.claudeSessionId) return s;
+          const transcriptPath = `${transcriptDiscovery.getProjectTranscriptDir(s.projectPath)}/${binding.claudeSessionId}.jsonl`;
+          return { ...s, claudeSessionId: binding.claudeSessionId, transcriptPath };
         } catch (err) {
           logError(
             `[SessionList] Failed to decorate session ${s.sessionId.slice(0, 8)}; serving raw entry: ${errorToString(err)}`,
@@ -83,10 +87,19 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       if (includeExternal) {
         const managedIds = new Set<string>(sessionRegistry.getActiveSessionIds());
         // Also exclude by Claude session ID (JSONL filename UUID is a different namespace from remi IDs).
+        // Per-entry try/catch (mirrors the decoration loop above): a disk hiccup on
+        // one lookup must not throw out of this void handler and hang the whole
+        // session-list response — degrade to a possibly-incomplete exclude set.
         for (const remiId of [...managedIds]) {
-          const stored = sessionStore.findByRemiSessionId(remiId as UUID);
-          if (stored?.claudeSessionId) {
-            managedIds.add(stored.claudeSessionId);
+          try {
+            const binding = bindingStore.get(remiId as UUID);
+            if (binding?.claudeSessionId) {
+              managedIds.add(binding.claudeSessionId);
+            }
+          } catch (err) {
+            logError(
+              `[SessionList] binding lookup failed for ${remiId.slice(0, 8)}; external exclusion may be incomplete: ${errorToString(err)}`,
+            );
           }
         }
         const externalSessions = transcriptDiscovery.discoverSessions(managedIds);

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -15,7 +15,7 @@ import { createError, createTranscriptLoadComplete, errorToString } from '@remi/
 import type { UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
-import type { SessionStore } from '../../session/index.ts';
+import type { SessionBindingStore } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
   TranscriptWatcher as TranscriptWatcherType,
@@ -31,14 +31,14 @@ export interface TranscriptHandlerDeps {
   transcriptWatchers: Map<UUID, TranscriptWatcherType>;
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, sessionStore, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, bindingStore, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -63,14 +63,23 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       // rotation handler keeps current (#451), so history loads even when the
       // streaming watcher is absent rather than failing with NOT_FOUND.
       if (!filePath) {
-        const boundClaudeId = sessionStore.findByRemiSessionId(sessionId as UUID)?.claudeSessionId;
-        if (boundClaudeId) {
-          filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
-          if (filePath) {
-            log(
-              `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via store binding ${boundClaudeId.slice(0, 8)}`,
-            );
+        // A disk hiccup on the binding lookup must not throw out of this void
+        // handler (the client would hang with no response). Fail soft: log and
+        // fall through to the NOT_FOUND path below.
+        try {
+          const boundClaudeId = bindingStore.get(sessionId as UUID)?.claudeSessionId;
+          if (boundClaudeId) {
+            filePath = transcriptDiscovery.findTranscriptBySessionId(boundClaudeId);
+            if (filePath) {
+              log(
+                `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via store binding ${boundClaudeId.slice(0, 8)}`,
+              );
+            }
           }
+        } catch (err) {
+          logError(
+            `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
+          );
         }
       }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -2,9 +2,8 @@
  * Wire the Claude Code hook event stream into our PTY's MessageAPI during
  * createNewSession.
  *
- * Three concerns are tangled here and kept together because they all depend
- * on the same per-session locks (claudeSessionId, mainSessionEnded,
- * hasSiblingInDir()):
+ * Two concerns live here, both depending on the same per-session locks
+ * (claudeSessionId, mainSessionEnded, hasSiblingInDir()):
  *
  *   1. **Session filtering.** Claude Code fires hook events that may belong
  *      to our PTY, a subagent inside it, or a sibling daemon's PTY in the
@@ -18,11 +17,14 @@
  *      keeps the same session id) tears down the old watcher, starts a fresh
  *      one, and emits a single session_rotated event.
  *
- *   3. **Auto-approve gate.** PermissionRequest events are intercepted
- *      before they reach the user. If auto-approve returns approve/deny we
- *      inject "1"/"3" into the PTY; otherwise (or on subagent PTY failure)
- *      we escalate to the user or default-deny to avoid hanging a subagent
- *      with no one to answer.
+ * A third concern, the **auto-approve gate**, used to be inlined here; it is now
+ * delegated to `AutoApproveGate` (#453 phase 1). The bridge does the session
+ * filtering, then routes PermissionRequest to the gate, which runs the
+ * auto-approve eval and injects "1"/"3"/pick into the PTY, escalates to the user,
+ * or default-denies a subagent prompt no one can answer. The gate is wired with
+ * the bridge's `isInSubagentContext` + the router's `onPermissionRequest` as
+ * callbacks; Pre/PostToolUse/Stop/SessionEnd call `gate.cancelStale()` to abort a
+ * stale in-flight eval once Claude has advanced past the prompt.
  *
  * The function registers 7 hookServer listeners (SessionStart, PreToolUse,
  * PostToolUse, Notification, PermissionRequest, Stop, SessionEnd) and
@@ -37,6 +39,7 @@ import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
 import type { QuestionPresenceTracker } from '../../api/question-presence-tracker.ts';
+import { AutoApproveGate } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
@@ -155,25 +158,6 @@ export function setupHookBridge(
   // reflected immediately. Issue #321: a stale `null`-once cache wedged
   // this state and permanently disabled hook-driven discovery for both
   // daemons.
-
-  /**
-   * Cancel any in-flight auto-approve LLM eval. Called on hook events that
-   * unambiguously confirm Claude advanced past a prompt: PreToolUse /
-   * PostToolUse / Stop / SessionEnd. At that point the user has already
-   * answered (probably in the local terminal) and a stale LLM result would
-   * either inject into the wrong PTY position or emit a phantom question.
-   *
-   * Deliberately NOT called on Notification events: idle_prompt can fire
-   * while a permission eval is still legitimately in flight, and
-   * auth_success / elicitation_dialog don't carry "user answered" semantics
-   * either.
-   */
-  const cancelStaleAutoApprove = (reason: string): void => {
-    if (autoApproveService === null) return;
-    if (autoApproveService.cancel(reason)) {
-      log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
-    }
-  };
 
   // ---- Helpers ------------------------------------------------------------
 
@@ -552,6 +536,21 @@ export function setupHookBridge(
 
   const handlers = hookBridge.hookHandlers();
 
+  // Auto-approve control plane (#453 phase 1): owns the PermissionRequest eval +
+  // inject + escalate + cancelStale. Constructed after the bridge + handlers so it
+  // can wrap the two outward couplings (isInSubagentContext, onPermissionRequest) as
+  // injected callbacks, read live at inject time (async TOCTOU).
+  const autoApproveGate = new AutoApproveGate(
+    {
+      service: autoApproveService,
+      sessionRegistry,
+      tracker,
+      isInSubagentContext: () => hookBridge.isInSubagentContext(),
+      escalate: (i) => handlers.onPermissionRequest?.(i),
+    },
+    sessionId,
+  );
+
   // Filter: accept events only from our own Claude. Before claudeSessionId
   // is known, block events when siblings exist (they could be from the
   // sibling's Claude).
@@ -611,14 +610,14 @@ export function setupHookBridge(
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    cancelStaleAutoApprove('PreToolUse');
+    autoApproveGate.cancelStale('PreToolUse');
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
     if (isSubagentEvent(input)) return;
-    cancelStaleAutoApprove('PostToolUse');
+    autoApproveGate.cancelStale('PostToolUse');
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
@@ -644,197 +643,17 @@ export function setupHookBridge(
   hookServer.on('PermissionRequest', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
-
-    // Phase 4 (#419): subagent PermissionRequest events (events with
-    // agent_id set, originating from Task/Agent-spawned subagents) used
-    // to be dropped at this seam. Under phase 3's PTY-presence model,
-    // "what's on screen" is the truth: a hot-switched subagent view
-    // that renders a permission prompt IS user-answerable, and dropping
-    // the hook here loses the rich tool/option metadata. Forward the
-    // event; the tracker pairs it with PTY confirmation. Auto-approve
-    // and the inSubagent default-deny safety net below still gate
-    // injection independently.
-    if (isSubagentEvent(input)) {
-      log(
-        `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
-      );
-    }
-
-    // Nested-Task context (secondary safety net for cases where
-    // agent_id is absent). Used by the auto-approve default-deny path
-    // below to avoid hanging a subagent whose only escalation route is
-    // a main-PTY prompt the user cannot see.
-    //
-    // Read live (not captured) at each branch: auto-approve evaluate()
-    // is async, so the Task context can open or close between when this
-    // listener fires and when the .then()/.catch() runs. Capturing
-    // would TOCTOU — a Task that closed mid-eval would still trigger
-    // default-deny, and a Task that opened mid-eval would escape it.
-    const sessionTag = sessionId.slice(0, 8);
-
-    // Inject an answer into the PTY. Returns true on success. On failure
-    // (session missing, PTY not running, submitInput throws, subagent
-    // off-screen gate trips) it logs and returns false so callers can
-    // fall back to escalating the prompt.
-    //
-    // Value is a 1-based numeric option index serialised as a string. Most
-    // permissions only need '1' (approve) or '3' (deny); multi-choice picks
-    // can land any index in the prompt's option range (#399).
-    //
-    // PTY-presence gate (subagent-only): a background subagent emits
-    // PermissionRequest hooks for its own tool calls, but its prompts
-    // never render on the main PTY — only a hot-switched subagent view
-    // does. Without this gate, auto-approve would type "1"/"3" into the
-    // MAIN AGENT's input every time a background subagent asked for
-    // permission.
-    //
-    // Detect subagent context two ways: (a) explicit `agent_id` on the
-    // hook event (Task tool with agent_id set), and (b)
-    // `hookBridge.isInSubagentContext()` (nested-Task tracker — the
-    // secondary safety net for legacy events without agent_id). Both
-    // are read at inject time, not captured, so the hot-switched case
-    // (PTY has rendered the subagent prompt between the hook firing
-    // and the LLM eval returning) still injects.
-    //
-    // Asymmetry: the default-deny path (subagent-escalate / subagent-
-    // error) passes `bypassSubagentPtyGate=true` to keep firing even
-    // without PTY confirmation, because the alternative is hanging the
-    // subagent indefinitely with no one to answer. That is a
-    // deliberately-different trade-off from the approve/deny/pick path,
-    // which falls through to escalateToUser when gated.
-    const inject = async (
-      value: string,
-      reason: string,
-      bypassSubagentPtyGate = false,
-    ): Promise<boolean> => {
-      try {
-        const session = sessionRegistry.getSession(sessionId);
-        if (!session) {
-          logError(`[AutoApprove ${sessionTag}] Session not found; cannot inject "${value}"`);
-          return false;
-        }
-        const inSubagentContext = isSubagentEvent(input) || hookBridge.isInSubagentContext();
-        if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
-          log(
-            `[AutoApprove ${sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
-          );
-          return false;
-        }
-        await session.pty.submitInput(value);
-        log(`[AutoApprove ${sessionTag}] Injected "${value}" into PTY (${reason})`);
-        sessionRegistry.updateStatus(sessionId, value === '1' ? 'executing' : 'thinking');
-        return true;
-      } catch (err) {
-        logError(`[AutoApprove ${sessionTag}] inject("${value}") threw:`, err);
-        return false;
-      }
-    };
-
-    // Safe escalation to the user. Used when inject fails or when auto-approve
-    // is off and we're in main context. Wrapped so bridge/push failures don't
-    // leave the hook handler with a dangling unhandled rejection.
-    const escalateToUser = () => {
-      try {
-        handlers.onPermissionRequest?.(input);
-      } catch (err) {
-        logError(`[AutoApprove ${sessionTag}] escalateToUser threw:`, err);
-      }
-    };
-
-    // Auto-approve gate: evaluate before creating a Question object.
-    if (autoApproveService) {
-      const aaService = autoApproveService;
-      // Pass the raw suggestions array; AutoApproveService does its own
-      // strict-string filtering before feeding the LLM. We forward the
-      // raw shape (rather than coercing) so the multi-choice classifier
-      // can see "non-string entry" and route through escalate instead
-      // of crashing on a future Claude Code permission_suggestions
-      // schema change.
-      aaService
-        .evaluate(
-          input.tool_name,
-          input.tool_input,
-          sessionTag,
-          input.permission_suggestions as readonly unknown[] | undefined,
-        )
-        .then(async (result) => {
-          if (result.decision === 'cancelled') {
-            // User already advanced past the prompt (terminal answer or
-            // hook event confirmed the tool ran). Do not inject, do not
-            // escalate. Drop the pending hook record so its stale option
-            // labels cannot merge onto the next unrelated PTY prompt
-            // (e.g. user typed /compact, no PreToolUse fires).
-            tracker.clearPending();
-            log(`[AutoApprove ${sessionTag}] Decision dropped: ${result.reasoning}`);
-            return;
-          }
-          if (result.decision === 'approve') {
-            if (!(await inject('1', 'approved'))) escalateToUser();
-            return;
-          }
-          if (result.decision === 'deny') {
-            if (!(await inject('3', 'denied'))) escalateToUser();
-            return;
-          }
-          if (result.decision === 'pick' && result.pickIndex !== undefined) {
-            // Multi-choice pick (#399): inject the 1-based index Claude Code
-            // expects on the terminal. parseMultiChoiceDecision already
-            // validated the index against options length, so out-of-range
-            // values cannot reach this branch.
-            if (!(await inject(String(result.pickIndex), `multichoice-pick-${result.pickIndex}`))) {
-              escalateToUser();
-            }
-            return;
-          }
-          // escalate: in a subagent context, default-deny to avoid hanging
-          // the subagent. The user could not answer it anyway. Bypass the
-          // subagent PTY gate (`bypassSubagentPtyGate=true`) because the
-          // alternative is letting the subagent hang forever; typing '3'
-          // into the parent PTY is accepted as the lesser evil here. The
-          // approve/deny/pick branches above use the gate because they
-          // have a fallback (escalateToUser); this branch does not.
-          if (hookBridge.isInSubagentContext()) {
-            log(`[AutoApprove ${sessionTag}] Subagent context; escalate->deny to prevent hang`);
-            await inject('3', 'subagent-escalate-default-deny', true);
-            return;
-          }
-          escalateToUser();
-        })
-        .catch(async (err) => {
-          // Last line of defense; must not leave an unhandled rejection.
-          try {
-            logError(`[AutoApprove ${sessionTag}] Unexpected error:`, err);
-            if (hookBridge.isInSubagentContext()) {
-              await inject('3', 'subagent-error-default-deny', true);
-              return;
-            }
-            escalateToUser();
-          } catch (inner) {
-            logError(`[AutoApprove ${sessionTag}] catch handler threw:`, inner);
-          }
-        });
-      return;
-    }
-
-    // No auto-approve. In a subagent context, still must not hang the
-    // subagent: default-deny rather than emit a question the user can't
-    // answer. Synchronous fallback — read live for symmetry with the
-    // async branches above; no TOCTOU here but the consistent shape
-    // helps a future maintainer.
-    if (hookBridge.isInSubagentContext()) {
-      log(`[${sessionTag}] Subagent context without auto-approve; default-deny`);
-      inject('3', 'subagent-no-aa-default-deny', true).catch((err) => {
-        logError(`[${sessionTag}] Failed to inject default-deny:`, err);
-      });
-      return;
-    }
-
-    escalateToUser();
+    // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
+    // owns the PTY injection, the subagent PTY-presence gate, the default-deny
+    // safety net, and the escalate fallback; session filtering above stays here in
+    // the bridge. isInSubagentContext / onPermissionRequest are injected into the
+    // gate and read live at inject time (async TOCTOU).
+    autoApproveGate.handlePermissionRequest(input);
   });
   hookServer.on('Stop', (input) => {
     initFromHookEvent(input);
     if (!filterBySession(input)) return;
-    cancelStaleAutoApprove('Stop');
+    autoApproveGate.cancelStale('Stop');
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
@@ -844,7 +663,7 @@ export function setupHookBridge(
       mainSessionEnded = true;
     }
     if (!filterBySession(input)) return;
-    cancelStaleAutoApprove('SessionEnd');
+    autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);
   });
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -45,7 +45,11 @@ import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
 import { classifySessionEvent } from '../../hooks/session-lock-classifier.ts';
 import { claudeChildLooksAlive } from '../../session/index.ts';
-import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../../session/index.ts';
 import { readTranscriptOwnerPort } from '../../transcript/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
@@ -53,7 +57,7 @@ import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
 export interface HookBridgeDeps {
   sessionRegistry: SessionRegistry;
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
   liveSessionsRegistry: SessionRegistryFile;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
@@ -90,7 +94,7 @@ export function setupHookBridge(
 ): HookBridgeHandle {
   const {
     sessionRegistry,
-    sessionStore,
+    bindingStore,
     liveSessionsRegistry,
     transcriptWatchers,
     transcriptFallbackTimers,
@@ -120,13 +124,15 @@ export function setupHookBridge(
    */
   const adoptLockFromStore = (): void => {
     try {
-      const stored = sessionStore.findByRemiSessionId(sessionId);
-      const storedId = stored?.claudeSessionId ?? null;
+      // Disk-backed read (no cache) via the binding accessor: a sibling/fallback
+      // write is observed every call, which is what preserves the #430 re-adopt
+      // and #321 no-wedge guarantees.
+      const storedId = bindingStore.get(sessionId)?.claudeSessionId ?? null;
       if (storedId === null || storedId === claudeSessionId) return;
       const previous = claudeSessionId;
       claudeSessionId = storedId;
       log(
-        `[Hooks] Lock ${previous === null ? 'adopted' : 'updated'} from sessionStore: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
+        `[Hooks] Lock ${previous === null ? 'adopted' : 'updated'} from binding store: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
       );
     } catch (err) {
       logError(`[Hooks] adoptLockFromStore failed: ${errorToString(err)}`);
@@ -377,7 +383,7 @@ export function setupHookBridge(
       log(
         `[Hooks] Transcript from ${input.hook_event_name ?? 'hook'}: claude=${claudeSessionId}, transcript=${input.transcript_path}`,
       );
-      sessionStore.updateClaudeSessionId(sessionId, claudeSessionId);
+      bindingStore.update(sessionId, claudeSessionId);
 
       // Announce the rotation as ONE atomic event so the client clears, swaps
       // the binding, and re-fetches the new transcript in a single step (#438).
@@ -489,7 +495,7 @@ export function setupHookBridge(
       try {
         claudeSessionId = hookClaudeSessionId;
         log(`[Hooks] SessionStart: claude=${hookClaudeSessionId}, transcript=${transcriptPath}`);
-        sessionStore.updateClaudeSessionId(sessionId, hookClaudeSessionId);
+        bindingStore.update(sessionId, hookClaudeSessionId);
 
         if (isRotation) {
           try {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -26,10 +26,14 @@
  * callbacks; Pre/PostToolUse/Stop/SessionEnd call `gate.cancelStale()` to abort a
  * stale in-flight eval once Claude has advanced past the prompt.
  *
- * The function registers 7 hookServer listeners (SessionStart, PreToolUse,
- * PostToolUse, Notification, PermissionRequest, Stop, SessionEnd) and
- * returns void. It runs once per session at createNewSession time, only
- * when a hookServer is configured.
+ * This listener block IS the per-session hook router (admit-then-fan-out); a
+ * formal HookRouter class is deferred until the shadow/drive dual path is
+ * deleted (the `driveBinder ? … : oldPath` ternaries collapse first). The
+ * function registers 11 hookServer listeners — the original 7 (SessionStart,
+ * PreToolUse, PostToolUse, Notification, PermissionRequest, Stop, SessionEnd)
+ * plus the 4 wired in phase 4 (StopFailure, PostToolUseFailure, SubagentStart,
+ * SubagentStop) — and returns void. It runs once per session at
+ * createNewSession time, only when a hookServer is configured.
  */
 
 import * as fs from 'node:fs';
@@ -1009,6 +1013,62 @@ export function setupHookBridge(
     if (!filterBySession(input)) return;
     autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);
+  });
+
+  // ---- The 4 previously-dropped events (#453 phase 4) -----------------------
+  // These were registered with Claude Code (REMI_REGISTERED_HOOK_EVENTS) but had
+  // NO listener here, so they reached only (absent) dynamic listeners — a silent
+  // no-op. Wired now, each following the same admit-then-fan-out template as the
+  // tool listeners (drive the binder first so admits() sees an up-to-date lock,
+  // then the per-event policy). The bridge handlers already exist + are tested.
+
+  hookServer.on('StopFailure', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('StopFailure', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // Question event: a failed Stop hook leaves the agent in an unknown state, so
+    // the bridge emits a "Retry?" card via onQuestion. Like PermissionRequest it
+    // is NOT agent_id-dropped — PTY-presence gating happens downstream in the
+    // tracker (#419).
+    handlers.onStopFailure?.(input);
+  });
+
+  hookServer.on('PostToolUseFailure', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('PostToolUseFailure', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // Status event: a subagent's tool failure must not flip MAIN's status, so
+    // drop on agent_id — the same split policy as Pre/PostToolUse (#419).
+    if (isSubagentEvent(input)) return;
+    handlers.onPostToolUseFailure?.(input);
+  });
+
+  // SubagentStart/SubagentStop are subagent-LIFECYCLE events: they ALWAYS carry
+  // agent_id by definition, so the isSubagentEvent drop would discard them
+  // entirely. The whole point is to surface subagent activity as a status
+  // breadcrumb, so gate them with admits() ONLY (the sibling defer + session
+  // scoping still apply via session_id) — a deliberate divergence from the
+  // Pre/PostToolUse agent_id drop (#453 phase 4).
+  hookServer.on('SubagentStart', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('SubagentStart', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    handlers.onSubagentStart?.(input);
+  });
+
+  hookServer.on('SubagentStop', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('SubagentStop', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    handlers.onSubagentStop?.(input);
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -50,8 +50,10 @@ import type {
   SessionRegistry,
   SessionRegistryFile,
 } from '../../session/index.ts';
-import { readTranscriptOwnerPort } from '../../transcript/index.ts';
+import { TranscriptBinder, readTranscriptOwnerPort } from '../../transcript/index.ts';
+import type { BinderDecision, BinderHookEvent } from '../../transcript/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
+import type { TranscriptDiscovery } from '../../transcript/transcript-discovery.ts';
 import { log, logError } from '../logger.ts';
 import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
@@ -64,6 +66,36 @@ export interface HookBridgeDeps {
   autoApproveService: AutoApproveService | null;
   /** PORT is reassigned during daemon-mode port probing; read lazily. */
   currentPort: () => number;
+  /**
+   * #453 phase 3, commit 3 (SHADOW MODE). When true, a compute-only
+   * `TranscriptBinder` runs alongside the old initFromHookEvent/onSessionInfo
+   * path and logs control-plane disagreements. It is constructed with no-op
+   * effect deps (no send, no store write, no watcher start, no rotation
+   * callback) so it is PROVABLY side-effect-free; the old path stays the sole
+   * driver. Default OFF (undefined) — zero behavior change when unset.
+   */
+  shadowBinder?: boolean;
+  /**
+   * #453 phase 3, commit 5 (DRIVE MODE). When true, a single drive-mode
+   * `TranscriptBinder` per session OWNS the binding/watcher/rotation control
+   * plane: each hook listener routes to `binder.onHookEvent` /
+   * `binder.admits` / `binder.preemptOnSessionStart` / `binder.onSessionEnd`
+   * INSTEAD of the old `initFromHookEvent` / `onSessionInfo` / `filterBySession`
+   * bodies, and `binder.start()` arms the fallback poll + #452 dir-watch. The
+   * binder's decisions are already proven equivalent to the old path by the
+   * shadow differential harness (commit 3); this flag lets it DRIVE. Mutually
+   * exclusive with `shadowBinder` (enabled wins; the caller never sets both).
+   * Default OFF (undefined) — flag-off path is byte-identical to pre-commit.
+   * Requires `transcriptDiscovery` (the binder's `start()` reads it).
+   */
+  binderEnabled?: boolean;
+  /**
+   * Required by the `TranscriptBinder` constructor (its `start()` reads it).
+   * Shadow never calls `start()`, but drive mode does; the dep is part of the
+   * binder's construction contract. Optional so callers/tests that use neither
+   * binder mode are unaffected.
+   */
+  transcriptDiscovery?: TranscriptDiscovery;
 }
 
 export interface HookBridgeArgs {
@@ -86,6 +118,15 @@ export interface HookBridgeHandle {
    *  alternate question sources (e.g. PTY parser) so subagent prompts are
    *  not surfaced to the user. */
   bridge: HookEventBridge;
+  /**
+   * Tear down the drive-mode `TranscriptBinder` for this session (its watcher,
+   * fallback timer, and the #452 rotation dir-poll). No-op when binderEnabled is
+   * off (no binder was constructed). The caller must invoke this on session
+   * teardown so the binder's rotation dir-poll interval — which the shared
+   * `transcriptWatchers` / `transcriptFallbackTimers` cleanup in cli.ts does NOT
+   * reach — never outlives the session.
+   */
+  closeBinder: () => void;
 }
 
 export function setupHookBridge(
@@ -100,8 +141,32 @@ export function setupHookBridge(
     transcriptFallbackTimers,
     autoApproveService,
     currentPort,
+    shadowBinder,
+    binderEnabled,
+    transcriptDiscovery,
   } = deps;
-  const { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker } = args;
+  const {
+    hookServer,
+    sessionId,
+    workingDirectory,
+    messageApi,
+    sendAndRecord: rawSendAndRecord,
+    tracker,
+  } = args;
+
+  // ---- Shadow-mode plumbing (#453 phase 3, commit 3) ----------------------
+  // When shadowBinder is OFF (the default), `sendAndRecord` and the binding
+  // writer below are the untouched originals: ZERO behavior change. When ON,
+  // sendAndRecord is wrapped in a forwarding tap that records (per old-path
+  // event) whether a session_rotated crossed the wire, then forwards EVERY
+  // message untouched. The tap never alters or drops a message.
+  let oldPathRotationEmitted = false;
+  const sendAndRecord = shadowBinder
+    ? (message: ProtocolMessage): void => {
+        if (message.type === 'session_rotated') oldPathRotationEmitted = true;
+        rawSendAndRecord(message);
+      }
+    : rawSendAndRecord;
 
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
@@ -454,6 +519,12 @@ export function setupHookBridge(
       tracker.recordPendingHook(question);
     },
     onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
+      // DRIVE: the binder's onHookEvent (fired from the SessionStart listener)
+      // already subsumes this SessionInfo bind/rotation; skip the old body so we
+      // never double-bind or double-emit. The bridge still fires this callback
+      // (status/subagent tracking lives on handlers.onSessionStart), but the
+      // binding control plane is the binder's alone.
+      if (binderEnabled) return;
       // Guard: skip if sibling daemons share this directory AND the transcript's
       // port marker does not prove this SessionStart is ours (#451). When the
       // marker matches our port we proceed so our own rotation rebinds even
@@ -582,7 +653,235 @@ export function setupHookBridge(
   const isSubagentEvent = (input: { agent_id?: string }): boolean =>
     typeof input.agent_id === 'string' && input.agent_id.length > 0;
 
+  // ---- Shadow TranscriptBinder (#453 phase 3, commit 3) -------------------
+  //
+  // ONE compute-only binder per session, constructed only when shadowBinder is
+  // on. It is provably side-effect-free:
+  //   - `sendAndRecord: () => {}`  -> cannot emit (no session_rotated on the wire).
+  //   - `bindingStore` wrapped read-only: `update()` is a no-op; `get(ourSession)`
+  //     returns the PER-EVENT snapshot (the store as it stood before the old path
+  //     ran) so the old path's same-event write cannot leak into the shadow's
+  //     adoptLockFromStore and race the classifier; foreign ids delegate through.
+  //   - `messageApi` no-op: `reset()` does nothing (the binder calls it on teardown).
+  //   - `onRotation: () => {}` -> no presence-tracker / question side effects.
+  //   - `start()` is a no-op in 'shadow' mode (no fs.watch, no fallback timer),
+  //     and we never call it anyway.
+  //
+  // After each old-path listener body runs, the same input is fed to the shadow
+  // binder mirroring the old listener order (preemptOnSessionStart + decide for
+  // SessionStart; decide for the events that call initFromHookEvent; onSessionEnd
+  // for SessionEnd), then we compare the binder's decision against the old path's
+  // observable outcome captured live from state.
+
+  // The real store's binding for OUR session as it stood at the START of the
+  // current event (captured before the old path runs). The shadow reads THIS,
+  // not the live store, so the old path's same-event write does not leak into
+  // the shadow's adoptLockFromStore and race the classifier into 'match' when
+  // the old path saw 'restart' (the #430/#433 snapshot invariant). For other
+  // sessions the wrapper delegates straight through (the binder only ever reads
+  // its own sessionId via get(), so this is exact).
+  let oldPathStoreSnapshot: ReturnType<SessionBindingStore['get']> = null;
+
+  const shadow: TranscriptBinder | null =
+    shadowBinder && transcriptDiscovery
+      ? new TranscriptBinder(
+          {
+            sessionRegistry,
+            // Read-only wrapper: get() delegates to the real store but, for our
+            // own session, returns the per-event entry snapshot taken before the
+            // old path mutated it (so the shadow adopts the same value the old
+            // path's adoptLockFromStore saw, not the old path's just-written id).
+            // update() is a no-op — the shadow must never write the binding.
+            bindingStore: {
+              get: (id: UUID) => (id === sessionId ? oldPathStoreSnapshot : bindingStore.get(id)),
+              getByClaudeSessionId: (id: string) => bindingStore.getByClaudeSessionId(id),
+              update: () => {},
+              preAssign: () => {},
+            } as unknown as SessionBindingStore,
+            liveSessionsRegistry,
+            transcriptWatchers,
+            transcriptFallbackTimers,
+            transcriptDiscovery,
+            // No-op MessageAPI: only reset() is reachable from the binder, and it
+            // must do nothing in shadow.
+            messageApi: { reset: () => {} } as unknown as MessageAPI,
+            sendAndRecord: () => {},
+            currentPort,
+            onRotation: () => {},
+          },
+          { sessionId, workingDirectory },
+          'shadow',
+        )
+      : null;
+
+  if (shadowBinder && !transcriptDiscovery) {
+    logError(
+      `[ShadowBinder] shadowBinder=true but no transcriptDiscovery dep supplied for ${sessionId.slice(0, 8)}; shadow comparison disabled`,
+    );
+  }
+
+  // ---- Drive TranscriptBinder (#453 phase 3, commit 5) --------------------
+  //
+  // ONE drive-mode binder per session, constructed only when binderEnabled is on
+  // (mutually exclusive with shadowBinder; the caller never sets both). It OWNS
+  // the binding/watcher/rotation control plane: the hook listeners below route to
+  // its `onHookEvent` / `admits` / `preemptOnSessionStart` / `onSessionEnd`
+  // INSTEAD of the old `initFromHookEvent` / `onSessionInfo` / `filterBySession`
+  // bodies. Wired with the REAL effect deps (the same `sendAndRecord`,
+  // `bindingStore`, `messageApi` the old path used) and the REAL rotation side
+  // effect (clear the presence tracker's pending record + sessionRegistry
+  // questions, exactly the old restart branch's
+  // `tracker.clearPending(); sessionRegistry.clearQuestions(sessionId)`).
+  //
+  // `start()` arms BOTH the existing fallback poll (Case A: our pre-assigned file
+  // appears) AND the #452 re-arming dir-watch (Case B: a no-hooks rotation), so
+  // in drive mode the cli.ts-level `startTranscriptFallback` is NOT also called
+  // (the caller skips it to avoid double-arming). The pre-assigned claudeSessionId
+  // is the binding cli.ts wrote to the store before spawn (#427); read it here.
+  const driveBinder: TranscriptBinder | null =
+    binderEnabled && transcriptDiscovery
+      ? new TranscriptBinder(
+          {
+            sessionRegistry,
+            bindingStore,
+            liveSessionsRegistry,
+            transcriptWatchers,
+            transcriptFallbackTimers,
+            transcriptDiscovery,
+            messageApi,
+            sendAndRecord: rawSendAndRecord,
+            currentPort,
+            onRotation: () => {
+              // The old restart branch's injected side effects: drop any hook
+              // record stashed before the rotation so the new session's first
+              // PTY prompt cannot merge stale option labels, and drop the
+              // pending-question collection so stale answers are refused.
+              tracker.clearPending();
+              sessionRegistry.clearQuestions(sessionId);
+            },
+          },
+          { sessionId, workingDirectory },
+          'drive',
+        )
+      : null;
+
+  if (binderEnabled && !transcriptDiscovery) {
+    logError(
+      `[Binder] binderEnabled=true but no transcriptDiscovery dep supplied for ${sessionId.slice(0, 8)}; drive mode disabled`,
+    );
+  }
+
+  if (driveBinder) {
+    // Arm the fallback poll + #452 dir-watch on the pre-assigned id (the binding
+    // cli.ts wrote to the store before Bun.spawn). On a fresh store read this is
+    // the deterministic claude id Claude will write under.
+    const preAssignedClaudeId = bindingStore.get(sessionId)?.claudeSessionId ?? null;
+    if (preAssignedClaudeId) {
+      driveBinder.start(preAssignedClaudeId);
+    } else {
+      logError(
+        `[Binder] No pre-assigned claudeSessionId for ${sessionId.slice(0, 8)}; fallback poll + dir-watch not armed`,
+      );
+    }
+  }
+
+  /**
+   * Capture the old path's observable control-plane outcome from LIVE state,
+   * read right after the old-path listener body ran. `boundId` is a disk-fresh
+   * read of the binding the old path may have written; `watcherPath` is the
+   * path of the watcher the old path may have (re)started; `rotationEmitted` is
+   * the per-event flag set by the sendAndRecord tap above.
+   */
+  const observeOldState = (): {
+    boundId: string | null;
+    watcherPath: string | null;
+    rotationEmitted: boolean;
+  } => ({
+    boundId: bindingStore.get(sessionId)?.claudeSessionId ?? null,
+    watcherPath: transcriptWatchers.get(sessionId)?.filePath ?? null,
+    rotationEmitted: oldPathRotationEmitted,
+  });
+
+  /**
+   * Emit a single structured DISAGREE line ONLY when the binder's decision and
+   * the old path's observed outcome diverge on a LOAD-BEARING control-plane
+   * field: the DURABLE store binding after the event, or whether a rotation was
+   * emitted. watcherPath is compared path-normalized but is advisory (the binder
+   * reports intent, the old path reports the live watcher). Silent on agreement.
+   *
+   * The compared "bound id" is the DURABLE store binding, not the binder's
+   * in-memory lock. The two diverge intentionally on a path-less restart: the
+   * old path NULLs its in-closure lock but does NOT write the store (no path to
+   * rebind on), so the store keeps the prior id; the binder likewise drops its
+   * in-memory `currentBoundId` to null WITHOUT writing the store. So the binder's
+   * store-after = `boundIdAfter` when it (re)bound this event, else the prior
+   * snapshot (it wrote nothing). That reconstruction matches the old path's
+   * post-event store exactly — which is the #430/#433 invariant we are pinning.
+   */
+  const compareAndLog = (
+    eventName: string,
+    input: BinderHookEvent,
+    decision: BinderDecision,
+    old: { boundId: string | null; watcherPath: string | null; rotationEmitted: boolean },
+  ): void => {
+    const diffs: string[] = [];
+    // The binder writes the store only when it (re)binds (boundIdAfter non-null);
+    // otherwise it leaves the durable binding untouched at its pre-event value.
+    const binderStoreAfter = decision.boundIdAfter ?? oldPathStoreSnapshot?.claudeSessionId ?? null;
+    if (binderStoreAfter !== old.boundId) {
+      diffs.push(`boundId binder=${binderStoreAfter ?? 'null'} old=${old.boundId ?? 'null'}`);
+    }
+    if (decision.wouldEmitRotation !== old.rotationEmitted) {
+      diffs.push(`rotation binder=${decision.wouldEmitRotation} old=${old.rotationEmitted}`);
+    }
+    const binderWatcher = decision.watcherPath ? path.resolve(decision.watcherPath) : null;
+    const oldWatcher = old.watcherPath ? path.resolve(old.watcherPath) : null;
+    if (decision.wouldStartWatcher && binderWatcher !== oldWatcher) {
+      diffs.push(`watcherPath binder=${binderWatcher ?? 'null'} old=${oldWatcher ?? 'null'}`);
+    }
+    if (diffs.length > 0) {
+      logError(
+        `[ShadowBinder] DISAGREE ${eventName}: ${diffs.join('; ')} (class=${decision.classification} incoming=${input.session_id?.slice(0, 8) ?? 'none'})`,
+      );
+    }
+  };
+
+  /**
+   * Run at the TOP of every listener (before the old path executes). Resets the
+   * per-event rotation tap and snapshots the real store's current binding for
+   * our session so the shadow's read reflects the pre-event truth. No-op when
+   * shadow is off.
+   */
+  const shadowEnterEvent = (): void => {
+    if (!shadow) return;
+    oldPathRotationEmitted = false;
+    oldPathStoreSnapshot = bindingStore.get(sessionId);
+  };
+
+  /**
+   * Feed an event that went through the `initFromHookEvent` old path to the
+   * shadow binder via `decide()`, then compare. `shadowEnterEvent` must have run
+   * at handler entry; here we just read the captured outcome. Called at the END
+   * of each old-path listener body.
+   */
+  const shadowDecide = (eventName: string, input: BinderHookEvent): void => {
+    if (!shadow) return;
+    const decision = shadow.decide(input);
+    compareAndLog(eventName, input, decision, observeOldState());
+  };
+
   hookServer.on('SessionStart', (input) => {
+    shadowEnterEvent(); // reset rotation tap + snapshot store (shadow-only)
+    if (driveBinder) {
+      // DRIVE: the binder owns the pre-empt + bind. Mirror the old listener
+      // order — pre-empt (flip its own mainSessionEnded) BEFORE onHookEvent.
+      // The old closure pre-empt + initFromHookEvent below are skipped; the
+      // bridge's onSessionInfo body is also skipped (binder subsumes it).
+      driveBinder.preemptOnSessionStart(input);
+      driveBinder.onHookEvent(input);
+      handlers.onSessionStart?.(input);
+      return;
+    }
     // Pre-empt the classifier into 'restart' on any session_id rotation while
     // our PTY is alive, regardless of `source` (Claude Code rotates session_id
     // through flows that omit source or carry undocumented values; the narrow
@@ -610,32 +909,49 @@ export function setupHookBridge(
     }
     initFromHookEvent(input);
     handlers.onSessionStart?.(input);
+    // Shadow: mirror the old listener order — pre-empt BEFORE decide so the
+    // binder flips its own mainSessionEnded exactly like the closure above did.
+    if (shadow) {
+      shadow.preemptOnSessionStart(input);
+      shadowDecide('SessionStart', input);
+    }
   });
 
   hookServer.on('PreToolUse', (input) => {
-    initFromHookEvent(input);
-    if (!filterBySession(input)) return;
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('PreToolUse', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PreToolUse');
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
-    initFromHookEvent(input);
-    if (!filterBySession(input)) return;
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('PostToolUse', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
     autoApproveGate.cancelStale('PostToolUse');
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {
-    initFromHookEvent(input);
-    if (!filterBySession(input)) return;
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('Notification', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // SessionEnd already cleared status to 'idle'; a late
     // Notification(permission_prompt) for the dying session would
     // re-populate tracker.pending and a final PTY echo could fire a
     // spurious push the user cannot answer. Gate at the listener
     // boundary; restart resets mainSessionEnded so legitimate
-    // post-restart notifications still pass.
-    if (mainSessionEnded) {
+    // post-restart notifications still pass. In drive mode the binder owns
+    // mainSessionEnded (and resets it on restart via rotate()), so read it
+    // there as the single source of truth; the closure flag is the old path's.
+    if (driveBinder ? driveBinder.isMainEnded() : mainSessionEnded) {
       log(`[Hooks] Dropped post-SessionEnd Notification: type=${input.notification_type}`);
       return;
     }
@@ -647,8 +963,11 @@ export function setupHookBridge(
     handlers.onNotification?.(input);
   });
   hookServer.on('PermissionRequest', (input) => {
-    initFromHookEvent(input);
-    if (!filterBySession(input)) return;
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('PermissionRequest', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
     // owns the PTY injection, the subagent PTY-presence gate, the default-deny
     // safety net, and the escalate fallback; session filtering above stays here in
@@ -657,17 +976,36 @@ export function setupHookBridge(
     autoApproveGate.handlePermissionRequest(input);
   });
   hookServer.on('Stop', (input) => {
-    initFromHookEvent(input);
-    if (!filterBySession(input)) return;
+    shadowEnterEvent();
+    if (driveBinder) driveBinder.onHookEvent(input);
+    else initFromHookEvent(input);
+    shadowDecide('Stop', input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     autoApproveGate.cancelStale('Stop');
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
+    shadowEnterEvent();
+    if (driveBinder) {
+      // DRIVE: the binder owns mainSessionEnded on id-match (and resets it on
+      // restart via rotate()). The post-SessionEnd Notification drop reads
+      // driveBinder.isMainEnded() directly, so there is no closure flag to keep
+      // in sync here — the binder is the single source of truth.
+      driveBinder.onSessionEnd(input);
+      if (!driveBinder.admits(input)) return;
+      autoApproveGate.cancelStale('SessionEnd');
+      handlers.onSessionEnd?.(input);
+      return;
+    }
     // Only mark our main as ended when the session_id matches what we locked.
     // Foreign SessionEnds (subagents, siblings) must not unlock our tracking.
     if (input.session_id && claudeSessionId && input.session_id === claudeSessionId) {
       mainSessionEnded = true;
     }
+    // Shadow: SessionEnd does NOT run initFromHookEvent/decide; it only flips
+    // mainSessionEnded on id-match. Mirror with onSessionEnd (no decide, no
+    // compare — there is no binding/rotation outcome to diff on this event).
+    shadow?.onSessionEnd(input);
     if (!filterBySession(input)) return;
     autoApproveGate.cancelStale('SessionEnd');
     handlers.onSessionEnd?.(input);
@@ -675,5 +1013,8 @@ export function setupHookBridge(
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);
 
-  return { bridge: hookBridge };
+  return {
+    bridge: hookBridge,
+    closeBinder: () => driveBinder?.close(),
+  };
 }

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -19,22 +19,19 @@
  */
 
 import { createStructuredAgentOutput, generateId, now } from '@remi/shared';
-import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } from '@remi/shared';
+import type { AgentStatus, ProtocolMessage, Question, UUID } from '@remi/shared';
 
 import type { MessageAPIEvents } from '../../api/message-api.ts';
 import { MessageAPI } from '../../api/message-api.ts';
-import { sendPushTrigger } from '../../notifications/push-client.ts';
-import { PushDedup } from '../../notifications/push-dedup.ts';
+import { NotificationDispatcher } from '../../notifications/notification-dispatcher.ts';
+import type { PushConfig } from '../../notifications/notification-dispatcher.ts';
 import type { SessionRegistry } from '../../session/index.ts';
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import type { DeviceTokenEntry } from '../handlers/trivial-events.ts';
 import { log, logError } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
 
-export interface PushConfig {
-  signalingUrl: string;
-  pushSecret?: string | undefined;
-}
+export type { PushConfig };
 
 export interface MessageApiSetupDeps {
   sessionRegistry: SessionRegistry;
@@ -65,18 +62,6 @@ export interface MessageApiHandle {
   sendAndRecord: (message: ProtocolMessage) => void;
 }
 
-/**
- * Select the APNS notification category based on the number of question
- * options. iOS renders action buttons matching the category; watchOS mirrors
- * them automatically.
- */
-export function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
-  if (options.length === 2) return 'REMI_YN';
-  if (options.length === 3) return 'REMI_YNA';
-  if (options.length === 4) return 'REMI_MULTI';
-  return undefined;
-}
-
 export function createMessageApiForSession(
   deps: MessageApiSetupDeps,
   sessionId: UUID,
@@ -101,11 +86,13 @@ export function createMessageApiForSession(
     sessionRegistry.recordOutgoingMessage(recordId, message);
   };
 
-  // Per-session push-dedup baseline. PTY + Hook double-emit one prompt
-  // with different ids; without this, the user gets two lock-screen
-  // notifications per prompt (#409). Reset whenever status leaves
-  // 'waiting' so a fresh prompt cycle starts with a clean baseline.
-  const pushDedup = new PushDedup();
+  // APNS push for this session's questions (#453 phase 1). Owns the
+  // active-client gate, the per-prompt PushDedup baseline (#409), and the
+  // device-token fan-out; the MessageAPI callback just hands it the question.
+  const notifications = new NotificationDispatcher(
+    { sessionRegistry, deviceTokens, pushConfig, getPrimarySessionId },
+    sessionId,
+  );
 
   const callbacks: MessageAPIEvents = {
     onStructuredMessage: (structured) => {
@@ -141,37 +128,7 @@ export function createMessageApiForSession(
       sessionRegistry.addQuestion(questionSessionId, question);
 
       // Push only when no client is attached; attached clients see it in-app.
-      const sessionForPush = sessionRegistry.getSession(questionSessionId);
-      const hasActiveClient =
-        sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-      if (deviceTokens.size > 0 && !hasActiveClient) {
-        // Push-dedup gate (#409): suppress the PTY/Hook double-emission
-        // for one prompt cycle. Mirrors the client's richer-wins guard
-        // so phone and in-app converge on the same option set.
-        if (!pushDedup.shouldPush(question)) {
-          log(`Push suppressed by dedup for session ${questionSessionId}`);
-          return;
-        }
-        const session = sessionRegistry.getSession(sessionId);
-        const sessionName = session?.name || 'Agent';
-        const cfg = pushConfig();
-        const pushSessionId = getPrimarySessionId() ?? sessionId;
-        const pushCategory = selectPushCategory(question.options);
-        const pushOptions = question.options.map((o) => o.value);
-        for (const dt of deviceTokens.values()) {
-          sendPushTrigger(cfg.signalingUrl, dt.token, {
-            title: `${sessionName} needs input`,
-            body: question.text.slice(0, 100),
-            ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
-            sessionId: pushSessionId,
-            questionId: question.id,
-            ...(pushCategory !== undefined ? { category: pushCategory } : {}),
-            ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
-          })
-            .then(() => log(`Push notification sent for session ${pushSessionId}`))
-            .catch((err) => log(`Push notification failed: ${err}`));
-        }
-      }
+      notifications.maybePush(questionSessionId, question);
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);
@@ -180,7 +137,7 @@ export function createMessageApiForSession(
       // prompt cycle starts fresh and is not silently absorbed by a
       // stale prior push (#409).
       if (status !== 'waiting') {
-        pushDedup.reset();
+        notifications.resetDedup();
       }
       const msg: ProtocolMessage = {
         type: 'session_update',

--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -21,13 +21,13 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionStore } from '../session/index.ts';
+import type { SessionBindingStore } from '../session/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../transcript/index.ts';
 import type { AssistantEntry } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
 
 export interface ExtractClaudeSessionIdDeps {
-  sessionStore: SessionStore;
+  bindingStore: SessionBindingStore;
 }
 
 /**
@@ -50,7 +50,7 @@ export function extractClaudeSessionId(
   const parts = basename.split('_');
   const candidateId = parts[parts.length - 1];
   if (candidateId && candidateId.length >= 8) {
-    deps.sessionStore.updateClaudeSessionId(sessionId, candidateId);
+    deps.bindingStore.update(sessionId, candidateId);
     log(`Claude session ID: ${candidateId}`);
     return candidateId;
   }

--- a/packages/daemon/src/cli/transcript-watcher-setup.ts
+++ b/packages/daemon/src/cli/transcript-watcher-setup.ts
@@ -6,56 +6,20 @@
  * shared `transcriptWatchers` map so other code (status refresh, cleanup,
  * fallback teardown) can find it by session id.
  *
- * `extractClaudeSessionId` is **deprecated** (post-#427/phase 1): the
- * daemon now pre-assigns the Claude session id via `resolveClaudeBinding`
- * before spawn and persists it directly to `SessionStore`, so no
- * filename-based inference is needed. The function is kept only because
- * the test suite still exercises it; remove once tests are migrated.
- *
- * Both helpers are pure over their inputs — no module-level singletons — so
- * tests can supply tmpdir-backed stores and an in-memory Map.
+ * Pure over its inputs — no module-level singletons — so tests can supply
+ * tmpdir-backed stores and an in-memory Map. (The deprecated
+ * `extractClaudeSessionId` filename-inference helper was removed in #469;
+ * the daemon pre-assigns the Claude session id via `resolveClaudeBinding`
+ * before spawn, so no runtime inference is needed.)
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
-import type { SessionBindingStore } from '../session/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../transcript/index.ts';
 import type { AssistantEntry } from '../transcript/index.ts';
 import { log, logError } from './logger.ts';
-
-export interface ExtractClaudeSessionIdDeps {
-  bindingStore: SessionBindingStore;
-}
-
-/**
- * @deprecated Superseded by `resolveClaudeBinding` (#427/phase 1). The
- * daemon now pre-assigns the Claude session id before spawn; no
- * filename-based inference happens at runtime. Retained only for the
- * legacy test surface; not called from any production code path.
- *
- * Extracts the Claude session id from a transcript filename and persists
- * it. Returns the extracted id, or null if the filename does not expose
- * one. Filenames are plain UUIDs (`abc123-def456.jsonl`); the underscore
- * split is defensive in case a prefixed format is ever introduced.
- */
-export function extractClaudeSessionId(
-  deps: ExtractClaudeSessionIdDeps,
-  transcriptPath: string,
-  sessionId: UUID,
-): string | null {
-  const basename = path.basename(transcriptPath, '.jsonl');
-  const parts = basename.split('_');
-  const candidateId = parts[parts.length - 1];
-  if (candidateId && candidateId.length >= 8) {
-    deps.bindingStore.update(sessionId, candidateId);
-    log(`Claude session ID: ${candidateId}`);
-    return candidateId;
-  }
-  return null;
-}
 
 export interface StartTranscriptWatcherDeps {
   transcriptWatchers: Map<UUID, TranscriptWatcher>;

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -49,6 +49,21 @@ export interface TelegramConfig {
   readonly authorized_user_ids: readonly number[];
 }
 
+/**
+ * Experimental feature flags (epic #453). Default OFF. Snapshotted into a const at
+ * daemon boot and treated as immutable for the process lifetime — never re-read per
+ * session (a mid-process flip would split sessions across the old/new code paths,
+ * which share the transcriptWatchers map).
+ */
+export interface FeaturesConfig {
+  /** Phase 3: run the TranscriptBinder in compute-only shadow mode alongside the old
+   *  path and log decision disagreements. No side effects; observation only. */
+  readonly transcript_binder_shadow: boolean;
+  /** Phase 3: the TranscriptBinder DRIVES the session-binding/watcher/rotation; the
+   *  old initFromHookEvent/onSessionInfo path is skipped. */
+  readonly transcript_binder_enabled: boolean;
+}
+
 /** Complete Remi configuration */
 export interface RemiConfig {
   readonly daemon: DaemonConfig;
@@ -57,6 +72,7 @@ export interface RemiConfig {
   readonly display: DisplayConfig;
   readonly telegram: TelegramConfig;
   readonly auto_approve: AutoApproveConfig;
+  readonly features: FeaturesConfig;
 }
 
 /** Built-in defaults used when no config file or CLI flags are provided */
@@ -98,6 +114,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     multichoice: 'skip',
     multichoice_model: '',
   },
+  features: {
+    transcript_binder_shadow: false,
+    transcript_binder_enabled: false,
+  },
 };
 
 /**
@@ -129,6 +149,10 @@ function deepMerge(base: RemiConfig, partial: Record<string, unknown>): RemiConf
     auto_approve: mergeSection(
       base.auto_approve,
       partial['auto_approve'] as Record<string, unknown> | undefined,
+    ),
+    features: mergeSection(
+      base.features,
+      partial['features'] as Record<string, unknown> | undefined,
     ),
   };
 }
@@ -346,6 +370,19 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       env['REMI_AUTO_APPROVE_MULTICHOICE_MODEL'];
   }
 
+  // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
+  const features = { ...config.features };
+  if (env['REMI_TRANSCRIPT_BINDER_SHADOW'] === 'true') {
+    (features as { transcript_binder_shadow: boolean }).transcript_binder_shadow = true;
+  } else if (env['REMI_TRANSCRIPT_BINDER_SHADOW'] === 'false') {
+    (features as { transcript_binder_shadow: boolean }).transcript_binder_shadow = false;
+  }
+  if (env['REMI_TRANSCRIPT_BINDER_ENABLED'] === 'true') {
+    (features as { transcript_binder_enabled: boolean }).transcript_binder_enabled = true;
+  } else if (env['REMI_TRANSCRIPT_BINDER_ENABLED'] === 'false') {
+    (features as { transcript_binder_enabled: boolean }).transcript_binder_enabled = false;
+  }
+
   return {
     ...config,
     daemon,
@@ -353,6 +390,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     display,
     telegram,
     auto_approve,
+    features,
   };
 }
 
@@ -490,6 +528,11 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  instructions = ${instrDisplay}`);
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
+  lines.push('');
+  lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
+  lines.push('[features]');
+  lines.push(`  transcript_binder_shadow = ${config.features.transcript_binder_shadow}`);
+  lines.push(`  transcript_binder_enabled = ${config.features.transcript_binder_enabled}`);
 
   return lines.join('\n');
 }

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -1,0 +1,127 @@
+/**
+ * NotificationDispatcher — owns APNS push for a session's questions.
+ *
+ * Epic #453 phase 1: extracted from `cli/session-phases/message-api-setup.ts`
+ * so the push concern (active-client gate + per-prompt dedup + the device-token
+ * fan-out) is a named member of the future `QuestionPipeline`, not inlined in
+ * the MessageAPI question callback.
+ *
+ * Push fires only when no client is actively viewing the session (attached
+ * clients see the question in-app over the WebSocket). The per-session
+ * PushDedup baseline suppresses the PTY+Hook double-emission of one prompt so
+ * the user does not get two lock-screen notifications per prompt (#409); it is
+ * reset whenever the agent leaves the 'waiting' state.
+ */
+
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+
+import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
+import { log } from '../cli/logger.ts';
+import type { SessionRegistry } from '../session/index.ts';
+import { sendPushTrigger } from './push-client.ts';
+import { PushDedup } from './push-dedup.ts';
+
+export interface PushConfig {
+  /**
+   * Signaling server base URL. Always provided by the caller; `sendPushTrigger`'s
+   * `string | undefined` first parameter is wider (it has its own fallback), but
+   * the dispatcher never passes undefined here.
+   */
+  signalingUrl: string;
+  pushSecret?: string | undefined;
+}
+
+/**
+ * Select the APNS notification category from the number of question options.
+ * iOS renders action buttons matching the category; watchOS mirrors them.
+ */
+export function selectPushCategory(options: readonly QuestionOption[]): string | undefined {
+  if (options.length === 2) return 'REMI_YN';
+  if (options.length === 3) return 'REMI_YNA';
+  if (options.length === 4) return 'REMI_MULTI';
+  return undefined;
+}
+
+/** Signature of the APNS-relay push call; injectable so the push branch is
+ *  observable in tests without mocking a network module. */
+export type PushFn = typeof sendPushTrigger;
+
+export interface NotificationDispatcherDeps {
+  sessionRegistry: SessionRegistry;
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  /**
+   * Current push config; read on every dispatch so the caller can swap the
+   * source without re-wiring. Must be synchronous and non-throwing.
+   */
+  pushConfig: () => PushConfig;
+  /**
+   * Reads the primary session id the client knows (from hello_ack) so pushes
+   * carry the id the phone can route on. Injected (not imported) so the
+   * dispatcher has no upward dependency on cli/session-state.
+   */
+  getPrimarySessionId: () => UUID | null;
+  /** Defaults to the real sendPushTrigger; overridden in tests. */
+  pushFn?: PushFn;
+}
+
+export class NotificationDispatcher {
+  private readonly pushDedup = new PushDedup();
+  /** Resolved once at construction: the real sendPushTrigger unless a test
+   *  injected an override. Fixed for the instance lifetime. */
+  private readonly pushFn: PushFn;
+
+  constructor(
+    private readonly deps: NotificationDispatcherDeps,
+    private readonly sessionId: UUID,
+  ) {
+    this.pushFn = deps.pushFn ?? sendPushTrigger;
+  }
+
+  /**
+   * Reset the dedup baseline when the prompt cycle ends (status != 'waiting'),
+   * same lifecycle as QuestionDedup so a new prompt starts fresh (#409).
+   */
+  resetDedup(): void {
+    this.pushDedup.reset();
+  }
+
+  /**
+   * Push `question` to all registered devices, unless a client is actively
+   * attached (they see it in-app) or the dedup gate suppresses it.
+   * `questionSessionId` is the primary id the client knows (from hello_ack).
+   */
+  maybePush(questionSessionId: UUID, question: Question): void {
+    const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
+
+    const sessionForPush = sessionRegistry.getSession(questionSessionId);
+    const hasActiveClient =
+      sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
+    if (deviceTokens.size === 0 || hasActiveClient) return;
+
+    if (!this.pushDedup.shouldPush(question)) {
+      log(`Push suppressed by dedup for session ${questionSessionId}`);
+      return;
+    }
+
+    const session = sessionRegistry.getSession(this.sessionId);
+    const sessionName = session?.name || 'Agent';
+    const cfg = pushConfig();
+    const pushSessionId = this.deps.getPrimarySessionId() ?? this.sessionId;
+    const pushCategory = selectPushCategory(question.options);
+    const pushOptions = question.options.map((o) => o.value);
+
+    for (const dt of deviceTokens.values()) {
+      this.pushFn(cfg.signalingUrl, dt.token, {
+        title: `${sessionName} needs input`,
+        body: question.text.slice(0, 100),
+        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+        sessionId: pushSessionId,
+        questionId: question.id,
+        ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+        ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+      })
+        .then(() => log(`Push notification sent for session ${pushSessionId}`))
+        .catch((err) => log(`Push notification failed: ${err}`));
+    }
+  }
+}

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -14,7 +14,13 @@
  *   peer-connected -> auth_challenge -> auth_response -> auth_result -> onConnect
  */
 
-import { createAgentOutput, createAuthResult, createQuestion, generateId } from '@remi/shared';
+import {
+  createAgentOutput,
+  createAuthResult,
+  createError,
+  createQuestion,
+  generateId,
+} from '@remi/shared';
 import type {
   AgentStatus,
   AuthResponseMessage,
@@ -332,11 +338,56 @@ export class RelayAdapter implements ConnectionAdapter {
         }
         this.events.onTerminalResize?.(connectionId, msg['cols'], msg['rows']);
         break;
+      case 'kill_session_request':
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid kill_session_request payload: missing sessionId or id');
+          return;
+        }
+        this.events.onKillSessionRequest?.(connectionId, msg['sessionId'], msg['id']);
+        break;
+      case 'detach_session':
+        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
+          console.warn('Invalid detach_session payload: missing sessionId or id');
+          return;
+        }
+        this.events.onDetachSession?.(connectionId, msg['sessionId'], msg['id']);
+        break;
+      case 'session_history_request': {
+        if (typeof msg['id'] !== 'string') {
+          console.warn('Invalid session_history_request payload: missing id');
+          return;
+        }
+        const limit = typeof msg['limit'] === 'number' ? msg['limit'] : undefined;
+        this.events.onSessionHistoryRequest?.(connectionId, msg['id'], limit);
+        break;
+      }
+      case 'register_device_token':
+        if (typeof msg['token'] !== 'string') {
+          console.warn('Invalid register_device_token payload: missing token');
+          return;
+        }
+        if (msg['platform'] !== 'ios' && msg['platform'] !== 'android') {
+          console.warn('Invalid register_device_token payload: platform must be ios or android');
+          return;
+        }
+        this.events.onRegisterDeviceToken?.(connectionId, msg['token'], msg['platform']);
+        break;
+      case 'ping':
+        // Liveness ping needs no reply over relay.
+        break;
       case 'hello':
         // Hello is handled at connection level, not message level
         break;
       default:
         console.warn(`Unknown relay message type: ${msg['type']}`);
+        this.client?.sendRelay(
+          JSON.stringify(
+            createError(
+              'UNSUPPORTED',
+              `Message type '${String(msg['type'])}' is not supported over relay`,
+            ),
+          ),
+        );
     }
   }
 

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -13,6 +13,8 @@ export {
 
 export { SessionStore, type StoredSession } from './session-store.ts';
 
+export { SessionBindingStore, type SessionBinding } from './session-binding-store.ts';
+
 export {
   SessionRegistryFile,
   type LiveSessionEntry,

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -1,0 +1,70 @@
+/**
+ * SessionBindingStore — the single typed accessor for the durable session binding
+ * (remiUUID <-> claudeSessionId) persisted in sessions.json.
+ *
+ * Epic #453 phase 2. Today the binding is read/written from ~12 scattered sites and
+ * the two resume resolvers read it independently (and can diverge after a rotation).
+ * This facade consolidates the binding surface so every reader/writer goes through
+ * one auditable API, and gives phase-3's TranscriptBinder a single binding dependency.
+ *
+ * NO CACHE — deliberately. It delegates straight to the stateless SessionStore
+ * (fs.readFileSync on every findBy* call), so every read stays disk-fresh and the
+ * accessor is behavior-identical to today's direct SessionStore calls. The phase-2
+ * adversarial review showed a write-through in-memory copy would reintroduce #321
+ * (a cached claudeSessionId wedging classify) and break the #430 "re-adopt on
+ * rotation" characterization test, because today's cross-process freshness comes
+ * precisely from SessionStore being stateless. The cost of a readFileSync on a
+ * <100-entry JSON is microseconds; binding reads are not a hot path. (Design §3.2 v3.)
+ *
+ * Scope: the durable binding ONLY. Liveness (pid/childPid/claudeChildExited) stays in
+ * SessionRegistryFile; transcriptPath has no disk column today (a phase-3 concern).
+ */
+
+import type { UUID } from '@remi/shared';
+
+import type { SessionStore, StoredSession } from './session-store.ts';
+
+export interface SessionBinding {
+  claudeSessionId: string | null;
+}
+
+export class SessionBindingStore {
+  constructor(private readonly store: SessionStore) {}
+
+  /**
+   * Current durable binding for this Remi session, or null when no record exists.
+   * Disk-backed every call (no cache) so a sibling/rotation write is always observed
+   * (#321/#430). Returns an object iff the record exists — exactly mirroring
+   * `findByRemiSessionId(id)?.claudeSessionId`: a record present with a null binding
+   * yields `{ claudeSessionId: null }`, an absent record yields `null`. Callers that
+   * want the id keep using `?.claudeSessionId`, so the substitution is behavior-identical.
+   */
+  get(remiSessionId: UUID): SessionBinding | null {
+    const stored = this.store.findByRemiSessionId(remiSessionId);
+    return stored ? { claudeSessionId: stored.claudeSessionId } : null;
+  }
+
+  /** Reverse lookup: the full record bound to a Claude session id (disk-backed). */
+  getByClaudeSessionId(claudeSessionId: string): StoredSession | null {
+    return this.store.findByClaudeSessionId(claudeSessionId);
+  }
+
+  /**
+   * Update the durable binding on rotation / first discovery. Delegates to
+   * SessionStore.updateClaudeSessionId (a no-op when the record is absent, matching
+   * today). Together with preAssign, the ONLY claudeSessionId writer.
+   */
+  update(remiSessionId: UUID, claudeSessionId: string): void {
+    this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+  }
+
+  /**
+   * Pre-spawn deterministic assignment: persist the full session record. Takes the
+   * whole StoredSession (not just the binding) because save() creates the row,
+   * including the liveness fields (pid/port/exitedAt) which are the CALLER's
+   * responsibility to populate correctly — the accessor does not own them.
+   */
+  preAssign(session: StoredSession): void {
+    this.store.save(session);
+  }
+}

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -79,9 +79,25 @@ export class SessionStore {
   private write(sessions: StoredSession[]): void {
     this.ensureDir();
     const data: SessionsFile = { version: 1, sessions };
-    const tmpPath = `${this.filePath}.tmp`;
+    // Per-writer-unique tmp path. A fixed `${filePath}.tmp` shared across
+    // processes is a multi-writer race (#461): when two daemons in the same
+    // ~/.remi write concurrently, both target the same tmp file and whichever
+    // renames second hits ENOENT because the first already moved it away.
+    // The pid scopes the tmp per process; the synchronous write+rename
+    // serialize within a process, so the pid alone makes collisions impossible.
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
     fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-    fs.renameSync(tmpPath, this.filePath);
+    try {
+      fs.renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      // Don't leave our tmp file behind if the rename fails.
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        // best-effort cleanup; surface the original error
+      }
+      throw err;
+    }
   }
 
   /** Save or update a session record. Trims to MAX_SESSIONS. */

--- a/packages/daemon/src/transcript/index.ts
+++ b/packages/daemon/src/transcript/index.ts
@@ -9,6 +9,14 @@ export { TranscriptWatcher } from './transcript-watcher.ts';
 export { TranscriptDiscovery } from './transcript-discovery.ts';
 export { TranscriptMessageBridge } from './transcript-message-bridge.ts';
 export { readTranscriptOwnerPort } from './transcript-owner.ts';
+export { TranscriptBinder } from './transcript-binder.ts';
+export type {
+  BinderDecision,
+  BinderHookEvent,
+  BinderMode,
+  TranscriptBinderArgs,
+  TranscriptBinderDeps,
+} from './transcript-binder.ts';
 export type { TranscriptDiscoveryConfig } from './transcript-discovery.ts';
 export type {
   TranscriptMessageBridgeConfig,

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -1,0 +1,952 @@
+/**
+ * TranscriptBinder — the single owner of one Remi session's binding state,
+ * transcript watcher, and Claude-restart rotation (epic #453, phase 3).
+ *
+ * This is a BEHAVIOR-PRESERVING extraction of the logic previously scattered
+ * across `cli/session-phases/hook-bridge-setup.ts` (`initFromHookEvent`,
+ * `onSessionInfo`, `teardownWatcher`, `ensureWatcher`, the SessionStart
+ * pre-empt, the SessionEnd id-match, `hasSiblingInDir`, `ownsTranscript`,
+ * `adoptLockFromStore`) plus the fallback poll arming previously done in
+ * `cli.ts`. The state machine reproduces the hook-bridge logic EXACTLY; the
+ * phase-0 characterization suite (`tests/cli/session-phases/hook-bridge-setup.test.ts`)
+ * is the contract this class must satisfy.
+ *
+ * Two entry points, with a strict ownership split:
+ *
+ *   - `decide(event)` is PURE — it runs the snapshot -> adopt -> rotation ->
+ *     classify pipeline and returns a `BinderDecision` describing what the
+ *     DRIVE path WOULD do, WITHOUT any external effect (no store write, no
+ *     watcher start, no send, no teardown). It MAY advance the binder's OWN
+ *     state fields so successive `decide()` calls track rotations the same
+ *     way the live path does. This is the shadow-mode tap (design §3.1 v4 #8).
+ *
+ *   - `onHookEvent(event)` is the DRIVE path = decide-equivalent ordering plus
+ *     the side effects, and the SINGLE caller of `rotate()`. Ordering mirrors
+ *     `initFromHookEvent` to the line: snapshot -> adopt -> classify ->
+ *     foreign/defer return -> restart funnels through `rotate()` -> the
+ *     `if (currentBoundId) { ensureWatching; return }` tripwire (BEFORE the
+ *     first-adopt emit, so the store-raced case stays zero-emit, #430) ->
+ *     first-adopt: bindingStore.update + ensureWatching + (isRotation &&
+ *     !announced) emitRotated.
+ *
+ * All rotation emits go through `emitRotated`, which is idempotent on
+ * `lastAnnouncedRotationId` (design §3.1 v4 #2) so an A->B->A re-resume emits
+ * A->B, B->A, and never a duplicate A->B.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createSessionRotated, errorToString } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+
+import type { MessageAPI } from '../api/message-api.ts';
+import { log, logError } from '../cli/logger.ts';
+import { startTranscriptFallback } from '../cli/transcript-fallback.ts';
+import { startTranscriptWatcher } from '../cli/transcript-watcher-setup.ts';
+import { classifySessionEvent } from '../hooks/session-lock-classifier.ts';
+import type { SessionEventClass } from '../hooks/session-lock-classifier.ts';
+import { claudeChildLooksAlive } from '../session/index.ts';
+import type {
+  SessionBindingStore,
+  SessionRegistry,
+  SessionRegistryFile,
+} from '../session/index.ts';
+import type { TranscriptDiscovery } from './transcript-discovery.ts';
+import { readTranscriptOwnerPort } from './transcript-owner.ts';
+import type { TranscriptWatcher } from './transcript-watcher.ts';
+
+/**
+ * Re-stat cadence for the #452 no-hooks rotation detector. 1500ms is a
+ * deliberate middle: fast enough that a no-hooks rotation surfaces within
+ * ~1.5–3s (comparable to the existing 2s fallback poll), slow enough that
+ * readdir+stat on a ~tens-of-files dir is negligible CPU.
+ */
+const ROTATION_POLL_INTERVAL_MS = 1500;
+/**
+ * How long a NEW `.jsonl` may sit with an unreadable `remi:<port>` head marker
+ * before we stop re-polling it. The marker-ready guard: an empty/unflushed file
+ * reads `null` and is re-polled (it may still be flushing), never classified on
+ * the empty edge. We discriminate "still flushing" from "settled non-remi file"
+ * by the file's mtime AGE, not a tick count — so a slow-flushing OWN transcript
+ * (or a transient EMFILE read) is NEVER permanently dropped within this window
+ * (that permanent drop would be the exact #452 wedge: the kept fallback poll
+ * only ever waits for the INITIAL transcript, not a rotated id). Only a file
+ * settled-and-markerless for longer than this is recorded as seen. 10s is far
+ * beyond Claude's synchronous create-to-marker gap.
+ */
+const MARKER_SETTLE_MS = 10_000;
+
+/** A hook event as the binder consumes it (the subset it reads). */
+export interface BinderHookEvent {
+  readonly session_id?: string;
+  readonly transcript_path?: string;
+  readonly hook_event_name?: string;
+  /** Subagent/team events carry agent_id; used by the SessionStart pre-empt. */
+  readonly agent_id?: string;
+}
+
+/**
+ * The pure result of `decide(event)`. Describes what the DRIVE path WOULD do
+ * for this event, with no external effect performed.
+ */
+export interface BinderDecision {
+  /** Three-way classification + the sibling-defer gate as a 4th outcome. */
+  readonly classification: 'match' | 'foreign' | 'restart' | 'defer';
+  /** Whether the drive path would emit a session_rotated for this event. */
+  readonly wouldEmitRotation: boolean;
+  /** Whether the drive path would (re)start a transcript watcher. */
+  readonly wouldStartWatcher: boolean;
+  /** The path the watcher would be (re)started on, when known. */
+  readonly watcherPath: string | null;
+  /** The bound claude session id AFTER this event is processed. */
+  readonly boundIdAfter: string | null;
+}
+
+/** Construction mode (immutable for the binder lifetime; design §3.1 v4 #9). */
+export type BinderMode = 'shadow' | 'drive';
+
+export interface TranscriptBinderDeps {
+  sessionRegistry: SessionRegistry;
+  bindingStore: SessionBindingStore;
+  liveSessionsRegistry: SessionRegistryFile;
+  transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  transcriptDiscovery: TranscriptDiscovery;
+  messageApi: MessageAPI;
+  sendAndRecord: (message: ProtocolMessage) => void;
+  /** PORT is reassigned during daemon-mode port probing; read lazily. */
+  currentPort: () => number;
+  /**
+   * Injected rotation side effects that live OUTSIDE the binder's concern
+   * (clear the presence tracker's pending record + sessionRegistry questions).
+   * Called from `rotate()` only, matching the old restart branch's
+   * `tracker.clearPending(); sessionRegistry.clearQuestions()`.
+   */
+  onRotation: () => void;
+}
+
+export interface TranscriptBinderArgs {
+  sessionId: UUID;
+  workingDirectory: string;
+}
+
+/** Test-only overrides for the rotation dir-poll cadence. */
+export interface TranscriptBinderTuning {
+  /** Rotation re-stat cadence (ms). Defaults to ROTATION_POLL_INTERVAL_MS. */
+  rotationPollIntervalMs?: number;
+  /** Marker-settle window (ms). Defaults to MARKER_SETTLE_MS. */
+  markerSettleMs?: number;
+}
+
+export class TranscriptBinder {
+  // --- Owned binding state (the OWN pre-adopt copy is the snapshot source) ---
+  /** Our currently-bound Claude session id, or null before first adopt. */
+  private currentBoundId: string | null = null;
+  /** Set when main explicitly ended (SessionEnd id-match) or the SessionStart
+   *  pre-empt fired; makes the classifier treat the next id as 'restart'. */
+  private mainSessionEnded = false;
+  /** Idempotency scalar: the last id we announced a rotation for. */
+  private lastAnnouncedRotationId: string | null = null;
+  /** Last transcript path we (re)started a watcher on; for snapshot(). */
+  private lastTranscriptPath: string | null = null;
+
+  // --- Re-arming rotation dir-poll (#452, drive-mode only) ---
+  /**
+   * The periodic dir RE-STAT interval handle; null when unarmed (shadow mode,
+   * pre-start, post-close). Distinct from `deps.transcriptFallbackTimers` —
+   * this is the rotation detector, NOT the first-bind fallback poll.
+   */
+  private rotationPollTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * The project transcript dir we re-stat. Resolved once at start() so the poll
+   * never recomputes the lossy path encoding per tick; null when unarmed.
+   */
+  private rotationPollDir: string | null = null;
+  /**
+   * Every Claude session id we have ALREADY considered for rotation — fed,
+   * bound, announced, or proven-foreign. A candidate in this set is never
+   * re-fed, so each rotation fires `onHookEvent` exactly once even though the
+   * poll re-stats the dir every tick. Seeded with the initial claudeId at
+   * start(); cleared by close().
+   */
+  private readonly seenRotationIds: Set<string> = new Set();
+  /** Test override for the poll cadence; defaults to ROTATION_POLL_INTERVAL_MS. */
+  private rotationPollIntervalMs: number = ROTATION_POLL_INTERVAL_MS;
+  /** Marker-settle window (ms): a new candidate whose `remi:<port>` marker is not
+   *  yet readable is re-polled until its file has been settled-and-markerless for
+   *  this long (by mtime), then recorded as seen. Test-overridable. */
+  private markerSettleMs: number = MARKER_SETTLE_MS;
+
+  private readonly deps: TranscriptBinderDeps;
+  private readonly sessionId: UUID;
+  private readonly workingDirectory: string;
+  private readonly mode: BinderMode;
+
+  constructor(
+    deps: TranscriptBinderDeps,
+    args: TranscriptBinderArgs,
+    mode: BinderMode,
+    tuning?: TranscriptBinderTuning,
+  ) {
+    this.deps = deps;
+    this.sessionId = args.sessionId;
+    this.workingDirectory = args.workingDirectory;
+    this.mode = mode;
+    if (tuning?.rotationPollIntervalMs !== undefined) {
+      this.rotationPollIntervalMs = tuning.rotationPollIntervalMs;
+    }
+    if (tuning?.markerSettleMs !== undefined) {
+      this.markerSettleMs = tuning.markerSettleMs;
+    }
+  }
+
+  // =========================================================================
+  // PURE decision path (shadow tap). NO external effects.
+  // =========================================================================
+
+  /**
+   * Compute the decision for an event WITHOUT performing any side effect.
+   * Mirrors `onHookEvent` ordering but performs nothing external: no
+   * bindingStore.update, no watcher start, no sendAndRecord, no teardown.
+   * It MAY advance the binder's own state fields (currentBoundId,
+   * mainSessionEnded, lastAnnouncedRotationId) so successive decide() calls
+   * track rotations identically to the drive path.
+   *
+   * MODE CONTRACT: a `'shadow'` instance receives ONLY `decide()`; a `'drive'`
+   * instance receives ONLY `onHookEvent()`. They mutate the same fields, so
+   * mixing them on one instance would let one advance `lastAnnouncedRotationId`
+   * and silently suppress the other's emit. The shadow harness (commit 3)
+   * constructs a dedicated shadow instance for this reason. (Tests may call both
+   * on one drive instance purely to inspect intermediate state.)
+   */
+  decide(event: BinderHookEvent): BinderDecision {
+    const inert: BinderDecision = {
+      classification: 'defer',
+      wouldEmitRotation: false,
+      wouldStartWatcher: false,
+      watcherPath: null,
+      boundIdAfter: this.currentBoundId,
+    };
+    if (!event.session_id) return inert;
+
+    // 1) Snapshot BEFORE adopt (preserves the #430/#433 invariant).
+    const previous = this.currentBoundId;
+
+    // 2) Adopt from the disk-backed binding store (a read, never a write).
+    this.adoptLockFromStore();
+
+    // 3) Rotation is decided against the pre-adopt snapshot, never the store.
+    const isRotation = previous !== null && previous !== event.session_id;
+
+    // 4) Classify.
+    const classification = this.classify(event.session_id);
+
+    if (classification === 'foreign') {
+      return {
+        classification: 'foreign',
+        wouldEmitRotation: false,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Restart PROLOGUE (pure mirror of rotate()): announce (idempotent +
+    // path-guarded), NULL the lock, reset mainSessionEnded — then FALL THROUGH to
+    // the tripwire + first-adopt gate below, so a restart with a live sibling and
+    // an unproven transcript defers (#451) instead of binding, and a path-less
+    // restart leaves the lock null (no rebind), exactly as the old code does.
+    let rotationAnnounced = false;
+    if (classification === 'restart') {
+      if (
+        isRotation &&
+        !!event.transcript_path &&
+        event.session_id !== this.lastAnnouncedRotationId
+      ) {
+        this.lastAnnouncedRotationId = event.session_id;
+        rotationAnnounced = true;
+      }
+      this.currentBoundId = null;
+      this.mainSessionEnded = false;
+    }
+
+    // Tripwire: a lock is already held (match, or store-raced) -> ensureWatching
+    // path, no emit, no store write. The store-raced zero-emit case (#430).
+    if (this.currentBoundId) {
+      return {
+        classification,
+        wouldEmitRotation: false,
+        // ensureWatching only starts when none running AND a path is present;
+        // for a pure decision we report intent on path presence.
+        wouldStartWatcher: !!event.transcript_path,
+        watcherPath: event.transcript_path ?? null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // First adopt. No path -> nothing to bind (a path-less restart lands here
+    // with the lock null; the prologue may already have announced).
+    if (!event.transcript_path) {
+      return {
+        classification,
+        wouldEmitRotation: rotationAnnounced,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Sibling-defer gate (separate from classify): a co-located sibling and the
+    // marker does not prove ownership -> defer (no bind, no watcher). A restart
+    // that already announced still reports the emit.
+    if (this.hasSiblingInDir() && !this.ownsTranscript(event.transcript_path)) {
+      return {
+        classification: 'defer',
+        wouldEmitRotation: rotationAnnounced,
+        wouldStartWatcher: false,
+        watcherPath: null,
+        boundIdAfter: this.currentBoundId,
+      };
+    }
+
+    // Adopt: bind the new id, maybe announce the rotation (unless the prologue
+    // already did).
+    const wouldEmit =
+      isRotation && !rotationAnnounced && event.session_id !== this.lastAnnouncedRotationId;
+    if (wouldEmit) {
+      this.lastAnnouncedRotationId = event.session_id;
+    }
+    this.currentBoundId = event.session_id;
+    this.lastTranscriptPath = event.transcript_path;
+    return {
+      classification,
+      wouldEmitRotation: wouldEmit || rotationAnnounced,
+      wouldStartWatcher: true,
+      watcherPath: event.transcript_path,
+      boundIdAfter: this.currentBoundId,
+    };
+  }
+
+  // =========================================================================
+  // DRIVE path. decide + side effects. SINGLE caller of rotate().
+  // =========================================================================
+
+  /**
+   * The drive entry point. Reproduces `initFromHookEvent` exactly: snapshot,
+   * adopt, classify, foreign/defer return, restart via `rotate()`, the
+   * tripwire BEFORE the first-adopt emit, then first-adopt
+   * (bindingStore.update + ensureWatching + rotation announce).
+   */
+  onHookEvent(event: BinderHookEvent): void {
+    if (!event.session_id) return;
+
+    // 1) Snapshot BEFORE adopt.
+    const previous = this.currentBoundId;
+
+    // 2) Adopt from the store.
+    this.adoptLockFromStore();
+
+    // 3) Rotation against the pre-adopt snapshot.
+    const isRotation = previous !== null && previous !== event.session_id;
+
+    // 4) Classify.
+    const classification = this.classify(event.session_id);
+
+    if (classification === 'foreign') {
+      log(
+        `[Binder] Dropped foreign ${event.hook_event_name ?? 'event'}: lock=${this.currentBoundId?.slice(0, 8)} incoming=${event.session_id.slice(0, 8)}`,
+      );
+      return;
+    }
+
+    let rotationAnnounced = false;
+    if (classification === 'restart') {
+      log(
+        `[Binder] Claude restart detected (ended=${this.mainSessionEnded}): ${this.currentBoundId} -> ${event.session_id}`,
+      );
+      // The single rotation funnel. Performs teardown -> onRotation ->
+      // emitRotated (path-guarded) -> bindingStore.update -> currentBoundId=new
+      // -> mainSessionEnded=false. emitRotated only fires when a path is
+      // present and isRotation holds.
+      rotationAnnounced = this.rotate(
+        event.session_id,
+        event.transcript_path,
+        previous,
+        isRotation,
+      );
+    }
+
+    // classification === 'match' (or restart fell through with the new lock).
+    // Tripwire: lock already held -> ensure a watcher, return BEFORE the
+    // first-adopt emit so the store-raced case stays zero-emit (#430).
+    if (this.currentBoundId) {
+      this.ensureWatching(event.transcript_path, 'match');
+      return;
+    }
+
+    // First adopt path.
+    if (!event.transcript_path) return;
+
+    if (this.hasSiblingInDir() && !this.ownsTranscript(event.transcript_path)) {
+      // Defer to the fallback poll: cannot prove this event is ours.
+      return;
+    }
+
+    try {
+      this.currentBoundId = event.session_id;
+      this.lastTranscriptPath = event.transcript_path;
+      log(
+        `[Binder] Transcript from ${event.hook_event_name ?? 'hook'}: claude=${this.currentBoundId}, transcript=${event.transcript_path}`,
+      );
+      this.deps.bindingStore.update(this.sessionId, this.currentBoundId);
+
+      // Announce the rotation as ONE atomic event. Skip on first-init (not a
+      // rotation) and skip if rotate() already announced it.
+      if (isRotation && !rotationAnnounced) {
+        this.emitRotated(event.session_id, event.transcript_path, previous);
+      }
+
+      this.startOrReplaceWatcher(event.transcript_path);
+    } catch (err) {
+      logError(`[Binder] onHookEvent failed for session ${this.sessionId}: ${errorToString(err)}`);
+      this.currentBoundId = null; // Reset so the fallback can take over.
+    }
+  }
+
+  // =========================================================================
+  // Classification.
+  // =========================================================================
+
+  /**
+   * Wraps `classifySessionEvent` with the binder's live inputs. The
+   * sibling-defer gate is applied SEPARATELY in onHookEvent/decide (it gates
+   * the first-adopt only), matching the old code where classify never knew
+   * about siblings.
+   */
+  private classify(incomingSessionId: string): SessionEventClass {
+    return classifySessionEvent({
+      currentLock: this.currentBoundId,
+      incomingSessionId,
+      mainPtyRunning: this.deps.sessionRegistry.getSession(this.sessionId)?.pty.isRunning ?? false,
+      mainSessionEnded: this.mainSessionEnded,
+    });
+  }
+
+  // =========================================================================
+  // SessionStart pre-empt + SessionEnd id-match.
+  // =========================================================================
+
+  /**
+   * The SessionStart pre-empt (old `hook-bridge-setup.ts:585-610`). On any
+   * in-process session_id rotation while our PTY is alive, flip
+   * mainSessionEnded=true so the classifier returns 'restart'. Gated by the
+   * subagent check + the sibling/ownership guard. Must be called by the
+   * driver BEFORE onHookEvent for SessionStart, mirroring the old order.
+   */
+  preemptOnSessionStart(event: BinderHookEvent): void {
+    if (
+      !this.isSubagentEvent(event) &&
+      this.currentBoundId &&
+      event.session_id &&
+      event.session_id !== this.currentBoundId &&
+      (!this.hasSiblingInDir() || this.ownsTranscript(event.transcript_path))
+    ) {
+      log(`[Binder] Main lifecycle transition: ${this.currentBoundId} -> ${event.session_id}`);
+      this.mainSessionEnded = true;
+    }
+  }
+
+  /**
+   * SessionEnd handler (old `hook-bridge-setup.ts:665-670`). Mark main ended
+   * ONLY when the session_id matches our lock — foreign SessionEnds (subagents,
+   * siblings) must not unlock our tracking. THIS WAS MISSING in v2; without it
+   * clean-exit restarts drop.
+   */
+  onSessionEnd(event: BinderHookEvent): void {
+    if (event.session_id && this.currentBoundId && event.session_id === this.currentBoundId) {
+      this.mainSessionEnded = true;
+    }
+  }
+
+  /**
+   * Session filter (DRIVE-mode replacement for the old `filterBySession`,
+   * `hook-bridge-setup.ts:603-607`). Accept events only from our own Claude.
+   * Before the lock is known, block events when a live sibling exists (they
+   * could be from the sibling's Claude). Ported line-for-line: adopt the
+   * disk-fresh lock first, then gate on it (or the sibling guard). Pure read
+   * (the adopt is a store read, never a write); no rotation, no watcher.
+   */
+  admits(event: BinderHookEvent): boolean {
+    this.adoptLockFromStore();
+    return this.currentBoundId ? event.session_id === this.currentBoundId : !this.hasSiblingInDir();
+  }
+
+  // =========================================================================
+  // Watcher lifecycle.
+  // =========================================================================
+
+  /**
+   * Idempotent watcher ensure (subsumes old `ensureWatcher` + the init start).
+   * No-op if a watcher exists; else cancel the fallback timer, replace a
+   * stale-path watcher, and start. Only called for 'match' events (our own
+   * Claude), whose transcript_path is therefore ours.
+   */
+  ensureWatching(transcriptPath: string | undefined, _source: string): void {
+    // Steady-state no-op: a watcher is already running.
+    if (this.deps.transcriptWatchers.has(this.sessionId)) return;
+    if (!this.deps.sessionRegistry.hasSession(this.sessionId)) return;
+    if (!transcriptPath) {
+      logError(
+        `[Binder] ensureWatching: match event without transcript_path for ${this.sessionId.slice(0, 8)}; watcher still missing`,
+      );
+      return;
+    }
+    this.cancelFallbackTimer();
+    log(
+      `[Binder] Ensuring watcher (self-heal) for ${this.sessionId.slice(0, 8)}: ${transcriptPath}`,
+    );
+    this.lastTranscriptPath = transcriptPath;
+    startTranscriptWatcher(
+      { transcriptWatchers: this.deps.transcriptWatchers },
+      this.sessionId,
+      transcriptPath,
+      this.deps.messageApi,
+      this.deps.sendAndRecord,
+    );
+  }
+
+  /**
+   * First-adopt watcher start with the stale-path replace (old
+   * initFromHookEvent tail). Cancels the fallback timer, replaces a watcher
+   * pointed at a different file, then starts if none running.
+   */
+  private startOrReplaceWatcher(transcriptPath: string): void {
+    this.cancelFallbackTimer();
+
+    const existingWatcher = this.deps.transcriptWatchers.get(this.sessionId);
+    if (
+      existingWatcher &&
+      path.resolve(existingWatcher.filePath) !== path.resolve(transcriptPath)
+    ) {
+      log(`[Binder] Replacing stale watcher: ${existingWatcher.filePath} -> ${transcriptPath}`);
+      this.teardownWatcher('stale-replace');
+    }
+
+    if (
+      !this.deps.transcriptWatchers.has(this.sessionId) &&
+      this.deps.sessionRegistry.hasSession(this.sessionId)
+    ) {
+      this.lastTranscriptPath = transcriptPath;
+      startTranscriptWatcher(
+        { transcriptWatchers: this.deps.transcriptWatchers },
+        this.sessionId,
+        transcriptPath,
+        this.deps.messageApi,
+        this.deps.sendAndRecord,
+      );
+    }
+  }
+
+  /**
+   * Tear down the existing watcher + reset message state. Errors from stop()
+   * are swallowed. Does NOT emit a wire message (the rotation is announced
+   * atomically via emitRotated, #438). Mirrors old `teardownWatcher`.
+   */
+  private teardownWatcher(label: string): void {
+    const watcher = this.deps.transcriptWatchers.get(this.sessionId);
+    if (!watcher) return;
+    this.deps.transcriptWatchers.delete(this.sessionId); // Remove FIRST.
+    try {
+      watcher.stop();
+    } catch (stopErr) {
+      logError(`[Binder] Failed to stop watcher (${label}): ${errorToString(stopErr)}`);
+    }
+    this.deps.messageApi.reset();
+  }
+
+  private cancelFallbackTimer(): void {
+    const fallbackTimer = this.deps.transcriptFallbackTimers.get(this.sessionId);
+    if (fallbackTimer) {
+      clearInterval(fallbackTimer);
+      this.deps.transcriptFallbackTimers.delete(this.sessionId);
+    }
+  }
+
+  // =========================================================================
+  // Rotation funnel + idempotent emit.
+  // =========================================================================
+
+  /**
+   * Restart PROLOGUE (#438 ordering) — mirrors `initFromHookEvent`'s restart
+   * branch EXACTLY: teardownWatcher -> onRotation() -> emitRotated (idempotent,
+   * path-guarded) -> NULL the lock -> reset mainSessionEnded. It deliberately
+   * does NOT bind the new id or write the store: `onHookEvent` falls through to
+   * the first-adopt path, so the sibling-defer / ownership gate (#451) still
+   * applies before any watcher start or store write, AND a path-less restart
+   * leaves the lock null (no rebind) — both matching the old code (`:353` nulls
+   * the lock; `:370` returns before the store write on a path-less restart).
+   * Returns whether the rotation was announced so the first-adopt emit is
+   * suppressed.
+   */
+  private rotate(
+    newId: string,
+    newPath: string | undefined,
+    previousId: string | null,
+    isRotation: boolean,
+  ): boolean {
+    this.teardownWatcher('restart');
+    // Injected: clear presence-tracker pending + sessionRegistry questions.
+    this.deps.onRotation();
+    // Announce (idempotent + path-guarded). A path-less restart emits nothing.
+    let announced = false;
+    if (isRotation && newPath) {
+      announced = this.emitRotated(newId, newPath, previousId);
+    }
+    this.currentBoundId = null;
+    this.mainSessionEnded = false;
+    return announced;
+  }
+
+  /**
+   * Idempotent rotation announce. ALL emit sites go through this. Emits only
+   * when a path is present and newId !== lastAnnouncedRotationId, so an
+   * A->B->A re-resume emits A->B, B->A, and never a duplicate A->B. Returns
+   * whether it emitted.
+   */
+  private emitRotated(
+    newId: string,
+    transcriptPath: string | undefined,
+    prev: string | null,
+  ): boolean {
+    if (!transcriptPath) return false;
+    if (newId === this.lastAnnouncedRotationId) return false;
+    try {
+      this.deps.sendAndRecord(
+        createSessionRotated(
+          this.sessionId,
+          newId as UUID,
+          transcriptPath,
+          'restart',
+          (prev ?? undefined) as UUID | undefined,
+        ),
+      );
+      this.lastAnnouncedRotationId = newId;
+      return true;
+    } catch (err) {
+      logError(`[Binder] Failed to emit session_rotated: ${errorToString(err)}`);
+      return false;
+    }
+  }
+
+  // =========================================================================
+  // Adopt + ownership/sibling helpers (ported verbatim from hook-bridge).
+  // =========================================================================
+
+  /**
+   * Adopt the canonical claudeSessionId from the disk-backed binding store.
+   * Disk-fresh every call (no cache) so a sibling/fallback write is observed
+   * (#321/#430). On change only; wrapped in try/catch so an EMFILE flake on
+   * the sessions file does not propagate into the dispatch loop.
+   */
+  private adoptLockFromStore(): void {
+    try {
+      const storedId = this.deps.bindingStore.get(this.sessionId)?.claudeSessionId ?? null;
+      if (storedId === null || storedId === this.currentBoundId) return;
+      const previous = this.currentBoundId;
+      this.currentBoundId = storedId;
+      log(
+        `[Binder] Lock ${previous === null ? 'adopted' : 'updated'} from binding store: claude=${storedId.slice(0, 8)}${previous ? ` (was ${previous.slice(0, 8)})` : ''}`,
+      );
+    } catch (err) {
+      logError(`[Binder] adoptLockFromStore failed: ${errorToString(err)}`);
+    }
+  }
+
+  /**
+   * Whether a co-located sibling daemon (live Claude child) serves the same
+   * directory. Ported verbatim from `hook-bridge-setup.ts:hasSiblingInDir`.
+   */
+  private hasSiblingInDir(): boolean {
+    try {
+      // Probe the dir ourselves so an enumeration failure flips to the safe
+      // default of "sibling present" (PR #358).
+      fs.readdirSync(this.deps.liveSessionsRegistry.dirPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return false; // first daemon
+      logError(
+        `[Binder] Could not enumerate live-sessions; assuming sibling present: ${errorToString(err)}`,
+      );
+      return true;
+    }
+    return this.deps.liveSessionsRegistry.listLive().some(
+      (e) =>
+        e.projectPath === this.workingDirectory &&
+        e.sessionId !== this.sessionId &&
+        e.wsPort !== this.deps.currentPort() &&
+        // A zombie (daemon alive, Claude dead) must not count as a sibling
+        // (#451). Legacy entries with no recorded child pid stay fail-safe live.
+        claudeChildLooksAlive(e),
+    );
+  }
+
+  /**
+   * Whether the transcript named by an event was written by OUR Claude (the
+   * remi:<port> head marker matches our port). Ported verbatim from
+   * `hook-bridge-setup.ts:ownsTranscript`.
+   */
+  private ownsTranscript(transcriptPath: string | undefined): boolean {
+    return (
+      typeof transcriptPath === 'string' &&
+      readTranscriptOwnerPort(transcriptPath) === this.deps.currentPort()
+    );
+  }
+
+  /** Subagent/team events carry agent_id. */
+  private isSubagentEvent(event: BinderHookEvent): boolean {
+    return typeof event.agent_id === 'string' && event.agent_id.length > 0;
+  }
+
+  // =========================================================================
+  // Lifecycle: start / close / snapshot.
+  // =========================================================================
+
+  /**
+   * Arm the transcript discovery. In SHADOW mode this is a NO-OP (no dir-poll,
+   * no fallback timer — the binder is provably side-effect-free, design §3.1
+   * v4 #8). In DRIVE mode it arms BOTH:
+   *
+   *   - the existing fallback poll (Case A: our pre-assigned file appears), the
+   *     safety net the #452 critic mandated — KEPT, unchanged;
+   *   - the re-arming rotation dir-poll (Case B: a NEW Claude id with NO hook
+   *     event — the hooks-down / no-hooks rotation the #452 dir-watcher targets).
+   */
+  start(claudeId: string): void {
+    if (this.mode === 'shadow') return;
+    startTranscriptFallback(
+      {
+        sessionRegistry: this.deps.sessionRegistry,
+        transcriptDiscovery: this.deps.transcriptDiscovery,
+        transcriptWatchers: this.deps.transcriptWatchers,
+        transcriptFallbackTimers: this.deps.transcriptFallbackTimers,
+      },
+      this.sessionId,
+      this.workingDirectory,
+      claudeId,
+      this.deps.messageApi,
+      this.deps.sendAndRecord,
+    );
+    this.armRotationPoll(claudeId);
+  }
+
+  /**
+   * Single teardown owner: clears the watcher, the fallback timer, AND the
+   * rotation dir-poll (fixes the transcriptFallbackTimers leak at
+   * cli.ts:822-829 and ensures the dir-poll never outlives the binder).
+   */
+  close(): void {
+    this.teardownWatcher('close');
+    this.cancelFallbackTimer();
+    this.cancelRotationPoll();
+  }
+
+  // =========================================================================
+  // Re-arming rotation dir-poll (#452 no-hooks rotation). Drive-mode only.
+  //
+  // ROBUSTNESS: a level-triggered RE-STAT poll over SETTLED state, not an
+  // edge-triggered fs.watch. The empty-file edge that wedged #452 is
+  // structurally absent — the poll observes the new `.jsonl` only at quantized
+  // ticks, by which point Claude has flushed the `remi:<port>` head marker. The
+  // marker-ready guard re-polls a not-yet-flushed candidate (RECENT by mtime),
+  // only seen-setting a settled-and-markerless file so a slow flush is never
+  // permanently dropped (#452); the seen-set is the exactly-once gate; the
+  // marker == currentPort check is
+  // the sibling gate. NON-EMITTING: every detection routes through the single
+  // funnel onHookEvent(); we never call rotate()/emitRotated directly.
+  // =========================================================================
+
+  /**
+   * Arm the periodic dir RE-STAT poll. Idempotent (no-op if already armed, so
+   * the post-rotation re-arm — which is a no-op by construction here — is safe).
+   * Seeds `seenRotationIds` with the initial claudeId so our own first
+   * transcript is never mistaken for a rotation. Resolves the dir ONCE.
+   */
+  private armRotationPoll(initialClaudeId: string): void {
+    if (this.mode === 'shadow') return;
+    if (this.rotationPollTimer !== null) return; // already armed
+    this.rotationPollDir = this.deps.transcriptDiscovery.getProjectTranscriptDir(
+      this.workingDirectory,
+    );
+    this.seenRotationIds.add(initialClaudeId);
+    this.rotationPollTimer = setInterval(
+      () => this.rotationPollTick(),
+      this.rotationPollIntervalMs,
+    );
+  }
+
+  private cancelRotationPoll(): void {
+    if (this.rotationPollTimer !== null) {
+      clearInterval(this.rotationPollTimer);
+      this.rotationPollTimer = null;
+    }
+    this.rotationPollDir = null;
+    this.seenRotationIds.clear();
+  }
+
+  /**
+   * One rotation-poll tick. Re-stats the project transcript dir, finds a NEW
+   * Claude session id (not our current bind, not previously seen), verifies the
+   * `remi:<port>` head marker proves it is OURS, and — only then — synthesizes a
+   * hook-shaped event into the SINGLE funnel `onHookEvent()`. NEVER calls
+   * `rotate()` / `emitRotated()` directly. Exposed (package-private) so a test
+   * can drive a deterministic tick without waiting on the interval.
+   */
+  rotationPollTick(): void {
+    // A throw escaping the setInterval callback permanently kills the timer with
+    // no log or recovery. The inner fs reads have their own catches; this is the
+    // backstop for an unexpected throw (sessionRegistry/currentPort/etc.).
+    try {
+      this.rotationPollTickInner();
+    } catch (err) {
+      logError(`[Binder] rotation poll tick failed unexpectedly: ${errorToString(err)}`);
+    }
+  }
+
+  private rotationPollTickInner(): void {
+    if (this.mode === 'shadow') return;
+    // Session gone -> the lifecycle owner will close() us; do nothing meanwhile.
+    if (!this.deps.sessionRegistry.hasSession(this.sessionId)) return;
+    if (this.rotationPollDir === null) return;
+
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.rotationPollDir);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // ENOENT is routine before Claude first writes the project dir; stay quiet.
+      if (code !== undefined && code !== 'ENOENT') {
+        logError(`[Binder] rotation poll readdir failed: ${errorToString(err)}`);
+      }
+      return;
+    }
+
+    for (const name of entries) {
+      if (!name.endsWith('.jsonl')) continue;
+      const candidateId = name.slice(0, -'.jsonl'.length);
+
+      // (a) EXACTLY-ONCE + non-duplication gate. Skip our current bind, the last
+      //     id we announced, and anything already considered. Re-read the lock
+      //     disk-fresh so a hook/fallback bind we already absorbed is excluded.
+      this.adoptLockFromStore();
+      if (candidateId === this.currentBoundId) continue;
+      if (candidateId === this.lastAnnouncedRotationId) continue;
+      if (this.seenRotationIds.has(candidateId)) continue;
+
+      const candidatePath = path.join(this.rotationPollDir, name);
+
+      // (b) MARKER-READY GUARD. Unlike fs.watch's instant rename edge, by the
+      //     time a tick observes the file Claude has almost always flushed the
+      //     head marker. We still bounded-re-poll: a null read (empty/unflushed
+      //     OR markerless) gives the candidate a few more ticks rather than
+      //     classifying on an unproven edge.
+      const ownerPort = readTranscriptOwnerPort(candidatePath);
+
+      if (ownerPort === null) {
+        // Null marker = empty/unflushed (mid-create), a non-remi session that
+        // will never carry our marker, OR a transient read error. Do NOT
+        // permanently drop on a tick count — a slow-flushing OWN transcript (or a
+        // transient EMFILE) would then silently never rotate (the #452 wedge).
+        // Keep re-polling RECENT files (still flushing); only stop touching a
+        // file once it has been settled-and-markerless (by mtime) beyond the
+        // grace window — a genuine non-remi/sibling file we'll never own.
+        let ageMs = 0;
+        try {
+          ageMs = Date.now() - fs.statSync(candidatePath).mtimeMs;
+        } catch {
+          ageMs = 0; // raced a delete/rename -> treat as recent, re-poll.
+        }
+        if (ageMs > this.markerSettleMs) {
+          this.seenRotationIds.add(candidateId);
+        }
+        continue;
+      }
+
+      // (c) SIBLING-MARKER GATE. The marker is readable AND must be OURS. A
+      //     sibling daemon's fresh transcript carries the sibling's port; it
+      //     must NOT rotate us. Mark seen so we never re-read it.
+      if (ownerPort !== this.deps.currentPort()) {
+        this.seenRotationIds.add(candidateId);
+        log(
+          `[Binder] rotation poll: ${candidateId.slice(0, 8)} owned by port ${ownerPort}, not ${this.deps.currentPort()}; ignoring`,
+        );
+        continue;
+      }
+
+      // (d) OURS + NEW. Mark seen BEFORE feeding so a re-entrant readdir on the
+      //     next tick (or a throw) can never double-feed.
+      this.seenRotationIds.add(candidateId);
+      this.feedSyntheticRotation(candidateId, candidatePath);
+
+      // One rotation per tick is enough; the next new id (if any) is picked up
+      // next tick. Bounding to one keeps the tick cheap and avoids feeding two
+      // synthetic restarts in a single synchronous frame.
+      return;
+    }
+  }
+
+  /**
+   * NON-EMITTING FEEDER: synthesizes a hook-shaped event and routes it through
+   * the SINGLE funnel `onHookEvent()`. Never calls `rotate()` / `emitRotated()`.
+   * The no-hooks case means NO SessionStart fired to flip `mainSessionEnded`, so
+   * we mirror `preemptOnSessionStart` first (gated identically) to make
+   * `classify()` return 'restart' rather than 'foreign' while our PTY is alive.
+   * Ownership is already proven (marker == our port), so the sibling guard
+   * inside the pre-empt is satisfied. After the funnel runs, re-arm (a no-op by
+   * construction for the dir-poll, but keeps the lifecycle explicit).
+   */
+  private feedSyntheticRotation(candidateId: string, candidatePath: string): void {
+    if (this.mode === 'shadow') return;
+    log(
+      `[Binder] No-hooks rotation detected via dir poll: ${this.currentBoundId?.slice(0, 8) ?? 'none'} -> ${candidateId.slice(0, 8)} (${candidatePath})`,
+    );
+    const synthetic: BinderHookEvent = {
+      session_id: candidateId,
+      transcript_path: candidatePath,
+      hook_event_name: 'DirPollRotation', // sentinel; not a real CC hook
+    };
+    try {
+      // Flip mainSessionEnded so a different id with a live PTY classifies as a
+      // restart, not foreign — the SessionStart that would normally do this
+      // never arrived (the hooks-down premise of #452).
+      this.preemptOnSessionStart(synthetic);
+      this.onHookEvent(synthetic);
+    } catch (err) {
+      logError(`[Binder] synthetic rotation funnel failed: ${errorToString(err)}`);
+    }
+    // Re-arm for the NEXT rotation. The interval keeps running, so this is a
+    // no-op in the common case; it only re-creates the timer if a prior
+    // teardown nulled it (defensive, keeps the lifecycle symmetric).
+    this.armRotationPoll(candidateId);
+  }
+
+  /** Current binding for callers that stamp outgoing messages. */
+  snapshot(): { claudeSessionId: string | null; transcriptPath: string | null } {
+    return {
+      claudeSessionId: this.currentBoundId,
+      transcriptPath: this.lastTranscriptPath,
+    };
+  }
+
+  /**
+   * Whether our main session has ended (SessionEnd id-match fired and no
+   * subsequent restart reset it). Read by the bridge's post-SessionEnd
+   * Notification drop so that gate reads the binder's single source of truth in
+   * drive mode rather than a duplicated closure flag (the closure
+   * `mainSessionEnded` is reset on restart by `rotate()`; mirroring that reset
+   * outside the binder would be fragile). The Notification-drop gate itself is
+   * a question-pipeline concern that moves onto the binder in phase 4.
+   */
+  isMainEnded(): boolean {
+    return this.mainSessionEnded;
+  }
+}

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -106,59 +106,6 @@ export class TranscriptDiscovery {
   }
 
   /**
-   * @deprecated Superseded by deterministic path construction in
-   * `transcript-fallback.ts:expectedTranscriptPath` (#427/phase 1). The
-   * daemon now knows the bound `.jsonl` path before Claude writes a
-   * single line; no mtime-based discovery is performed at runtime. Only
-   * the test suite still references this method.
-   *
-   * Find the most recent transcript file for a given project directory
-   * by modification time.
-   */
-  findLatestTranscript(projectPath: string): string | null {
-    const transcriptDir = this.getProjectTranscriptDir(projectPath);
-
-    if (!fs.existsSync(transcriptDir)) {
-      return null;
-    }
-
-    const files = this.listJsonlFiles(transcriptDir);
-    if (files.length === 0) {
-      return null;
-    }
-
-    // Sort by modification time, most recent first
-    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-    return files[0]?.filePath ?? null;
-  }
-
-  /**
-   * @deprecated Superseded by deterministic binding (#427/phase 1). The
-   * sibling-exclusion race this guarded against is now structurally
-   * impossible because each daemon writes its claudeSessionId into the
-   * store before spawn. Only the test suite still references this
-   * method.
-   *
-   * Find the most recent transcript for a project, skipping specific
-   * session IDs.
-   */
-  findLatestTranscriptExcluding(projectPath: string, excludeIds: Set<string>): string | null {
-    const transcriptDir = this.getProjectTranscriptDir(projectPath);
-    if (!fs.existsSync(transcriptDir)) return null;
-
-    const files = this.listJsonlFiles(transcriptDir);
-    if (files.length === 0) return null;
-
-    files.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-    for (const file of files) {
-      if (!excludeIds.has(file.sessionId)) {
-        return file.filePath;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Find a transcript file path by its session ID (the UUID filename without .jsonl).
    * Returns the file path if found, null otherwise.
    */

--- a/packages/daemon/src/transcript/transcript-owner.ts
+++ b/packages/daemon/src/transcript/transcript-owner.ts
@@ -21,6 +21,8 @@
 
 import * as fs from 'node:fs';
 
+import { logError } from '../cli/logger.ts';
+
 /** Only the first few lines can hold the head marker; cap the read. */
 const HEAD_BYTES = 8192;
 
@@ -75,7 +77,7 @@ export function readTranscriptOwnerPort(transcriptPath: string): number | null {
     // see why ownership checks are coming up empty.
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== undefined && code !== 'ENOENT') {
-      console.error(`[transcript-owner] Failed to read ${transcriptPath}: ${code}`);
+      logError(`[transcript-owner] Failed to read ${transcriptPath}: ${code}`);
     }
     return null;
   } finally {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+// Real test double for the PTY: records every submitInput so inject() is
+// observable. `throws` exercises the inject() failure -> escalate fallback.
+function fakePTY(submits: string[], opts: { throws?: boolean } = {}): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async (content: string) => {
+      submits.push(content);
+      if (opts.throws) throw new Error('test: submitInput synthetic failure');
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+// Real AutoApproveResult builders (no mock framework; plain domain objects).
+const approve: AutoApproveResult = {
+  decision: 'approve',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+const deny: AutoApproveResult = { decision: 'deny', reasoning: 't', durationMs: 0, model: 'm' };
+const escalate: AutoApproveResult = {
+  decision: 'escalate',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+const cancelled: AutoApproveResult = { decision: 'cancelled', reasoning: 't', durationMs: 0 };
+const pick = (pickIndex: number): AutoApproveResult => ({
+  decision: 'pick',
+  pickIndex,
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+});
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 20));
+
+describe('AutoApproveGate', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let cancels: string[];
+  let tracker: QuestionPresenceTracker;
+  let subagent: boolean;
+
+  function evaluator(
+    result: AutoApproveResult,
+    opts: { throws?: boolean } = {},
+  ): AutoApproveEvaluator {
+    return {
+      evaluate: async () => {
+        if (opts.throws) throw new Error('test: llm provider down');
+        return result;
+      },
+      cancel: (reason: string) => {
+        cancels.push(reason);
+        return true;
+      },
+    };
+  }
+
+  function gateWith(service: AutoApproveEvaluator | null, ptyThrows = false): AutoApproveGate {
+    // (Re)register the session with the desired PTY behavior.
+    registry.registerSession(SID, '/d', fakePTY(submits, { throws: ptyThrows }), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => subagent,
+        escalate: (i) => escalations.push(i),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    cancels = [];
+    subagent = false;
+    tracker = new QuestionPresenceTracker(() => {});
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve injects "1" and sets status executing (main context)', async () => {
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']);
+    expect(registry.getSession(SID)?.currentStatus).toBe('executing');
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('deny injects "3" and sets status thinking (main context)', async () => {
+    gateWith(evaluator(deny)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(registry.getSession(SID)?.currentStatus).toBe('thinking');
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('pick injects the 1-based index (main context)', async () => {
+    gateWith(evaluator(pick(2))).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['2']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('escalate in main context calls escalate, never injects', async () => {
+    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]?.tool_name).toBe('Bash');
+  });
+
+  test('escalate in subagent context default-denies ("3"), never escalates', async () => {
+    subagent = true;
+    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('cancelled clears the tracker pending; no inject, no escalate', async () => {
+    // Stash a pending hook so clearPending() is observable.
+    tracker.recordPendingHook({
+      id: generateId(),
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(tracker.hasPendingForTest()).toBe(true);
+
+    gateWith(evaluator(cancelled)).handlePermissionRequest(pr());
+    await flush();
+
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('subagent + no PTY presence: inject is gated; approve falls back to escalate', async () => {
+    subagent = true; // background subagent, prompt not on the main PTY
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0); // PTY-presence gate blocked the inject
+    expect(escalations).toHaveLength(1); // approve has a fallback -> escalate
+  });
+
+  test('subagent + PTY prompt visible: inject proceeds', async () => {
+    subagent = true;
+    tracker.onPTYPromptVisible({
+      id: generateId(),
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    gateWith(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']);
+  });
+
+  test('explicit agent_id (no isInSubagentContext) also gates inject by PTY presence', async () => {
+    subagent = false; // gate must rely on input.agent_id alone
+    gateWith(evaluator(approve)).handlePermissionRequest(pr({ agent_id: 'agent-xyz' }));
+    await flush();
+    expect(submits).toHaveLength(0); // no PTY presence -> gated
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('inject failure (PTY throws) falls back to escalate (main context)', async () => {
+    gateWith(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
+    await flush();
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('eval rejection in main context escalates (the outer .catch)', async () => {
+    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('eval rejection in subagent context default-denies', async () => {
+    subagent = true;
+    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('no service + subagent: default-deny "3"', async () => {
+    subagent = true;
+    gateWith(null).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['3']);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('no service + main context: escalate to user', async () => {
+    gateWith(null).handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('cancelStale forwards the reason to service.cancel', () => {
+    gateWith(evaluator(approve)).cancelStale('PreToolUse');
+    expect(cancels).toEqual(['PreToolUse']);
+  });
+
+  test('cancelStale is a no-op when no service is configured', () => {
+    expect(() => gateWith(null).cancelStale('Stop')).not.toThrow();
+    expect(cancels).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createInputHandlers } from '../../../src/cli/handlers/input-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 
@@ -51,6 +52,7 @@ const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 describe('createInputHandlers', () => {
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let tmpDir: string;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
@@ -59,6 +61,7 @@ describe('createInputHandlers', () => {
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-input-events-'));
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     sendCalls = [];
     send = (connectionId, message) => {
       sendCalls.push({ connectionId, message });
@@ -85,7 +88,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
 
       expect(ptyCapture.writes).toEqual(['\x1b[A']);
@@ -103,7 +106,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, 'hello world', false);
 
       expect(ptyCapture.submits).toEqual(['hello world']);
@@ -113,7 +116,7 @@ describe('createInputHandlers', () => {
     test('logs and returns when no session is attached to the connection', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       await handlers.onUserInput(
         CID,
@@ -142,7 +145,7 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Should not throw
       await handlers.onUserInput(CID, sessionId, 'x', true);
 
@@ -173,7 +176,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
@@ -203,7 +206,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Pass a bogus sessionId, handler should still find the session via connection
       await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
@@ -228,7 +231,7 @@ describe('createInputHandlers', () => {
       // must signal the drop back to the iOS client so the user is not left
       // wondering whether their tap landed.
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -259,7 +262,7 @@ describe('createInputHandlers', () => {
       });
 
       const stale = 'stal0000-0000-0000-0000-000000000000' as UUID;
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -301,7 +304,7 @@ describe('createInputHandlers', () => {
         agentId: 'sub-7',
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       // Answer the first; it should inject and be removed, the second stays.
       await handlers.onAnswer(CID, sessionId, QID, 'one');
       expect(ptyCapture.submits).toEqual(['one']);
@@ -320,7 +323,7 @@ describe('createInputHandlers', () => {
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
 
@@ -330,7 +333,7 @@ describe('createInputHandlers', () => {
 
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
 
@@ -349,7 +352,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -367,7 +370,7 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map([[7, 'full expanded content']])),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -413,7 +416,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y', bound);
 
       expect(capture.submits).toEqual(['y']);
@@ -432,7 +435,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y', stale);
 
       expect(capture.submits).toEqual([]);
@@ -455,7 +458,7 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onAnswer(CID, sessionId, QID, 'y');
 
       expect(capture.submits).toEqual(['y']);
@@ -467,7 +470,7 @@ describe('createInputHandlers', () => {
       const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
 
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, 'ls', false, stale);
 
       expect(capture.submits).toEqual([]);
@@ -496,7 +499,7 @@ describe('createInputHandlers', () => {
         allowsFreeText: false,
         isAnswered: false,
       });
-      const handlers = createInputHandlers({ sessionRegistry, sessionStore, send });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
 
       const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
       await handlers.onAnswer(CID, sessionId, QID, 'y', claudeId);

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createResumeSessionHandlers } from '../../../src/cli/handlers/resume-session-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
@@ -35,6 +36,7 @@ describe('createResumeSessionHandlers', () => {
   let projectsDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let transcriptDiscovery: TranscriptDiscovery;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
@@ -49,6 +51,7 @@ describe('createResumeSessionHandlers', () => {
     fs.mkdirSync(projectsDir, { recursive: true });
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
@@ -73,6 +76,7 @@ describe('createResumeSessionHandlers', () => {
     return createResumeSessionHandlers({
       sessionRegistry,
       sessionStore,
+      bindingStore,
       transcriptDiscovery,
       createNewSession,
       send,

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -8,6 +8,7 @@ import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createSessionHandlers } from '../../../src/cli/handlers/session-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
@@ -38,6 +39,7 @@ describe('createSessionHandlers', () => {
   let tmpDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let liveSessionsRegistry: SessionRegistryFile;
   let transcriptDiscovery: TranscriptDiscovery;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
@@ -50,6 +52,7 @@ describe('createSessionHandlers', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-session-events-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     liveSessionsRegistry = new SessionRegistryFile(tmpDir);
     transcriptDiscovery = new TranscriptDiscovery({
       projectsDir: path.join(tmpDir, 'claude-projects'),
@@ -73,7 +76,7 @@ describe('createSessionHandlers', () => {
   function makeHandlers() {
     return createSessionHandlers({
       sessionRegistry,
-      sessionStore,
+      bindingStore,
       transcriptDiscovery,
       liveSessionsRegistry,
       currentPort: () => PORT,

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
 import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
@@ -43,6 +44,7 @@ describe('createTranscriptHandlers', () => {
   let transcriptDiscovery: TranscriptDiscovery;
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
   function send(connectionId: UUID, message: ProtocolMessage): boolean {
@@ -57,6 +59,7 @@ describe('createTranscriptHandlers', () => {
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
   });
@@ -70,7 +73,7 @@ describe('createTranscriptHandlers', () => {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
-      sessionStore,
+      bindingStore,
       send,
     });
   }

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -10,6 +10,7 @@ import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.
 import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
 import type { HookServer } from '../../../src/hooks/index.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
@@ -105,6 +106,7 @@ describe('setupHookBridge', () => {
   let tmpDir: string;
   let sessionRegistry: SessionRegistry;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
   let liveSessionsRegistry: SessionRegistryFile;
   // Stored loosely so tests can inject a minimal fake watcher without
   // dragging in a real TranscriptWatcher instance.
@@ -118,6 +120,7 @@ describe('setupHookBridge', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-hook-bridge-'));
     sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     // Live-sessions registry gets its OWN subdir so its listLive() scan does
     // not see (and delete as "invalid") the SessionStore's sessions.json that
     // shares the tmp root. Create it up front so tests that write sibling
@@ -230,7 +233,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1129,7 +1132,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1207,7 +1210,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1279,7 +1282,7 @@ describe('setupHookBridge', () => {
     setupHookBridge(
       {
         sessionRegistry,
-        sessionStore,
+        bindingStore,
         liveSessionsRegistry,
         transcriptWatchers: transcriptWatchers as unknown as Map<
           UUID,
@@ -1752,7 +1755,7 @@ describe('setupHookBridge', () => {
       setupHookBridge(
         {
           sessionRegistry,
-          sessionStore,
+          bindingStore,
           liveSessionsRegistry,
           transcriptWatchers: transcriptWatchers as unknown as Map<
             UUID,

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -262,7 +262,7 @@ describe('setupHookBridge', () => {
     return { tracker };
   }
 
-  test('registers listeners for all 7 hook events', () => {
+  test('registers listeners for all 11 hook events', () => {
     build();
     const events = new Set(hookServer.listeners.keys());
     expect(events).toEqual(
@@ -274,8 +274,87 @@ describe('setupHookBridge', () => {
         'PermissionRequest',
         'Stop',
         'SessionEnd',
+        // Wired in phase 4 (#453).
+        'StopFailure',
+        'PostToolUseFailure',
+        'SubagentStart',
+        'SubagentStop',
       ]),
     );
+  });
+
+  describe('phase 4 (#453): the 4 previously-dropped events', () => {
+    /** Fire a SessionStart so the bridge locks onto `id` (admit gate then passes). */
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('StopFailure emits a "Retry?" question + waiting status (no agent_id drop)', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('StopFailure', { session_id: 'claude-A', error_type: 'timeout' });
+      expect(messageApiLog.questionCalls).toBeGreaterThanOrEqual(1);
+      expect(messageApiLog.statusCalls).toContain('waiting');
+    });
+
+    test('StopFailure for a FOREIGN session_id is dropped by the admit gate', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('StopFailure', { session_id: 'claude-OTHER', error_type: 'timeout' });
+      expect(messageApiLog.questionCalls).toBe(0);
+    });
+
+    test('PostToolUseFailure sets executing status (main); a subagent failure is dropped', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-A',
+        tool_name: 'Bash',
+        error: 'exit 1',
+      });
+      expect(messageApiLog.statusCalls).toEqual(['executing']);
+
+      // A subagent's tool failure (agent_id set) must NOT flip main's status.
+      messageApiLog.statusCalls.length = 0;
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-A',
+        agent_id: 'sub-1',
+        tool_name: 'Bash',
+        error: 'exit 1',
+      });
+      expect(messageApiLog.statusCalls).toEqual([]);
+    });
+
+    test('SubagentStart/Stop set the status breadcrumb (admit-gated, NOT agent_id-dropped)', () => {
+      build();
+      lock('claude-A');
+      // SubagentStart/Stop ALWAYS carry agent_id; they must NOT be dropped.
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-A',
+        agent_id: 'sub-1',
+        agent_type: 'code-architect',
+      });
+      expect(messageApiLog.statusCalls).toEqual(['executing']);
+
+      messageApiLog.statusCalls.length = 0;
+      hookServer.fire('SubagentStop', { session_id: 'claude-A', agent_id: 'sub-1' });
+      expect(messageApiLog.statusCalls).toEqual(['thinking']);
+    });
+
+    test('SubagentStart for a FOREIGN session_id is dropped by the admit gate', () => {
+      build();
+      lock('claude-A');
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-OTHER',
+        agent_id: 'sub-1',
+        agent_type: 'task',
+      });
+      expect(messageApiLog.statusCalls).toEqual([]);
+    });
   });
 
   test('does not throw when autoApproveService is null (common case)', () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -134,6 +134,17 @@ describe('setupHookBridge', () => {
 
   afterEach(async () => {
     __resetLoggerForTests();
+    // Stop any transcript watchers a test left running (tests that fire
+    // SessionStart start a real TranscriptWatcher with an fs.watch + 1s poll;
+    // without this they leak a timer + fd past the test). Covers the
+    // pre-existing rotation tests too.
+    for (const w of transcriptWatchers.values()) {
+      try {
+        w.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
     await sessionRegistry.shutdown();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -1824,6 +1835,136 @@ describe('setupHookBridge', () => {
       expect(events[0]?.newTranscriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
       expect(events[0]?.reason).toBe('restart');
     });
+
+    // Epic #453 phase 0 characterization. The #430/#433 hazard: the
+    // transcript-fallback writes the NEW claudeSessionId to sessionStore
+    // BEFORE the hook event for it arrives, so adoptLockFromStore pulls the
+    // new id and classifySessionEvent sees currentLock === incoming = 'match'.
+    // The bug-regression + Codex critics flagged that this exact race is
+    // untested. This pins TODAY's behavior so the TranscriptBinder refactor
+    // (phase 3) cannot change it unnoticed: when the store has already raced
+    // to the new id, the early-return at hook-bridge-setup.ts:370 is hit and
+    // NO session_rotated is emitted (the snapshot's isRotation is computed but
+    // never reaches the restart/adopt announce). Reconnect reconcile then
+    // relies on the store-binding + hello_ack decoration, not a replayed
+    // session_rotated. The binder must consciously preserve OR fix this.
+    test('store raced to the new id before SessionStart: characterize session_rotated', () => {
+      const { sent } = buildWithCapture();
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      // Establish the lock on claude-A.
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      // Fallback races the store to claude-B BEFORE the SessionStart for B.
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-B',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      // SessionStart for B arrives; adoptLockFromStore pulls B -> 'match'.
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+
+      // Baseline: the store-raced case does NOT re-emit session_rotated.
+      expect(sent.filter((m) => m.type === 'session_rotated')).toHaveLength(0);
+      // But the binding DID advance to B (store + lock), so a reconnect still
+      // reconciles via the store, not via a replayed rotation event.
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-B');
+    });
+
+    // Epic #453 phase 0: golden-master / differential baseline. A
+    // representative multi-rotation session lifecycle (fresh -> /clear ->
+    // /clear) replayed through the CURRENT path, capturing the control-plane
+    // contract: the ordered session_rotated sequence + the final durable
+    // binding. Phase 3's TranscriptBinder must reproduce this exactly
+    // (shadow-mode diffs against it). Deterministic (synchronous control
+    // plane only; async transcript content is out of scope here).
+    test('golden master: multi-rotation control-plane sequence + final binding', () => {
+      const { sent } = buildWithCapture();
+      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
+        handleMessage: () => {},
+        handleQuestion: () => {},
+        handleStatusChange: () => {},
+        reset: () => {},
+      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
+
+      // Pre-spawn binding (createNewSession writes this before spawn).
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-1',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      const t1 = path.join(tmpDir, 'm1.jsonl');
+      const t2 = path.join(tmpDir, 'm2.jsonl');
+      const t3 = path.join(tmpDir, 'm3.jsonl');
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-1',
+        transcript_path: t1,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-2',
+        transcript_path: t2,
+        hook_event_name: 'SessionStart',
+        source: 'clear',
+      });
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-3',
+        transcript_path: t3,
+        hook_event_name: 'SessionStart',
+        source: 'clear',
+      });
+
+      const rotations = sent
+        .filter((m) => m.type === 'session_rotated')
+        .map((m) => {
+          const r = m as unknown as {
+            oldClaudeSessionId?: string;
+            newClaudeSessionId: string;
+            newTranscriptPath: string;
+            reason: string;
+          };
+          return {
+            old: r.oldClaudeSessionId,
+            new: r.newClaudeSessionId,
+            path: r.newTranscriptPath,
+            reason: r.reason,
+          };
+        });
+
+      // THE GOLDEN MASTER — phase 3 must reproduce this byte-for-byte.
+      expect(rotations).toEqual([
+        { old: 'claude-1', new: 'claude-2', path: t2, reason: 'restart' },
+        { old: 'claude-2', new: 'claude-3', path: t3, reason: 'restart' },
+      ]);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-3');
+    });
   });
 
   describe('child-liveness + port-ownership rotation (#451)', () => {
@@ -2078,6 +2219,49 @@ describe('setupHookBridge', () => {
       } finally {
         stopWatchers();
       }
+    });
+  });
+
+  // Epic #453 phase 0: pin TODAY's behavior so the QuestionPipeline / binder
+  // refactor is verified against a baseline. These tests change no production
+  // code; they characterize. The migration-safety + Codex critics flagged
+  // that the existing realTracker tests assert hasPendingForTest() but never
+  // that the push itself is gated on PTY presence, so a refactor could
+  // collapse the two-step recordPendingHook -> onPTYPromptVisible contract
+  // into a direct handleQuestion and still pass.
+  describe('phase 0 characterization (#453 baseline)', () => {
+    test('two-step push: a hook stashes pending WITHOUT pushing; only PTY presence fires the push', () => {
+      const { tracker } = build({ realTracker: true });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-twostep',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'twostep.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      hookServer.fire('PermissionRequest', {
+        session_id: 'claude-twostep',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      // The hook recorded a pending question but did NOT push (no handleQuestion).
+      expect(tracker.hasPendingForTest()).toBe(true);
+      expect(messageApiLog.questionCalls).toBe(0);
+
+      // The PTY confirms the prompt is on screen -> the push fires exactly once.
+      tracker.onPTYPromptVisible({
+        id: 'pty-twostep',
+        text: 'Allow Bash?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as unknown as Question);
+
+      expect(messageApiLog.questionCalls).toBe(1);
     });
   });
 });

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -3,14 +3,12 @@ import type { AgentStatus, ProtocolMessage, Question, QuestionOption, UUID } fro
 import { generateId, now } from '@remi/shared';
 import type { DeviceTokenEntry } from '../../../src/cli/handlers/trivial-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
-import {
-  createMessageApiForSession,
-  selectPushCategory,
-} from '../../../src/cli/session-phases/message-api-setup.ts';
+import { createMessageApiForSession } from '../../../src/cli/session-phases/message-api-setup.ts';
 import {
   __resetSessionStateForTests,
   setPrimarySessionId,
 } from '../../../src/cli/session-state.ts';
+import { selectPushCategory } from '../../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Differential (shadow-mode) test for the TranscriptBinder — epic #453 phase 3,
+ * commit 3.
+ *
+ * Drives `setupHookBridge` with `shadowBinder=true` through the same
+ * RecordingHookServer harness the characterization suite uses, replaying the
+ * four MANDATORY event streams from the design doc (§3.1 v4 #10):
+ *
+ *   (a) SessionEnd-then-restart  (SessionStart A, SessionEnd A, SessionStart B)
+ *   (b) A -> B -> A re-resume
+ *   (c) path-less restart        (SessionStart B without transcript_path)
+ *   (d) foreign-subagent-after-rotation (agent_id event right after a rotation)
+ *
+ * Two assertions per stream:
+ *   1. ZERO `[ShadowBinder] DISAGREE` lines: the shadow binder's load-bearing
+ *      control-plane decision (bound id after, would-emit-rotation, watcher
+ *      path) matches the old path's observed outcome on every event.
+ *   2. ZERO shadow side effects: running the SAME stream with the shadow OFF
+ *      (baseline) vs ON produces byte-identical observable output — same
+ *      session_rotated messages on the wire, same final store binding, same
+ *      final watcher path. The shadow cannot emit, write the store, or start a
+ *      watcher, so the two runs must be indistinguishable.
+ *
+ * NO MOCKS: real SessionStore / SessionBindingStore / SessionRegistry /
+ * TranscriptWatcher over a tmpdir; a fake PTY (the only seam, matching the
+ * characterization suite).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
+import type { HookServer } from '../../../src/hooks/index.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/index.ts';
+import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+/** Recording HookServer: capture `.on()` registrations, fire them directly. */
+class RecordingHookServer {
+  readonly listeners = new Map<string, (input: unknown) => void>();
+  on(event: string, listener: (input: unknown) => void): () => void {
+    this.listeners.set(event, listener);
+    return () => this.listeners.delete(event);
+  }
+  fire(event: string, input: unknown): void {
+    const fn = this.listeners.get(event);
+    if (!fn) throw new Error(`No listener registered for ${event}`);
+    fn(input);
+  }
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+/** Minimal no-op MessageAPI — the bridge calls reset() on rotation. */
+function noopMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+
+/** One replay step: the hook event name + the raw input payload. */
+interface Step {
+  event: string;
+  input: Record<string, unknown>;
+}
+
+/** Observable output of running a stream (for the side-effect-free diff). */
+interface RunResult {
+  /** Every session_rotated message that crossed the wire, in order. */
+  rotations: Array<{ newClaudeSessionId: string; oldClaudeSessionId?: string | undefined }>;
+  /** The durable binding after the whole stream ran. */
+  finalBoundId: string | null;
+  /** The final watcher's filePath (path-resolved), or null. */
+  finalWatcherPath: string | null;
+  /** Captured DISAGREE lines (only ever non-empty in the shadow-on run). */
+  disagreements: string[];
+}
+
+describe('TranscriptBinder differential (shadow mode)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-diff-'));
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build one isolated bridge + its backing state, replay `steps`, and return
+   * the observable outcome. Each run gets a FRESH SessionStore/Registry/watcher
+   * map under its own subdir so the shadow-on and shadow-off runs cannot share
+   * state. The shadow binder writes nothing, so the two runs must match.
+   */
+  async function runStream(
+    steps: Step[],
+    shadowBinder: boolean,
+    txBase: string,
+  ): Promise<RunResult> {
+    // Isolated per-run state dir (store + live-sessions) so the baseline and
+    // shadow runs never share persisted state; transcript paths resolve against
+    // the SHARED `txBase` so both runs produce identical absolute watcher paths.
+    const stateDir = fs.mkdtempSync(path.join(tmpDir, 'state-'));
+    const disagreements: string[] = [];
+    configureLogger({
+      writeLog: (msg: string) => {
+        if (msg.includes('[ShadowBinder] DISAGREE')) disagreements.push(msg);
+      },
+    });
+
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const sessionStore = new SessionStore(path.join(stateDir, 'sessions.json'));
+    const bindingStore = new SessionBindingStore(sessionStore);
+    const liveSessionsRegistry = new SessionRegistryFile(path.join(stateDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    const transcriptWatchers = new Map<UUID, TranscriptWatcher>();
+    const transcriptFallbackTimers = new Map<UUID, ReturnType<typeof setInterval>>();
+    const transcriptDiscovery = new TranscriptDiscovery();
+    const hookServer = new RecordingHookServer();
+    const messageApi = noopMessageAPI();
+    const tracker = new QuestionPresenceTracker(() => {});
+
+    sessionRegistry.registerSession(SID, txBase, fakePTY(), messageApi);
+
+    // Mirror production cli.ts: the deterministic pre-spawn binding is written
+    // to the store BEFORE the bridge sees any hook event. Without this record
+    // SessionStore.updateClaudeSessionId is a no-op (it never creates a row),
+    // so bindingStore.get() would always read null and the binding can never be
+    // observed. Pre-assign the FIRST event's claude session id, exactly as
+    // resolveClaudeBinding + bindingStore.preAssign do at spawn time.
+    const firstClaudeId = steps[0]?.input['session_id'] as string | undefined;
+    if (firstClaudeId) {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: firstClaudeId,
+        projectPath: txBase,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    const rotations: RunResult['rotations'] = [];
+    const sendAndRecord = (message: ProtocolMessage): void => {
+      if (message.type === 'session_rotated') {
+        rotations.push({
+          newClaudeSessionId: message.newClaudeSessionId as string,
+          oldClaudeSessionId: message.oldClaudeSessionId as string | undefined,
+        });
+      }
+    };
+
+    setupHookBridge(
+      {
+        sessionRegistry,
+        bindingStore,
+        liveSessionsRegistry,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        autoApproveService: null,
+        currentPort: () => 8765,
+        shadowBinder,
+        transcriptDiscovery,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: txBase,
+        messageApi,
+        sendAndRecord,
+        tracker,
+      },
+    );
+
+    // Resolve relative transcript paths against this run's dir so the two runs
+    // produce identical absolute paths for the diff.
+    for (const step of steps) {
+      const input: Record<string, unknown> = { ...step.input };
+      if (typeof input['transcript_path'] === 'string') {
+        const abs = path.join(txBase, input['transcript_path'] as string);
+        // Create the (empty) transcript file so the real TranscriptWatcher's
+        // waitForFile resolves immediately instead of leaving a 1s poll alive
+        // across runs (a harness flake under rapid back-to-back invocation). No
+        // sibling in these streams, so the absent head marker never gates
+        // ownsTranscript; both baseline and shadow runs share txBase so they see
+        // identical files.
+        if (!fs.existsSync(abs)) fs.writeFileSync(abs, '');
+        input['transcript_path'] = abs;
+      }
+      hookServer.fire(step.event, input);
+    }
+
+    const finalWatcher = transcriptWatchers.get(SID);
+    const result: RunResult = {
+      rotations,
+      finalBoundId: bindingStore.get(SID)?.claudeSessionId ?? null,
+      finalWatcherPath: finalWatcher ? path.resolve(finalWatcher.filePath) : null,
+      disagreements,
+    };
+
+    // Cleanup: stop any real watchers this run started (fs.watch + 1s poll).
+    for (const w of transcriptWatchers.values()) {
+      try {
+        w.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    await sessionRegistry.shutdown();
+    return result;
+  }
+
+  /**
+   * Replay a stream with the shadow OFF and ON, assert ZERO disagreements and
+   * that the two runs are observationally identical (the shadow added no side
+   * effect). Returns the shadow-on result for any stream-specific assertions.
+   */
+  async function assertNoDivergence(name: string, steps: Step[]): Promise<RunResult> {
+    // Shared transcript base so both runs resolve identical absolute paths; each
+    // run still gets its own isolated state dir inside runStream.
+    const txBase = fs.mkdtempSync(path.join(tmpDir, 'tx-'));
+    const baseline = await runStream(steps, /* shadowBinder */ false, txBase);
+    const shadow = await runStream(steps, /* shadowBinder */ true, txBase);
+
+    // 1) The shadow binder logged no control-plane disagreement.
+    expect(shadow.disagreements, `${name}: shadow DISAGREE lines`).toEqual([]);
+    // The baseline run never constructs a shadow, so it cannot disagree.
+    expect(baseline.disagreements).toEqual([]);
+
+    // 2) Side-effect-free: shadow-on output is identical to shadow-off output.
+    expect(shadow.rotations, `${name}: rotations on wire`).toEqual(baseline.rotations);
+    expect(shadow.finalBoundId, `${name}: final bound id`).toBe(baseline.finalBoundId);
+    expect(shadow.finalWatcherPath, `${name}: final watcher path`).toBe(baseline.finalWatcherPath);
+
+    return shadow;
+  }
+
+  test('(a) SessionEnd-then-restart: SessionStart A, SessionEnd A, SessionStart B', async () => {
+    const result = await assertNoDivergence('end-then-restart', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'logout' } },
+      { event: 'SessionStart', input: { session_id: 'claude-B', transcript_path: 'b.jsonl' } },
+    ]);
+
+    // Exactly one rotation (A -> B); final lock is B.
+    expect(result.rotations.length).toBe(1);
+    expect(result.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(result.rotations[0]?.oldClaudeSessionId).toBe('claude-A');
+    expect(result.finalBoundId).toBe('claude-B');
+    expect(result.finalWatcherPath?.endsWith(`${path.sep}b.jsonl`)).toBe(true);
+  });
+
+  test('(b) A -> B -> A re-resume', async () => {
+    // /clear from A to B, then /resume back to A. The idempotent emit guard
+    // must produce A->B, B->A and never a duplicate; the shadow must agree.
+    const result = await assertNoDivergence('a-b-a', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-A', transcript_path: 'a.jsonl', source: 'resume' },
+      },
+    ]);
+
+    expect(result.rotations.length).toBe(2);
+    expect(result.rotations.map((r) => r.newClaudeSessionId)).toEqual(['claude-B', 'claude-A']);
+    expect(result.finalBoundId).toBe('claude-A');
+  });
+
+  test('(c) path-less restart emits nothing for the path-less event', async () => {
+    // SessionStart B with NO transcript_path. The old path nulls the lock but
+    // does not emit (the :337 path guard); the shadow must match (zero emit,
+    // lock null after the path-less event), then a follow-up event with a path
+    // rebinds and emits the rotation.
+    const result = await assertNoDivergence('path-less-restart', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'logout' } },
+      // Path-less restart: nulls the lock, emits nothing.
+      { event: 'SessionStart', input: { session_id: 'claude-B' } },
+    ]);
+
+    // No rotation crossed the wire (B carried no path on its SessionStart).
+    expect(result.rotations.length).toBe(0);
+  });
+
+  test('(d) foreign subagent event (agent_id set) immediately after a rotation', async () => {
+    // After A -> B rotates, a subagent event arrives with a DISTINCT session_id
+    // (and agent_id) while the PTY is still running. It must classify FOREIGN
+    // (different id, PTY running, mainSessionEnded reset to false by the rotate)
+    // -> no new bind, no rotation, lock stays B. The distinct id is essential:
+    // reusing B short-circuits the classifier to 'match' BEFORE mainSessionEnded
+    // is read, so it would NOT exercise the v4 #5 reset (the reviewer proved
+    // deleting the reset still passed the same-id form). With a distinct id this
+    // stream genuinely depends on rotate() resetting mainSessionEnded.
+    const result = await assertNoDivergence('foreign-after-rotation', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      // Foreign subagent event right after the rotation: agent_id set, DISTINCT
+      // session_id so it reaches the mainPtyRunning && !mainSessionEnded branch.
+      {
+        event: 'PostToolUse',
+        input: {
+          session_id: 'claude-foreign-sub',
+          agent_id: 'subagent-xyz',
+          agent_type: 'task',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+          transcript_path: 'b.jsonl',
+        },
+      },
+    ]);
+
+    // Exactly one rotation (A -> B); the foreign subagent event adds nothing.
+    expect(result.rotations.length).toBe(1);
+    expect(result.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(result.finalBoundId).toBe('claude-B');
+  });
+});

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Drive-mode test for the TranscriptBinder — epic #453 phase 3, commit 5.
+ *
+ * The shadow differential test (transcript-binder-differential.test.ts) proves
+ * the binder's DECISIONS are equivalent to the old path. THIS test proves that
+ * when `binderEnabled=true` the binder actually DRIVES — applies those decisions
+ * (emits session_rotated on the wire, writes the durable store binding, starts
+ * the watcher) — producing the SAME observable output the OLD path produces with
+ * `binderEnabled=false`.
+ *
+ * Method: replay the same event streams through `setupHookBridge` twice over a
+ * SHARED transcript base — once with the OLD path (binderEnabled=false) and once
+ * with the binder DRIVING (binderEnabled=true) — and assert the two runs are
+ * observationally identical:
+ *   - the same session_rotated messages on the wire (in order),
+ *   - the same final durable store binding,
+ *   - the same final watcher path (proves the watcher started on the same file).
+ *
+ * Streams (mirroring the differential corpus, plus a sibling-defer case):
+ *   (a) normal first-bind + a /clear rotation (A -> B),
+ *   (b) A -> B -> A re-resume (idempotent emit guard),
+ *   (c) sibling-defer: a live co-located sibling owns the dir and the incoming
+ *       event's transcript carries the sibling's port marker -> both paths
+ *       defer (no bind, no watcher, no rotation).
+ *
+ * NO MOCKS: real SessionStore / SessionBindingStore / SessionRegistry /
+ * SessionRegistryFile / TranscriptWatcher over a tmpdir; a fake PTY (the only
+ * seam, matching the characterization + differential suites).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
+import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
+import type { HookServer } from '../../../src/hooks/index.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../../src/transcript/index.ts';
+import type { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
+
+/** Recording HookServer: capture `.on()` registrations, fire them directly. */
+class RecordingHookServer {
+  readonly listeners = new Map<string, (input: unknown) => void>();
+  on(event: string, listener: (input: unknown) => void): () => void {
+    this.listeners.set(event, listener);
+    return () => this.listeners.delete(event);
+  }
+  fire(event: string, input: unknown): void {
+    const fn = this.listeners.get(event);
+    if (!fn) throw new Error(`No listener registered for ${event}`);
+    fn(input);
+  }
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+/** Minimal no-op MessageAPI — the bridge calls reset() on rotation. */
+function noopMessageAPI(): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {},
+  } as unknown as MessageAPI;
+}
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+const PORT = 8765;
+
+/** One replay step: the hook event name + the raw input payload. */
+interface Step {
+  event: string;
+  input: Record<string, unknown>;
+}
+
+/** Optional per-run injection of a live sibling into the live-sessions dir. */
+interface SiblingSpec {
+  /** Sibling's wsPort (must differ from PORT so it counts as a sibling). */
+  wsPort: number;
+  /** A live pid so claudeChildLooksAlive() treats it as a live sibling. */
+  claudeChildPid: number;
+}
+
+interface RunOptions {
+  sibling?: SiblingSpec;
+  /**
+   * Skip the pre-spawn binding write. The sibling-defer case needs the lock
+   * UNBOUND (no stored binding to adopt) so the first-adopt sibling/ownership
+   * gate — not the already-bound tripwire — is what defers.
+   */
+  skipPreAssign?: boolean;
+}
+
+/** Observable output of running a stream (for the drive-vs-old diff). */
+interface RunResult {
+  /** Every session_rotated message that crossed the wire, in order. */
+  rotations: Array<{ newClaudeSessionId: string; oldClaudeSessionId?: string | undefined }>;
+  /** The durable binding after the whole stream ran. */
+  finalBoundId: string | null;
+  /** The final watcher's filePath (path-resolved), or null. */
+  finalWatcherPath: string | null;
+  /** Any unexpected error lines (should always be empty). */
+  errors: string[];
+}
+
+describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-drive-'));
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build one isolated bridge + its backing state, replay `steps`, and return
+   * the observable outcome. Each run gets a FRESH SessionStore/Registry/watcher
+   * map under its own subdir so the old-path and drive runs cannot share state.
+   * Transcript paths resolve against the SHARED `txBase` so both runs produce
+   * identical absolute watcher paths. When `binderEnabled` is true the binder
+   * DRIVES; the returned handle's closeBinder() is called in cleanup so the
+   * binder's fallback poll + #452 rotation dir-poll never outlive the run.
+   */
+  async function runStream(
+    steps: Step[],
+    binderEnabled: boolean,
+    txBase: string,
+    options: RunOptions = {},
+  ): Promise<RunResult> {
+    const { sibling, skipPreAssign } = options;
+    const stateDir = fs.mkdtempSync(path.join(tmpDir, 'state-'));
+    const errors: string[] = [];
+    configureLogger({
+      writeLog: (msg: string) => {
+        // Surface only genuine failure lines; the binder/old path log routine
+        // [Hooks]/[Binder] info lines that are not errors.
+        if (msg.includes('failed') || msg.includes('Failed')) errors.push(msg);
+      },
+    });
+
+    const sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    const sessionStore = new SessionStore(path.join(stateDir, 'sessions.json'));
+    const bindingStore = new SessionBindingStore(sessionStore);
+    const liveSessionsRegistry = new SessionRegistryFile(path.join(stateDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    const transcriptWatchers = new Map<UUID, TranscriptWatcher>();
+    const transcriptFallbackTimers = new Map<UUID, ReturnType<typeof setInterval>>();
+    const transcriptDiscovery = new TranscriptDiscovery();
+    const hookServer = new RecordingHookServer();
+    const messageApi = noopMessageAPI();
+    const tracker = new QuestionPresenceTracker(() => {});
+
+    sessionRegistry.registerSession(SID, txBase, fakePTY(), messageApi);
+
+    // Mirror production cli.ts: the deterministic pre-spawn binding is written to
+    // the store BEFORE the bridge sees any hook event (and BEFORE binder.start(),
+    // which reads it for the fallback/dir-watch arm).
+    const firstClaudeId = steps[0]?.input['session_id'] as string | undefined;
+    if (firstClaudeId && !skipPreAssign) {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: firstClaudeId,
+        projectPath: txBase,
+        port: PORT,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    // Optional: register a LIVE co-located sibling so hasSiblingInDir() returns
+    // true for both paths (the sibling-defer case). Written as a raw registry
+    // file (matching the #451 tests): projectPath equals our workingDirectory,
+    // wsPort differs from PORT, and a live claudeChildPid keeps it from being
+    // treated as a zombie.
+    if (sibling) {
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sibling.json'),
+        JSON.stringify({
+          sessionId: 'sib-drive-test',
+          pid: process.pid, // sibling DAEMON is alive
+          wsPort: sibling.wsPort,
+          hookPort: sibling.wsPort + 1,
+          projectPath: txBase,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+          claudeChildPid: sibling.claudeChildPid,
+        }),
+      );
+    }
+
+    const rotations: RunResult['rotations'] = [];
+    const sendAndRecord = (message: ProtocolMessage): void => {
+      if (message.type === 'session_rotated') {
+        rotations.push({
+          newClaudeSessionId: message.newClaudeSessionId as string,
+          oldClaudeSessionId: message.oldClaudeSessionId as string | undefined,
+        });
+      }
+    };
+
+    const handle = setupHookBridge(
+      {
+        sessionRegistry,
+        bindingStore,
+        liveSessionsRegistry,
+        transcriptWatchers,
+        transcriptFallbackTimers,
+        autoApproveService: null,
+        currentPort: () => PORT,
+        binderEnabled,
+        transcriptDiscovery,
+      },
+      {
+        hookServer: hookServer as unknown as HookServer,
+        sessionId: SID,
+        workingDirectory: txBase,
+        messageApi,
+        sendAndRecord,
+        tracker,
+      },
+    );
+
+    // Resolve relative transcript paths against this run's dir so the two runs
+    // produce identical absolute paths for the diff.
+    for (const step of steps) {
+      const input: Record<string, unknown> = { ...step.input };
+      if (typeof input['transcript_path'] === 'string') {
+        const abs = path.join(txBase, input['transcript_path'] as string);
+        // Create the (empty) transcript file so the real TranscriptWatcher's
+        // waitForFile resolves immediately instead of leaving a 1s poll alive.
+        if (!fs.existsSync(abs)) fs.writeFileSync(abs, '');
+        input['transcript_path'] = abs;
+      }
+      hookServer.fire(step.event, input);
+    }
+
+    const finalWatcher = transcriptWatchers.get(SID);
+    const result: RunResult = {
+      rotations,
+      finalBoundId: bindingStore.get(SID)?.claudeSessionId ?? null,
+      finalWatcherPath: finalWatcher ? path.resolve(finalWatcher.filePath) : null,
+      errors,
+    };
+
+    // Cleanup: close the binder (drive mode only — no-op when off) so its
+    // fallback poll + #452 rotation dir-poll intervals are cleared, then stop any
+    // watchers + remaining fallback timers this run started.
+    handle.closeBinder();
+    for (const w of transcriptWatchers.values()) {
+      try {
+        w.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    for (const t of transcriptFallbackTimers.values()) clearInterval(t);
+    await sessionRegistry.shutdown();
+    return result;
+  }
+
+  /**
+   * Replay a stream through the OLD path and the DRIVING binder and assert the
+   * two runs are observationally identical. Returns the drive result for any
+   * stream-specific assertions.
+   */
+  async function assertDriveMatchesOld(
+    name: string,
+    steps: Step[],
+    options: RunOptions = {},
+  ): Promise<RunResult> {
+    const txBase = fs.mkdtempSync(path.join(tmpDir, 'tx-'));
+    const old = await runStream(steps, /* binderEnabled */ false, txBase, options);
+    const drive = await runStream(steps, /* binderEnabled */ true, txBase, options);
+
+    expect(old.errors, `${name}: old-path errors`).toEqual([]);
+    expect(drive.errors, `${name}: drive errors`).toEqual([]);
+
+    expect(drive.rotations, `${name}: rotations on wire`).toEqual(old.rotations);
+    expect(drive.finalBoundId, `${name}: final bound id`).toBe(old.finalBoundId);
+    expect(drive.finalWatcherPath, `${name}: final watcher path`).toBe(old.finalWatcherPath);
+
+    return drive;
+  }
+
+  test('(a) normal first-bind + /clear rotation A -> B', async () => {
+    const drive = await assertDriveMatchesOld('first-bind-rotation', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+    ]);
+
+    // The binder DROVE: exactly one rotation A -> B reached the wire, the store
+    // is bound to B, and the watcher started on b.jsonl.
+    expect(drive.rotations.length).toBe(1);
+    expect(drive.rotations[0]?.newClaudeSessionId).toBe('claude-B');
+    expect(drive.rotations[0]?.oldClaudeSessionId).toBe('claude-A');
+    expect(drive.finalBoundId).toBe('claude-B');
+    expect(drive.finalWatcherPath?.endsWith(`${path.sep}b.jsonl`)).toBe(true);
+  });
+
+  test('(b) A -> B -> A re-resume (idempotent emit)', async () => {
+    const drive = await assertDriveMatchesOld('a-b-a', [
+      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+      },
+      {
+        event: 'SessionStart',
+        input: { session_id: 'claude-A', transcript_path: 'a.jsonl', source: 'resume' },
+      },
+    ]);
+
+    // The binder DROVE A->B then B->A and never a duplicate; final lock is A.
+    expect(drive.rotations.map((r) => r.newClaudeSessionId)).toEqual(['claude-B', 'claude-A']);
+    expect(drive.finalBoundId).toBe('claude-A');
+  });
+
+  test('(c) sibling-defer: live sibling owns the dir, incoming marker is not ours', async () => {
+    // A live co-located sibling shares the directory. The pre-assigned binding is
+    // never written by a hook here (we start at the UNBOUND state and the first
+    // event's transcript carries no remi:<port> head marker proving ownership),
+    // so admits()/initFromHookEvent both defer: no bind, no watcher, no rotation.
+    // The empty transcript file the harness writes carries no marker, so
+    // ownsTranscript() is false for both paths -> both defer identically.
+    const drive = await assertDriveMatchesOld(
+      'sibling-defer',
+      [
+        // Use PreToolUse (not SessionStart) so the SessionStart pre-empt does not
+        // fire; this exercises the first-adopt sibling/ownership gate directly.
+        {
+          event: 'PreToolUse',
+          input: {
+            session_id: 'claude-X',
+            transcript_path: 'x.jsonl',
+            tool_name: 'Bash',
+            tool_input: { command: 'ls' },
+          },
+        },
+      ],
+      {
+        // Lock must stay UNBOUND so the first-adopt sibling/ownership gate (not
+        // the already-bound tripwire) is what defers; the empty x.jsonl carries
+        // no remi:<port> marker so ownsTranscript() is false for both paths.
+        skipPreAssign: true,
+        sibling: { wsPort: 9999, claudeChildPid: process.pid },
+      },
+    );
+
+    // Both paths deferred: nothing bound, nothing emitted, no watcher.
+    expect(drive.rotations.length).toBe(0);
+    expect(drive.finalWatcherPath).toBe(null);
+  });
+});

--- a/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
+++ b/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
@@ -5,12 +5,7 @@ import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import type { MessageAPI } from '../../src/api/message-api.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
-import {
-  extractClaudeSessionId,
-  startTranscriptWatcher,
-} from '../../src/cli/transcript-watcher-setup.ts';
-import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
-import { SessionStore } from '../../src/session/session-store.ts';
+import { startTranscriptWatcher } from '../../src/cli/transcript-watcher-setup.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
 const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
@@ -25,58 +20,15 @@ function fakeMessageAPI(): MessageAPI {
 
 describe('transcript-watcher-setup', () => {
   let tmpDir: string;
-  let sessionStore: SessionStore;
-  let bindingStore: SessionBindingStore;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tws-'));
-    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
-    bindingStore = new SessionBindingStore(sessionStore);
     configureLogger({ writeLog: () => {} });
-    // Seed a session so updateClaudeSessionId has a row to update
-    sessionStore.save({
-      remiSessionId: SID,
-      claudeSessionId: null,
-      projectPath: tmpDir,
-      port: 0,
-      pid: null,
-      startedAt: new Date().toISOString(),
-      exitedAt: null,
-      exitCode: null,
-    });
   });
 
   afterEach(() => {
     __resetLoggerForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  describe('extractClaudeSessionId', () => {
-    test('reads UUID from a plain filename and persists it', () => {
-      const claudeId = '11111111-2222-3333-4444-555555555555';
-      const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
-
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-
-      expect(result).toBe(claudeId);
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(claudeId);
-    });
-
-    test('accepts prefixed _UUID filenames (picks the last segment)', () => {
-      const claudeId = '66666666-7777-8888-9999-000000000000';
-      const filePath = path.join(tmpDir, `prefix_${claudeId}.jsonl`);
-
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-
-      expect(result).toBe(claudeId);
-    });
-
-    test('returns null and does not persist when the filename has no usable id', () => {
-      const filePath = path.join(tmpDir, 'ab.jsonl'); // under 8 chars
-      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
-      expect(result).toBeNull();
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBeNull();
-    });
   });
 
   describe('startTranscriptWatcher', () => {

--- a/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
+++ b/packages/daemon/tests/cli/transcript-watcher-setup.test.ts
@@ -9,6 +9,7 @@ import {
   extractClaudeSessionId,
   startTranscriptWatcher,
 } from '../../src/cli/transcript-watcher-setup.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../src/session/session-store.ts';
 import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
 
@@ -25,10 +26,12 @@ function fakeMessageAPI(): MessageAPI {
 describe('transcript-watcher-setup', () => {
   let tmpDir: string;
   let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tws-'));
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
     configureLogger({ writeLog: () => {} });
     // Seed a session so updateClaudeSessionId has a row to update
     sessionStore.save({
@@ -53,7 +56,7 @@ describe('transcript-watcher-setup', () => {
       const claudeId = '11111111-2222-3333-4444-555555555555';
       const filePath = path.join(tmpDir, `${claudeId}.jsonl`);
 
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
 
       expect(result).toBe(claudeId);
       expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(claudeId);
@@ -63,14 +66,14 @@ describe('transcript-watcher-setup', () => {
       const claudeId = '66666666-7777-8888-9999-000000000000';
       const filePath = path.join(tmpDir, `prefix_${claudeId}.jsonl`);
 
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
 
       expect(result).toBe(claudeId);
     });
 
     test('returns null and does not persist when the filename has no usable id', () => {
       const filePath = path.join(tmpDir, 'ab.jsonl'); // under 8 chars
-      const result = extractClaudeSessionId({ sessionStore }, filePath, SID);
+      const result = extractClaudeSessionId({ bindingStore }, filePath, SID);
       expect(result).toBeNull();
       expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBeNull();
     });

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -140,6 +140,30 @@ describe('applyEnvOverrides', () => {
     expect(config.display.max_bullet_length).toBe(100);
   });
 
+  test('transcript-binder feature flags default OFF', () => {
+    expect(DEFAULT_CONFIG.features.transcript_binder_shadow).toBe(false);
+    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_shadow).toBe(true);
+    expect(config.features.transcript_binder_enabled).toBe(false);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_ENABLED=true enables drive', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'true';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_enabled).toBe(true);
+  });
+
+  test('REMI_TRANSCRIPT_BINDER_SHADOW=false keeps shadow off', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'false';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.features.transcript_binder_shadow).toBe(false);
+  });
+
   test('TELEGRAM_BOT_TOKEN enables telegram', () => {
     process.env['TELEGRAM_BOT_TOKEN'] = 'test-token-123';
     const config = applyEnvOverrides(DEFAULT_CONFIG);

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+import type { DeviceTokenEntry } from '../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import {
+  NotificationDispatcher,
+  type PushFn,
+  selectPushCategory,
+} from '../../src/notifications/notification-dispatcher.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+const yesOpt: QuestionOption = {
+  value: 'y',
+  label: 'Yes',
+  isRecommended: true,
+  isYes: true,
+  isNo: false,
+};
+const noOpt: QuestionOption = {
+  value: 'n',
+  label: 'No',
+  isRecommended: false,
+  isYes: false,
+  isNo: true,
+};
+
+function question(id: string, options: QuestionOption[]): Question {
+  return { id: id as UUID, text: 'proceed?', options, allowsFreeText: false, isAnswered: false };
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: 'pty' as unknown as PTYSession['id'],
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+describe('selectPushCategory', () => {
+  test('maps option count to the iOS category', () => {
+    expect(selectPushCategory([yesOpt, noOpt])).toBe('REMI_YN');
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt])).toBe('REMI_YNA');
+    expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt])).toBe('REMI_MULTI');
+    expect(selectPushCategory([yesOpt])).toBeUndefined();
+    expect(selectPushCategory([])).toBeUndefined();
+  });
+});
+
+describe('NotificationDispatcher.maybePush', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ url: string | undefined; token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (url, token, opts) => {
+    pushed.push({ url, token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('pushes to every registered device when no client is attached', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    deviceTokens.set('b', { token: 'b', platform: 'ios', registeredAt: 2, connectionId: SID });
+
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed.map((p) => p.token).sort()).toEqual(['a', 'b']);
+    // The dispatcher forwards the raw signaling URL; sendPushTrigger does the
+    // wss->https normalization downstream.
+    expect(pushed[0]?.url).toBe('ws://x');
+    expect(pushed[0]?.opts['category']).toBe('REMI_YN');
+    expect(pushed[0]?.opts['options']).toEqual(['y', 'n']);
+  });
+
+  test('does NOT push when a client is attached (it sees the question in-app)', () => {
+    register(true);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed).toHaveLength(0);
+  });
+
+  test('does NOT push when no devices are registered', () => {
+    register(false);
+    make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pushed).toHaveLength(0);
+  });
+
+  test('dedup: a second identical prompt is suppressed; resetDedup re-allows', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    const d = make();
+
+    d.maybePush(SID, question('q1', [yesOpt, noOpt]));
+    d.maybePush(SID, question('q2', [yesOpt, noOpt])); // same shape -> suppressed
+    expect(pushed).toHaveLength(1);
+
+    d.resetDedup(); // prompt cycle ended (status left 'waiting')
+    d.maybePush(SID, question('q3', [yesOpt, noOpt]));
+    expect(pushed).toHaveLength(2);
+  });
+});

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -22,6 +22,21 @@ function makeAdapter(events: object): RelayAdapter {
   return adapter;
 }
 
+/**
+ * Inject a fake SignalingClient whose `sendRelay` records every payload.
+ * routeMessage's default (rejection) branch routes through `this.client?.sendRelay`,
+ * which is the same seam the real adapter uses for challenges/auth results.
+ */
+function attachSendRelaySpy(adapter: RelayAdapter): string[] {
+  const sent: string[] = [];
+  (adapter as unknown as { client: { sendRelay: (p: string) => void } }).client = {
+    sendRelay: (payload: string) => {
+      sent.push(payload);
+    },
+  };
+  return sent;
+}
+
 function callRoute(adapter: RelayAdapter, msg: Record<string, unknown>): void {
   (adapter as unknown as { routeMessage: (m: Record<string, unknown>) => void }).routeMessage(msg);
 }
@@ -127,5 +142,123 @@ describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.claudeSessionId).toBeUndefined();
+  });
+});
+
+describe('relay-adapter routeMessage no-longer-silently-drops requests (#453 phase 5)', () => {
+  const RID = 'req00000-0000-0000-0000-000000000000' as UUID;
+
+  test('kill_session_request dispatches onKillSessionRequest with sessionId + requestId', () => {
+    const calls: Array<{ connectionId: UUID; sessionId: UUID; requestId: UUID }> = [];
+    const adapter = makeAdapter({
+      onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
+        calls.push({ connectionId, sessionId, requestId });
+      },
+    });
+
+    callRoute(adapter, { type: 'kill_session_request', sessionId: SID, id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.sessionId).toBe(SID);
+    expect(calls[0]?.requestId).toBe(RID);
+  });
+
+  test('detach_session dispatches onDetachSession with sessionId + requestId', () => {
+    const calls: Array<{ connectionId: UUID; sessionId: UUID; requestId: UUID }> = [];
+    const adapter = makeAdapter({
+      onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => {
+        calls.push({ connectionId, sessionId, requestId });
+      },
+    });
+
+    callRoute(adapter, { type: 'detach_session', sessionId: SID, id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.sessionId).toBe(SID);
+    expect(calls[0]?.requestId).toBe(RID);
+  });
+
+  test('session_history_request dispatches onSessionHistoryRequest with requestId + limit', () => {
+    const calls: Array<{ connectionId: UUID; requestId: UUID; limit: number | undefined }> = [];
+    const adapter = makeAdapter({
+      onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => {
+        calls.push({ connectionId, requestId, limit });
+      },
+    });
+
+    callRoute(adapter, { type: 'session_history_request', id: RID, limit: 5 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.requestId).toBe(RID);
+    expect(calls[0]?.limit).toBe(5);
+  });
+
+  test('session_history_request without limit forwards undefined', () => {
+    const calls: Array<{ limit: number | undefined }> = [];
+    const adapter = makeAdapter({
+      onSessionHistoryRequest: (_c: UUID, _r: UUID, limit: number | undefined) => {
+        calls.push({ limit });
+      },
+    });
+
+    callRoute(adapter, { type: 'session_history_request', id: RID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.limit).toBeUndefined();
+  });
+
+  test('register_device_token with valid platform dispatches onRegisterDeviceToken', () => {
+    const calls: Array<{ connectionId: UUID; token: string; platform: 'ios' | 'android' }> = [];
+    const adapter = makeAdapter({
+      onRegisterDeviceToken: (connectionId: UUID, token: string, platform: 'ios' | 'android') => {
+        calls.push({ connectionId, token, platform });
+      },
+    });
+
+    callRoute(adapter, { type: 'register_device_token', token: 'abc123', platform: 'ios' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.connectionId).toBe(CID);
+    expect(calls[0]?.token).toBe('abc123');
+    expect(calls[0]?.platform).toBe('ios');
+  });
+
+  test('register_device_token with invalid platform is NOT dispatched', () => {
+    const calls: Array<{ token: string }> = [];
+    const adapter = makeAdapter({
+      onRegisterDeviceToken: (_c: UUID, token: string) => {
+        calls.push({ token });
+      },
+    });
+
+    callRoute(adapter, { type: 'register_device_token', token: 'abc123', platform: 'windows' });
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test('unknown type now rejects via sendRelay with error + UNSUPPORTED (no silent drop)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'bogus_request', id: RID });
+
+    expect(sent).toHaveLength(1);
+    const parsed = JSON.parse(sent[0] as string);
+    expect(parsed.type).toBe('error');
+    expect(parsed.code).toBe('UNSUPPORTED');
+    expect(typeof parsed.message).toBe('string');
+    expect(parsed.message).toContain('bogus_request');
+  });
+
+  test('ping is an explicit no-op: no rejection emitted', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'ping', id: RID });
+
+    expect(sent).toHaveLength(0);
   });
 });

--- a/packages/daemon/tests/session/session-binding-store.test.ts
+++ b/packages/daemon/tests/session/session-binding-store.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionStore, type StoredSession } from '../../src/session/session-store.ts';
+
+function makeTmpPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binding-test-'));
+  return path.join(dir, 'sessions.json');
+}
+
+function makeSession(overrides: Partial<StoredSession> = {}): StoredSession {
+  return {
+    remiSessionId: crypto.randomUUID() as UUID,
+    claudeSessionId: null,
+    projectPath: '/tmp/project',
+    port: 18765,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+    ...overrides,
+  };
+}
+
+describe('SessionBindingStore', () => {
+  let filePath: string;
+  let store: SessionStore;
+  let binding: SessionBindingStore;
+
+  beforeEach(() => {
+    filePath = makeTmpPath();
+    store = new SessionStore(filePath);
+    binding = new SessionBindingStore(store);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('preAssign persists the full record; get reads the binding back', () => {
+    const session = makeSession({ claudeSessionId: 'claude-A' });
+    binding.preAssign(session);
+
+    expect(binding.get(session.remiSessionId)).toEqual({ claudeSessionId: 'claude-A' });
+    // Durable: a fresh accessor over a fresh store off the same file reads it.
+    const fresh = new SessionBindingStore(new SessionStore(filePath));
+    expect(fresh.get(session.remiSessionId)?.claudeSessionId).toBe('claude-A');
+  });
+
+  test('update sets the binding (rotation / first discovery)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-A' });
+    binding.preAssign(session);
+
+    binding.update(session.remiSessionId, 'claude-B');
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-B');
+    // Persisted, not just in memory.
+    expect(
+      new SessionStore(filePath).findByRemiSessionId(session.remiSessionId)?.claudeSessionId,
+    ).toBe('claude-B');
+  });
+
+  test('get mirrors findByRemiSessionId(id)?.claudeSessionId exactly', () => {
+    // absent record -> null (not an object)
+    const absent = crypto.randomUUID() as UUID;
+    expect(binding.get(absent)).toBeNull();
+
+    // present record with a null binding -> object carrying null
+    const session = makeSession({ claudeSessionId: null });
+    binding.preAssign(session);
+    expect(binding.get(session.remiSessionId)).toEqual({ claudeSessionId: null });
+    // ?.claudeSessionId yields null in both today and post-migration form
+    expect(binding.get(session.remiSessionId)?.claudeSessionId ?? null).toBe(
+      store.findByRemiSessionId(session.remiSessionId)?.claudeSessionId ?? null,
+    );
+  });
+
+  test('update on an absent record is a no-op (matches SessionStore)', () => {
+    const absent = crypto.randomUUID() as UUID;
+    binding.update(absent, 'claude-X');
+    expect(binding.get(absent)).toBeNull();
+  });
+
+  test('getByClaudeSessionId reverse-looks-up the record (or null)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-rev' });
+    binding.preAssign(session);
+
+    expect(binding.getByClaudeSessionId('claude-rev')?.remiSessionId).toBe(session.remiSessionId);
+    expect(binding.getByClaudeSessionId('nope')).toBeNull();
+  });
+
+  test('cross-process freshness: a second store handle writing the same file is seen immediately', () => {
+    // This is the load-bearing no-cache property. A sibling daemon (a DIFFERENT
+    // SessionStore handle on the same sessions.json) rotates the binding; the
+    // accessor must observe it on the very next get() with zero staleness — this
+    // is exactly what preserves #321 (no cached id wedges classify) and the #430
+    // "re-adopt on rotation" characterization test.
+    const session = makeSession({ claudeSessionId: 'claude-1' });
+    binding.preAssign(session);
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-1');
+
+    // A separate handle (simulating a sibling/fallback writer in another context)
+    // writes a new id straight to disk, NOT through `binding`.
+    const sibling = new SessionStore(filePath);
+    sibling.updateClaudeSessionId(session.remiSessionId, 'claude-2');
+
+    // No cache: the next read observes the external write.
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-2');
+  });
+
+  test('multi-rotation sequence ends on the final id (golden)', () => {
+    const session = makeSession({ claudeSessionId: 'claude-1' });
+    binding.preAssign(session);
+    binding.update(session.remiSessionId, 'claude-2');
+    binding.update(session.remiSessionId, 'claude-3');
+
+    expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-3');
+    expect(binding.getByClaudeSessionId('claude-3')?.remiSessionId).toBe(session.remiSessionId);
+    expect(binding.getByClaudeSessionId('claude-1')).toBeNull();
+  });
+});

--- a/packages/daemon/tests/session/session-store-concurrency.test.ts
+++ b/packages/daemon/tests/session/session-store-concurrency.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Regression test for #461: two daemons sharing one ~/.remi raced on a fixed
+ * `sessions.json.tmp` path — whichever process renamed second hit ENOENT
+ * because the other had already moved the shared tmp away. The fix scopes the
+ * tmp file per process (`sessions.json.<pid>.tmp`), so concurrent writers can
+ * never collide. This drives REAL concurrent subprocesses (no mocks): on the
+ * pre-fix code some workers crash with ENOENT; with the fix all exit cleanly.
+ */
+describe('SessionStore multi-process concurrency (#461)', () => {
+  let filePath: string;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-store-conc-'));
+    filePath = path.join(dir, 'sessions.json');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('concurrent writers never crash on the tmp-rename race', async () => {
+    const worker = path.join(import.meta.dir, 'store-concurrency-worker.ts');
+    const WORKERS = 6;
+    const ITERATIONS = 60;
+
+    const procs = Array.from({ length: WORKERS }, () =>
+      Bun.spawn(['bun', worker, filePath, String(ITERATIONS)], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }),
+    );
+
+    const results = await Promise.all(
+      procs.map(async (proc, i) => ({ i, code: await proc.exited, proc })),
+    );
+
+    // Surface the first crashing worker's stderr for a useful failure message.
+    for (const { i, code, proc } of results) {
+      if (code !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`worker ${i} exited with code ${code}: ${stderr.trim()}`);
+      }
+    }
+    expect(results.every((r) => r.code === 0)).toBe(true);
+
+    // The final file must be intact and valid (no torn write).
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw) as { version: number; sessions: unknown[] };
+    expect(data.version).toBe(1);
+    expect(Array.isArray(data.sessions)).toBe(true);
+    expect(data.sessions.length).toBeGreaterThan(0);
+
+    // Every writer completes its rename, so no per-process tmp files linger.
+    const leftovers = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  }, 30000);
+});

--- a/packages/daemon/tests/session/store-concurrency-worker.ts
+++ b/packages/daemon/tests/session/store-concurrency-worker.ts
@@ -1,0 +1,34 @@
+// Worker process for session-store-concurrency.test.ts. NOT a test file
+// (its name does not match the bun test glob). It hammers a shared
+// sessions.json via SessionStore.save() so the test can exercise the
+// multi-writer tmp-rename race (#461) with REAL concurrent processes.
+//
+// Usage: bun store-concurrency-worker.ts <sessionsFilePath> <iterations>
+import type { UUID } from '@remi/shared';
+import { SessionStore } from '../../src/session/session-store.ts';
+
+const filePath = process.argv[2];
+const iterations = Number(process.argv[3]) || 50;
+
+if (!filePath) {
+  process.stderr.write('worker: missing sessions file path\n');
+  process.exit(2);
+}
+
+const store = new SessionStore(filePath);
+const workerTag = crypto.randomUUID();
+
+for (let i = 0; i < iterations; i++) {
+  store.save({
+    remiSessionId: crypto.randomUUID() as UUID,
+    claudeSessionId: `claude-${workerTag}-${i}`,
+    projectPath: '/tmp/concurrency-project',
+    port: 18000 + (i % 200),
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+}
+
+process.exit(0);

--- a/packages/daemon/tests/telegram-adapter.test.ts
+++ b/packages/daemon/tests/telegram-adapter.test.ts
@@ -6,19 +6,25 @@
  * the adapter object directly.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import type {
   AgentOutputMessage,
+  DaemonUpdateAvailableMessage,
   ErrorMessage,
   HelloAckMessage,
+  KillSessionResponseMessage,
   ProtocolMessage,
   QuestionMessage,
   ReplayBatchMessage,
+  ResumeSessionResponseMessage,
+  SessionHistoryResponseMessage,
   SessionListResponseMessage,
+  SessionRotatedMessage,
   SessionUpdateMessage,
   StructuredAgentOutputMessage,
   TranscriptContentMessage,
   TranscriptLoadCompleteMessage,
+  UUID,
 } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { AdapterEvents } from '../src/adapters/connection-adapter.ts';
@@ -36,6 +42,58 @@ function createAdapter(events: Partial<AdapterEvents> = {}): TelegramAdapter {
 }
 
 const unknownConnectionId = generateId();
+
+/** Minimal grammY bot/api stub with a sendMessage spy. */
+interface SendMessageSpy {
+  (chatId: number, text: string, opts?: unknown): Promise<{ message_id: number }>;
+  mock: { calls: unknown[][] };
+}
+
+/**
+ * Register a session on the adapter with a stubbed bot so render cases that
+ * call `bot.api.sendMessage` can be observed. Reaches into private fields the
+ * same way the production code populates them in handleStart().
+ */
+function withBoundSession(events: Partial<AdapterEvents> = {}): {
+  adapter: TelegramAdapter;
+  connectionId: UUID;
+  sendMessage: SendMessageSpy;
+} {
+  const adapter = createAdapter(events);
+  const sendMessage = mock(async () => ({ message_id: 1 })) as unknown as SendMessageSpy;
+
+  const internal = adapter as unknown as {
+    bot: { api: { sendMessage: SendMessageSpy } };
+    sessions: Map<string, Record<string, unknown>>;
+    connectionToSession: Map<UUID, string>;
+  };
+
+  internal.bot = { api: { sendMessage } };
+
+  const connectionId = generateId();
+  const chatId = 100;
+  const topicId = 200;
+  const sessionKey = `${chatId}:${topicId}`;
+
+  internal.sessions.set(sessionKey, {
+    connectionId,
+    sessionId: generateId(),
+    chatId,
+    topicId,
+    workingDirectory: '/tmp',
+    machineName: 'test-machine',
+    topicName: 'test-topic',
+    sessionNumber: 1,
+    startedAt: now(),
+    currentMessageId: undefined,
+    streamBuffer: '',
+    lastSentContent: '',
+    paused: false,
+  });
+  internal.connectionToSession.set(connectionId, sessionKey);
+
+  return { adapter, connectionId, sendMessage };
+}
 
 describe('TelegramAdapter constructor defaults', () => {
   test('connectionCount is 0 before any sessions', () => {
@@ -308,14 +366,157 @@ describe('sendRaw routing', () => {
     expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
   });
 
-  test('unknown type returns false', () => {
+  test('unknown type returns false and emits a warn', () => {
     const adapter = createAdapter();
     const msg = {
       type: 'totally_unknown_type',
       id: generateId(),
       timestamp: now(),
     } as unknown as ProtocolMessage;
-    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+
+    const originalWarn = console.warn;
+    const warnSpy = mock((..._args: unknown[]) => {});
+    console.warn = warnSpy as unknown as typeof console.warn;
+    try {
+      expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnSpy.mock.calls.length).toBe(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('totally_unknown_type');
+  });
+
+  test('detach_session_ack returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'detach_session_ack',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      success: true,
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('raw_pty_output returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'raw_pty_output',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      data: 'YmFzZTY0',
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('auth_challenge returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'auth_challenge',
+      id: generateId(),
+      timestamp: now(),
+      challenge: 'abc',
+      serverFingerprint: 'fp',
+      serverPublicKey: 'pk',
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+
+  test('auth_result returns true (no-op, was false before)', () => {
+    const adapter = createAdapter();
+    const msg = {
+      type: 'auth_result',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+    } as unknown as ProtocolMessage;
+    expect(adapter.sendRaw(unknownConnectionId, msg)).toBe(true);
+  });
+});
+
+describe('sendRaw render cases with a bound session', () => {
+  test('kill_session_response (success) sends a "Session stopped" line', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: KillSessionResponseMessage = {
+      type: 'kill_session_response',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('Session stopped');
+  });
+
+  test('resume_session_response (success) sends a "Resumed session" line with the id', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const resumedId = generateId();
+    const msg: ResumeSessionResponseMessage = {
+      type: 'resume_session_response',
+      id: generateId(),
+      timestamp: now(),
+      success: true,
+      sessionId: resumedId,
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    const text = String(sendMessage.mock.calls[0]?.[1]);
+    expect(text).toContain('Resumed session');
+    expect(text).toContain(resumedId);
+  });
+
+  test('session_rotated sends a "Session restarted" line with the new claude id', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const newClaudeId = generateId();
+    const msg: SessionRotatedMessage = {
+      type: 'session_rotated',
+      id: generateId(),
+      timestamp: now(),
+      sessionId: generateId(),
+      newClaudeSessionId: newClaudeId,
+      newTranscriptPath: '/tmp/new.jsonl',
+      reason: 'clear',
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    const text = String(sendMessage.mock.calls[0]?.[1]);
+    expect(text).toContain('Session restarted');
+    expect(text).toContain(newClaudeId);
+  });
+
+  test('daemon_update_available sends a line with the new version', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: DaemonUpdateAvailableMessage = {
+      type: 'daemon_update_available',
+      id: generateId(),
+      timestamp: now(),
+      currentVersion: '0.9.9',
+      binaryPath: '/opt/homebrew/bin/remi',
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('0.9.9');
+  });
+
+  test('session_history_response sends a best-effort summary line', () => {
+    const { adapter, connectionId, sendMessage } = withBoundSession();
+    const msg: SessionHistoryResponseMessage = {
+      type: 'session_history_response',
+      id: generateId(),
+      timestamp: now(),
+      directories: [
+        { directory: '/a', lastUsed: now(), sessionCount: 2, displayName: 'a' },
+        { directory: '/b', lastUsed: now(), sessionCount: 1, displayName: 'b' },
+      ],
+      requestId: generateId(),
+    };
+    expect(adapter.sendRaw(connectionId, msg)).toBe(true);
+    expect(sendMessage.mock.calls.length).toBe(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain('2');
   });
 });
 

--- a/packages/daemon/tests/transcript-discovery.test.ts
+++ b/packages/daemon/tests/transcript-discovery.test.ts
@@ -184,26 +184,6 @@ describe('TranscriptDiscovery', () => {
     expect(sessions2[0]?.status).toBe('completed');
   });
 
-  test('findLatestTranscript returns most recent file', async () => {
-    const projectDir = makeProjectDir('/Users/test/myproject');
-
-    writeTranscript(projectDir, 'old-session', [makeUserEntry('old')]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    writeTranscript(projectDir, 'new-session', [makeUserEntry('new')]);
-
-    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
-    const latest = discovery.findLatestTranscript('/Users/test/myproject');
-
-    expect(latest).toContain('new-session.jsonl');
-  });
-
-  test('findLatestTranscript returns null for unknown project', () => {
-    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
-    const latest = discovery.findLatestTranscript('/nonexistent/project');
-
-    expect(latest).toBeNull();
-  });
-
   test('handles empty projects directory', () => {
     const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
     const sessions = discovery.discoverSessions();

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1,0 +1,929 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import {
+  type BinderHookEvent,
+  TranscriptBinder,
+  type TranscriptBinderDeps,
+} from '../../src/transcript/transcript-binder.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import type { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+/**
+ * No-mock unit tests for TranscriptBinder. Real SessionRegistry / SessionStore /
+ * SessionBindingStore / SessionRegistryFile on tmp files; a fakePTY capturing
+ * submits; sendAndRecord captured into an array. The binder must reproduce the
+ * hook-bridge-setup.ts behavior the phase-0 characterization suite pins.
+ */
+
+const SID = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789' as UUID;
+
+/** PTYSession fake: isRunning toggles via the closure so tests can "exit" it. */
+function fakePTY(submits: string[], state: { running: boolean }): PTYSession {
+  return {
+    id: generateId(),
+    get isRunning() {
+      return state.running;
+    },
+    write: () => {},
+    submitInput: async (content: string) => {
+      submits.push(content);
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+interface MessageApiLog {
+  resetCalls: number;
+}
+
+function fakeMessageAPI(logRef: MessageApiLog): MessageAPI {
+  return {
+    handleMessage: () => {},
+    handleStatusChange: () => {},
+    handleQuestion: () => {},
+    reset: () => {
+      logRef.resetCalls += 1;
+    },
+  } as unknown as MessageAPI;
+}
+
+describe('TranscriptBinder', () => {
+  let tmpDir: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let transcriptDiscovery: TranscriptDiscovery;
+  let transcriptWatchers: Map<UUID, TranscriptWatcher>;
+  let transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
+  let sent: ProtocolMessage[];
+  let ptySubmits: string[];
+  let ptyState: { running: boolean };
+  let messageApiLog: MessageApiLog;
+  let messageApi: MessageAPI;
+  let rotationCallbacks: number;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binder-'));
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    // Point Claude's transcript-dir encoding at our tmp root so the fallback
+    // poll's expectedTranscriptPath stays inside tmp (no real ~/.claude touch).
+    transcriptDiscovery = new TranscriptDiscovery({ projectsDir: tmpDir });
+    transcriptWatchers = new Map();
+    transcriptFallbackTimers = new Map();
+    sent = [];
+    ptySubmits = [];
+    ptyState = { running: true };
+    messageApiLog = { resetCalls: 0 };
+    messageApi = fakeMessageAPI(messageApiLog);
+    rotationCallbacks = 0;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    for (const w of transcriptWatchers.values()) {
+      try {
+        (w as unknown as { stop: () => void }).stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    for (const t of transcriptFallbackTimers.values()) clearInterval(t);
+    await sessionRegistry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function registerSession(): void {
+    sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits, ptyState), messageApi);
+  }
+
+  function deps(): TranscriptBinderDeps {
+    return {
+      sessionRegistry,
+      bindingStore,
+      liveSessionsRegistry,
+      transcriptWatchers,
+      transcriptFallbackTimers,
+      transcriptDiscovery,
+      messageApi,
+      sendAndRecord: (m) => sent.push(m),
+      currentPort: () => 8765,
+      onRotation: () => {
+        rotationCallbacks += 1;
+      },
+    };
+  }
+
+  function makeBinder(mode: 'shadow' | 'drive' = 'drive'): TranscriptBinder {
+    return new TranscriptBinder(deps(), { sessionId: SID, workingDirectory: tmpDir }, mode);
+  }
+
+  /** Insert a fake watcher into the map so teardown/stale-replace has a target. */
+  function seedWatcher(filePath: string, stopCalls: number[]): void {
+    transcriptWatchers.set(SID, {
+      filePath,
+      stop: () => stopCalls.push(1),
+    } as unknown as TranscriptWatcher);
+  }
+
+  function rotations(): Array<{
+    old: string | undefined;
+    new: string;
+    path: string;
+    reason: string;
+  }> {
+    return sent
+      .filter((m) => m.type === 'session_rotated')
+      .map((m) => {
+        const r = m as unknown as {
+          oldClaudeSessionId?: string;
+          newClaudeSessionId: string;
+          newTranscriptPath: string;
+          reason: string;
+        };
+        return {
+          old: r.oldClaudeSessionId,
+          new: r.newClaudeSessionId,
+          path: r.newTranscriptPath,
+          reason: r.reason,
+        };
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // classify: 3-way + defer
+  // -------------------------------------------------------------------------
+
+  describe('classification (3-way + defer)', () => {
+    test('match: first event with no lock locks and starts a watcher', () => {
+      registerSession();
+      const binder = makeBinder();
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+        hook_event_name: 'SessionStart',
+      };
+      const decision = binder.decide(ev);
+      expect(decision.classification).toBe('match');
+      // Re-run via the drive path (fresh binder so state is clean).
+      const driver = makeBinder();
+      driver.onHookEvent(ev);
+      expect(transcriptWatchers.has(SID)).toBe(true);
+      expect(driver.snapshot().claudeSessionId).toBe('claude-A');
+      // First-init is not a rotation: no emit.
+      expect(rotations()).toHaveLength(0);
+    });
+
+    test('foreign: a different session_id while our PTY is alive is dropped', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Lock on A.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      const before = transcriptWatchers.get(SID)?.filePath;
+      // A sibling/subagent id arrives while PTY runs.
+      const d = binder.decide({
+        session_id: 'claude-FOREIGN',
+        transcript_path: path.join(tmpDir, 'f.jsonl'),
+      });
+      expect(d.classification).toBe('foreign');
+      binder.onHookEvent({
+        session_id: 'claude-FOREIGN',
+        transcript_path: path.join(tmpDir, 'f.jsonl'),
+      });
+      // Binding + watcher unchanged.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(before);
+    });
+
+    test('restart: a different session_id after PTY exited classifies restart', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      // PTY exits -> main is gone.
+      ptyState.running = false;
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+    });
+
+    test('defer: sibling present + no ownership marker defers first-adopt (no lock, no watcher)', () => {
+      registerSession();
+      // Live sibling in the same dir.
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sib.json'),
+        JSON.stringify({
+          sessionId: 'sib-1',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18001,
+          projectPath: tmpDir,
+          name: 'sib',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const binder = makeBinder();
+      // Transcript carries no remi:<port> marker -> ownership unproven.
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      };
+      const d = binder.decide(ev);
+      expect(d.classification).toBe('defer');
+      binder.onHookEvent(ev);
+      expect(binder.snapshot().claudeSessionId).toBeNull();
+      expect(transcriptWatchers.has(SID)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // rotation ordering
+  // -------------------------------------------------------------------------
+
+  describe('rotation ordering (#438)', () => {
+    test('rotate() ordering: teardown -> onRotation -> emit -> store update -> bind', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      // First event adopts A from the store + starts a watcher.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      const resetsBefore = messageApiLog.resetCalls;
+
+      // PTY exits so the next different id classifies restart.
+      ptyState.running = false;
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      // teardown stopped the old watcher + reset messageApi.
+      expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+      expect(messageApiLog.resetCalls).toBeGreaterThan(resetsBefore);
+      // onRotation injected callback fired.
+      expect(rotationCallbacks).toBeGreaterThanOrEqual(1);
+      // exactly one session_rotated, store + lock advanced to B.
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: path.join(tmpDir, 'b.jsonl'), reason: 'restart' },
+      ]);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-B');
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+    });
+
+    test('path-less restart emits NOTHING and resets the lock without rebinding', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      ptyState.running = false;
+      // Restart event without a transcript_path: the old code nulls the lock and
+      // returns BEFORE the store write (initFromHookEvent :353 then :370). The
+      // binder must match: no emit, lock null, store unchanged at claude-A.
+      binder.onHookEvent({ session_id: 'claude-B' });
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBeNull();
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A');
+    });
+
+    test('#451: restart with a live sibling + unmarked transcript defers (no watcher, no store write)', () => {
+      // The blocker the rotation reviewer caught: a genuine `restart`
+      // classification (PTY exited) with a co-located live sibling and a
+      // transcript that carries NO remi:<port> marker must DEFER — emit the
+      // rotation (old emits before the guard) but NOT start a watcher or rebind
+      // the store, leaving the fallback poll to adopt. The old code reaches the
+      // sibling-defer gate because the restart branch nulls the lock first.
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A');
+
+      // Seed a live sibling in the same project dir (different port + alive pid).
+      const sibFile = path.join(liveSessionsRegistry.dirPath, 'sibling.json');
+      fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+      fs.writeFileSync(
+        sibFile,
+        JSON.stringify({
+          sessionId: 'sibling-session',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18000,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+
+      ptyState.running = false; // PTY exited -> a different id classifies 'restart'
+      // The rotated transcript (b.jsonl) has NO custom-title marker -> ownership
+      // unproven -> with a live sibling present, defer.
+      fs.writeFileSync(path.join(tmpDir, 'b.jsonl'), '{"type":"user"}\n');
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      // Emitted the rotation (old emits before the guard), but DEFERRED the bind:
+      expect(rotations()).toHaveLength(1);
+      expect(binder.snapshot().claudeSessionId).toBeNull(); // lock not latched to the sibling's id
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-A'); // store not rebound
+      expect(transcriptWatchers.has(SID)).toBe(false); // no watcher started on the unproven transcript
+    });
+
+    test('golden master: multi-rotation control-plane sequence + final binding', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-1',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      const t1 = path.join(tmpDir, 'm1.jsonl');
+      const t2 = path.join(tmpDir, 'm2.jsonl');
+      const t3 = path.join(tmpDir, 'm3.jsonl');
+
+      // Mirror the hook-bridge driver: SessionStart pre-empt then onHookEvent.
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-1', t1);
+      fire('claude-2', t2);
+      fire('claude-3', t3);
+
+      expect(rotations()).toEqual([
+        { old: 'claude-1', new: 'claude-2', path: t2, reason: 'restart' },
+        { old: 'claude-2', new: 'claude-3', path: t3, reason: 'restart' },
+      ]);
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-3');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // emitRotated idempotency
+  // -------------------------------------------------------------------------
+
+  describe('emitRotated idempotency (#438 scalar gate)', () => {
+    test('re-emit of the same id does not duplicate the rotation', () => {
+      registerSession();
+      const binder = makeBinder();
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-A', path.join(tmpDir, 'a.jsonl'));
+      fire('claude-B', path.join(tmpDir, 'b.jsonl'));
+      // A duplicate SessionStart for B (e.g. coalesced replay): same id, must
+      // not re-emit. preempt is a no-op (same id), onHookEvent classifies match.
+      fire('claude-B', path.join(tmpDir, 'b.jsonl'));
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: path.join(tmpDir, 'b.jsonl'), reason: 'restart' },
+      ]);
+    });
+
+    test('A->B->A re-resume emits A->B, B->A, and NOT a duplicate A->B', () => {
+      registerSession();
+      const binder = makeBinder();
+      const aPath = path.join(tmpDir, 'a.jsonl');
+      const bPath = path.join(tmpDir, 'b.jsonl');
+      const fire = (id: string, p: string) => {
+        const ev = { session_id: id, transcript_path: p, hook_event_name: 'SessionStart' };
+        binder.preemptOnSessionStart(ev);
+        binder.onHookEvent(ev);
+      };
+      fire('claude-A', aPath); // first-init, no emit
+      fire('claude-B', bPath); // A->B
+      fire('claude-A', aPath); // B->A re-resume
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: bPath, reason: 'restart' },
+        { old: 'claude-B', new: 'claude-A', path: aPath, reason: 'restart' },
+      ]);
+      // The scalar gate now holds A; a coalesced replay of A must NOT re-emit.
+      fire('claude-A', aPath);
+      expect(rotations()).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // store-raced zero-emit (#430)
+  // -------------------------------------------------------------------------
+
+  describe('store-raced zero-emit (#430 tripwire)', () => {
+    test('store already at the new id: 0 session_rotated but binding advances', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Lock on A.
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+
+      // Fallback races the store to B before the SessionStart for B.
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-B',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+
+      // SessionStart for B arrives; adopt pulls B -> classify 'match' ->
+      // tripwire (currentBoundId set) -> ensureWatching -> return BEFORE emit.
+      binder.onHookEvent({ session_id: 'claude-B', transcript_path: path.join(tmpDir, 'b.jsonl') });
+
+      expect(rotations()).toHaveLength(0);
+      // But the binding DID advance to B.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onSessionEnd
+  // -------------------------------------------------------------------------
+
+  describe('onSessionEnd sets mainSessionEnded', () => {
+    test('matching id: a subsequent different-id event classifies restart not foreign (PTY still running)', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(ptyState.running).toBe(true);
+
+      // SessionEnd for our locked id -> mainSessionEnded = true.
+      binder.onSessionEnd({ session_id: 'claude-A' });
+
+      // PTY is STILL running, but because mainSessionEnded is set, the next
+      // different id is a restart (clean-exit restart), not foreign.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+    });
+
+    test('foreign id: SessionEnd for a non-matching id does NOT set the flag', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+
+      // SessionEnd from a sibling/subagent (different id) must not unlock us.
+      binder.onSessionEnd({ session_id: 'claude-OTHER' });
+
+      // PTY running + flag NOT set -> a different id is still foreign.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('foreign');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // close()
+  // -------------------------------------------------------------------------
+
+  describe('close()', () => {
+    test('clears the watcher AND the fallback timer', () => {
+      registerSession();
+      const binder = makeBinder();
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      const timer = setInterval(() => {}, 100000);
+      transcriptFallbackTimers.set(SID, timer);
+
+      binder.close();
+
+      expect(stopCalls.length).toBe(1);
+      expect(transcriptWatchers.has(SID)).toBe(false);
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // decide() purity
+  // -------------------------------------------------------------------------
+
+  describe('decide() purity', () => {
+    test('decide performs NO external effect (no send, no store write, no watcher)', () => {
+      registerSession();
+      const binder = makeBinder();
+      const storeBefore = sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null;
+
+      // A restart-shaped scenario (which on the drive path WOULD emit + write).
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      // Snapshot external state after the legitimate drive call.
+      const sentAfterDrive = sent.length;
+      const watcherAfterDrive = transcriptWatchers.has(SID);
+      const rotCbAfterDrive = rotationCallbacks;
+      const resetsAfterDrive = messageApiLog.resetCalls;
+      // Clear the binding store write the drive path made, to detect a fresh one.
+      const storeAfterDrive = sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null;
+
+      ptyState.running = false;
+      // Now call decide() for a rotation. It must NOT send, write, or start.
+      const d = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d.classification).toBe('restart');
+      expect(d.wouldEmitRotation).toBe(true);
+      expect(d.wouldStartWatcher).toBe(true);
+      expect(d.boundIdAfter).toBe('claude-B');
+
+      // No NEW external effect from decide().
+      expect(sent.length).toBe(sentAfterDrive); // no send
+      expect(transcriptWatchers.has(SID)).toBe(watcherAfterDrive); // no watcher change
+      expect(rotationCallbacks).toBe(rotCbAfterDrive); // onRotation not called
+      expect(messageApiLog.resetCalls).toBe(resetsAfterDrive); // no teardown/reset
+      // Store still holds the drive-path value, NOT a decide() write to B.
+      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId ?? null).toBe(storeAfterDrive);
+      expect(storeBefore).toBeNull();
+    });
+
+    test('decide advances internal state so successive calls track rotations', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Pure decisions only.
+      const d1 = binder.decide({
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      });
+      expect(d1.classification).toBe('match');
+      expect(d1.boundIdAfter).toBe('claude-A');
+      expect(d1.wouldEmitRotation).toBe(false); // first-init
+
+      ptyState.running = false;
+      const d2 = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d2.classification).toBe('restart');
+      expect(d2.boundIdAfter).toBe('claude-B');
+      expect(d2.wouldEmitRotation).toBe(true);
+
+      // Re-decide the same B (coalesced replay): scalar gate suppresses emit.
+      const d3 = binder.decide({
+        session_id: 'claude-B',
+        transcript_path: path.join(tmpDir, 'b.jsonl'),
+      });
+      expect(d3.wouldEmitRotation).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // start() shadow vs drive
+  // -------------------------------------------------------------------------
+
+  describe('start() mode behavior', () => {
+    test('shadow mode start() is a no-op (no fallback timer)', () => {
+      registerSession();
+      const binder = makeBinder('shadow');
+      binder.start('claude-A');
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+
+    test('drive mode start() arms the fallback poll', () => {
+      registerSession();
+      const binder = makeBinder('drive');
+      binder.start('claude-A');
+      expect(transcriptFallbackTimers.has(SID)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ensureWatching idempotency + self-heal
+  // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // Re-arming rotation dir-poll (#452 no-hooks rotation)
+  // -------------------------------------------------------------------------
+
+  describe('rotation dir-poll (#452 no-hooks rotation)', () => {
+    /** The dir the rotation poll re-stats (Claude's encoded project dir). */
+    function rotationDir(): string {
+      return transcriptDiscovery.getProjectTranscriptDir(tmpDir);
+    }
+
+    /** Write a transcript file. With `port` it carries a remi:<port> marker. */
+    function writeTranscript(claudeId: string, port?: number): string {
+      const dir = rotationDir();
+      fs.mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, `${claudeId}.jsonl`);
+      const head =
+        port === undefined
+          ? '{"type":"user","message":{"role":"user","content":"hi"}}\n'
+          : `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${port}`, sessionId: claudeId })}\n`;
+      fs.writeFileSync(filePath, head);
+      return filePath;
+    }
+
+    /** A binder with a fast poll cadence for deterministic tests. */
+    function makeDriveBinder(): TranscriptBinder {
+      return new TranscriptBinder(deps(), { sessionId: SID, workingDirectory: tmpDir }, 'drive', {
+        rotationPollIntervalMs: 20,
+      });
+    }
+
+    test('marker-ready: empty new .jsonl does NOT rotate; once the remi marker is written it DOES', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      // Lock on A first (our current bind).
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.start('claude-A');
+
+      // A NEW rotation file appears EMPTY (the #452 empty-file edge): the marker
+      // is not yet flushed. A poll tick must NOT classify it as a rotation.
+      const dir = rotationDir();
+      const newPath = path.join(dir, 'claude-B.jsonl');
+      fs.writeFileSync(newPath, ''); // zero bytes -> readTranscriptOwnerPort === null
+      ptyState.running = false; // PTY exited so a different id would classify restart
+
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A'); // unchanged
+
+      // Now Claude flushes the head marker (our port). The next tick rotates.
+      fs.writeFileSync(
+        newPath,
+        `${JSON.stringify({ type: 'custom-title', customTitle: 'remi:8765', sessionId: 'claude-B' })}\n`,
+      );
+      binder.rotationPollTick();
+
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: newPath, reason: 'restart' },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('exactly-once: repeated ticks seeing the same new file rotate only once', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A fully-flushed rotation file (marker present) appears.
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+
+      // Drive several ticks; the file persists on disk and is re-listed each time.
+      binder.rotationPollTick();
+      binder.rotationPollTick();
+      binder.rotationPollTick();
+
+      // Despite the poll re-stat'ing the same file every tick, exactly ONE
+      // session_rotated crossed the wire (lastAnnouncedRotationId + seen-set).
+      expect(rotations()).toEqual([
+        {
+          old: 'claude-A',
+          new: 'claude-B',
+          path: path.join(rotationDir(), 'claude-B.jsonl'),
+          reason: 'restart',
+        },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('sibling gate: a new .jsonl carrying a DIFFERENT port marker does NOT rotate us', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A sibling daemon (port 19999) writes its own fresh transcript into the
+      // SHARED project dir. Its marker proves it is the sibling's, not ours.
+      writeTranscript('claude-SIB', 19999);
+      ptyState.running = false;
+
+      binder.rotationPollTick();
+      binder.rotationPollTick(); // a 2nd tick must not change the verdict
+
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A'); // not rotated
+      binder.close();
+    });
+
+    test('markerless RECENT file is re-polled (never rotates), never permanently dropped', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A markerless transcript (non-remi / user `-n`). It never proves
+      // ownership -> never rotated. Because it stays RECENT it is re-polled
+      // (not seen-set), so a later-appearing marker is NOT permanently lost.
+      writeTranscript('claude-NOMARK'); // no port -> no remi marker
+      ptyState.running = false;
+
+      for (let i = 0; i < 8; i++) binder.rotationPollTick();
+
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.close();
+    });
+
+    test('#452: a SLOW-FLUSH rotation (marker appears after many empty ticks) is NOT dropped', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // The rotated file is created EMPTY and stays empty across MANY ticks (more
+      // than the old hard cap of 4) — the slow-flush / transient-EMFILE case the
+      // old tick-cap permanently dropped. The dir-poll must keep re-polling.
+      const dir = rotationDir();
+      const newPath = path.join(dir, 'claude-B.jsonl');
+      fs.writeFileSync(newPath, '');
+      ptyState.running = false;
+      for (let i = 0; i < 10; i++) binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0); // no false rotation on the empty edge
+
+      // Claude finally flushes the head marker. Because the candidate was never
+      // permanently dropped, the next tick rotates it (the #452 fix).
+      fs.writeFileSync(
+        newPath,
+        `${JSON.stringify({ type: 'custom-title', customTitle: 'remi:8765', sessionId: 'claude-B' })}\n`,
+      );
+      binder.rotationPollTick();
+      expect(rotations()).toEqual([
+        { old: 'claude-A', new: 'claude-B', path: newPath, reason: 'restart' },
+      ]);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+      binder.close();
+    });
+
+    test('markerless SETTLED file (mtime past the grace window) is recorded seen', () => {
+      registerSession();
+      // Short settle window so the test is fast + deterministic.
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: tmpDir },
+        'drive',
+        { rotationPollIntervalMs: 20, markerSettleMs: 50 },
+      );
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A markerless file whose mtime is already well past the settle window: a
+      // genuine settled non-remi file we will never own. It is recorded seen so
+      // the poll stops re-reading it (bounds the re-stat cost).
+      const stale = writeTranscript('claude-NOMARK');
+      const old = new Date(Date.now() - 60_000);
+      fs.utimesSync(stale, old, old);
+      ptyState.running = false;
+
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+      binder.close();
+    });
+
+    test('close() clears the dir-poll (no leaked timer/handle after close)', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.start('claude-A');
+      // Drive-mode start armed BOTH the fallback poll and the rotation poll.
+      expect(transcriptFallbackTimers.has(SID)).toBe(true);
+
+      binder.close();
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+
+      // After close, a new fully-marked rotation file must NOT rotate: the poll
+      // is torn down, and a late manual tick is inert (mode-guard / dir null).
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+    });
+
+    test('shadow mode arms NO dir-poll', () => {
+      registerSession();
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: tmpDir },
+        'shadow',
+        { rotationPollIntervalMs: 20 },
+      );
+      binder.start('claude-A');
+      // No fallback timer (shadow start is a no-op) AND a manual tick is inert.
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+
+      writeTranscript('claude-B', 8765);
+      ptyState.running = false;
+      binder.rotationPollTick();
+      expect(rotations()).toHaveLength(0);
+    });
+  });
+
+  describe('ensureWatching', () => {
+    test('idempotent: no-op when a watcher already exists', () => {
+      registerSession();
+      const binder = makeBinder();
+      const stopCalls: number[] = [];
+      seedWatcher(path.join(tmpDir, 'a.jsonl'), stopCalls);
+      binder.ensureWatching(path.join(tmpDir, 'b.jsonl'), 'match');
+      // Existing watcher untouched (still the seeded one, never stopped).
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, 'a.jsonl'));
+      expect(stopCalls.length).toBe(0);
+    });
+
+    test('self-heal: locked-from-store but watcher gone -> next match event starts it', () => {
+      registerSession();
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-A',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      const binder = makeBinder();
+      expect(transcriptWatchers.has(SID)).toBe(false);
+      // A match event from our own Claude with a path self-heals the watcher.
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+        hook_event_name: 'PreToolUse',
+      });
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, 'a.jsonl'));
+    });
+
+    test('cancels the fallback timer when it starts a watcher', () => {
+      registerSession();
+      const binder = makeBinder();
+      const timer = setInterval(() => {}, 100000);
+      transcriptFallbackTimers.set(SID, timer);
+      binder.onHookEvent({ session_id: 'claude-A', transcript_path: path.join(tmpDir, 'a.jsonl') });
+      expect(transcriptFallbackTimers.has(SID)).toBe(false);
+    });
+  });
+});

--- a/tests/e2e/transcript-binding/README.md
+++ b/tests/e2e/transcript-binding/README.md
@@ -1,0 +1,65 @@
+# Transcript-binding e2e harness
+
+A **manual / semi-automated** end-to-end harness that drives **real `claude`
+sessions** under a **real remi daemon** and validates the session-binding +
+transcript-watcher subsystem (the TranscriptBinder, epic #453) against the
+historical failure modes.
+
+Unlike `tests/integration/` (Docker, cross-machine `ls`/`attach` lifecycle) and
+`tests/e2e/specs/` (Playwright web UI), this harness exercises the part that
+needs a live model: a real `claude` writing real transcripts and rotating them
+via `/clear` and `/compact`, observed from a separate client the way the phone
+would.
+
+It is **not wired into CI** — it needs an authenticated `claude` and a trusted
+working directory, and it drives a TUI with timing-sensitive input. Run it by
+hand when changing the binding/rotation code or before flipping the binder flag.
+
+## What it validates
+
+| Scenario | Failure modes | Key checks |
+|---|---|---|
+| 1. Shadow (shipping default) | fm-430, fm-438, fm-435b, GAP-6 | binding correct; **0 `[ShadowBinder] DISAGREE`** on a normal session and across a `/clear`; rotation announced once; follow-up routes to the new transcript; old transcript frozen; `/compact` does not rotate |
+| 2. Drive (the binder itself) | fm-452, fm-438, GAP-6 | binder drives the bind (shadow suppressed); `/clear` caught by the **new re-arming dir-poll** (`No-hooks rotation detected via dir poll`), rebound + watcher rearmed; no "Transcript not found"; `/compact` does not over-fire the dir-poll |
+| 3. Two daemons, same cwd | fm-427, fm-451 | distinct binds, content segregated (ALPHA↔D1, BETA↔D2), per-port `remi:<port>` markers; zombie sibling (dead claude child, live wrapper) does **not** poison the other daemon's binding |
+
+See `failure-mode-matrix.md` for the full per-mode repro + oracle reference and
+the two non-negotiable traps (assert the on-disk id actually changed; in the
+zombie variant kill the inner claude child, never the wrapper).
+
+## Prerequisites
+
+1. **A remi binary built from the branch under test:**
+   ```bash
+   bun build --compile --outfile=/tmp/remi-tb/remi packages/daemon/src/cli.ts
+   ```
+2. **An authenticated `claude`** (`claude -p "say OK" --model haiku` returns).
+3. **A claude-trusted working directory.** claude shows a one-time
+   "Do you trust the files in this folder?" dialog in a new directory, which
+   blocks an unattended session. Use a directory you have already opened claude
+   in (`hasTrustDialogAccepted: true` in `~/.claude.json`). Trust is keyed by
+   path, so an already-trusted scratch path can be recreated and reused. Do
+   **not** disable the permission framework to work around this.
+
+## Run
+
+```bash
+REMI_BIN=/tmp/remi-tb/remi \
+E2E_TRUSTED=/private/tmp/your-trusted-scratch-dir \
+  tests/e2e/transcript-binding/run.sh
+```
+
+Exit code = number of failed checks. Daemon logs and the captured client
+renders are left in the printed `E2E_STATE` dir for inspection.
+
+## How it works (notes for maintainers)
+
+- `--daemon` mode does **not** forward `claude` args, so the model is set via
+  `ANTHROPIC_MODEL=haiku` (the daemon's env is merged into the claude PTY).
+- The driver is a persistent `remi attach` whose stdin is a FIFO held open by a
+  background `sleep`; it is both the input channel and the observer (the real
+  client path). claude's composer treats the first burst as a bracketed paste,
+  so a prompt is submitted with a **separate** Enter keystroke.
+- The oracle is the daemon log: `[ShadowBinder] DISAGREE` (shadow), the
+  `[Binder] …` rotation lines (drive), and `owned by port X, not Y; ignoring`
+  (marker-based sibling/zombie defer), plus the on-disk `<id>.jsonl` files.

--- a/tests/e2e/transcript-binding/failure-mode-matrix.md
+++ b/tests/e2e/transcript-binding/failure-mode-matrix.md
@@ -1,0 +1,56 @@
+# Transcript-binding failure-mode matrix
+
+Reference for the e2e harness: each historical failure mode, how to reproduce it
+with a real `claude` under remi, and the exact PASS/FAIL oracle. Distilled from
+the epic #453 bug history (#321, #427/#428, #429/#430/#433, #438, #451, #452,
+#435) and validated against the merged binder.
+
+## The oracle
+
+The shadow binder (`REMI_TRANSCRIPT_BINDER_SHADOW=true`) computes decisions
+alongside the live old path and logs `[ShadowBinder] DISAGREE <event>: <diffs>`
+on any divergence in three fields only: durable-store **boundId**, **rotation**
+emitted-this-event, **watcherPath** (advisory). Silent on agreement. It is
+**hook-fed only** — silent when hooks are down.
+
+`[ShadowBinder] DISAGREE` is a valid pass/fail signal **only** for:
+- **fm-438** — `rotation binder=false old=true` on the duplicate-carrying event (binder dedups the old path's double-emit).
+- **fm-430** — `rotation binder=true old=false` on the `/clear` SessionStart when the store raced ahead of the hook.
+- **fm-451** — `boundId binder=<new> old=<old>` when the old path defers on a false-live zombie sibling and the binder rebinds.
+
+It is **silent-by-design / not a bug** for fm-321 (no field captures admit-vs-drop), fm-427 (`watcherPath` is advisory; deterministic binding already agrees), and **structurally blind** for fm-452 (the dir-poll is disabled in shadow). Those are **drive-mode** validations.
+
+## Two non-negotiable traps
+
+1. **Assert the on-disk `<id>.jsonl` actually changed (B ≠ A) before scoring.** A
+   reused/`/compact` session id makes `isRotation` false and the classifier
+   short-circuits to `match` (`session-lock-classifier.ts`) — the code under
+   test never runs and the test passes for the wrong reason.
+2. **In any zombie variant, kill the inner `claude` child PID only, never the
+   remi wrapper.** `pkill remi` self-reaps the sibling and the wedge never forms
+   (vacuous). The zombie is: live remi pid + dead `claudeChildPid`.
+
+## Per-mode summary
+
+| Mode | Symptom (pre-epic) | Trigger | Oracle | Flag |
+|---|---|---|---|---|
+| **fm-321** sibling hook-lock cached | a daemon goes permanently deaf to its own claude with a sibling in the dir; killing the sibling never recovers it | two daemons same cwd; kill sibling; permission in survivor | drive: survivor processes its own PermissionRequest after sibling dies (shadow silent here) | drive |
+| **fm-427** cross-bind | daemon-B answers a question claude-A asked; "messages not from this session" | two daemons same cwd, fresh bindings | each binds its own `<uuid>.jsonl`; content segregated; co-located events classify `foreign` | both |
+| **fm-430** binding drift / STALE_BINDING | after `/clear`, second client stuck on old id, no `session_rotated` | single daemon; `/clear` (store pre-assigns new id before SessionStart) | shadow: `DISAGREE SessionStart rotation binder=true old=false`; drive: one `session_rotated`, binding updates | both |
+| **fm-438** double-emit | chat clears/reloads twice; or a stale re-emit re-binds to the dead id → STALE_BINDING | `/clear`, or kill+resume (store-race ordering), or A→B→A re-resume | exactly one rotation per A→B; shadow `DISAGREE rotation binder=false old=true` on the duplicate event | both |
+| **fm-451** zombie poisons sibling-defer | long session returns "Transcript for session not found" after `/clear`; log floods `Dropped foreign` | two daemons same cwd; kill one's inner claude child; `/clear` the other | victim rebinds + streams; `owned by port X, not Y; ignoring`; no "not found" | both |
+| **fm-452** no-hooks / slow-flush wedge | `/clear` with hooks down → locked-but-unwatched → "Transcript for session not found" | single daemon, hooks down; `/clear`; follow-up | drive: `[Binder] No-hooks rotation detected via dir poll`, watcher rearmed | **drive only** |
+| **fm-435** (a/c/d) false-positive questions, multi-question, fails-to-connect | phantom question cards; one question slot; retries a dead port | numbered-list prompt; concurrent subagent+main permission; occupy default port then attach | flag-independent (epic #435 phases 1/2/4); binder must be **inert** (no `[Binder]`/`[ShadowBinder]` lines) | off |
+
+## Minimal run order
+
+1. Two daemons, same cwd, **shadow** — fm-427 race + fm-451 zombie shadow leg.
+2. Two daemons, same cwd, **drive** — fm-427 + fm-451 + fm-321 recovery end-to-end.
+3. Single daemon, hooks up, **shadow**, one long session — fm-430 + fm-438 + A→B→A + `/compact` negative.
+4. Single daemon, hooks up, **drive**, one long session — the same, end-to-end + the positive binding invariant + the newly-wired dropped hooks.
+5. Single daemon, hooks **down**, **drive** — fm-452 (the only run exercising the dir-poll; highest value, lowest redundancy).
+6. Single daemon, binder **off** — fm-435 a/c/d (binder must be inert).
+
+`run.sh` implements a practical subset (shadow + drive single-daemon, and the
+two-daemon cross-bind/zombie). The hooks-down (5) and binder-off (6) legs are
+documented here for manual execution.

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Transcript-binding e2e harness primitives.
+#
+# Drives REAL `claude` sessions under a real remi daemon and observes binding,
+# rotation, and persistence the way a remi client (the phone) would. This is a
+# MANUAL / semi-automated harness: it needs a real authenticated `claude` and a
+# trusted working directory. It is NOT wired into CI (see README.md).
+#
+# Source this in a scenario script. Required env (see README):
+#   REMI_BIN       path to the remi binary to test (built from the branch)
+#   E2E_TRUSTED    a claude-trusted working dir (hasTrustDialogAccepted=true)
+# Optional:
+#   E2E_STATE      scratch dir for logs/pids/fifos (default: mktemp -d)
+
+set -uo pipefail
+
+REMI_BIN="${REMI_BIN:?set REMI_BIN to the remi binary under test}"
+E2E_TRUSTED="${E2E_TRUSTED:?set E2E_TRUSTED to a claude-trusted working dir}"
+E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tbe2e-XXXXXX")}"
+mkdir -p "$E2E_STATE"
+
+# Strip ANSI/OSC so logs and renders are greppable.
+deansi() { sed -E 's/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\x1b\][0-9;]*\x07//g; s/\r//g'; }
+
+# start_daemon NAME CWD PORT MODE(shadow|drive|off)
+# Launches a daemon with ANTHROPIC_MODEL=haiku (claude --model is not forwarded
+# by --daemon, but the daemon's env is, and claude honours ANTHROPIC_MODEL).
+start_daemon() {
+  local name=$1 cwd=$2 port=$3 mode=$4
+  local log="$E2E_STATE/$name.log"
+  rm -f "$log"
+  local sh=false dr=false
+  case "$mode" in
+    shadow) sh=true ;;
+    drive)  dr=true ;;
+    off)    : ;;
+  esac
+  cat > "$E2E_STATE/launch-$name.sh" <<LAUNCH
+#!/usr/bin/env bash
+cd "$cwd"
+exec "$REMI_BIN" --daemon --bind 127.0.0.1 --port $port --no-auth --no-relay --no-mdns
+LAUNCH
+  chmod +x "$E2E_STATE/launch-$name.sh"
+  ANTHROPIC_MODEL=haiku \
+  REMI_TRANSCRIPT_BINDER_SHADOW=$sh \
+  REMI_TRANSCRIPT_BINDER_ENABLED=$dr \
+    nohup bash "$E2E_STATE/launch-$name.sh" > "$log" 2>&1 &
+  echo "$!" > "$E2E_STATE/$name.pid"
+  echo "$port" > "$E2E_STATE/$name.port"
+  echo "daemon[$name] pid=$(cat "$E2E_STATE/$name.pid") port=$port mode=$mode log=$log"
+}
+
+wait_ready() {
+  local name=$1 secs=${2:-20}
+  local log="$E2E_STATE/$name.log"
+  local i
+  for ((i = 0; i < secs; i++)); do
+    grep -q "Remi daemon ready" "$log" 2>/dev/null && return 0
+    kill -0 "$(cat "$E2E_STATE/$name.pid")" 2>/dev/null || { echo "daemon[$name] DIED"; tail -8 "$log"; return 1; }
+    sleep 1
+  done
+  echo "daemon[$name] not ready in ${secs}s"; tail -8 "$log"; return 1
+}
+
+# Session id/name as `remi ls` reports it (one daemon = one session).
+session_id() {
+  "$REMI_BIN" ls --host 127.0.0.1 --port "$1" 2>/dev/null | deansi \
+    | grep -iE 'active|idle|orphan|starting|available' | awk '{print $1}' | head -1
+}
+
+# attach_start NAME PORT SESSION
+# Persistent FIFO-driven `remi attach` acting as BOTH input driver and observer
+# (this is literally how a remi client drives claude). A holder keeps the FIFO
+# write-end open so the attach never sees EOF across multiple sends.
+attach_start() {
+  local name=$1 port=$2 session=$3
+  local fifo="$E2E_STATE/$name.fifo" render="$E2E_STATE/$name.render"
+  rm -f "$fifo" "$render"; mkfifo "$fifo"
+  nohup sleep 100000 > "$fifo" 2>/dev/null &
+  echo "$!" > "$E2E_STATE/$name.holder.pid"
+  nohup "$REMI_BIN" attach "$session" --host 127.0.0.1 --port "$port" < "$fifo" > "$render" 2>&1 &
+  echo "$!" > "$E2E_STATE/$name.attach.pid"
+}
+
+# Type text then submit with a SEPARATE Enter. claude's composer treats the
+# initial burst as a bracketed paste, so an inline \r is NOT a submit; the
+# standalone Enter (a distinct write) is what submits.
+prompt() {
+  local name=$1; shift
+  printf '%s' "$*" > "$E2E_STATE/$name.fifo"
+  sleep 0.5
+  printf '\r' > "$E2E_STATE/$name.fifo"
+}
+enter() { printf '\r' > "$E2E_STATE/$1.fifo"; }
+
+attach_stop() {
+  local name=$1
+  kill "$(cat "$E2E_STATE/$name.attach.pid" 2>/dev/null)" 2>/dev/null
+  kill "$(cat "$E2E_STATE/$name.holder.pid" 2>/dev/null)" 2>/dev/null
+}
+
+stop_daemon() {
+  local name=$1
+  kill -TERM "$(cat "$E2E_STATE/$name.pid" 2>/dev/null)" 2>/dev/null
+  local i
+  for ((i = 0; i < 8; i++)); do kill -0 "$(cat "$E2E_STATE/$name.pid" 2>/dev/null)" 2>/dev/null || break; sleep 0.5; done
+  pkill -f "remi:$(cat "$E2E_STATE/$name.port" 2>/dev/null)" 2>/dev/null || true
+}
+
+# claude encodes the cwd into the transcript dir: / -> -
+tdir_for() { echo "$HOME/.claude/projects/$(echo "$1" | sed 's#/#-#g')"; }
+
+# Newest transcript in CWD carrying THIS daemon's `remi:<port>` head marker.
+# Prints "<claudeId> <path>"; non-zero if none.
+bound_transcript() {
+  local cwd=$1 port=$2 td f
+  td=$(tdir_for "$cwd")
+  # Newest-first by mtime; filenames are controlled `<uuid>.jsonl` (no spaces).
+  # shellcheck disable=SC2045
+  for f in $(ls -t "$td"/*.jsonl 2>/dev/null); do
+    if head -c 4000 "$f" 2>/dev/null | grep -q "remi:$port"; then
+      echo "$(basename "$f" .jsonl) $f"; return 0
+    fi
+  done
+  return 1
+}
+
+# Wait until a daemon binds a transcript with >= MINLINES lines. Prints id.
+wait_bound() {
+  local cwd=$1 port=$2 minlines=${3:-8} secs=${4:-100} i bt cid f
+  for ((i = 0; i < secs; i += 2)); do
+    if bt=$(bound_transcript "$cwd" "$port" 2>/dev/null); then
+      cid=$(echo "$bt" | awk '{print $1}'); f=$(echo "$bt" | awk '{print $2}')
+      [ "$(wc -l < "$f" 2>/dev/null || echo 0)" -ge "$minlines" ] && { echo "$cid"; return 0; }
+    fi
+    sleep 2
+  done
+  return 1
+}

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -16,7 +16,7 @@ set -uo pipefail
 
 REMI_BIN="${REMI_BIN:?set REMI_BIN to the remi binary under test}"
 E2E_TRUSTED="${E2E_TRUSTED:?set E2E_TRUSTED to a claude-trusted working dir}"
-E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tbe2e-XXXXXX")}"
+E2E_STATE="${E2E_STATE:-$(mktemp -d "${TMPDIR:-/tmp}/remi-tb-e2e-XXXXXX")}"
 mkdir -p "$E2E_STATE"
 
 # Strip ANSI/OSC so logs and renders are greppable.

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -125,6 +125,17 @@ bound_transcript() {
   return 1
 }
 
+# Wait until a log line matching PATTERN (grep -E) appears, or time out.
+wait_log() {
+  local name=$1 pattern=$2 secs=${3:-20} i
+  local log="$E2E_STATE/$name.log"
+  for ((i = 0; i < secs; i++)); do
+    grep -qE "$pattern" "$log" 2>/dev/null && return 0
+    sleep 1
+  done
+  return 1
+}
+
 # Wait until a daemon binds a transcript with >= MINLINES lines. Prints id.
 wait_bound() {
   local cwd=$1 port=$2 minlines=${3:-8} secs=${4:-100} i bt cid f

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -11,6 +11,14 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$HERE/lib.sh"
 
+# reset_cwd deletes this dir's transcript history AND its .claude (trust+hooks).
+# Refuse to run unless E2E_TRUSTED is a throwaway temp path, so a wrong value
+# can never delete a real project's history/config.
+case "$E2E_TRUSTED" in
+  /tmp/* | /private/tmp/* | /var/folders/*) ;;
+  *) echo "ABORT: E2E_TRUSTED must be under a temp dir (/tmp, /private/tmp, /var/folders); got: $E2E_TRUSTED"; exit 1 ;;
+esac
+
 PASS=0; FAIL=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
@@ -62,7 +70,6 @@ echo "### Scenario 2: DRIVE (the binder itself) — bind + /clear via dir-poll +
 # ---------------------------------------------------------------------------
 reset_cwd
 start_daemon s2 "$CWD" 18812 drive; wait_ready s2 || exit 1
-check "drive: shadow suppressed when enabled" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
 SID=$(session_id 18812); attach_start s2 18812 "$SID"; sleep 2
 prompt s2 "$EXPLORE"
 A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
@@ -79,6 +86,9 @@ check "drive: no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_ST
 rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s2.log")
 prompt s2 "/compact"; sleep 12
 check "drive: /compact did NOT over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s2.log') -eq $rc ]"
+# Checked after events have flowed (a bind + a real rotation), so a leaked
+# shadow comparison would have had its chance to log.
+check "drive: shadow suppressed throughout (no [ShadowBinder] lines)" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
 attach_stop s2; stop_daemon s2
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -17,7 +17,13 @@ bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 check(){ if eval "$2"; then ok "$1"; else bad "$1 ($2)"; fi; }
 
 CWD="$E2E_TRUSTED"
-reset_cwd() { rm -rf "$CWD/.claude" 2>/dev/null; }
+# Isolate each scenario: drop the daemon hook config AND the transcript history
+# for this cwd, so a prior run's same-port transcripts cannot contaminate the
+# dir-poll. E2E_TRUSTED MUST be a throwaway scratch dir (see README).
+reset_cwd() {
+  rm -rf "$CWD/.claude" 2>/dev/null
+  rm -f "$(tdir_for "$CWD")"/*.jsonl 2>/dev/null
+}
 
 EXPLORE="Read README.md or list the files here, then give a 2-sentence summary. Read-only, do not modify anything."
 
@@ -32,10 +38,11 @@ A=$(wait_bound "$CWD" 18811 8 100) || { bad "shadow: initial bind"; A=""; }
 [ -n "$A" ] && ok "shadow: claude bound (honoured pre-assigned --session-id): $A"
 check "shadow: 0 DISAGREE on a normal session" "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
 
-prompt s1 "/clear"; sleep 6
+prompt s1 "/clear"
+wait_log s1 "restart detected" 25   # the new transcript file appears slightly before the daemon logs the rotation
 B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
 check "shadow: /clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
-check "shadow: rotation announced exactly once"     "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
+check "shadow: rotation announced exactly once (old path drives)" "[ \$(grep -c '\[Hooks\] Claude restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
 check "shadow: still 0 DISAGREE after /clear"        "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
 
 Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
@@ -61,7 +68,8 @@ prompt s2 "$EXPLORE"
 A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
 check "drive: binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s2.log'"
 
-prompt s2 "/clear"; sleep 6
+prompt s2 "/clear"
+wait_log s2 "DirPollRotation|restart detected" 25
 B2=$(bound_transcript "$CWD" 18812 2>/dev/null | awk '{print $1}')
 check "drive: /clear rotated (B != A)" "[ -n '$B2' ] && [ '$B2' != '$A2' ]"
 check "drive: new dir-poll detected the rotation (#452 machinery)" "grep -q 'No-hooks rotation detected via dir poll' '$E2E_STATE/s2.log'"
@@ -95,7 +103,9 @@ check "two-daemon: each binds its own port marker" "head -c 4000 '$F1' | grep -q
 CC=$(pgrep -f "claude .*remi:18813" | head -1)
 kill -9 "$CC" 2>/dev/null
 check "zombie: D1 daemon wrapper still alive (false-live sibling)" "kill -0 \$(cat '$E2E_STATE/d1.pid') 2>/dev/null"
-prompt d2 "/clear"; sleep 6; prompt d2 "Say the word GAMMA."
+prompt d2 "/clear"
+wait_log d2 "owned by port 18813, not 18814|DirPollRotation|restart detected" 25
+prompt d2 "Say the word GAMMA."
 C2B=$(bound_transcript "$CWD" 18814 2>/dev/null | awk '{print $1}')
 check "zombie: D2 rebound despite the zombie sibling" "[ -n '$C2B' ] && [ '$C2B' != '$C2' ]"
 check "zombie: D2 ignored the foreign/zombie transcript by marker" "grep -q 'owned by port 18813, not 18814; ignoring' '$E2E_STATE/d2.log'"

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Transcript-binding e2e runner. Executes the validated failure-mode scenarios
+# against a real claude + real daemon and prints PASS/FAIL per check.
+#
+#   REMI_BIN=/path/to/remi E2E_TRUSTED=/private/tmp/remi-tb-e2e ./run.sh
+#
+# See README.md for prerequisites (trusted dir, real claude auth) and what each
+# scenario validates. Exit code = number of failed checks.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$HERE/lib.sh"
+
+PASS=0; FAIL=0
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+check(){ if eval "$2"; then ok "$1"; else bad "$1 ($2)"; fi; }
+
+CWD="$E2E_TRUSTED"
+reset_cwd() { rm -rf "$CWD/.claude" 2>/dev/null; }
+
+EXPLORE="Read README.md or list the files here, then give a 2-sentence summary. Read-only, do not modify anything."
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 1: SHADOW (shipping default) — bind + /clear rotation + /compact"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon s1 "$CWD" 18811 shadow; wait_ready s1 || exit 1
+SID=$(session_id 18811); attach_start s1 18811 "$SID"; sleep 2
+prompt s1 "$EXPLORE"
+A=$(wait_bound "$CWD" 18811 8 100) || { bad "shadow: initial bind"; A=""; }
+[ -n "$A" ] && ok "shadow: claude bound (honoured pre-assigned --session-id): $A"
+check "shadow: 0 DISAGREE on a normal session" "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+
+prompt s1 "/clear"; sleep 6
+B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
+check "shadow: /clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
+check "shadow: rotation announced exactly once"     "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
+check "shadow: still 0 DISAGREE after /clear"        "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+
+Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
+bb=$(wc -l < "$Bf" 2>/dev/null || echo 0); ab=$(wc -l < "$Af" 2>/dev/null || echo 0)
+prompt s1 "Say the word DELTA."
+for i in $(seq 1 20); do [ "$(wc -l < "$Bf" 2>/dev/null||echo 0)" -gt "$bb" ] && break; sleep 2; done
+check "shadow: follow-up landed in rotated session B" "[ \$(grep -c DELTA '$Bf' 2>/dev/null) -ge 1 ]"
+check "shadow: old session A stayed frozen"           "[ \$(wc -l < '$Af' 2>/dev/null) -eq $ab ]"
+
+rb=$(grep -c 'restart detected' "$E2E_STATE/s1.log")
+prompt s1 "/compact"; sleep 12
+check "shadow: /compact did NOT rotate (no new restart)" "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq $rb ]"
+attach_stop s1; stop_daemon s1
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 2: DRIVE (the binder itself) — bind + /clear via dir-poll + /compact"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon s2 "$CWD" 18812 drive; wait_ready s2 || exit 1
+check "drive: shadow suppressed when enabled" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
+SID=$(session_id 18812); attach_start s2 18812 "$SID"; sleep 2
+prompt s2 "$EXPLORE"
+A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
+check "drive: binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s2.log'"
+
+prompt s2 "/clear"; sleep 6
+B2=$(bound_transcript "$CWD" 18812 2>/dev/null | awk '{print $1}')
+check "drive: /clear rotated (B != A)" "[ -n '$B2' ] && [ '$B2' != '$A2' ]"
+check "drive: new dir-poll detected the rotation (#452 machinery)" "grep -q 'No-hooks rotation detected via dir poll' '$E2E_STATE/s2.log'"
+check "drive: rebound + rearmed watcher on B" "grep -q 'Transcript from DirPollRotation' '$E2E_STATE/s2.log'"
+check "drive: no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_STATE/s2.log') -eq 0 ]"
+
+rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s2.log")
+prompt s2 "/compact"; sleep 12
+check "drive: /compact did NOT over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s2.log') -eq $rc ]"
+attach_stop s2; stop_daemon s2
+
+# ---------------------------------------------------------------------------
+echo "### Scenario 3: TWO daemons, same cwd — cross-bind (fm-427) + zombie (fm-451)"
+# ---------------------------------------------------------------------------
+reset_cwd
+start_daemon d1 "$CWD" 18813 drive; wait_ready d1 || exit 1
+sleep 2   # stagger so the two daemons do not collide writing ~/.remi/sessions.json
+start_daemon d2 "$CWD" 18814 drive; wait_ready d2 || exit 1
+S1=$(session_id 18813); S2=$(session_id 18814)
+attach_start d1 18813 "$S1"; attach_start d2 18814 "$S2"; sleep 2
+prompt d1 "Say the word ALPHA."
+prompt d2 "Say the word BETA."
+C1=$(wait_bound "$CWD" 18813 8 100); C2=$(wait_bound "$CWD" 18814 8 100)
+check "two-daemon: distinct binds (no cross-bind)" "[ -n '$C1' ] && [ -n '$C2' ] && [ '$C1' != '$C2' ]"
+F1=$(tdir_for "$CWD")/$C1.jsonl; F2=$(tdir_for "$CWD")/$C2.jsonl
+check "two-daemon: ALPHA only in D1's transcript" "[ \$(grep -c ALPHA '$F1' 2>/dev/null) -ge 1 ] && [ \$(grep -c BETA '$F1' 2>/dev/null) -eq 0 ]"
+check "two-daemon: BETA only in D2's transcript"  "[ \$(grep -c BETA '$F2' 2>/dev/null) -ge 1 ] && [ \$(grep -c ALPHA '$F2' 2>/dev/null) -eq 0 ]"
+check "two-daemon: each binds its own port marker" "head -c 4000 '$F1' | grep -q 'remi:18813' && head -c 4000 '$F2' | grep -q 'remi:18814'"
+
+# fm-451 zombie: kill D1's INNER claude child only (wrapper stays alive).
+CC=$(pgrep -f "claude .*remi:18813" | head -1)
+kill -9 "$CC" 2>/dev/null
+check "zombie: D1 daemon wrapper still alive (false-live sibling)" "kill -0 \$(cat '$E2E_STATE/d1.pid') 2>/dev/null"
+prompt d2 "/clear"; sleep 6; prompt d2 "Say the word GAMMA."
+C2B=$(bound_transcript "$CWD" 18814 2>/dev/null | awk '{print $1}')
+check "zombie: D2 rebound despite the zombie sibling" "[ -n '$C2B' ] && [ '$C2B' != '$C2' ]"
+check "zombie: D2 ignored the foreign/zombie transcript by marker" "grep -q 'owned by port 18813, not 18814; ignoring' '$E2E_STATE/d2.log'"
+check "zombie: no Transcript-not-found wedge in D2" "[ \$(grep -ci 'not found' '$E2E_STATE/d2.log') -eq 0 ]"
+attach_stop d1; attach_stop d2; stop_daemon d1; stop_daemon d2
+
+echo
+echo "==================== RESULT: $PASS passed, $FAIL failed ===================="
+echo "logs + renders: $E2E_STATE"
+exit "$FAIL"


### PR DESCRIPTION
## Release 0.6.0 → 0.6.1

Promotes `develop` to `main`. Merging triggers the release pipeline (CI strips the `-dev` suffix → tag, npm publish, Homebrew).

### Highlights

**Epic #453 — session-binding + transcript-watcher unified into one `TranscriptBinder`** (PRs #457/#459/#462/#464/#466/#468/#471 → #472)
- Ships **behind a feature flag, default OFF** (`transcript_binder_shadow`/`transcript_binder_enabled`). With the defaults, behaviour is **runtime-equivalent to 0.6.0** — proven live: 0 `[ShadowBinder] DISAGREE` on real sessions including `/clear`.
- Collapses the binding↔watcher↔ownership, question-pipeline, and hook-filtering concerns out of a ~770-line `hook-bridge-setup.ts`. Includes the #452 re-arming dir-poll (drive mode), `QuestionPipeline` (NotificationDispatcher + AutoApproveGate), `SessionBindingStore` (no-cache), the 4 previously-dropped hook events, and adapter silent-drop fixes.
- The flip-to-drive is a **separate future step** gated on a production shadow soak + #470 + #476.

**fix(daemon): per-process tmp path for `sessions.json` write (#461)**
- Concurrent daemons no longer crash on the shared `sessions.json.tmp` rename race. Real multi-process concurrency test included.

**test(e2e): `tests/e2e/transcript-binding/` harness (#475)**
- Manual/semi-automated real-`claude` validation of the binding/rotation subsystem. Not in CI.

### Validation

- Each phase + the integrated epic individually reviewed; full e2e validation with real `claude --model haiku` sessions (shadow equivalence, drive-mode rotation via the new dir-poll, two-daemon cross-bind + zombie defer). All passed.
- The binder ships **dormant**, so the one open binder finding (#476, drive-mode-only stale-restart) is **not reachable** in the default config.

### Scope
45 files, +5626/-560. Commits: #472 (epic), #474 (#461), #475 (harness).