### PR TITLE
Phase 3a: buffer PTY prompt during eval, push only on escalate (#484)

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -69,6 +69,19 @@ export class QuestionPresenceTracker {
    *  dropped instead of typing into the main agent's input. */
   private ptyShowingQuestion = false;
 
+  /** True while the auto-approve LLM is deciding a permission. A PTY prompt
+   *  that appears during this window is BUFFERED (not pushed): if the verdict
+   *  is approve/deny/pick the prompt is auto-handled and must never reach the
+   *  user; only an escalate verdict releases the buffered prompt. This is the
+   *  fix for "every auto-approved permission still pushed APNS" (#484) — and it
+   *  must buffer (not suppress-and-replay) because the rising-edge PTY emit
+   *  (#486) fires only once, so a suppressed prompt would never re-emit. */
+  private autoApproveInFlight = false;
+  /** The PTY prompt held while an auto-approve eval is in flight. Released by
+   *  `onAutoApproveEscalate` (verdict = escalate), discarded by the
+   *  status/clearPending resets (verdict = handled, or the prompt is gone). */
+  private bufferedDuringEval: Question | null = null;
+
   constructor(private readonly push: PushQuestion) {}
 
   /**
@@ -111,6 +124,13 @@ export class QuestionPresenceTracker {
    * numbered options), which beats crashing on a network blip during APNS.
    */
   onPTYPromptVisible(ptyQuestion: Question): void {
+    if (this.autoApproveInFlight) {
+      // A permission eval owns this prompt: buffer it, do not push yet. The
+      // verdict decides — onAutoApproveEscalate releases it; a status-leaves-
+      // waiting / clearPending reset (auto-handled, or prompt gone) discards it.
+      this.bufferedDuringEval = ptyQuestion;
+      return;
+    }
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
     if (recordKey === undefined && this.pending.size === 1) {
@@ -165,6 +185,35 @@ export class QuestionPresenceTracker {
     if (status !== 'waiting') {
       this.pending.clear();
       this.ptyShowingQuestion = false;
+      // The verdict window is over: any buffered prompt was auto-handled (the
+      // agent advanced) or left the screen. Discard it — do not ping the user.
+      this.autoApproveInFlight = false;
+      this.bufferedDuringEval = null;
+    }
+  }
+
+  /**
+   * An auto-approve LLM eval has STARTED for a permission. Until it resolves,
+   * a PTY prompt for it is buffered, not pushed (so a silently auto-approved
+   * permission never reaches the user). Paired with `onAutoApproveEscalate`
+   * (release) and the status/clearPending resets (discard).
+   */
+  onAutoApproveStart(): void {
+    this.autoApproveInFlight = true;
+  }
+
+  /**
+   * The auto-approve verdict was ESCALATE: the user must answer. End the buffer
+   * window and release the held PTY prompt (re-running the normal pair+push
+   * path, which now finds the hook record the escalation just stashed). If no
+   * prompt was buffered yet, the next `onPTYPromptVisible` pushes normally.
+   */
+  onAutoApproveEscalate(): void {
+    this.autoApproveInFlight = false;
+    const buffered = this.bufferedDuringEval;
+    this.bufferedDuringEval = null;
+    if (buffered !== null) {
+      this.onPTYPromptVisible(buffered);
     }
   }
 
@@ -177,6 +226,8 @@ export class QuestionPresenceTracker {
   clearPending(): void {
     this.pending.clear();
     this.ptyShowingQuestion = false;
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
   }
 
   /**

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -218,6 +218,19 @@ export class QuestionPresenceTracker {
   }
 
   /**
+   * The auto-approve verdict was HANDLED automatically (approve/deny/pick
+   * injected, or a subagent default-deny): the user must NOT see this prompt.
+   * Close the buffer window and discard any buffered prompt. Surgical (does not
+   * touch pending hook records of OTHER agents). EVERY `onAutoApproveStart` must
+   * be matched by exactly one of escalate / handled / a status-or-clear reset,
+   * or the buffer would stick true and silently drop later prompts.
+   */
+  onAutoApproveHandled(): void {
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
+  }
+
+  /**
    * Drop all pending hook records without firing a push, and clear the
    * PTY-presence flag. Used by the auto-approve cancelled branch and on
    * Claude restart (where the dying session's prompts must not merge stale

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -65,6 +65,12 @@ export interface AutoApproveGateDeps {
    *  absorbed rather than propagated; implementations should still prefer to
    *  handle their own errors. */
   escalate: (input: PermissionRequestHookInput) => void;
+  /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
+   *  prompt until the verdict (don't push an auto-approved permission). #484. */
+  onEvalStart?: () => void;
+  /** Called when the verdict is escalate (the user must answer), so the tracker
+   *  releases the buffered PTY prompt. #484. */
+  onEscalate?: () => void;
 }
 
 export class AutoApproveGate {
@@ -115,6 +121,9 @@ export class AutoApproveGate {
 
     // Auto-approve gate: evaluate before creating a Question object.
     if (service) {
+      // Open the buffer window: a PTY prompt that renders during the eval is
+      // held (not pushed) until we know the verdict. #484.
+      this.deps.onEvalStart?.();
       // Pass the raw suggestions array; AutoApproveService does its own strict-string
       // filtering before feeding the LLM. We forward the raw shape (rather than
       // coercing) so the multi-choice classifier can see "non-string entry" and route
@@ -261,7 +270,11 @@ export class AutoApproveGate {
    */
   private escalateToUser(input: PermissionRequestHookInput): void {
     try {
+      // escalate() stashes the hook record (onPermissionRequest -> recordPendingHook)
+      // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
+      // finds that record. Order matters; do not reorder. #484.
       this.deps.escalate(input);
+      this.deps.onEscalate?.();
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
     }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -147,11 +147,15 @@ export class AutoApproveGate {
             return;
           }
           if (result.decision === 'approve') {
-            if (!(await this.inject(input, '1', 'approved'))) this.escalateToUser(input);
+            // inject success -> auto-handled (close the buffer; user never sees
+            // it); inject failure -> escalate (which releases the buffer). #484.
+            if (await this.inject(input, '1', 'approved')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'deny') {
-            if (!(await this.inject(input, '3', 'denied'))) this.escalateToUser(input);
+            if (await this.inject(input, '3', 'denied')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'pick' && result.pickIndex !== undefined) {
@@ -159,12 +163,14 @@ export class AutoApproveGate {
             // parseMultiChoiceDecision already validated the index against options
             // length, so out-of-range values cannot reach this branch.
             if (
-              !(await this.inject(
+              await this.inject(
                 input,
                 String(result.pickIndex),
                 `multichoice-pick-${result.pickIndex}`,
-              ))
+              )
             ) {
+              this.deps.tracker.onAutoApproveHandled();
+            } else {
               this.escalateToUser(input);
             }
             return;
@@ -179,6 +185,7 @@ export class AutoApproveGate {
               `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
             );
             await this.inject(input, '3', 'subagent-escalate-default-deny', true);
+            this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
             return;
           }
           this.escalateToUser(input);
@@ -189,6 +196,7 @@ export class AutoApproveGate {
             logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
             if (isInSubagentContext()) {
               await this.inject(input, '3', 'subagent-error-default-deny', true);
+              this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
               return;
             }
             this.escalateToUser(input);
@@ -274,9 +282,13 @@ export class AutoApproveGate {
       // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
       // finds that record. Order matters; do not reorder. #484.
       this.deps.escalate(input);
-      this.deps.onEscalate?.();
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
+    } finally {
+      // Release the buffer UNCONDITIONALLY: the verdict is "user must answer".
+      // Even if escalate() threw (push will fail), the buffer must not stay
+      // locked, or every later prompt in this session would buffer forever. #484.
+      this.deps.onEscalate?.();
     }
   }
 }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -628,6 +628,10 @@ export function setupHookBridge(
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
       escalate: (i) => handlers.onPermissionRequest?.(i),
+      // #484: buffer the PTY prompt while the eval runs; release it only on an
+      // escalate verdict, so silently auto-approved permissions never push APNS.
+      onEvalStart: () => tracker.onAutoApproveStart(),
+      onEscalate: () => tracker.onAutoApproveEscalate(),
     },
     sessionId,
   );

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -319,4 +319,50 @@ describe('QuestionPresenceTracker', () => {
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
     });
   });
+
+  describe('auto-approve buffer (#484)', () => {
+    it('PTY prompt during an eval is BUFFERED, not pushed', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0); // held until the verdict
+    });
+
+    it('escalate verdict releases the buffered prompt once, merged with the hook', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0);
+      // escalate() stashes the hook record first, THEN onEscalate releases.
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate();
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('auto-approved (no escalate): status-leaves-waiting discards the buffer, never pushes', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onStatusChange('idle'); // injected silently -> agent advanced
+      expect(pushes.length).toBe(0);
+      // A later prompt (new cycle, eval window closed) pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Different prompt?'));
+      expect(pushes.length).toBe(1);
+    });
+
+    it('escalate before any PTY prompt -> the next PTY prompt pushes normally', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate(); // nothing buffered yet
+      expect(pushes.length).toBe(0);
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(1);
+    });
+  });
 });

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -364,5 +364,17 @@ describe('QuestionPresenceTracker', () => {
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
       expect(pushes.length).toBe(1);
     });
+
+    it('onAutoApproveHandled discards the buffer and closes the window (#484)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onAutoApproveHandled(); // auto-approved -> discard, no push
+      expect(pushes.length).toBe(0);
+      // Window is closed (not stuck): a later prompt pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Next?'));
+      expect(pushes.length).toBe(1);
+    });
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -155,6 +155,35 @@ describe('AutoApproveGate', () => {
     expect(escalations[0]?.tool_name).toBe('Bash');
   });
 
+  test('escalate that THROWS still fires onEscalate (buffer must not stick) (#484)', async () => {
+    // The worst outcome is a stuck buffer that silently drops later prompts.
+    // onEscalate is in a finally, so it runs even when the escalate target throws.
+    let onEscalateCalls = 0;
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const gate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => {
+          throw new Error('test: escalate target down');
+        },
+        onEscalate: () => {
+          onEscalateCalls++;
+        },
+      },
+      SID,
+    );
+    gate.handlePermissionRequest(pr());
+    await flush();
+    expect(onEscalateCalls).toBe(1);
+  });
+
   test('escalate in subagent context default-denies ("3"), never escalates', async () => {
     subagent = true;
     gateWith(evaluator(escalate)).handlePermissionRequest(pr());


### PR DESCRIPTION
Part of epic #481 (#484, item 4 — the headline APNS fix).

**Fixes the regression** where every auto-approved permission still pushed APNS. Epic #453 phase 1 dropped the permission-dedup gate, so the PTY parser re-emitted an auto-approved prompt and pushed.

**Design (your call — buffer, not suppress-and-replay):** the tracker BUFFERS a PTY prompt that appears while an auto-approve eval is in flight, and releases it ONLY on an *escalate* verdict. approve/deny/pick are auto-handled silently and the buffered prompt is discarded on status-leaves-waiting. Buffering (vs the suppress-and-replay I first sketched) is required because the rising-edge PTY emit (#486, the dup-fix) fires once — a suppressed prompt would never re-emit, silently losing a real escalation.

- Gate gains `onEvalStart` (open buffer window before `evaluate`) + `onEscalate` (release, called AFTER `escalate` stashes the hook record so the released prompt pairs with it). All escalate paths (LLM verdict + inject-failed fallbacks + no-service) route through `escalateToUser`, so they all release correctly.
- Tracker: `onAutoApproveStart`/`onAutoApproveEscalate` + buffer cleared on status-leaves-waiting / clearPending.

**Tests:** buffered-not-pushed; escalate releases once (merged with hook); auto-approved discards on status change; escalate-before-PTY pushes the next prompt. 127 pipeline tests green (incl. the hook-bridge characterization suite), typecheck + biome clean.

**Remaining in phase 3 (item 5):** native terminal notification (OSC) + mobile escalation badge — additive UX, deferred to a follow-up.