### PR TITLE
fix: 0.6.3 release-review silent-failure findings

### DIFF
--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -49,6 +49,9 @@ export class SubagentViewRegistry {
     // anything that could escape the subagents dir. Real values are hex like
     // "ab2e2dd0b25acb847"; a path-traversal payload must never reach the FS.
     if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return;
+    // The path is derived by replacing the `.jsonl` suffix with a subdir; if a
+    // future Claude format drops it, the derivation would be wrong, so require it.
+    if (!mainTranscriptPath.endsWith('.jsonl')) return;
     if (this.currentMain !== null && this.currentMain !== mainTranscriptPath) {
       this.views.clear();
     }

--- a/packages/daemon/src/cli/current-session.ts
+++ b/packages/daemon/src/cli/current-session.ts
@@ -40,15 +40,22 @@ export function makeCurrentSessionResolver(
 ): () => CurrentOwnedSession | null {
   const { getPrimarySessionId, sessionStore, transcriptDiscovery } = deps;
   return () => {
-    const sessionId = getPrimarySessionId();
-    if (!sessionId) return null;
-    const stored = sessionStore.findByRemiSessionId(sessionId);
-    const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
-    const projectPath = stored?.projectPath ?? null;
-    const transcriptPath =
-      claudeSessionId && projectPath
-        ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
-        : null;
-    return { sessionId, claudeSessionId, transcriptPath };
+    // Must never throw: this runs in the void transcript-load handler's
+    // NOT_FOUND path, which is not wrapped — a disk hiccup on the store read
+    // would otherwise escape and leave the client with no response.
+    try {
+      const sessionId = getPrimarySessionId();
+      if (!sessionId) return null;
+      const stored = sessionStore.findByRemiSessionId(sessionId);
+      const claudeSessionId = (stored?.claudeSessionId ?? null) as UUID | null;
+      const projectPath = stored?.projectPath ?? null;
+      const transcriptPath =
+        claudeSessionId && projectPath
+          ? `${transcriptDiscovery.getProjectTranscriptDir(projectPath)}/${claudeSessionId}.jsonl`
+          : null;
+      return { sessionId, claudeSessionId, transcriptPath };
+    } catch {
+      return null;
+    }
   };
 }

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -11,6 +11,7 @@
  * callers don't need to know which naming scheme the session uses.
  */
 
+import * as fs from 'node:fs';
 import { createError, createTranscriptLoadComplete, errorToString } from '@remi/shared';
 import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
@@ -103,6 +104,19 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
       if (!filePath) {
         const subPath = subagentViews.resolvePath(sessionId);
         if (subPath) {
+          // The path is derived from the hook, not verified — the subagent may
+          // not have written its first line yet (tapped right after start).
+          // Send a plain NOT_FOUND (no current-session redirect, which would
+          // wrongly bounce the user to the main session); the client clears its
+          // loaded marker on the error so a re-tap retries once it's written.
+          if (!fs.existsSync(subPath)) {
+            log(`[TranscriptLoad] Subagent ${sessionId} transcript not written yet: ${subPath}`);
+            send(
+              connectionId,
+              createError('NOT_FOUND', `Subagent transcript not ready: ${sessionId}`),
+            );
+            return;
+          }
           filePath = subPath;
           log(`[TranscriptLoad] Resolved subagent ${sessionId} to ${subPath}`);
         }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -1097,9 +1097,17 @@ export function setupHookBridge(
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     // input.transcript_path is the MAIN transcript; the subagent file is the
     // deterministic <main>/subagents/agent-<id>.jsonl (registry derives it).
-    subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
-    pushSubagentViews();
-    handlers.onSubagentStart?.(input);
+    // Wrapped so a send/registry throw can't escape into the hook dispatch loop
+    // (mirrors initFromHookEvent/onSessionInfo) (#499 phase 3).
+    try {
+      subagentViews?.recordStart(input.agent_id, input.agent_type, input.transcript_path);
+      pushSubagentViews();
+      handlers.onSubagentStart?.(input);
+    } catch (err) {
+      logError(
+        `[Hooks] SubagentStart view-tracking failed for ${sessionId}: ${errorToString(err)}`,
+      );
+    }
   });
 
   hookServer.on('SubagentStop', (input) => {
@@ -1108,9 +1116,13 @@ export function setupHookBridge(
     else initFromHookEvent(input);
     shadowDecide('SubagentStop', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
-    subagentViews?.recordStop(input.agent_id);
-    pushSubagentViews();
-    handlers.onSubagentStop?.(input);
+    try {
+      subagentViews?.recordStop(input.agent_id);
+      pushSubagentViews();
+      handlers.onSubagentStop?.(input);
+    } catch (err) {
+      logError(`[Hooks] SubagentStop view-tracking failed for ${sessionId}: ${errorToString(err)}`);
+    }
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -75,6 +75,12 @@ describe('SubagentViewRegistry', () => {
     expect(reg.size).toBe(1);
   });
 
+  test('rejects a main transcript path without a .jsonl suffix (derivation guard)', () => {
+    const reg = new SubagentViewRegistry();
+    reg.recordStart('a1', 'Explore', '/Users/y/.claude/projects/-Users-y-proj/sess'); // no .jsonl
+    expect(reg.size).toBe(0);
+  });
+
   test('self-clears when the parent session rotates (main transcript path changes)', () => {
     const reg = new SubagentViewRegistry();
     const MAIN2 = MAIN.replace('7c3a497d', '99999999');

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -173,6 +173,25 @@ describe('createTranscriptHandlers', () => {
     );
   });
 
+  test('subagent whose transcript is not written yet -> NOT_FOUND, not an empty load', async () => {
+    // Tapped right after SubagentStart: registry has it, but the file does not
+    // exist yet. Must send NOT_FOUND (so the client retries) rather than a
+    // transcript_load_complete with 0 messages (which would cache an empty chat).
+    const mainPath = path.join(projectsDir, '-Users-test-project', 'mainsess.jsonl');
+    const agentId = 'b9c8d7e6f5a4';
+    const reg = new SubagentViewRegistry();
+    reg.recordStart(agentId, 'Explore', mainPath); // no file written
+
+    makeHandlers(() => null, reg).onTranscriptLoadRequest(CID, agentId, REQ);
+
+    // Synchronous early-return; no microtasks.
+    expect(sendCalls).toHaveLength(1);
+    const msg = sendCalls[0]?.message as { type: string; code?: string };
+    expect(msg.type).toBe('error');
+    expect(msg.code).toBe('NOT_FOUND');
+    expect(sendCalls.some((c) => c.message.type === 'transcript_load_complete')).toBe(false);
+  });
+
   test('reads a transcript by Claude session id and sends a completion envelope', async () => {
     const claudeSessionId = '11111111-1111-1111-1111-111111111111';
     writeTranscript(claudeSessionId, [

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -223,7 +223,12 @@ function App() {
     // daemon to its current session (reconnect adopt, stale redirect) loads the
     // chat automatically instead of waiting for a user tap (#499).
     const ensureTranscriptLoaded = (connId: ConnectionId, sid: string) => {
-      if (loadedTranscriptsRef.current.has(sid)) return;
+      if (loadedTranscriptsRef.current.has(sid)) {
+        // Already loaded -> intentionally not re-fetched (the content is the
+        // current session's). Logged so the skip is diagnosable (#499 review).
+        console.debug('[App] ensureTranscriptLoaded: already loaded, skipping', sid);
+        return;
+      }
       loadedTranscriptsRef.current.add(sid);
       requestTranscriptLoadRef.current?.(connId, sid);
     };


### PR DESCRIPTION
Addresses the silent-failure findings from the dev->main complete review of #510: subagent-not-ready -> NOT_FOUND (not an empty cached load); SubagentStart/Stop view-tracking try/catch; defensive currentOwnedSession resolver; .jsonl derivation guard; ensureTranscriptLoaded skip log. Merging into develop before the 0.6.3 release. +2 tests; daemon typecheck + web tsc/eslint/build green.