### PR TITLE
Phase 1: PR-review auto-approve defaults (#482)

### DIFF
--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -29,8 +29,9 @@ APPROVE these operations:
 - Bash: git status, git log, git diff, git branch, git show, git stash list
 - Bash: read-only repo/CLI queries that only FETCH data (no mutation), e.g.
   gh pr view/diff/list/status/checks, gh issue view/list, gh run view/list,
-  gh api <path> with the default GET method. These read a remote but change
-  nothing, so they are safe (this is the common /review-pr command set).
+  gh api <path> with a BARE path and NO -X/--method and NO -f/-F/--field/
+  --raw-field flags (a bare gh api path is a GET). These read a remote but
+  change nothing, so they are safe (this is the common /review-pr command set).
 - Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
@@ -44,9 +45,11 @@ ESCALATE these operations (ask the user):
 - Bash: file creation, modification, or deletion under the project tree
 - Bash: package install (bun add, npm install, pip install, uv add, etc.)
 - Bash: remote MUTATIONS or pushes — git push, gh pr merge/close/create,
-  gh pr review, gh issue create/close, gh api with -X POST/PUT/DELETE/PATCH,
-  curl/wget POST, ssh (read-only gh/git fetches are approvable per above; this
-  is for anything that CHANGES remote state)
+  gh pr review, gh pr checkout, gh issue create/close, curl/wget POST, ssh, and
+  any gh api that mutates: -X/--method POST/PUT/DELETE/PATCH OR ANY
+  -f/-F/--field/--raw-field flag (adding parameters silently switches gh api
+  from GET to POST). Read-only gh/git fetches are approvable per above; this is
+  for anything that CHANGES remote state.
 - Bash: any command you are not sure about
 - Any tool not listed above
 

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -27,6 +27,10 @@ DEFAULT GUIDELINES:
 APPROVE these operations:
 - Read/Glob/Grep: all file reads and searches
 - Bash: git status, git log, git diff, git branch, git show, git stash list
+- Bash: read-only repo/CLI queries that only FETCH data (no mutation), e.g.
+  gh pr view/diff/list/status/checks, gh issue view/list, gh run view/list,
+  gh api <path> with the default GET method. These read a remote but change
+  nothing, so they are safe (this is the common /review-pr command set).
 - Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
@@ -39,7 +43,10 @@ ESCALATE these operations (ask the user):
 - Bash: git add, git commit, git push, git checkout, git merge, git rebase, git reset
 - Bash: file creation, modification, or deletion under the project tree
 - Bash: package install (bun add, npm install, pip install, uv add, etc.)
-- Bash: anything that talks to a remote (curl POST, gh api with POST/PUT/DELETE, ssh)
+- Bash: remote MUTATIONS or pushes — git push, gh pr merge/close/create,
+  gh pr review, gh issue create/close, gh api with -X POST/PUT/DELETE/PATCH,
+  curl/wget POST, ssh (read-only gh/git fetches are approvable per above; this
+  is for anything that CHANGES remote state)
 - Bash: any command you are not sure about
 - Any tool not listed above
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -108,7 +108,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
     base_url: 'http://localhost:11434/v1',
     timeout: 30,
     log_decisions: true,
-    allow: [],
+    // Safe read-only TOOLS, fast-pathed without an LLM call. These are
+    // tool-name matches (not Bash substrings), so a compound command cannot
+    // bypass them — `Read` matches the Read tool, never a `Bash` string. Bash
+    // git/gh commands are intentionally NOT defaulted here (substring matching
+    // is compound-command-unsafe); the LLM prompt evaluates those in full.
+    allow: ['Read', 'Glob', 'Grep'],
     deny: [],
     instructions: '',
     multichoice: 'skip',

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -89,4 +89,17 @@ describe('buildPrompt', () => {
     const [system] = buildPrompt('Bash', { command: 'ls && cat foo' });
     expect(system?.content).toContain('Compound commands');
   });
+
+  test('system prompt approves read-only gh queries and escalates gh mutations (#482)', () => {
+    // PR review (/review-pr) leans on read-only gh; without this clause the
+    // catch-all "talks to a remote -> escalate" rule made the LLM escalate
+    // every gh command. Read-only fetches approve; remote mutations escalate.
+    const [system] = buildPrompt('Bash', { command: 'gh pr view 123' });
+    const content = system?.content ?? '';
+    expect(content).toContain('gh pr view');
+    expect(content).toContain('gh api'); // GET approvable, mutating verbs escalate
+    expect(content).toContain('gh pr merge'); // named as an escalation
+    // The approve clause must mention fetching read-only data without mutation.
+    expect(content.toLowerCase()).toContain('fetch data');
+  });
 });

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -101,5 +101,8 @@ describe('buildPrompt', () => {
     expect(content).toContain('gh pr merge'); // named as an escalation
     // The approve clause must mention fetching read-only data without mutation.
     expect(content.toLowerCase()).toContain('fetch data');
+    // `gh api -f/-F` silently switches GET->POST, so the field flags must be
+    // named as an escalation (a 4B model would otherwise read it as a GET).
+    expect(content).toContain('--field');
   });
 });

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -145,6 +145,18 @@ describe('applyEnvOverrides', () => {
     expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
   });
 
+  test('auto-approve stays opt-in but defaults safe read-only tools in allow (#482)', () => {
+    // Off by default (the trust line we never cross silently).
+    expect(DEFAULT_CONFIG.auto_approve.enabled).toBe(false);
+    // Read-only TOOL-NAME matches (not Bash substrings) so a compound command
+    // cannot bypass them; these fast-path file reads without an LLM call.
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Read');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Glob');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Grep');
+    // No Bash command substrings are defaulted (compound-command-unsafe).
+    expect(DEFAULT_CONFIG.auto_approve.allow.some((p) => p.includes(' '))).toBe(false);
+  });
+
   test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
     process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
@@ -290,7 +302,7 @@ describe('auto_approve config', () => {
       base_url: 'http://localhost:11434/v1',
       timeout: 30,
       log_decisions: true,
-      allow: [],
+      allow: ['Read', 'Glob', 'Grep'],
       deny: [],
       instructions: '',
       multichoice: 'skip',
@@ -402,10 +414,12 @@ Escalate anything touching secrets.
     expect(config.auto_approve.instructions).toContain('Escalate anything touching secrets');
   });
 
-  test('allow/deny default to empty arrays', () => {
+  test('allow defaults to safe read-only tools; deny/instructions default empty (#482)', () => {
+    // An [auto_approve] section that omits `allow` inherits the safe read-only
+    // tool defaults (Read/Glob/Grep); deny and instructions stay empty.
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nenabled = true\n');
     const config = loadConfig(TEST_CONFIG);
-    expect(config.auto_approve.allow).toEqual([]);
+    expect(config.auto_approve.allow).toEqual(['Read', 'Glob', 'Grep']);
     expect(config.auto_approve.deny).toEqual([]);
     expect(config.auto_approve.instructions).toBe('');
   });


### PR DESCRIPTION
Part of epic #481. Closes #482. Default allow=['Read','Glob','Grep'] (tool-name matches, opt-in) + prompt clause approving read-only gh/git fetches and escalating remote mutations. Fixes PR review escalating every gh command. Tests green; LLM-instruction tests pre-existing flaky + CI-skipped.