### PR TITLE
feat(questions): escalated prompts carry tool/command + agent context (#497)

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -113,10 +113,12 @@ export class QuestionPresenceTracker {
    * sole pending hook when exactly one exists (unambiguous). With 2+ pending
    * hooks from different agents and no agent match, push bare to avoid
    * misattributing another agent's labels (#425 / #483). When paired, the hook
-   * contributes `options` and
-   * `agentId` (so the client keys the prompt to the right agent) while PTY
-   * contributes `id` / `text` / `allowsFreeText` / `isAnswered` (it reflects
-   * the screen). The consumed hook entry is removed.
+   * contributes `options`, `agentId` (so the client keys the prompt to the right
+   * agent), AND `text` — the hook's text carries the tool + command + agent
+   * context (e.g. "code-reviewer · Bash: git push origin main"), whereas the
+   * PTY's literal screen text is the bare terminal prompt ("Do you want to
+   * proceed?"). The PTY contributes `id` / `allowsFreeText` / `isAnswered` and
+   * its presence is the push trigger (#497). The consumed hook entry is removed.
    *
    * Pending is mutated BEFORE the push so a re-entrant call cannot re-merge
    * the same record. Push errors are caught and logged but not rethrown — the
@@ -160,6 +162,9 @@ export class QuestionPresenceTracker {
       hookRecord && hookRecord.options.length > 0
         ? {
             ...ptyQuestion,
+            // The hook text carries the tool/command/agent context; the PTY's is
+            // the bare terminal prompt. Use the hook's when it has one (#497).
+            text: hookRecord.text || ptyQuestion.text,
             options: [...hookRecord.options],
             agentId: ptyQuestion.agentId ?? hookRecord.agentId,
           }

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -189,7 +189,11 @@ export class HookEventBridge {
     // cases; this method now only builds the question payload.
     const toolName = input.tool_name || 'unknown tool';
     const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
-    const promptText = inputSummary ? `Allow ${toolName}: ${inputSummary}` : `Allow ${toolName}?`;
+    // The action carries the command/path/pattern context (#497).
+    const action = inputSummary ? `${toolName}: ${inputSummary}` : toolName;
+    // A subagent prompt names the agent so the user knows WHO is asking, e.g.
+    // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
+    const promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
 
     let options: QuestionOption[];
 

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -84,23 +84,36 @@ describe('QuestionPresenceTracker', () => {
     expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
   });
 
-  it('hook then PTY — pushes once with merged options from hook metadata', () => {
+  it('hook then PTY — pushes once with the hook rich text + options (#497)', () => {
     const pushes: Question[] = [];
     const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
-    const hookMeta = makeHookQuestion('Edit');
-    const ptyQ = makePTYQuestion('Allow Edit: /tmp/foo.ts?');
+    // Reality: the hook carries the rich tool/command text; the PTY is the bare
+    // terminal prompt that confirms the prompt is on screen.
+    const hookMeta = makeHookQuestion('Allow Edit: /tmp/foo.ts');
+    const ptyQ = makePTYQuestion('Do you want to proceed?');
 
     tracker.recordPendingHook(hookMeta);
     tracker.onPTYPromptVisible(ptyQ);
 
     expect(pushes.length).toBe(1);
-    expect(pushes[0]?.text).toBe('Allow Edit: /tmp/foo.ts?');
-    // PTY id/text wins; hook options replace PTY's numbered fallback.
+    // The hook's rich text wins so the user sees the command, not the bare prompt.
+    expect(pushes[0]?.text).toBe('Allow Edit: /tmp/foo.ts');
+    // PTY id (answer routing) + hook options.
     expect(pushes[0]?.id).toBe(ptyQ.id);
     expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
     expect(pushes[0]?.options[0]?.isYes).toBe(true);
     expect(pushes[0]?.options[2]?.isNo).toBe(true);
     expect(tracker.hasPendingForTest()).toBe(false);
+  });
+
+  it('falls back to the PTY text when the hook text is empty (#497)', () => {
+    const pushes: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const hookMeta = { ...makeHookQuestion(''), text: '' };
+    const ptyQ = makePTYQuestion('Do you want to proceed?');
+    tracker.recordPendingHook(hookMeta);
+    tracker.onPTYPromptVisible(ptyQ);
+    expect(pushes[0]?.text).toBe('Do you want to proceed?');
   });
 
   it('hook only — no push until PTY confirms or status clears', () => {

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -275,6 +275,22 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.options[2]?.label).toBe('No');
   });
 
+  it('a subagent PermissionRequest names the agent in the text (#497)', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      agent_id: 'agent-1',
+      agent_type: 'code-reviewer',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push origin main' },
+    } as PermissionRequestHookInput);
+
+    // The user sees WHO is asking + the command, not a bare "Allow Bash".
+    expect(questions[0]?.text).toBe('code-reviewer · Bash: git push origin main');
+  });
+
   it('maps PostToolUseFailure to executing status with error context', () => {
     const { bridge, statuses } = createBridge();
 


### PR DESCRIPTION
## Summary
Fixes the "the app gives no context, just 'Do you want to proceed?'" complaint. That bare text was the **PTY-parsed terminal prompt**: the tracker's hook<->PTY merge took the hook's *options* but kept the PTY's literal *text*, discarding the rich question the bridge already builds.

- **tracker** (`question-presence-tracker.ts`): the merged push now uses the **hook's text** (tool + command + agent context) while keeping the PTY `id` (answer routing) and its presence as the push trigger. Falls back to the PTY text only if the hook text is empty.
- **bridge** (`hook-event-bridge.ts`): a subagent PermissionRequest names the agent — `code-reviewer · Bash: git push origin main` — vs `Allow Bash: ...` for the main agent. The user sees WHO is asking + the command.

So on the phone you now get e.g. "Allow Bash: git push origin develop" or "code-reviewer · Bash: git push origin main" with the correct Yes / Yes-always / No options, instead of a bare "Do you want to proceed?".

Part of #497 (the escalation-context half). Retiring the now-dead PTY-inject/buffer/PTY-presence machinery (dead for verdicts since #496) is a separate follow-up.

## Test plan
- tracker: merged push uses the hook rich text + PTY id + hook options; empty-hook-text falls back to the PTY text.
- bridge: subagent prompt names the agent; main-agent format unchanged.
- **Full daemon suite green (2102 pass)**; typecheck + biome clean.