### PR TITLE
fix(config): show disable_thinking in config output

### DIFF
--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -621,6 +621,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  instructions = ${instrDisplay}`);
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
+  lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
   lines.push('[features]');

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -283,6 +283,9 @@ describe('formatConfig', () => {
     expect(output).toContain('[auto_approve]');
     expect(output).toContain('enabled = false');
     expect(output).toContain('provider = "ollama"');
+    // disable_thinking must be visible in `config show` so a user who set it
+    // can confirm it (it was missed in the initial formatConfig wiring).
+    expect(output).toContain('disable_thinking = false');
   });
 
   test('masks auto_approve api_key', () => {


### PR DESCRIPTION
`formatConfig` (the `remi config show` display path) omitted `disable_thinking`, so a user who set it could not see it. One-line display fix + test assertion. Caught by the 0.6.4 develop->main integration review (#516).