### PR TITLE
Epic #499 phase 3: subagent views

### DIFF
--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -1,0 +1,82 @@
+/**
+ * SubagentViewRegistry — tracks the subagent conversations a session has
+ * spawned, so the client can switch the displayed view to a subagent's chat
+ * (epic #499, phase 3).
+ *
+ * Claude Code stores each subagent's transcript at a DETERMINISTIC path:
+ *   <mainTranscriptDir>/<mainSessionId>/subagents/agent-<agentId>.jsonl
+ * i.e. the main session's `.jsonl` path with its extension replaced by a
+ * per-session `subagents/` subdir. `agentId` is exactly the hook's `agent_id`.
+ * So we derive the path from the SubagentStart hook (which carries the MAIN
+ * `transcript_path` + the subagent's `agent_id`) with no scanning/correlation.
+ */
+
+export interface SubagentView {
+  /** The subagent's agent_id (matches the on-disk `agent-<id>.jsonl`). */
+  readonly agentId: string;
+  /** e.g. "general-purpose", "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType: string;
+  /** Absolute path to the subagent's transcript file. */
+  readonly transcriptPath: string;
+  /** false once SubagentStop fired; the transcript stays viewable. */
+  readonly active: boolean;
+}
+
+/**
+ * Derive a subagent transcript path from the main transcript path + agent_id.
+ * `/a/b/<mainId>.jsonl` + `agent-x` -> `/a/b/<mainId>/subagents/agent-x.jsonl`.
+ */
+export function deriveSubagentTranscriptPath(mainTranscriptPath: string, agentId: string): string {
+  const base = mainTranscriptPath.replace(/\.jsonl$/, '');
+  return `${base}/subagents/agent-${agentId}.jsonl`;
+}
+
+export class SubagentViewRegistry {
+  private readonly views = new Map<
+    string,
+    { agentType: string; transcriptPath: string; active: boolean }
+  >();
+
+  /** Record (or refresh) a subagent from a SubagentStart event. No-op without an agentId. */
+  recordStart(agentId: string | undefined, agentType: string, mainTranscriptPath: string): void {
+    if (!agentId || !mainTranscriptPath) return;
+    this.views.set(agentId, {
+      agentType,
+      transcriptPath: deriveSubagentTranscriptPath(mainTranscriptPath, agentId),
+      active: true,
+    });
+  }
+
+  /** Mark a subagent inactive (SubagentStop); keep it listed so its chat stays viewable. */
+  recordStop(agentId: string | undefined): void {
+    if (!agentId) return;
+    const v = this.views.get(agentId);
+    if (v) this.views.set(agentId, { ...v, active: false });
+  }
+
+  /** The transcript path for a known subagent, or null. */
+  resolvePath(agentId: string): string | null {
+    return this.views.get(agentId)?.transcriptPath ?? null;
+  }
+
+  /** All known subagent views (active first, then by insertion order). */
+  list(): SubagentView[] {
+    const entries = [...this.views.entries()].map(([agentId, v]) => ({
+      agentId,
+      agentType: v.agentType,
+      transcriptPath: v.transcriptPath,
+      active: v.active,
+    }));
+    // Active subagents first so the client surfaces what's running now.
+    return entries.sort((a, b) => Number(b.active) - Number(a.active));
+  }
+
+  get size(): number {
+    return this.views.size;
+  }
+
+  /** Forget all views (call on session rotation / clear). */
+  clear(): void {
+    this.views.clear();
+  }
+}

--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -36,10 +36,23 @@ export class SubagentViewRegistry {
     string,
     { agentType: string; transcriptPath: string; active: boolean }
   >();
+  /** The parent main-transcript path the current views belong to. When the
+   *  parent session rotates (/clear) its path changes, so we drop the old
+   *  session's subagents — robust regardless of which binding path drives the
+   *  rotation (the drive-mode onRotation also clears+pushes for immediacy). */
+  private currentMain: string | null = null;
 
   /** Record (or refresh) a subagent from a SubagentStart event. No-op without an agentId. */
   recordStart(agentId: string | undefined, agentType: string, mainTranscriptPath: string): void {
     if (!agentId || !mainTranscriptPath) return;
+    // agentId becomes a filesystem path segment (agent-<id>.jsonl), so reject
+    // anything that could escape the subagents dir. Real values are hex like
+    // "ab2e2dd0b25acb847"; a path-traversal payload must never reach the FS.
+    if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return;
+    if (this.currentMain !== null && this.currentMain !== mainTranscriptPath) {
+      this.views.clear();
+    }
+    this.currentMain = mainTranscriptPath;
     this.views.set(agentId, {
       agentType,
       transcriptPath: deriveSubagentTranscriptPath(mainTranscriptPath, agentId),
@@ -78,5 +91,6 @@ export class SubagentViewRegistry {
   /** Forget all views (call on session rotation / clear). */
   clear(): void {
     this.views.clear();
+    this.currentMain = null;
   }
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -823,6 +823,10 @@ const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new 
 // transcript_binder_enabled is off (no binder is ever constructed).
 const binderClosers: Map<UUID, () => void> = new Map();
 const sessionStore = new SessionStore();
+// Tracks the subagent chats the primary session spawns, so the client can
+// switch the displayed view to a subagent (epic #499 phase 3). Shared by the
+// hook bridge (writes) and the transcript handler (resolves agentId -> path).
+const subagentViews = new SubagentViewRegistry();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
 // both resume resolvers route through it. No cache — see session-binding-store.ts.
@@ -912,6 +916,7 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
+import { SubagentViewRegistry } from './api/subagent-view-registry.ts';
 import { makeCurrentSessionResolver } from './cli/current-session.ts';
 // The primary session ID (in wrapper mode, this is the one running in the terminal).
 // Stored in cli/session-state.ts so extracted handler modules can read it via
@@ -1123,6 +1128,7 @@ async function createNewSession(
         shadowBinder: binderShadow,
         binderEnabled,
         transcriptDiscovery,
+        subagentViews,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1264,6 +1270,7 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptWatchers,
   bindingStore,
   currentOwnedSession,
+  subagentViews,
   send: sendToConnection,
 });
 

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -15,6 +15,7 @@ import { createError, createTranscriptLoadComplete, errorToString } from '@remi/
 import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
+import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import type { SessionBindingStore } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
@@ -36,13 +37,23 @@ export interface TranscriptHandlerDeps {
   /** Resolves the daemon's current owned session, so a stale/unknown request is
    *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
   currentOwnedSession: () => CurrentOwnedSession | null;
+  /** Resolves a subagent agentId -> its transcript file so the client can load a
+   *  subagent view by the agentId it got in `session_views` (#499 phase 3). */
+  subagentViews: Pick<SubagentViewRegistry, 'resolvePath'>;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, bindingStore, currentOwnedSession, send } = deps;
+  const {
+    transcriptDiscovery,
+    transcriptWatchers,
+    bindingStore,
+    currentOwnedSession,
+    subagentViews,
+    send,
+  } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -84,6 +95,16 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
           logError(
             `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
           );
+        }
+      }
+
+      // A subagent view: the client echoes the agent_id back from session_views;
+      // resolve its deterministic <main>/subagents/agent-<id>.jsonl (#499 phase 3).
+      if (!filePath) {
+        const subPath = subagentViews.resolvePath(sessionId);
+        if (subPath) {
+          filePath = subPath;
+          log(`[TranscriptLoad] Resolved subagent ${sessionId} to ${subPath}`);
         }
       }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -181,6 +181,24 @@ export function setupHookBridge(
       }
     : rawSendAndRecord;
 
+  // Push the session's subagent views to clients (epic #499 phase 3). Declared
+  // here (before the binder/handlers reference it) so there is no fragile
+  // forward-reference. The SessionViewMeta omits the on-disk path: the client
+  // echoes agentId back and the daemon resolves the path via the registry.
+  const pushSubagentViews = (): void => {
+    if (!subagentViews) return;
+    sendAndRecord(
+      createSessionViews(
+        sessionId,
+        subagentViews.list().map((v) => ({
+          agentId: v.agentId,
+          agentType: v.agentType,
+          active: v.active,
+        })),
+      ),
+    );
+  };
+
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
   // Track the Claude session ID so we can filter hook events by session.
@@ -1071,23 +1089,6 @@ export function setupHookBridge(
   // breadcrumb, so gate them with admits() ONLY (the sibling defer + session
   // scoping still apply via session_id) — a deliberate divergence from the
   // Pre/PostToolUse agent_id drop (#453 phase 4).
-  // Push the session's subagent views to clients (epic #499 phase 3). The
-  // SessionViewMeta omits the on-disk path: the client echoes agentId back and
-  // the daemon resolves the path via the registry.
-  const pushSubagentViews = (): void => {
-    if (!subagentViews) return;
-    sendAndRecord(
-      createSessionViews(
-        sessionId,
-        subagentViews.list().map((v) => ({
-          agentId: v.agentId,
-          agentType: v.agentType,
-          active: v.active,
-        })),
-      ),
-    );
-  };
-
   hookServer.on('SubagentStart', (input) => {
     shadowEnterEvent();
     if (driveBinder) driveBinder.onHookEvent(input);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -38,11 +38,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionRotated, errorToString } from '@remi/shared';
+import { createSessionRotated, createSessionViews, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
 import type { QuestionPresenceTracker } from '../../api/question-presence-tracker.ts';
+import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import { AutoApproveGate } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
@@ -100,6 +101,13 @@ export interface HookBridgeDeps {
    * binder mode are unaffected.
    */
   transcriptDiscovery?: TranscriptDiscovery;
+  /**
+   * Tracks the subagent conversations this session spawns (epic #499 phase 3).
+   * Populated from SubagentStart/Stop; a `session_views` push tells the client
+   * which subagent chats it can switch to. Optional so tests/old callers are
+   * unaffected.
+   */
+  subagentViews?: SubagentViewRegistry;
 }
 
 export interface HookBridgeArgs {
@@ -148,6 +156,7 @@ export function setupHookBridge(
     shadowBinder,
     binderEnabled,
     transcriptDiscovery,
+    subagentViews,
   } = deps;
   const {
     hookServer,
@@ -766,6 +775,11 @@ export function setupHookBridge(
               // pending-question collection so stale answers are refused.
               tracker.clearPending();
               sessionRegistry.clearQuestions(sessionId);
+              // The new session starts with no subagents (#499 phase 3).
+              if (subagentViews) {
+                subagentViews.clear();
+                pushSubagentViews();
+              }
             },
           },
           { sessionId, workingDirectory },
@@ -1057,12 +1071,33 @@ export function setupHookBridge(
   // breadcrumb, so gate them with admits() ONLY (the sibling defer + session
   // scoping still apply via session_id) — a deliberate divergence from the
   // Pre/PostToolUse agent_id drop (#453 phase 4).
+  // Push the session's subagent views to clients (epic #499 phase 3). The
+  // SessionViewMeta omits the on-disk path: the client echoes agentId back and
+  // the daemon resolves the path via the registry.
+  const pushSubagentViews = (): void => {
+    if (!subagentViews) return;
+    sendAndRecord(
+      createSessionViews(
+        sessionId,
+        subagentViews.list().map((v) => ({
+          agentId: v.agentId,
+          agentType: v.agentType,
+          active: v.active,
+        })),
+      ),
+    );
+  };
+
   hookServer.on('SubagentStart', (input) => {
     shadowEnterEvent();
     if (driveBinder) driveBinder.onHookEvent(input);
     else initFromHookEvent(input);
     shadowDecide('SubagentStart', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // input.transcript_path is the MAIN transcript; the subagent file is the
+    // deterministic <main>/subagents/agent-<id>.jsonl (registry derives it).
+    subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
+    pushSubagentViews();
     handlers.onSubagentStart?.(input);
   });
 
@@ -1072,6 +1107,8 @@ export function setupHookBridge(
     else initFromHookEvent(input);
     shadowDecide('SubagentStop', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    subagentViews?.recordStop(input.agent_id);
+    pushSubagentViews();
     handlers.onSubagentStop?.(input);
   });
 

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -64,4 +64,24 @@ describe('SubagentViewRegistry', () => {
     expect(reg.size).toBe(0);
     expect(reg.list()).toEqual([]);
   });
+
+  test('rejects a path-traversal agentId (it becomes a path segment)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('../../etc/passwd', 'X', MAIN);
+    reg.recordStart('a/b', 'X', MAIN);
+    reg.recordStart('a.b', 'X', MAIN);
+    expect(reg.size).toBe(0);
+    reg.recordStart('ab2e2dd0b25acb847', 'Explore', MAIN); // the real hex shape
+    expect(reg.size).toBe(1);
+  });
+
+  test('self-clears when the parent session rotates (main transcript path changes)', () => {
+    const reg = new SubagentViewRegistry();
+    const MAIN2 = MAIN.replace('7c3a497d', '99999999');
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.recordStart('a2', 'code-reviewer', MAIN); // same parent -> both kept
+    expect(reg.size).toBe(2);
+    reg.recordStart('a3', 'Explore', MAIN2); // new parent -> drop a1/a2
+    expect(reg.list().map((v) => v.agentId)).toEqual(['a3']);
+  });
 });

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  SubagentViewRegistry,
+  deriveSubagentTranscriptPath,
+} from '../../src/api/subagent-view-registry.ts';
+
+const MAIN = '/Users/y/.claude/projects/-Users-y-proj/7c3a497d-a1d8-4337-a359-d48bf74e69f8.jsonl';
+
+describe('deriveSubagentTranscriptPath', () => {
+  test('replaces .jsonl with the per-session subagents subdir (the on-disk layout)', () => {
+    expect(deriveSubagentTranscriptPath(MAIN, 'ab2e2dd0b25acb847')).toBe(
+      '/Users/y/.claude/projects/-Users-y-proj/7c3a497d-a1d8-4337-a359-d48bf74e69f8/subagents/agent-ab2e2dd0b25acb847.jsonl',
+    );
+  });
+});
+
+describe('SubagentViewRegistry', () => {
+  test('records a subagent on start with the derived path, active', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    expect(reg.size).toBe(1);
+    expect(reg.list()).toEqual([
+      {
+        agentId: 'a1',
+        agentType: 'Explore',
+        transcriptPath: deriveSubagentTranscriptPath(MAIN, 'a1'),
+        active: true,
+      },
+    ]);
+    expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+  });
+
+  test('stop marks inactive but keeps it viewable', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.recordStop('a1');
+    expect(reg.size).toBe(1);
+    expect(reg.list()[0]?.active).toBe(false);
+    expect(reg.resolvePath('a1')).not.toBeNull();
+  });
+
+  test('active subagents are listed before finished ones', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('done', 'code-reviewer', MAIN);
+    reg.recordStop('done');
+    reg.recordStart('running', 'Explore', MAIN);
+    expect(reg.list().map((v) => v.agentId)).toEqual(['running', 'done']);
+  });
+
+  test('ignores empty agentId or transcript path (defensive)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(undefined, 'X', MAIN);
+    reg.recordStart('', 'X', MAIN);
+    reg.recordStart('a1', 'X', '');
+    expect(reg.size).toBe(0);
+    expect(reg.resolvePath('missing')).toBeNull();
+    expect(() => reg.recordStop(undefined)).not.toThrow();
+  });
+
+  test('clear forgets everything (rotation)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.clear();
+    expect(reg.size).toBe(0);
+    expect(reg.list()).toEqual([]);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import { SubagentViewRegistry } from '../../../src/api/subagent-view-registry.ts';
 import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
@@ -70,12 +71,16 @@ describe('createTranscriptHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
+  function makeHandlers(
+    currentOwnedSession: () => CurrentOwnedSession | null = () => null,
+    subagentViews: SubagentViewRegistry = new SubagentViewRegistry(),
+  ) {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
       currentOwnedSession,
+      subagentViews,
       send,
     });
   }
@@ -134,6 +139,38 @@ describe('createTranscriptHandlers', () => {
     const msg = sendCalls[0]?.message as { code?: string; details?: unknown };
     expect(msg.code).toBe('NOT_FOUND');
     expect(msg.details).toBeUndefined();
+  });
+
+  test('resolves a subagent view by agentId and loads its transcript (#499 phase 3)', async () => {
+    // The client loads a subagent by the agentId it got in session_views; the
+    // daemon resolves the deterministic <main>/subagents/agent-<id>.jsonl path.
+    const mainPath = path.join(projectsDir, '-Users-test-project', 'mainsess.jsonl');
+    const agentId = 'a1b2c3d4e5f6';
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(agentId, 'Explore', mainPath);
+    const subPath = reg.resolvePath(agentId);
+    expect(subPath).not.toBeNull();
+    if (!subPath) return;
+    fs.mkdirSync(path.dirname(subPath), { recursive: true });
+    fs.writeFileSync(
+      subPath,
+      JSON.stringify({
+        type: 'user',
+        uuid: 'u1',
+        sessionId: agentId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'subagent prompt' },
+      }),
+    );
+
+    makeHandlers(() => null, reg).onTranscriptLoadRequest(CID, agentId, REQ);
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+    expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+      false,
+    );
   });
 
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -88,6 +88,8 @@ export type {
   RegisterDeviceTokenMessage,
   DaemonUpdateAvailableMessage,
   SessionRotatedMessage,
+  SessionViewsMessage,
+  SessionViewMeta,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -135,6 +137,7 @@ export {
   createRegisterDeviceToken,
   createDaemonUpdateAvailable,
   createSessionRotated,
+  createSessionViews,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -100,7 +100,8 @@ export type ProtocolMessage =
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
   | DaemonUpdateAvailableMessage
-  | SessionRotatedMessage;
+  | SessionRotatedMessage
+  | SessionViewsMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -378,6 +379,30 @@ export interface SessionRotatedMessage {
   readonly newTranscriptPath: string;
   /** Diagnostic: what triggered the rotation. */
   readonly reason: 'clear' | 'resume' | 'restart';
+}
+
+/** One selectable view a session exposes: a subagent's chat (epic #499 phase 3). */
+export interface SessionViewMeta {
+  /** The subagent's agent_id; the client echoes it back to load that view. */
+  readonly agentId: string;
+  /** e.g. "general-purpose", "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType: string;
+  /** false once the subagent finished (its transcript stays viewable). */
+  readonly active: boolean;
+}
+
+/**
+ * Daemon -> client push: the subagent conversations a session has spawned, so
+ * the client can switch the displayed view to a subagent's chat. The main
+ * conversation is always implicitly available; this lists only the subagents.
+ */
+export interface SessionViewsMessage {
+  readonly type: 'session_views';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** The Remi session these views belong to. */
+  readonly sessionId: UUID;
+  readonly subagents: readonly SessionViewMeta[];
 }
 
 /** Token usage information from a transcript entry */
@@ -753,6 +778,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'register_device_token',
     'daemon_update_available',
     'session_rotated',
+    'session_views',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1446,6 +1472,20 @@ export function createSessionRotated(
     newClaudeSessionId,
     newTranscriptPath,
     reason,
+  };
+}
+
+/** Create a session_views push listing the session's subagent views. */
+export function createSessionViews(
+  sessionId: UUID,
+  subagents: readonly SessionViewMeta[],
+): SessionViewsMessage {
+  return {
+    type: 'session_views',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    subagents,
   };
 }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -463,6 +463,41 @@ function App() {
         break;
       }
 
+      case 'session_views': {
+        // The parent session's subagent chats (#499 phase 3). Surface each as a
+        // navigable entry whose id IS the agentId; opening it loads
+        // agent-<id>.jsonl through the normal transcript flow. Replace this
+        // parent's whole subagent set each push (active first, finished kept).
+        const parentId = message.sessionId;
+        const subs = message.subagents;
+        setSessions((prev) => {
+          const parent = prev.find((s) => s.id === parentId);
+          const withoutOldSubs = prev.filter(
+            (s) =>
+              !(s.isSubagent && s.parentSessionId === parentId && s.connectionId === connectionId),
+          );
+          const subRows: UISession[] = subs.map((v) => {
+            const existing = prev.find((s) => s.id === (v.agentId as UUID));
+            return {
+              id: v.agentId as UUID,
+              name: v.agentType,
+              connectionId,
+              createdAt: existing?.createdAt ?? new Date().toISOString(),
+              lastActiveAt: new Date().toISOString(),
+              status: 'idle',
+              connectionStatus: parent?.connectionStatus ?? 'connected',
+              unreadCount: 0,
+              isSubagent: true,
+              parentSessionId: parentId,
+              agentType: v.agentType,
+              subagentActive: v.active,
+            } satisfies UISession;
+          });
+          return [...withoutOldSubs, ...subRows];
+        });
+        break;
+      }
+
       case 'session_rotated': {
         // Atomic rotation (#438): /clear or /resume started a NEW transcript
         // under a new Claude session id (NOT /compact, which keeps the same

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1487,6 +1487,10 @@ function App() {
   const handleSend = useCallback(
     (content: string) => {
       if (!activeSessionId) return;
+      // Subagent views are read-only monitoring: their id is an agentId, not a
+      // real daemon session, so input would route nowhere. Block the send
+      // (the input is also hidden in ChatView) (#499 phase 3).
+      if (sessionsRef.current.find((s) => s.id === activeSessionId)?.isSubagent) return;
       const connId = getActiveConnectionId();
       if (!connId) {
         const systemMsg: UIMessage = {

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -151,23 +151,27 @@ export function ChatView({
         showTimestamps={showTimestamps}
       />
 
-      <InputArea
-        onSend={onSend}
-        onAnswer={(answer) => {
-          if (primaryQuestion) onAnswer(primaryQuestion, answer);
-        }}
-        onCancel={onCancel}
-        question={null}
-        isAgentBusy={isAgentBusy}
-        disabled={!isConnected}
-        replyContext={replyContext ?? null}
-        onClearReply={onClearReply}
-        // Session-scoped draft persistence so a half-typed message survives
-        // app suspension on iOS (#226) and switching to a different session
-        // doesn't leak the draft across.
-        draftKey={`remi-draft-${session.id}`}
-        placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
-      />
+      {/* Subagent views are read-only monitoring (their id is an agentId, not a
+          real daemon session), so there is no input to route (#499 phase 3). */}
+      {!session.isSubagent && (
+        <InputArea
+          onSend={onSend}
+          onAnswer={(answer) => {
+            if (primaryQuestion) onAnswer(primaryQuestion, answer);
+          }}
+          onCancel={onCancel}
+          question={null}
+          isAgentBusy={isAgentBusy}
+          disabled={!isConnected}
+          replyContext={replyContext ?? null}
+          onClearReply={onClearReply}
+          // Session-scoped draft persistence so a half-typed message survives
+          // app suspension on iOS (#226) and switching to a different session
+          // doesn't leak the draft across.
+          draftKey={`remi-draft-${session.id}`}
+          placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -129,6 +129,18 @@ export interface UISession {
   readonly claudeSessionId?: UUID;
   /** Absolute path to the bound .jsonl transcript (#430). */
   readonly transcriptPath?: string;
+  /**
+   * This entry is a subagent view spawned by a parent session, not a
+   * top-level session (epic #499 phase 3). Its `id` is the subagent's
+   * `agentId`; tapping it loads `agent-<id>.jsonl` via the normal flow.
+   */
+  readonly isSubagent?: boolean;
+  /** For a subagent view: the parent session's id. */
+  readonly parentSessionId?: UUID;
+  /** For a subagent view: e.g. "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType?: string;
+  /** For a subagent view: false once it finished (transcript stays viewable). */
+  readonly subagentActive?: boolean;
 }
 
 /** Structured option for a question */


### PR DESCRIPTION
Epic #499 phase 3. Closes #502.

## What
Surface the subagent chats a session spawns so the client can switch the displayed view to a subagent's conversation. Built on the finding that Claude Code stores subagents at a **deterministic** path: `<projectDir>/<mainSessionId>/subagents/agent-<agentId>.jsonl`, where `agentId` is exactly the hook's `agent_id` — so no scanning/correlation.

- **shared:** `session_views` push (`{ sessionId, subagents: [{agentId, agentType, active}] }`).
- **daemon:** `SubagentViewRegistry` records each subagent on SubagentStart (path derived from the hook's main `transcript_path` + `agent_id`), marks inactive on SubagentStop, clears on rotation; the hook bridge pushes `session_views`. The transcript handler resolves a load-by-`agentId` to the subagent file, so it loads through the normal transcript flow.
- **web:** each subagent is surfaced as a navigable read-only entry (id = agentId); opening it loads `agent-<id>.jsonl` via the existing path — reuses the session list + transcript machinery, no new component.

## Tests
- `subagent-view-registry.test.ts` (path derivation, active/finished, clear, defensive) — 6 cases.
- `transcript-events.test.ts` — subagent agentId resolves + loads.
- protocol round-trip; daemon sweep 1036 pass; web `tsc -b` + `eslint` + `vite build` clean.
- Real-Claude e2e (spawn a subagent → it appears as a view → its transcript renders) to run via the manual harness.

Part of #499 (epic stays open for #503).
