### PR TITLE
Release 0.6.2: auto-approve notification pipeline + duplicate-notif fix

### DIFF
--- a/.github/workflows/auto-bump-dev.yml
+++ b/.github/workflows/auto-bump-dev.yml
@@ -1,0 +1,66 @@
+name: Auto Bump Dev
+
+# Increment the -dev.N counter on every push to develop, so each dev build has a
+# unique version. Version-only: NO builds and NO npm publish (those happen on
+# main via release.yml, triggered by stable version tags). Stable releases and
+# the post-release main->develop sync are handled by the auto-release and
+# sync-develop jobs in ci.yml.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize bumps so two quick pushes can't race the branch push.
+  group: auto-bump-dev
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+
+jobs:
+  bump:
+    name: Auto Bump Dev
+    # Skip the bot's own bump commits (so this never loops) and any commit that
+    # opts out with [skip-bump] in its message.
+    if: >-
+      github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
+      && !startsWith(github.event.head_commit.message, 'chore: bump version to')
+      && !contains(github.event.head_commit.message, '[skip-bump]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Bump dev counter and push branch (no tag)
+        run: |
+          CURRENT=$(jq -r '.version' package.json)
+          if [[ ! "$CURRENT" =~ -dev\.[0-9]+$ ]]; then
+            echo "Version $CURRENT has no -dev.N suffix; nothing to increment."
+            echo "Start a new dev line with bump-version.sh patch|minor|major first."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bun install --frozen-lockfile
+          ./scripts/bump-version.sh dev
+          # Push the branch only. bump-version.sh also creates a local v<ver> tag
+          # which we intentionally do NOT push — dev versions are never released.
+          git push origin develop

--- a/.github/workflows/auto-bump-dev.yml
+++ b/.github/workflows/auto-bump-dev.yml
@@ -25,11 +25,14 @@ jobs:
   bump:
     name: Auto Bump Dev
     # Skip the bot's own bump commits (so this never loops) and any commit that
-    # opts out with [skip-bump] in its message.
+    # opts out with [skip-bump]. The message prefix is the primary guard — it
+    # exactly matches bump-version.sh's commit; the author-email checks (both
+    # noreply forms GitHub may emit) are belt-and-suspenders.
     if: >-
-      github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
-      && !startsWith(github.event.head_commit.message, 'chore: bump version to')
+      !startsWith(github.event.head_commit.message, 'chore: bump version to')
       && !contains(github.event.head_commit.message, '[skip-bump]')
+      && github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
+      && github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com'
     runs-on: ubuntu-latest
     steps:
       - name: Generate App Token
@@ -64,3 +67,10 @@ jobs:
           # Push the branch only. bump-version.sh also creates a local v<ver> tag
           # which we intentionally do NOT push — dev versions are never released.
           git push origin develop
+          # Belt-and-suspenders: a dev tag must never reach origin (it would
+          # trigger release.yml). Fail loudly if a future edit ever pushes one.
+          NEW=$(jq -r '.version' package.json)
+          if git ls-remote --tags origin "refs/tags/v$NEW" | grep -q .; then
+            echo "ERROR: dev tag v$NEW was unexpectedly pushed to origin" >&2
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,37 +155,51 @@ bun run build:binary   # /opt/homebrew/bin/remi picks it up
 
 ## Releasing
 
-**Always use `bump-version.sh`** — never hand-edit version numbers.
+**Always use `bump-version.sh`** — never hand-edit version numbers. Most of the
+release flow is automated by CI; you rarely run the script by hand.
+
+**What's automated:**
+
+- **Dev counter** — `auto-bump-dev.yml` increments `-dev.N` on every push to
+  `develop` (e.g. `0.6.2-dev.1` → `0.6.2-dev.2`). Version-only; no builds or
+  publishes. Skip it on a given commit with `[skip-bump]` in the message.
+- **Stable release** — merging `develop` → `main` triggers `auto-release`
+  (ci.yml): it strips the `-dev.N` suffix, commits, and pushes the stable tag
+  `vX.Y.Z`, which triggers `release.yml` (per-platform binary build, npm
+  `@latest` publish to `@yooz-labs/remi` + platform packages, GitHub release,
+  Homebrew tap update).
+- **Post-release sync** — `sync-develop` (ci.yml) then merges `main` back into
+  `develop` and bumps to the next dev line (`X.Y.Z` → `X.Y.(Z+1)-dev.1`).
+
+**What you do by hand:**
 
 ```bash
-# Dev release on develop (npm @dev tag, GitHub prerelease)
-git checkout develop
-./scripts/bump-version.sh --push dev   # 0.4.3 → 0.4.4-dev.1
-./scripts/bump-version.sh --push dev   # 0.4.4-dev.1 → 0.4.4-dev.2
+# Cut a release: PR develop -> main (never push to main directly), merge when
+# green. CI does the strip/tag/publish/sync. Update CHANGELOG before the PR.
 
-# Promote to main when stable (CI strips dev suffix and releases)
-git checkout main && git merge develop && git push origin main
-# CI: 0.4.4-dev.6 → 0.4.4 (tag + npm publish + Homebrew)
+# Start a new minor/major (or explicit) line on develop, via a normal PR.
+# The dev counter then auto-increments from there on each push.
+./scripts/bump-version.sh minor          # 0.6.x-dev.N -> 0.7.0-dev.1
+./scripts/bump-version.sh major          # -> 1.0.0-dev.1
+./scripts/bump-version.sh set 1.2.0-dev.1
+# 'dev' (manual counter bump) and 'patch' still exist but are rarely needed
+# now that auto-bump-dev / sync-develop handle them.
 
-# After release: sync develop and start the next dev cycle
-git checkout develop && git merge origin/main && git push origin develop
-./scripts/bump-version.sh --push dev   # 0.4.4 → 0.4.5-dev.1
-
-# Stable release (CI: build, npm @latest, GitHub release, Homebrew)
-./scripts/bump-version.sh --push patch     # 0.4.4-dev.2 → 0.4.4
-./scripts/bump-version.sh --push minor     # 0.3.9 → 0.4.0
-./scripts/bump-version.sh --push major     # 0.3.9 → 1.0.0
-./scripts/bump-version.sh --push set 1.0.0 # explicit
-
-# Without --push: commits and tags locally, prints push commands
-./scripts/bump-version.sh patch
+# Without --push: commits + tags locally, prints push commands.
 ```
 
-The script updates `package.json` and the `REMI_COMPILED_VERSION` fallback in `cli.ts`, commits, tags, and (with `--push`) pushes to trigger the release pipeline.
+The script updates `package.json` and the `REMI_COMPILED_VERSION` fallback in
+`cli.ts`, commits, and tags. `stable` is blocked on `develop` (CI-only).
 
 ## CI
 
-GitHub Actions on push / PR to `main`: `bunx biome check`, `bun run typecheck`, `bun test --coverage` with a 60% minimum threshold.
+GitHub Actions:
+- **Gates** (PR to `main`/`develop`, push to `main`): `bunx biome check`,
+  `bun run typecheck`, `bun test --coverage` (60% minimum), spelling (`typos`).
+- **auto-bump-dev** (push to `develop`): increments the dev counter.
+- **auto-release + sync-develop** (push to `main`): stable release + dev sync.
+- **release.yml** (stable `vX.Y.Z` tag): build, npm publish, GitHub release,
+  Homebrew.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-07
+
+A pass over the question -> auto-approve -> notification pipeline, plus a
+duplicate-notification fix and CI automation.
+
+### Fixed
+- Duplicate APNS notifications: the output processor re-emitted the same
+  on-screen prompt on every parse cycle (a fresh question id each time),
+  flooding the notification pipeline. It now emits a question only on the
+  rising edge (when the on-screen prompt actually changes), cleared when the
+  agent leaves the `waiting` state (#486).
+
+### Changed
+- Auto-approve now buffers a permission prompt while the local LLM is
+  evaluating it and pushes a notification **only when the verdict is
+  escalate** (the user must answer). Auto-approved/denied permissions no
+  longer fire a phantom push. Auto-approve remains opt-in (`enabled = false`),
+  and read-only tools (`Read`/`Glob`/`Grep`) plus read-only `gh`/`git` queries
+  are approved by default while remote mutations escalate (#482, #484).
+- Question dedup is now per-agent, so a background subagent's prompt no longer
+  suppresses the main agent's identically-worded one; ambiguous cross-agent
+  prompts are surfaced without misattributed option labels (#483).
+
+### Internal
+- `auto-bump-dev` workflow: the `-dev.N` counter now increments automatically
+  on every push to `develop` (version-only; no publish) (#479).
+
 ## [0.6.1] - 2026-06-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.2-dev.1",
+  "version": "0.6.2-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.2-dev.3",
+  "version": "0.6.2-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.2-dev.2",
+  "version": "0.6.2-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.2-dev.4",
+  "version": "0.6.2-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.1",
+  "version": "0.6.2-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -6,10 +6,12 @@
  * richer (more options, or gains allowsFreeText) — that is allowed through
  * as an upgrade and replaces the baseline.
  *
- * Single-slot tracking is deliberate: callers (`MessageAPI`) are expected
- * to clear the state on every meaningful boundary (status change away from
- * 'waiting', session reset). The window is a safety net against same-tick
- * re-renders, not a long-lived cache.
+ * Tracking is PER-AGENT (keyed by `question.agentId ?? 'main'`): a background
+ * subagent's "Allow Bash?" must NOT suppress the main agent's identically-worded
+ * prompt (they are two distinct questions the user must answer). Within one
+ * agent it is single-slot. Callers (`MessageAPI`) clear the state on every
+ * meaningful boundary (status change away from 'waiting', session reset). The
+ * window is a safety net against same-tick re-renders, not a long-lived cache.
  *
  * The fingerprint normalizes case + whitespace and truncates to 80 chars,
  * so minor terminal redraw differences don't defeat the dedup. Genuinely
@@ -18,7 +20,7 @@
  * which are usually <80 chars after normalization.
  */
 
-import { QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
+import { MAIN_AGENT_ID, QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
 
 interface LastEmitted {
   fingerprint: string;
@@ -28,7 +30,9 @@ interface LastEmitted {
 }
 
 export class QuestionDedup {
-  private last: LastEmitted | null = null;
+  /** Most-recent emission per agent (`agentId ?? 'main'`), so concurrent
+   *  prompts from different agents never suppress each other. */
+  private readonly last = new Map<string, LastEmitted>();
 
   constructor(
     private readonly windowMs: number = QUESTION_DEDUP_WINDOW_MS,
@@ -38,37 +42,38 @@ export class QuestionDedup {
   /**
    * Returns true if the question should be emitted, false to suppress.
    * On true, internal state is updated so subsequent same-fingerprint
-   * lower-rank questions are suppressed within the window.
+   * lower-rank questions FROM THE SAME AGENT are suppressed within the window.
    */
   shouldEmit(question: Question): boolean {
     const fp = fingerprint(question.text);
     const t = this.clock();
-    const last = this.last;
+    const agent = question.agentId ?? MAIN_AGENT_ID;
+    const last = this.last.get(agent);
 
-    if (last !== null && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
+    if (last !== undefined && t - last.emittedAt < this.windowMs && last.fingerprint === fp) {
       const richer =
         question.options.length > last.optionCount ||
         (question.allowsFreeText && !last.allowsFreeText);
       if (!richer) {
         console.debug(
-          `[QuestionDedup] Suppressed (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
+          `[QuestionDedup] Suppressed agent=${agent} (lastOpts=${last.optionCount}, newOpts=${question.options.length}, ageMs=${t - last.emittedAt}): ${question.text.slice(0, 80)}`,
         );
         return false;
       }
     }
 
-    this.last = {
+    this.last.set(agent, {
       fingerprint: fp,
       optionCount: question.options.length,
       allowsFreeText: question.allowsFreeText,
       emittedAt: t,
-    };
+    });
     return true;
   }
 
-  /** Clear state (call on session reset / new prompt cycle). */
+  /** Clear state for all agents (call on session reset / new prompt cycle). */
   reset(): void {
-    this.last = null;
+    this.last.clear();
   }
 }
 

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -69,6 +69,19 @@ export class QuestionPresenceTracker {
    *  dropped instead of typing into the main agent's input. */
   private ptyShowingQuestion = false;
 
+  /** True while the auto-approve LLM is deciding a permission. A PTY prompt
+   *  that appears during this window is BUFFERED (not pushed): if the verdict
+   *  is approve/deny/pick the prompt is auto-handled and must never reach the
+   *  user; only an escalate verdict releases the buffered prompt. This is the
+   *  fix for "every auto-approved permission still pushed APNS" (#484) — and it
+   *  must buffer (not suppress-and-replay) because the rising-edge PTY emit
+   *  (#486) fires only once, so a suppressed prompt would never re-emit. */
+  private autoApproveInFlight = false;
+  /** The PTY prompt held while an auto-approve eval is in flight. Released by
+   *  `onAutoApproveEscalate` (verdict = escalate), discarded by the
+   *  status/clearPending resets (verdict = handled, or the prompt is gone). */
+  private bufferedDuringEval: Question | null = null;
+
   constructor(private readonly push: PushQuestion) {}
 
   /**
@@ -111,6 +124,13 @@ export class QuestionPresenceTracker {
    * numbered options), which beats crashing on a network blip during APNS.
    */
   onPTYPromptVisible(ptyQuestion: Question): void {
+    if (this.autoApproveInFlight) {
+      // A permission eval owns this prompt: buffer it, do not push yet. The
+      // verdict decides — onAutoApproveEscalate releases it; a status-leaves-
+      // waiting / clearPending reset (auto-handled, or prompt gone) discards it.
+      this.bufferedDuringEval = ptyQuestion;
+      return;
+    }
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
     if (recordKey === undefined && this.pending.size === 1) {
@@ -165,7 +185,49 @@ export class QuestionPresenceTracker {
     if (status !== 'waiting') {
       this.pending.clear();
       this.ptyShowingQuestion = false;
+      // The verdict window is over: any buffered prompt was auto-handled (the
+      // agent advanced) or left the screen. Discard it — do not ping the user.
+      this.autoApproveInFlight = false;
+      this.bufferedDuringEval = null;
     }
+  }
+
+  /**
+   * An auto-approve LLM eval has STARTED for a permission. Until it resolves,
+   * a PTY prompt for it is buffered, not pushed (so a silently auto-approved
+   * permission never reaches the user). Paired with `onAutoApproveEscalate`
+   * (release) and the status/clearPending resets (discard).
+   */
+  onAutoApproveStart(): void {
+    this.autoApproveInFlight = true;
+  }
+
+  /**
+   * The auto-approve verdict was ESCALATE: the user must answer. End the buffer
+   * window and release the held PTY prompt (re-running the normal pair+push
+   * path, which now finds the hook record the escalation just stashed). If no
+   * prompt was buffered yet, the next `onPTYPromptVisible` pushes normally.
+   */
+  onAutoApproveEscalate(): void {
+    this.autoApproveInFlight = false;
+    const buffered = this.bufferedDuringEval;
+    this.bufferedDuringEval = null;
+    if (buffered !== null) {
+      this.onPTYPromptVisible(buffered);
+    }
+  }
+
+  /**
+   * The auto-approve verdict was HANDLED automatically (approve/deny/pick
+   * injected, or a subagent default-deny): the user must NOT see this prompt.
+   * Close the buffer window and discard any buffered prompt. Surgical (does not
+   * touch pending hook records of OTHER agents). EVERY `onAutoApproveStart` must
+   * be matched by exactly one of escalate / handled / a status-or-clear reset,
+   * or the buffer would stick true and silently drop later prompts.
+   */
+  onAutoApproveHandled(): void {
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
   }
 
   /**
@@ -177,6 +239,8 @@ export class QuestionPresenceTracker {
   clearPending(): void {
     this.pending.clear();
     this.ptyShowingQuestion = false;
+    this.autoApproveInFlight = false;
+    this.bufferedDuringEval = null;
   }
 
   /**

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -54,8 +54,9 @@ export class QuestionPresenceTracker {
   /** Hook-derived questions not yet paired with PTY confirmation or cleared,
    *  keyed by agent. At most one per agent: a second hook for the SAME agent
    *  (e.g. PermissionRequest then Notification for one prompt) replaces the
-   *  first, but different agents keep separate entries. Insertion order is
-   *  preserved so the PTY-pairing fallback can pick the most recent. */
+   *  first, but different agents keep separate entries. A PTY prompt pairs with
+   *  the same-agent entry, or (only when exactly one entry exists) the sole
+   *  candidate; with 2+ different-agent entries it pushes bare (no guessing). */
   private pending = new Map<string, Question>();
 
   /** True while a permission prompt is on the main PTY. Set by
@@ -95,9 +96,11 @@ export class QuestionPresenceTracker {
 
   /**
    * PTY parser saw a prompt on screen. Push immediately. Pair with a hook
-   * record for option labels / agent_id: prefer the same agent, else fall
-   * back to the most-recent pending hook (PTY output does not reliably name
-   * the agent — #425). When paired, the hook contributes `options` and
+   * record for option labels / agent_id: prefer the same-agent entry, else the
+   * sole pending hook when exactly one exists (unambiguous). With 2+ pending
+   * hooks from different agents and no agent match, push bare to avoid
+   * misattributing another agent's labels (#425 / #483). When paired, the hook
+   * contributes `options` and
    * `agentId` (so the client keys the prompt to the right agent) while PTY
    * contributes `id` / `text` / `allowsFreeText` / `isAnswered` (it reflects
    * the screen). The consumed hook entry is removed.
@@ -110,16 +113,23 @@ export class QuestionPresenceTracker {
   onPTYPromptVisible(ptyQuestion: Question): void {
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
-    if (recordKey === undefined && this.pending.size > 0) {
-      // Most-recent pending hook (Map preserves insertion order). The PTY did
-      // not name an agent we have a record for, so this may attach the wrong
-      // agent's option labels (#425). Log it so the misattribution is
-      // observable rather than silent.
-      const keys = [...this.pending.keys()];
-      recordKey = keys[keys.length - 1];
+    if (recordKey === undefined && this.pending.size === 1) {
+      // Exactly one pending hook and the PTY did not name an agent we have a
+      // record for: pairing is unambiguous (one candidate), so attach it.
+      recordKey = [...this.pending.keys()][0];
+    } else if (recordKey === undefined && this.pending.size > 1) {
+      // 2+ pending hooks from DIFFERENT agents and the PTY question matches
+      // none: do NOT guess. Pairing the most-recent would attach the wrong
+      // agent's option labels (#425). Push the bare PTY question instead — its
+      // numbered options suffice for the user to answer — and log loudly so the
+      // ambiguity is observable rather than a silent misattribution.
       console.warn(
-        `[QuestionPresenceTracker] PTY prompt (agent "${key}") has no matching hook; pairing most-recent "${recordKey}" of [${keys.join(', ')}] — option labels may be misattributed`,
+        `[QuestionPresenceTracker] PTY prompt (agent "${key}") matches none of [${[...this.pending.keys()].join(', ')}]; pushing bare to avoid cross-agent misattribution`,
       );
+      // The ambiguous hooks are unresolvable for this prompt; drop them so they
+      // can't stale-merge onto a later unrelated prompt (recordKey stays
+      // undefined here, so the delete below would otherwise skip them).
+      this.pending.clear();
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -65,6 +65,12 @@ export interface AutoApproveGateDeps {
    *  absorbed rather than propagated; implementations should still prefer to
    *  handle their own errors. */
   escalate: (input: PermissionRequestHookInput) => void;
+  /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
+   *  prompt until the verdict (don't push an auto-approved permission). #484. */
+  onEvalStart?: () => void;
+  /** Called when the verdict is escalate (the user must answer), so the tracker
+   *  releases the buffered PTY prompt. #484. */
+  onEscalate?: () => void;
 }
 
 export class AutoApproveGate {
@@ -115,6 +121,9 @@ export class AutoApproveGate {
 
     // Auto-approve gate: evaluate before creating a Question object.
     if (service) {
+      // Open the buffer window: a PTY prompt that renders during the eval is
+      // held (not pushed) until we know the verdict. #484.
+      this.deps.onEvalStart?.();
       // Pass the raw suggestions array; AutoApproveService does its own strict-string
       // filtering before feeding the LLM. We forward the raw shape (rather than
       // coercing) so the multi-choice classifier can see "non-string entry" and route
@@ -138,11 +147,15 @@ export class AutoApproveGate {
             return;
           }
           if (result.decision === 'approve') {
-            if (!(await this.inject(input, '1', 'approved'))) this.escalateToUser(input);
+            // inject success -> auto-handled (close the buffer; user never sees
+            // it); inject failure -> escalate (which releases the buffer). #484.
+            if (await this.inject(input, '1', 'approved')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'deny') {
-            if (!(await this.inject(input, '3', 'denied'))) this.escalateToUser(input);
+            if (await this.inject(input, '3', 'denied')) this.deps.tracker.onAutoApproveHandled();
+            else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'pick' && result.pickIndex !== undefined) {
@@ -150,12 +163,14 @@ export class AutoApproveGate {
             // parseMultiChoiceDecision already validated the index against options
             // length, so out-of-range values cannot reach this branch.
             if (
-              !(await this.inject(
+              await this.inject(
                 input,
                 String(result.pickIndex),
                 `multichoice-pick-${result.pickIndex}`,
-              ))
+              )
             ) {
+              this.deps.tracker.onAutoApproveHandled();
+            } else {
               this.escalateToUser(input);
             }
             return;
@@ -170,6 +185,7 @@ export class AutoApproveGate {
               `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
             );
             await this.inject(input, '3', 'subagent-escalate-default-deny', true);
+            this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
             return;
           }
           this.escalateToUser(input);
@@ -180,6 +196,7 @@ export class AutoApproveGate {
             logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
             if (isInSubagentContext()) {
               await this.inject(input, '3', 'subagent-error-default-deny', true);
+              this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
               return;
             }
             this.escalateToUser(input);
@@ -261,9 +278,17 @@ export class AutoApproveGate {
    */
   private escalateToUser(input: PermissionRequestHookInput): void {
     try {
+      // escalate() stashes the hook record (onPermissionRequest -> recordPendingHook)
+      // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
+      // finds that record. Order matters; do not reorder. #484.
       this.deps.escalate(input);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
+    } finally {
+      // Release the buffer UNCONDITIONALLY: the verdict is "user must answer".
+      // Even if escalate() threw (push will fail), the buffer must not stay
+      // locked, or every later prompt in this session would buffer forever. #484.
+      this.deps.onEscalate?.();
     }
   }
 }

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -27,6 +27,11 @@ DEFAULT GUIDELINES:
 APPROVE these operations:
 - Read/Glob/Grep: all file reads and searches
 - Bash: git status, git log, git diff, git branch, git show, git stash list
+- Bash: read-only repo/CLI queries that only FETCH data (no mutation), e.g.
+  gh pr view/diff/list/status/checks, gh issue view/list, gh run view/list,
+  gh api <path> with a BARE path and NO -X/--method and NO -f/-F/--field/
+  --raw-field flags (a bare gh api path is a GET). These read a remote but
+  change nothing, so they are safe (this is the common /review-pr command set).
 - Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
@@ -39,7 +44,12 @@ ESCALATE these operations (ask the user):
 - Bash: git add, git commit, git push, git checkout, git merge, git rebase, git reset
 - Bash: file creation, modification, or deletion under the project tree
 - Bash: package install (bun add, npm install, pip install, uv add, etc.)
-- Bash: anything that talks to a remote (curl POST, gh api with POST/PUT/DELETE, ssh)
+- Bash: remote MUTATIONS or pushes — git push, gh pr merge/close/create,
+  gh pr review, gh pr checkout, gh issue create/close, curl/wget POST, ssh, and
+  any gh api that mutates: -X/--method POST/PUT/DELETE/PATCH OR ANY
+  -f/-F/--field/--raw-field flag (adding parameters silently switches gh api
+  from GET to POST). Read-only gh/git fetches are approvable per above; this is
+  for anything that CHANGES remote state.
 - Bash: any command you are not sure about
 - Any tool not listed above
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.2-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.2-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.2-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.2-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.2-dev.4'; // REMI_COMPILED_VERSION
+      return '0.6.2-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.2-dev.4'; // REMI_COMPILED_VERSION
+    return '0.6.2-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.2-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.2-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.2-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.2-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.2-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.2-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.2-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.2-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.1'; // REMI_COMPILED_VERSION
+      return '0.6.2-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.1'; // REMI_COMPILED_VERSION
+    return '0.6.2-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -628,6 +628,10 @@ export function setupHookBridge(
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
       escalate: (i) => handlers.onPermissionRequest?.(i),
+      // #484: buffer the PTY prompt while the eval runs; release it only on an
+      // escalate verdict, so silently auto-approved permissions never push APNS.
+      onEvalStart: () => tracker.onAutoApproveStart(),
+      onEscalate: () => tracker.onAutoApproveEscalate(),
     },
     sessionId,
   );

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -108,7 +108,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
     base_url: 'http://localhost:11434/v1',
     timeout: 30,
     log_decisions: true,
-    allow: [],
+    // Safe read-only TOOLS, fast-pathed without an LLM call. These are
+    // tool-name matches (not Bash substrings), so a compound command cannot
+    // bypass them — `Read` matches the Read tool, never a `Bash` string. Bash
+    // git/gh commands are intentionally NOT defaulted here (substring matching
+    // is compound-command-unsafe); the LLM prompt evaluates those in full.
+    allow: ['Read', 'Glob', 'Grep'],
     deny: [],
     instructions: '',
     multichoice: 'skip',

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -63,6 +63,19 @@ const DEFAULT_BUFFER_SIZE = 4096;
  * - Parsing questions and status
  * - Progressive updates for long outputs
  */
+/**
+ * Stable fingerprint of a prompt's content (NOT its id, which is minted fresh
+ * on every parse). Two detections of the same on-screen prompt produce the same
+ * fingerprint, so the rising-edge gate can suppress the re-emit. Keyed on the
+ * normalized text + option values + free-text flag — a genuine prompt change
+ * (different text or options) yields a different fingerprint and re-emits.
+ */
+function questionFingerprint(q: Question): string {
+  const text = q.text.trim().toLowerCase().replace(/\s+/g, ' ');
+  const opts = q.options.map((o) => o.value).join('');
+  return `${text}${opts}${q.allowsFreeText ? 'f' : ''}`;
+}
+
 export class OutputProcessor {
   private readonly config: Required<ProcessorConfig>;
   private readonly events: Partial<OutputEvents>;
@@ -73,6 +86,10 @@ export class OutputProcessor {
   private currentStatus: AgentStatus = 'idle';
   private lastUpdateTime = 0;
   private pendingQuestion: Question | null = null;
+  /** Fingerprint of the prompt currently on screen, so the SAME prompt
+   *  re-parsed on later buffer cycles is not re-emitted as a new question
+   *  (rising-edge gate). Cleared when status leaves 'waiting'. */
+  private pendingQuestionFp: string | null = null;
   private seenContent: Set<string> = new Set(); // Track unique content chunks
   private hasEmittedCurrentMessage = false; // Track if onMessage was called for currentMessageId
 
@@ -125,6 +142,7 @@ export class OutputProcessor {
     this.currentStatus = 'idle';
     this.lastUpdateTime = 0;
     this.pendingQuestion = null;
+    this.pendingQuestionFp = null;
     this.seenContent.clear();
     this.hasEmittedCurrentMessage = false;
   }
@@ -178,15 +196,30 @@ export class OutputProcessor {
     const statusResult = parseStatus(content);
     if (statusResult.status !== this.currentStatus && statusResult.confidence >= 0.5) {
       this.currentStatus = statusResult.status;
+      // The prompt (if any) is gone once the agent advances past 'waiting'.
+      // Clear the rising-edge gate so the NEXT prompt — even one with identical
+      // text — re-emits instead of being mistaken for the one just answered.
+      if (statusResult.status !== 'waiting') {
+        this.pendingQuestion = null;
+        this.pendingQuestionFp = null;
+      }
       this.events.onStatusChange?.(statusResult.status, statusResult.context);
     }
 
-    // Check for questions
+    // Check for questions. A prompt that stays on screen is re-parsed on every
+    // buffer cycle; emitting it each time mints a fresh question id and floods
+    // the notification pipeline (downstream dedup can't catch a new id once its
+    // window lapses). Emit only on the RISING EDGE — when the on-screen prompt's
+    // fingerprint actually changes. See #486.
     if (hasQuestionIndicator(content)) {
       const parseResult = parseQuestion(content);
       if (parseResult.detected && parseResult.question) {
-        this.pendingQuestion = parseResult.question;
-        this.events.onQuestion?.(parseResult.question);
+        const fp = questionFingerprint(parseResult.question);
+        if (fp !== this.pendingQuestionFp) {
+          this.pendingQuestion = parseResult.question;
+          this.pendingQuestionFp = fp;
+          this.events.onQuestion?.(parseResult.question);
+        }
       }
     }
 

--- a/packages/daemon/src/parser/output-processor.ts
+++ b/packages/daemon/src/parser/output-processor.ts
@@ -130,6 +130,11 @@ export class OutputProcessor {
     if (this.currentMessageId !== null) {
       this.finalizeMessage();
     }
+
+    // Drop the rising-edge gate on PTY exit so a reused processor can't suppress
+    // the next session's first identical prompt. (flush() is exit-only.)
+    this.pendingQuestion = null;
+    this.pendingQuestionFp = null;
   }
 
   /**
@@ -196,10 +201,18 @@ export class OutputProcessor {
     const statusResult = parseStatus(content);
     if (statusResult.status !== this.currentStatus && statusResult.confidence >= 0.5) {
       this.currentStatus = statusResult.status;
-      // The prompt (if any) is gone once the agent advances past 'waiting'.
-      // Clear the rising-edge gate so the NEXT prompt — even one with identical
-      // text — re-emits instead of being mistaken for the one just answered.
+      // Clear the rising-edge gate at BOTH edges of a non-waiting span so the
+      // NEXT prompt — even one with identical text — re-emits instead of being
+      // mistaken for the one just answered. We bias toward re-emit (a duplicate
+      // is recoverable; a missed prompt is not): the gate only suppresses
+      // re-parses WITHIN a single 'waiting' span.
       if (statusResult.status !== 'waiting') {
+        // Left 'waiting': the prompt (if any) is gone.
+        this.pendingQuestion = null;
+        this.pendingQuestionFp = null;
+      } else if (this.currentStatus !== 'waiting') {
+        // Entered 'waiting' from a non-waiting state: a fresh prompt cycle, so
+        // a same-text prompt must not be suppressed as the previous one.
         this.pendingQuestion = null;
         this.pendingQuestionFp = null;
       }

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -41,6 +41,20 @@ describe('QuestionDedup', () => {
     expect(dedup.shouldEmit(q('Allow Bash: ls', 3))).toBe(false);
   });
 
+  test('does NOT suppress an identical prompt from a DIFFERENT agent (#483)', () => {
+    let t = 1000;
+    const dedup = new QuestionDedup(5000, () => t);
+    // Main agent asks; then a background subagent asks the identical thing.
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3) })).toBe(true);
+    t += 200;
+    const subagent: Question = { ...q('Allow Bash: ls', 3), agentId: 'subagent-A' };
+    // Different agent -> a genuinely distinct question the user must answer.
+    expect(dedup.shouldEmit(subagent)).toBe(true);
+    // But the subagent's own re-emit within the window is still suppressed.
+    t += 100;
+    expect(dedup.shouldEmit({ ...q('Allow Bash: ls', 3), agentId: 'subagent-A' })).toBe(false);
+  });
+
   test('suppresses same-fingerprint question with fewer options within window', () => {
     let t = 1000;
     const dedup = new QuestionDedup(5000, () => t);

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -57,6 +57,33 @@ describe('QuestionPresenceTracker', () => {
     expect(tracker.hasPendingForTest()).toBe(false);
   });
 
+  it('2+ pending hooks from different agents, PTY names none -> pushes BARE (#483)', () => {
+    // Fail-safe: concurrent prompts from two subagents + a PTY question that
+    // matches neither must NOT guess — push the bare PTY question rather than
+    // attach the wrong agent's option labels (#425).
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash A?'), agentId: 'subagent-A' });
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Edit B?'), agentId: 'subagent-B' });
+    const ptyQ = makePTYQuestion('Some prompt'); // no agentId -> 'main', matches neither
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]).toBe(ptyQ); // bare, not merged
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['1', '2', '3']);
+    // Ambiguous hooks are dropped, not leaked into the next prompt cycle.
+    expect(tracker.hasPendingForTest()).toBe(false);
+  });
+
+  it('exactly one pending hook, PTY names no agent -> still pairs unambiguously (#483)', () => {
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash?'), agentId: 'subagent-A' });
+    const ptyQ = makePTYQuestion('Allow Bash?'); // no agentId, but only one candidate
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes.length).toBe(1);
+    expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+  });
+
   it('hook then PTY — pushes once with merged options from hook metadata', () => {
     const pushes: Question[] = [];
     const tracker = new QuestionPresenceTracker((q) => pushes.push(q));

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -319,4 +319,62 @@ describe('QuestionPresenceTracker', () => {
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
     });
   });
+
+  describe('auto-approve buffer (#484)', () => {
+    it('PTY prompt during an eval is BUFFERED, not pushed', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0); // held until the verdict
+    });
+
+    it('escalate verdict releases the buffered prompt once, merged with the hook', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0);
+      // escalate() stashes the hook record first, THEN onEscalate releases.
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate();
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('auto-approved (no escalate): status-leaves-waiting discards the buffer, never pushes', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onStatusChange('idle'); // injected silently -> agent advanced
+      expect(pushes.length).toBe(0);
+      // A later prompt (new cycle, eval window closed) pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Different prompt?'));
+      expect(pushes.length).toBe(1);
+    });
+
+    it('escalate before any PTY prompt -> the next PTY prompt pushes normally', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate(); // nothing buffered yet
+      expect(pushes.length).toBe(0);
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(1);
+    });
+
+    it('onAutoApproveHandled discards the buffer and closes the window (#484)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
+      tracker.onAutoApproveHandled(); // auto-approved -> discard, no push
+      expect(pushes.length).toBe(0);
+      // Window is closed (not stuck): a later prompt pushes normally.
+      tracker.onPTYPromptVisible(makePTYQuestion('Next?'));
+      expect(pushes.length).toBe(1);
+    });
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -155,6 +155,35 @@ describe('AutoApproveGate', () => {
     expect(escalations[0]?.tool_name).toBe('Bash');
   });
 
+  test('escalate that THROWS still fires onEscalate (buffer must not stick) (#484)', async () => {
+    // The worst outcome is a stuck buffer that silently drops later prompts.
+    // onEscalate is in a finally, so it runs even when the escalate target throws.
+    let onEscalateCalls = 0;
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const gate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => {
+          throw new Error('test: escalate target down');
+        },
+        onEscalate: () => {
+          onEscalateCalls++;
+        },
+      },
+      SID,
+    );
+    gate.handlePermissionRequest(pr());
+    await flush();
+    expect(onEscalateCalls).toBe(1);
+  });
+
   test('escalate in subagent context default-denies ("3"), never escalates', async () => {
     subagent = true;
     gateWith(evaluator(escalate)).handlePermissionRequest(pr());

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -89,4 +89,20 @@ describe('buildPrompt', () => {
     const [system] = buildPrompt('Bash', { command: 'ls && cat foo' });
     expect(system?.content).toContain('Compound commands');
   });
+
+  test('system prompt approves read-only gh queries and escalates gh mutations (#482)', () => {
+    // PR review (/review-pr) leans on read-only gh; without this clause the
+    // catch-all "talks to a remote -> escalate" rule made the LLM escalate
+    // every gh command. Read-only fetches approve; remote mutations escalate.
+    const [system] = buildPrompt('Bash', { command: 'gh pr view 123' });
+    const content = system?.content ?? '';
+    expect(content).toContain('gh pr view');
+    expect(content).toContain('gh api'); // GET approvable, mutating verbs escalate
+    expect(content).toContain('gh pr merge'); // named as an escalation
+    // The approve clause must mention fetching read-only data without mutation.
+    expect(content.toLowerCase()).toContain('fetch data');
+    // `gh api -f/-F` silently switches GET->POST, so the field flags must be
+    // named as an escalation (a 4B model would otherwise read it as a GET).
+    expect(content).toContain('--field');
+  });
 });

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -145,6 +145,18 @@ describe('applyEnvOverrides', () => {
     expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
   });
 
+  test('auto-approve stays opt-in but defaults safe read-only tools in allow (#482)', () => {
+    // Off by default (the trust line we never cross silently).
+    expect(DEFAULT_CONFIG.auto_approve.enabled).toBe(false);
+    // Read-only TOOL-NAME matches (not Bash substrings) so a compound command
+    // cannot bypass them; these fast-path file reads without an LLM call.
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Read');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Glob');
+    expect(DEFAULT_CONFIG.auto_approve.allow).toContain('Grep');
+    // No Bash command substrings are defaulted (compound-command-unsafe).
+    expect(DEFAULT_CONFIG.auto_approve.allow.some((p) => p.includes(' '))).toBe(false);
+  });
+
   test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
     process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
@@ -290,7 +302,7 @@ describe('auto_approve config', () => {
       base_url: 'http://localhost:11434/v1',
       timeout: 30,
       log_decisions: true,
-      allow: [],
+      allow: ['Read', 'Glob', 'Grep'],
       deny: [],
       instructions: '',
       multichoice: 'skip',
@@ -402,10 +414,12 @@ Escalate anything touching secrets.
     expect(config.auto_approve.instructions).toContain('Escalate anything touching secrets');
   });
 
-  test('allow/deny default to empty arrays', () => {
+  test('allow defaults to safe read-only tools; deny/instructions default empty (#482)', () => {
+    // An [auto_approve] section that omits `allow` inherits the safe read-only
+    // tool defaults (Read/Glob/Grep); deny and instructions stay empty.
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nenabled = true\n');
     const config = loadConfig(TEST_CONFIG);
-    expect(config.auto_approve.allow).toEqual([]);
+    expect(config.auto_approve.allow).toEqual(['Read', 'Glob', 'Grep']);
     expect(config.auto_approve.deny).toEqual([]);
     expect(config.auto_approve.instructions).toBe('');
   });

--- a/packages/daemon/tests/output-processor.test.ts
+++ b/packages/daemon/tests/output-processor.test.ts
@@ -132,6 +132,39 @@ describe('OutputProcessor', () => {
     expect(questions[0]?.text).toBe('Do you want to proceed?');
   });
 
+  test('emits onQuestion only on the rising edge: same prompt re-parsed does not re-emit (#486)', () => {
+    const questions: Question[] = [];
+    const processor = new OutputProcessor({ sessionId }, { onQuestion: (q) => questions.push(q) });
+
+    // The same on-screen prompt re-parsed across buffer cycles must emit ONCE
+    // (it is one pending question, not many). This is the duplicate-APNS source.
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(1);
+
+    // Agent advances past 'waiting' -> the rising-edge gate clears.
+    processor.process('Thinking...\n');
+    processor.flush();
+
+    // A new decision with identical text must re-emit (not be mistaken for the
+    // one just answered).
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(2);
+  });
+
+  test('a genuinely different prompt re-emits without a status change (#486)', () => {
+    const questions: Question[] = [];
+    const processor = new OutputProcessor({ sessionId }, { onQuestion: (q) => questions.push(q) });
+
+    processor.process('Do you want to proceed? (y/n)\n');
+    processor.process('Overwrite the existing file? (y/n)\n');
+    processor.flush();
+    expect(questions.length).toBe(2);
+  });
+
   test('does not emit messages in streamStatusOnly mode', () => {
     const messages: Message[] = [];
     const processor = new OutputProcessor(


### PR DESCRIPTION
## Release 0.6.1 -> 0.6.2

Promotes develop to main. Merging triggers the release pipeline (strip -dev -> tag vX.Y.Z -> npm @latest + platform packages + GitHub release + Homebrew).

### Highlights
- **Duplicate APNS fix** (#486) — the output processor re-emitted the same on-screen prompt every parse; now rising-edge only. (Source fix, not dedup.)
- **Auto-approve notification pipeline** (epic #481 phases 1-3a, #491):
  - **APNS only on escalate** (#484) — buffers a permission prompt during the LLM eval, pushes only on an escalate verdict. No more phantom push for auto-approved permissions.
  - **PR-review-friendly auto-approve** (#482) — read-only tool + gh/git defaults (opt-in).
  - **Agent-aware dedup** (#483) — subagent prompts don't suppress the main agent's.
- **auto-bump-dev** CI (#479).

The auto-approve gate stays opt-in (`enabled = false`); everything is flag-independent. Holistic epic->develop review was clean (composition, flag-independence, full buffer-lifecycle matrix, no regressions).

Epic #481 remains OPEN for items 5 (terminal cue + mobile badge) and 6 (cross-client dismissal + token pruning) — follow-ups, not in this release.