### PR TITLE
refactor(auto-approve): retire dead PTY-inject param + document dormant buffer (#497 phase 3b)

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -130,6 +130,14 @@ export class QuestionPresenceTracker {
       // A permission eval owns this prompt: buffer it, do not push yet. The
       // verdict decides — onAutoApproveEscalate releases it; a status-leaves-
       // waiting / clearPending reset (auto-handled, or prompt gone) discards it.
+      //
+      // DORMANT under synchronous decisions (#496): Claude now BLOCKS on the
+      // hook response and does not render the permission prompt during the eval,
+      // so this branch is effectively never taken (the verdict is returned before
+      // any prompt renders; escalate clears the flag before the passthrough
+      // prompt appears). Retained as defense-in-depth — it is the #484
+      // APNS-flood guard for any future async/parallel eval path, and removing it
+      // buys nothing while risking the flood it prevents.
       this.bufferedDuringEval = ptyQuestion;
       return;
     }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -324,7 +324,6 @@ export class AutoApproveGate {
     input: PermissionRequestHookInput,
     value: string,
     reason: string,
-    bypassSubagentPtyGate = false,
   ): Promise<boolean> {
     const { sessionRegistry, tracker, isInSubagentContext } = this.deps;
     try {
@@ -334,7 +333,7 @@ export class AutoApproveGate {
         return false;
       }
       const inSubagentContext = this.isSubagentEvent(input) || isInSubagentContext();
-      if (!bypassSubagentPtyGate && inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
+      if (inSubagentContext && !tracker.isPromptVisibleOnPTY()) {
         log(
           `[AutoApprove ${this.sessionTag}] Subagent ${input.tool_name}: skipping inject "${value}" (${reason}); no prompt visible on main PTY (agent=${input.agent_id?.slice(0, 8) ?? 'nested'} type=${input.agent_type ?? 'n/a'})`,
         );


### PR DESCRIPTION
## Summary
Phase 3b cleanup after #496 (synchronous decisions). approve/deny/subagent-deny now return verdicts via the hook response, so `inject()` is reached ONLY for multi-choice pick.

- Remove the now-dead `bypassSubagentPtyGate` param from `inject()` (no caller passes `true` since the subagent default-deny paths no longer inject). The PTY-presence gate stays for the pick path.
- Document the #484 buffer-until-verdict as **dormant** under synchronous decisions (Claude blocks before rendering the prompt, so the buffer branch is never taken) but **retained** as defense-in-depth — it is the APNS-flood guard for any future async/parallel eval path, and removing it buys nothing while risking the flood it prevents.

Pure cleanup, no behavior change. (The PTY-injection answer path for verdicts was already retired by #496; this finishes the dead-param removal. #503 step 2 — deleting the old hook-binding path — remains separate.)

Part of #497.

## Test plan
- Full daemon suite green (2102 pass); typecheck + biome clean. No behavior change (the removed param was always false; the buffer branch is dormant).