### PR TITLE
Phase 2: agent-aware dedup + fail-safe cross-agent pairing (#483)

### DIFF
--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -6,10 +6,12 @@
  * richer (more options, or gains allowsFreeText) — that is allowed through
  * as an upgrade and replaces the baseline.
  *
- * Single-slot tracking is deliberate: callers (`MessageAPI`) are expected
- * to clear the state on every meaningful boundary (status change away from
- * 'waiting', session reset). The window is a safety net against same-tick
- * re-renders, not a long-lived cache.
+ * Tracking is PER-AGENT (keyed by `question.agentId ?? 'main'`): a background
+ * subagent's "Allow Bash?" must NOT suppress the main agent's identically-worded
+ * prompt (they are two distinct questions the user must answer). Within one
+ * agent it is single-slot. Callers (`MessageAPI`) clear the state on every
+ * meaningful boundary (status change away from 'waiting', session reset). The
+ * window is a safety net against same-tick re-renders, not a long-lived cache.
  *
  * The fingerprint normalizes case + whitespace and truncates to 80 chars,
  * so minor terminal redraw differences don't defeat the dedup. Genuinely
@@ -18,7 +20,7 @@
  * which are usually <80 chars after normalization.
  */
 
-import { QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
+import { MAIN_AGENT_ID, QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
 
 interface LastEmitted {
   fingerprint: string;
@@ -28,7 +30,9 @@ interface LastEmitted {
 }
 
 export class QuestionDedup {
-  private last: LastEmitted | null = null;
+  /** Most-recent emission per agent (`agentId ?? 'main'`), so concurrent
+   *  prompts from different agents never suppress each other. */
+  private readonly last = new Map<string, LastEmitted>();
 
   constructor(
     private readonly windowMs: number = QUESTION_DEDUP_WINDOW_MS,
@@ -38,37 +42,38 @@ export class QuestionDedup {
   /**
    * Returns true if the question should be emitted, false to suppress.
    * On true, internal state is updated so subsequent same-fingerprint
-   * lower-rank questions are suppressed within the window.
+   * lower-rank questions FROM THE SAME AGENT are suppressed within the window.
    */
   shouldEmit(question: Question): boolean {
     const fp = fingerprint(question.text);
     const t = this.clock();
-    const last = this.last;
+    const agent = question.agentId ?? MAIN_AGENT_ID;
+    const last = this.last.get(agent);
 
-    if (last !== null && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
+    if (last !== undefined && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
       const richer =
         question.options.length > last.optionCount ||
         (question.allowsFreeText && !last.allowsFreeText);
       if (!richer) {
         console.debug(
-          `[QuestionDedup] Suppressed (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
+          `[QuestionDedup] Suppressed agent=${agent} (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
         );
         return false;
       }
     }
 
-    this.last = {
+    this.last.set(agent, {
       fingerprint: fp,
       optionCount: question.options.length,
       allowsFreeText: question.allowsFreeText,
       emittedAt: t,
-    };
+    });
     return true;
   }
 
-  /** Clear state (call on session reset / new prompt cycle). */
+  /** Clear state for all agents (call on session reset / new prompt cycle). */
   reset(): void {
-    this.last = null;
+    this.last.clear();
   }
 }
 

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -54,8 +54,9 @@ export class QuestionPresenceTracker {
   /** Hook-derived questions not yet paired with PTY confirmation or cleared,
    *  keyed by agent. At most one per agent: a second hook for the SAME agent
    *  (e.g. PermissionRequest then Notification for one prompt) replaces the
-   *  first, but different agents keep separate entries. Insertion order is
-   *  preserved so the PTY-pairing fallback can pick the most recent. */
+   *  first, but different agents keep separate entries. A PTY prompt pairs with
+   *  the same-agent entry, or (only when exactly one entry exists) the sole
+   *  candidate; with 2+ different-agent entries it pushes bare (no guessing). */
   private pending = new Map<string, Question>();
 
   /** True while a permission prompt is on the main PTY. Set by
@@ -95,9 +96,11 @@ export class QuestionPresenceTracker {
 
   /**
    * PTY parser saw a prompt on screen. Push immediately. Pair with a hook
-   * record for option labels / agent_id: prefer the same agent, else fall
-   * back to the most-recent pending hook (PTY output does not reliably name
-   * the agent — #425). When paired, the hook contributes `options` and
+   * record for option labels / agent_id: prefer the same-agent entry, else the
+   * sole pending hook when exactly one exists (unambiguous). With 2+ pending
+   * hooks from different agents and no agent match, push bare to avoid
+   * misattributing another agent's labels (#425 / #483). When paired, the hook
+   * contributes `options` and
    * `agentId` (so the client keys the prompt to the right agent) while PTY
    * contributes `id` / `text` / `allowsFreeText` / `isAnswered` (it reflects
    * the screen). The consumed hook entry is removed.
@@ -123,6 +126,10 @@ export class QuestionPresenceTracker {
       console.warn(
         `[QuestionPresenceTracker] PTY prompt (agent "${key}") matches none of [${[...this.pending.keys()].join(', ')}]; pushing bare to avoid cross-agent misattribution`,
       );
+      // The ambiguous hooks are unresolvable for this prompt; drop them so they
+      // can't stale-merge onto a later unrelated prompt (recordKey stays
+      // undefined here, so the delete below would otherwise skip them).
+      this.pending.clear();
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -110,15 +110,18 @@ export class QuestionPresenceTracker {
   onPTYPromptVisible(ptyQuestion: Question): void {
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
-    if (recordKey === undefined && this.pending.size > 0) {
-      // Most-recent pending hook (Map preserves insertion order). The PTY did
-      // not name an agent we have a record for, so this may attach the wrong
-      // agent's option labels (#425). Log it so the misattribution is
-      // observable rather than silent.
-      const keys = [...this.pending.keys()];
-      recordKey = keys[keys.length - 1];
+    if (recordKey === undefined && this.pending.size === 1) {
+      // Exactly one pending hook and the PTY did not name an agent we have a
+      // record for: pairing is unambiguous (one candidate), so attach it.
+      recordKey = [...this.pending.keys()][0];
+    } else if (recordKey === undefined && this.pending.size > 1) {
+      // 2+ pending hooks from DIFFERENT agents and the PTY question matches
+      // none: do NOT guess. Pairing the most-recent would attach the wrong
+      // agent's option labels (#425). Push the bare PTY question instead — its
+      // numbered options suffice for the user to answer — and log loudly so the
+      // ambiguity is observable rather than a silent misattribution.
       console.warn(
-        `[QuestionPresenceTracker] PTY prompt (agent "${key}") has no matching hook; pairing most-recent "${recordKey}" of [${keys.join(', ')}] — option labels may be misattributed`,
+        `[QuestionPresenceTracker] PTY prompt (agent "${key}") matches none of [${[...this.pending.keys()].join(', ')}]; pushing bare to avoid cross-agent misattribution`,
       );
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -41,6 +41,20 @@ describe('QuestionDedup', () => {
     expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(false);
   });
 
+  test('does NOT suppress an identical prompt from a DIFFERENT agent (#483)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    // Main agent asks; then a background subagent asks the identical thing.
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3) })).toBe(true);
+    t += 200;
+    const subagent: Question = { ...q('Allow Bash: ls', 3), agentId: 'subagent-A' };
+    // Different agent -> a genuinely distinct question the user must answer.
+    expect(dedup.shouldEmit(subagent)).toBe(true);
+    // But the subagent's own re-emit within the window is still suppressed.
+    t += 100;
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3), agentId: 'subagent-A' })).toBe(false);
+  });
+
   test('suppresses same-fingerprint question with fewer options within window', () => {
     let t = 1000;
     const dedup = new QuestionDedup(5000, () => t);

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -57,6 +57,31 @@ describe('QuestionPresenceTracker', () => {
     expect(tracker.hasPendingForTest()).toBe(false);
   });
 
+  it('2+ pending hooks from different agents, PTY names none -> pushes BARE (#483)', () => {
+    // Fail-safe: concurrent prompts from two subagents + a PTY question that
+    // matches neither must NOT guess — push the bare PTY question rather than
+    // attach the wrong agent's option labels (#425).
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash A?'), agentId: 'subagent-A' });
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Edit B?'), agentId: 'subagent-B' });
+    const ptyQ = makePTYQuestion('Some prompt'); // no agentId -> 'main', matches neither
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]).toBe(ptyQ); // bare, not merged
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['1', '2', '3']);
+  });
+
+  it('exactly one pending hook, PTY names no agent -> still pairs unambiguously (#483)', () => {
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash?'), agentId: 'subagent-A' });
+    const ptyQ = makePTYQuestion('Allow Bash?'); // no agentId, but only one candidate
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+  });
+
   it('hook then PTY — pushes once with merged options from hook metadata', () => {
     const pushes: Question[] = [];
     const tracker = new QuestionPresenceTracker((q) => pushes.push(q));

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -70,6 +70,8 @@ describe('QuestionPresenceTracker', () => {
     expect(pushes.length).toBe(1);
     expect(pushes[0]).toBe(ptyQ); // bare, not merged
     expect(pushes[0]?.options.map((o) => o.label)).toEqual(['1', '2', '3']);
+    // Ambiguous hooks are dropped, not leaked into the next prompt cycle.
+    expect(tracker.hasPendingForTest()).toBe(false);
   });
 
   it('exactly one pending hook, PTY names no agent -> still pairs unambiguously (#483)', () => {


### PR DESCRIPTION
Part of epic #481. Closes #483.

**Live-log finding reframed this phase.** The subagent 'GPU idle' symptom is NOT a routing bug — the eval fires and routing is correct (sibling daemon's events dropped as foreign; subagents forwarded). The perception is the **10-30s eval latency** of the 4B model: the prompt surfaces on the PTY before the eval finishes. That's fixed by **phase 3's in-flight flag** (hold the surface until the eval decides), so I left the cross-daemon isolation untouched.

This phase lands the safe robustness:
- **Agent-aware dedup** (`QuestionDedup` keyed by `agentId ?? 'main'`) so a subagent's identically-worded prompt doesn't suppress the main agent's.
- **Fail-safe pairing**: 2+ pending hooks from different agents + a PTY prompt naming none -> push **bare** (don't misattribute option labels across agents); one candidate still pairs.

Tests: agent-aware dedup + fail-safe pairing (no mocks). typecheck + biome clean.