### PR TITLE
feat(auto-approve): synchronous PermissionRequest decisions (#496)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -188,10 +188,17 @@ export class AutoApproveGate {
       this.markHandled();
       return 'deny';
     }
-    if (result.decision === 'pick' && result.pickIndex !== undefined) {
+    if (result.decision === 'pick') {
       // Multi-choice pick (#399): the response can't express it, so render the
       // prompt (passthrough) and inject the 1-based index into the PTY. The
-      // index was validated against options length upstream.
+      // index was validated against options length upstream. The discriminated
+      // union guarantees pickIndex, but guard defensively: a malformed result
+      // must escalate, not silently fall through to the subagent-deny below.
+      if (result.pickIndex === undefined) {
+        logError(`[AutoApprove ${this.sessionTag}] pick result missing pickIndex; escalating`);
+        this.escalateToUser(input);
+        return 'passthrough';
+      }
       if (
         await this.inject(input, String(result.pickIndex), `multichoice-pick-${result.pickIndex}`)
       ) {
@@ -201,8 +208,17 @@ export class AutoApproveGate {
       }
       return 'passthrough';
     }
-    // escalate
+    // escalate: a subagent prompt the user cannot answer is default-denied via
+    // the response (no hang, no PTY).
     if (isInSubagentContext()) {
+      if (!this.isSubagentEvent(input)) {
+        // A MAIN-agent event reaching here means the subagent-context tracker
+        // leaked (a PostToolUse(Task) was dropped). Surface it loudly — otherwise
+        // the main session silently denies every permission.
+        logError(
+          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}); denying. Possible subagent-context tracker leak.`,
+        );
+      }
       log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
       this.markHandled();
       return 'deny';
@@ -248,16 +264,14 @@ export class AutoApproveGate {
    * missing, PTY not running, submitInput throws, subagent off-screen gate trips)
    * it logs and returns false so callers can fall back to escalating.
    *
-   * `value` is a 1-based numeric option index serialised as a string. Most
-   * permissions only need '1' (approve) or '3' (deny); multi-choice picks can land
-   * any index in the prompt's option range (#399).
+   * `value` is a 1-based numeric option index serialised as a string. Since #496
+   * (synchronous decisions) approve/deny no longer inject — this is now reached
+   * ONLY for a multi-choice pick, where `value` is the chosen index (#399).
    *
    * PTY-presence gate (subagent-only): a background subagent emits PermissionRequest
    * hooks for its own tool calls, but its prompts never render on the main PTY — only
-   * a hot-switched subagent view does. Without this gate, auto-approve would type
-   * "1"/"3" into the MAIN AGENT's input every time a background subagent asked.
-   * `bypassSubagentPtyGate` is set by the default-deny paths, whose alternative is
-   * hanging the subagent indefinitely.
+   * a hot-switched subagent view does. Without this gate, auto-approve would type the
+   * pick index into the MAIN AGENT's input every time a background subagent asked.
    */
   private async inject(
     input: PermissionRequestHookInput,
@@ -281,7 +295,9 @@ export class AutoApproveGate {
       }
       await session.pty.submitInput(value);
       log(`[AutoApprove ${this.sessionTag}] Injected "${value}" into PTY (${reason})`);
-      sessionRegistry.updateStatus(this.sessionId, value === '1' ? 'executing' : 'thinking');
+      // Optimistic: the picked option will run a tool. The authoritative status
+      // follows from Claude's own PreToolUse hook.
+      sessionRegistry.updateStatus(this.sessionId, 'executing');
       return true;
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] inject("${value}") threw:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -25,7 +25,7 @@ import type { UUID } from '@remi/shared';
 
 import type { QuestionPresenceTracker } from '../api/question-presence-tracker.ts';
 import { log, logError } from '../cli/logger.ts';
-import type { PermissionRequestHookInput } from '../hooks/index.ts';
+import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import type { AutoApproveResult } from './types.ts';
 
@@ -112,120 +112,103 @@ export class AutoApproveGate {
    * Caller is responsible for session filtering (the bridge runs initFromHookEvent
    * + filterBySession before delegating here).
    */
-  handlePermissionRequest(input: PermissionRequestHookInput): void {
+  /**
+   * Resolve a PermissionRequest to a synchronous decision (#496). Claude BLOCKS
+   * on the hook response, so this returns the verdict INSTEAD of injecting it:
+   *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
+   *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
+   *     prompt; the user answers).
+   *   - escalate / no-service in a SUBAGENT context -> 'deny' via the hook
+   *     response. This is the core fix: the old PTY-inject default-deny couldn't
+   *     tell whose prompt was on the PTY for parallel subagents and leaked; the
+   *     synchronous deny needs no PTY at all.
+   *   - pick (multi-choice) -> inject the index + 'passthrough' (the hook
+   *     response can't express "pick option N"; keep the PTY for this rare case).
+   *   - cancelled -> 'passthrough' (the user already advanced).
+   */
+  async resolvePermission(input: PermissionRequestHookInput): Promise<PermissionDecision> {
     const { service, isInSubagentContext } = this.deps;
 
-    // Phase 4 (#419): subagent PermissionRequest events are forwarded (not dropped).
-    // The PTY-presence model treats "what's on screen" as truth: a hot-switched
-    // subagent view that renders a permission prompt IS user-answerable, and
-    // dropping the hook here would lose the rich tool/option metadata.
     if (this.isSubagentEvent(input)) {
       log(
         `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
       );
     }
 
-    // Auto-approve gate: evaluate before creating a Question object.
-    if (service) {
-      // Open the buffer window: a PTY prompt that renders during the eval is
-      // held (not pushed) until we know the verdict. #484. The terminal cue
-      // (#513) rides this signal but must never throw into the dispatch loop.
-      this.safeCue('onEvalStart', this.deps.onEvalStart);
-      // Pass the raw suggestions array; AutoApproveService does its own strict-string
-      // filtering before feeding the LLM. We forward the raw shape (rather than
-      // coercing) so the multi-choice classifier can see "non-string entry" and route
-      // through escalate instead of crashing on a future permission_suggestions schema
-      // change.
-      service
-        .evaluate(
-          input.tool_name,
-          input.tool_input,
-          this.sessionTag,
-          input.permission_suggestions as readonly unknown[] | undefined,
-        )
-        .then(async (result) => {
-          if (result.decision === 'cancelled') {
-            // User already advanced past the prompt. Do not inject, do not escalate.
-            // Drop the pending hook record so its stale option labels cannot merge
-            // onto the next unrelated PTY prompt (e.g. user typed /compact, no
-            // PreToolUse fires).
-            this.deps.tracker.clearPending();
-            this.safeCue('onCancelled', this.deps.onCancelled);
-            log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
-            return;
-          }
-          if (result.decision === 'approve') {
-            // inject success -> auto-handled (close the buffer; user never sees
-            // it); inject failure -> escalate (which releases the buffer). #484.
-            if (await this.inject(input, '1', 'approved')) this.markHandled();
-            else this.escalateToUser(input);
-            return;
-          }
-          if (result.decision === 'deny') {
-            if (await this.inject(input, '3', 'denied')) this.markHandled();
-            else this.escalateToUser(input);
-            return;
-          }
-          if (result.decision === 'pick' && result.pickIndex !== undefined) {
-            // Multi-choice pick (#399): inject the 1-based index Claude Code expects.
-            // parseMultiChoiceDecision already validated the index against options
-            // length, so out-of-range values cannot reach this branch.
-            if (
-              await this.inject(
-                input,
-                String(result.pickIndex),
-                `multichoice-pick-${result.pickIndex}`,
-              )
-            ) {
-              this.markHandled();
-            } else {
-              this.escalateToUser(input);
-            }
-            return;
-          }
-          // escalate: in a subagent context, default-deny to avoid hanging the
-          // subagent (the user could not answer it anyway). Bypass the subagent PTY
-          // gate because the alternative is letting it hang forever; typing '3' into
-          // the parent PTY is the lesser evil. The approve/deny/pick branches above
-          // use the gate because they have a fallback (escalateToUser); this does not.
-          if (isInSubagentContext()) {
-            log(
-              `[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`,
-            );
-            await this.inject(input, '3', 'subagent-escalate-default-deny', true);
-            this.markHandled(); // close the buffer window (#484)
-            return;
-          }
-          this.escalateToUser(input);
-        })
-        .catch(async (err) => {
-          // Last line of defense; must not leave an unhandled rejection.
-          try {
-            logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
-            if (isInSubagentContext()) {
-              await this.inject(input, '3', 'subagent-error-default-deny', true);
-              this.markHandled(); // close the buffer window (#484)
-              return;
-            }
-            this.escalateToUser(input);
-          } catch (inner) {
-            logError(`[AutoApprove ${this.sessionTag}] catch handler threw:`, inner);
-          }
-        });
-      return;
+    // No auto-approve: subagent default-denies via the response (no PTY, no
+    // leak); main escalates to the user.
+    if (!service) {
+      if (isInSubagentContext()) {
+        log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
+        return 'deny';
+      }
+      this.escalateToUser(input);
+      return 'passthrough';
     }
 
-    // No auto-approve. In a subagent context, still must not hang the subagent:
-    // default-deny rather than emit a question the user can't answer.
+    // Open the buffer/cue window (#484/#513). With synchronous decisions Claude
+    // does not render the prompt during the eval, so the buffer rarely holds a
+    // PTY prompt now; the cue lifecycle still rides these signals.
+    this.safeCue('onEvalStart', this.deps.onEvalStart);
+
+    let result: AutoApproveResult;
+    try {
+      // Raw suggestions: the service does its own strict-string filtering; we
+      // forward the raw shape so the multi-choice classifier can route a
+      // non-string entry through escalate instead of crashing.
+      result = await service.evaluate(
+        input.tool_name,
+        input.tool_input,
+        this.sessionTag,
+        input.permission_suggestions as readonly unknown[] | undefined,
+      );
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
+      if (isInSubagentContext()) {
+        this.markHandled();
+        return 'deny';
+      }
+      this.escalateToUser(input);
+      return 'passthrough';
+    }
+
+    if (result.decision === 'cancelled') {
+      // The user already advanced past the prompt. Drop the pending hook record
+      // so its stale option labels cannot merge onto the next PTY prompt.
+      this.deps.tracker.clearPending();
+      this.safeCue('onCancelled', this.deps.onCancelled);
+      log(`[AutoApprove ${this.sessionTag}] Decision dropped: ${result.reasoning}`);
+      return 'passthrough';
+    }
+    if (result.decision === 'approve') {
+      this.markHandled();
+      return 'allow';
+    }
+    if (result.decision === 'deny') {
+      this.markHandled();
+      return 'deny';
+    }
+    if (result.decision === 'pick' && result.pickIndex !== undefined) {
+      // Multi-choice pick (#399): the response can't express it, so render the
+      // prompt (passthrough) and inject the 1-based index into the PTY. The
+      // index was validated against options length upstream.
+      if (
+        await this.inject(input, String(result.pickIndex), `multichoice-pick-${result.pickIndex}`)
+      ) {
+        this.markHandled();
+      } else {
+        this.escalateToUser(input);
+      }
+      return 'passthrough';
+    }
+    // escalate
     if (isInSubagentContext()) {
-      log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
-      this.inject(input, '3', 'subagent-no-aa-default-deny', true).catch((err) => {
-        logError(`[${this.sessionTag}] Failed to inject default-deny:`, err);
-      });
-      return;
+      log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
+      this.markHandled();
+      return 'deny';
     }
-
     this.escalateToUser(input);
+    return 'passthrough';
   }
 
   /**

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -1146,6 +1146,11 @@ export function setupHookBridge(
 
   return {
     bridge: hookBridge,
-    closeBinder: () => driveBinder?.close(),
+    closeBinder: () => {
+      driveBinder?.close();
+      // Drop the per-session PermissionRequest resolver (#496) so a stale
+      // closure (over this session's gate/tracker) can't fire after teardown.
+      hookServer.setPermissionResolver(null);
+    },
   };
 }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -1018,18 +1018,19 @@ export function setupHookBridge(
     // a background subagent does not (PTY never confirms presence).
     handlers.onNotification?.(input);
   });
-  hookServer.on('PermissionRequest', (input) => {
+  // Synchronous PermissionRequest decision (#496). Claude BLOCKS on this
+  // response; the gate returns allow/deny (Claude proceeds without rendering the
+  // prompt) or passthrough (escalated to the user / multi-choice inject). The
+  // binder binding + shadow tap run first (as for any event); a foreign event we
+  // do not own returns 'passthrough' ({}) so we ABSTAIN and the owning daemon
+  // decides. Replaces the old fire-and-forget PTY-injection handler.
+  hookServer.setPermissionResolver(async (input) => {
     shadowEnterEvent();
     if (driveBinder) driveBinder.onHookEvent(input);
     else initFromHookEvent(input);
     shadowDecide('PermissionRequest', input);
-    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
-    // Auto-approve eval + inject, or escalate to the user (#453 phase 1). The gate
-    // owns the PTY injection, the subagent PTY-presence gate, the default-deny
-    // safety net, and the escalate fallback; session filtering above stays here in
-    // the bridge. isInSubagentContext / onPermissionRequest are injected into the
-    // gate and read live at inject time (async TOCTOU).
-    autoApproveGate.handlePermissionRequest(input);
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return 'passthrough';
+    return autoApproveGate.resolvePermission(input);
   });
   hookServer.on('Stop', (input) => {
     shadowEnterEvent();

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -53,11 +53,30 @@ export interface HookServerConfig {
 
 type Listener<T> = (input: T) => void;
 
+/**
+ * Synchronous decision for a PermissionRequest (#496). Claude Code BLOCKS on
+ * the hook response and honors `hookSpecificOutput.decision.behavior`:
+ *   - 'allow' / 'deny' => Claude proceeds WITHOUT rendering the prompt.
+ *   - 'passthrough'    => `{}` body; Claude renders the prompt as usual (the
+ *                         resolver has already escalated to the user / injected
+ *                         a multi-choice pick).
+ */
+export type PermissionDecision = 'allow' | 'deny' | 'passthrough';
+
+export type PermissionResolver = (input: PermissionRequestHookInput) => Promise<PermissionDecision>;
+
 export class HookServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private readonly config: Required<HookServerConfig>;
   private readonly events: Partial<HookServerEvents>;
   private readonly listeners: Map<string, Listener<HookInput>[]> = new Map();
+  /**
+   * Synchronous PermissionRequest decider (#496). When set, `handleRequest`
+   * AWAITS it for PermissionRequest events and returns the decision in the 2xx
+   * body INSTEAD of the fire-and-forget dispatch + `{}`. Null => legacy path
+   * (dispatch to listeners, return `{}`; the old PTY-injection answers).
+   */
+  private permissionResolver: PermissionResolver | null = null;
   /** Whether we've already warned about REMI_HOOK_DEBUG write failures. Throttles spam. */
   private diagLogWarned = false;
 
@@ -94,6 +113,17 @@ export class HookServer {
         if (idx !== -1) current.splice(idx, 1);
       }
     };
+  }
+
+  /**
+   * Install the synchronous PermissionRequest decider (#496). At most one; a
+   * later call replaces the earlier. Pass null to clear (revert to the legacy
+   * dispatch path). The resolver MUST resolve (not reject) — it is wrapped so a
+   * rejection is treated as 'passthrough' (fail to the user), but it should
+   * return 'passthrough' explicitly on its own errors.
+   */
+  setPermissionResolver(resolver: PermissionResolver | null): void {
+    this.permissionResolver = resolver;
   }
 
   /** Remove all listeners for a specific event or all events */
@@ -176,6 +206,24 @@ export class HookServer {
       });
     }
 
+    // Synchronous PermissionRequest decision (#496). When a resolver is
+    // installed, Claude BLOCKS on this response; we AWAIT the verdict and
+    // return allow/deny (Claude proceeds without rendering the prompt) or
+    // passthrough ({}). The resolver owns the eval + escalate-to-user side
+    // effects, so we do NOT also fire the legacy dispatch for this event.
+    if (eventName === 'PermissionRequest' && this.permissionResolver) {
+      let decision: PermissionDecision = 'passthrough';
+      try {
+        decision = await this.permissionResolver(body as unknown as PermissionRequestHookInput);
+      } catch (err) {
+        // Fail to the user: a resolver error must never block Claude or
+        // silently allow. passthrough renders the prompt for a human.
+        this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+        decision = 'passthrough';
+      }
+      return this.permissionDecisionResponse(decision);
+    }
+
     // Accept all events with 200 to future-proof against new Claude Code events.
     // Only dispatch known events to typed handlers; unknown events are logged.
     if (isValidHookEvent(eventName)) {
@@ -192,6 +240,25 @@ export class HookServer {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+
+  /**
+   * Serialise a PermissionDecision into the Claude Code hook response. allow/deny
+   * use the verified `hookSpecificOutput.decision.behavior` shape; passthrough is
+   * the bare `{}` that lets Claude render the prompt.
+   */
+  private permissionDecisionResponse(decision: PermissionDecision): Response {
+    const headers = { 'Content-Type': 'application/json' };
+    if (decision === 'passthrough') {
+      return new Response('{}', { status: 200, headers });
+    }
+    const body = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        decision: { behavior: decision },
+      },
+    });
+    return new Response(body, { status: 200, headers });
   }
 
   private dispatch(input: HookInput): void {

--- a/packages/daemon/src/hooks/index.ts
+++ b/packages/daemon/src/hooks/index.ts
@@ -1,5 +1,10 @@
 export { HookServer } from './hook-server.ts';
-export type { HookServerConfig, HookServerEvents } from './hook-server.ts';
+export type {
+  HookServerConfig,
+  HookServerEvents,
+  PermissionDecision,
+  PermissionResolver,
+} from './hook-server.ts';
 export { HookConfigManager } from './hook-config-manager.ts';
 export { HookEventBridge } from './hook-event-bridge.ts';
 export type { HookBridgeEvents } from './hook-event-bridge.ts';

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -50,8 +50,6 @@ const pick = (pickIndex: number): AutoApproveResult => ({
   model: 'm',
 });
 
-const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 20));
-
 describe('AutoApproveGate', () => {
   const SID = generateId() as UUID;
   let registry: SessionRegistry;
@@ -124,32 +122,30 @@ describe('AutoApproveGate', () => {
     await registry.shutdown();
   });
 
-  test('approve injects "1" and sets status executing (main context)', async () => {
-    gateWith(evaluator(approve)).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['1']);
-    expect(registry.getSession(SID)?.currentStatus).toBe('executing');
+  test('approve returns "allow" with NO inject (main context) (#496)', async () => {
+    const d = await gateWith(evaluator(approve)).resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(submits).toHaveLength(0); // synchronous decision, no PTY inject
     expect(escalations).toHaveLength(0);
   });
 
-  test('deny injects "3" and sets status thinking (main context)', async () => {
-    gateWith(evaluator(deny)).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['3']);
-    expect(registry.getSession(SID)?.currentStatus).toBe('thinking');
+  test('deny returns "deny" with NO inject (main context) (#496)', async () => {
+    const d = await gateWith(evaluator(deny)).resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });
 
-  test('pick injects the 1-based index (main context)', async () => {
-    gateWith(evaluator(pick(2))).handlePermissionRequest(pr());
-    await flush();
+  test('pick injects the 1-based index and returns passthrough (main context)', async () => {
+    const d = await gateWith(evaluator(pick(2))).resolvePermission(pr());
+    expect(d).toBe('passthrough');
     expect(submits).toEqual(['2']);
     expect(escalations).toHaveLength(0);
   });
 
-  test('escalate in main context calls escalate, never injects', async () => {
-    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
-    await flush();
+  test('escalate in main context escalates + passthrough, never injects', async () => {
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr());
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(1);
     expect(escalations[0]?.tool_name).toBe('Bash');
@@ -179,20 +175,20 @@ describe('AutoApproveGate', () => {
       },
       SID,
     );
-    gate.handlePermissionRequest(pr());
-    await flush();
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough');
     expect(onEscalateCalls).toBe(1);
   });
 
-  test('escalate in subagent context default-denies ("3"), never escalates', async () => {
+  test('escalate in subagent context default-denies via the response, no inject (#496)', async () => {
     subagent = true;
-    gateWith(evaluator(escalate)).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['3']);
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(submits).toHaveLength(0); // the core fix: deny without touching the PTY
     expect(escalations).toHaveLength(0);
   });
 
-  test('cancelled clears the tracker pending; no inject, no escalate', async () => {
+  test('cancelled clears the tracker pending and returns passthrough; no inject/escalate', async () => {
     // Stash a pending hook so clearPending() is observable.
     tracker.recordPendingHook({
       id: generateId(),
@@ -203,23 +199,33 @@ describe('AutoApproveGate', () => {
     });
     expect(tracker.hasPendingForTest()).toBe(true);
 
-    gateWith(evaluator(cancelled)).handlePermissionRequest(pr());
-    await flush();
+    const d = await gateWith(evaluator(cancelled)).resolvePermission(pr());
 
+    expect(d).toBe('passthrough');
     expect(tracker.hasPendingForTest()).toBe(false);
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });
 
-  test('subagent + no PTY presence: inject is gated; approve falls back to escalate', async () => {
-    subagent = true; // background subagent, prompt not on the main PTY
-    gateWith(evaluator(approve)).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toHaveLength(0); // PTY-presence gate blocked the inject
-    expect(escalations).toHaveLength(1); // approve has a fallback -> escalate
+  test('approve in a subagent returns "allow" with NO inject (no leak; #496)', async () => {
+    // The headline fix: approve no longer needs the PTY, so a parallel subagent
+    // read approves with no inject and no contention, regardless of presence.
+    subagent = true;
+    const d = await gateWith(evaluator(approve)).resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
   });
 
-  test('subagent + PTY prompt visible: inject proceeds', async () => {
+  test('pick in a subagent without PTY presence is gated -> escalate (the only inject path)', async () => {
+    subagent = true; // background subagent, prompt not on the main PTY
+    const d = await gateWith(evaluator(pick(2))).resolvePermission(pr());
+    expect(submits).toHaveLength(0); // PTY-presence gate blocked the pick inject
+    expect(escalations).toHaveLength(1); // pick has a fallback -> escalate
+    expect(d).toBe('passthrough');
+  });
+
+  test('pick in a subagent WITH PTY presence injects', async () => {
     subagent = true;
     tracker.onPTYPromptVisible({
       id: generateId(),
@@ -228,51 +234,43 @@ describe('AutoApproveGate', () => {
       allowsFreeText: false,
       isAnswered: false,
     });
-    gateWith(evaluator(approve)).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['1']);
+    const d = await gateWith(evaluator(pick(2))).resolvePermission(pr());
+    expect(submits).toEqual(['2']);
+    expect(d).toBe('passthrough');
   });
 
-  test('explicit agent_id (no isInSubagentContext) also gates inject by PTY presence', async () => {
-    subagent = false; // gate must rely on input.agent_id alone
-    gateWith(evaluator(approve)).handlePermissionRequest(pr({ agent_id: 'agent-xyz' }));
-    await flush();
-    expect(submits).toHaveLength(0); // no PTY presence -> gated
+  test('pick inject failure (PTY throws) falls back to escalate (main context)', async () => {
+    const d = await gateWith(evaluator(pick(2)), /* ptyThrows */ true).resolvePermission(pr());
     expect(escalations).toHaveLength(1);
+    expect(d).toBe('passthrough');
   });
 
-  test('inject failure (PTY throws) falls back to escalate (main context)', async () => {
-    gateWith(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
-    await flush();
-    expect(escalations).toHaveLength(1);
-  });
-
-  test('eval rejection in main context escalates (the outer .catch)', async () => {
-    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
-    await flush();
+  test('eval rejection in main context escalates + passthrough', async () => {
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(pr());
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(1);
   });
 
-  test('eval rejection in subagent context default-denies', async () => {
+  test('eval rejection in subagent context default-denies via the response', async () => {
     subagent = true;
-    gateWith(evaluator(approve, { throws: true })).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['3']);
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });
 
-  test('no service + subagent: default-deny "3"', async () => {
+  test('no service + subagent: default-deny via the response', async () => {
     subagent = true;
-    gateWith(null).handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['3']);
+    const d = await gateWith(null).resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });
 
-  test('no service + main context: escalate to user', async () => {
-    gateWith(null).handlePermissionRequest(pr());
-    await flush();
+  test('no service + main context: escalate to user, passthrough', async () => {
+    const d = await gateWith(null).resolvePermission(pr());
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(1);
   });
@@ -354,48 +352,44 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
   });
 
   test('approve fires start then handled (never escalate/cancelled)', async () => {
-    gate(evaluator(approve)).handlePermissionRequest(pr());
-    await flush();
+    expect(await gate(evaluator(approve)).resolvePermission(pr())).toBe('allow');
     expect(events).toEqual(['start', 'handled']);
   });
 
   test('deny fires start then handled', async () => {
-    gate(evaluator(deny)).handlePermissionRequest(pr());
-    await flush();
+    expect(await gate(evaluator(deny)).resolvePermission(pr())).toBe('deny');
     expect(events).toEqual(['start', 'handled']);
   });
 
   test('escalate fires start then escalate (never handled)', async () => {
-    gate(evaluator(escalate)).handlePermissionRequest(pr());
-    await flush();
+    expect(await gate(evaluator(escalate)).resolvePermission(pr())).toBe('passthrough');
     expect(events).toEqual(['start', 'escalate']);
   });
 
   test('cancelled fires start then cancelled (never handled/escalate)', async () => {
-    gate(evaluator(cancelled)).handlePermissionRequest(pr());
-    await flush();
+    expect(await gate(evaluator(cancelled)).resolvePermission(pr())).toBe('passthrough');
     expect(events).toEqual(['start', 'cancelled']);
   });
 
-  test('approve whose inject fails escalates -> start then escalate (not handled)', async () => {
-    gate(evaluator(approve), /* ptyThrows */ true).handlePermissionRequest(pr());
-    await flush();
+  test('pick whose inject fails escalates -> start then escalate (not handled)', async () => {
+    // approve/deny no longer inject; the inject-failure->escalate path is now pick-only.
+    expect(await gate(evaluator(pick(2)), /* ptyThrows */ true).resolvePermission(pr())).toBe(
+      'passthrough',
+    );
     expect(events).toEqual(['start', 'escalate']);
   });
 
-  test('subagent default-deny still fires handled (buffer + cue close)', async () => {
+  test('subagent escalate->deny still fires handled (buffer + cue close), no inject', async () => {
     subagent = true;
-    gate(evaluator(escalate)).handlePermissionRequest(pr());
-    await flush();
-    // Subagent escalate default-denies via inject "3" -> markHandled.
-    expect(submits).toEqual(['3']);
+    expect(await gate(evaluator(escalate)).resolvePermission(pr())).toBe('deny');
+    // Subagent escalate default-denies via the RESPONSE (no inject) -> markHandled.
+    expect(submits).toHaveLength(0);
     expect(events).toEqual(['start', 'handled']);
   });
 
   test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {
-    // The cue is cosmetic. If onHandled throws it must NOT propagate into the
-    // .then()/.catch() chain (where the catch would re-run the decision and
-    // could re-open the #484 buffer). The permission stays approved-once.
+    // The cue is cosmetic. If onHandled throws it must NOT change the verdict
+    // (approve stays 'allow') or trigger an escalation.
     registry.registerSession(SID, '/d', fakePTY(submits), {
       handleMessage: () => {},
       handleQuestion: () => {},
@@ -417,9 +411,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
       },
       SID,
     );
-    g.handlePermissionRequest(pr());
-    await flush();
-    expect(submits).toEqual(['1']); // approved exactly once
-    expect(escalations).toBe(0); // the catch did NOT re-escalate
+    expect(await g.resolvePermission(pr())).toBe('allow'); // approved once, verdict intact
+    expect(escalations).toBe(0); // no re-escalation
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -143,6 +143,22 @@ describe('AutoApproveGate', () => {
     expect(escalations).toHaveLength(0);
   });
 
+  test('malformed pick (no pickIndex) escalates, never silently denies (#521 review)', async () => {
+    const malformed = {
+      decision: 'pick',
+      reasoning: 't',
+      durationMs: 0,
+      model: 'm',
+    } as unknown as AutoApproveResult;
+    const d = await gateWith({
+      evaluate: async () => malformed,
+      cancel: () => true,
+    }).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1);
+  });
+
   test('escalate in main context escalates + passthrough, never injects', async () => {
     const d = await gateWith(evaluator(escalate)).resolvePermission(pr());
     expect(d).toBe('passthrough');

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -22,16 +22,36 @@ import { SessionStore } from '../../../src/session/session-store.ts';
  */
 class RecordingHookServer {
   readonly listeners = new Map<string, (input: unknown) => void>();
+  /** The synchronous PermissionRequest resolver (#496); set via setPermissionResolver. */
+  permissionResolver: ((input: unknown) => Promise<string>) | null = null;
   on(event: string, listener: (input: unknown) => void): () => void {
     // Only the last listener per event survives; for setupHookBridge this is
     // fine because it installs exactly one per event name.
     this.listeners.set(event, listener);
     return () => this.listeners.delete(event);
   }
+  setPermissionResolver(resolver: ((input: unknown) => Promise<string>) | null): void {
+    this.permissionResolver = resolver;
+  }
   fire(event: string, input: unknown): void {
+    // PermissionRequest is no longer a `.on()` listener (#496) — it is the
+    // synchronous resolver. Tests that fire it purely to drive the binder
+    // (binding/foreign-drop/rotation) keep working: the binder bind + admit run
+    // SYNCHRONOUSLY inside the resolver before the async decision, which we
+    // fire-and-forget here. Decision-asserting tests use `await firePermission`.
+    if (event === 'PermissionRequest' && !this.listeners.has(event) && this.permissionResolver) {
+      void this.permissionResolver(input);
+      return;
+    }
     const fn = this.listeners.get(event);
     if (!fn) throw new Error(`No listener registered for ${event}`);
     fn(input);
+  }
+  /** Fire a PermissionRequest through the synchronous resolver (#496) and return
+   *  the decision ('allow' | 'deny' | 'passthrough'). */
+  async firePermission(input: unknown): Promise<string> {
+    if (!this.permissionResolver) throw new Error('No permission resolver registered');
+    return this.permissionResolver(input);
   }
 }
 
@@ -262,16 +282,17 @@ describe('setupHookBridge', () => {
     return { tracker };
   }
 
-  test('registers listeners for all 11 hook events', () => {
+  test('registers 10 .on() listeners + the synchronous PermissionRequest resolver (#496)', () => {
     build();
     const events = new Set(hookServer.listeners.keys());
+    // PermissionRequest is NO LONGER a .on() listener — it is the synchronous
+    // resolver (#496), installed via setPermissionResolver.
     expect(events).toEqual(
       new Set([
         'SessionStart',
         'PreToolUse',
         'PostToolUse',
         'Notification',
-        'PermissionRequest',
         'Stop',
         'SessionEnd',
         // Wired in phase 4 (#453).
@@ -281,6 +302,7 @@ describe('setupHookBridge', () => {
         'SubagentStop',
       ]),
     );
+    expect(hookServer.permissionResolver).not.toBeNull();
   });
 
   describe('phase 4 (#453): the 4 previously-dropped events', () => {
@@ -386,7 +408,7 @@ describe('setupHookBridge', () => {
       isAnswered: false,
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-sub-123',
       agent_id: 'subagent-abc',
       agent_type: 'task',
@@ -394,10 +416,11 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    // Wait for evaluate() + inject() to resolve.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(ptySubmits).toEqual(['1']);
+    // #496: approve returns 'allow' via the hook response — no PTY inject
+    // (the old inject was what the PTY-presence gate guarded; approve no
+    // longer needs the PTY at all).
+    expect(decision).toBe('allow');
+    expect(ptySubmits).toEqual([]);
   });
 
   test('PTY gate covers legacy subagents: nested-Task PermissionRequest WITHOUT agent_id is dropped when no PTY presence', async () => {
@@ -442,7 +465,7 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual([]);
   });
 
-  test('PermissionRequest with auto-approve APPROVE injects "1" (status: executing)', async () => {
+  test('PermissionRequest with auto-approve APPROVE returns "allow" (no inject) (#496)', async () => {
     build({ autoApprove: true });
 
     // Fire SessionStart first so claudeSessionId locks; subsequent events
@@ -453,17 +476,17 @@ describe('setupHookBridge', () => {
       hook_event_name: 'SessionStart',
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-locked-123',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
 
-    // Auto-approve .evaluate() is async; wait for the inject promise chain.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(ptySubmits).toEqual(['1']);
-    expect(sessionRegistry.getSession(SID)?.currentStatus).toBe('executing');
+    // #496: synchronous APPROVE returns 'allow'; Claude proceeds without a
+    // prompt and remi never injects. (Status is no longer set here — the tool's
+    // own PreToolUse hook sets 'executing' when Claude runs it.)
+    expect(decision).toBe('allow');
+    expect(ptySubmits).toEqual([]);
   });
 
   test('regression #321: sibling daemon dying re-enables hook lock acquisition AND filterBySession recovers', () => {
@@ -566,7 +589,7 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.statusCalls).toContain('executing');
   });
 
-  test('sibling-in-dir + fallback-discovered claudeSessionId: lock adopted from sessionStore on next hook', () => {
+  test('sibling-in-dir + fallback-discovered claudeSessionId: lock adopted from sessionStore on next hook', async () => {
     // The dev.3 inconsistency the user hit: when 2+ Remi wrappers share a
     // project directory, hasSiblingInDir() defers hook-event-based locking
     // to the transcript-fallback poll. The fallback discovers our own
@@ -616,21 +639,17 @@ describe('setupHookBridge', () => {
     // The first hook arrives WHILE hasSiblingInDir is still true. Pre-fix
     // this dropped silently. Post-fix, adoptLockFromStore pulls the lock
     // from sessionStore and filterBySession returns true.
-    hookServer.fire('PermissionRequest', {
+    // If the lock was adopted, the event is admitted and auto-approve evaluates
+    // -> 'allow' (#496). If not (regression), it is dropped as foreign ->
+    // 'passthrough'. So the decision proves adoption (the old proof was an inject).
+    const decision = await hookServer.firePermission({
       session_id: 'claude-mine-via-fallback',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
-
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        // If the lock was adopted, auto-approve fired and injected '1'.
-        // If not (regression), ptySubmits is empty.
-        expect(ptySubmits).toEqual(['1']);
-        resolve();
-      }, 50);
-    });
+    expect(decision).toBe('allow');
+    expect(ptySubmits).toEqual([]);
   });
 
   test("sibling-in-dir + fallback-discovered lock: foreign session's hooks still drop", () => {
@@ -683,7 +702,7 @@ describe('setupHookBridge', () => {
     });
   });
 
-  test('sibling-in-dir + sessionStore rotation: adoptLockFromStore re-adopts the new claudeSessionId', () => {
+  test('sibling-in-dir + sessionStore rotation: adoptLockFromStore re-adopts the new claudeSessionId', async () => {
     // After initial adoption from sessionStore (claude-A), the user runs
     // /clear in the sibling-wrapper scenario. The transcript-fallback
     // rediscovers and writes claude-B to the store. The hook-bridge MUST
@@ -717,45 +736,39 @@ describe('setupHookBridge', () => {
 
     build({ autoApprove: true, autoApproveDecision: 'approve' });
 
-    // Initial adoption: hook for claude-A passes the filter.
-    hookServer.fire('PermissionRequest', {
-      session_id: 'claude-A-initial',
-      hook_event_name: 'PermissionRequest',
-      tool_name: 'Bash',
-      tool_input: { command: 'ls' },
+    // Initial adoption: hook for claude-A is admitted -> approve -> 'allow' (#496).
+    expect(
+      await hookServer.firePermission({
+        session_id: 'claude-A-initial',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      }),
+    ).toBe('allow');
+
+    // Fallback rediscovers after /clear and writes the new id.
+    sessionStore.save({
+      remiSessionId: SID,
+      claudeSessionId: 'claude-B-rotated',
+      projectPath: tmpDir,
+      port: 8765,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      exitedAt: null,
+      exitCode: null,
     });
 
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        expect(ptySubmits).toEqual(['1']);
-
-        // Fallback rediscovers after /clear and writes the new id.
-        sessionStore.save({
-          remiSessionId: SID,
-          claudeSessionId: 'claude-B-rotated',
-          projectPath: tmpDir,
-          port: 8765,
-          pid: process.pid,
-          startedAt: new Date().toISOString(),
-          exitedAt: null,
-          exitCode: null,
-        });
-
-        // Hook for claude-B arrives. Lock must rotate; otherwise filterBySession
-        // sees claudeSessionId='claude-A-initial' and drops the event.
-        hookServer.fire('PermissionRequest', {
-          session_id: 'claude-B-rotated',
-          hook_event_name: 'PermissionRequest',
-          tool_name: 'Bash',
-          tool_input: { command: 'pwd' },
-        });
-
-        setTimeout(() => {
-          expect(ptySubmits).toEqual(['1', '1']);
-          resolve();
-        }, 50);
-      }, 50);
-    });
+    // Hook for claude-B: the lock must re-adopt; otherwise it is dropped as
+    // foreign -> 'passthrough'. 'allow' proves the rotation was picked up.
+    expect(
+      await hookServer.firePermission({
+        session_id: 'claude-B-rotated',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'pwd' },
+      }),
+    ).toBe('allow');
+    expect(ptySubmits).toEqual([]);
   });
 
   test('adoptLockFromStore catches sessionStore throws and keeps the daemon running', () => {
@@ -1439,7 +1452,7 @@ describe('setupHookBridge', () => {
     expect(tracker.hasPendingForTest()).toBe(true);
   });
 
-  test('subagent PermissionRequest with no PTY-visible prompt: inject is dropped, fallback escalates', async () => {
+  test('subagent approve returns "allow" via the response — no inject, no escalate (#496)', async () => {
     // Regression guard for the dev.3 misfiring: a background subagent's
     // PermissionRequest cannot answer by injecting into the MAIN PTY
     // because the subagent's prompt isn't there — "1" would land in the
@@ -1460,7 +1473,7 @@ describe('setupHookBridge', () => {
       model: 'test',
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-sub-AA',
       agent_id: 'subagent-AA',
       agent_type: 'general-purpose',
@@ -1469,14 +1482,14 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    // Inject was gated → no submit. Escalation fires → one question call.
+    // approve -> 'allow' via the response; no PTY inject and no escalation,
+    // regardless of subagent PTY presence.
+    expect(decision).toBe('allow');
     expect(ptySubmits).toEqual([]);
-    expect(messageApiLog.questionCalls).toBe(1);
+    expect(messageApiLog.questionCalls).toBe(0);
   });
 
-  test('subagent PermissionRequest with PTY-visible prompt (hot-switched view) still injects', async () => {
+  test('subagent approve with PTY-visible prompt returns "allow" (no inject) (#496)', async () => {
     // Preserves PR #419's hot-switched-subagent case: when the user
     // has switched to the subagent's view, its permission prompt IS
     // rendered on the main PTY. Simulate that by firing
@@ -1501,7 +1514,7 @@ describe('setupHookBridge', () => {
       isAnswered: false,
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-sub-hot',
       agent_id: 'subagent-hot',
       agent_type: 'general-purpose',
@@ -1510,12 +1523,13 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(ptySubmits).toEqual(['1']);
+    // #496: approve allows via the response even with a hot-switched subagent
+    // view; no inject.
+    expect(decision).toBe('allow');
+    expect(ptySubmits).toEqual([]);
   });
 
-  test('subagent PermissionRequest + auto-approve deny with no PTY presence: inject dropped, escalates', async () => {
+  test('subagent deny returns "deny" via the response — no inject, no escalate (#496)', async () => {
     // Mirrors the approve case for the deny branch — same gate, same
     // fallthrough. The non-hang guarantee for background subagents is
     // now structural: with no PTY presence the subagent has no answerable
@@ -1531,7 +1545,7 @@ describe('setupHookBridge', () => {
       model: 'test',
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-sub-deny',
       agent_id: 'subagent-deny',
       agent_type: 'general-purpose',
@@ -1540,13 +1554,13 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'rm -rf /' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
+    // deny -> 'deny' via the response; no inject, no escalation.
+    expect(decision).toBe('deny');
     expect(ptySubmits).toEqual([]);
-    expect(messageApiLog.questionCalls).toBe(1);
+    expect(messageApiLog.questionCalls).toBe(0);
   });
 
-  test('subagent PermissionRequest + auto-approve deny with PTY-visible prompt injects "3"', async () => {
+  test('subagent deny with PTY-visible prompt returns "deny" (no inject) (#496)', async () => {
     const { tracker } = build({ autoApprove: true, autoApproveDecision: 'deny' });
 
     hookServer.fire('SessionStart', {
@@ -1565,7 +1579,7 @@ describe('setupHookBridge', () => {
       isAnswered: false,
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-sub-deny-hot',
       agent_id: 'subagent-deny-hot',
       agent_type: 'general-purpose',
@@ -1574,9 +1588,10 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'rm -rf /' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(ptySubmits).toEqual(['3']);
+    // #496: deny returns 'deny' via the response; no PTY inject even with a
+    // visible prompt.
+    expect(decision).toBe('deny');
+    expect(ptySubmits).toEqual([]);
   });
 
   test('Phase 4 wiring: escalate + active Task context default-denies (no hang)', async () => {
@@ -1608,16 +1623,17 @@ describe('setupHookBridge', () => {
 
     // Subagent-internal Bash PermissionRequest (no agent_id; the
     // Task-context safety net catches it).
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-esc-task',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(ptySubmits).toEqual(['3']);
+    // #496: escalate in a subagent (Task) context -> 'deny' via the response —
+    // no hang, no PTY inject, no question.
+    expect(decision).toBe('deny');
+    expect(ptySubmits).toEqual([]);
     expect(messageApiLog.questionCalls).toBe(0);
   });
 
@@ -1644,16 +1660,16 @@ describe('setupHookBridge', () => {
       tool_use_id: 'tu_task_throws',
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-throws-task',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(ptySubmits).toEqual(['3']);
+    // #496: eval error in a subagent (Task) context -> 'deny' via the response.
+    expect(decision).toBe('deny');
+    expect(ptySubmits).toEqual([]);
   });
 
   test('Phase 4 wiring: no auto-approve + active Task context default-denies', async () => {
@@ -1680,14 +1696,16 @@ describe('setupHookBridge', () => {
       tool_use_id: 'tu_task_noaa',
     });
 
-    hookServer.fire('PermissionRequest', {
+    const decision = await hookServer.firePermission({
       session_id: 'claude-noaa-task',
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
 
-    expect(ptySubmits).toEqual(['3']);
+    // #496: no auto-approve + subagent (Task) context -> 'deny' via the response.
+    expect(decision).toBe('deny');
+    expect(ptySubmits).toEqual([]);
     expect(messageApiLog.questionCalls).toBe(0);
   });
 

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-differential.test.ts
@@ -48,11 +48,21 @@ import type { TranscriptWatcher } from '../../../src/transcript/transcript-watch
 /** Recording HookServer: capture `.on()` registrations, fire them directly. */
 class RecordingHookServer {
   readonly listeners = new Map<string, (input: unknown) => void>();
+  permissionResolver: ((input: unknown) => Promise<string>) | null = null;
   on(event: string, listener: (input: unknown) => void): () => void {
     this.listeners.set(event, listener);
     return () => this.listeners.delete(event);
   }
+  setPermissionResolver(resolver: ((input: unknown) => Promise<string>) | null): void {
+    this.permissionResolver = resolver;
+  }
   fire(event: string, input: unknown): void {
+    // PermissionRequest is the synchronous resolver (#496), not a .on() listener;
+    // fire it through the resolver (the binder bind runs synchronously inside).
+    if (event === 'PermissionRequest' && !this.listeners.has(event) && this.permissionResolver) {
+      void this.permissionResolver(input);
+      return;
+    }
     const fn = this.listeners.get(event);
     if (!fn) throw new Error(`No listener registered for ${event}`);
     fn(input);

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
@@ -50,11 +50,21 @@ import type { TranscriptWatcher } from '../../../src/transcript/transcript-watch
 /** Recording HookServer: capture `.on()` registrations, fire them directly. */
 class RecordingHookServer {
   readonly listeners = new Map<string, (input: unknown) => void>();
+  permissionResolver: ((input: unknown) => Promise<string>) | null = null;
   on(event: string, listener: (input: unknown) => void): () => void {
     this.listeners.set(event, listener);
     return () => this.listeners.delete(event);
   }
+  setPermissionResolver(resolver: ((input: unknown) => Promise<string>) | null): void {
+    this.permissionResolver = resolver;
+  }
   fire(event: string, input: unknown): void {
+    // PermissionRequest is the synchronous resolver (#496), not a .on() listener;
+    // fire it through the resolver (the binder bind runs synchronously inside).
+    if (event === 'PermissionRequest' && !this.listeners.has(event) && this.permissionResolver) {
+      void this.permissionResolver(input);
+      return;
+    }
     const fn = this.listeners.get(event);
     if (!fn) throw new Error(`No listener registered for ${event}`);
     fn(input);

--- a/packages/daemon/tests/hooks/hook-server.test.ts
+++ b/packages/daemon/tests/hooks/hook-server.test.ts
@@ -438,4 +438,83 @@ describe('HookServer', () => {
     server = new HookServer({ port });
     expect(server.url).toBe(`http://127.0.0.1:${port}/hooks`);
   });
+
+  // -------------------------------------------------------------------------
+  // Synchronous PermissionRequest resolver (#496)
+  // -------------------------------------------------------------------------
+  describe('synchronous PermissionRequest decision', () => {
+    async function postPermission(p: number): Promise<Response> {
+      return fetch(makeUrl(p), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          makePayload({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' }),
+        ),
+      });
+    }
+
+    it("returns hookSpecificOutput decision behavior 'allow'", async () => {
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => 'allow');
+      server.start();
+      const res = await postPermission(port);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'allow' } },
+      });
+    });
+
+    it("returns hookSpecificOutput decision behavior 'deny'", async () => {
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => 'deny');
+      server.start();
+      const res = await postPermission(port);
+      expect(await res.json()).toEqual({
+        hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'deny' } },
+      });
+    });
+
+    it("returns {} for 'passthrough' (Claude renders the prompt)", async () => {
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => 'passthrough');
+      server.start();
+      const res = await postPermission(port);
+      expect(await res.json()).toEqual({});
+    });
+
+    it('falls back to {} when no resolver is installed (legacy path)', async () => {
+      server = new HookServer({ port });
+      server.start();
+      const res = await postPermission(port);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({});
+    });
+
+    it('a throwing resolver fails to passthrough ({}) and reports onError', async () => {
+      const errors: Error[] = [];
+      server = new HookServer({ port }, { onError: (e) => errors.push(e) });
+      server.setPermissionResolver(async () => {
+        throw new Error('resolver boom');
+      });
+      server.start();
+      const res = await postPermission(port);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({}); // fail to the user, never block/allow
+      expect(errors.length).toBe(1);
+    });
+
+    it('only intercepts PermissionRequest; other events still dispatch + {}', async () => {
+      let preToolFired = 0;
+      server = new HookServer({ port }, { onPreToolUse: () => preToolFired++ });
+      server.setPermissionResolver(async () => 'deny');
+      server.start();
+      const res = await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makePayload({ hook_event_name: 'PreToolUse', tool_name: 'Bash' })),
+      });
+      expect(await res.json()).toEqual({});
+      expect(preToolFired).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Phase 2 of epic #494. Replaces PTY-injection answers with **synchronous decisions in the hook response**. Claude blocks on the `PermissionRequest` hook and honors `hookSpecificOutput.decision.behavior`, so remi no longer types `1`/`3` into the PTY.

**The core fix** (the parallel-subagent leak seen live): the old default-deny injected `3` into the PTY, but for parallel pr-review subagents it couldn't tell whose prompt was on screen, skipped the inject, and the prompt leaked to the app — growing the pending list until a tap hit a superseded id ("no longer active"). Now a subagent escalate/deny returns `deny` in the response — **no PTY, no contention, no leak.** It also removes the `Cancelled stale LLM eval -> Decision dropped` drops (Claude waits for the verdict).

### Changes
- **hook-server**: `PermissionDecision` + `setPermissionResolver`; `handleRequest` AWAITs the resolver for PermissionRequest and returns allow/deny (Claude proceeds without rendering) or `{}` (passthrough). A throwing resolver fails to passthrough. No resolver = legacy dispatch (back-compat).
- **gate**: `handlePermissionRequest` (void/inject) -> `resolvePermission(input): Promise<PermissionDecision>`. approve->allow, deny->deny (no inject); subagent escalate/no-service/error -> deny via the response; pick injects + passthrough; main escalate -> escalateToUser + passthrough; cancelled -> passthrough.
- **hook-bridge-setup**: `setPermissionResolver` replaces the fire-and-forget `.on('PermissionRequest')`; a foreign event returns passthrough (abstain, so the owning daemon decides).

### Tradeoff (by design)
The eval now blocks Claude until it returns (<< the 600s hook timeout). The permission-groups fast-path (#495) already approves reads/VCS/build-test with **no LLM at all**, so most prompts never hit the model. The **default-4b config + an `escalate_model` second-opinion tier (35b "elsewhere", only on would-escalate) are a follow-up PR.**

Closes #496 · Part of epic #494

## Test plan
- gate unit tests assert the returned decision (24); 6 hook-server real-server tests for the response shapes; characterization + binder differential/drive updated to the synchronous model.
- **Full daemon suite green: 2022 pass, 0 fail.** typecheck + biome clean.