### PR TITLE
Phase 1: Daemon current-session redirect for stale transcript requests (#500)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -908,6 +908,7 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
+import { makeCurrentSessionResolver } from './cli/current-session.ts';
 // The primary session ID (in wrapper mode, this is the one running in the terminal).
 // Stored in cli/session-state.ts so extracted handler modules can read it via
 // getPrimarySessionId() without closing over a cli.ts-local `let` that flips
@@ -1246,10 +1247,19 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
   send: sendToConnection,
 });
 
+// The single authoritative "current owned session" accessor (#499), shared by
+// the transcript-request redirect and the hello_ack binding so they never diverge.
+const currentOwnedSession = makeCurrentSessionResolver({
+  getPrimarySessionId,
+  sessionStore,
+  transcriptDiscovery,
+});
+
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
   bindingStore,
+  currentOwnedSession,
   send: sendToConnection,
 });
 
@@ -1283,6 +1293,7 @@ const createSessionHandlers_: CreateSessionHandlers = createCreateSessionHandler
 
 const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
   sessionRegistry,
+  currentOwnedSession,
   trackConnection: (id, adapterType) => registry.trackConnection(id, adapterType),
   untrackConnection: (id) => registry.untrackConnection(id),
   onConnectionAdded: () => updateRemiStatus({ connections: remiStatus.connections + 1 }),

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -869,6 +869,10 @@ const sessionRegistry = new SessionRegistry(
     },
     onConnectionPromoted: (sessionId, connectionId, result) => {
       log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
+      // NOTE: this resolves the hello_ack binding inline rather than via
+      // currentOwnedSession() because the promoted connection may be attaching
+      // to a specific `sessionId` that is not necessarily the daemon's primary.
+      // Both read the same disk-backed store, so they stay in sync (#499).
       const stored = sessionStore.findByRemiSessionId(sessionId);
       const claudeId = stored?.claudeSessionId ?? null;
       const projPath = stored?.projectPath ?? null;

--- a/packages/daemon/src/cli/current-session.ts
+++ b/packages/daemon/src/cli/current-session.ts
@@ -1,0 +1,54 @@
+/**
+ * The daemon's single authoritative "current owned session" accessor (epic #499).
+ *
+ * One source of truth, read by BOTH the connect path (to stamp hello_ack with the
+ * live binding) and the transcript-request handler (to redirect a stale request to
+ * the current session instead of dead-ending on NOT_FOUND). Derived from the
+ * primary Remi session id + the persisted binding, which the rotation handler /
+ * TranscriptBinder keeps current — so it follows /clear rotations.
+ */
+
+import type { UUID } from '@remi/shared';
+import type { SessionStore } from '../session/session-store.ts';
+import type { TranscriptDiscovery } from '../transcript/index.ts';
+
+/** The daemon's current owned session, resolved on demand. */
+export interface CurrentOwnedSession {
+  /** The primary Remi session id (stable across /clear). */
+  readonly sessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
+  readonly claudeSessionId: UUID | null;
+  /** The current transcript file path; null if the Claude id/project is unknown. */
+  readonly transcriptPath: string | null;
+}
+
+export interface CurrentSessionResolverDeps {
+  /** Reads the primary Remi session id (the per-process global). */
+  getPrimarySessionId: () => UUID | null;
+  sessionStore: Pick<SessionStore, 'findByRemiSessionId'>;
+  transcriptDiscovery: Pick<TranscriptDiscovery, 'getProjectTranscriptDir'>;
+}
+
+/**
+ * Build the resolver. Returns null when the daemon has no primary session.
+ * Mirrors the transcript-path derivation used by the connection promote path
+ * (`<projectTranscriptDir>/<claudeSessionId>.jsonl`) so all hello_ack bindings
+ * agree on one path scheme.
+ */
+export function makeCurrentSessionResolver(
+  deps: CurrentSessionResolverDeps,
+): () => CurrentOwnedSession | null {
+  const { getPrimarySessionId, sessionStore, transcriptDiscovery } = deps;
+  return () => {
+    const sessionId = getPrimarySessionId();
+    if (!sessionId) return null;
+    const stored = sessionStore.findByRemiSessionId(sessionId);
+    const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
+    const projectPath = stored?.projectPath ?? null;
+    const transcriptPath =
+      claudeSessionId && projectPath
+        ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
+        : null;
+    return { sessionId, claudeSessionId, transcriptPath };
+  };
+}

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -18,12 +18,16 @@ import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
 import type { SessionRegistry } from '../../session/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface ConnectionHandlerDeps {
   sessionRegistry: SessionRegistry;
+  /** Resolves the daemon's current owned session so every hello_ack carries the
+   *  authoritative claudeSessionId + transcriptPath the client must follow (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   /** Forward to AdapterRegistry.trackConnection. */
   trackConnection: (connectionId: UUID, adapterType: string) => void;
   /** Forward to AdapterRegistry.untrackConnection. */
@@ -42,6 +46,7 @@ export type ConnectionHandlers = ReturnType<typeof createConnectionHandlers>;
 export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
   const {
     sessionRegistry,
+    currentOwnedSession,
     trackConnection,
     untrackConnection,
     onConnectionAdded,
@@ -49,6 +54,15 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
     cancelOrphanTimeout,
     send,
   } = deps;
+
+  /** The current binding for hello_ack: {claudeSessionId, transcriptPath}. */
+  const currentBinding = (): { claudeSessionId: UUID | null; transcriptPath: string | null } => {
+    const current = currentOwnedSession();
+    return {
+      claudeSessionId: current?.claudeSessionId ?? null,
+      transcriptPath: current?.transcriptPath ?? null,
+    };
+  };
 
   return {
     onConnect: async (connectionId: UUID, metadata: AdapterMetadata): Promise<void> => {
@@ -90,11 +104,16 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
           if (result.success) {
             send(
               connectionId,
-              createHelloAck('1.0.0', currentPrimary, {
-                isResume: result.replayMessages.length > 0,
-                replayCount: result.replayMessages.length,
-                nextBulletId: result.nextBulletId,
-              }),
+              createHelloAck(
+                '1.0.0',
+                currentPrimary,
+                {
+                  isResume: result.replayMessages.length > 0,
+                  replayCount: result.replayMessages.length,
+                  nextBulletId: result.nextBulletId,
+                },
+                currentBinding(),
+              ),
             );
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
@@ -106,8 +125,9 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
         }
 
         // Query mode or attach failed (session busy); send hello_ack without
-        // attach so utility clients (ls, kill) can still send requests.
-        send(connectionId, createHelloAck('1.0.0', currentPrimary));
+        // attach so utility clients (ls, kill) can still send requests. Still
+        // carry the binding so the client follows the current session (#499).
+        send(connectionId, createHelloAck('1.0.0', currentPrimary, undefined, currentBinding()));
         log(
           `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
         );

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -12,7 +12,7 @@
  */
 
 import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
-import type { UUID } from '@remi/shared';
+import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
 import type { SessionBindingStore } from '../../session/index.ts';
@@ -22,6 +22,7 @@ import type {
 } from '../../transcript/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../../transcript/index.ts';
 import type { AssistantEntry } from '../../transcript/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
@@ -32,13 +33,16 @@ export interface TranscriptHandlerDeps {
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
   bindingStore: SessionBindingStore;
+  /** Resolves the daemon's current owned session, so a stale/unknown request is
+   *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, bindingStore, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, bindingStore, currentOwnedSession, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -84,9 +88,20 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       }
 
       if (!filePath) {
+        // Don't dead-end: tell the client the daemon's current authoritative
+        // session so it can re-bind + re-fetch instead of getting stuck on a
+        // stale id (the "Transcript for session X not found" screenshot) (#499).
+        const current = currentOwnedSession();
+        const details: Record<string, unknown> | undefined = current
+          ? ({
+              currentSessionId: current.sessionId,
+              currentClaudeSessionId: current.claudeSessionId,
+              currentTranscriptPath: current.transcriptPath,
+            } satisfies StaleSessionErrorDetails)
+          : undefined;
         send(
           connectionId,
-          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`),
+          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`, details),
         );
         return;
       }

--- a/packages/daemon/tests/cli/current-session.test.ts
+++ b/packages/daemon/tests/cli/current-session.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { makeCurrentSessionResolver } from '../../src/cli/current-session.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+
+let tmpDir: string;
+let projectsDir: string;
+let sessionStore: SessionStore;
+let transcriptDiscovery: TranscriptDiscovery;
+
+const REMI = 'aaaaaaaa-0000-0000-0000-000000000000' as UUID;
+const CLAUDE = '22222222-2222-2222-2222-222222222222';
+const PROJECT = '/Users/test/project';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-current-session-'));
+  projectsDir = path.join(tmpDir, 'claude-projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+  transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function resolver(primary: UUID | null) {
+  return makeCurrentSessionResolver({
+    getPrimarySessionId: () => primary,
+    sessionStore,
+    transcriptDiscovery,
+  });
+}
+
+test('returns null when there is no primary session', () => {
+  expect(resolver(null)()).toBeNull();
+});
+
+test('resolves claudeSessionId + transcriptPath from the stored binding', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: CLAUDE,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current).not.toBeNull();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBe(CLAUDE as UUID);
+  // <projectTranscriptDir>/<claudeSessionId>.jsonl, dirs encoded with '-'.
+  expect(current?.transcriptPath).toBe(
+    `${transcriptDiscovery.getProjectTranscriptDir(PROJECT)}/${CLAUDE}.jsonl`,
+  );
+});
+
+test('claudeSessionId + transcriptPath are null when the binding is unbound', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: null,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});
+
+test('claude id present but no stored record -> null binding (sessionId still returned)', () => {
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createConnectionHandlers } from '../../../src/cli/handlers/connection-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import {
@@ -61,9 +62,10 @@ describe('createConnectionHandlers', () => {
     await sessionRegistry.shutdown();
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createConnectionHandlers({
       sessionRegistry,
+      currentOwnedSession,
       trackConnection: (id, type) => {
         trackedConnections.push({ id, type });
       },
@@ -113,6 +115,31 @@ describe('createConnectionHandlers', () => {
       expect(msg.type).toBe('hello_ack');
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
       expect(cancelOrphanCalls).toBe(1);
+    });
+
+    test('helloAck carries the authoritative current binding (#499)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+      const current: CurrentOwnedSession = {
+        sessionId,
+        claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+        transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+      };
+
+      await makeHandlers(() => current).onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const ack = sendCalls[0]?.message as {
+        type: string;
+        claudeSessionId?: string | null;
+        transcriptPath?: string | null;
+      };
+      expect(ack.type).toBe('hello_ack');
+      expect(ack.claudeSessionId).toBe(current.claudeSessionId);
+      expect(ack.transcriptPath).toBe(current.transcriptPath);
     });
 
     test('query-mode clients get a helloAck without attaching', async () => {

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
@@ -69,11 +70,12 @@ describe('createTranscriptHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
+      currentOwnedSession,
       send,
     });
   }
@@ -94,6 +96,44 @@ describe('createTranscriptHandlers', () => {
     const msg = sendCalls[0]?.message as { type: string; code?: string };
     expect(msg.type).toBe('error');
     expect(msg.code).toBe('NOT_FOUND');
+  });
+
+  test('NOT_FOUND redirects to the daemon current session (#499)', async () => {
+    // A stale request must not dead-end: the error carries the current session
+    // so the client can re-bind + re-fetch instead of getting stuck.
+    const current: CurrentOwnedSession = {
+      sessionId: 'cccccccc-0000-0000-0000-000000000000' as UUID,
+      claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+      transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+    };
+    makeHandlers(() => current).onTranscriptLoadRequest(
+      CID,
+      'd8f1613d-15a3-4f16-94e2-667b740d5fd0',
+      REQ,
+    );
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as {
+      code?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toEqual({
+      currentSessionId: current.sessionId,
+      currentClaudeSessionId: current.claudeSessionId,
+      currentTranscriptPath: current.transcriptPath,
+    });
+  });
+
+  test('NOT_FOUND details omitted when the daemon has no owned session', async () => {
+    makeHandlers(() => null).onTranscriptLoadRequest(
+      CID,
+      'bogus0-0000-0000-0000-000000000000',
+      REQ,
+    );
+    const msg = sendCalls[0]?.message as { code?: string; details?: unknown };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toBeUndefined();
   });
 
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,7 @@ export type {
   PingMessage,
   PongMessage,
   ErrorMessage,
+  StaleSessionErrorDetails,
   ReplayBatchMessage,
   BulletExpandRequestMessage,
   BulletExpandResponseMessage,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -285,9 +285,10 @@ export interface ErrorMessage {
  * All fields may be null if the daemon currently has no owned session.
  */
 export interface StaleSessionErrorDetails {
-  /** The daemon's current Remi session id. */
-  readonly currentSessionId: UUID | null;
-  /** The current Claude session id (rotates on /clear). */
+  /** The daemon's current Remi session id. Always present (the daemon only
+   *  attaches these details when it has a current owned session). */
+  readonly currentSessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
   readonly currentClaudeSessionId: UUID | null;
   /** The current transcript file path. */
   readonly currentTranscriptPath: string | null;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -277,6 +277,22 @@ export interface ErrorMessage {
   readonly details?: Record<string, unknown> | undefined;
 }
 
+/**
+ * Details attached to a `NOT_FOUND` error for a stale transcript/session request
+ * (epic #499). When a client asks for a session the daemon no longer owns, the
+ * daemon answers with its current authoritative session so the client can
+ * self-correct (re-bind + re-fetch) instead of dead-ending on "not found".
+ * All fields may be null if the daemon currently has no owned session.
+ */
+export interface StaleSessionErrorDetails {
+  /** The daemon's current Remi session id. */
+  readonly currentSessionId: UUID | null;
+  /** The current Claude session id (rotates on /clear). */
+  readonly currentClaudeSessionId: UUID | null;
+  /** The current transcript file path. */
+  readonly currentTranscriptPath: string | null;
+}
+
 /** Batch of messages to replay on session resume */
 export interface ReplayBatchMessage {
   readonly type: 'replay_batch';


### PR DESCRIPTION
Phase 1 of epic #499. Closes #500.

## What
The daemon stops dead-ending stale transcript requests. When a client asks for a session the daemon no longer owns, it now answers with its **current authoritative session** so the client can re-bind + re-fetch — instead of the stuck "Transcript for session X not found" screen.

- New `cli/current-session.ts` — one `makeCurrentSessionResolver()` returning the daemon's current owned `{sessionId, claudeSessionId, transcriptPath}` from the primary id + persisted binding (kept current by the rotation handler / TranscriptBinder, so it follows `/clear`). Single source of truth, read by both the redirect and `hello_ack`.
- `transcript-events.ts` — on an unknown/stale id, attach `StaleSessionErrorDetails` (`currentSessionId` / `currentClaudeSessionId` / `currentTranscriptPath`) to the `NOT_FOUND` error.
- `connection-events.ts` — the connect-path `hello_ack` now **always** carries the authoritative binding (it previously omitted it, so the client got no current session on connect).
- shared: `StaleSessionErrorDetails` type.

## Scope
Per the approved plan: **no binder default flip** (it drives via the existing flag, which is set in the user's config); **enrich the existing response** (no new protocol message).

## Tests
- `current-session.test.ts` resolver unit tests (real `SessionStore` + `TranscriptDiscovery`, no mocks).
- `transcript-events.test.ts` — NOT_FOUND now carries the redirect details (and omits them when the daemon has no owned session).
- `connection-events.test.ts` — hello_ack carries the binding.
- Full daemon + shared sweep green (1017 pass); typecheck + biome clean.
- Real-Claude e2e (`/clear` → serves new transcript; stale id → redirect) to run via the manual `tests/e2e/transcript-binding/` harness after Phase 2 (client consumes the redirect).
