### PR TITLE
Epic #499: TranscriptBinder drives by default (#503 step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- Subagent views (epic #499): the app can switch the displayed view to a
+  subagent's chat. The daemon tracks each subagent the session spawns
+  (deterministic transcript path `<main>/subagents/agent-<id>.jsonl`) and
+  pushes a `session_views` message; the client surfaces each subagent as a
+  read-only entry that loads its transcript through the normal flow (#502).
+
+### Changed
+- The TranscriptBinder is now the **default** session-binding driver (epic
+  #499). It is the single source of truth for the live Claude session and was
+  shadow- and real-Claude-validated as equivalent to the old path.
+  `REMI_TRANSCRIPT_BINDER_ENABLED=false` is a kill-switch back to the old path
+  until that path is removed (#503).
+
 ### Fixed
 - Session source of truth (epic #499): the client no longer gets stuck on
   "Transcript for session X not found" after a daemon restart or `/clear`

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -453,7 +453,8 @@ const liveSessionsRegistry = new SessionRegistryFile();
 // module-level consts at boot and NEVER re-read per session: a mid-process flip
 // would split sessions across the old/new code paths, which share the
 // transcriptWatchers map. SIGUSR1 / config reload is a no-op for these; an
-// instant flip-back means a daemon restart (design §3.1 v4 #9). Default OFF.
+// instant flip-back means a daemon restart (design §3.1 v4 #9).
+// transcript_binder_enabled defaults ON (#503); transcript_binder_shadow OFF.
 const binderEnabled = remiConfig.features.transcript_binder_enabled;
 // Drive mode and shadow mode are mutually exclusive: enabled wins. When the
 // binder DRIVES, running the shadow alongside it would be meaningless (and would

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -121,7 +121,15 @@ export const DEFAULT_CONFIG: RemiConfig = {
   },
   features: {
     transcript_binder_shadow: false,
-    transcript_binder_enabled: false,
+    // The TranscriptBinder is now the DEFAULT session-binding driver (epic
+    // #499 / #503 step 1). It was shadow- and real-Claude-e2e-validated as
+    // equivalent to the old path, and is the single source of truth for the
+    // live session. Kept as a flag so `REMI_TRANSCRIPT_BINDER_ENABLED=false`
+    // is a kill-switch back to the old path until that path is deleted (#503
+    // step 2, after this default soaks). Setting `transcript_binder_shadow`
+    // alone no longer yields shadow-only — drive wins; for compare-only set
+    // `transcript_binder_enabled=false` too.
+    transcript_binder_enabled: true,
   },
 };
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -50,10 +50,12 @@ export interface TelegramConfig {
 }
 
 /**
- * Experimental feature flags (epic #453). Default OFF. Snapshotted into a const at
- * daemon boot and treated as immutable for the process lifetime — never re-read per
- * session (a mid-process flip would split sessions across the old/new code paths,
- * which share the transcriptWatchers map).
+ * TranscriptBinder feature flags (epic #453/#499). `transcript_binder_enabled`
+ * defaults ON (the binder is the default driver, #503); `transcript_binder_shadow`
+ * defaults OFF. Snapshotted into a const at daemon boot and treated as immutable
+ * for the process lifetime — never re-read per session (a mid-process flip would
+ * split sessions across the old/new code paths, which share the transcriptWatchers
+ * map).
  */
 export interface FeaturesConfig {
   /** Phase 3: run the TranscriptBinder in compute-only shadow mode alongside the old

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -140,9 +140,11 @@ describe('applyEnvOverrides', () => {
     expect(config.display.max_bullet_length).toBe(100);
   });
 
-  test('transcript-binder feature flags default OFF', () => {
+  test('transcript-binder drives by default; shadow off (#499/#503)', () => {
     expect(DEFAULT_CONFIG.features.transcript_binder_shadow).toBe(false);
-    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
+    // The binder is now the default session-binding driver (kill-switch:
+    // REMI_TRANSCRIPT_BINDER_ENABLED=false).
+    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(true);
   });
 
   test('auto-approve stays opt-in but defaults safe read-only tools in allow (#482)', () => {
@@ -157,17 +159,19 @@ describe('applyEnvOverrides', () => {
     expect(DEFAULT_CONFIG.auto_approve.allow.some((p) => p.includes(' '))).toBe(false);
   });
 
-  test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
+  test('shadow-only (compare without driving) needs SHADOW=true + ENABLED=false', () => {
+    // Drive is the default now, so shadow-only must explicitly opt out of drive.
     process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'false';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
     expect(config.features.transcript_binder_shadow).toBe(true);
     expect(config.features.transcript_binder_enabled).toBe(false);
   });
 
-  test('REMI_TRANSCRIPT_BINDER_ENABLED=true enables drive', () => {
-    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'true';
+  test('REMI_TRANSCRIPT_BINDER_ENABLED=false is the kill-switch back to the old path', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'false';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
-    expect(config.features.transcript_binder_enabled).toBe(true);
+    expect(config.features.transcript_binder_enabled).toBe(false);
   });
 
   test('REMI_TRANSCRIPT_BINDER_SHADOW=false keeps shadow off', () => {


### PR DESCRIPTION
Epic #499, **step 1 of #503**: make the TranscriptBinder the default driver. The risky old-path deletion + 55-test migration is step 2, after this default soaks (per #470).

## What
- `transcript_binder_enabled` default → **true**. The binder is now the production session-binding driver and the single source of truth for the live Claude session (shadow- + real-Claude-e2e-validated as equivalent to the old path).
- `REMI_TRANSCRIPT_BINDER_ENABLED=false` is the kill-switch back to the old path until it's deleted.
- Flag semantics: with drive as default, shadow-only (compare without driving) now needs `SHADOW=true` + `ENABLED=false`.
- Changelog: adds the [Unreleased] entries for #499 phase 3 (subagent views) + this flip.

## Scope / safety
- The old path + its code remain (reachable via the kill-switch); nothing deleted here.
- The 55-test characterization suite is unaffected (it passes `binderEnabled` explicitly, not via config default).
- Config tests updated for the new flag semantics. Daemon sweep green (859 pass); typecheck + biome clean.

Part of #499; #503 stays open for step 2 (delete the old path).
