### PR TITLE
Epic #499 (phases 1-2): transcript source of truth + client follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Session source of truth (epic #499): the client no longer gets stuck on
+  "Transcript for session X not found" after a daemon restart or `/clear`
+  rotation. The daemon now answers a stale transcript request with its
+  **current** session (`currentSessionId` / `currentClaudeSessionId` /
+  `currentTranscriptPath`) instead of a dead-end `NOT_FOUND`, and always
+  stamps `hello_ack` with the authoritative binding; the client follows that
+  redirect (and the reconnect-mid-rotation adopt) by switching to the current
+  session and auto-loading its transcript (#500, #501).
+
 ## [0.6.2] - 2026-06-07
 
 A pass over the question -> auto-approve -> notification pipeline, plus a

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -869,6 +869,10 @@ const sessionRegistry = new SessionRegistry(
     },
     onConnectionPromoted: (sessionId, connectionId, result) => {
       log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
+      // NOTE: this resolves the hello_ack binding inline rather than via
+      // currentOwnedSession() because the promoted connection may be attaching
+      // to a specific `sessionId` that is not necessarily the daemon's primary.
+      // Both read the same disk-backed store, so they stay in sync (#499).
       const stored = sessionStore.findByRemiSessionId(sessionId);
       const claudeId = stored?.claudeSessionId ?? null;
       const projPath = stored?.projectPath ?? null;
@@ -908,6 +912,7 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
+import { makeCurrentSessionResolver } from './cli/current-session.ts';
 // The primary session ID (in wrapper mode, this is the one running in the terminal).
 // Stored in cli/session-state.ts so extracted handler modules can read it via
 // getPrimarySessionId() without closing over a cli.ts-local `let` that flips
@@ -1246,10 +1251,19 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
   send: sendToConnection,
 });
 
+// The single authoritative "current owned session" accessor (#499), shared by
+// the transcript-request redirect and the hello_ack binding so they never diverge.
+const currentOwnedSession = makeCurrentSessionResolver({
+  getPrimarySessionId,
+  sessionStore,
+  transcriptDiscovery,
+});
+
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
   bindingStore,
+  currentOwnedSession,
   send: sendToConnection,
 });
 
@@ -1283,6 +1297,7 @@ const createSessionHandlers_: CreateSessionHandlers = createCreateSessionHandler
 
 const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
   sessionRegistry,
+  currentOwnedSession,
   trackConnection: (id, adapterType) => registry.trackConnection(id, adapterType),
   untrackConnection: (id) => registry.untrackConnection(id),
   onConnectionAdded: () => updateRemiStatus({ connections: remiStatus.connections + 1 }),

--- a/packages/daemon/src/cli/current-session.ts
+++ b/packages/daemon/src/cli/current-session.ts
@@ -1,0 +1,54 @@
+/**
+ * The daemon's single authoritative "current owned session" accessor (epic #499).
+ *
+ * One source of truth, read by BOTH the connect path (to stamp hello_ack with the
+ * live binding) and the transcript-request handler (to redirect a stale request to
+ * the current session instead of dead-ending on NOT_FOUND). Derived from the
+ * primary Remi session id + the persisted binding, which the rotation handler /
+ * TranscriptBinder keeps current — so it follows /clear rotations.
+ */
+
+import type { UUID } from '@remi/shared';
+import type { SessionStore } from '../session/session-store.ts';
+import type { TranscriptDiscovery } from '../transcript/index.ts';
+
+/** The daemon's current owned session, resolved on demand. */
+export interface CurrentOwnedSession {
+  /** The primary Remi session id (stable across /clear). */
+  readonly sessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
+  readonly claudeSessionId: UUID | null;
+  /** The current transcript file path; null if the Claude id/project is unknown. */
+  readonly transcriptPath: string | null;
+}
+
+export interface CurrentSessionResolverDeps {
+  /** Reads the primary Remi session id (the per-process global). */
+  getPrimarySessionId: () => UUID | null;
+  sessionStore: Pick<SessionStore, 'findByRemiSessionId'>;
+  transcriptDiscovery: Pick<TranscriptDiscovery, 'getProjectTranscriptDir'>;
+}
+
+/**
+ * Build the resolver. Returns null when the daemon has no primary session.
+ * Mirrors the transcript-path derivation used by the connection promote path
+ * (`<projectTranscriptDir>/<claudeSessionId>.jsonl`) so all hello_ack bindings
+ * agree on one path scheme.
+ */
+export function makeCurrentSessionResolver(
+  deps: CurrentSessionResolverDeps,
+): () => CurrentOwnedSession | null {
+  const { getPrimarySessionId, sessionStore, transcriptDiscovery } = deps;
+  return () => {
+    const sessionId = getPrimarySessionId();
+    if (!sessionId) return null;
+    const stored = sessionStore.findByRemiSessionId(sessionId);
+    const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
+    const projectPath = stored?.projectPath ?? null;
+    const transcriptPath =
+      claudeSessionId && projectPath
+        ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
+        : null;
+    return { sessionId, claudeSessionId, transcriptPath };
+  };
+}

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -18,12 +18,16 @@ import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
 import type { SessionRegistry } from '../../session/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface ConnectionHandlerDeps {
   sessionRegistry: SessionRegistry;
+  /** Resolves the daemon's current owned session so every hello_ack carries the
+   *  authoritative claudeSessionId + transcriptPath the client must follow (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   /** Forward to AdapterRegistry.trackConnection. */
   trackConnection: (connectionId: UUID, adapterType: string) => void;
   /** Forward to AdapterRegistry.untrackConnection. */
@@ -42,6 +46,7 @@ export type ConnectionHandlers = ReturnType<typeof createConnectionHandlers>;
 export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
   const {
     sessionRegistry,
+    currentOwnedSession,
     trackConnection,
     untrackConnection,
     onConnectionAdded,
@@ -49,6 +54,15 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
     cancelOrphanTimeout,
     send,
   } = deps;
+
+  /** The current binding for hello_ack: {claudeSessionId, transcriptPath}. */
+  const currentBinding = (): { claudeSessionId: UUID | null; transcriptPath: string | null } => {
+    const current = currentOwnedSession();
+    return {
+      claudeSessionId: current?.claudeSessionId ?? null,
+      transcriptPath: current?.transcriptPath ?? null,
+    };
+  };
 
   return {
     onConnect: async (connectionId: UUID, metadata: AdapterMetadata): Promise<void> => {
@@ -90,11 +104,16 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
           if (result.success) {
             send(
               connectionId,
-              createHelloAck('1.0.0', currentPrimary, {
-                isResume: result.replayMessages.length > 0,
-                replayCount: result.replayMessages.length,
-                nextBulletId: result.nextBulletId,
-              }),
+              createHelloAck(
+                '1.0.0',
+                currentPrimary,
+                {
+                  isResume: result.replayMessages.length > 0,
+                  replayCount: result.replayMessages.length,
+                  nextBulletId: result.nextBulletId,
+                },
+                currentBinding(),
+              ),
             );
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
@@ -106,8 +125,9 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
         }
 
         // Query mode or attach failed (session busy); send hello_ack without
-        // attach so utility clients (ls, kill) can still send requests.
-        send(connectionId, createHelloAck('1.0.0', currentPrimary));
+        // attach so utility clients (ls, kill) can still send requests. Still
+        // carry the binding so the client follows the current session (#499).
+        send(connectionId, createHelloAck('1.0.0', currentPrimary, undefined, currentBinding()));
         log(
           `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
         );

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -12,7 +12,7 @@
  */
 
 import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
-import type { UUID } from '@remi/shared';
+import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
 import type { SessionBindingStore } from '../../session/index.ts';
@@ -22,6 +22,7 @@ import type {
 } from '../../transcript/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../../transcript/index.ts';
 import type { AssistantEntry } from '../../transcript/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
@@ -32,13 +33,16 @@ export interface TranscriptHandlerDeps {
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
   bindingStore: SessionBindingStore;
+  /** Resolves the daemon's current owned session, so a stale/unknown request is
+   *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, bindingStore, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, bindingStore, currentOwnedSession, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -84,9 +88,20 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       }
 
       if (!filePath) {
+        // Don't dead-end: tell the client the daemon's current authoritative
+        // session so it can re-bind + re-fetch instead of getting stuck on a
+        // stale id (the "Transcript for session X not found" screenshot) (#499).
+        const current = currentOwnedSession();
+        const details: Record<string, unknown> | undefined = current
+          ? ({
+              currentSessionId: current.sessionId,
+              currentClaudeSessionId: current.claudeSessionId,
+              currentTranscriptPath: current.transcriptPath,
+            } satisfies StaleSessionErrorDetails)
+          : undefined;
         send(
           connectionId,
-          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`),
+          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`, details),
         );
         return;
       }

--- a/packages/daemon/tests/cli/current-session.test.ts
+++ b/packages/daemon/tests/cli/current-session.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { makeCurrentSessionResolver } from '../../src/cli/current-session.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+
+let tmpDir: string;
+let projectsDir: string;
+let sessionStore: SessionStore;
+let transcriptDiscovery: TranscriptDiscovery;
+
+const REMI = 'aaaaaaaa-0000-0000-0000-000000000000' as UUID;
+const CLAUDE = '22222222-2222-2222-2222-222222222222';
+const PROJECT = '/Users/test/project';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-current-session-'));
+  projectsDir = path.join(tmpDir, 'claude-projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+  transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function resolver(primary: UUID | null) {
+  return makeCurrentSessionResolver({
+    getPrimarySessionId: () => primary,
+    sessionStore,
+    transcriptDiscovery,
+  });
+}
+
+test('returns null when there is no primary session', () => {
+  expect(resolver(null)()).toBeNull();
+});
+
+test('resolves claudeSessionId + transcriptPath from the stored binding', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: CLAUDE,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current).not.toBeNull();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBe(CLAUDE as UUID);
+  // <projectTranscriptDir>/<claudeSessionId>.jsonl, dirs encoded with '-'.
+  expect(current?.transcriptPath).toBe(
+    `${transcriptDiscovery.getProjectTranscriptDir(PROJECT)}/${CLAUDE}.jsonl`,
+  );
+});
+
+test('claudeSessionId + transcriptPath are null when the binding is unbound', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: null,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});
+
+test('claude id present but no stored record -> null binding (sessionId still returned)', () => {
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createConnectionHandlers } from '../../../src/cli/handlers/connection-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import {
@@ -61,9 +62,10 @@ describe('createConnectionHandlers', () => {
     await sessionRegistry.shutdown();
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createConnectionHandlers({
       sessionRegistry,
+      currentOwnedSession,
       trackConnection: (id, type) => {
         trackedConnections.push({ id, type });
       },
@@ -113,6 +115,31 @@ describe('createConnectionHandlers', () => {
       expect(msg.type).toBe('hello_ack');
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
       expect(cancelOrphanCalls).toBe(1);
+    });
+
+    test('helloAck carries the authoritative current binding (#499)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+      const current: CurrentOwnedSession = {
+        sessionId,
+        claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+        transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+      };
+
+      await makeHandlers(() => current).onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const ack = sendCalls[0]?.message as {
+        type: string;
+        claudeSessionId?: string | null;
+        transcriptPath?: string | null;
+      };
+      expect(ack.type).toBe('hello_ack');
+      expect(ack.claudeSessionId).toBe(current.claudeSessionId);
+      expect(ack.transcriptPath).toBe(current.transcriptPath);
     });
 
     test('query-mode clients get a helloAck without attaching', async () => {

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
@@ -69,11 +70,12 @@ describe('createTranscriptHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
+      currentOwnedSession,
       send,
     });
   }
@@ -94,6 +96,44 @@ describe('createTranscriptHandlers', () => {
     const msg = sendCalls[0]?.message as { type: string; code?: string };
     expect(msg.type).toBe('error');
     expect(msg.code).toBe('NOT_FOUND');
+  });
+
+  test('NOT_FOUND redirects to the daemon current session (#499)', async () => {
+    // A stale request must not dead-end: the error carries the current session
+    // so the client can re-bind + re-fetch instead of getting stuck.
+    const current: CurrentOwnedSession = {
+      sessionId: 'cccccccc-0000-0000-0000-000000000000' as UUID,
+      claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+      transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+    };
+    makeHandlers(() => current).onTranscriptLoadRequest(
+      CID,
+      'd8f1613d-15a3-4f16-94e2-667b740d5fd0',
+      REQ,
+    );
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as {
+      code?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toEqual({
+      currentSessionId: current.sessionId,
+      currentClaudeSessionId: current.claudeSessionId,
+      currentTranscriptPath: current.transcriptPath,
+    });
+  });
+
+  test('NOT_FOUND details omitted when the daemon has no owned session', async () => {
+    makeHandlers(() => null).onTranscriptLoadRequest(
+      CID,
+      'bogus0-0000-0000-0000-000000000000',
+      REQ,
+    );
+    const msg = sendCalls[0]?.message as { code?: string; details?: unknown };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toBeUndefined();
   });
 
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,7 @@ export type {
   PingMessage,
   PongMessage,
   ErrorMessage,
+  StaleSessionErrorDetails,
   ReplayBatchMessage,
   BulletExpandRequestMessage,
   BulletExpandResponseMessage,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -277,6 +277,23 @@ export interface ErrorMessage {
   readonly details?: Record<string, unknown> | undefined;
 }
 
+/**
+ * Details attached to a `NOT_FOUND` error for a stale transcript/session request
+ * (epic #499). When a client asks for a session the daemon no longer owns, the
+ * daemon answers with its current authoritative session so the client can
+ * self-correct (re-bind + re-fetch) instead of dead-ending on "not found".
+ * All fields may be null if the daemon currently has no owned session.
+ */
+export interface StaleSessionErrorDetails {
+  /** The daemon's current Remi session id. Always present (the daemon only
+   *  attaches these details when it has a current owned session). */
+  readonly currentSessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
+  readonly currentClaudeSessionId: UUID | null;
+  /** The current transcript file path. */
+  readonly currentTranscriptPath: string | null;
+}
+
 /** Batch of messages to replay on session resume */
 export interface ReplayBatchMessage {
   readonly type: 'replay_batch';

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -172,6 +172,12 @@ function App() {
   const messagesRef = useRef(messages);
   const questionsRef = useRef(questions);
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
+  // Stable handle so handleMessage (empty deps) can re-fetch a transcript when
+  // it follows the daemon to its current session (reconnect adopt + stale
+  // redirect), without depending on requestTranscriptLoad's identity (#499).
+  const requestTranscriptLoadRef = useRef<
+    ((connId: ConnectionId, sessionId: string) => void) | null
+  >(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
   // Mirror replyContexts in a ref so handleSend can read the active
@@ -211,6 +217,15 @@ function App() {
       setMessages((prev) => prev.filter((m) => m.sessionId !== sid));
       setQuestions((prev) => clearSessionQuestions(prev, sid));
       loadedTranscriptsRef.current.delete(sid);
+    };
+
+    // Fetch a session's transcript if we haven't already, so that FOLLOWING the
+    // daemon to its current session (reconnect adopt, stale redirect) loads the
+    // chat automatically instead of waiting for a user tap (#499).
+    const ensureTranscriptLoaded = (connId: ConnectionId, sid: string) => {
+      if (loadedTranscriptsRef.current.has(sid)) return;
+      loadedTranscriptsRef.current.add(sid);
+      requestTranscriptLoadRef.current?.(connId, sid);
     };
 
     switch (message.type) {
@@ -311,6 +326,9 @@ function App() {
             setActiveSessionId(message.sessionId);
             setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
             setQuestions((prev) => clearSessionQuestions(prev, oldActive));
+            // Load the followed session's transcript so the chat isn't left
+            // empty after a reconnect-mid-rotation adopt (#499).
+            ensureTranscriptLoaded(connectionId, message.sessionId);
           }
         }
         break;
@@ -837,6 +855,66 @@ function App() {
         // packages/daemon/src/cli/handlers/input-events.ts:guardBinding;
         // update both ends together if the field names change.
         const errorCode = (message as { code?: string }).code;
+        // NOT_FOUND with a current-session redirect (#499): the requested
+        // session is stale (the daemon restarted or rotated past it). Follow the
+        // daemon to its current session and load it, instead of dead-ending on a
+        // "Transcript for session X not found" bubble the user can't escape.
+        if (errorCode === 'NOT_FOUND') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const currentSessionId = asNonEmptyString(details?.['currentSessionId']) as
+            | UUID
+            | undefined;
+          if (currentSessionId) {
+            const currentClaudeSessionId = asNonEmptyString(details?.['currentClaudeSessionId']);
+            const currentTranscriptPath = asNonEmptyString(details?.['currentTranscriptPath']);
+            const claudePatch = currentClaudeSessionId
+              ? { claudeSessionId: currentClaudeSessionId as UUID }
+              : {};
+            const transcriptPatch = currentTranscriptPath
+              ? { transcriptPath: currentTranscriptPath }
+              : {};
+            // Upsert: patch the binding if the session is already listed, else
+            // add a placeholder row (the NOT_FOUND can race ahead of the
+            // hello_ack that adds it) so setActiveSessionId has something to
+            // render instead of a blank screen (#499 review).
+            setSessions((prev) => {
+              if (prev.some((s) => s.id === currentSessionId && s.connectionId === connectionId)) {
+                return prev.map((s) =>
+                  s.id === currentSessionId && s.connectionId === connectionId
+                    ? { ...s, ...claudePatch, ...transcriptPatch }
+                    : s,
+                );
+              }
+              return [
+                ...prev,
+                {
+                  id: currentSessionId,
+                  name: 'Claude Code Session',
+                  createdAt: new Date().toISOString(),
+                  lastActiveAt: new Date().toISOString(),
+                  status: 'idle',
+                  connectionStatus: 'connected',
+                  connectionId,
+                  unreadCount: 0,
+                  preview: 'Connected',
+                  ...claudePatch,
+                  ...transcriptPatch,
+                } satisfies UISession,
+              ];
+            });
+            // Do NOT clearSessionForRebind here -- that would wipe the current
+            // session's already-rendered messages. ensureTranscriptLoaded gates
+            // on the loaded marker, so it fetches only if not already loaded
+            // (no wipe, no duplicate append) (#499 review).
+            setActiveSessionId(currentSessionId);
+            ensureTranscriptLoaded(connectionId, currentSessionId);
+            console.warn(
+              '[App] Stale transcript request; following daemon to current session',
+              currentSessionId,
+            );
+            break;
+          }
+        }
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;
@@ -964,6 +1042,7 @@ function App() {
   getSessionIdRef.current = getSessionId;
   sessionsRef.current = sessions;
   requestSessionListRef.current = requestSessionList;
+  requestTranscriptLoadRef.current = requestTranscriptLoad;
   connectionsRef.current = connections;
 
   // Derived connection status


### PR DESCRIPTION
Epic #499 (source of truth for the live session), shipping **Phases 1-2** — the core that fixes the recurring "Transcript for session X not found" / wedge / stale-binding pain on both sides.

## The point
remi had no single source of truth for "which Claude session/transcript is live." The daemon bound to a session id that rotates on `/clear`; the **app cached a stale id and requested it** even after the daemon moved on (proven by a phone screenshot: header on `cdc0a0c2`, app asked for `d8f1613d` → "not found", stuck).

## What ships
- **Phase 1 (#500)** — daemon: one authoritative `currentOwnedSession()` accessor; a stale/unknown transcript request is answered with the **current** session (`StaleSessionErrorDetails`) instead of a dead-end `NOT_FOUND`; `hello_ack` always carries the authoritative binding (it previously omitted it on connect).
- **Phase 2 (#501)** — client: follows that redirect (adopt + upsert + auto-fetch the current transcript) and auto-loads on the reconnect-mid-rotation adopt, instead of getting stuck on the not-found bubble.

Validated: the clean signal is the `transcript_path` Claude stamps on every hook event (no PTY content-parsing); content stays the stable transcript.

## Deferred (open, with reasons)
- **Phase 3 (#502) subagent/team views** — DEFERRED. Real hook data shows subagent events carry the **main** session's `transcript_path`, not the subagent's file, and nothing links `agent_id` → that file. Surfacing subagent chat needs fragile file-correlation (the hard-parsing we deliberately avoid); it needs its own research pass.
- **Phase 4 (#503) delete old binding path** — BLOCKED on flipping the TranscriptBinder to default, which was intentionally deferred (it drives via the existing flag for now).

Closes #500, #501. Part of #499 (epic stays open for #502/#503).

## Test plan
- Phase PRs individually reviewed (sonnet) + addressed.
- Daemon: resolver + redirect + hello_ack-binding unit tests; full daemon+shared sweep green (1017 pass).
- Web: tsc -b + eslint + vite build clean.
- Real-Claude e2e (`/clear` + daemon-restart → follow to current, no "not found") to run via the manual `tests/e2e/transcript-binding/` harness.
