### PR TITLE
fix(daemon): emit question only on the rising edge (duplicate APNS flood) (#486)

### DIFF
--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -63,6 +63,19 @@ const DEFAULT_BUFFER_SIZE = 4096;
  * - Parsing questions and status
  * - Progressive updates for long outputs
  */
+/**
+ * Stable fingerprint of a prompt's content (NOT its id, which is minted fresh
+ * on every parse). Two detections of the same on-screen prompt produce the same
+ * fingerprint, so the rising-edge gate can suppress the re-emit. Keyed on the
+ * normalized text + option values + free-text flag — a genuine prompt change
+ * (different text or options) yields a different fingerprint and re-emits.
+ */
+function questionFingerprint(q: Question): string {
+  const text = q.text.trim().toLowerCase().replace(/\s+/g, ' ');
+  const opts = q.options.map((o) => o.value).join('');
+  return `${text}${opts}${q.allowsFreeText ? 'f' : ''}`;
+}
+
 export class OutputProcessor {
   private readonly config: Required<ProcessorConfig>;
   private readonly events: Partial<OutputEvents>;
@@ -73,6 +86,10 @@ export class OutputProcessor {
   private currentStatus: AgentStatus = 'idle';
   private lastUpdateTime = 0;
   private pendingQuestion: Question | null = null;
+  /** Fingerprint of the prompt currently on screen, so the SAME prompt
+   *  re-parsed on later buffer cycles is not re-emitted as a new question
+   *  (rising-edge gate). Cleared when status leaves 'waiting'. */
+  private pendingQuestionFp: string | null = null;
   private seenContent: Set<string> = new Set(); // Track unique content chunks
   private hasEmittedCurrentMessage = false; // Track if onMessage was called for currentMessageId
 
@@ -125,6 +142,7 @@ export class OutputProcessor {
     this.currentStatus = 'idle';
     this.lastUpdateTime = 0;
     this.pendingQuestion = null;
+    this.pendingQuestionFp = null;
     this.seenContent.clear();
     this.hasEmittedCurrentMessage = false;
   }
@@ -178,15 +196,30 @@ export class OutputProcessor {
     const statusResult = parseStatus(content);
     if (statusResult.status !== this.currentStatus && statusResult.confidence >= 0.5) {
       this.currentStatus = statusResult.status;
+      // The prompt (if any) is gone once the agent advances past 'waiting'.
+      // Clear the rising-edge gate so the NEXT prompt — even one with identical
+      // text — re-emits instead of being mistaken for the one just answered.
+      if (statusResult.status !== 'waiting') {
+        this.pendingQuestion = null;
+        this.pendingQuestionFp = null;
+      }
       this.events.onStatusChange?.(statusResult.status, statusResult.context);
     }
 
-    // Check for questions
+    // Check for questions. A prompt that stays on screen is re-parsed on every
+    // buffer cycle; emitting it each time mints a fresh question id and floods
+    // the notification pipeline (downstream dedup can't catch a new id once its
+    // window lapses). Emit only on the RISING EDGE — when the on-screen prompt's
+    // fingerprint actually changes. See #486.
     if (hasQuestionIndicator(content)) {
       const parseResult = parseQuestion(content);
       if (parseResult.detected && parseResult.question) {
-        this.pendingQuestion = parseResult.question;
-        this.events.onQuestion?.(parseResult.question);
+        const fp = questionFingerprint(parseResult.question);
+        if (fp !== this.pendingQuestionFp) {
+          this.pendingQuestion = parseResult.question;
+          this.pendingQuestionFp = fp;
+          this.events.onQuestion?.(parseResult.question);
+        }
       }
     }
 

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -130,6 +130,11 @@ export class OutputProcessor {
     if (this.currentMessageId !== null) {
       this.finalizeMessage();
     }
+
+    // Drop the rising-edge gate on PTY exit so a reused processor can't suppress
+    // the next session's first identical prompt. (flush() is exit-only.)
+    this.pendingQuestion = null;
+    this.pendingQuestionFp = null;
   }
 
   /**
@@ -196,10 +201,18 @@ export class OutputProcessor {
     const statusResult = parseStatus(content);
     if (statusResult.status !== this.currentStatus && statusResult.confidence >= 0.5) {
       this.currentStatus = statusResult.status;
-      // The prompt (if any) is gone once the agent advances past 'waiting'.
-      // Clear the rising-edge gate so the NEXT prompt — even one with identical
-      // text — re-emits instead of being mistaken for the one just answered.
+      // Clear the rising-edge gate at BOTH edges of a non-waiting span so the
+      // NEXT prompt — even one with identical text — re-emits instead of being
+      // mistaken for the one just answered. We bias toward re-emit (a duplicate
+      // is recoverable; a missed prompt is not): the gate only suppresses
+      // re-parses WITHIN a single 'waiting' span.
       if (statusResult.status !== 'waiting') {
+        // Left 'waiting': the prompt (if any) is gone.
+        this.pendingQuestion = null;
+        this.pendingQuestionFp = null;
+      } else if (this.currentStatus !== 'waiting') {
+        // Entered 'waiting' from a non-waiting state: a fresh prompt cycle, so
+        // a same-text prompt must not be suppressed as the previous one.
         this.pendingQuestion = null;
         this.pendingQuestionFp = null;
       }

--- a/packages/daemon/tests/output-processor.test.ts
+++ b/packages/daemon/tests/output-processor.test.ts
@@ -132,6 +132,39 @@ describe('OutputProcessor', () => {
     expect(questions[0]?.text).toBe('Do you want to proceed?');
   });
 
+  test('emits onQuestion only on the rising edge: same prompt re-parsed does not re-emit (#486)', () => {
+    const questions: Question[] = [];
+    const processor = new OutputProcessor({ sessionId }, { onQuestion: (q) => questions.push(q) });
+
+    // The same on-screen prompt re-parsed across buffer cycles must emit ONCE
+    // (it is one pending question, not many). This is the duplicate-APNS source.
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(1);
+
+    // Agent advances past 'waiting' -> the rising-edge gate clears.
+    processor.process('Thinking...\n');
+    processor.flush();
+
+    // A new decision with identical text must re-emit (not be mistaken for the
+    // one just answered).
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(2);
+  });
+
+  test('a genuinely different prompt re-emits without a status change (#486)', () => {
+    const questions: Question[] = [];
+    const processor = new OutputProcessor({ sessionId }, { onQuestion: (q) => questions.push(q) });
+
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Overwrite the existing file? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(2);
+  });
+
   test('does not emit messages in streamStatusOnly mode', () => {
     const messages: Message[] = [];
     const processor = new OutputProcessor(


### PR DESCRIPTION
## Summary

Fixes the **source** of the duplicate APNS notifications you've been hitting (not by adding dedup — by removing the cause).

**Root cause, from your live daemon logs:** `parser/output-processor.ts` emitted `onQuestion` on **every** buffer parse where a prompt was detected. A prompt sitting on screen (`"Do you want to proceed?"`) is re-parsed continuously, so it re-emitted with a fresh question id each time — overflowing the pending-question cap (logs showed `d9582775 → a6bebb49 → b30ff2a8`, all the same text, evicting oldest) and firing a `Push notification sent` each time the downstream `PushDedup` 5s window lapsed.

**Fix:** emit only on the **rising edge** — when the on-screen prompt's fingerprint (normalized text + option values + free-text flag, NOT the per-parse id) actually changes — and clear the gate when status leaves `waiting` so a later identical prompt still re-emits. The `pendingQuestion` field already existed but was never read to suppress the re-emit.

This makes `PushDedup` largely redundant for this case (one emit per prompt now reaches the pipeline). I left `PushDedup` in as a backstop; it can be revisited.

## Not included (separate, tracked)
Your iPhone also has **two** device tokens registered (APNS rotated, old never pruned), so each push fans out 2×. That needs a device-stable identity to prune safely (you're going multi-device), so it's epic #481 phase 4 — not this PR.

## Test plan
- New rising-edge tests (no mocks): same prompt re-parsed 3× emits **once**; after a status change a new identical prompt re-emits; a different prompt re-emits without a status change.
- Full output-processor suite (31) + question-pipeline-adjacent suites (142) green; `tsc` + `biome` clean.

Closes #486