### PR TITLE
Auto-approve notification pipeline (phases 1-3a): PR-review allow-list, agent-aware dedup, APNS-only-on-escalate

### DIFF
--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -6,10 +6,12 @@
  * richer (more options, or gains allowsFreeText) — that is allowed through
  * as an upgrade and replaces the baseline.
  *
- * Single-slot tracking is deliberate: callers (`MessageAPI`) are expected
- * to clear the state on every meaningful boundary (status change away from
- * 'waiting', session reset). The window is a safety net against same-tick
- * re-renders, not a long-lived cache.
+ * Tracking is PER-AGENT (keyed by `question.agentId ?? 'main'`): a background
+ * subagent's "Allow Bash?" must NOT suppress the main agent's identically-worded
+ * prompt (they are two distinct questions the user must answer). Within one
+ * agent it is single-slot. Callers (`MessageAPI`) clear the state on every
+ * meaningful boundary (status change away from 'waiting', session reset). The
+ * window is a safety net against same-tick re-renders, not a long-lived cache.
  *
  * The fingerprint normalizes case + whitespace and truncates to 80 chars,
  * so minor terminal redraw differences don't defeat the dedup. Genuinely
@@ -18,7 +20,7 @@
  * which are usually <80 chars after normalization.
  */
 
-import { QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
+import { MAIN_AGENT_ID, QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
 
 interface LastEmitted {
   fingerprint: string;
@@ -28,7 +30,9 @@ interface LastEmitted {
 }
 
 export class QuestionDedup {
-  private last: LastEmitted | null = null;
+  /** Most-recent emission per agent (`agentId ?? 'main'`), so concurrent
+   *  prompts from different agents never suppress each other. */
+  private readonly last = new Map<string, LastEmitted>();
 
   constructor(
     private readonly windowMs: number = QUESTION_DEDUP_WINDOW_MS,
@@ -38,37 +42,38 @@ export class QuestionDedup {
   /**
    * Returns true if the question should be emitted, false to suppress.
    * On true, internal state is updated so subsequent same-fingerprint
-   * lower-rank questions are suppressed within the window.
+   * lower-rank questions FROM THE SAME AGENT are suppressed within the window.
    */
   shouldEmit(question: Question): boolean {
     const fp = fingerprint(question.text);
     const t = this.clock();
-    const last = this.last;
+    const agent = question.agentId ?? MAIN_AGENT_ID;
+    const last = this.last.get(agent);
 
-    if (last !== null && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
+    if (last !== undefined && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
       const richer =
         question.options.length > last.optionCount ||
         (question.allowsFreeText && !last.allowsFreeText);
       if (!richer) {
         console.debug(
-          `[QuestionDedup] Suppressed (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
+          `[QuestionDedup] Suppressed agent=${agent} (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
         );
         return false;
       }
     }
 
-    this.last = {
+    this.last.set(agent, {
       fingerprint: fp,
       optionCount: question.options.length,
       allowsFreeText: question.allowsFreeText,
       emittedAt: t,
-    };
+    });
     return true;
   }
 
-  /** Clear state (call on session reset / new prompt cycle). */
+  /** Clear state for all agents (call on session reset / new prompt cycle). */
   reset(): void {
-    this.last = null;
+    this.last.clear();
   }
 }
 

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -69,6 +69,19 @@ export class QuestionPresenceTracker {
    *  dropped instead of typing into the main agent's input. */
   private ptyShowingQuestion = false;
 
+  /** True while the auto-approve LLM is deciding a permission. A PTY prompt
+   *  that appears during this window is BUFFERED (not pushed): if the verdict
+   *  is approve/deny/pick the prompt is auto-handled and must never reach the
+   *  user; only an escalate verdict releases the buffered prompt. This is the
+   *  fix for "every auto-approved permission still pushed APNS" (#484) — and it
+   *  must buffer (not suppress-and-replay) because the rising-edge PTY emit
+   *  (#486) fires only once, so a suppressed prompt would never re-emit. */
+  private autoApproveInFlight = false;
+  /** The PTY prompt held while an auto-approve eval is in flight. Released by
+   *  `onAutoApproveEscalate` (verdict = escalate), discarded by the
+   *  status/clearPending resets (verdict = handled, or the prompt is gone). */
+  private bufferedDuringEval: Question | null = null;
+
   constructor(private readonly push: PushQuestion) {}
 
   /**
@@ -111,6 +124,13 @@ export class QuestionPresenceTracker {
    * numbered options), which beats crashing on a network blip during APNS.
    */
   onPTYPromptVisible(ptyQuestion: Question): void {
+    if (this.autoApproveInFlight) {
+      // A permission eval owns this prompt: buffer it, do not push yet. The
+      // verdict decides — onAutoApproveEscalate releases it; a status-leaves-
+      // waiting / clearPending reset (auto-handled, or prompt gone) discards it.
+      this.bufferedDuringEval = ptyQuestion;
+      return;
+    }
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
     if (recordKey === undefined && this.pending.size === 1) {
@@ -165,7 +185,49 @@ export class QuestionPresenceTracker {
     if (status !== 'waiting') {
       this.pending.clear();
       this.ptyShowingQuestion = false;
+      // The verdict window is over: any buffered prompt was auto-handled (the
+      // agent advanced) or left the screen. Discard it — do not ping the user.
+      this.autoApproveInFlight = false;
+      this.bufferedDuringEval = null;
     }
+  }
+
+  /**
+   * An auto-approve LLM eval has STARTED for a permission. Until it resolves,
+   * a PTY prompt for it is buffered, not pushed (so a silently auto-approved
+   * permission never reaches the user). Paired with `onAutoApproveEscalate`
+   * (release) and the status/clearPending resets (discard).
+   */
+  onAutoApproveStart(): void {
+    this.autoApproveInFlight = true;
+  }
+
+  /**
+   * The auto-approve verdict was ESCALATE: the user must answer. End the buffer
+   * window and release the held PTY prompt (re-running the normal pair+push
+   * path, which now finds the hook record the escalation just stashed). If no
+   * prompt was buffered yet, the next `onPTYPromptVisible` pushes normally.
+   */
+  onAutoApproveEscalate(): void {
+    this.autoApproveInFlight = false;
+    const buffered = this.bufferedDuringEval;
+    this.bufferedDuringEval = null;
+    if (buffered !== null) {
+      this.onPTYPromptVisible(buffered);
+    }
+  }
+
+  /**
+   * The auto-approve verdict was HANDLED automatically (approve/deny/pick
+   * injected, or a subagent default-deny): the user must NOT see this prompt.
+   * Close the buffer window and discard any buffered prompt. Surgical (does not
+   * touch pending hook records of OTHER agents). EVERY `onAutoApproveStart` must
+   * be matched by exactly one of escalate / handled / a status-or-clear reset,
+   * or the buffer would stick true and silently drop later prompts.
+   */
+  onAutoApproveHandled(): void {
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
   }
 
   /**
@@ -177,6 +239,8 @@ export class QuestionPresenceTracker {
   clearPending(): void {
     this.pending.clear();
     this.ptyShowingQuestion = false;
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
   }
 
   /**

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -54,8 +54,9 @@ export class QuestionPresenceTracker {
   /** Hook-derived questions not yet paired with PTY confirmation or cleared,
    *  keyed by agent. At most one per agent: a second hook for the SAME agent
    *  (e.g. PermissionRequest then Notification for one prompt) replaces the
-   *  first, but different agents keep separate entries. Insertion order is
-   *  preserved so the PTY-pairing fallback can pick the most recent. */
+   *  first, but different agents keep separate entries. A PTY prompt pairs with
+   *  the same-agent entry, or (only when exactly one entry exists) the sole
+   *  candidate; with 2+ different-agent entries it pushes bare (no guessing). */
   private pending = new Map<string, Question>();
 
   /** True while a permission prompt is on the main PTY. Set by
@@ -95,9 +96,11 @@ export class QuestionPresenceTracker {
 
   /**
    * PTY parser saw a prompt on screen. Push immediately. Pair with a hook
-   * record for option labels / agent_id: prefer the same agent, else fall
-   * back to the most-recent pending hook (PTY output does not reliably name
-   * the agent — #425). When paired, the hook contributes `options` and
+   * record for option labels / agent_id: prefer the same-agent entry, else the
+   * sole pending hook when exactly one exists (unambiguous). With 2+ pending
+   * hooks from different agents and no agent match, push bare to avoid
+   * misattributing another agent's labels (#425 / #483). When paired, the hook
+   * contributes `options` and
    * `agentId` (so the client keys the prompt to the right agent) while PTY
    * contributes `id` / `text` / `allowsFreeText` / `isAnswered` (it reflects
    * the screen). The consumed hook entry is removed.
@@ -110,16 +113,23 @@ export class QuestionPresenceTracker {
   onPTYPromptVisible(ptyQuestion: Question): void {
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
-    if (recordKey === undefined && this.pending.size > 0) {
-      // Most-recent pending hook (Map preserves insertion order). The PTY did
-      // not name an agent we have a record for, so this may attach the wrong
-      // agent's option labels (#425). Log it so the misattribution is
-      // observable rather than silent.
-      const keys = [...this.pending.keys()];
-      recordKey = keys[keys.length - 1];
+    if (recordKey === undefined && this.pending.size === 1) {
+      // Exactly one pending hook and the PTY did not name an agent we have a
+      // record for: pairing is unambiguous (one candidate), so attach it.
+      recordKey = [...this.pending.keys()][0];
+    } else if (recordKey === undefined && this.pending.size > 1) {
+      // 2+ pending hooks from DIFFERENT agents and the PTY question matches
+      // none: do NOT guess. Pairing the most-recent would attach the wrong
+      // agent's option labels (#425). Push the bare PTY question instead — its
+      // numbered options suffice for the user to answer — and log loudly so the
+      // ambiguity is observable rather than a silent misattribution.
       console.warn(
-        `[QuestionPresenceTracker] PTY prompt (agent "${key}") has no matching hook; pairing most-recent "${recordKey}" of [${keys.join(', ')}] — option labels may be misattributed`,
+        `[QuestionPresenceTracker] PTY prompt (agent "${key}") matches none of [${[...this.pending.keys()].join(', ')}]; pushing bare to avoid cross-agent misattribution`,
       );
+      // The ambiguous hooks are unresolvable for this prompt; drop them so they
+      // can't stale-merge onto a later unrelated prompt (recordKey stays
+      // undefined here, so the delete below would otherwise skip them).
+      this.pending.clear();
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -65,6 +65,12 @@ export interface AutoApproveGateDeps {
    *  absorbed rather than propagated; implementations should still prefer to
    *  handle their own errors. */
   escalate: (input: PermissionRequestHookInput) => void;
+  /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
+   *  prompt until the verdict (don't push an auto-approved permission). #484. */
+  onEvalStart?: () => void;
+  /** Called when the verdict is escalate (the user must answer), so the tracker
+   *  releases the buffered PTY prompt. #484. */
+  onEscalate?: () => void;
 }
 
 export class AutoApproveGate {
@@ -115,6 +121,9 @@ export class AutoApproveGate {
 
     // Auto-approve gate: evaluate before creating a Question object.
     if (service) {
+      // Open the buffer window: a PTY prompt that renders during the eval is
+      // held (not pushed) until we know the verdict. #484.
+      this.deps.onEvalStart?.();
       // Pass the raw suggestions array; AutoApproveService does its own strict-string
       // filtering before feeding the LLM. We forward the raw shape (rather than
       // coercing) so the multi-choice classifier can see "non-string entry" and route
@@ -138,11 +147,15 @@ export class AutoApproveGate {
             return;
           }
           if (result.decision === 'approve') {
-            if (!(await this.inject(input, '1', 'approved'))) this.escalateToUser(input);
+            // inject success -> auto-handled (close the buffer; user never sees
+            // it); inject failure -> escalate (which releases the buffer). #484.
+            if (await this.inject(input, '1', 'approved')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'deny') {
-            if (!(await this.inject(input, '3', 'denied'))) this.escalateToUser(input);
+            if (await this.inject(input, '3', 'denied')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'pick' && result.pickIndex !== undefined) {
@@ -150,12 +163,14 @@ export class AutoApproveGate {
             // parseMultiChoiceDecision already validated the index against options
             // length, so out-of-range values cannot reach this branch.
             if (
-              !(await this.inject(
+              await this.inject(
                 input,
                 String(result.pickIndex),
                 `multichoice-pick-${result.pickIndex}`,
-              ))
+              )
             ) {
+              this.deps.tracker.onAutoApproveHandled();
+            } else {
               this.escalateToUser(input);
             }
             return;
@@ -170,6 +185,7 @@ export class AutoApproveGate {
               `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
             );
             await this.inject(input, '3', 'subagent-escalate-default-deny', true);
+            this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
             return;
           }
           this.escalateToUser(input);
@@ -180,6 +196,7 @@ export class AutoApproveGate {
             logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
             if (isInSubagentContext()) {
               await this.inject(input, '3', 'subagent-error-default-deny', true);
+              this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
               return;
             }
             this.escalateToUser(input);
@@ -261,9 +278,17 @@ export class AutoApproveGate {
    */
   private escalateToUser(input: PermissionRequestHookInput): void {
     try {
+      // escalate() stashes the hook record (onPermissionRequest -> recordPendingHook)
+      // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
+      // finds that record. Order matters; do not reorder. #484.
       this.deps.escalate(input);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
+    } finally {
+      // Release the buffer UNCONDITIONALLY: the verdict is "user must answer".
+      // Even if escalate() threw (push will fail), the buffer must not stay
+      // locked, or every later prompt in this session would buffer forever. #484.
+      this.deps.onEscalate?.();
     }
   }
 }

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -27,6 +27,11 @@ DEFAULT GUIDELINES:
 APPROVE these operations:
 - Read/Glob/Grep: all file reads and searches
 - Bash: git status, git log, git diff, git branch, git show, git stash list
+- Bash: read-only repo/CLI queries that only FETCH data (no mutation), e.g.
+  gh pr view/diff/list/status/checks, gh issue view/list, gh run view/list,
+  gh api <path> with a BARE path and NO -X/--method and NO -f/-F/--field/
+  --raw-field flags (a bare gh api path is a GET). These read a remote but
+  change nothing, so they are safe (this is the common /review-pr command set).
 - Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
@@ -39,7 +44,12 @@ ESCALATE these operations (ask the user):
 - Bash: git add, git commit, git push, git checkout, git merge, git rebase, git reset
 - Bash: file creation, modification, or deletion under the project tree
 - Bash: package install (bun add, npm install, pip install, uv add, etc.)
-- Bash: anything that talks to a remote (curl POST, gh api with POST/PUT/DELETE, ssh)
+- Bash: remote MUTATIONS or pushes — git push, gh pr merge/close/create,
+  gh pr review, gh pr checkout, gh issue create/close, curl/wget POST, ssh, and
+  any gh api that mutates: -X/--method POST/PUT/DELETE/PATCH OR ANY
+  -f/-F/--field/--raw-field flag (adding parameters silently switches gh api
+  from GET to POST). Read-only gh/git fetches are approvable per above; this is
+  for anything that CHANGES remote state.
 - Bash: any command you are not sure about
 - Any tool not listed above
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -628,6 +628,10 @@ export function setupHookBridge(
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
       escalate: (i) => handlers.onPermissionRequest?.(i),
+      // #484: buffer the PTY prompt while the eval runs; release it only on an
+      // escalate verdict, so silently auto-approved permissions never push APNS.
+      onEvalStart: () => tracker.onAutoApproveStart(),
+      onEscalate: () => tracker.onAutoApproveEscalate(),
     },
     sessionId,
   );

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -108,7 +108,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
     base_url: 'http://localhost:11434/v1',
     timeout: 30,
     log_decisions: true,
-    allow: [],
+    // Safe read-only TOOLS, fast-pathed without an LLM call. These are
+    // tool-name matches (not Bash substrings), so a compound command cannot
+    // bypass them — `Read` matches the Read tool, never a `Bash` string. Bash
+    // git/gh commands are intentionally NOT defaulted here (substring matching
+    // is compound-command-unsafe); the LLM prompt evaluates those in full.
+    allow: ['Read', 'Glob', 'Grep'],
     deny: [],
     instructions: '',
     multichoice: 'skip',

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -41,6 +41,20 @@ describe('QuestionDedup', () => {
     expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(false);
   });
 
+  test('does NOT suppress an identical prompt from a DIFFERENT agent (#483)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    // Main agent asks; then a background subagent asks the identical thing.
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3) })).toBe(true);
+    t += 200;
+    const subagent: Question = { ...q('Allow Bash: ls', 3), agentId: 'subagent-A' };
+    // Different agent -> a genuinely distinct question the user must answer.
+    expect(dedup.shouldEmit(subagent)).toBe(true);
+    // But the subagent's own re-emit within the window is still suppressed.
+    t += 100;
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3), agentId: 'subagent-A' })).toBe(false);
+  });
+
   test('suppresses same-fingerprint question with fewer options within window', () => {
     let t = 1000;
     const dedup = new QuestionDedup(5000, () => t);

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -57,6 +57,33 @@ describe('QuestionPresenceTracker', () => {
     expect(tracker.hasPendingForTest()).toBe(false);
   });
 
+  it('2+ pending hooks from different agents, PTY names none -> pushes BARE (#483)', () => {
+    // Fail-safe: concurrent prompts from two subagents + a PTY question that
+    // matches neither must NOT guess — push the bare PTY question rather than
+    // attach the wrong agent's option labels (#425).
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash A?'), agentId: 'subagent-A' });
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Edit B?'), agentId: 'subagent-B' });
+    const ptyQ = makePTYQuestion('Some prompt'); // no agentId -> 'main', matches neither
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]).toBe(ptyQ); // bare, not merged
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['1', '2', '3']);
+    // Ambiguous hooks are dropped, not leaked into the next prompt cycle.
+    expect(tracker.hasPendingForTest()).toBe(false);
+  });
+
+  it('exactly one pending hook, PTY names no agent -> still pairs unambiguously (#483)', () => {
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash?'), agentId: 'subagent-A' });
+    const ptyQ = makePTYQuestion('Allow Bash?'); // no agentId, but only one candidate
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+  });
+
   it('hook then PTY — pushes once with merged options from hook metadata', () => {
     const pushes: Question[] = [];
     const tracker = new QuestionPresenceTracker((q) => pushes.push(q));

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -319,4 +319,62 @@ describe('QuestionPresenceTracker', () => {
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
     });
   });
+
+  describe('auto-approve buffer (#484)', () => {
+    it('PTY prompt during an eval is BUFFERED, not pushed', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0); // held until the verdict
+    });
+
+    it('escalate verdict releases the buffered prompt once, merged with the hook', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0);
+      // escalate() stashes the hook record first, THEN onEscalate releases.
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate();
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('auto-approved (no escalate): status-leaves-waiting discards the buffer, never pushes', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onStatusChange('idle'); // injected silently -> agent advanced
+      expect(pushes.length).toBe(0);
+      // A later prompt (new cycle, eval window closed) pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Different prompt?'));
+      expect(pushes.length).toBe(1);
+    });
+
+    it('escalate before any PTY prompt -> the next PTY prompt pushes normally', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate(); // nothing buffered yet
+      expect(pushes.length).toBe(0);
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(1);
+    });
+
+    it('onAutoApproveHandled discards the buffer and closes the window (#484)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onAutoApproveHandled(); // auto-approved -> discard, no push
+      expect(pushes.length).toBe(0);
+      // Window is closed (not stuck): a later prompt pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Next?'));
+      expect(pushes.length).toBe(1);
+    });
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -155,6 +155,35 @@ describe('AutoApproveGate', () => {
     expect(escalations[0]?.tool_name).toBe('Bash');
   });
 
+  test('escalate that THROWS still fires onEscalate (buffer must not stick) (#484)', async () => {
+    // The worst outcome is a stuck buffer that silently drops later prompts.
+    // onEscalate is in a finally, so it runs even when the escalate target throws.
+    let onEscalateCalls = 0;
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const gate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => {
+          throw new Error('test: escalate target down');
+        },
+        onEscalate: () => {
+          onEscalateCalls++;
+        },
+      },
+      SID,
+    );
+    gate.handlePermissionRequest(pr());
+    await flush();
+    expect(onEscalateCalls).toBe(1);
+  });
+
   test('escalate in subagent context default-denies ("3"), never escalates', async () => {
     subagent = true;
     gateWith(evaluator(escalate)).handlePermissionRequest(pr());

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -89,4 +89,20 @@ describe('buildPrompt', () => {
     const [system] = buildPrompt('Bash', { command: 'ls && cat foo' });
     expect(system?.content).toContain('Compound commands');
   });
+
+  test('system prompt approves read-only gh queries and escalates gh mutations (#482)', () => {
+    // PR review (/review-pr) leans on read-only gh; without this clause the
+    // catch-all "talks to a remote -> escalate" rule made the LLM escalate
+    // every gh command. Read-only fetches approve; remote mutations escalate.
+    const [system] = buildPrompt('Bash', { command: 'gh pr view 123' });
+    const content = system?.content ?? '';
+    expect(content).toContain('gh pr view');
+    expect(content).toContain('gh api'); // GET approvable, mutating verbs escalate
+    expect(content).toContain('gh pr merge'); // named as an escalation
+    // The approve clause must mention fetching read-only data without mutation.
+    expect(content.toLowerCase()).toContain('fetch data');
+    // `gh api -f/-F` silently switches GET->POST, so the field flags must be
+    // named as an escalation (a 4B model would otherwise read it as a GET).
+    expect(content).toContain('--field');
+  });
 });

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -145,6 +145,18 @@ describe('applyEnvOverrides', () => {
     expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
   });
 
+  test('auto-approve stays opt-in but defaults safe read-only tools in allow (#482)', () => {
+    // Off by default (the trust line we never cross silently).
+    expect(DEFAULT_CONFIG.auto_approve.enabled).toBe(false);
+    // Read-only TOOL-NAME matches (not Bash substrings) so a compound command
+    // cannot bypass them; these fast-path file reads without an LLM call.
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Read');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Glob');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Grep');
+    // No Bash command substrings are defaulted (compound-command-unsafe).
+    expect(DEFAULT_CONFIG.auto_approve.allow.some((p) => p.includes(' '))).toBe(false);
+  });
+
   test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
     process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
@@ -290,7 +302,7 @@ describe('auto_approve config', () => {
       base_url: 'http://localhost:11434/v1',
       timeout: 30,
       log_decisions: true,
-      allow: [],
+      allow: ['Read', 'Glob', 'Grep'],
       deny: [],
       instructions: '',
       multichoice: 'skip',
@@ -402,10 +414,12 @@ Escalate anything touching secrets.
     expect(config.auto_approve.instructions).toContain('Escalate anything touching secrets');
   });
 
-  test('allow/deny default to empty arrays', () => {
+  test('allow defaults to safe read-only tools; deny/instructions default empty (#482)', () => {
+    // An [auto_approve] section that omits `allow` inherits the safe read-only
+    // tool defaults (Read/Glob/Grep); deny and instructions stay empty.
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nenabled = true\n');
     const config = loadConfig(TEST_CONFIG);
-    expect(config.auto_approve.allow).toEqual([]);
+    expect(config.auto_approve.allow).toEqual(['Read', 'Glob', 'Grep']);
     expect(config.auto_approve.deny).toEqual([]);
     expect(config.auto_approve.instructions).toBe('');
   });


### PR DESCRIPTION
Ships phases 1-3a of epic #481 (items 2, 3, and 4). **Does not close #481** — items 5 (terminal cue + mobile badge) and 6 (cross-client dismissal + token pruning) follow.

Each phase was individually reviewed + merged to the epic branch; this is the integration PR.

## Phase 1 (#482) — PR-review auto-approve
Default `allow` = `['Read','Glob','Grep']` (tool-name matches, compound-safe; opt-in stays `enabled:false`). Prompt approves read-only `gh`/`git` fetches and escalates remote mutations (incl. the `gh api -f/-F` silent-POST hole).

## Phase 2 (#483) — agent-aware dedup + fail-safe pairing
`QuestionDedup` is per-agent so a subagent's prompt no longer suppresses the main agent's identical one. Tracker pairing pushes bare (no misattribution) when 2+ different-agent hooks are ambiguous; clears ambiguous hooks so they can't stale-merge.

## Phase 3a (#484, item 4) — APNS only on escalate (the headline)
Fixes the regression where every auto-approved permission still pushed APNS (epic #453 phase 1 dropped the dedup gate). The tracker now **buffers** a PTY prompt while the auto-approve eval is in flight and pushes only on an **escalate** verdict; approve/deny/pick are discarded. Buffer (not suppress-and-replay) is required because the rising-edge PTY emit (#486) fires once. Every verdict path closes the buffer window (escalate-throws uses a `finally`; auto-handled paths call `onAutoApproveHandled`).

## Safety
All changes are flag-independent (no behavior gated on a flag). The auto-approve gate stays opt-in. No device-token lifecycle touched. The most dangerous failure mode (a buffered escalation silently lost) is covered by tests for every close path.

## Test plan
Per-phase unit tests (no mocks) + the hook-bridge characterization suite green at each merge. CI (biome/typecheck/test 60%) gates this PR.