### PR TITLE
feat(terminal): auto-approve OSC notification + animated title cue

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -128,8 +128,9 @@ export class AutoApproveGate {
     // Auto-approve gate: evaluate before creating a Question object.
     if (service) {
       // Open the buffer window: a PTY prompt that renders during the eval is
-      // held (not pushed) until we know the verdict. #484.
-      this.deps.onEvalStart?.();
+      // held (not pushed) until we know the verdict. #484. The terminal cue
+      // (#513) rides this signal but must never throw into the dispatch loop.
+      this.safeCue('onEvalStart', this.deps.onEvalStart);
       // Pass the raw suggestions array; AutoApproveService does its own strict-string
       // filtering before feeding the LLM. We forward the raw shape (rather than
       // coercing) so the multi-choice classifier can see "non-string entry" and route
@@ -149,7 +150,7 @@ export class AutoApproveGate {
             // onto the next unrelated PTY prompt (e.g. user typed /compact, no
             // PreToolUse fires).
             this.deps.tracker.clearPending();
-            this.deps.onCancelled?.();
+            this.safeCue('onCancelled', this.deps.onCancelled);
             log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
             return;
           }
@@ -235,7 +236,23 @@ export class AutoApproveGate {
    */
   private markHandled(): void {
     this.deps.tracker.onAutoApproveHandled();
-    this.deps.onHandled?.();
+    this.safeCue('onHandled', this.deps.onHandled);
+  }
+
+  /**
+   * Invoke a COSMETIC lifecycle callback (the #513 terminal cue). The cue must
+   * never affect the decision path or the #484 buffer state, so a throw is
+   * logged and absorbed here rather than propagating into the .then()/.catch()
+   * chain (where the outer catch would re-run the decision and could re-open an
+   * already-closed buffer). Mirrors how `escalateToUser` shields `onEscalate`.
+   */
+  private safeCue(label: string, fn: (() => void) | undefined): void {
+    if (!fn) return;
+    try {
+      fn();
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
   }
 
   /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */
@@ -306,7 +323,9 @@ export class AutoApproveGate {
       // Release the buffer UNCONDITIONALLY: the verdict is "user must answer".
       // Even if escalate() threw (push will fail), the buffer must not stay
       // locked, or every later prompt in this session would buffer forever. #484.
-      this.deps.onEscalate?.();
+      // safeCue: the wired callback releases the buffer (critical) then fires the
+      // terminal cue (#513, cosmetic); a cue throw must not break the finally.
+      this.safeCue('onEscalate', this.deps.onEscalate);
     }
   }
 }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -71,6 +71,12 @@ export interface AutoApproveGateDeps {
   /** Called when the verdict is escalate (the user must answer), so the tracker
    *  releases the buffered PTY prompt. #484. */
   onEscalate?: () => void;
+  /** Called when the permission was auto-approved/denied silently (inject
+   *  succeeded; the user never sees it). Drives the terminal "done" cue. #513. */
+  onHandled?: () => void;
+  /** Called when the eval ended without a verdict (cancelled — the user already
+   *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
+  onCancelled?: () => void;
 }
 
 export class AutoApproveGate {
@@ -143,18 +149,19 @@ export class AutoApproveGate {
             // onto the next unrelated PTY prompt (e.g. user typed /compact, no
             // PreToolUse fires).
             this.deps.tracker.clearPending();
+            this.deps.onCancelled?.();
             log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
             return;
           }
           if (result.decision === 'approve') {
             // inject success -> auto-handled (close the buffer; user never sees
             // it); inject failure -> escalate (which releases the buffer). #484.
-            if (await this.inject(input, '1', 'approved')) this.deps.tracker.onAutoApproveHandled();
+            if (await this.inject(input, '1', 'approved')) this.markHandled();
             else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'deny') {
-            if (await this.inject(input, '3', 'denied')) this.deps.tracker.onAutoApproveHandled();
+            if (await this.inject(input, '3', 'denied')) this.markHandled();
             else this.escalateToUser(input);
             return;
           }
@@ -169,7 +176,7 @@ export class AutoApproveGate {
                 `multichoice-pick-${result.pickIndex}`,
               )
             ) {
-              this.deps.tracker.onAutoApproveHandled();
+              this.markHandled();
             } else {
               this.escalateToUser(input);
             }
@@ -185,7 +192,7 @@ export class AutoApproveGate {
               `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
             );
             await this.inject(input, '3', 'subagent-escalate-default-deny', true);
-            this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
+            this.markHandled(); // close the buffer window (#484)
             return;
           }
           this.escalateToUser(input);
@@ -196,7 +203,7 @@ export class AutoApproveGate {
             logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
             if (isInSubagentContext()) {
               await this.inject(input, '3', 'subagent-error-default-deny', true);
-              this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
+              this.markHandled(); // close the buffer window (#484)
               return;
             }
             this.escalateToUser(input);
@@ -218,6 +225,17 @@ export class AutoApproveGate {
     }
 
     this.escalateToUser(input);
+  }
+
+  /**
+   * Buffer-closing success path: the permission was auto-approved/denied
+   * silently (inject succeeded), so the user never sees it. Notifies the
+   * tracker (closes the #484 buffer window) AND the terminal cue (#513). Every
+   * silent-handle site routes through here so neither signal can be missed.
+   */
+  private markHandled(): void {
+    this.deps.tracker.onAutoApproveHandled();
+    this.deps.onHandled?.();
   }
 
   /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -134,6 +134,7 @@ import { createMessageApiForSession } from './cli/session-phases/message-api-set
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { installSuspendHandler } from './cli/suspend-handler.ts';
+import { type TerminalIndicator, createTerminalIndicator } from './cli/terminal-indicator.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
 import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
@@ -783,6 +784,19 @@ let autoApproveService: AutoApproveService | null = null;
 }
 
 // ---------------------------------------------------------------------------
+// Terminal cue (#513): animates the wrapper terminal title + fires a desktop
+// notification across the auto-approve lifecycle. Built only when auto-approve
+// is enabled (the gate is its sole driver). Process-wide; one terminal. The
+// writer no-ops in headless/daemon mode (no real terminal fd).
+// ---------------------------------------------------------------------------
+const terminalIndicator: TerminalIndicator | undefined = autoApproveService
+  ? createTerminalIndicator(
+      { notify: remiConfig.terminal.notify, statusCue: remiConfig.terminal.status_cue },
+      process.cwd(),
+    )
+  : undefined;
+
+// ---------------------------------------------------------------------------
 // SIGTSTP / Ctrl+Z handling.
 //
 // Wrapper mode (`remi <args>`): the wrapper installs `cli/suspend-handler.ts`
@@ -1130,6 +1144,7 @@ async function createNewSession(
         binderEnabled,
         transcriptDiscovery,
         subagentViews,
+        terminalIndicator,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -60,6 +60,7 @@ import type { BinderDecision, BinderHookEvent } from '../../transcript/index.ts'
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/transcript-discovery.ts';
 import { log, logError } from '../logger.ts';
+import type { TerminalIndicator } from '../terminal-indicator.ts';
 import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
 export interface HookBridgeDeps {
@@ -108,6 +109,12 @@ export interface HookBridgeDeps {
    * unaffected.
    */
   subagentViews?: SubagentViewRegistry;
+  /**
+   * Process-wide terminal cue (#513): animates the wrapper terminal title and
+   * fires a desktop notification across the auto-approve lifecycle. Shared by
+   * all sessions (one terminal). Optional; inert when absent or headless.
+   */
+  terminalIndicator?: TerminalIndicator | undefined;
 }
 
 export interface HookBridgeArgs {
@@ -657,8 +664,17 @@ export function setupHookBridge(
       escalate: (i) => handlers.onPermissionRequest?.(i),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
-      onEvalStart: () => tracker.onAutoApproveStart(),
-      onEscalate: () => tracker.onAutoApproveEscalate(),
+      // #513: the same lifecycle drives the terminal cue (spinner -> done / needs-you).
+      onEvalStart: () => {
+        tracker.onAutoApproveStart();
+        deps.terminalIndicator?.start();
+      },
+      onEscalate: () => {
+        tracker.onAutoApproveEscalate();
+        deps.terminalIndicator?.resolve('escalate');
+      },
+      onHandled: () => deps.terminalIndicator?.resolve('handled'),
+      onCancelled: () => deps.terminalIndicator?.stop(),
     },
     sessionId,
   );

--- a/packages/daemon/src/cli/terminal-indicator.ts
+++ b/packages/daemon/src/cli/terminal-indicator.ts
@@ -1,0 +1,254 @@
+/**
+ * Out-of-band terminal feedback for the auto-approve lifecycle (#513, epic
+ * #481 item 5).
+ *
+ * Two channels, both written to the REAL terminal fd (the saved
+ * `ptyStdoutFd`) as OSC escape sequences. OSC is out-of-band: it sets the
+ * window title / fires a desktop notification without drawing into the screen
+ * grid, so it never corrupts Claude's alternate-screen TUI (an in-viewport
+ * "corner badge" would be overwritten on Claude's next redraw — the title bar
+ * is the only cue channel that does not fight the renderer).
+ *
+ *  1. Animated TITLE status cue: a spinner while the LLM evaluates, then a
+ *     check (auto-handled) or warning (escalated) glyph; restored to an idle
+ *     title afterward.
+ *  2. Escalation NOTIFICATION: a desktop notification at the escalate seam
+ *     (osc9 / osc777 / bell / off), so a user looking away from a terminal
+ *     that swallows the prompt (e.g. Ghostty) still gets pinged.
+ *
+ * The writer is injected, so the class is testable without a real terminal and
+ * the production writer can guard on fd-present / not-detached and silently
+ * no-op in headless/daemon mode.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getPtyStdoutFd, isWrapperDetached } from './wrapper-state.ts';
+
+const ESC = '\x1b';
+const BEL = '\x07';
+
+/** Where to fire the escalation notification. */
+export type TerminalNotifyChannel = 'osc9' | 'osc777' | 'bell' | 'off';
+
+export interface TerminalCueConfig {
+  /** Escalation notification channel. 'off' disables it. */
+  readonly notify: TerminalNotifyChannel;
+  /** Animate the terminal title (evaluating spinner -> done/needs-you). */
+  readonly statusCue: boolean;
+}
+
+/** Spinner frames (braille) cycled while the eval is in flight. */
+export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
+
+const SPINNER_INTERVAL_MS = 120;
+/** How long the ✓ title lingers before restoring the idle title. */
+const HANDLED_LINGER_MS = 1500;
+
+/**
+ * Strip the bytes that would terminate or break out of an OSC string, so an
+ * interpolated value can never inject its own escape sequence. Our texts are
+ * static today; this is defensive for future dynamic titles.
+ */
+function sanitize(text: string): string {
+  return text.replace(/[\x00-\x1f\x7f]/g, ' ');
+}
+
+/** OSC 2: set the window/tab title. */
+export function oscTitle(text: string): string {
+  return `${ESC}]2;${sanitize(text)}${BEL}`;
+}
+
+/** OSC 9: iTerm2 / Ghostty desktop notification (single string). */
+export function osc9Notify(text: string): string {
+  return `${ESC}]9;${sanitize(text)}${BEL}`;
+}
+
+/** OSC 777: kitty / wezterm / urxvt desktop notification (title + body). */
+export function osc777Notify(title: string, body: string): string {
+  return `${ESC}]777;notify;${sanitize(title)};${sanitize(body)}${BEL}`;
+}
+
+/**
+ * Wrap an escape sequence for tmux passthrough so OSC reaches the outer
+ * terminal instead of being eaten by tmux. Requires `set -g allow-passthrough
+ * on` in tmux; harmless if absent (the sequence is just ignored). The inner
+ * ESC bytes must be doubled.
+ */
+export function wrapTmuxPassthrough(seq: string): string {
+  return `${ESC}Ptmux;${ESC}${seq.replaceAll(ESC, ESC + ESC)}${ESC}\\`;
+}
+
+export interface TerminalIndicatorDeps {
+  /** Write a (possibly tmux-wrapped) sequence to the terminal. Must no-op when
+   *  no terminal is attached (headless/detached). */
+  readonly write: (sequence: string) => void;
+  readonly config: TerminalCueConfig;
+  /** Title to restore to when idle. Empty string clears the title. */
+  readonly idleTitle?: string;
+  /** True when running inside tmux; OSC is passthrough-wrapped. */
+  readonly tmux?: boolean;
+  /** Injected timers (defaults to globals) so tests stay deterministic. */
+  readonly setIntervalFn?: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  readonly clearIntervalFn?: (handle: ReturnType<typeof setInterval>) => void;
+  readonly setTimeoutFn?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+/**
+ * Renders the auto-approve eval lifecycle to the terminal. One instance per
+ * daemon process (a single terminal); shared across sessions. Concurrent evals
+ * are rare in wrapper mode (one foreground Claude); the last writer wins and
+ * `resolve`/`stop` always clears the spinner, so no spinner can leak.
+ */
+export class TerminalIndicator {
+  private readonly write: (sequence: string) => void;
+  private readonly config: TerminalCueConfig;
+  private readonly idleTitle: string;
+  private readonly tmux: boolean;
+  private readonly setIntervalFn: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  private readonly clearIntervalFn: (handle: ReturnType<typeof setInterval>) => void;
+  private readonly setTimeoutFn: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimeoutFn: (handle: ReturnType<typeof setTimeout>) => void;
+
+  private spinnerHandle: ReturnType<typeof setInterval> | null = null;
+  private lingerHandle: ReturnType<typeof setTimeout> | null = null;
+  private frame = 0;
+
+  constructor(deps: TerminalIndicatorDeps) {
+    this.write = deps.write;
+    this.config = deps.config;
+    this.idleTitle = deps.idleTitle ?? '';
+    this.tmux = deps.tmux ?? false;
+    this.setIntervalFn = deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+    this.clearIntervalFn = deps.clearIntervalFn ?? ((h) => clearInterval(h));
+    this.setTimeoutFn = deps.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimeoutFn = deps.clearTimeoutFn ?? ((h) => clearTimeout(h));
+  }
+
+  /** Emit a sequence, tmux-wrapped when inside tmux. */
+  private emit(sequence: string): void {
+    this.write(this.tmux ? wrapTmuxPassthrough(sequence) : sequence);
+  }
+
+  private setTitle(text: string): void {
+    this.emit(oscTitle(text));
+  }
+
+  /** Eval started: begin the animated title spinner. */
+  start(): void {
+    this.clearTimers();
+    if (!this.config.statusCue) return;
+    this.frame = 0;
+    this.renderSpinnerFrame();
+    this.spinnerHandle = this.setIntervalFn(() => {
+      this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
+      this.renderSpinnerFrame();
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  private renderSpinnerFrame(): void {
+    this.setTitle(`${SPINNER_FRAMES[this.frame]} Remi · evaluating…`);
+  }
+
+  /**
+   * Verdict reached. 'handled' => the permission was auto-approved/denied
+   * silently (✓, then restore idle). 'escalate' => the user must answer (⚠,
+   * persist + fire the notification).
+   */
+  resolve(outcome: 'handled' | 'escalate'): void {
+    this.stopSpinner();
+    if (outcome === 'escalate') {
+      if (this.config.statusCue) this.setTitle('⚠ Remi · needs you');
+      this.notifyEscalation();
+      return;
+    }
+    // handled
+    if (this.config.statusCue) {
+      this.setTitle('✓ Remi');
+      this.lingerHandle = this.setTimeoutFn(() => {
+        this.setTitle(this.idleTitle);
+        this.lingerHandle = null;
+      }, HANDLED_LINGER_MS);
+    }
+  }
+
+  /** Eval ended without a verdict (cancelled — user already advanced). Stop the
+   *  spinner and restore the idle title; no notification. */
+  stop(): void {
+    this.stopSpinner();
+    if (this.config.statusCue) this.setTitle(this.idleTitle);
+  }
+
+  private notifyEscalation(): void {
+    const title = 'Remi';
+    const body = 'A permission needs your approval';
+    switch (this.config.notify) {
+      case 'osc9':
+        this.emit(osc9Notify(`${title}: ${body}`));
+        break;
+      case 'osc777':
+        this.emit(osc777Notify(title, body));
+        break;
+      case 'bell':
+        this.emit(BEL);
+        break;
+      case 'off':
+        break;
+    }
+  }
+
+  private stopSpinner(): void {
+    if (this.spinnerHandle !== null) {
+      this.clearIntervalFn(this.spinnerHandle);
+      this.spinnerHandle = null;
+    }
+  }
+
+  private clearTimers(): void {
+    this.stopSpinner();
+    if (this.lingerHandle !== null) {
+      this.clearTimeoutFn(this.lingerHandle);
+      this.lingerHandle = null;
+    }
+  }
+
+  /** Teardown: clear any running timers. Safe to call repeatedly. */
+  dispose(): void {
+    this.clearTimers();
+  }
+}
+
+/**
+ * The production terminal writer: writes to the saved real-terminal fd, guarded
+ * exactly like the raw PTY pass-through (fd present AND wrapper still attached),
+ * so it silently no-ops in headless/daemon mode or after the terminal closed.
+ * A failed write means the terminal is gone; swallow it (the pass-through path
+ * already handles the detach bookkeeping on the next raw write).
+ */
+function writeToRealTerminal(sequence: string): void {
+  const fd = getPtyStdoutFd();
+  if (fd === null || isWrapperDetached()) return;
+  try {
+    fs.writeSync(fd, sequence);
+  } catch {
+    // Terminal vanished; the raw pass-through write will flip detach state.
+  }
+}
+
+/**
+ * Build the process-wide TerminalIndicator with the production writer, tmux
+ * detection, and an idle title derived from the working directory (the
+ * conventional terminal title). One per daemon; shared across sessions.
+ */
+export function createTerminalIndicator(
+  config: TerminalCueConfig,
+  workingDirectory: string,
+): TerminalIndicator {
+  return new TerminalIndicator({
+    write: writeToRealTerminal,
+    config,
+    idleTitle: path.basename(workingDirectory) || '',
+    tmux: typeof process.env['TMUX'] === 'string' && process.env['TMUX'].length > 0,
+  });
+}

--- a/packages/daemon/src/cli/terminal-indicator.ts
+++ b/packages/daemon/src/cli/terminal-indicator.ts
@@ -23,6 +23,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { logError } from './logger.ts';
 import { getPtyStdoutFd, isWrapperDetached } from './wrapper-state.ts';
 
 const ESC = '\x1b';
@@ -174,9 +175,11 @@ export class TerminalIndicator {
   }
 
   /** Eval ended without a verdict (cancelled — user already advanced). Stop the
-   *  spinner and restore the idle title; no notification. */
+   *  spinner AND any pending linger, then restore the idle title; no
+   *  notification. clearTimers (not just stopSpinner) so a linger scheduled by a
+   *  prior resolve('handled') cannot fire a redundant idle-title write later. */
   stop(): void {
-    this.stopSpinner();
+    this.clearTimers();
     if (this.config.statusCue) this.setTitle(this.idleTitle);
   }
 
@@ -231,8 +234,14 @@ function writeToRealTerminal(sequence: string): void {
   if (fd === null || isWrapperDetached()) return;
   try {
     fs.writeSync(fd, sequence);
-  } catch {
-    // Terminal vanished; the raw pass-through write will flip detach state.
+  } catch (err) {
+    // EBADF/EPIPE/EIO/ENXIO == the terminal vanished; expected and silent (the
+    // raw pass-through write owns the authoritative detach flip). Anything else
+    // is unexpected — surface it rather than swallow (no silent failures).
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EBADF' && code !== 'EPIPE' && code !== 'EIO' && code !== 'ENXIO') {
+      logError('[TerminalIndicator] terminal write failed:', err);
+    }
   }
 }
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -41,6 +41,24 @@ export interface DisplayConfig {
   readonly max_bullet_length: number;
 }
 
+/**
+ * Terminal cue settings (#513): out-of-band feedback drawn on the wrapper's
+ * real terminal during the auto-approve lifecycle. Only fires when auto-approve
+ * is enabled (it is driven by the gate). Inert in headless/daemon mode.
+ */
+export interface TerminalConfig {
+  /**
+   * Desktop notification fired when auto-approve escalates a permission to the
+   * user. 'osc9' (iTerm2/Ghostty), 'osc777' (kitty/wezterm), 'bell', or 'off'.
+   */
+  readonly notify: 'osc9' | 'osc777' | 'bell' | 'off';
+  /**
+   * Animate the terminal title during evaluation (spinner -> check / warning).
+   * The title bar is the only cue channel that does not fight Claude's renderer.
+   */
+  readonly status_cue: boolean;
+}
+
 /** Telegram settings */
 export interface TelegramConfig {
   readonly enabled: boolean;
@@ -72,6 +90,7 @@ export interface RemiConfig {
   readonly network: NetworkConfig;
   readonly auth: AuthConfig;
   readonly display: DisplayConfig;
+  readonly terminal: TerminalConfig;
   readonly telegram: TelegramConfig;
   readonly auto_approve: AutoApproveConfig;
   readonly features: FeaturesConfig;
@@ -95,6 +114,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
   },
   display: {
     max_bullet_length: 500,
+  },
+  terminal: {
+    // Fires only when auto-approve is enabled and escalates; osc9 reaches
+    // iTerm2/Ghostty. The animated title is a subtle in-terminal cue.
+    notify: 'osc9',
+    status_cue: true,
   },
   telegram: {
     enabled: false,
@@ -157,6 +182,10 @@ function deepMerge(base: RemiConfig, partial: Record<string, unknown>): RemiConf
     network: mergeSection(base.network, partial['network'] as Record<string, unknown> | undefined),
     auth: mergeSection(base.auth, partial['auth'] as Record<string, unknown> | undefined),
     display: mergeSection(base.display, partial['display'] as Record<string, unknown> | undefined),
+    terminal: mergeSection(
+      base.terminal,
+      partial['terminal'] as Record<string, unknown> | undefined,
+    ),
     telegram: mergeSection(
       base.telegram,
       partial['telegram'] as Record<string, unknown> | undefined,
@@ -196,6 +225,7 @@ export function loadConfig(configPath: string = CONFIG_PATH): RemiConfig {
     const parsed = parseToml(raw) as Record<string, unknown>;
     const merged = deepMerge(DEFAULT_CONFIG, parsed);
     validateAutoApprove(merged.auto_approve, configPath);
+    validateTerminal(merged.terminal, configPath);
     return merged;
   } catch (err) {
     throw new Error(
@@ -287,6 +317,21 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   }
 }
 
+/** Validate the terminal cue section has correct runtime types. */
+function validateTerminal(cfg: TerminalConfig, configPath: string): void {
+  const channels = ['osc9', 'osc777', 'bell', 'off'];
+  if (!channels.includes(cfg.notify)) {
+    throw new Error(
+      `Invalid terminal.notify in ${configPath}: must be one of ${channels.map((c) => `"${c}"`).join(', ')}, got ${typeof cfg.notify === 'string' ? `"${cfg.notify}"` : typeof cfg.notify}.`,
+    );
+  }
+  if (typeof cfg.status_cue !== 'boolean') {
+    throw new Error(
+      `Invalid terminal.status_cue in ${configPath}: must be a boolean (true/false), got ${typeof cfg.status_cue === 'string' ? `string "${cfg.status_cue}"` : typeof cfg.status_cue}.`,
+    );
+  }
+}
+
 /**
  * Apply environment variable overrides to a config.
  * Env vars take precedence over config file values.
@@ -297,6 +342,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
   const daemon = { ...config.daemon };
   const network = { ...config.network };
   const display = { ...config.display };
+  const terminal = { ...config.terminal };
   const telegram = { ...config.telegram };
 
   // REMI_PORT overrides base_port
@@ -313,6 +359,17 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     if (!Number.isNaN(len) && len >= 0) {
       (display as { max_bullet_length: number }).max_bullet_length = len;
     }
+  }
+
+  // Terminal cue env vars
+  const tn = env['REMI_TERMINAL_NOTIFY'];
+  if (tn === 'osc9' || tn === 'osc777' || tn === 'bell' || tn === 'off') {
+    (terminal as { notify: TerminalConfig['notify'] }).notify = tn;
+  }
+  if (env['REMI_TERMINAL_STATUS_CUE'] === 'true') {
+    (terminal as { status_cue: boolean }).status_cue = true;
+  } else if (env['REMI_TERMINAL_STATUS_CUE'] === 'false') {
+    (terminal as { status_cue: boolean }).status_cue = false;
   }
 
   // Telegram env vars
@@ -403,6 +460,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     daemon,
     network,
     display,
+    terminal,
     telegram,
     auto_approve,
     features,
@@ -433,6 +491,12 @@ enabled = "${DEFAULT_CONFIG.auth.enabled}"  # "auto" | true | false
 
 [display]
 max_bullet_length = ${DEFAULT_CONFIG.display.max_bullet_length}  # 0 = disabled
+
+[terminal]
+# Out-of-band cue on the wrapper terminal during auto-approve (only active when
+# auto_approve is enabled). notify fires when a permission ESCALATES to you.
+notify = "${DEFAULT_CONFIG.terminal.notify}"        # osc9 | osc777 | bell | off
+status_cue = ${DEFAULT_CONFIG.terminal.status_cue}     # animate the title: evaluating -> done/needs-you
 
 [telegram]
 enabled = ${DEFAULT_CONFIG.telegram.enabled}
@@ -521,6 +585,10 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push('');
   lines.push('[display]');
   lines.push(`  max_bullet_length = ${config.display.max_bullet_length}`);
+  lines.push('');
+  lines.push('[terminal]');
+  lines.push(`  notify = "${config.terminal.notify}"`);
+  lines.push(`  status_cue = ${config.terminal.status_cue}`);
   lines.push('');
   lines.push('[telegram]');
   lines.push(`  enabled = ${config.telegram.enabled}`);

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -287,3 +287,108 @@ describe('AutoApproveGate', () => {
     expect(cancels).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lifecycle callbacks that drive the terminal cue (#513). They must fire on the
+// matching verdict and never cross-fire (a leaked spinner / missed notification
+// would be the symptom).
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate lifecycle callbacks (#513)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let events: string[];
+  let tracker: QuestionPresenceTracker;
+  let subagent: boolean;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  function gate(service: AutoApproveEvaluator, ptyThrows = false): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits, { throws: ptyThrows }), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => subagent,
+        escalate: () => {},
+        onEvalStart: () => events.push('start'),
+        onEscalate: () => events.push('escalate'),
+        onHandled: () => events.push('handled'),
+        onCancelled: () => events.push('cancelled'),
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    events = [];
+    subagent = false;
+    tracker = new QuestionPresenceTracker(() => {});
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve fires start then handled (never escalate/cancelled)', async () => {
+    gate(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'handled']);
+  });
+
+  test('deny fires start then handled', async () => {
+    gate(evaluator(deny)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'handled']);
+  });
+
+  test('escalate fires start then escalate (never handled)', async () => {
+    gate(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'escalate']);
+  });
+
+  test('cancelled fires start then cancelled (never handled/escalate)', async () => {
+    gate(evaluator(cancelled)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'cancelled']);
+  });
+
+  test('approve whose inject fails escalates -> start then escalate (not handled)', async () => {
+    gate(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'escalate']);
+  });
+
+  test('subagent default-deny still fires handled (buffer + cue close)', async () => {
+    subagent = true;
+    gate(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    // Subagent escalate default-denies via inject "3" -> markHandled.
+    expect(submits).toEqual(['3']);
+    expect(events).toEqual(['start', 'handled']);
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -391,4 +391,35 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     expect(submits).toEqual(['3']);
     expect(events).toEqual(['start', 'handled']);
   });
+
+  test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {
+    // The cue is cosmetic. If onHandled throws it must NOT propagate into the
+    // .then()/.catch() chain (where the catch would re-run the decision and
+    // could re-open the #484 buffer). The permission stays approved-once.
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    let escalations = 0;
+    const g = new AutoApproveGate(
+      {
+        service: evaluator(approve),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => {
+          escalations++;
+        },
+        onHandled: () => {
+          throw new Error('test: cue boom');
+        },
+      },
+      SID,
+    );
+    g.handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']); // approved exactly once
+    expect(escalations).toBe(0); // the catch did NOT re-escalate
+  });
 });

--- a/packages/daemon/tests/cli/terminal-indicator.test.ts
+++ b/packages/daemon/tests/cli/terminal-indicator.test.ts
@@ -171,6 +171,17 @@ describe('TerminalIndicator lifecycle', () => {
     expect(h.out.at(-1)).toBe(oscTitle('proj'));
   });
 
+  test('stop clears a pending linger from a prior handled (no late idle write)', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('handled'); // schedules the linger timeout
+    h.ind.stop(); // must clear that linger and write idle exactly once
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+    const afterStop = h.out.length;
+    h.fireLinger(); // the linger was cleared -> no-op
+    expect(h.out.length).toBe(afterStop);
+  });
+
   test('tmux mode wraps every sequence in passthrough', () => {
     const h = makeHarness(FULL, { tmux: true });
     h.ind.start();

--- a/packages/daemon/tests/cli/terminal-indicator.test.ts
+++ b/packages/daemon/tests/cli/terminal-indicator.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  SPINNER_FRAMES,
+  type TerminalCueConfig,
+  TerminalIndicator,
+  createTerminalIndicator,
+  osc9Notify,
+  osc777Notify,
+  oscTitle,
+  wrapTmuxPassthrough,
+} from '../../src/cli/terminal-indicator.ts';
+import { __resetWrapperStateForTests, setPtyStdoutFd } from '../../src/cli/wrapper-state.ts';
+
+const ESC = '\x1b';
+const BEL = '\x07';
+
+// ---------------------------------------------------------------------------
+// OSC builders (pure)
+// ---------------------------------------------------------------------------
+describe('OSC builders', () => {
+  test('oscTitle wraps OSC 2', () => {
+    expect(oscTitle('hello')).toBe(`${ESC}]2;hello${BEL}`);
+  });
+  test('osc9Notify wraps OSC 9', () => {
+    expect(osc9Notify('ping')).toBe(`${ESC}]9;ping${BEL}`);
+  });
+  test('osc777Notify wraps OSC 777 with title;body', () => {
+    expect(osc777Notify('T', 'B')).toBe(`${ESC}]777;notify;T;B${BEL}`);
+  });
+  test('sanitize strips control bytes (no sequence break-out)', () => {
+    // A crafted title containing BEL/ESC must not terminate the OSC early.
+    const out = oscTitle(`a${BEL}b${ESC}c`);
+    expect(out).toBe(`${ESC}]2;a b c${BEL}`);
+  });
+  test('wrapTmuxPassthrough doubles inner ESC and brackets with DCS', () => {
+    expect(wrapTmuxPassthrough(`${ESC}]2;x${BEL}`)).toBe(
+      `${ESC}Ptmux;${ESC}${ESC}${ESC}]2;x${BEL}${ESC}\\`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic lifecycle (injected timers — real recording functions, no mocks)
+// ---------------------------------------------------------------------------
+interface Harness {
+  ind: TerminalIndicator;
+  out: string[];
+  tickSpinner: () => void;
+  fireLinger: () => void;
+  spinnerRunning: () => boolean;
+}
+
+function makeHarness(config: TerminalCueConfig, opts?: { tmux?: boolean }): Harness {
+  const out: string[] = [];
+  let intervalCb: (() => void) | null = null;
+  let timeoutCb: (() => void) | null = null;
+  const ind = new TerminalIndicator({
+    write: (s) => out.push(s),
+    config,
+    idleTitle: 'proj',
+    tmux: opts?.tmux ?? false,
+    setIntervalFn: (cb) => {
+      intervalCb = cb;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    },
+    clearIntervalFn: () => {
+      intervalCb = null;
+    },
+    setTimeoutFn: (cb) => {
+      timeoutCb = cb;
+      return 2 as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimeoutFn: () => {
+      timeoutCb = null;
+    },
+  });
+  return {
+    ind,
+    out,
+    tickSpinner: () => intervalCb?.(),
+    fireLinger: () => timeoutCb?.(),
+    spinnerRunning: () => intervalCb !== null,
+  };
+}
+
+const FULL: TerminalCueConfig = { notify: 'osc9', statusCue: true };
+
+describe('TerminalIndicator lifecycle', () => {
+  test('start renders frame 0 then animates on tick', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    expect(h.out.at(-1)).toBe(oscTitle(`${SPINNER_FRAMES[0]} Remi · evaluating…`));
+    h.tickSpinner();
+    expect(h.out.at(-1)).toBe(oscTitle(`${SPINNER_FRAMES[1]} Remi · evaluating…`));
+    expect(h.spinnerRunning()).toBe(true);
+  });
+
+  test('start writes nothing when statusCue is off', () => {
+    const h = makeHarness({ notify: 'osc9', statusCue: false });
+    h.ind.start();
+    expect(h.out).toHaveLength(0);
+    expect(h.spinnerRunning()).toBe(false);
+  });
+
+  test('resolve(handled) stops spinner, shows check, then restores idle after linger', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('handled');
+    expect(h.spinnerRunning()).toBe(false);
+    expect(h.out.at(-1)).toBe(oscTitle('✓ Remi'));
+    h.fireLinger();
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+  });
+
+  test('resolve(escalate) stops spinner, shows warning, fires osc9 notification', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    const before = h.out.length;
+    h.ind.resolve('escalate');
+    expect(h.spinnerRunning()).toBe(false);
+    const emitted = h.out.slice(before);
+    expect(emitted).toContain(oscTitle('⚠ Remi · needs you'));
+    expect(emitted).toContain(osc9Notify('Remi: A permission needs your approval'));
+  });
+
+  test('escalate does not auto-restore the idle title (persists as the cue)', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('escalate');
+    // No linger timeout was scheduled, so nothing restores the title.
+    expect(h.out.at(-1)).not.toBe(oscTitle('proj'));
+  });
+
+  test('notify=osc777 fires the OSC 777 notification', () => {
+    const h = makeHarness({ notify: 'osc777', statusCue: true });
+    h.ind.start();
+    h.ind.resolve('escalate');
+    expect(h.out).toContain(osc777Notify('Remi', 'A permission needs your approval'));
+  });
+
+  test('notify=bell fires a bare BEL', () => {
+    const h = makeHarness({ notify: 'bell', statusCue: true });
+    h.ind.start();
+    h.ind.resolve('escalate');
+    expect(h.out).toContain(BEL);
+  });
+
+  test('notify=off emits the warning title but no notification', () => {
+    const h = makeHarness({ notify: 'off', statusCue: true });
+    h.ind.start();
+    const before = h.out.length;
+    h.ind.resolve('escalate');
+    const emitted = h.out.slice(before);
+    expect(emitted).toEqual([oscTitle('⚠ Remi · needs you')]);
+  });
+
+  test('statusCue off + escalate fires only the notification (no title writes)', () => {
+    const h = makeHarness({ notify: 'osc9', statusCue: false });
+    h.ind.resolve('escalate');
+    expect(h.out).toEqual([osc9Notify('Remi: A permission needs your approval')]);
+  });
+
+  test('stop restores idle title and clears the spinner', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.stop();
+    expect(h.spinnerRunning()).toBe(false);
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+  });
+
+  test('tmux mode wraps every sequence in passthrough', () => {
+    const h = makeHarness(FULL, { tmux: true });
+    h.ind.start();
+    expect(h.out.at(-1)).toBe(
+      wrapTmuxPassthrough(oscTitle(`${SPINNER_FRAMES[0]} Remi · evaluating…`)),
+    );
+  });
+
+  test('dispose clears a running spinner', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.dispose();
+    expect(h.spinnerRunning()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Production writer (real fd -> temp file; verifies the guard + real bytes)
+// ---------------------------------------------------------------------------
+describe('createTerminalIndicator production writer', () => {
+  afterEach(() => __resetWrapperStateForTests());
+
+  test('no-ops when no terminal fd is attached (headless)', () => {
+    __resetWrapperStateForTests(); // fd = null
+    const ind = createTerminalIndicator({ notify: 'osc9', statusCue: true }, '/tmp/proj');
+    // Must not throw despite there being no terminal.
+    expect(() => {
+      ind.start();
+      ind.resolve('escalate');
+      ind.dispose();
+    }).not.toThrow();
+  });
+
+  test('writes real OSC bytes to the attached terminal fd', () => {
+    const file = path.join(os.tmpdir(), `remi-term-${process.pid}-${Date.now()}.out`);
+    const fd = fs.openSync(file, 'w');
+    try {
+      setPtyStdoutFd(fd);
+      const ind = createTerminalIndicator({ notify: 'osc9', statusCue: true }, '/tmp/myproj');
+      ind.resolve('escalate');
+      ind.dispose();
+      fs.fsyncSync(fd);
+      const written = fs.readFileSync(file, 'utf-8');
+      expect(written).toContain(oscTitle('⚠ Remi · needs you'));
+      expect(written).toContain(osc9Notify('Remi: A permission needs your approval'));
+    } finally {
+      fs.closeSync(fd);
+      fs.rmSync(file, { force: true });
+    }
+  });
+
+  test('derives the idle title from the working directory basename', () => {
+    const file = path.join(os.tmpdir(), `remi-term-idle-${process.pid}-${Date.now()}.out`);
+    const fd = fs.openSync(file, 'w');
+    try {
+      setPtyStdoutFd(fd);
+      const ind = createTerminalIndicator(
+        { notify: 'off', statusCue: true },
+        '/home/dev/cool-project',
+      );
+      ind.stop();
+      fs.fsyncSync(fd);
+      expect(fs.readFileSync(file, 'utf-8')).toContain(oscTitle('cool-project'));
+    } finally {
+      fs.closeSync(fd);
+      fs.rmSync(file, { force: true });
+    }
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -474,3 +474,63 @@ Escalate anything touching secrets.
     delete process.env['REMI_AUTO_APPROVE_INSTRUCTIONS'];
   });
 });
+
+describe('terminal config (#513)', () => {
+  test('defaults: osc9 notify + status cue on', () => {
+    expect(DEFAULT_CONFIG.terminal).toEqual({ notify: 'osc9', status_cue: true });
+  });
+
+  test('loads terminal from TOML', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nnotify = "osc777"\nstatus_cue = false\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.terminal.notify).toBe('osc777');
+    expect(config.terminal.status_cue).toBe(false);
+  });
+
+  test('preserves terminal defaults when section missing', () => {
+    fs.writeFileSync(TEST_CONFIG, '[daemon]\nbase_port = 19000\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.terminal).toEqual(DEFAULT_CONFIG.terminal);
+  });
+
+  test('rejects an unknown notify channel', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nnotify = "growl"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.notify/);
+  });
+
+  test('rejects status_cue as a string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nstatus_cue = "yes"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.status_cue/);
+  });
+
+  test('REMI_TERMINAL_NOTIFY env override', () => {
+    process.env['REMI_TERMINAL_NOTIFY'] = 'bell';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.notify).toBe('bell');
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_NOTIFY'];
+  });
+
+  test('REMI_TERMINAL_NOTIFY ignores an invalid value', () => {
+    process.env['REMI_TERMINAL_NOTIFY'] = 'nonsense';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.notify).toBe('osc9'); // default preserved
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_NOTIFY'];
+  });
+
+  test('REMI_TERMINAL_STATUS_CUE=false disables the cue', () => {
+    process.env['REMI_TERMINAL_STATUS_CUE'] = 'false';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.status_cue).toBe(false);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_STATUS_CUE'];
+  });
+
+  test('formatConfig includes the terminal section', () => {
+    const output = formatConfig(DEFAULT_CONFIG, path.join(TEST_DIR, 'nonexistent.toml'));
+    expect(output).toContain('[terminal]');
+    expect(output).toContain('notify = "osc9"');
+    expect(output).toContain('status_cue = true');
+  });
+});


### PR DESCRIPTION
## Summary
When auto-approve escalates a permission, the only signal was the on-screen PTY prompt + mobile APNS. Terminals that swallow the prompt (e.g. Ghostty) left a looking-away user unaware, and there was no at-a-glance cue that the LLM was mid-evaluation. This adds out-of-band terminal feedback driven by the existing auto-approve lifecycle.

- **`TerminalIndicator`** writes OSC escape sequences to the real terminal fd (`ptyStdoutFd`). OSC is out-of-band: it sets the window title / fires a desktop notification without drawing into the screen grid, so it never corrupts Claude's alternate-screen TUI. (An in-viewport "corner badge" would be overwritten on Claude's next redraw; the title bar is the only cue channel that does not fight the renderer.)
- **Animated title status** (`terminal.status_cue`, default on): a spinner while the LLM evaluates, then a check (auto-handled) or warning (escalated) glyph, restored to an idle title afterward.
- **Escalation notification** (`terminal.notify`, default `osc9`): `osc9` (iTerm2/Ghostty) / `osc777` (kitty/wezterm) / `bell` / `off`, tmux-passthrough aware.
- **Gate**: the silent-handle signal is centralized into `markHandled()`, and `onHandled`/`onCancelled` callbacks are added so every verdict (handled / escalate / cancelled) drives the cue. `onEvalStart`/`onEscalate` are extended (they still drive the #484 buffer window).

Inert when auto-approve is off (the gate is the sole driver) or headless (the writer no-ops without a real terminal fd).

Part of epic #481 (Phase 3 / #484 — the terminal-cue half; the APNS-only-on-escalate half shipped in 0.6.2).

Closes #513

## Test plan
- `terminal-indicator.test.ts` (20): OSC builders + sanitize (no sequence break-out) + tmux wrap; deterministic lifecycle via injected timers (spinner frame advance, handled->check->idle linger, escalate->warning+notify, each notify channel, off, statusCue off, stop, dispose); real-fd end-to-end writing OSC bytes to a temp file + the headless no-op guard.
- `auto-approve-gate.test.ts` (+6): onHandled/onEscalate/onCancelled fire on the matching verdict and never cross-fire, incl. inject-failure->escalate and subagent default-deny->handled.
- `config.test.ts` (+9): `[terminal]` defaults, TOML load, missing-section defaults, validation rejects unknown channel / non-boolean cue, env overrides (incl. invalid-value ignored), formatConfig, and the generateDefaultConfig roundtrip.
- `bun run typecheck` + `bunx biome check` clean.