### PR TITLE
Release 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-06-09
+
+A reliability fix for session binding. When a project directory accumulates many
+past Remi sessions (Remi reuses one loopback port per directory, so each run
+leaves a `remi:<port>` transcript behind), the no-hooks rotation detector could
+crawl that history and lock onto a long-dead session, then drop the live
+session's hook events as "foreign". This made auto-approve appear dead in a
+freshly restarted session.
+
+### Fixed
+- **Binder dir-poll no longer locks onto stale history** (#529): the no-hooks
+  rotation poll now applies a freshness gate, so a same-port transcript whose
+  file is older than 5 minutes is treated as historical and ignored rather than
+  adopted as a live rotation. A genuine rotation writes a fresh transcript and
+  is still picked up immediately.
+
 ## [0.6.5] - 2026-06-09
 
 Auto-approve becomes synchronous and far more reliable: the daemon now answers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.6-dev.1",
+  "version": "0.6.6-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.5",
+  "version": "0.6.6-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.6-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.6-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.6-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.6-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.5'; // REMI_COMPILED_VERSION
+      return '0.6.6-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.5'; // REMI_COMPILED_VERSION
+    return '0.6.6-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -75,6 +75,17 @@ const ROTATION_POLL_INTERVAL_MS = 1500;
  * beyond Claude's synchronous create-to-marker gap.
  */
 const MARKER_SETTLE_MS = 10_000;
+/**
+ * Freshness window for a dir-poll rotation candidate that already owns our port
+ * marker (#518 follow-up). A real no-hooks rotation produces a FRESHLY-written
+ * transcript; a historical same-port transcript (a prior daemon run reusing this
+ * port in this directory — remi reuses one port per dir) is stale. Without this
+ * gate the poll crawls the dir's accumulated `remi:<port>` history and mis-locks
+ * onto a dead session, then drops the live session's hooks as foreign. 5 minutes
+ * is far longer than any gap between writes in an active session, and far shorter
+ * than the hours/days that separate historical transcripts.
+ */
+const ROTATION_FRESHNESS_MS = 5 * 60_000;
 
 /** A hook event as the binder consumes it (the subset it reads). */
 export interface BinderHookEvent {
@@ -942,6 +953,26 @@ export class TranscriptBinder {
       // (d) OURS + NEW. Mark seen BEFORE feeding so a re-entrant readdir on the
       //     next tick (or a throw) can never double-feed.
       this.seenRotationIds.add(candidateId);
+
+      // FRESHNESS GATE (#518 follow-up). The marker proves the port, NOT that
+      // this is the LIVE session: a directory where remi has run before
+      // accumulates historical `remi:<port>` transcripts (port is reused per
+      // dir). A genuine no-hooks rotation is a freshly-written transcript; a
+      // stale historical one must NOT rotate us onto a dead session (the
+      // nemar-cli "auto-approve never fires / hooks dropped foreign" wedge).
+      let ageMs = 0;
+      try {
+        ageMs = Date.now() - fs.statSync(candidatePath).mtimeMs;
+      } catch {
+        ageMs = 0; // raced a delete/rename -> treat as fresh, attempt.
+      }
+      if (ageMs > ROTATION_FRESHNESS_MS) {
+        log(
+          `[Binder] rotation poll: ${candidateId.slice(0, 8)} owns our port but is stale (${Math.round(ageMs / 1000)}s old); not a live rotation, ignoring`,
+        );
+        continue;
+      }
+
       this.feedSyntheticRotation(candidateId, candidatePath);
 
       // One rotation per tick is enough; the next new id (if any) is picked up

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -80,8 +80,8 @@ const MARKER_SETTLE_MS = 10_000;
  * marker (#518 follow-up). A real no-hooks rotation produces a FRESHLY-written
  * transcript; a historical same-port transcript (a prior daemon run reusing this
  * port in this directory — remi reuses one port per dir) is stale. Without this
- * gate the poll crawls the dir's accumulated `remi:<port>` history and mis-locks
- * onto a dead session, then drops the live session's hooks as foreign. 5 minutes
+ * gate the poll crawls the dir's accumulated `remi:<port>` history and wrongly
+ * locks onto a dead session, then drops the live session's hooks as foreign. 5 min
  * is far longer than any gap between writes in an active session, and far shorter
  * than the hours/days that separate historical transcripts.
  */

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -861,6 +861,32 @@ describe('TranscriptBinder', () => {
       binder.close();
     });
 
+    test('freshness gate: a STALE same-port transcript (old mtime) does NOT rotate us (#518)', () => {
+      registerSession();
+      const binder = makeDriveBinder();
+      binder.onHookEvent({
+        session_id: 'claude-A',
+        transcript_path: writeTranscript('claude-A', 8765),
+      });
+      binder.start('claude-A');
+
+      // A HISTORICAL transcript from a prior run on the SAME port (remi reuses
+      // one port per dir, so the dir accumulates our-port transcripts). It
+      // carries our marker but is an hour old -> not a live rotation. Without the
+      // freshness gate the poll would crawl onto it and strand the live session.
+      const stalePath = writeTranscript('claude-OLD', 8765);
+      const old = new Date(Date.now() - 3_600_000); // 1h ago (> ROTATION_FRESHNESS_MS)
+      fs.utimesSync(stalePath, old, old);
+      ptyState.running = false;
+
+      binder.rotationPollTick();
+      binder.rotationPollTick();
+
+      expect(rotations()).toHaveLength(0);
+      expect(binder.snapshot().claudeSessionId).toBe('claude-A'); // stays on the live bind
+      binder.close();
+    });
+
     test('markerless RECENT file is re-polled (never rotates), never permanently dropped', () => {
       registerSession();
       const binder = makeDriveBinder();


### PR DESCRIPTION
## Release 0.6.6

Single-fix reliability release for session binding.

### Fixed
- **Binder dir-poll no longer locks onto stale history** (#529, PR #530): the
  no-hooks rotation poll now applies a freshness gate, so a same-port transcript
  whose file is older than 5 minutes is treated as historical and ignored rather
  than adopted as a live rotation. A genuine rotation writes a fresh transcript
  and is still picked up immediately.

  Root cause: a project directory accumulates many past Remi transcripts (Remi
  reuses one loopback port per directory, so each run leaves a `remi:<port>`
  transcript behind). The rotation detector could crawl that history and lock
  onto a long-dead session, then drop the live session's hook events as
  "foreign", which made auto-approve appear dead in a freshly restarted session.

### Verification
- PR #530 sonnet-reviewed: no high-confidence issues; confirmed the gate cannot
  skip a live session (a real rotation writes a fresh-mtime transcript), the
  mark-seen-before-gate is correct (historical transcripts never become live via
  the poll), and statSync-error fails fresh (safe).
- All gates green on #530 (Lint, Type Check, Test 2546, Spelling).
- 34 binder unit tests pass, including the new stale-transcript test.

Merge with a merge commit to trigger auto-release (strip -dev -> tag v0.6.6 ->
npm + Homebrew + GitHub release), then sync-develop bumps develop to the next
dev line.