### PR TITLE
Release 0.6.4: auto-approve instruction-following + terminal cue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-06-08
+
+Auto-approve fixes (instruction-following + an Ollama transport seam) and a
+terminal cue so escalations are visible without looking at the phone.
+
+### Added
+- Terminal cue for the auto-approve lifecycle (#513): an animated terminal-title
+  status (spinner while the LLM evaluates, then a check when auto-handled or a
+  warning when escalated) plus a desktop notification on escalation. Configurable
+  via a new `[terminal]` section: `notify = "osc9"` (default; also `osc777`,
+  `bell`, `off`) and `status_cue = true`. Written out-of-band to the terminal, so
+  it never disturbs Claude's display; tmux-passthrough aware; inert when
+  auto-approve is off or running headless.
+- Optional Ollama-native transport for auto-approve (`auto_approve.disable_thinking`,
+  default off): routes through `/api/chat` with reasoning disabled. Faster, but it
+  lowers decision quality (the reasoning is load-bearing for following broad
+  instructions), so it stays opt-in (#512).
+
+### Fixed
+- Auto-approve now follows the user's `instructions` over the built-in defaults:
+  the guidance is framed as the primary authority and only the deny floor can
+  override it, so a broad "approve everything except irreversible deletes" policy
+  is honored instead of being silently escalated (#512).
+
 ## [0.6.3] - 2026-06-08
 
 Epic #499: a single source of truth for the live Claude session, plus

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.4-dev.4",
+  "version": "0.6.4-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.4-dev.2",
+  "version": "0.6.4-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.4-dev.1",
+  "version": "0.6.4-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.3",
+  "version": "0.6.4-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.4-dev.3",
+  "version": "0.6.4-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -128,8 +128,9 @@ export class AutoApproveGate {
     // Auto-approve gate: evaluate before creating a Question object.
     if (service) {
       // Open the buffer window: a PTY prompt that renders during the eval is
-      // held (not pushed) until we know the verdict. #484.
-      this.deps.onEvalStart?.();
+      // held (not pushed) until we know the verdict. #484. The terminal cue
+      // (#513) rides this signal but must never throw into the dispatch loop.
+      this.safeCue('onEvalStart', this.deps.onEvalStart);
       // Pass the raw suggestions array; AutoApproveService does its own strict-string
       // filtering before feeding the LLM. We forward the raw shape (rather than
       // coercing) so the multi-choice classifier can see "non-string entry" and route
@@ -149,7 +150,7 @@ export class AutoApproveGate {
             // onto the next unrelated PTY prompt (e.g. user typed /compact, no
             // PreToolUse fires).
             this.deps.tracker.clearPending();
-            this.deps.onCancelled?.();
+            this.safeCue('onCancelled', this.deps.onCancelled);
             log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
             return;
           }
@@ -235,7 +236,23 @@ export class AutoApproveGate {
    */
   private markHandled(): void {
     this.deps.tracker.onAutoApproveHandled();
-    this.deps.onHandled?.();
+    this.safeCue('onHandled', this.deps.onHandled);
+  }
+
+  /**
+   * Invoke a COSMETIC lifecycle callback (the #513 terminal cue). The cue must
+   * never affect the decision path or the #484 buffer state, so a throw is
+   * logged and absorbed here rather than propagating into the .then()/.catch()
+   * chain (where the outer catch would re-run the decision and could re-open an
+   * already-closed buffer). Mirrors how `escalateToUser` shields `onEscalate`.
+   */
+  private safeCue(label: string, fn: (() => void) | undefined): void {
+    if (!fn) return;
+    try {
+      fn();
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
   }
 
   /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */
@@ -306,7 +323,9 @@ export class AutoApproveGate {
       // Release the buffer UNCONDITIONALLY: the verdict is "user must answer".
       // Even if escalate() threw (push will fail), the buffer must not stay
       // locked, or every later prompt in this session would buffer forever. #484.
-      this.deps.onEscalate?.();
+      // safeCue: the wired callback releases the buffer (critical) then fires the
+      // terminal cue (#513, cosmetic); a cue throw must not break the finally.
+      this.safeCue('onEscalate', this.deps.onEscalate);
     }
   }
 }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -71,6 +71,12 @@ export interface AutoApproveGateDeps {
   /** Called when the verdict is escalate (the user must answer), so the tracker
    *  releases the buffered PTY prompt. #484. */
   onEscalate?: () => void;
+  /** Called when the permission was auto-approved/denied silently (inject
+   *  succeeded; the user never sees it). Drives the terminal "done" cue. #513. */
+  onHandled?: () => void;
+  /** Called when the eval ended without a verdict (cancelled — the user already
+   *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
+  onCancelled?: () => void;
 }
 
 export class AutoApproveGate {
@@ -143,18 +149,19 @@ export class AutoApproveGate {
             // onto the next unrelated PTY prompt (e.g. user typed /compact, no
             // PreToolUse fires).
             this.deps.tracker.clearPending();
+            this.deps.onCancelled?.();
             log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
             return;
           }
           if (result.decision === 'approve') {
             // inject success -> auto-handled (close the buffer; user never sees
             // it); inject failure -> escalate (which releases the buffer). #484.
-            if (await this.inject(input, '1', 'approved')) this.deps.tracker.onAutoApproveHandled();
+            if (await this.inject(input, '1', 'approved')) this.markHandled();
             else this.escalateToUser(input);
             return;
           }
           if (result.decision === 'deny') {
-            if (await this.inject(input, '3', 'denied')) this.deps.tracker.onAutoApproveHandled();
+            if (await this.inject(input, '3', 'denied')) this.markHandled();
             else this.escalateToUser(input);
             return;
           }
@@ -169,7 +176,7 @@ export class AutoApproveGate {
                 `multichoice-pick-${result.pickIndex}`,
               )
             ) {
-              this.deps.tracker.onAutoApproveHandled();
+              this.markHandled();
             } else {
               this.escalateToUser(input);
             }
@@ -185,7 +192,7 @@ export class AutoApproveGate {
               `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
             );
             await this.inject(input, '3', 'subagent-escalate-default-deny', true);
-            this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
+            this.markHandled(); // close the buffer window (#484)
             return;
           }
           this.escalateToUser(input);
@@ -196,7 +203,7 @@ export class AutoApproveGate {
             logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
             if (isInSubagentContext()) {
               await this.inject(input, '3', 'subagent-error-default-deny', true);
-              this.deps.tracker.onAutoApproveHandled(); // close the buffer window (#484)
+              this.markHandled(); // close the buffer window (#484)
               return;
             }
             this.escalateToUser(input);
@@ -218,6 +225,17 @@ export class AutoApproveGate {
     }
 
     this.escalateToUser(input);
+  }
+
+  /**
+   * Buffer-closing success path: the permission was auto-approved/denied
+   * silently (inject succeeded), so the user never sees it. Notifies the
+   * tracker (closes the #484 buffer window) AND the terminal cue (#513). Every
+   * silent-handle site routes through here so neither signal can be missed.
+   */
+  private markHandled(): void {
+    this.deps.tracker.onAutoApproveHandled();
+    this.deps.onHandled?.();
   }
 
   /** Subagent/team-member events carry a non-empty `agent_id`; main events do not. */

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -103,10 +103,11 @@ export class AutoApproveService {
       apiKey: config.api_key,
       model: config.model,
       timeoutMs: config.timeout * 1000,
-      // Ollama: use the native /api/chat with `think: false` so the model
-      // skips its reasoning (a quick approve/deny classify needs none, and the
-      // thinking is most of the latency). Other providers use OpenAI-compat.
-      kind: config.provider === 'ollama' ? 'ollama' : 'openai',
+      // Opt-in (Ollama only): native /api/chat with `think: false` to disable
+      // reasoning. Faster, but lowers decision quality (the chain-of-thought is
+      // load-bearing for following broad user instructions), so default OFF.
+      // Everyone else uses the OpenAI-compat path with reasoning on.
+      kind: config.provider === 'ollama' && config.disable_thinking ? 'ollama' : 'openai',
     };
     this.logFn = logFn;
     this.logDecisions = config.log_decisions;

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -103,6 +103,10 @@ export class AutoApproveService {
       apiKey: config.api_key,
       model: config.model,
       timeoutMs: config.timeout * 1000,
+      // Ollama: use the native /api/chat with `think: false` so the model
+      // skips its reasoning (a quick approve/deny classify needs none, and the
+      // thinking is most of the latency). Other providers use OpenAI-compat.
+      kind: config.provider === 'ollama' ? 'ollama' : 'openai',
     };
     this.logFn = logFn;
     this.logDecisions = config.log_decisions;

--- a/packages/daemon/src/auto-approve/llm-client.ts
+++ b/packages/daemon/src/auto-approve/llm-client.ts
@@ -1,9 +1,14 @@
 import { errorToString } from '@remi/shared';
 /**
- * Minimal OpenAI-compatible chat completions client using raw fetch().
+ * Chat-completions client for the auto-approve evaluator.
  *
- * Works with Ollama (localhost:11434/v1), OpenRouter, and any endpoint
- * that implements the OpenAI chat completions API.
+ * Two transports:
+ *  - 'openai': the OpenAI-compatible /v1/chat/completions (OpenRouter, custom).
+ *  - 'ollama': Ollama's NATIVE /api/chat, so we can pass `think: false` and turn
+ *    OFF the model's reasoning. The OpenAI-compat /v1 endpoint has no way to
+ *    disable thinking, and for a quick approve/deny classify the reasoning is
+ *    pure latency (a 4B model spends most of its tokens "thinking"). When we
+ *    move to the Yooz engine this stays a clean transport seam.
  */
 
 export interface ChatMessage {
@@ -16,6 +21,11 @@ export interface LLMClientConfig {
   readonly apiKey: string;
   readonly model: string;
   readonly timeoutMs: number;
+  /**
+   * Transport. 'ollama' uses the native /api/chat with `think: false` (no
+   * reasoning). Defaults to 'openai' (the OpenAI-compatible /v1 endpoint).
+   */
+  readonly kind?: 'openai' | 'ollama';
 }
 
 export interface LLMResponse {
@@ -52,8 +62,17 @@ export function resolveProviderUrl(provider: string, fallbackUrl: string): strin
 }
 
 /**
- * Send a chat completion request to an OpenAI-compatible endpoint.
- * Throws on network errors, timeouts, or non-200 responses.
+ * Derive the Ollama NATIVE API root (…/api/chat) from a base URL that may end
+ * in /v1 (the OpenAI-compat path). `http://h:11434/v1` -> `http://h:11434`.
+ * Exported for testing.
+ */
+export function ollamaNativeBase(baseUrl: string): string {
+  return baseUrl.replace(/\/v1\/?$/, '');
+}
+
+/**
+ * Send a chat completion request. Throws on network errors, timeouts, or
+ * non-200 responses.
  *
  * If `externalSignal` is provided and aborts before the request completes,
  * the fetch is aborted and the abort propagates as a DOMException
@@ -65,7 +84,6 @@ export async function chatCompletion(
   messages: readonly ChatMessage[],
   externalSignal?: AbortSignal,
 ): Promise<LLMResponse> {
-  const url = `${config.baseUrl}/chat/completions`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), config.timeoutMs);
   const onExternalAbort = (): void => controller.abort();
@@ -74,38 +92,69 @@ export async function chatCompletion(
     else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
   }
 
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (config.apiKey) {
     headers['Authorization'] = `Bearer ${config.apiKey}`;
   }
+
+  const ollama = config.kind === 'ollama';
+  const url = ollama
+    ? `${ollamaNativeBase(config.baseUrl)}/api/chat`
+    : `${config.baseUrl}/chat/completions`;
+  // Ollama native: `think: false` disables reasoning; `format: 'json'` forces a
+  // JSON body. OpenAI-compat: temperature 0 + json_object response format.
+  const body = ollama
+    ? {
+        model: config.model,
+        messages,
+        stream: false,
+        think: false,
+        format: 'json',
+        options: { temperature: 0 },
+      }
+    : {
+        model: config.model,
+        messages,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      };
 
   try {
     const response = await fetch(url, {
       method: 'POST',
       headers,
-      body: JSON.stringify({
-        model: config.model,
-        messages,
-        temperature: 0,
-        response_format: { type: 'json_object' },
-      }),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
 
     if (!response.ok) {
-      const body = await response.text().catch((e) => `[body unreadable: ${errorToString(e)}]`);
-      throw new Error(`LLM API error ${response.status}: ${body.slice(0, 200)}`);
+      const errBody = await response.text().catch((e) => `[body unreadable: ${errorToString(e)}]`);
+      throw new Error(`LLM API error ${response.status}: ${errBody.slice(0, 200)}`);
     }
 
-    // biome-ignore lint/suspicious/noExplicitAny: OpenAI response shape
+    // biome-ignore lint/suspicious/noExplicitAny: provider response shapes differ
     const data: any = await response.json();
+
+    if (ollama) {
+      const content = data.message?.content;
+      if (!content) throw new Error('LLM response missing content (ollama /api/chat)');
+      return {
+        content,
+        model: data.model ?? config.model,
+        usage:
+          data.prompt_eval_count != null || data.eval_count != null
+            ? {
+                prompt_tokens: data.prompt_eval_count ?? 0,
+                completion_tokens: data.eval_count ?? 0,
+              }
+            : undefined,
+      };
+    }
+
     const choice = data.choices?.[0];
     if (!choice?.message?.content) {
       throw new Error('LLM response missing content');
     }
-
     return {
       content: choice.message.content,
       model: data.model ?? config.model,

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -7,22 +7,31 @@
 
 import type { ChatMessage } from './llm-client.ts';
 
-const SYSTEM_PROMPT = `You are a security-aware permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
+// Header: the action definitions + the decision order. User guidance (when
+// present) is injected by buildPrompt right after this, AHEAD of the default
+// guidelines, so a small model treats it as the primary authority instead of
+// burying it after the built-in rules (which caused user "approve broadly"
+// instructions to be ignored — the model followed the prominent ESCALATE list).
+const SYSTEM_PROMPT_HEADER = `You are a security-aware permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
 
 Claude Code is requesting permission to use a tool. You must decide one of three actions:
 
-- "approve": The operation is clearly safe, read-only, or a routine development action whose effects are reversible.
-- "deny": The operation is clearly dangerous, destructive, or should never be auto-approved.
-- "escalate": You are unsure, or the operation needs human judgment (design, direction, scope, or irreversible side effects).
+- "approve": The operation is safe, read-only, or a routine reversible action.
+- "deny": ONLY for an operation that literally matches the DENY FLOOR list below (rm -rf /, sudo rm, curl|sh, chmod 777, data exfiltration). A risky-but-not-listed operation — a remote POST, a push, a write, an admin API call — is NOT a deny; it is an "escalate".
+- "escalate": You are unsure, or the operation needs human judgment (design, direction, scope), OR it is a mutation/remote/write that the user has not pre-approved.
 
-CRITICAL RULES:
-1. When in doubt, ALWAYS escalate. It is better to ask the user than to approve something risky.
-2. Deny should be rare. Only deny clearly destructive operations. Prefer escalate over deny.
-3. Reversibility test: if the action's effect can be undone with a routine follow-up (delete a created file, revert a local edit, re-run a build), it leans APPROVE. If undoing requires git surgery, talking to a remote, restoring from backup, or is impossible, it leans ESCALATE.
-4. Compound commands (chained with &&, ||, ;, |) are evaluated as a whole. APPROVE only when every part is safe AND reversible. If ANY part is risky, irreversible, or unfamiliar, escalate.
-5. Design / direction / steering decisions always escalate. The LLM cannot infer user intent for "which approach", "which library", "what to name it", "should we proceed".
+HOW TO DECIDE — apply in this order:
+1. USER GUIDANCE: if a "USER GUIDANCE" section appears below, it is the PRIMARY authority and OVERRIDES the default approve/escalate guidelines. Follow it directly — e.g. if it says to approve a class of operations, approve them even if the defaults would escalate. Only the DENY FLOOR below still applies on top of it.
+2. DEFAULTS: if there is no user guidance, or it does not address this operation, apply the DEFAULT GUIDELINES and escalate when in doubt.
+3. Design / direction / steering decisions ("which approach", "which library", "what to name it", "should we proceed") escalate — unless user guidance says to approve them.
+4. DENY IS RARE: deny ONLY operations in the DENY FLOOR (catastrophic, irreversible system damage). For anything else you would not approve — remote mutations, pushes, writes, unknown commands — ESCALATE, never deny. Escalating lets the user answer; denying blocks them.`;
 
-DEFAULT GUIDELINES:
+// Body: the fallback default guidelines + the always-on DENY floor + format.
+const SYSTEM_PROMPT_BODY = `DEFAULT GUIDELINES (fallback — used when no user guidance covers the operation):
+
+Compound commands (chained with &&, ||, ;, |) are judged as a whole: under the
+defaults, approve only if EVERY part is approvable; if any part is risky or
+irreversible, escalate.
 
 APPROVE these operations:
 - Read/Glob/Grep: all file reads and searches
@@ -30,30 +39,26 @@ APPROVE these operations:
 - Bash: read-only repo/CLI queries that only FETCH data (no mutation), e.g.
   gh pr view/diff/list/status/checks, gh issue view/list, gh run view/list,
   gh api <path> with a BARE path and NO -X/--method and NO -f/-F/--field/
-  --raw-field flags (a bare gh api path is a GET). These read a remote but
-  change nothing, so they are safe (this is the common /review-pr command set).
+  --raw-field flags (a bare gh api path is a GET).
 - Bash: ls, cat, head, tail, find, wc, file, stat, which, echo, printf, date, pwd, env
 - Bash: build/test commands (bun test, npm test, cargo test, pytest, make, etc.)
 - Bash: linting/formatting (biome, eslint, ruff, prettier, etc.)
 - Bash: package info (bun --version, node --version, etc.)
-- Bash: cd into a directory chained with any otherwise-approvable command (cd && ls, cd && git status)
-- Bash: writes to /tmp, $TMPDIR, or process-local scratch paths the agent can clean up
+- Bash: cd into a directory chained with any otherwise-approvable command
+- Bash: writes to /tmp, $TMPDIR, or process-local scratch paths
 
 ESCALATE these operations (ask the user):
-- Write/Edit/NotebookEdit: any file modifications outside scratch paths
+- Write/Edit/NotebookEdit: file modifications outside scratch paths
 - Bash: git add, git commit, git push, git checkout, git merge, git rebase, git reset
 - Bash: file creation, modification, or deletion under the project tree
 - Bash: package install (bun add, npm install, pip install, uv add, etc.)
-- Bash: remote MUTATIONS or pushes — git push, gh pr merge/close/create,
-  gh pr review, gh pr checkout, gh issue create/close, curl/wget POST, ssh, and
-  any gh api that mutates: -X/--method POST/PUT/DELETE/PATCH OR ANY
-  -f/-F/--field/--raw-field flag (adding parameters silently switches gh api
-  from GET to POST). Read-only gh/git fetches are approvable per above; this is
-  for anything that CHANGES remote state.
+- Bash: remote MUTATIONS — git push, gh pr merge/close/create, gh pr review,
+  gh issue create/close, curl/wget POST, ssh, and any gh api that mutates
+  (-X/--method POST/PUT/DELETE/PATCH or any -f/-F/--field/--raw-field flag).
 - Bash: any command you are not sure about
 - Any tool not listed above
 
-DENY these operations:
+DENY FLOOR (always applies, even over USER GUIDANCE — catastrophic / irreversible):
 - Bash: rm -rf /, sudo rm, commands targeting system directories (/etc, /usr, /System)
 - Bash: curl/wget piped to sh/bash (remote code execution)
 - Bash: chmod 777 on sensitive paths
@@ -70,8 +75,8 @@ Respond with JSON ONLY. No markdown, no explanation outside JSON:
  * @param toolName Claude Code tool name (Bash, Edit, etc.)
  * @param toolInput Raw tool input from the PermissionRequest hook
  * @param instructions Optional natural-language guidance from user config.
- *                     Appended to the system prompt so the LLM considers
- *                     user-specific conventions alongside the default rules.
+ *                     Injected AHEAD of the default guidelines as the primary
+ *                     authority so the model honors it over the defaults.
  */
 export function buildPrompt(
   toolName: string,
@@ -84,12 +89,24 @@ export function buildPrompt(
 
   const userMessage = `Tool: ${toolName}\nInput: ${truncated}`;
 
-  // If the user provided instructions, append them as an additional section.
-  // They come AFTER the default guidelines so user rules can refine defaults.
+  // User guidance goes BETWEEN the header and the default guidelines, framed as
+  // the primary authority, so it overrides the defaults (the DENY floor still
+  // applies). Empty/whitespace guidance falls back to defaults only.
   const trimmedInstructions = instructions?.trim() ?? '';
-  const systemContent = trimmedInstructions
-    ? `${SYSTEM_PROMPT}\n\nUSER-SPECIFIC GUIDANCE (overrides/refines the defaults above):\n${trimmedInstructions}`
-    : SYSTEM_PROMPT;
+  const guidanceBlock = trimmedInstructions
+    ? `\n\nUSER GUIDANCE — HIGHEST PRIORITY, MANDATORY:
+${trimmedInstructions}
+
+This guidance is the user's explicit policy and OVERRIDES every default rule below except the DENY FLOOR. When it applies to the operation, you MUST return the action it dictates — e.g. if it says to approve, return "approve" even for remote mutations / POST / writes. Do NOT escalate or deny based on your own risk assessment; the user has explicitly accepted that risk. Only the DENY FLOOR (catastrophic, irreversible system damage) can override this guidance.\n`
+    : '';
+
+  // Reinforce at the end too (recency): a small model otherwise reverts to its
+  // cautious prior by the time it decides.
+  const guidanceReminder = trimmedInstructions
+    ? '\n\nREMEMBER: the USER GUIDANCE above is mandatory and outranks the default approve/escalate guidelines. Apply it unless the DENY FLOOR matches.'
+    : '';
+
+  const systemContent = `${SYSTEM_PROMPT_HEADER}${guidanceBlock}\n\n${SYSTEM_PROMPT_BODY}${guidanceReminder}`;
 
   return [
     { role: 'system', content: systemContent },

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -109,4 +109,16 @@ export interface AutoApproveConfig {
    * Ignored unless `multichoice = "evaluate"`.
    */
   readonly multichoice_model: string;
+  /**
+   * Ollama only: route through the native /api/chat with `think: false` to
+   * turn OFF the model's reasoning. This is FASTER but lowers decision quality
+   * — live testing showed the chain-of-thought is load-bearing for following
+   * broad user `instructions` (without it even a 35B model reverts to its
+   * cautious prior and escalates mutations it would otherwise approve). The
+   * buffer-until-verdict design already hides eval latency from the user, so
+   * the default is `false` (keep thinking). Opt in only if you value raw speed
+   * over nuance. No effect on non-Ollama providers (the OpenAI-compat endpoint
+   * has no knob to disable reasoning).
+   */
+  readonly disable_thinking: boolean;
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.4-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.4-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.4-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.4-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.4-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.4-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.4-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.4-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -134,6 +134,7 @@ import { createMessageApiForSession } from './cli/session-phases/message-api-set
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { installSuspendHandler } from './cli/suspend-handler.ts';
+import { type TerminalIndicator, createTerminalIndicator } from './cli/terminal-indicator.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
 import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
@@ -783,6 +784,19 @@ let autoApproveService: AutoApproveService | null = null;
 }
 
 // ---------------------------------------------------------------------------
+// Terminal cue (#513): animates the wrapper terminal title + fires a desktop
+// notification across the auto-approve lifecycle. Built only when auto-approve
+// is enabled (the gate is its sole driver). Process-wide; one terminal. The
+// writer no-ops in headless/daemon mode (no real terminal fd).
+// ---------------------------------------------------------------------------
+const terminalIndicator: TerminalIndicator | undefined = autoApproveService
+  ? createTerminalIndicator(
+      { notify: remiConfig.terminal.notify, statusCue: remiConfig.terminal.status_cue },
+      process.cwd(),
+    )
+  : undefined;
+
+// ---------------------------------------------------------------------------
 // SIGTSTP / Ctrl+Z handling.
 //
 // Wrapper mode (`remi <args>`): the wrapper installs `cli/suspend-handler.ts`
@@ -1130,6 +1144,7 @@ async function createNewSession(
         binderEnabled,
         transcriptDiscovery,
         subagentViews,
+        terminalIndicator,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.4-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.4-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.4-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.4-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.3'; // REMI_COMPILED_VERSION
+      return '0.6.4-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.3'; // REMI_COMPILED_VERSION
+    return '0.6.4-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.4-dev.4'; // REMI_COMPILED_VERSION
+      return '0.6.4-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.4-dev.4'; // REMI_COMPILED_VERSION
+    return '0.6.4-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -60,6 +60,7 @@ import type { BinderDecision, BinderHookEvent } from '../../transcript/index.ts'
 import type { TranscriptWatcher } from '../../transcript/index.ts';
 import type { TranscriptDiscovery } from '../../transcript/transcript-discovery.ts';
 import { log, logError } from '../logger.ts';
+import type { TerminalIndicator } from '../terminal-indicator.ts';
 import { startTranscriptWatcher } from '../transcript-watcher-setup.ts';
 
 export interface HookBridgeDeps {
@@ -108,6 +109,12 @@ export interface HookBridgeDeps {
    * unaffected.
    */
   subagentViews?: SubagentViewRegistry;
+  /**
+   * Process-wide terminal cue (#513): animates the wrapper terminal title and
+   * fires a desktop notification across the auto-approve lifecycle. Shared by
+   * all sessions (one terminal). Optional; inert when absent or headless.
+   */
+  terminalIndicator?: TerminalIndicator | undefined;
 }
 
 export interface HookBridgeArgs {
@@ -657,8 +664,17 @@ export function setupHookBridge(
       escalate: (i) => handlers.onPermissionRequest?.(i),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
-      onEvalStart: () => tracker.onAutoApproveStart(),
-      onEscalate: () => tracker.onAutoApproveEscalate(),
+      // #513: the same lifecycle drives the terminal cue (spinner -> done / needs-you).
+      onEvalStart: () => {
+        tracker.onAutoApproveStart();
+        deps.terminalIndicator?.start();
+      },
+      onEscalate: () => {
+        tracker.onAutoApproveEscalate();
+        deps.terminalIndicator?.resolve('escalate');
+      },
+      onHandled: () => deps.terminalIndicator?.resolve('handled'),
+      onCancelled: () => deps.terminalIndicator?.stop(),
     },
     sessionId,
   );

--- a/packages/daemon/src/cli/terminal-indicator.ts
+++ b/packages/daemon/src/cli/terminal-indicator.ts
@@ -1,0 +1,254 @@
+/**
+ * Out-of-band terminal feedback for the auto-approve lifecycle (#513, epic
+ * #481 item 5).
+ *
+ * Two channels, both written to the REAL terminal fd (the saved
+ * `ptyStdoutFd`) as OSC escape sequences. OSC is out-of-band: it sets the
+ * window title / fires a desktop notification without drawing into the screen
+ * grid, so it never corrupts Claude's alternate-screen TUI (an in-viewport
+ * "corner badge" would be overwritten on Claude's next redraw — the title bar
+ * is the only cue channel that does not fight the renderer).
+ *
+ *  1. Animated TITLE status cue: a spinner while the LLM evaluates, then a
+ *     check (auto-handled) or warning (escalated) glyph; restored to an idle
+ *     title afterward.
+ *  2. Escalation NOTIFICATION: a desktop notification at the escalate seam
+ *     (osc9 / osc777 / bell / off), so a user looking away from a terminal
+ *     that swallows the prompt (e.g. Ghostty) still gets pinged.
+ *
+ * The writer is injected, so the class is testable without a real terminal and
+ * the production writer can guard on fd-present / not-detached and silently
+ * no-op in headless/daemon mode.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getPtyStdoutFd, isWrapperDetached } from './wrapper-state.ts';
+
+const ESC = '\x1b';
+const BEL = '\x07';
+
+/** Where to fire the escalation notification. */
+export type TerminalNotifyChannel = 'osc9' | 'osc777' | 'bell' | 'off';
+
+export interface TerminalCueConfig {
+  /** Escalation notification channel. 'off' disables it. */
+  readonly notify: TerminalNotifyChannel;
+  /** Animate the terminal title (evaluating spinner -> done/needs-you). */
+  readonly statusCue: boolean;
+}
+
+/** Spinner frames (braille) cycled while the eval is in flight. */
+export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
+
+const SPINNER_INTERVAL_MS = 120;
+/** How long the ✓ title lingers before restoring the idle title. */
+const HANDLED_LINGER_MS = 1500;
+
+/**
+ * Strip the bytes that would terminate or break out of an OSC string, so an
+ * interpolated value can never inject its own escape sequence. Our texts are
+ * static today; this is defensive for future dynamic titles.
+ */
+function sanitize(text: string): string {
+  return text.replace(/[\x00-\x1f\x7f]/g, ' ');
+}
+
+/** OSC 2: set the window/tab title. */
+export function oscTitle(text: string): string {
+  return `${ESC}]2;${sanitize(text)}${BEL}`;
+}
+
+/** OSC 9: iTerm2 / Ghostty desktop notification (single string). */
+export function osc9Notify(text: string): string {
+  return `${ESC}]9;${sanitize(text)}${BEL}`;
+}
+
+/** OSC 777: kitty / wezterm / urxvt desktop notification (title + body). */
+export function osc777Notify(title: string, body: string): string {
+  return `${ESC}]777;notify;${sanitize(title)};${sanitize(body)}${BEL}`;
+}
+
+/**
+ * Wrap an escape sequence for tmux passthrough so OSC reaches the outer
+ * terminal instead of being eaten by tmux. Requires `set -g allow-passthrough
+ * on` in tmux; harmless if absent (the sequence is just ignored). The inner
+ * ESC bytes must be doubled.
+ */
+export function wrapTmuxPassthrough(seq: string): string {
+  return `${ESC}Ptmux;${ESC}${seq.replaceAll(ESC, ESC + ESC)}${ESC}\\`;
+}
+
+export interface TerminalIndicatorDeps {
+  /** Write a (possibly tmux-wrapped) sequence to the terminal. Must no-op when
+   *  no terminal is attached (headless/detached). */
+  readonly write: (sequence: string) => void;
+  readonly config: TerminalCueConfig;
+  /** Title to restore to when idle. Empty string clears the title. */
+  readonly idleTitle?: string;
+  /** True when running inside tmux; OSC is passthrough-wrapped. */
+  readonly tmux?: boolean;
+  /** Injected timers (defaults to globals) so tests stay deterministic. */
+  readonly setIntervalFn?: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  readonly clearIntervalFn?: (handle: ReturnType<typeof setInterval>) => void;
+  readonly setTimeoutFn?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+/**
+ * Renders the auto-approve eval lifecycle to the terminal. One instance per
+ * daemon process (a single terminal); shared across sessions. Concurrent evals
+ * are rare in wrapper mode (one foreground Claude); the last writer wins and
+ * `resolve`/`stop` always clears the spinner, so no spinner can leak.
+ */
+export class TerminalIndicator {
+  private readonly write: (sequence: string) => void;
+  private readonly config: TerminalCueConfig;
+  private readonly idleTitle: string;
+  private readonly tmux: boolean;
+  private readonly setIntervalFn: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  private readonly clearIntervalFn: (handle: ReturnType<typeof setInterval>) => void;
+  private readonly setTimeoutFn: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimeoutFn: (handle: ReturnType<typeof setTimeout>) => void;
+
+  private spinnerHandle: ReturnType<typeof setInterval> | null = null;
+  private lingerHandle: ReturnType<typeof setTimeout> | null = null;
+  private frame = 0;
+
+  constructor(deps: TerminalIndicatorDeps) {
+    this.write = deps.write;
+    this.config = deps.config;
+    this.idleTitle = deps.idleTitle ?? '';
+    this.tmux = deps.tmux ?? false;
+    this.setIntervalFn = deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+    this.clearIntervalFn = deps.clearIntervalFn ?? ((h) => clearInterval(h));
+    this.setTimeoutFn = deps.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimeoutFn = deps.clearTimeoutFn ?? ((h) => clearTimeout(h));
+  }
+
+  /** Emit a sequence, tmux-wrapped when inside tmux. */
+  private emit(sequence: string): void {
+    this.write(this.tmux ? wrapTmuxPassthrough(sequence) : sequence);
+  }
+
+  private setTitle(text: string): void {
+    this.emit(oscTitle(text));
+  }
+
+  /** Eval started: begin the animated title spinner. */
+  start(): void {
+    this.clearTimers();
+    if (!this.config.statusCue) return;
+    this.frame = 0;
+    this.renderSpinnerFrame();
+    this.spinnerHandle = this.setIntervalFn(() => {
+      this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
+      this.renderSpinnerFrame();
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  private renderSpinnerFrame(): void {
+    this.setTitle(`${SPINNER_FRAMES[this.frame]} Remi · evaluating…`);
+  }
+
+  /**
+   * Verdict reached. 'handled' => the permission was auto-approved/denied
+   * silently (✓, then restore idle). 'escalate' => the user must answer (⚠,
+   * persist + fire the notification).
+   */
+  resolve(outcome: 'handled' | 'escalate'): void {
+    this.stopSpinner();
+    if (outcome === 'escalate') {
+      if (this.config.statusCue) this.setTitle('⚠ Remi · needs you');
+      this.notifyEscalation();
+      return;
+    }
+    // handled
+    if (this.config.statusCue) {
+      this.setTitle('✓ Remi');
+      this.lingerHandle = this.setTimeoutFn(() => {
+        this.setTitle(this.idleTitle);
+        this.lingerHandle = null;
+      }, HANDLED_LINGER_MS);
+    }
+  }
+
+  /** Eval ended without a verdict (cancelled — user already advanced). Stop the
+   *  spinner and restore the idle title; no notification. */
+  stop(): void {
+    this.stopSpinner();
+    if (this.config.statusCue) this.setTitle(this.idleTitle);
+  }
+
+  private notifyEscalation(): void {
+    const title = 'Remi';
+    const body = 'A permission needs your approval';
+    switch (this.config.notify) {
+      case 'osc9':
+        this.emit(osc9Notify(`${title}: ${body}`));
+        break;
+      case 'osc777':
+        this.emit(osc777Notify(title, body));
+        break;
+      case 'bell':
+        this.emit(BEL);
+        break;
+      case 'off':
+        break;
+    }
+  }
+
+  private stopSpinner(): void {
+    if (this.spinnerHandle !== null) {
+      this.clearIntervalFn(this.spinnerHandle);
+      this.spinnerHandle = null;
+    }
+  }
+
+  private clearTimers(): void {
+    this.stopSpinner();
+    if (this.lingerHandle !== null) {
+      this.clearTimeoutFn(this.lingerHandle);
+      this.lingerHandle = null;
+    }
+  }
+
+  /** Teardown: clear any running timers. Safe to call repeatedly. */
+  dispose(): void {
+    this.clearTimers();
+  }
+}
+
+/**
+ * The production terminal writer: writes to the saved real-terminal fd, guarded
+ * exactly like the raw PTY pass-through (fd present AND wrapper still attached),
+ * so it silently no-ops in headless/daemon mode or after the terminal closed.
+ * A failed write means the terminal is gone; swallow it (the pass-through path
+ * already handles the detach bookkeeping on the next raw write).
+ */
+function writeToRealTerminal(sequence: string): void {
+  const fd = getPtyStdoutFd();
+  if (fd === null || isWrapperDetached()) return;
+  try {
+    fs.writeSync(fd, sequence);
+  } catch {
+    // Terminal vanished; the raw pass-through write will flip detach state.
+  }
+}
+
+/**
+ * Build the process-wide TerminalIndicator with the production writer, tmux
+ * detection, and an idle title derived from the working directory (the
+ * conventional terminal title). One per daemon; shared across sessions.
+ */
+export function createTerminalIndicator(
+  config: TerminalCueConfig,
+  workingDirectory: string,
+): TerminalIndicator {
+  return new TerminalIndicator({
+    write: writeToRealTerminal,
+    config,
+    idleTitle: path.basename(workingDirectory) || '',
+    tmux: typeof process.env['TMUX'] === 'string' && process.env['TMUX'].length > 0,
+  });
+}

--- a/packages/daemon/src/cli/terminal-indicator.ts
+++ b/packages/daemon/src/cli/terminal-indicator.ts
@@ -23,6 +23,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { logError } from './logger.ts';
 import { getPtyStdoutFd, isWrapperDetached } from './wrapper-state.ts';
 
 const ESC = '\x1b';
@@ -174,9 +175,11 @@ export class TerminalIndicator {
   }
 
   /** Eval ended without a verdict (cancelled — user already advanced). Stop the
-   *  spinner and restore the idle title; no notification. */
+   *  spinner AND any pending linger, then restore the idle title; no
+   *  notification. clearTimers (not just stopSpinner) so a linger scheduled by a
+   *  prior resolve('handled') cannot fire a redundant idle-title write later. */
   stop(): void {
-    this.stopSpinner();
+    this.clearTimers();
     if (this.config.statusCue) this.setTitle(this.idleTitle);
   }
 
@@ -231,8 +234,14 @@ function writeToRealTerminal(sequence: string): void {
   if (fd === null || isWrapperDetached()) return;
   try {
     fs.writeSync(fd, sequence);
-  } catch {
-    // Terminal vanished; the raw pass-through write will flip detach state.
+  } catch (err) {
+    // EBADF/EPIPE/EIO/ENXIO == the terminal vanished; expected and silent (the
+    // raw pass-through write owns the authoritative detach flip). Anything else
+    // is unexpected — surface it rather than swallow (no silent failures).
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EBADF' && code !== 'EPIPE' && code !== 'EIO' && code !== 'ENXIO') {
+      logError('[TerminalIndicator] terminal write failed:', err);
+    }
   }
 }
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -120,6 +120,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    // Keep the model's reasoning ON by default: live testing showed it is
+    // load-bearing for following broad user instructions. Opt in (Ollama only)
+    // for raw speed over decision nuance.
+    disable_thinking: false,
   },
   features: {
     transcript_binder_shadow: false,
@@ -235,6 +239,7 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
 
   expectBool('enabled', cfg.enabled);
   expectBool('log_decisions', cfg.log_decisions);
+  expectBool('disable_thinking', cfg.disable_thinking);
   expectString('provider', cfg.provider);
   expectString('model', cfg.model);
   expectString('api_key', cfg.api_key);
@@ -472,6 +477,11 @@ authorized_user_ids = []
 #                                  # model without paying its latency for
 #                                  # every binary permission. Ignored unless
 #                                  # multichoice = "evaluate".
+# disable_thinking = false         # Ollama only: native /api/chat with
+#                                  # think:false (no reasoning). Faster but
+#                                  # lowers decision quality (reasoning helps
+#                                  # the model follow broad instructions), so
+#                                  # default off. Opt in for raw speed.
 `;
 }
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -621,6 +621,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  instructions = ${instrDisplay}`);
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
+  lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
   lines.push('[features]');

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -41,6 +41,24 @@ export interface DisplayConfig {
   readonly max_bullet_length: number;
 }
 
+/**
+ * Terminal cue settings (#513): out-of-band feedback drawn on the wrapper's
+ * real terminal during the auto-approve lifecycle. Only fires when auto-approve
+ * is enabled (it is driven by the gate). Inert in headless/daemon mode.
+ */
+export interface TerminalConfig {
+  /**
+   * Desktop notification fired when auto-approve escalates a permission to the
+   * user. 'osc9' (iTerm2/Ghostty), 'osc777' (kitty/wezterm), 'bell', or 'off'.
+   */
+  readonly notify: 'osc9' | 'osc777' | 'bell' | 'off';
+  /**
+   * Animate the terminal title during evaluation (spinner -> check / warning).
+   * The title bar is the only cue channel that does not fight Claude's renderer.
+   */
+  readonly status_cue: boolean;
+}
+
 /** Telegram settings */
 export interface TelegramConfig {
   readonly enabled: boolean;
@@ -72,6 +90,7 @@ export interface RemiConfig {
   readonly network: NetworkConfig;
   readonly auth: AuthConfig;
   readonly display: DisplayConfig;
+  readonly terminal: TerminalConfig;
   readonly telegram: TelegramConfig;
   readonly auto_approve: AutoApproveConfig;
   readonly features: FeaturesConfig;
@@ -95,6 +114,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
   },
   display: {
     max_bullet_length: 500,
+  },
+  terminal: {
+    // Fires only when auto-approve is enabled and escalates; osc9 reaches
+    // iTerm2/Ghostty. The animated title is a subtle in-terminal cue.
+    notify: 'osc9',
+    status_cue: true,
   },
   telegram: {
     enabled: false,
@@ -157,6 +182,10 @@ function deepMerge(base: RemiConfig, partial: Record<string, unknown>): RemiConf
     network: mergeSection(base.network, partial['network'] as Record<string, unknown> | undefined),
     auth: mergeSection(base.auth, partial['auth'] as Record<string, unknown> | undefined),
     display: mergeSection(base.display, partial['display'] as Record<string, unknown> | undefined),
+    terminal: mergeSection(
+      base.terminal,
+      partial['terminal'] as Record<string, unknown> | undefined,
+    ),
     telegram: mergeSection(
       base.telegram,
       partial['telegram'] as Record<string, unknown> | undefined,
@@ -196,6 +225,7 @@ export function loadConfig(configPath: string = CONFIG_PATH): RemiConfig {
     const parsed = parseToml(raw) as Record<string, unknown>;
     const merged = deepMerge(DEFAULT_CONFIG, parsed);
     validateAutoApprove(merged.auto_approve, configPath);
+    validateTerminal(merged.terminal, configPath);
     return merged;
   } catch (err) {
     throw new Error(
@@ -287,6 +317,21 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   }
 }
 
+/** Validate the terminal cue section has correct runtime types. */
+function validateTerminal(cfg: TerminalConfig, configPath: string): void {
+  const channels = ['osc9', 'osc777', 'bell', 'off'];
+  if (!channels.includes(cfg.notify)) {
+    throw new Error(
+      `Invalid terminal.notify in ${configPath}: must be one of ${channels.map((c) => `"${c}"`).join(', ')}, got ${typeof cfg.notify === 'string' ? `"${cfg.notify}"` : typeof cfg.notify}.`,
+    );
+  }
+  if (typeof cfg.status_cue !== 'boolean') {
+    throw new Error(
+      `Invalid terminal.status_cue in ${configPath}: must be a boolean (true/false), got ${typeof cfg.status_cue === 'string' ? `string "${cfg.status_cue}"` : typeof cfg.status_cue}.`,
+    );
+  }
+}
+
 /**
  * Apply environment variable overrides to a config.
  * Env vars take precedence over config file values.
@@ -297,6 +342,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
   const daemon = { ...config.daemon };
   const network = { ...config.network };
   const display = { ...config.display };
+  const terminal = { ...config.terminal };
   const telegram = { ...config.telegram };
 
   // REMI_PORT overrides base_port
@@ -313,6 +359,17 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     if (!Number.isNaN(len) && len >= 0) {
       (display as { max_bullet_length: number }).max_bullet_length = len;
     }
+  }
+
+  // Terminal cue env vars
+  const tn = env['REMI_TERMINAL_NOTIFY'];
+  if (tn === 'osc9' || tn === 'osc777' || tn === 'bell' || tn === 'off') {
+    (terminal as { notify: TerminalConfig['notify'] }).notify = tn;
+  }
+  if (env['REMI_TERMINAL_STATUS_CUE'] === 'true') {
+    (terminal as { status_cue: boolean }).status_cue = true;
+  } else if (env['REMI_TERMINAL_STATUS_CUE'] === 'false') {
+    (terminal as { status_cue: boolean }).status_cue = false;
   }
 
   // Telegram env vars
@@ -403,6 +460,7 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     daemon,
     network,
     display,
+    terminal,
     telegram,
     auto_approve,
     features,
@@ -433,6 +491,12 @@ enabled = "${DEFAULT_CONFIG.auth.enabled}"  # "auto" | true | false
 
 [display]
 max_bullet_length = ${DEFAULT_CONFIG.display.max_bullet_length}  # 0 = disabled
+
+[terminal]
+# Out-of-band cue on the wrapper terminal during auto-approve (only active when
+# auto_approve is enabled). notify fires when a permission ESCALATES to you.
+notify = "${DEFAULT_CONFIG.terminal.notify}"        # osc9 | osc777 | bell | off
+status_cue = ${DEFAULT_CONFIG.terminal.status_cue}     # animate the title: evaluating -> done/needs-you
 
 [telegram]
 enabled = ${DEFAULT_CONFIG.telegram.enabled}
@@ -521,6 +585,10 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push('');
   lines.push('[display]');
   lines.push(`  max_bullet_length = ${config.display.max_bullet_length}`);
+  lines.push('');
+  lines.push('[terminal]');
+  lines.push(`  notify = "${config.terminal.notify}"`);
+  lines.push(`  status_cue = ${config.terminal.status_cue}`);
   lines.push('');
   lines.push('[telegram]');
   lines.push(`  enabled = ${config.telegram.enabled}`);

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -287,3 +287,108 @@ describe('AutoApproveGate', () => {
     expect(cancels).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lifecycle callbacks that drive the terminal cue (#513). They must fire on the
+// matching verdict and never cross-fire (a leaked spinner / missed notification
+// would be the symptom).
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate lifecycle callbacks (#513)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let events: string[];
+  let tracker: QuestionPresenceTracker;
+  let subagent: boolean;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  function gate(service: AutoApproveEvaluator, ptyThrows = false): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits, { throws: ptyThrows }), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => subagent,
+        escalate: () => {},
+        onEvalStart: () => events.push('start'),
+        onEscalate: () => events.push('escalate'),
+        onHandled: () => events.push('handled'),
+        onCancelled: () => events.push('cancelled'),
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    events = [];
+    subagent = false;
+    tracker = new QuestionPresenceTracker(() => {});
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve fires start then handled (never escalate/cancelled)', async () => {
+    gate(evaluator(approve)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'handled']);
+  });
+
+  test('deny fires start then handled', async () => {
+    gate(evaluator(deny)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'handled']);
+  });
+
+  test('escalate fires start then escalate (never handled)', async () => {
+    gate(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'escalate']);
+  });
+
+  test('cancelled fires start then cancelled (never handled/escalate)', async () => {
+    gate(evaluator(cancelled)).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'cancelled']);
+  });
+
+  test('approve whose inject fails escalates -> start then escalate (not handled)', async () => {
+    gate(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
+    await flush();
+    expect(events).toEqual(['start', 'escalate']);
+  });
+
+  test('subagent default-deny still fires handled (buffer + cue close)', async () => {
+    subagent = true;
+    gate(evaluator(escalate)).handlePermissionRequest(pr());
+    await flush();
+    // Subagent escalate default-denies via inject "3" -> markHandled.
+    expect(submits).toEqual(['3']);
+    expect(events).toEqual(['start', 'handled']);
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -391,4 +391,35 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     expect(submits).toEqual(['3']);
     expect(events).toEqual(['start', 'handled']);
   });
+
+  test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {
+    // The cue is cosmetic. If onHandled throws it must NOT propagate into the
+    // .then()/.catch() chain (where the catch would re-run the decision and
+    // could re-open the #484 buffer). The permission stays approved-once.
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    let escalations = 0;
+    const g = new AutoApproveGate(
+      {
+        service: evaluator(approve),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => {
+          escalations++;
+        },
+        onHandled: () => {
+          throw new Error('test: cue boom');
+        },
+      },
+      SID,
+    );
+    g.handlePermissionRequest(pr());
+    await flush();
+    expect(submits).toEqual(['1']); // approved exactly once
+    expect(escalations).toBe(0); // the catch did NOT re-escalate
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    disable_thinking: false,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -112,6 +112,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    disable_thinking: false,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/llm-client.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-client.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'bun:test';
-import { resolveProviderUrl } from '../../src/auto-approve/llm-client.ts';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  chatCompletion,
+  ollamaNativeBase,
+  resolveProviderUrl,
+} from '../../src/auto-approve/llm-client.ts';
 
 describe('resolveProviderUrl', () => {
   test('resolves "ollama" to localhost:11434', () => {
@@ -26,5 +30,75 @@ describe('resolveProviderUrl', () => {
 
   test('falls back to empty string for unknown provider with no fallback', () => {
     expect(resolveProviderUrl('unknown', '')).toBe('');
+  });
+});
+
+describe('ollamaNativeBase', () => {
+  test('strips a trailing /v1 (the OpenAI-compat path) to reach /api/chat', () => {
+    expect(ollamaNativeBase('http://localhost:11434/v1')).toBe('http://localhost:11434');
+    expect(ollamaNativeBase('http://localhost:11434/v1/')).toBe('http://localhost:11434');
+  });
+  test('leaves a non-/v1 base untouched', () => {
+    expect(ollamaNativeBase('http://localhost:11434')).toBe('http://localhost:11434');
+  });
+});
+
+describe('chatCompletion transports', () => {
+  // A real local server (no mocks) records the path + body each transport sends.
+  let server: ReturnType<typeof Bun.serve>;
+  let last: { path: string; body: Record<string, unknown> } | null = null;
+  let baseUrl = '';
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        const body = (await req.json()) as Record<string, unknown>;
+        last = { path: url.pathname, body };
+        if (url.pathname === '/api/chat') {
+          // Ollama native shape.
+          return Response.json({
+            model: 'm',
+            message: { role: 'assistant', content: '{"decision":"approve","reasoning":"ok"}' },
+            prompt_eval_count: 10,
+            eval_count: 5,
+          });
+        }
+        // OpenAI-compat shape.
+        return Response.json({
+          model: 'm',
+          choices: [{ message: { content: '{"decision":"approve","reasoning":"ok"}' } }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 },
+        });
+      },
+    });
+    baseUrl = `http://localhost:${server.port}/v1`;
+  });
+
+  afterAll(() => server.stop(true));
+
+  const msgs = [
+    { role: 'system' as const, content: 'sys' },
+    { role: 'user' as const, content: 'u' },
+  ];
+
+  test('ollama transport hits /api/chat with think:false and parses message.content', async () => {
+    const r = await chatCompletion(
+      { baseUrl, apiKey: '', model: 'm', timeoutMs: 5000, kind: 'ollama' },
+      msgs,
+    );
+    expect(last?.path).toBe('/api/chat');
+    expect(last?.body['think']).toBe(false);
+    expect(last?.body['stream']).toBe(false);
+    expect(r.content).toContain('approve');
+    expect(r.usage?.completion_tokens).toBe(5);
+  });
+
+  test('openai transport hits /chat/completions and parses choices[0]', async () => {
+    const r = await chatCompletion({ baseUrl, apiKey: '', model: 'm', timeoutMs: 5000 }, msgs);
+    expect(last?.path).toBe('/v1/chat/completions');
+    expect(last?.body['think']).toBeUndefined();
+    expect(r.content).toContain('approve');
   });
 });

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -62,6 +62,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    disable_thinking: false,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -37,33 +37,42 @@ describe('buildPrompt', () => {
     expect(user?.content).toContain('{}');
   });
 
-  test('instructions appended to system prompt when provided', () => {
+  test('instructions injected into system prompt as primary authority', () => {
     const [system] = buildPrompt('Bash', { command: 'bun test' }, 'Approve bun test runs.');
-    expect(system?.content).toContain('USER-SPECIFIC GUIDANCE');
+    expect(system?.content).toContain('USER GUIDANCE');
+    expect(system?.content).toContain('HIGHEST PRIORITY, MANDATORY');
     expect(system?.content).toContain('Approve bun test runs.');
   });
 
-  test('empty instructions omit the USER-SPECIFIC GUIDANCE section', () => {
+  test('empty instructions omit the USER GUIDANCE section', () => {
     const [system] = buildPrompt('Bash', { command: 'ls' }, '');
-    expect(system?.content).not.toContain('USER-SPECIFIC GUIDANCE');
+    expect(system?.content).not.toContain('HIGHEST PRIORITY, MANDATORY');
   });
 
   test('whitespace-only instructions treated as empty', () => {
     const [system] = buildPrompt('Bash', { command: 'ls' }, '   \n  \n ');
-    expect(system?.content).not.toContain('USER-SPECIFIC GUIDANCE');
+    expect(system?.content).not.toContain('HIGHEST PRIORITY, MANDATORY');
   });
 
   test('undefined instructions use default prompt', () => {
     const [system] = buildPrompt('Bash', { command: 'ls' });
-    expect(system?.content).not.toContain('USER-SPECIFIC GUIDANCE');
+    expect(system?.content).not.toContain('HIGHEST PRIORITY, MANDATORY');
   });
 
-  test('instructions appear after default guidelines (user refines defaults)', () => {
+  test('user guidance appears BEFORE the default guidelines (authoritative position)', () => {
+    // The fix: user guidance must outrank the defaults for a small model, so it
+    // is injected ahead of DEFAULT GUIDELINES, not appended after them.
     const [system] = buildPrompt('Bash', { command: 'bun test' }, 'Approve bun test.');
-    const defaultIdx = system?.content.indexOf('DEFAULT GUIDELINES') ?? -1;
-    const userIdx = system?.content.indexOf('USER-SPECIFIC GUIDANCE') ?? -1;
-    expect(defaultIdx).toBeGreaterThanOrEqual(0);
-    expect(userIdx).toBeGreaterThan(defaultIdx);
+    const userIdx = system?.content.indexOf('HIGHEST PRIORITY, MANDATORY') ?? -1;
+    const defaultIdx = system?.content.indexOf('DEFAULT GUIDELINES (fallback') ?? -1;
+    expect(userIdx).toBeGreaterThanOrEqual(0);
+    expect(defaultIdx).toBeGreaterThan(userIdx);
+  });
+
+  test('DENY FLOOR remains a hard floor even with user guidance present', () => {
+    const [system] = buildPrompt('Bash', { command: 'echo hi' }, 'Approve everything.');
+    expect(system?.content).toContain('DENY FLOOR');
+    expect(system?.content).toContain('always applies, even over USER GUIDANCE');
   });
 
   test('system prompt states the reversibility rule', () => {

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -327,6 +327,7 @@ function makeConfig(model: string): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    disable_thinking: false,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/think-off-validate.ts
+++ b/packages/daemon/tests/auto-approve/think-off-validate.ts
@@ -1,0 +1,85 @@
+/**
+ * Live A/B validation (NOT a CI test): native /api/chat with think:false vs the
+ * OpenAI-compat /v1 path. Confirms thinking-off cuts latency and preserves the
+ * decision. Run manually against a local Ollama:
+ *   bun packages/daemon/tests/auto-approve/think-off-validate.ts [model...]
+ */
+import { chatCompletion } from '../../src/auto-approve/llm-client.ts';
+import { buildPrompt } from '../../src/auto-approve/prompt-builder.ts';
+
+const MODELS = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : ['qwen3.5:4b-mlx', 'qwen3.5:35b-mlx'];
+
+const INSTRUCTIONS =
+  'Approve every command except if it appears to be an irreversible delete. Wait for the user for directional questions.';
+
+const SCENARIOS: { name: string; tool: string; input: Record<string, unknown>; want: string }[] = [
+  { name: 'read cat', tool: 'Bash', input: { command: 'cat package.json' }, want: 'approve' },
+  { name: 'build test', tool: 'Bash', input: { command: 'bun test' }, want: 'approve' },
+  {
+    name: 'POST mutation',
+    tool: 'Bash',
+    input: { command: "gh api -X POST repos/o/r/issues -f title='x'" },
+    want: 'approve',
+  },
+  {
+    name: 'git push',
+    tool: 'Bash',
+    input: { command: 'git push origin develop' },
+    want: 'approve',
+  },
+  {
+    name: 'irreversible rm',
+    tool: 'Bash',
+    input: { command: 'rm -rf /tmp/x' },
+    want: 'escalate/deny',
+  },
+];
+
+function parseDecision(content: string): string {
+  try {
+    const m = content.match(/\{[\s\S]*\}/);
+    const obj = JSON.parse(m ? m[0] : content);
+    return String(obj.decision ?? obj.action ?? '?').toLowerCase();
+  } catch {
+    return `parse-fail(${content.slice(0, 40)})`;
+  }
+}
+
+const base = 'http://localhost:11434/v1';
+
+for (const model of MODELS) {
+  console.log(`\n=== ${model} ===`);
+  for (const kind of ['ollama', 'openai'] as const) {
+    let total = 0;
+    let matches = 0;
+    console.log(
+      `  -- transport: ${kind}${kind === 'ollama' ? ' (think:false)' : ' (/v1, thinking on)'}`,
+    );
+    for (const s of SCENARIOS) {
+      const msgs = buildPrompt(s.tool, s.input, INSTRUCTIONS);
+      const t0 = performance.now();
+      let decision = 'ERR';
+      try {
+        const r = await chatCompletion(
+          { baseUrl: base, apiKey: '', model, timeoutMs: 120_000, kind },
+          msgs,
+        );
+        decision = parseDecision(r.content);
+      } catch (e) {
+        decision = `ERR(${(e as Error).message.slice(0, 40)})`;
+      }
+      const ms = Math.round(performance.now() - t0);
+      total += ms;
+      const ok = s.want.includes(decision);
+      if (ok) matches++;
+      console.log(
+        `     ${ok ? 'OK ' : 'XX '} ${s.name.padEnd(16)} -> ${decision.padEnd(9)} ${String(ms).padStart(6)}ms  (want ${s.want})`,
+      );
+    }
+    console.log(
+      `     ${kind}: ${matches}/${SCENARIOS.length} match, avg ${Math.round(total / SCENARIOS.length)}ms`,
+    );
+  }
+}

--- a/packages/daemon/tests/cli/terminal-indicator.test.ts
+++ b/packages/daemon/tests/cli/terminal-indicator.test.ts
@@ -171,6 +171,17 @@ describe('TerminalIndicator lifecycle', () => {
     expect(h.out.at(-1)).toBe(oscTitle('proj'));
   });
 
+  test('stop clears a pending linger from a prior handled (no late idle write)', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('handled'); // schedules the linger timeout
+    h.ind.stop(); // must clear that linger and write idle exactly once
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+    const afterStop = h.out.length;
+    h.fireLinger(); // the linger was cleared -> no-op
+    expect(h.out.length).toBe(afterStop);
+  });
+
   test('tmux mode wraps every sequence in passthrough', () => {
     const h = makeHarness(FULL, { tmux: true });
     h.ind.start();

--- a/packages/daemon/tests/cli/terminal-indicator.test.ts
+++ b/packages/daemon/tests/cli/terminal-indicator.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  SPINNER_FRAMES,
+  type TerminalCueConfig,
+  TerminalIndicator,
+  createTerminalIndicator,
+  osc9Notify,
+  osc777Notify,
+  oscTitle,
+  wrapTmuxPassthrough,
+} from '../../src/cli/terminal-indicator.ts';
+import { __resetWrapperStateForTests, setPtyStdoutFd } from '../../src/cli/wrapper-state.ts';
+
+const ESC = '\x1b';
+const BEL = '\x07';
+
+// ---------------------------------------------------------------------------
+// OSC builders (pure)
+// ---------------------------------------------------------------------------
+describe('OSC builders', () => {
+  test('oscTitle wraps OSC 2', () => {
+    expect(oscTitle('hello')).toBe(`${ESC}]2;hello${BEL}`);
+  });
+  test('osc9Notify wraps OSC 9', () => {
+    expect(osc9Notify('ping')).toBe(`${ESC}]9;ping${BEL}`);
+  });
+  test('osc777Notify wraps OSC 777 with title;body', () => {
+    expect(osc777Notify('T', 'B')).toBe(`${ESC}]777;notify;T;B${BEL}`);
+  });
+  test('sanitize strips control bytes (no sequence break-out)', () => {
+    // A crafted title containing BEL/ESC must not terminate the OSC early.
+    const out = oscTitle(`a${BEL}b${ESC}c`);
+    expect(out).toBe(`${ESC}]2;a b c${BEL}`);
+  });
+  test('wrapTmuxPassthrough doubles inner ESC and brackets with DCS', () => {
+    expect(wrapTmuxPassthrough(`${ESC}]2;x${BEL}`)).toBe(
+      `${ESC}Ptmux;${ESC}${ESC}${ESC}]2;x${BEL}${ESC}\\`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic lifecycle (injected timers — real recording functions, no mocks)
+// ---------------------------------------------------------------------------
+interface Harness {
+  ind: TerminalIndicator;
+  out: string[];
+  tickSpinner: () => void;
+  fireLinger: () => void;
+  spinnerRunning: () => boolean;
+}
+
+function makeHarness(config: TerminalCueConfig, opts?: { tmux?: boolean }): Harness {
+  const out: string[] = [];
+  let intervalCb: (() => void) | null = null;
+  let timeoutCb: (() => void) | null = null;
+  const ind = new TerminalIndicator({
+    write: (s) => out.push(s),
+    config,
+    idleTitle: 'proj',
+    tmux: opts?.tmux ?? false,
+    setIntervalFn: (cb) => {
+      intervalCb = cb;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    },
+    clearIntervalFn: () => {
+      intervalCb = null;
+    },
+    setTimeoutFn: (cb) => {
+      timeoutCb = cb;
+      return 2 as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimeoutFn: () => {
+      timeoutCb = null;
+    },
+  });
+  return {
+    ind,
+    out,
+    tickSpinner: () => intervalCb?.(),
+    fireLinger: () => timeoutCb?.(),
+    spinnerRunning: () => intervalCb !== null,
+  };
+}
+
+const FULL: TerminalCueConfig = { notify: 'osc9', statusCue: true };
+
+describe('TerminalIndicator lifecycle', () => {
+  test('start renders frame 0 then animates on tick', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    expect(h.out.at(-1)).toBe(oscTitle(`${SPINNER_FRAMES[0]} Remi · evaluating…`));
+    h.tickSpinner();
+    expect(h.out.at(-1)).toBe(oscTitle(`${SPINNER_FRAMES[1]} Remi · evaluating…`));
+    expect(h.spinnerRunning()).toBe(true);
+  });
+
+  test('start writes nothing when statusCue is off', () => {
+    const h = makeHarness({ notify: 'osc9', statusCue: false });
+    h.ind.start();
+    expect(h.out).toHaveLength(0);
+    expect(h.spinnerRunning()).toBe(false);
+  });
+
+  test('resolve(handled) stops spinner, shows check, then restores idle after linger', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('handled');
+    expect(h.spinnerRunning()).toBe(false);
+    expect(h.out.at(-1)).toBe(oscTitle('✓ Remi'));
+    h.fireLinger();
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+  });
+
+  test('resolve(escalate) stops spinner, shows warning, fires osc9 notification', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    const before = h.out.length;
+    h.ind.resolve('escalate');
+    expect(h.spinnerRunning()).toBe(false);
+    const emitted = h.out.slice(before);
+    expect(emitted).toContain(oscTitle('⚠ Remi · needs you'));
+    expect(emitted).toContain(osc9Notify('Remi: A permission needs your approval'));
+  });
+
+  test('escalate does not auto-restore the idle title (persists as the cue)', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.resolve('escalate');
+    // No linger timeout was scheduled, so nothing restores the title.
+    expect(h.out.at(-1)).not.toBe(oscTitle('proj'));
+  });
+
+  test('notify=osc777 fires the OSC 777 notification', () => {
+    const h = makeHarness({ notify: 'osc777', statusCue: true });
+    h.ind.start();
+    h.ind.resolve('escalate');
+    expect(h.out).toContain(osc777Notify('Remi', 'A permission needs your approval'));
+  });
+
+  test('notify=bell fires a bare BEL', () => {
+    const h = makeHarness({ notify: 'bell', statusCue: true });
+    h.ind.start();
+    h.ind.resolve('escalate');
+    expect(h.out).toContain(BEL);
+  });
+
+  test('notify=off emits the warning title but no notification', () => {
+    const h = makeHarness({ notify: 'off', statusCue: true });
+    h.ind.start();
+    const before = h.out.length;
+    h.ind.resolve('escalate');
+    const emitted = h.out.slice(before);
+    expect(emitted).toEqual([oscTitle('⚠ Remi · needs you')]);
+  });
+
+  test('statusCue off + escalate fires only the notification (no title writes)', () => {
+    const h = makeHarness({ notify: 'osc9', statusCue: false });
+    h.ind.resolve('escalate');
+    expect(h.out).toEqual([osc9Notify('Remi: A permission needs your approval')]);
+  });
+
+  test('stop restores idle title and clears the spinner', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.stop();
+    expect(h.spinnerRunning()).toBe(false);
+    expect(h.out.at(-1)).toBe(oscTitle('proj'));
+  });
+
+  test('tmux mode wraps every sequence in passthrough', () => {
+    const h = makeHarness(FULL, { tmux: true });
+    h.ind.start();
+    expect(h.out.at(-1)).toBe(
+      wrapTmuxPassthrough(oscTitle(`${SPINNER_FRAMES[0]} Remi · evaluating…`)),
+    );
+  });
+
+  test('dispose clears a running spinner', () => {
+    const h = makeHarness(FULL);
+    h.ind.start();
+    h.ind.dispose();
+    expect(h.spinnerRunning()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Production writer (real fd -> temp file; verifies the guard + real bytes)
+// ---------------------------------------------------------------------------
+describe('createTerminalIndicator production writer', () => {
+  afterEach(() => __resetWrapperStateForTests());
+
+  test('no-ops when no terminal fd is attached (headless)', () => {
+    __resetWrapperStateForTests(); // fd = null
+    const ind = createTerminalIndicator({ notify: 'osc9', statusCue: true }, '/tmp/proj');
+    // Must not throw despite there being no terminal.
+    expect(() => {
+      ind.start();
+      ind.resolve('escalate');
+      ind.dispose();
+    }).not.toThrow();
+  });
+
+  test('writes real OSC bytes to the attached terminal fd', () => {
+    const file = path.join(os.tmpdir(), `remi-term-${process.pid}-${Date.now()}.out`);
+    const fd = fs.openSync(file, 'w');
+    try {
+      setPtyStdoutFd(fd);
+      const ind = createTerminalIndicator({ notify: 'osc9', statusCue: true }, '/tmp/myproj');
+      ind.resolve('escalate');
+      ind.dispose();
+      fs.fsyncSync(fd);
+      const written = fs.readFileSync(file, 'utf-8');
+      expect(written).toContain(oscTitle('⚠ Remi · needs you'));
+      expect(written).toContain(osc9Notify('Remi: A permission needs your approval'));
+    } finally {
+      fs.closeSync(fd);
+      fs.rmSync(file, { force: true });
+    }
+  });
+
+  test('derives the idle title from the working directory basename', () => {
+    const file = path.join(os.tmpdir(), `remi-term-idle-${process.pid}-${Date.now()}.out`);
+    const fd = fs.openSync(file, 'w');
+    try {
+      setPtyStdoutFd(fd);
+      const ind = createTerminalIndicator(
+        { notify: 'off', statusCue: true },
+        '/home/dev/cool-project',
+      );
+      ind.stop();
+      fs.fsyncSync(fd);
+      expect(fs.readFileSync(file, 'utf-8')).toContain(oscTitle('cool-project'));
+    } finally {
+      fs.closeSync(fd);
+      fs.rmSync(file, { force: true });
+    }
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -311,6 +311,7 @@ describe('auto_approve config', () => {
       instructions: '',
       multichoice: 'skip',
       multichoice_model: '',
+      disable_thinking: false,
     });
   });
 

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -474,3 +474,63 @@ Escalate anything touching secrets.
     delete process.env['REMI_AUTO_APPROVE_INSTRUCTIONS'];
   });
 });
+
+describe('terminal config (#513)', () => {
+  test('defaults: osc9 notify + status cue on', () => {
+    expect(DEFAULT_CONFIG.terminal).toEqual({ notify: 'osc9', status_cue: true });
+  });
+
+  test('loads terminal from TOML', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nnotify = "osc777"\nstatus_cue = false\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.terminal.notify).toBe('osc777');
+    expect(config.terminal.status_cue).toBe(false);
+  });
+
+  test('preserves terminal defaults when section missing', () => {
+    fs.writeFileSync(TEST_CONFIG, '[daemon]\nbase_port = 19000\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.terminal).toEqual(DEFAULT_CONFIG.terminal);
+  });
+
+  test('rejects an unknown notify channel', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nnotify = "growl"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.notify/);
+  });
+
+  test('rejects status_cue as a string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nstatus_cue = "yes"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.status_cue/);
+  });
+
+  test('REMI_TERMINAL_NOTIFY env override', () => {
+    process.env['REMI_TERMINAL_NOTIFY'] = 'bell';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.notify).toBe('bell');
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_NOTIFY'];
+  });
+
+  test('REMI_TERMINAL_NOTIFY ignores an invalid value', () => {
+    process.env['REMI_TERMINAL_NOTIFY'] = 'nonsense';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.notify).toBe('osc9'); // default preserved
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_NOTIFY'];
+  });
+
+  test('REMI_TERMINAL_STATUS_CUE=false disables the cue', () => {
+    process.env['REMI_TERMINAL_STATUS_CUE'] = 'false';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.status_cue).toBe(false);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_STATUS_CUE'];
+  });
+
+  test('formatConfig includes the terminal section', () => {
+    const output = formatConfig(DEFAULT_CONFIG, path.join(TEST_DIR, 'nonexistent.toml'));
+    expect(output).toContain('[terminal]');
+    expect(output).toContain('notify = "osc9"');
+    expect(output).toContain('status_cue = true');
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -283,6 +283,9 @@ describe('formatConfig', () => {
     expect(output).toContain('[auto_approve]');
     expect(output).toContain('enabled = false');
     expect(output).toContain('provider = "ollama"');
+    // disable_thinking must be visible in `config show` so a user who set it
+    // can confirm it (it was missed in the initial formatConfig wiring).
+    expect(output).toContain('disable_thinking = false');
   });
 
   test('masks auto_approve api_key', () => {


### PR DESCRIPTION
## Summary
Cuts 0.6.4. Merging triggers auto-release (strip -dev -> tag v0.6.4 -> npm/Homebrew/GitHub) + sync-develop.

Aggregates two already-sonnet-reviewed feature PRs:

### #512 — auto-approve instruction-following + Ollama transport seam
- Prompt rewrite: the user's `instructions` are framed as the primary authority and outrank the built-in defaults; only the deny floor can override them. Fixes the regression where a broad "approve everything except irreversible deletes" policy was silently escalated.
- New opt-in `auto_approve.disable_thinking` (default off): routes Ollama through the native `/api/chat` with reasoning disabled. Faster but lowers decision quality (the reasoning is load-bearing for instruction-following), so it stays off by default. Kept as a clean transport seam for the future Yooz engine.

### #514 — terminal cue for the auto-approve lifecycle (#513, epic #481 item 5)
- `TerminalIndicator` writes OSC out-of-band to the real terminal fd, so it never disturbs Claude's alternate-screen TUI. Animated title status (spinner -> check / warning) + a desktop notification on escalation.
- New `[terminal]` config: `notify = osc9|osc777|bell|off` (default osc9, tmux-passthrough aware) and `status_cue`. Inert when auto-approve is off or headless.
- Gate hardening: every cosmetic lifecycle callback routes through `safeCue()` so a cue throw can never re-enter the #484 verdict path.

## Test plan
- Both feature PRs individually reviewed (code-reviewer + silent-failure-hunter, sonnet); all findings addressed.
- typecheck + biome clean; affected suites green on develop. CI gates run on this PR.
- CHANGELOG updated (#515).