### PR TITLE
fix(binder): reclaim own session via port marker on a stale lock

### DIFF
--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -239,16 +239,23 @@ export class TranscriptBinder {
     const isRotation = previous !== null && previous !== event.session_id;
 
     // 4) Classify.
-    const classification = this.classify(event.session_id);
+    let classification = this.classify(event.session_id);
 
     if (classification === 'foreign') {
-      return {
-        classification: 'foreign',
-        wouldEmitRotation: false,
-        wouldStartWatcher: false,
-        watcherPath: null,
-        boundIdAfter: this.currentBoundId,
-      };
+      // Stale-lock recovery (#518): an event the classifier calls foreign is
+      // actually OURS when its transcript carries our port marker. Re-adopt it
+      // as a restart instead of dropping. See `incomingReclaimsViaMarker`.
+      if (this.incomingReclaimsViaMarker(event)) {
+        classification = 'restart';
+      } else {
+        return {
+          classification: 'foreign',
+          wouldEmitRotation: false,
+          wouldStartWatcher: false,
+          watcherPath: null,
+          boundIdAfter: this.currentBoundId,
+        };
+      }
     }
 
     // Restart PROLOGUE (pure mirror of rotate()): announce (idempotent +
@@ -350,13 +357,24 @@ export class TranscriptBinder {
     const isRotation = previous !== null && previous !== event.session_id;
 
     // 4) Classify.
-    const classification = this.classify(event.session_id);
+    let classification = this.classify(event.session_id);
 
     if (classification === 'foreign') {
-      log(
-        `[Binder] Dropped foreign ${event.hook_event_name ?? 'event'}: lock=${this.currentBoundId?.slice(0, 8)} incoming=${event.session_id.slice(0, 8)}`,
-      );
-      return;
+      // Stale-lock recovery (#518): the incoming transcript carries OUR port
+      // marker, so it is provably our own Claude — a rotation we missed because
+      // we adopted a stale lock (mid-session attach / restart) and never saw the
+      // SessionStart. Re-adopt it as a restart instead of dropping it forever.
+      if (this.incomingReclaimsViaMarker(event)) {
+        log(
+          `[Binder] Reclaiming own session via port marker (stale lock): lock=${this.currentBoundId?.slice(0, 8)} -> ${event.session_id.slice(0, 8)}`,
+        );
+        classification = 'restart';
+      } else {
+        log(
+          `[Binder] Dropped foreign ${event.hook_event_name ?? 'event'}: lock=${this.currentBoundId?.slice(0, 8)} incoming=${event.session_id.slice(0, 8)}`,
+        );
+        return;
+      }
     }
 
     let rotationAnnounced = false;
@@ -478,7 +496,28 @@ export class TranscriptBinder {
    */
   admits(event: BinderHookEvent): boolean {
     this.adoptLockFromStore();
-    return this.currentBoundId ? event.session_id === this.currentBoundId : !this.hasSiblingInDir();
+    if (!this.currentBoundId) return !this.hasSiblingInDir();
+    if (event.session_id === this.currentBoundId) return true;
+    // Stale-lock recovery (#518): the lock disagrees, but the incoming event's
+    // transcript carries OUR port marker, so it is provably ours. Admit it; the
+    // next binding event's onHookEvent re-adopts the lock. Pure read (the marker
+    // check is read-only), so admits() stays side-effect-free.
+    return this.incomingReclaimsViaMarker(event);
+  }
+
+  /**
+   * Stale-lock recovery test (#518). The classifier calls an event `foreign`
+   * whenever its session_id differs from our lock and our PTY is running. That
+   * is wrong when the daemon adopted a STALE lock (a mid-session attach or a
+   * restart that missed the live session's SessionStart): the live session is
+   * then dropped forever. Its transcript, however, carries our `remi:<port>`
+   * head marker — content only OUR daemon's `-n remi:<port>` causes Claude to
+   * write — so `ownsTranscript` proves it is ours. A genuine sibling's
+   * transcript carries the sibling's port, so this stays false for it and
+   * cross-session isolation (#451) is preserved.
+   */
+  private incomingReclaimsViaMarker(event: BinderHookEvent): boolean {
+    return !!event.transcript_path && this.ownsTranscript(event.transcript_path);
   }
 
   // =========================================================================

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -385,13 +385,21 @@ export class TranscriptBinder {
       // The single rotation funnel. Performs teardown -> onRotation ->
       // emitRotated (path-guarded) -> bindingStore.update -> currentBoundId=new
       // -> mainSessionEnded=false. emitRotated only fires when a path is
-      // present and isRotation holds.
-      rotationAnnounced = this.rotate(
-        event.session_id,
-        event.transcript_path,
-        previous,
-        isRotation,
-      );
+      // present and isRotation holds. Wrapped: rotate() runs the injected
+      // onRotation + teardown, and a throw must not escape into the hook
+      // dispatch loop. rotate() nulls the lock first, so a failure leaves the
+      // safe re-adopt-on-next-event state.
+      try {
+        rotationAnnounced = this.rotate(
+          event.session_id,
+          event.transcript_path,
+          previous,
+          isRotation,
+        );
+      } catch (err) {
+        logError(`[Binder] rotate() failed for session ${this.sessionId}: ${errorToString(err)}`);
+        return;
+      }
     }
 
     // classification === 'match' (or restart fell through with the new lock).
@@ -500,8 +508,11 @@ export class TranscriptBinder {
     if (event.session_id === this.currentBoundId) return true;
     // Stale-lock recovery (#518): the lock disagrees, but the incoming event's
     // transcript carries OUR port marker, so it is provably ours. Admit it; the
-    // next binding event's onHookEvent re-adopts the lock. Pure read (the marker
-    // check is read-only), so admits() stays side-effect-free.
+    // next binding event's onHookEvent re-adopts the lock. No state mutation —
+    // the marker check is a read. After a successful onHookEvent reclaim this
+    // id-matches above (no read); the marker read only fires while the event
+    // stays genuinely foreign (a real sibling), where the 8KB head read is
+    // bounded and acceptable.
     return this.incomingReclaimsViaMarker(event);
   }
 
@@ -517,7 +528,14 @@ export class TranscriptBinder {
    * cross-session isolation (#451) is preserved.
    */
   private incomingReclaimsViaMarker(event: BinderHookEvent): boolean {
-    return !!event.transcript_path && this.ownsTranscript(event.transcript_path);
+    try {
+      return !!event.transcript_path && this.ownsTranscript(event.transcript_path);
+    } catch (err) {
+      // Fail closed: an unexpected throw (e.g. currentPort()) must not escape
+      // into the hook dispatch loop. Stays foreign — the safe default.
+      logError(`[Binder] incomingReclaimsViaMarker failed (fail-closed): ${errorToString(err)}`);
+      return false;
+    }
   }
 
   // =========================================================================

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -134,6 +134,20 @@ describe('TranscriptBinder', () => {
     return new TranscriptBinder(deps(), { sessionId: SID, workingDirectory: tmpDir }, mode);
   }
 
+  /**
+   * Write a real transcript file whose head carries Claude's `custom-title`
+   * ownership marker `remi:<port>` (what `-n remi:<port>` produces). Returns the
+   * path. currentPort() in deps() is 8765, so port 8765 == "owned by us".
+   */
+  function writeMarkedTranscript(name: string, port: number): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(
+      p,
+      `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${port}`, sessionId: 's' })}\n`,
+    );
+    return p;
+  }
+
   /** Insert a fake watcher into the map so teardown/stale-replace has a target. */
   function seedWatcher(filePath: string, stopCalls: number[]): void {
     transcriptWatchers.set(SID, {
@@ -209,6 +223,92 @@ describe('TranscriptBinder', () => {
       // Binding + watcher unchanged.
       expect(binder.snapshot().claudeSessionId).toBe('claude-A');
       expect(transcriptWatchers.get(SID)?.filePath).toBe(before);
+    });
+
+    // -----------------------------------------------------------------------
+    // Stale-lock recovery via the port marker (#518)
+    // -----------------------------------------------------------------------
+
+    test('reclaim: a "foreign" event whose transcript owns our port marker re-adopts (drive)', () => {
+      registerSession();
+      const binder = makeBinder();
+      // Lock on a STALE id (simulates a mid-session attach / dead prior session).
+      binder.onHookEvent({
+        session_id: 'claude-STALE',
+        transcript_path: path.join(tmpDir, 'stale.jsonl'),
+      });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-STALE');
+
+      // The live session arrives; its transcript carries OUR marker (remi:8765).
+      const livePath = writeMarkedTranscript('live.jsonl', 8765);
+      binder.onHookEvent({ session_id: 'claude-LIVE', transcript_path: livePath });
+
+      // Re-adopted, not dropped: lock moved, rotation announced, watcher re-pointed.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-LIVE');
+      expect(transcriptWatchers.get(SID)?.filePath).toBe(livePath);
+      const rs = rotations();
+      expect(rs).toHaveLength(1);
+      expect(rs[0]?.new).toBe('claude-LIVE');
+    });
+
+    test('reclaim: decide() reports restart (not foreign) for an owned-marker event', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'claude-STALE',
+        transcript_path: path.join(tmpDir, 'stale.jsonl'),
+      });
+      const d = binder.decide({
+        session_id: 'claude-LIVE',
+        transcript_path: writeMarkedTranscript('live.jsonl', 8765),
+      });
+      expect(d.classification).toBe('restart');
+    });
+
+    test('no reclaim: a foreign transcript owning a DIFFERENT port stays foreign (sibling isolation)', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'claude-STALE',
+        transcript_path: path.join(tmpDir, 'stale.jsonl'),
+      });
+      // A genuine sibling: its transcript carries the sibling's port (9999), not ours.
+      const siblingPath = writeMarkedTranscript('sibling.jsonl', 9999);
+      const d = binder.decide({ session_id: 'claude-SIBLING', transcript_path: siblingPath });
+      expect(d.classification).toBe('foreign');
+      binder.onHookEvent({ session_id: 'claude-SIBLING', transcript_path: siblingPath });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-STALE'); // unchanged
+      expect(rotations()).toHaveLength(0);
+    });
+
+    test('admits: owned-marker event is admitted despite a disagreeing lock; sibling is not', () => {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'claude-STALE',
+        transcript_path: path.join(tmpDir, 'stale.jsonl'),
+      });
+      // Owns our marker -> admitted even though session_id != lock.
+      expect(
+        binder.admits({
+          session_id: 'claude-LIVE',
+          transcript_path: writeMarkedTranscript('live.jsonl', 8765),
+        }),
+      ).toBe(true);
+      // Sibling port -> rejected.
+      expect(
+        binder.admits({
+          session_id: 'claude-SIBLING',
+          transcript_path: writeMarkedTranscript('sibling.jsonl', 9999),
+        }),
+      ).toBe(false);
+      // Lock match -> admitted (no marker needed).
+      expect(
+        binder.admits({
+          session_id: 'claude-STALE',
+          transcript_path: path.join(tmpDir, 's.jsonl'),
+        }),
+      ).toBe(true);
     });
 
     test('restart: a different session_id after PTY exited classifies restart', () => {


### PR DESCRIPTION
## Summary
Fixes the binder wedge where a daemon that restarts or attaches mid-session adopts a **stale** claude session id from the persisted store, then classifies every live event as `foreign` while the PTY runs — with no recovery. The daemon drops its own live session's `PermissionRequest`/tool hooks forever, so auto-approve never evaluates (the LLM is never called) and questions never surface. This is the recurring root behind "messages not from this session" / auto-approve-silent.

Observed live: `[Binder] Dropped foreign PermissionRequest: lock=72ff3fd6 incoming=<live>` where `72ff3fd6` was a days-old zombie session.

## Fix
The `remi:<port>` transcript head marker (`readTranscriptOwnerPort`, written by Claude via `-n remi:<port>`) is authoritative — only our own daemon produces it. Consult it on the foreign path:
- `admits()`: admit a lock-disagreeing event whose transcript owns our port marker (pure read).
- `onHookEvent()`/`decide()`: in the `foreign` branch, if the transcript owns our marker, reclassify as `restart` and re-adopt (heals the stale lock).

A genuine sibling's transcript carries the **sibling's** port, so `ownsTranscript` is false and it correctly stays foreign — cross-session isolation (#451) preserved.

Closes #518

## Test plan
- 4 new real-file regression tests (no mocks): owned-marker event re-adopts (drive) / decide() reports `restart`; different-port (sibling) stays foreign; `admits()` admits owned-marker, rejects sibling, admits lock-match.
- Differential harness + characterization suite unchanged (synthetic transcript paths carry no marker → behavior identical). 125 transcript+session-phase tests green; typecheck + biome clean.

## Not covered
A bare `claude -n <custom>` session (no `remi:<port>` marker) cannot be auto-claimed by port — operationally correct; run it under `remi` to get the marker.