### PR TITLE
feat(auto-approve): fast 4b default + escalate_model second-opinion tier (#522)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -6,11 +6,15 @@
  * QuestionPipeline boundary, alongside `NotificationDispatcher` and the already-
  * standalone `QuestionPresenceTracker`.
  *
- * Given a PermissionRequest hook event, it either:
- *   - runs the auto-approve LLM eval and injects "1" (approve) / "3" (deny) /
- *     a 1-based pick index into the PTY, or
- *   - escalates the prompt to the user (the normal Question flow), or
- *   - default-denies a subagent prompt the user cannot answer (to avoid hanging it).
+ * Given a PermissionRequest hook event, `resolvePermission` returns a synchronous
+ * decision (#496) that Claude honors in the hook response — it either:
+ *   - returns 'allow'/'deny' from the auto-approve LLM verdict (NO PTY inject), or
+ *   - escalates the prompt to the user and returns 'passthrough' (normal Question flow), or
+ *   - default-denies a subagent prompt the user cannot answer via 'deny' (no hang, no PTY), or
+ *   - on a primary 'escalate', consults an optional `escalate_model` second opinion
+ *     (#522) before bothering the user.
+ * The PTY inject path now survives only for multi-choice picks, which the response
+ * cannot express.
  *
  * The two outward couplings the hook bridge used directly are injected as callbacks
  * so the gate has no back-reference to the bridge or the hook router:
@@ -47,6 +51,7 @@ export interface AutoApproveEvaluator {
     toolInput: Record<string, unknown>,
     tag?: string,
     permissionSuggestions?: readonly unknown[],
+    modelOverride?: string,
   ): Promise<AutoApproveResult>;
   /** Abort any in-flight `evaluate`. Returns true if an abort was issued, false
    *  if nothing was in flight (idempotent). */
@@ -77,6 +82,9 @@ export interface AutoApproveGateDeps {
   /** Called when the eval ended without a verdict (cancelled — the user already
    *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
   onCancelled?: () => void;
+  /** Second-opinion model consulted on a primary 'escalate' in main context
+   *  (#522). Empty/absent => no second opinion (escalate straight to the user). */
+  escalateModel?: string;
 }
 
 export class AutoApproveGate {
@@ -107,11 +115,6 @@ export class AutoApproveGate {
     }
   }
 
-  /**
-   * Handle a PermissionRequest hook event: auto-approve eval + inject, or escalate.
-   * Caller is responsible for session filtering (the bridge runs initFromHookEvent
-   * + filterBySession before delegating here).
-   */
   /**
    * Resolve a PermissionRequest to a synchronous decision (#496). Claude BLOCKS
    * on the hook response, so this returns the verdict INSTEAD of injecting it:
@@ -222,6 +225,42 @@ export class AutoApproveGate {
       log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
       this.markHandled();
       return 'deny';
+    }
+    // Second opinion (#522): the fast model would escalate, but a heavier
+    // escalate_model may resolve it (honoring a broad approve policy) before we
+    // bother the user. Its latency only hits would-escalate cases. Main context
+    // only; never re-escalates into a third call.
+    const escalateModel = this.deps.escalateModel;
+    if (escalateModel) {
+      let second: AutoApproveResult;
+      try {
+        second = await service.evaluate(
+          input.tool_name,
+          input.tool_input,
+          this.sessionTag,
+          input.permission_suggestions as readonly unknown[] | undefined,
+          escalateModel,
+        );
+      } catch (err) {
+        logError(`[AutoApprove ${this.sessionTag}] escalate_model second opinion threw:`, err);
+        second = {
+          decision: 'escalate',
+          reasoning: 'second-opinion error',
+          durationMs: 0,
+          model: escalateModel,
+        };
+      }
+      if (second.decision === 'approve') {
+        log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) approved`);
+        this.markHandled();
+        return 'allow';
+      }
+      if (second.decision === 'deny') {
+        log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) denied`);
+        this.markHandled();
+        return 'deny';
+      }
+      // second opinion still unsure (escalate/pick/cancelled) -> ask the user.
     }
     this.escalateToUser(input);
     return 'passthrough';

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -260,7 +260,15 @@ export class AutoApproveGate {
         this.markHandled();
         return 'deny';
       }
-      // second opinion still unsure (escalate/pick/cancelled) -> ask the user.
+      if (second.decision === 'cancelled') {
+        // Claude already advanced (cancelStale fired during the slower second
+        // eval). Mirror the primary cancelled path — do NOT escalate a phantom.
+        this.deps.tracker.clearPending();
+        this.safeCue('onCancelled', this.deps.onCancelled);
+        log(`[AutoApprove ${this.sessionTag}] Second-opinion cancelled: ${second.reasoning}`);
+        return 'passthrough';
+      }
+      // second opinion still unsure (escalate/pick) -> ask the user.
     }
     this.escalateToUser(input);
     return 'passthrough';

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -90,6 +90,9 @@ export class AutoApproveService {
   private readonly multichoiceMode: MultiChoiceMode;
   /** Falls back to llmConfig.model when empty. */
   private readonly multichoiceModel: string;
+  /** Second-opinion model on a primary 'escalate' (#522); empty = none. Public
+   *  so the gate can read it without re-threading the config. */
+  readonly escalateModel: string;
   /** Prevents concurrent evaluations. Second request escalates immediately. */
   private evaluating = false;
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
@@ -121,6 +124,7 @@ export class AutoApproveService {
     this.instructions = config.instructions;
     this.multichoiceMode = config.multichoice;
     this.multichoiceModel = config.multichoice_model;
+    this.escalateModel = config.escalate_model;
   }
 
   /**
@@ -141,9 +145,13 @@ export class AutoApproveService {
     toolInput: Record<string, unknown>,
     tag?: string,
     permissionSuggestions?: readonly unknown[],
+    modelOverride?: string,
   ): Promise<AutoApproveResult> {
     const start = Date.now();
-    const model = this.llmConfig.model;
+    // modelOverride (#522: the escalate_model second opinion) replaces the base
+    // model for this call; the fast-path deny/allow/group checks below still run.
+    const baseModel = modelOverride || this.llmConfig.model;
+    const model = baseModel;
     const prefix = tag ? `[AutoApprove ${tag}]` : '[AutoApprove]';
 
     const normalisedSuggestions = Array.isArray(permissionSuggestions)
@@ -246,7 +254,7 @@ export class AutoApproveService {
         // Otherwise the binary approve/deny prompt.
         const useMultiChoice = isMultiChoice && this.multichoiceMode === 'evaluate';
         const callModel =
-          useMultiChoice && this.multichoiceModel ? this.multichoiceModel : this.llmConfig.model;
+          useMultiChoice && this.multichoiceModel ? this.multichoiceModel : baseModel;
         const callConfig: LLMClientConfig =
           callModel === this.llmConfig.model
             ? this.llmConfig

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -124,6 +124,16 @@ export interface AutoApproveConfig {
    */
   readonly multichoice_model: string;
   /**
+   * Optional second-opinion model consulted ONLY when the primary `model`
+   * returns `escalate` in a main (non-subagent) context (#522). If it approves
+   * the broad-but-mutating action -> auto-approve; if it denies -> deny;
+   * otherwise the user is asked. Lets a heavy model (e.g. a 35B that honors a
+   * broad "approve everything except deletes" policy) improve only the cases
+   * that would otherwise interrupt the user, so its latency never hits the
+   * common fast path. Empty (default) = no second opinion.
+   */
+  readonly escalate_model: string;
+  /**
    * Ollama only: route through the native /api/chat with `think: false` to
    * turn OFF the model's reasoning. This is FASTER but lowers decision quality
    * — live testing showed the chain-of-thought is load-bearing for following

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -675,6 +675,9 @@ export function setupHookBridge(
       },
       onHandled: () => deps.terminalIndicator?.resolve('handled'),
       onCancelled: () => deps.terminalIndicator?.stop(),
+      // #522: second-opinion model on a primary escalate (read from the service's
+      // config). Empty when unset -> escalate straight to the user.
+      escalateModel: autoApproveService?.escalateModel ?? '',
     },
     sessionId,
   );

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -131,7 +131,11 @@ export const DEFAULT_CONFIG: RemiConfig = {
   auto_approve: {
     enabled: false,
     provider: 'ollama',
-    model: 'gemma4:e2b',
+    // Fast small default: with synchronous decisions (#496) the eval blocks
+    // Claude, so the default must be quick + RAM-light across platforms (incl.
+    // MacBook Air). qwen3.5:4b is benchmarked safe (38/38). Heavier models go in
+    // `escalate_model` (second opinion only on would-escalate cases).
+    model: 'qwen3.5:4b',
     api_key: '',
     base_url: 'http://localhost:11434/v1',
     timeout: 30,
@@ -152,6 +156,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    // Second-opinion model on a primary 'escalate' (main context only). Empty =
+    // no second opinion. Put a heavy model here (e.g. qwen3.5:35b) to honor a
+    // broad approve policy without paying its latency on every permission.
+    escalate_model: '',
     // Keep the model's reasoning ON by default: live testing showed it is
     // load-bearing for following broad user instructions. Opt in (Ollama only)
     // for raw speed over decision nuance.
@@ -327,6 +335,7 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
     );
   }
   expectString('multichoice_model', cfg.multichoice_model);
+  expectString('escalate_model', cfg.escalate_model);
 
   // Warn about dangerously short patterns that would match too broadly.
   const MIN_PATTERN_LENGTH = 2;
@@ -470,6 +479,10 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     (auto_approve as { multichoice_model: string }).multichoice_model =
       env['REMI_AUTO_APPROVE_MULTICHOICE_MODEL'];
   }
+  if (env['REMI_AUTO_APPROVE_ESCALATE_MODEL']) {
+    (auto_approve as { escalate_model: string }).escalate_model =
+      env['REMI_AUTO_APPROVE_ESCALATE_MODEL'];
+  }
 
   // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
   const features = { ...config.features };
@@ -536,7 +549,7 @@ authorized_user_ids = []
 # [auto_approve]
 # enabled = false
 # provider = "ollama"           # "ollama" | "openrouter" | custom base URL
-# model = "gemma4:e2b"
+# model = "qwen3.5:4b"          # Fast small default; the eval blocks Claude (#496)
 # api_key = ""                  # Required for OpenRouter, empty for Ollama
 # base_url = "http://localhost:11434/v1"
 # timeout = 30                  # Seconds; falls through to user if exceeded
@@ -565,6 +578,10 @@ authorized_user_ids = []
 #                                  # model without paying its latency for
 #                                  # every binary permission. Ignored unless
 #                                  # multichoice = "evaluate".
+# escalate_model = ""              # Second opinion on a primary 'escalate'
+#                                  # (main context only). Put a heavy model here
+#                                  # (e.g. qwen3.5:35b) to honor a broad approve
+#                                  # policy without its latency on every prompt.
 # disable_thinking = false         # Ollama only: native /api/chat with
 #                                  # think:false (no reasoning). Faster but
 #                                  # lowers decision quality (reasoning helps
@@ -651,6 +668,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  instructions = ${instrDisplay}`);
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
+  lines.push(`  escalate_model = "${config.auto_approve.escalate_model}"`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -94,6 +94,32 @@ describe('AutoApproveGate', () => {
     );
   }
 
+  /** Gate whose PRIMARY model escalates but whose escalate_model ('big-model')
+   *  returns `secondResult` (#522 second opinion). */
+  function gateWithSecondOpinion(secondResult: AutoApproveResult): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const service: AutoApproveEvaluator = {
+      evaluate: async (_t, _i, _tag, _s, modelOverride) =>
+        modelOverride === 'big-model' ? secondResult : escalate,
+      cancel: () => true,
+    };
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => subagent,
+        escalate: (i) => escalations.push(i),
+        escalateModel: 'big-model',
+      },
+      SID,
+    );
+  }
+
   function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
     return {
       session_id: 'claude-test',
@@ -289,6 +315,35 @@ describe('AutoApproveGate', () => {
     expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(1);
+  });
+
+  test('escalate_model second opinion approves -> "allow" (no escalation) (#522)', async () => {
+    const d = await gateWithSecondOpinion(approve).resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(escalations).toHaveLength(0);
+    expect(submits).toHaveLength(0);
+  });
+
+  test('escalate_model second opinion denies -> "deny" (no escalation) (#522)', async () => {
+    const d = await gateWithSecondOpinion(deny).resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(escalations).toHaveLength(0);
+    expect(submits).toHaveLength(0);
+  });
+
+  test('escalate_model still unsure -> escalate to the user (#522)', async () => {
+    const d = await gateWithSecondOpinion(escalate).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('escalate_model is NOT consulted in a subagent context (denies via response) (#522)', async () => {
+    subagent = true;
+    const d = await gateWithSecondOpinion(approve).resolvePermission(pr());
+    // Subagent escalate denies directly; the second opinion (which would allow)
+    // must not run, since the user could not answer a subagent prompt anyway.
+    expect(d).toBe('deny');
+    expect(escalations).toHaveLength(0);
   });
 
   test('cancelStale forwards the reason to service.cancel', () => {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -337,6 +337,20 @@ describe('AutoApproveGate', () => {
     expect(escalations).toHaveLength(1);
   });
 
+  test('escalate_model cancelled -> passthrough, clears pending, no phantom escalation (#523 review)', async () => {
+    tracker.recordPendingHook({
+      id: generateId(),
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    const d = await gateWithSecondOpinion(cancelled).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(0); // no phantom question
+    expect(tracker.hasPendingForTest()).toBe(false); // pending cleared
+  });
+
   test('escalate_model is NOT consulted in a subagent context (denies via response) (#522)', async () => {
     subagent = true;
     const d = await gateWithSecondOpinion(approve).resolvePermission(pr());

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -49,6 +49,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    escalate_model: '',
     disable_thinking: false,
     ...overrides,
   };

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -114,6 +114,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    escalate_model: '',
     disable_thinking: false,
   };
 }

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -64,6 +64,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    escalate_model: '',
     disable_thinking: false,
     ...overrides,
   };

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -329,6 +329,7 @@ function makeConfig(model: string): AutoApproveConfig {
     instructions: '',
     multichoice: 'skip',
     multichoice_model: '',
+    escalate_model: '',
     disable_thinking: false,
   };
 }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -289,6 +289,26 @@ describe('formatConfig', () => {
     // approve_groups/deny_groups likewise visible (#494 phase 1).
     expect(output).toContain('approve_groups = ["read-only", "vcs-read", "build-test"]');
     expect(output).toContain('deny_groups = []');
+    // escalate_model visible (#522).
+    expect(output).toContain('escalate_model = ""');
+  });
+
+  test('default model is a fast 4b; escalate_model empty (#522)', () => {
+    expect(DEFAULT_CONFIG.auto_approve.model).toBe('qwen3.5:4b');
+    expect(DEFAULT_CONFIG.auto_approve.escalate_model).toBe('');
+  });
+
+  test('REMI_AUTO_APPROVE_ESCALATE_MODEL env override (#522)', () => {
+    process.env['REMI_AUTO_APPROVE_ESCALATE_MODEL'] = 'qwen3.5:35b';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.auto_approve.escalate_model).toBe('qwen3.5:35b');
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_ESCALATE_MODEL'];
+  });
+
+  test('rejects escalate_model as a non-string (#522)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nescalate_model = 35\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/escalate_model/);
   });
 
   test('masks auto_approve api_key', () => {
@@ -307,7 +327,7 @@ describe('auto_approve config', () => {
     expect(DEFAULT_CONFIG.auto_approve).toEqual({
       enabled: false,
       provider: 'ollama',
-      model: 'gemma4:e2b',
+      model: 'qwen3.5:4b',
       api_key: '',
       base_url: 'http://localhost:11434/v1',
       timeout: 30,
@@ -319,6 +339,7 @@ describe('auto_approve config', () => {
       instructions: '',
       multichoice: 'skip',
       multichoice_model: '',
+      escalate_model: '',
       disable_thinking: false,
     });
   });


### PR DESCRIPTION
## Summary
Follow-up to #496. Now that the eval blocks Claude, the model choice is user-visible latency. This makes the model story configurable with a fast default and a heavy-model "second opinion" that only runs when it matters.

- **Default model `gemma4:e2b` -> `qwen3.5:4b`**: fast + RAM-light across platforms (incl. MacBook Air); benchmarked safe (38/38). Reads/VCS/build-test already fast-path with **no LLM** (#495), so most prompts never reach the model.
- **`auto_approve.escalate_model`** (optional, default empty): on a primary `escalate` in a **main** context, consult this heavier model (e.g. a 35B) for a second opinion **before** asking the user. approve -> allow, deny -> deny, else -> ask. The heavy model's 10-30s latency only hits would-escalate cases (where you're already being interrupted), never the common path. Subagent escalates still deny via the response (no second opinion — you couldn't answer a subagent prompt anyway).

This is the "default 4b everywhere, 35b elsewhere" you asked for: **elsewhere = the escalation tier.**

### Changes
- types/config: `escalate_model: string` default ''; default model -> `qwen3.5:4b`; validate, env `REMI_AUTO_APPROVE_ESCALATE_MODEL`, formatConfig, generateDefaultConfig.
- `service.evaluate(..., modelOverride?)` runs the call with the escalate model; the gate reads `escalate_model` off the service.
- gate `resolvePermission` main-escalate branch runs the second opinion when set.

Closes #522 · Part of epic #494

## Test plan
- gate: second opinion approve -> 'allow' / deny -> 'deny' / still-escalate -> ask; subagent context skips the second opinion (denies via response).
- config: default model + escalate_model empty; formatConfig shows it; env override; non-string rejected.
- **Full daemon suite green (2099 pass)**; typecheck + biome clean.