### PR TITLE
Release 0.6.3: epic #499 source-of-truth + subagent views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Session source of truth (epic #499): the client no longer gets stuck on
+  "Transcript for session X not found" after a daemon restart or `/clear`
+  rotation. The daemon now answers a stale transcript request with its
+  **current** session (`currentSessionId` / `currentClaudeSessionId` /
+  `currentTranscriptPath`) instead of a dead-end `NOT_FOUND`, and always
+  stamps `hello_ack` with the authoritative binding; the client follows that
+  redirect (and the reconnect-mid-rotation adopt) by switching to the current
+  session and auto-loading its transcript (#500, #501).
+
 ## [0.6.2] - 2026-06-07
 
 A pass over the question -> auto-approve -> notification pipeline, plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- Subagent views (epic #499): the app can switch the displayed view to a
+  subagent's chat. The daemon tracks each subagent the session spawns
+  (deterministic transcript path `<main>/subagents/agent-<id>.jsonl`) and
+  pushes a `session_views` message; the client surfaces each subagent as a
+  read-only entry that loads its transcript through the normal flow (#502).
+
+### Changed
+- The TranscriptBinder is now the **default** session-binding driver (epic
+  #499). It is the single source of truth for the live Claude session and was
+  shadow- and real-Claude-validated as equivalent to the old path.
+  `REMI_TRANSCRIPT_BINDER_ENABLED=false` is a kill-switch back to the old path
+  until that path is removed (#503).
+
 ### Fixed
 - Session source of truth (epic #499): the client no longer gets stuck on
   "Transcript for session X not found" after a daemon restart or `/clear`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-08
+
+Epic #499: a single source of truth for the live Claude session, plus
+subagent views.
+
 ### Added
 - Subagent views (epic #499): the app can switch the displayed view to a
   subagent's chat. The daemon tracks each subagent the session spawns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3-dev.5",
+  "version": "0.6.3-dev.6",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3-dev.1",
+  "version": "0.6.3-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3-dev.3",
+  "version": "0.6.3-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3-dev.2",
+  "version": "0.6.3-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3-dev.4",
+  "version": "0.6.3-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.2",
+  "version": "0.6.3-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -1,0 +1,96 @@
+/**
+ * SubagentViewRegistry — tracks the subagent conversations a session has
+ * spawned, so the client can switch the displayed view to a subagent's chat
+ * (epic #499, phase 3).
+ *
+ * Claude Code stores each subagent's transcript at a DETERMINISTIC path:
+ *   <mainTranscriptDir>/<mainSessionId>/subagents/agent-<agentId>.jsonl
+ * i.e. the main session's `.jsonl` path with its extension replaced by a
+ * per-session `subagents/` subdir. `agentId` is exactly the hook's `agent_id`.
+ * So we derive the path from the SubagentStart hook (which carries the MAIN
+ * `transcript_path` + the subagent's `agent_id`) with no scanning/correlation.
+ */
+
+export interface SubagentView {
+  /** The subagent's agent_id (matches the on-disk `agent-<id>.jsonl`). */
+  readonly agentId: string;
+  /** e.g. "general-purpose", "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType: string;
+  /** Absolute path to the subagent's transcript file. */
+  readonly transcriptPath: string;
+  /** false once SubagentStop fired; the transcript stays viewable. */
+  readonly active: boolean;
+}
+
+/**
+ * Derive a subagent transcript path from the main transcript path + agent_id.
+ * `/a/b/<mainId>.jsonl` + `agent-x` -> `/a/b/<mainId>/subagents/agent-x.jsonl`.
+ */
+export function deriveSubagentTranscriptPath(mainTranscriptPath: string, agentId: string): string {
+  const base = mainTranscriptPath.replace(/\.jsonl$/, '');
+  return `${base}/subagents/agent-${agentId}.jsonl`;
+}
+
+export class SubagentViewRegistry {
+  private readonly views = new Map<
+    string,
+    { agentType: string; transcriptPath: string; active: boolean }
+  >();
+  /** The parent main-transcript path the current views belong to. When the
+   *  parent session rotates (/clear) its path changes, so we drop the old
+   *  session's subagents — robust regardless of which binding path drives the
+   *  rotation (the drive-mode onRotation also clears+pushes for immediacy). */
+  private currentMain: string | null = null;
+
+  /** Record (or refresh) a subagent from a SubagentStart event. No-op without an agentId. */
+  recordStart(agentId: string | undefined, agentType: string, mainTranscriptPath: string): void {
+    if (!agentId || !mainTranscriptPath) return;
+    // agentId becomes a filesystem path segment (agent-<id>.jsonl), so reject
+    // anything that could escape the subagents dir. Real values are hex like
+    // "ab2e2dd0b25acb847"; a path-traversal payload must never reach the FS.
+    if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return;
+    if (this.currentMain !== null && this.currentMain !== mainTranscriptPath) {
+      this.views.clear();
+    }
+    this.currentMain = mainTranscriptPath;
+    this.views.set(agentId, {
+      agentType,
+      transcriptPath: deriveSubagentTranscriptPath(mainTranscriptPath, agentId),
+      active: true,
+    });
+  }
+
+  /** Mark a subagent inactive (SubagentStop); keep it listed so its chat stays viewable. */
+  recordStop(agentId: string | undefined): void {
+    if (!agentId) return;
+    const v = this.views.get(agentId);
+    if (v) this.views.set(agentId, { ...v, active: false });
+  }
+
+  /** The transcript path for a known subagent, or null. */
+  resolvePath(agentId: string): string | null {
+    return this.views.get(agentId)?.transcriptPath ?? null;
+  }
+
+  /** All known subagent views (active first, then by insertion order). */
+  list(): SubagentView[] {
+    const entries = [...this.views.entries()].map(([agentId, v]) => ({
+      agentId,
+      agentType: v.agentType,
+      transcriptPath: v.transcriptPath,
+      active: v.active,
+    }));
+    // Active subagents first so the client surfaces what's running now.
+    return entries.sort((a, b) => Number(b.active) - Number(a.active));
+  }
+
+  get size(): number {
+    return this.views.size;
+  }
+
+  /** Forget all views (call on session rotation / clear). */
+  clear(): void {
+    this.views.clear();
+    this.currentMain = null;
+  }
+}

--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -49,6 +49,9 @@ export class SubagentViewRegistry {
     // anything that could escape the subagents dir. Real values are hex like
     // "ab2e2dd0b25acb847"; a path-traversal payload must never reach the FS.
     if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return;
+    // The path is derived by replacing the `.jsonl` suffix with a subdir; if a
+    // future Claude format drops it, the derivation would be wrong, so require it.
+    if (!mainTranscriptPath.endsWith('.jsonl')) return;
     if (this.currentMain !== null && this.currentMain !== mainTranscriptPath) {
       this.views.clear();
     }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3-dev.4'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3-dev.4'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -823,6 +823,10 @@ const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new 
 // transcript_binder_enabled is off (no binder is ever constructed).
 const binderClosers: Map<UUID, () => void> = new Map();
 const sessionStore = new SessionStore();
+// Tracks the subagent chats the primary session spawns, so the client can
+// switch the displayed view to a subagent (epic #499 phase 3). Shared by the
+// hook bridge (writes) and the transcript handler (resolves agentId -> path).
+const subagentViews = new SubagentViewRegistry();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
 // both resume resolvers route through it. No cache — see session-binding-store.ts.
@@ -912,6 +916,7 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
+import { SubagentViewRegistry } from './api/subagent-view-registry.ts';
 import { makeCurrentSessionResolver } from './cli/current-session.ts';
 // The primary session ID (in wrapper mode, this is the one running in the terminal).
 // Stored in cli/session-state.ts so extracted handler modules can read it via
@@ -1123,6 +1128,7 @@ async function createNewSession(
         shadowBinder: binderShadow,
         binderEnabled,
         transcriptDiscovery,
+        subagentViews,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1264,6 +1270,7 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptWatchers,
   bindingStore,
   currentOwnedSession,
+  subagentViews,
   send: sendToConnection,
 });
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3-dev.5'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.6'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3-dev.5'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.6'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -453,7 +453,8 @@ const liveSessionsRegistry = new SessionRegistryFile();
 // module-level consts at boot and NEVER re-read per session: a mid-process flip
 // would split sessions across the old/new code paths, which share the
 // transcriptWatchers map. SIGUSR1 / config reload is a no-op for these; an
-// instant flip-back means a daemon restart (design §3.1 v4 #9). Default OFF.
+// instant flip-back means a daemon restart (design §3.1 v4 #9).
+// transcript_binder_enabled defaults ON (#503); transcript_binder_shadow OFF.
 const binderEnabled = remiConfig.features.transcript_binder_enabled;
 // Drive mode and shadow mode are mutually exclusive: enabled wins. When the
 // binder DRIVES, running the shadow alongside it would be meaningless (and would

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.2'; // REMI_COMPILED_VERSION
+      return '0.6.3-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.2'; // REMI_COMPILED_VERSION
+    return '0.6.3-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -869,6 +869,10 @@ const sessionRegistry = new SessionRegistry(
     },
     onConnectionPromoted: (sessionId, connectionId, result) => {
       log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
+      // NOTE: this resolves the hello_ack binding inline rather than via
+      // currentOwnedSession() because the promoted connection may be attaching
+      // to a specific `sessionId` that is not necessarily the daemon's primary.
+      // Both read the same disk-backed store, so they stay in sync (#499).
       const stored = sessionStore.findByRemiSessionId(sessionId);
       const claudeId = stored?.claudeSessionId ?? null;
       const projPath = stored?.projectPath ?? null;
@@ -908,6 +912,7 @@ const sessionRegistry = new SessionRegistry(
   },
 );
 
+import { makeCurrentSessionResolver } from './cli/current-session.ts';
 // The primary session ID (in wrapper mode, this is the one running in the terminal).
 // Stored in cli/session-state.ts so extracted handler modules can read it via
 // getPrimarySessionId() without closing over a cli.ts-local `let` that flips
@@ -1246,10 +1251,19 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
   send: sendToConnection,
 });
 
+// The single authoritative "current owned session" accessor (#499), shared by
+// the transcript-request redirect and the hello_ack binding so they never diverge.
+const currentOwnedSession = makeCurrentSessionResolver({
+  getPrimarySessionId,
+  sessionStore,
+  transcriptDiscovery,
+});
+
 const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
   bindingStore,
+  currentOwnedSession,
   send: sendToConnection,
 });
 
@@ -1283,6 +1297,7 @@ const createSessionHandlers_: CreateSessionHandlers = createCreateSessionHandler
 
 const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
   sessionRegistry,
+  currentOwnedSession,
   trackConnection: (id, adapterType) => registry.trackConnection(id, adapterType),
   untrackConnection: (id) => registry.untrackConnection(id),
   onConnectionAdded: () => updateRemiStatus({ connections: remiStatus.connections + 1 }),

--- a/packages/daemon/src/cli/current-session.ts
+++ b/packages/daemon/src/cli/current-session.ts
@@ -1,0 +1,54 @@
+/**
+ * The daemon's single authoritative "current owned session" accessor (epic #499).
+ *
+ * One source of truth, read by BOTH the connect path (to stamp hello_ack with the
+ * live binding) and the transcript-request handler (to redirect a stale request to
+ * the current session instead of dead-ending on NOT_FOUND). Derived from the
+ * primary Remi session id + the persisted binding, which the rotation handler /
+ * TranscriptBinder keeps current — so it follows /clear rotations.
+ */
+
+import type { UUID } from '@remi/shared';
+import type { SessionStore } from '../session/session-store.ts';
+import type { TranscriptDiscovery } from '../transcript/index.ts';
+
+/** The daemon's current owned session, resolved on demand. */
+export interface CurrentOwnedSession {
+  /** The primary Remi session id (stable across /clear). */
+  readonly sessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
+  readonly claudeSessionId: UUID | null;
+  /** The current transcript file path; null if the Claude id/project is unknown. */
+  readonly transcriptPath: string | null;
+}
+
+export interface CurrentSessionResolverDeps {
+  /** Reads the primary Remi session id (the per-process global). */
+  getPrimarySessionId: () => UUID | null;
+  sessionStore: Pick<SessionStore, 'findByRemiSessionId'>;
+  transcriptDiscovery: Pick<TranscriptDiscovery, 'getProjectTranscriptDir'>;
+}
+
+/**
+ * Build the resolver. Returns null when the daemon has no primary session.
+ * Mirrors the transcript-path derivation used by the connection promote path
+ * (`<projectTranscriptDir>/<claudeSessionId>.jsonl`) so all hello_ack bindings
+ * agree on one path scheme.
+ */
+export function makeCurrentSessionResolver(
+  deps: CurrentSessionResolverDeps,
+): () => CurrentOwnedSession | null {
+  const { getPrimarySessionId, sessionStore, transcriptDiscovery } = deps;
+  return () => {
+    const sessionId = getPrimarySessionId();
+    if (!sessionId) return null;
+    const stored = sessionStore.findByRemiSessionId(sessionId);
+    const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
+    const projectPath = stored?.projectPath ?? null;
+    const transcriptPath =
+      claudeSessionId && projectPath
+        ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
+        : null;
+    return { sessionId, claudeSessionId, transcriptPath };
+  };
+}

--- a/packages/daemon/src/cli/current-session.ts
+++ b/packages/daemon/src/cli/current-session.ts
@@ -40,15 +40,22 @@ export function makeCurrentSessionResolver(
 ): () => CurrentOwnedSession | null {
   const { getPrimarySessionId, sessionStore, transcriptDiscovery } = deps;
   return () => {
-    const sessionId = getPrimarySessionId();
-    if (!sessionId) return null;
-    const stored = sessionStore.findByRemiSessionId(sessionId);
-    const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
-    const projectPath = stored?.projectPath ?? null;
-    const transcriptPath =
-      claudeSessionId && projectPath
-        ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
-        : null;
-    return { sessionId, claudeSessionId, transcriptPath };
+    // Must never throw: this runs in the void transcript-load handler's
+    // NOT_FOUND path, which is not wrapped — a disk hiccup on the store read
+    // would otherwise escape and leave the client with no response.
+    try {
+      const sessionId = getPrimarySessionId();
+      if (!sessionId) return null;
+      const stored = sessionStore.findByRemiSessionId(sessionId);
+      const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
+      const projectPath = stored?.projectPath ?? null;
+      const transcriptPath =
+        claudeSessionId && projectPath
+          ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
+          : null;
+      return { sessionId, claudeSessionId, transcriptPath };
+    } catch {
+      return null;
+    }
   };
 }

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -18,12 +18,16 @@ import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
 import type { SessionRegistry } from '../../session/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface ConnectionHandlerDeps {
   sessionRegistry: SessionRegistry;
+  /** Resolves the daemon's current owned session so every hello_ack carries the
+   *  authoritative claudeSessionId + transcriptPath the client must follow (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   /** Forward to AdapterRegistry.trackConnection. */
   trackConnection: (connectionId: UUID, adapterType: string) => void;
   /** Forward to AdapterRegistry.untrackConnection. */
@@ -42,6 +46,7 @@ export type ConnectionHandlers = ReturnType<typeof createConnectionHandlers>;
 export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
   const {
     sessionRegistry,
+    currentOwnedSession,
     trackConnection,
     untrackConnection,
     onConnectionAdded,
@@ -49,6 +54,15 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
     cancelOrphanTimeout,
     send,
   } = deps;
+
+  /** The current binding for hello_ack: {claudeSessionId, transcriptPath}. */
+  const currentBinding = (): { claudeSessionId: UUID | null; transcriptPath: string | null } => {
+    const current = currentOwnedSession();
+    return {
+      claudeSessionId: current?.claudeSessionId ?? null,
+      transcriptPath: current?.transcriptPath ?? null,
+    };
+  };
 
   return {
     onConnect: async (connectionId: UUID, metadata: AdapterMetadata): Promise<void> => {
@@ -90,11 +104,16 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
           if (result.success) {
             send(
               connectionId,
-              createHelloAck('1.0.0', currentPrimary, {
-                isResume: result.replayMessages.length > 0,
-                replayCount: result.replayMessages.length,
-                nextBulletId: result.nextBulletId,
-              }),
+              createHelloAck(
+                '1.0.0',
+                currentPrimary,
+                {
+                  isResume: result.replayMessages.length > 0,
+                  replayCount: result.replayMessages.length,
+                  nextBulletId: result.nextBulletId,
+                },
+                currentBinding(),
+              ),
             );
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
@@ -106,8 +125,9 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
         }
 
         // Query mode or attach failed (session busy); send hello_ack without
-        // attach so utility clients (ls, kill) can still send requests.
-        send(connectionId, createHelloAck('1.0.0', currentPrimary));
+        // attach so utility clients (ls, kill) can still send requests. Still
+        // carry the binding so the client follows the current session (#499).
+        send(connectionId, createHelloAck('1.0.0', currentPrimary, undefined, currentBinding()));
         log(
           `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
         );

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -12,7 +12,7 @@
  */
 
 import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
-import type { UUID } from '@remi/shared';
+import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
 import type { SessionBindingStore } from '../../session/index.ts';
@@ -22,6 +22,7 @@ import type {
 } from '../../transcript/index.ts';
 import { TranscriptMessageBridge, TranscriptWatcher } from '../../transcript/index.ts';
 import type { AssistantEntry } from '../../transcript/index.ts';
+import type { CurrentOwnedSession } from '../current-session.ts';
 import { log, logError } from '../logger.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
@@ -32,13 +33,16 @@ export interface TranscriptHandlerDeps {
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
   bindingStore: SessionBindingStore;
+  /** Resolves the daemon's current owned session, so a stale/unknown request is
+   *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
+  currentOwnedSession: () => CurrentOwnedSession | null;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, bindingStore, send } = deps;
+  const { transcriptDiscovery, transcriptWatchers, bindingStore, currentOwnedSession, send } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -84,9 +88,20 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       }
 
       if (!filePath) {
+        // Don't dead-end: tell the client the daemon's current authoritative
+        // session so it can re-bind + re-fetch instead of getting stuck on a
+        // stale id (the "Transcript for session X not found" screenshot) (#499).
+        const current = currentOwnedSession();
+        const details: Record<string, unknown> | undefined = current
+          ? ({
+              currentSessionId: current.sessionId,
+              currentClaudeSessionId: current.claudeSessionId,
+              currentTranscriptPath: current.transcriptPath,
+            } satisfies StaleSessionErrorDetails)
+          : undefined;
         send(
           connectionId,
-          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`),
+          createError('NOT_FOUND', `Transcript for session ${sessionId} not found`, details),
         );
         return;
       }

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -11,6 +11,7 @@
  * callers don't need to know which naming scheme the session uses.
  */
 
+import * as fs from 'node:fs';
 import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
 import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
@@ -103,6 +104,19 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       if (!filePath) {
         const subPath = subagentViews.resolvePath(sessionId);
         if (subPath) {
+          // The path is derived from the hook, not verified — the subagent may
+          // not have written its first line yet (tapped right after start).
+          // Send a plain NOT_FOUND (no current-session redirect, which would
+          // wrongly bounce the user to the main session); the client clears its
+          // loaded marker on the error so a re-tap retries once it's written.
+          if (!fs.existsSync(subPath)) {
+            log(`[TranscriptLoad] Subagent ${sessionId} transcript not written yet: ${subPath}`);
+            send(
+              connectionId,
+              createError('NOT_FOUND', `Subagent transcript not ready: ${sessionId}`),
+            );
+            return;
+          }
           filePath = subPath;
           log(`[TranscriptLoad] Resolved subagent ${sessionId} to ${subPath}`);
         }

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -15,6 +15,7 @@ import { createError, createTranscriptLoadComplete, errorToString } from '@remi/
 import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
+import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import type { SessionBindingStore } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
@@ -36,13 +37,23 @@ export interface TranscriptHandlerDeps {
   /** Resolves the daemon's current owned session, so a stale/unknown request is
    *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
   currentOwnedSession: () => CurrentOwnedSession | null;
+  /** Resolves a subagent agentId -> its transcript file so the client can load a
+   *  subagent view by the agentId it got in `session_views` (#499 phase 3). */
+  subagentViews: Pick<SubagentViewRegistry, 'resolvePath'>;
   send: SendToConnection;
 }
 
 export type TranscriptHandlers = ReturnType<typeof createTranscriptHandlers>;
 
 export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
-  const { transcriptDiscovery, transcriptWatchers, bindingStore, currentOwnedSession, send } = deps;
+  const {
+    transcriptDiscovery,
+    transcriptWatchers,
+    bindingStore,
+    currentOwnedSession,
+    subagentViews,
+    send,
+  } = deps;
 
   return {
     onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID): void => {
@@ -84,6 +95,16 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
           logError(
             `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
           );
+        }
+      }
+
+      // A subagent view: the client echoes the agent_id back from session_views;
+      // resolve its deterministic <main>/subagents/agent-<id>.jsonl (#499 phase 3).
+      if (!filePath) {
+        const subPath = subagentViews.resolvePath(sessionId);
+        if (subPath) {
+          filePath = subPath;
+          log(`[TranscriptLoad] Resolved subagent ${sessionId} to ${subPath}`);
         }
       }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -1097,9 +1097,17 @@ export function setupHookBridge(
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // input.transcript_path is the MAIN transcript; the subagent file is the
     // deterministic <main>/subagents/agent-<id>.jsonl (registry derives it).
-    subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
-    pushSubagentViews();
-    handlers.onSubagentStart?.(input);
+    // Wrapped so a send/registry throw can't escape into the hook dispatch loop
+    // (mirrors initFromHookEvent/onSessionInfo) (#499 phase 3).
+    try {
+      subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
+      pushSubagentViews();
+      handlers.onSubagentStart?.(input);
+    } catch (err) {
+      logError(
+        `[Hooks] SubagentStart view-tracking failed for ${sessionId}: ${errorToString(err)}`,
+      );
+    }
   });
 
   hookServer.on('SubagentStop', (input) => {
@@ -1108,9 +1116,13 @@ export function setupHookBridge(
     else initFromHookEvent(input);
     shadowDecide('SubagentStop', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
-    subagentViews?.recordStop(input.agent_id);
-    pushSubagentViews();
-    handlers.onSubagentStop?.(input);
+    try {
+      subagentViews?.recordStop(input.agent_id);
+      pushSubagentViews();
+      handlers.onSubagentStop?.(input);
+    } catch (err) {
+      logError(`[Hooks] SubagentStop view-tracking failed for ${sessionId}: ${errorToString(err)}`);
+    }
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -38,11 +38,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionRotated, errorToString } from '@remi/shared';
+import { createSessionRotated, createSessionViews, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
 import type { QuestionPresenceTracker } from '../../api/question-presence-tracker.ts';
+import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import { AutoApproveGate } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
@@ -100,6 +101,13 @@ export interface HookBridgeDeps {
    * binder mode are unaffected.
    */
   transcriptDiscovery?: TranscriptDiscovery;
+  /**
+   * Tracks the subagent conversations this session spawns (epic #499 phase 3).
+   * Populated from SubagentStart/Stop; a `session_views` push tells the client
+   * which subagent chats it can switch to. Optional so tests/old callers are
+   * unaffected.
+   */
+  subagentViews?: SubagentViewRegistry;
 }
 
 export interface HookBridgeArgs {
@@ -148,6 +156,7 @@ export function setupHookBridge(
     shadowBinder,
     binderEnabled,
     transcriptDiscovery,
+    subagentViews,
   } = deps;
   const {
     hookServer,
@@ -171,6 +180,24 @@ export function setupHookBridge(
         rawSendAndRecord(message);
       }
     : rawSendAndRecord;
+
+  // Push the session's subagent views to clients (epic #499 phase 3). Declared
+  // here (before the binder/handlers reference it) so there is no fragile
+  // forward-reference. The SessionViewMeta omits the on-disk path: the client
+  // echoes agentId back and the daemon resolves the path via the registry.
+  const pushSubagentViews = (): void => {
+    if (!subagentViews) return;
+    sendAndRecord(
+      createSessionViews(
+        sessionId,
+        subagentViews.list().map((v) => ({
+          agentId: v.agentId,
+          agentType: v.agentType,
+          active: v.active,
+        })),
+      ),
+    );
+  };
 
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
@@ -766,6 +793,11 @@ export function setupHookBridge(
               // pending-question collection so stale answers are refused.
               tracker.clearPending();
               sessionRegistry.clearQuestions(sessionId);
+              // The new session starts with no subagents (#499 phase 3).
+              if (subagentViews) {
+                subagentViews.clear();
+                pushSubagentViews();
+              }
             },
           },
           { sessionId, workingDirectory },
@@ -1063,6 +1095,10 @@ export function setupHookBridge(
     else initFromHookEvent(input);
     shadowDecide('SubagentStart', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    // input.transcript_path is the MAIN transcript; the subagent file is the
+    // deterministic <main>/subagents/agent-<id>.jsonl (registry derives it).
+    subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
+    pushSubagentViews();
     handlers.onSubagentStart?.(input);
   });
 
@@ -1072,6 +1108,8 @@ export function setupHookBridge(
     else initFromHookEvent(input);
     shadowDecide('SubagentStop', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
+    subagentViews?.recordStop(input.agent_id);
+    pushSubagentViews();
     handlers.onSubagentStop?.(input);
   });
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -50,10 +50,12 @@ export interface TelegramConfig {
 }
 
 /**
- * Experimental feature flags (epic #453). Default OFF. Snapshotted into a const at
- * daemon boot and treated as immutable for the process lifetime — never re-read per
- * session (a mid-process flip would split sessions across the old/new code paths,
- * which share the transcriptWatchers map).
+ * TranscriptBinder feature flags (epic #453/#499). `transcript_binder_enabled`
+ * defaults ON (the binder is the default driver, #503); `transcript_binder_shadow`
+ * defaults OFF. Snapshotted into a const at daemon boot and treated as immutable
+ * for the process lifetime — never re-read per session (a mid-process flip would
+ * split sessions across the old/new code paths, which share the transcriptWatchers
+ * map).
  */
 export interface FeaturesConfig {
   /** Phase 3: run the TranscriptBinder in compute-only shadow mode alongside the old
@@ -121,7 +123,15 @@ export const DEFAULT_CONFIG: RemiConfig = {
   },
   features: {
     transcript_binder_shadow: false,
-    transcript_binder_enabled: false,
+    // The TranscriptBinder is now the DEFAULT session-binding driver (epic
+    // #499 / #503 step 1). It was shadow- and real-Claude-e2e-validated as
+    // equivalent to the old path, and is the single source of truth for the
+    // live session. Kept as a flag so `REMI_TRANSCRIPT_BINDER_ENABLED=false`
+    // is a kill-switch back to the old path until that path is deleted (#503
+    // step 2, after this default soaks). Setting `transcript_binder_shadow`
+    // alone no longer yields shadow-only — drive wins; for compare-only set
+    // `transcript_binder_enabled=false` too.
+    transcript_binder_enabled: true,
   },
 };
 

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  SubagentViewRegistry,
+  deriveSubagentTranscriptPath,
+} from '../../src/api/subagent-view-registry.ts';
+
+const MAIN = '/Users/y/.claude/projects/-Users-y-proj/7c3a497d-a1d8-4337-a359-d48bf74e69f8.jsonl';
+
+describe('deriveSubagentTranscriptPath', () => {
+  test('replaces .jsonl with the per-session subagents subdir (the on-disk layout)', () => {
+    expect(deriveSubagentTranscriptPath(MAIN, 'ab2e2dd0b25acb847')).toBe(
+      '/Users/y/.claude/projects/-Users-y-proj/7c3a497d-a1d8-4337-a359-d48bf74e69f8/subagents/agent-ab2e2dd0b25acb847.jsonl',
+    );
+  });
+});
+
+describe('SubagentViewRegistry', () => {
+  test('records a subagent on start with the derived path, active', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    expect(reg.size).toBe(1);
+    expect(reg.list()).toEqual([
+      {
+        agentId: 'a1',
+        agentType: 'Explore',
+        transcriptPath: deriveSubagentTranscriptPath(MAIN, 'a1'),
+        active: true,
+      },
+    ]);
+    expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+  });
+
+  test('stop marks inactive but keeps it viewable', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.recordStop('a1');
+    expect(reg.size).toBe(1);
+    expect(reg.list()[0]?.active).toBe(false);
+    expect(reg.resolvePath('a1')).not.toBeNull();
+  });
+
+  test('active subagents are listed before finished ones', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('done', 'code-reviewer', MAIN);
+    reg.recordStop('done');
+    reg.recordStart('running', 'Explore', MAIN);
+    expect(reg.list().map((v) => v.agentId)).toEqual(['running', 'done']);
+  });
+
+  test('ignores empty agentId or transcript path (defensive)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(undefined, 'X', MAIN);
+    reg.recordStart('', 'X', MAIN);
+    reg.recordStart('a1', 'X', '');
+    expect(reg.size).toBe(0);
+    expect(reg.resolvePath('missing')).toBeNull();
+    expect(() => reg.recordStop(undefined)).not.toThrow();
+  });
+
+  test('clear forgets everything (rotation)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.clear();
+    expect(reg.size).toBe(0);
+    expect(reg.list()).toEqual([]);
+  });
+
+  test('rejects a path-traversal agentId (it becomes a path segment)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('../../etc/passwd', 'X', MAIN);
+    reg.recordStart('a/b', 'X', MAIN);
+    reg.recordStart('a.b', 'X', MAIN);
+    expect(reg.size).toBe(0);
+    reg.recordStart('ab2e2dd0b25acb847', 'Explore', MAIN); // the real hex shape
+    expect(reg.size).toBe(1);
+  });
+
+  test('self-clears when the parent session rotates (main transcript path changes)', () => {
+    const reg = new SubagentViewRegistry();
+    const MAIN2 = MAIN.replace('7c3a497d', '99999999');
+    reg.recordStart('a1', 'Explore', MAIN);
+    reg.recordStart('a2', 'code-reviewer', MAIN); // same parent -> both kept
+    expect(reg.size).toBe(2);
+    reg.recordStart('a3', 'Explore', MAIN2); // new parent -> drop a1/a2
+    expect(reg.list().map((v) => v.agentId)).toEqual(['a3']);
+  });
+});

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -75,6 +75,12 @@ describe('SubagentViewRegistry', () => {
     expect(reg.size).toBe(1);
   });
 
+  test('rejects a main transcript path without a .jsonl suffix (derivation guard)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', '/Users/y/.claude/projects/-Users-y-proj/sess'); // no .jsonl
+    expect(reg.size).toBe(0);
+  });
+
   test('self-clears when the parent session rotates (main transcript path changes)', () => {
     const reg = new SubagentViewRegistry();
     const MAIN2 = MAIN.replace('7c3a497d', '99999999');

--- a/packages/daemon/tests/cli/current-session.test.ts
+++ b/packages/daemon/tests/cli/current-session.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { makeCurrentSessionResolver } from '../../src/cli/current-session.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+
+let tmpDir: string;
+let projectsDir: string;
+let sessionStore: SessionStore;
+let transcriptDiscovery: TranscriptDiscovery;
+
+const REMI = 'aaaaaaaa-0000-0000-0000-000000000000' as UUID;
+const CLAUDE = '22222222-2222-2222-2222-222222222222';
+const PROJECT = '/Users/test/project';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-current-session-'));
+  projectsDir = path.join(tmpDir, 'claude-projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+  transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function resolver(primary: UUID | null) {
+  return makeCurrentSessionResolver({
+    getPrimarySessionId: () => primary,
+    sessionStore,
+    transcriptDiscovery,
+  });
+}
+
+test('returns null when there is no primary session', () => {
+  expect(resolver(null)()).toBeNull();
+});
+
+test('resolves claudeSessionId + transcriptPath from the stored binding', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: CLAUDE,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current).not.toBeNull();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBe(CLAUDE as UUID);
+  // <projectTranscriptDir>/<claudeSessionId>.jsonl, dirs encoded with '-'.
+  expect(current?.transcriptPath).toBe(
+    `${transcriptDiscovery.getProjectTranscriptDir(PROJECT)}/${CLAUDE}.jsonl`,
+  );
+});
+
+test('claudeSessionId + transcriptPath are null when the binding is unbound', () => {
+  sessionStore.save({
+    remiSessionId: REMI,
+    claudeSessionId: null,
+    projectPath: PROJECT,
+    port: 18765,
+    pid: 1,
+    startedAt: new Date(0).toISOString(),
+    exitedAt: null,
+    exitCode: null,
+  });
+
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});
+
+test('claude id present but no stored record -> null binding (sessionId still returned)', () => {
+  const current = resolver(REMI)();
+  expect(current?.sessionId).toBe(REMI);
+  expect(current?.claudeSessionId).toBeNull();
+  expect(current?.transcriptPath).toBeNull();
+});

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createConnectionHandlers } from '../../../src/cli/handlers/connection-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import {
@@ -61,9 +62,10 @@ describe('createConnectionHandlers', () => {
     await sessionRegistry.shutdown();
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createConnectionHandlers({
       sessionRegistry,
+      currentOwnedSession,
       trackConnection: (id, type) => {
         trackedConnections.push({ id, type });
       },
@@ -113,6 +115,31 @@ describe('createConnectionHandlers', () => {
       expect(msg.type).toBe('hello_ack');
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
       expect(cancelOrphanCalls).toBe(1);
+    });
+
+    test('helloAck carries the authoritative current binding (#499)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+      const current: CurrentOwnedSession = {
+        sessionId,
+        claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+        transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+      };
+
+      await makeHandlers(() => current).onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const ack = sendCalls[0]?.message as {
+        type: string;
+        claudeSessionId?: string | null;
+        transcriptPath?: string | null;
+      };
+      expect(ack.type).toBe('hello_ack');
+      expect(ack.claudeSessionId).toBe(current.claudeSessionId);
+      expect(ack.transcriptPath).toBe(current.transcriptPath);
     });
 
     test('query-mode clients get a helloAck without attaching', async () => {

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -173,6 +173,25 @@ describe('createTranscriptHandlers', () => {
     );
   });
 
+  test('subagent whose transcript is not written yet -> NOT_FOUND, not an empty load', async () => {
+    // Tapped right after SubagentStart: registry has it, but the file does not
+    // exist yet. Must send NOT_FOUND (so the client retries) rather than a
+    // transcript_load_complete with 0 messages (which would cache an empty chat).
+    const mainPath = path.join(projectsDir, '-Users-test-project', 'mainsess.jsonl');
+    const agentId = 'b9c8d7e6f5a4';
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(agentId, 'Explore', mainPath); // no file written
+
+    makeHandlers(() => null, reg).onTranscriptLoadRequest(CID, agentId, REQ);
+
+    // Synchronous early-return; no microtasks.
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; code?: string };
+    expect(msg.type).toBe('error');
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(sendCalls.some((c) => c.message.type === 'transcript_load_complete')).toBe(false);
+  });
+
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {
     const claudeSessionId = '11111111-1111-1111-1111-111111111111';
     writeTranscript(claudeSessionId, [

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import { SubagentViewRegistry } from '../../../src/api/subagent-view-registry.ts';
 import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
@@ -70,12 +71,16 @@ describe('createTranscriptHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
+  function makeHandlers(
+    currentOwnedSession: () => CurrentOwnedSession | null = () => null,
+    subagentViews: SubagentViewRegistry = new SubagentViewRegistry(),
+  ) {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
       currentOwnedSession,
+      subagentViews,
       send,
     });
   }
@@ -134,6 +139,38 @@ describe('createTranscriptHandlers', () => {
     const msg = sendCalls[0]?.message as { code?: string; details?: unknown };
     expect(msg.code).toBe('NOT_FOUND');
     expect(msg.details).toBeUndefined();
+  });
+
+  test('resolves a subagent view by agentId and loads its transcript (#499 phase 3)', async () => {
+    // The client loads a subagent by the agentId it got in session_views; the
+    // daemon resolves the deterministic <main>/subagents/agent-<id>.jsonl path.
+    const mainPath = path.join(projectsDir, '-Users-test-project', 'mainsess.jsonl');
+    const agentId = 'a1b2c3d4e5f6';
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(agentId, 'Explore', mainPath);
+    const subPath = reg.resolvePath(agentId);
+    expect(subPath).not.toBeNull();
+    if (!subPath) return;
+    fs.mkdirSync(path.dirname(subPath), { recursive: true });
+    fs.writeFileSync(
+      subPath,
+      JSON.stringify({
+        type: 'user',
+        uuid: 'u1',
+        sessionId: agentId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'subagent prompt' },
+      }),
+    );
+
+    makeHandlers(() => null, reg).onTranscriptLoadRequest(CID, agentId, REQ);
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+    expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+      false,
+    );
   });
 
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { CurrentOwnedSession } from '../../../src/cli/current-session.ts';
 import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
@@ -69,11 +70,12 @@ describe('createTranscriptHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers() {
+  function makeHandlers(currentOwnedSession: () => CurrentOwnedSession | null = () => null) {
     return createTranscriptHandlers({
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
+      currentOwnedSession,
       send,
     });
   }
@@ -94,6 +96,44 @@ describe('createTranscriptHandlers', () => {
     const msg = sendCalls[0]?.message as { type: string; code?: string };
     expect(msg.type).toBe('error');
     expect(msg.code).toBe('NOT_FOUND');
+  });
+
+  test('NOT_FOUND redirects to the daemon current session (#499)', async () => {
+    // A stale request must not dead-end: the error carries the current session
+    // so the client can re-bind + re-fetch instead of getting stuck.
+    const current: CurrentOwnedSession = {
+      sessionId: 'cccccccc-0000-0000-0000-000000000000' as UUID,
+      claudeSessionId: '22222222-2222-2222-2222-222222222222' as UUID,
+      transcriptPath: '/p/22222222-2222-2222-2222-222222222222.jsonl',
+    };
+    makeHandlers(() => current).onTranscriptLoadRequest(
+      CID,
+      'd8f1613d-15a3-4f16-94e2-667b740d5fd0',
+      REQ,
+    );
+
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as {
+      code?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toEqual({
+      currentSessionId: current.sessionId,
+      currentClaudeSessionId: current.claudeSessionId,
+      currentTranscriptPath: current.transcriptPath,
+    });
+  });
+
+  test('NOT_FOUND details omitted when the daemon has no owned session', async () => {
+    makeHandlers(() => null).onTranscriptLoadRequest(
+      CID,
+      'bogus0-0000-0000-0000-000000000000',
+      REQ,
+    );
+    const msg = sendCalls[0]?.message as { code?: string; details?: unknown };
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(msg.details).toBeUndefined();
   });
 
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -140,9 +140,11 @@ describe('applyEnvOverrides', () => {
     expect(config.display.max_bullet_length).toBe(100);
   });
 
-  test('transcript-binder feature flags default OFF', () => {
+  test('transcript-binder drives by default; shadow off (#499/#503)', () => {
     expect(DEFAULT_CONFIG.features.transcript_binder_shadow).toBe(false);
-    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(false);
+    // The binder is now the default session-binding driver (kill-switch:
+    // REMI_TRANSCRIPT_BINDER_ENABLED=false).
+    expect(DEFAULT_CONFIG.features.transcript_binder_enabled).toBe(true);
   });
 
   test('auto-approve stays opt-in but defaults safe read-only tools in allow (#482)', () => {
@@ -157,17 +159,19 @@ describe('applyEnvOverrides', () => {
     expect(DEFAULT_CONFIG.auto_approve.allow.some((p) => p.includes(' '))).toBe(false);
   });
 
-  test('REMI_TRANSCRIPT_BINDER_SHADOW=true enables shadow only', () => {
+  test('shadow-only (compare without driving) needs SHADOW=true + ENABLED=false', () => {
+    // Drive is the default now, so shadow-only must explicitly opt out of drive.
     process.env['REMI_TRANSCRIPT_BINDER_SHADOW'] = 'true';
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'false';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
     expect(config.features.transcript_binder_shadow).toBe(true);
     expect(config.features.transcript_binder_enabled).toBe(false);
   });
 
-  test('REMI_TRANSCRIPT_BINDER_ENABLED=true enables drive', () => {
-    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'true';
+  test('REMI_TRANSCRIPT_BINDER_ENABLED=false is the kill-switch back to the old path', () => {
+    process.env['REMI_TRANSCRIPT_BINDER_ENABLED'] = 'false';
     const config = applyEnvOverrides(DEFAULT_CONFIG);
-    expect(config.features.transcript_binder_enabled).toBe(true);
+    expect(config.features.transcript_binder_enabled).toBe(false);
   });
 
   test('REMI_TRANSCRIPT_BINDER_SHADOW=false keeps shadow off', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,7 @@ export type {
   PingMessage,
   PongMessage,
   ErrorMessage,
+  StaleSessionErrorDetails,
   ReplayBatchMessage,
   BulletExpandRequestMessage,
   BulletExpandResponseMessage,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -88,6 +88,8 @@ export type {
   RegisterDeviceTokenMessage,
   DaemonUpdateAvailableMessage,
   SessionRotatedMessage,
+  SessionViewsMessage,
+  SessionViewMeta,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -135,6 +137,7 @@ export {
   createRegisterDeviceToken,
   createDaemonUpdateAvailable,
   createSessionRotated,
+  createSessionViews,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -100,7 +100,8 @@ export type ProtocolMessage =
   | DetachSessionAckMessage
   | RegisterDeviceTokenMessage
   | DaemonUpdateAvailableMessage
-  | SessionRotatedMessage;
+  | SessionRotatedMessage
+  | SessionViewsMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -378,6 +379,30 @@ export interface SessionRotatedMessage {
   readonly newTranscriptPath: string;
   /** Diagnostic: what triggered the rotation. */
   readonly reason: 'clear' | 'resume' | 'restart';
+}
+
+/** One selectable view a session exposes: a subagent's chat (epic #499 phase 3). */
+export interface SessionViewMeta {
+  /** The subagent's agent_id; the client echoes it back to load that view. */
+  readonly agentId: string;
+  /** e.g. "general-purpose", "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType: string;
+  /** false once the subagent finished (its transcript stays viewable). */
+  readonly active: boolean;
+}
+
+/**
+ * Daemon -> client push: the subagent conversations a session has spawned, so
+ * the client can switch the displayed view to a subagent's chat. The main
+ * conversation is always implicitly available; this lists only the subagents.
+ */
+export interface SessionViewsMessage {
+  readonly type: 'session_views';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** The Remi session these views belong to. */
+  readonly sessionId: UUID;
+  readonly subagents: readonly SessionViewMeta[];
 }
 
 /** Token usage information from a transcript entry */
@@ -753,6 +778,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'register_device_token',
     'daemon_update_available',
     'session_rotated',
+    'session_views',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1446,6 +1472,20 @@ export function createSessionRotated(
     newClaudeSessionId,
     newTranscriptPath,
     reason,
+  };
+}
+
+/** Create a session_views push listing the session's subagent views. */
+export function createSessionViews(
+  sessionId: UUID,
+  subagents: readonly SessionViewMeta[],
+): SessionViewsMessage {
+  return {
+    type: 'session_views',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    subagents,
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -277,6 +277,23 @@ export interface ErrorMessage {
   readonly details?: Record<string, unknown> | undefined;
 }
 
+/**
+ * Details attached to a `NOT_FOUND` error for a stale transcript/session request
+ * (epic #499). When a client asks for a session the daemon no longer owns, the
+ * daemon answers with its current authoritative session so the client can
+ * self-correct (re-bind + re-fetch) instead of dead-ending on "not found".
+ * All fields may be null if the daemon currently has no owned session.
+ */
+export interface StaleSessionErrorDetails {
+  /** The daemon's current Remi session id. Always present (the daemon only
+   *  attaches these details when it has a current owned session). */
+  readonly currentSessionId: UUID;
+  /** The current Claude session id (rotates on /clear); null if unbound. */
+  readonly currentClaudeSessionId: UUID | null;
+  /** The current transcript file path. */
+  readonly currentTranscriptPath: string | null;
+}
+
 /** Batch of messages to replay on session resume */
 export interface ReplayBatchMessage {
   readonly type: 'replay_batch';

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -223,7 +223,12 @@ function App() {
     // daemon to its current session (reconnect adopt, stale redirect) loads the
     // chat automatically instead of waiting for a user tap (#499).
     const ensureTranscriptLoaded = (connId: ConnectionId, sid: string) => {
-      if (loadedTranscriptsRef.current.has(sid)) return;
+      if (loadedTranscriptsRef.current.has(sid)) {
+        // Already loaded -> intentionally not re-fetched (the content is the
+        // current session's). Logged so the skip is diagnosable (#499 review).
+        console.debug('[App] ensureTranscriptLoaded: already loaded, skipping', sid);
+        return;
+      }
       loadedTranscriptsRef.current.add(sid);
       requestTranscriptLoadRef.current?.(connId, sid);
     };

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -463,6 +463,41 @@ function App() {
         break;
       }
 
+      case 'session_views': {
+        // The parent session's subagent chats (#499 phase 3). Surface each as a
+        // navigable entry whose id IS the agentId; opening it loads
+        // agent-<id>.jsonl through the normal transcript flow. Replace this
+        // parent's whole subagent set each push (active first, finished kept).
+        const parentId = message.sessionId;
+        const subs = message.subagents;
+        setSessions((prev) => {
+          const parent = prev.find((s) => s.id === parentId);
+          const withoutOldSubs = prev.filter(
+            (s) =>
+              !(s.isSubagent && s.parentSessionId === parentId && s.connectionId === connectionId),
+          );
+          const subRows: UISession[] = subs.map((v) => {
+            const existing = prev.find((s) => s.id === (v.agentId as UUID));
+            return {
+              id: v.agentId as UUID,
+              name: v.agentType,
+              connectionId,
+              createdAt: existing?.createdAt ?? new Date().toISOString(),
+              lastActiveAt: new Date().toISOString(),
+              status: 'idle',
+              connectionStatus: parent?.connectionStatus ?? 'connected',
+              unreadCount: 0,
+              isSubagent: true,
+              parentSessionId: parentId,
+              agentType: v.agentType,
+              subagentActive: v.active,
+            } satisfies UISession;
+          });
+          return [...withoutOldSubs, ...subRows];
+        });
+        break;
+      }
+
       case 'session_rotated': {
         // Atomic rotation (#438): /clear or /resume started a NEW transcript
         // under a new Claude session id (NOT /compact, which keeps the same
@@ -1452,6 +1487,10 @@ function App() {
   const handleSend = useCallback(
     (content: string) => {
       if (!activeSessionId) return;
+      // Subagent views are read-only monitoring: their id is an agentId, not a
+      // real daemon session, so input would route nowhere. Block the send
+      // (the input is also hidden in ChatView) (#499 phase 3).
+      if (sessionsRef.current.find((s) => s.id === activeSessionId)?.isSubagent) return;
       const connId = getActiveConnectionId();
       if (!connId) {
         const systemMsg: UIMessage = {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -172,6 +172,12 @@ function App() {
   const messagesRef = useRef(messages);
   const questionsRef = useRef(questions);
   const getSessionIdRef = useRef<((connId: ConnectionId) => string | null) | null>(null);
+  // Stable handle so handleMessage (empty deps) can re-fetch a transcript when
+  // it follows the daemon to its current session (reconnect adopt + stale
+  // redirect), without depending on requestTranscriptLoad's identity (#499).
+  const requestTranscriptLoadRef = useRef<
+    ((connId: ConnectionId, sessionId: string) => void) | null
+  >(null);
   const sessionsRef = useRef<UISession[]>([]);
   const lastQuestionIdRef = useRef<string | null>(null);
   // Mirror replyContexts in a ref so handleSend can read the active
@@ -211,6 +217,15 @@ function App() {
       setMessages((prev) => prev.filter((m) => m.sessionId !== sid));
       setQuestions((prev) => clearSessionQuestions(prev, sid));
       loadedTranscriptsRef.current.delete(sid);
+    };
+
+    // Fetch a session's transcript if we haven't already, so that FOLLOWING the
+    // daemon to its current session (reconnect adopt, stale redirect) loads the
+    // chat automatically instead of waiting for a user tap (#499).
+    const ensureTranscriptLoaded = (connId: ConnectionId, sid: string) => {
+      if (loadedTranscriptsRef.current.has(sid)) return;
+      loadedTranscriptsRef.current.add(sid);
+      requestTranscriptLoadRef.current?.(connId, sid);
     };
 
     switch (message.type) {
@@ -311,6 +326,9 @@ function App() {
             setActiveSessionId(message.sessionId);
             setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
             setQuestions((prev) => clearSessionQuestions(prev, oldActive));
+            // Load the followed session's transcript so the chat isn't left
+            // empty after a reconnect-mid-rotation adopt (#499).
+            ensureTranscriptLoaded(connectionId, message.sessionId);
           }
         }
         break;
@@ -837,6 +855,66 @@ function App() {
         // packages/daemon/src/cli/handlers/input-events.ts:guardBinding;
         // update both ends together if the field names change.
         const errorCode = (message as { code?: string }).code;
+        // NOT_FOUND with a current-session redirect (#499): the requested
+        // session is stale (the daemon restarted or rotated past it). Follow the
+        // daemon to its current session and load it, instead of dead-ending on a
+        // "Transcript for session X not found" bubble the user can't escape.
+        if (errorCode === 'NOT_FOUND') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const currentSessionId = asNonEmptyString(details?.['currentSessionId']) as
+            | UUID
+            | undefined;
+          if (currentSessionId) {
+            const currentClaudeSessionId = asNonEmptyString(details?.['currentClaudeSessionId']);
+            const currentTranscriptPath = asNonEmptyString(details?.['currentTranscriptPath']);
+            const claudePatch = currentClaudeSessionId
+              ? { claudeSessionId: currentClaudeSessionId as UUID }
+              : {};
+            const transcriptPatch = currentTranscriptPath
+              ? { transcriptPath: currentTranscriptPath }
+              : {};
+            // Upsert: patch the binding if the session is already listed, else
+            // add a placeholder row (the NOT_FOUND can race ahead of the
+            // hello_ack that adds it) so setActiveSessionId has something to
+            // render instead of a blank screen (#499 review).
+            setSessions((prev) => {
+              if (prev.some((s) => s.id === currentSessionId && s.connectionId === connectionId)) {
+                return prev.map((s) =>
+                  s.id === currentSessionId && s.connectionId === connectionId
+                    ? { ...s, ...claudePatch, ...transcriptPatch }
+                    : s,
+                );
+              }
+              return [
+                ...prev,
+                {
+                  id: currentSessionId,
+                  name: 'Claude Code Session',
+                  createdAt: new Date().toISOString(),
+                  lastActiveAt: new Date().toISOString(),
+                  status: 'idle',
+                  connectionStatus: 'connected',
+                  connectionId,
+                  unreadCount: 0,
+                  preview: 'Connected',
+                  ...claudePatch,
+                  ...transcriptPatch,
+                } satisfies UISession,
+              ];
+            });
+            // Do NOT clearSessionForRebind here -- that would wipe the current
+            // session's already-rendered messages. ensureTranscriptLoaded gates
+            // on the loaded marker, so it fetches only if not already loaded
+            // (no wipe, no duplicate append) (#499 review).
+            setActiveSessionId(currentSessionId);
+            ensureTranscriptLoaded(connectionId, currentSessionId);
+            console.warn(
+              '[App] Stale transcript request; following daemon to current session',
+              currentSessionId,
+            );
+            break;
+          }
+        }
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;
@@ -964,6 +1042,7 @@ function App() {
   getSessionIdRef.current = getSessionId;
   sessionsRef.current = sessions;
   requestSessionListRef.current = requestSessionList;
+  requestTranscriptLoadRef.current = requestTranscriptLoad;
   connectionsRef.current = connections;
 
   // Derived connection status

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -151,23 +151,27 @@ export function ChatView({
         showTimestamps={showTimestamps}
       />
 
-      <InputArea
-        onSend={onSend}
-        onAnswer={(answer) => {
-          if (primaryQuestion) onAnswer(primaryQuestion, answer);
-        }}
-        onCancel={onCancel}
-        question={null}
-        isAgentBusy={isAgentBusy}
-        disabled={!isConnected}
-        replyContext={replyContext ?? null}
-        onClearReply={onClearReply}
-        // Session-scoped draft persistence so a half-typed message survives
-        // app suspension on iOS (#226) and switching to a different session
-        // doesn't leak the draft across.
-        draftKey={`remi-draft-${session.id}`}
-        placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
-      />
+      {/* Subagent views are read-only monitoring (their id is an agentId, not a
+          real daemon session), so there is no input to route (#499 phase 3). */}
+      {!session.isSubagent && (
+        <InputArea
+          onSend={onSend}
+          onAnswer={(answer) => {
+            if (primaryQuestion) onAnswer(primaryQuestion, answer);
+          }}
+          onCancel={onCancel}
+          question={null}
+          isAgentBusy={isAgentBusy}
+          disabled={!isConnected}
+          replyContext={replyContext ?? null}
+          onClearReply={onClearReply}
+          // Session-scoped draft persistence so a half-typed message survives
+          // app suspension on iOS (#226) and switching to a different session
+          // doesn't leak the draft across.
+          draftKey={`remi-draft-${session.id}`}
+          placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -129,6 +129,18 @@ export interface UISession {
   readonly claudeSessionId?: UUID;
   /** Absolute path to the bound .jsonl transcript (#430). */
   readonly transcriptPath?: string;
+  /**
+   * This entry is a subagent view spawned by a parent session, not a
+   * top-level session (epic #499 phase 3). Its `id` is the subagent's
+   * `agentId`; tapping it loads `agent-<id>.jsonl` via the normal flow.
+   */
+  readonly isSubagent?: boolean;
+  /** For a subagent view: the parent session's id. */
+  readonly parentSessionId?: UUID;
+  /** For a subagent view: e.g. "Explore", "pr-review-toolkit:code-reviewer". */
+  readonly agentType?: string;
+  /** For a subagent view: false once it finished (transcript stays viewable). */
+  readonly subagentActive?: boolean;
 }
 
 /** Structured option for a question */


### PR DESCRIPTION
## Release 0.6.3 — epic #499 (source of truth for the live session) + subagent views

Consolidating everything that landed in `develop` since 0.6.2 into `main`. Merging this triggers the auto-release (strip `-dev`, tag `v0.6.3`, publish npm/Homebrew/GitHub, then sync `main` back into `develop`).

### What's in 0.6.3 (epic #499)
- **Phase 1 (#500/#504)** — daemon: a stale transcript request is answered with the **current** session (`StaleSessionErrorDetails`) instead of a dead-end `NOT_FOUND`; `hello_ack` always carries the authoritative binding.
- **Phase 2 (#501/#505)** — client: follows that redirect (adopt + upsert + auto-fetch) and auto-loads on the reconnect-mid-rotation adopt — kills the "Transcript for session X not found" stuck screen.
- **Phase 3 (#502/#507)** — subagent views: the daemon tracks subagents at the deterministic `<main>/subagents/agent-<id>.jsonl` path and pushes `session_views`; the client surfaces each as a read-only entry.
- **Binder default (#503 step 1 / #508)** — the TranscriptBinder is now the default session-binding driver (kill-switch `REMI_TRANSCRIPT_BINDER_ENABLED=false`).

### Still open (post-release)
- **#503 step 2** — delete the old binding path (after this default soaks).
- **#494** — auto-approve → synchronous decisions (separate epic, phase 1 merged, phase 2 designed).

### Review
Every phase was individually reviewed (sonnet) + CI-green before landing in develop. This PR gets a final holistic release review.
