### PR TITLE
ci: auto-bump dev counter on push to develop

### DIFF
--- a/.github/workflows/auto-bump-dev.yml
+++ b/.github/workflows/auto-bump-dev.yml
@@ -1,0 +1,66 @@
+name: Auto Bump Dev
+
+# Increment the -dev.N counter on every push to develop, so each dev build has a
+# unique version. Version-only: NO builds and NO npm publish (those happen on
+# main via release.yml, triggered by stable version tags). Stable releases and
+# the post-release main->develop sync are handled by the auto-release and
+# sync-develop jobs in ci.yml.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize bumps so two quick pushes can't race the branch push.
+  group: auto-bump-dev
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+
+jobs:
+  bump:
+    name: Auto Bump Dev
+    # Skip the bot's own bump commits (so this never loops) and any commit that
+    # opts out with [skip-bump] in its message.
+    if: >-
+      github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
+      && !startsWith(github.event.head_commit.message, 'chore: bump version to')
+      && !contains(github.event.head_commit.message, '[skip-bump]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Bump dev counter and push branch (no tag)
+        run: |
+          CURRENT=$(jq -r '.version' package.json)
+          if [[ ! "$CURRENT" =~ -dev\.[0-9]+$ ]]; then
+            echo "Version $CURRENT has no -dev.N suffix; nothing to increment."
+            echo "Start a new dev line with bump-version.sh patch|minor|major first."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bun install --frozen-lockfile
+          ./scripts/bump-version.sh dev
+          # Push the branch only. bump-version.sh also creates a local v<ver> tag
+          # which we intentionally do NOT push — dev versions are never released.
+          git push origin develop

--- a/.github/workflows/auto-bump-dev.yml
+++ b/.github/workflows/auto-bump-dev.yml
@@ -25,11 +25,14 @@ jobs:
   bump:
     name: Auto Bump Dev
     # Skip the bot's own bump commits (so this never loops) and any commit that
-    # opts out with [skip-bump] in its message.
+    # opts out with [skip-bump]. The message prefix is the primary guard — it
+    # exactly matches bump-version.sh's commit; the author-email checks (both
+    # noreply forms GitHub may emit) are belt-and-suspenders.
     if: >-
-      github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
-      && !startsWith(github.event.head_commit.message, 'chore: bump version to')
+      !startsWith(github.event.head_commit.message, 'chore: bump version to')
       && !contains(github.event.head_commit.message, '[skip-bump]')
+      && github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
+      && github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com'
     runs-on: ubuntu-latest
     steps:
       - name: Generate App Token
@@ -64,3 +67,10 @@ jobs:
           # Push the branch only. bump-version.sh also creates a local v<ver> tag
           # which we intentionally do NOT push — dev versions are never released.
           git push origin develop
+          # Belt-and-suspenders: a dev tag must never reach origin (it would
+          # trigger release.yml). Fail loudly if a future edit ever pushes one.
+          NEW=$(jq -r '.version' package.json)
+          if git ls-remote --tags origin "refs/tags/v$NEW" | grep -q .; then
+            echo "ERROR: dev tag v$NEW was unexpectedly pushed to origin" >&2
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,37 +155,51 @@ bun run build:binary   # /opt/homebrew/bin/remi picks it up
 
 ## Releasing
 
-**Always use `bump-version.sh`** — never hand-edit version numbers.
+**Always use `bump-version.sh`** — never hand-edit version numbers. Most of the
+release flow is automated by CI; you rarely run the script by hand.
+
+**What's automated:**
+
+- **Dev counter** — `auto-bump-dev.yml` increments `-dev.N` on every push to
+  `develop` (e.g. `0.6.2-dev.1` → `0.6.2-dev.2`). Version-only; no builds or
+  publishes. Skip it on a given commit with `[skip-bump]` in the message.
+- **Stable release** — merging `develop` → `main` triggers `auto-release`
+  (ci.yml): it strips the `-dev.N` suffix, commits, and pushes the stable tag
+  `vX.Y.Z`, which triggers `release.yml` (per-platform binary build, npm
+  `@latest` publish to `@yooz-labs/remi` + platform packages, GitHub release,
+  Homebrew tap update).
+- **Post-release sync** — `sync-develop` (ci.yml) then merges `main` back into
+  `develop` and bumps to the next dev line (`X.Y.Z` → `X.Y.(Z+1)-dev.1`).
+
+**What you do by hand:**
 
 ```bash
-# Dev release on develop (npm @dev tag, GitHub prerelease)
-git checkout develop
-./scripts/bump-version.sh --push dev   # 0.4.3 → 0.4.4-dev.1
-./scripts/bump-version.sh --push dev   # 0.4.4-dev.1 → 0.4.4-dev.2
+# Cut a release: PR develop -> main (never push to main directly), merge when
+# green. CI does the strip/tag/publish/sync. Update CHANGELOG before the PR.
 
-# Promote to main when stable (CI strips dev suffix and releases)
-git checkout main && git merge develop && git push origin main
-# CI: 0.4.4-dev.6 → 0.4.4 (tag + npm publish + Homebrew)
+# Start a new minor/major (or explicit) line on develop, via a normal PR.
+# The dev counter then auto-increments from there on each push.
+./scripts/bump-version.sh minor          # 0.6.x-dev.N -> 0.7.0-dev.1
+./scripts/bump-version.sh major          # -> 1.0.0-dev.1
+./scripts/bump-version.sh set 1.2.0-dev.1
+# 'dev' (manual counter bump) and 'patch' still exist but are rarely needed
+# now that auto-bump-dev / sync-develop handle them.
 
-# After release: sync develop and start the next dev cycle
-git checkout develop && git merge origin/main && git push origin develop
-./scripts/bump-version.sh --push dev   # 0.4.4 → 0.4.5-dev.1
-
-# Stable release (CI: build, npm @latest, GitHub release, Homebrew)
-./scripts/bump-version.sh --push patch     # 0.4.4-dev.2 → 0.4.4
-./scripts/bump-version.sh --push minor     # 0.3.9 → 0.4.0
-./scripts/bump-version.sh --push major     # 0.3.9 → 1.0.0
-./scripts/bump-version.sh --push set 1.0.0 # explicit
-
-# Without --push: commits and tags locally, prints push commands
-./scripts/bump-version.sh patch
+# Without --push: commits + tags locally, prints push commands.
 ```
 
-The script updates `package.json` and the `REMI_COMPILED_VERSION` fallback in `cli.ts`, commits, tags, and (with `--push`) pushes to trigger the release pipeline.
+The script updates `package.json` and the `REMI_COMPILED_VERSION` fallback in
+`cli.ts`, commits, and tags. `stable` is blocked on `develop` (CI-only).
 
 ## CI
 
-GitHub Actions on push / PR to `main`: `bunx biome check`, `bun run typecheck`, `bun test --coverage` with a 60% minimum threshold.
+GitHub Actions:
+- **Gates** (PR to `main`/`develop`, push to `main`): `bunx biome check`,
+  `bun run typecheck`, `bun test --coverage` (60% minimum), spelling (`typos`).
+- **auto-bump-dev** (push to `develop`): increments the dev counter.
+- **auto-release + sync-develop** (push to `main`): stable release + dev sync.
+- **release.yml** (stable `vX.Y.Z` tag): build, npm publish, GitHub release,
+  Homebrew.
 
 ---
 


### PR DESCRIPTION
## Summary

Adopts nemar-cli's `auto-bump-dev` pattern (adapted to remi's `-dev.N` format). Adds `.github/workflows/auto-bump-dev.yml`: on every push to `develop`, increments the `-dev.N` counter (e.g. `0.6.2-dev.1` → `0.6.2-dev.2`) so each dev build has a unique version.

**Version-only** — no builds, no npm publish (those stay on `main` via `release.yml`). This addresses the rationale for the original auto-bump-dev removal (ci.yml:92, which was about dev *builds/publishes*, not the version bump itself).

remi already had the other two pieces of the pattern, so this completes it:
- `auto-release` (ci.yml) — strip `-dev` → tag → release on merge to main ✓
- `sync-develop` (ci.yml) — merge main→develop + bump next dev after release ✓
- **auto-bump-dev (this PR)** — increment the dev counter on each develop push

### Details
- Mirrors remi's conventions: App token (`APP_ID`/`APP_PRIVATE_KEY`), `github-actions[bot]` identity, `bun install --frozen-lockfile` + `bump-version.sh dev`, branch-only push (the local dev tag is intentionally not pushed — same as `sync-develop`).
- **Loop-safe**: skips the bot's own bump commits (`!startsWith('chore: bump version to')` + author guard) and any `[skip-bump]` commit; `concurrency` serializes bumps so two quick pushes can't race.
- No-op guard: if the version has no `-dev.N` suffix (e.g. just after a stable line starts), it exits cleanly.
- Updates the AGENTS.md release section to document the now-fully-automated flow.

### Test plan
- YAML valid; `typos` clean; the `if:`/`concurrency`/steps mirror the working `auto-release`/`sync-develop` jobs verbatim.
- Behavior is observable on the first merge to develop after this lands (a `chore: bump version to 0.6.2-dev.2` bot commit appears).

Part of adopting standardized release automation across the yooz ecosystem (whisper et al. tracked separately).