### PR TITLE
Release 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-06-10
+
+Makes auto-approve actually work with reasoning-tuned local models. A model that
+wraps its verdict in a markdown code fence (notably `qwen3.6:35b-mlx`, which
+fences every response) was escalating 100% of its decisions on formatting alone:
+the parser did a strict `JSON.parse` of the raw text, choked on the leading
+backtick, and fell back to "ask the user" even when the model had clearly
+approved. This release makes the parser tolerant and tunes the heavy
+second-opinion tier so it can actually answer.
+
+### Fixed
+- **Fenced-JSON verdicts are now parsed, not escalated** (#533): a deterministic,
+  string-aware extractor strips a `` ```json `` code fence or a short preamble
+  and parses the inner object, wired into both the binary decision parser and the
+  multi-choice parser. Free text still escalates (no keyword guessing), and a
+  top-level array still escalates rather than having an inner object lifted out as
+  the verdict, including when the array follows a preamble or sits inside a fence.
+  The model sweep for `qwen3.6:35b-mlx` went from 25/38 to 37/38 with no code
+  change other than this parse fix.
+
+### Added
+- **Dedicated `escalate_model` timeout** (`[auto_approve] escalate_timeout`,
+  seconds; `0` = reuse `timeout`): the heavy second-opinion model is usually cold
+  and needs a longer budget than the fast model, so it no longer degrades into a
+  timeout-then-escalate.
+- **Second-opinion model warm-up**: on Ollama, the daemon pre-loads
+  `escalate_model` at startup (best-effort, `keep_alive` 30m) so the first
+  escalation isn't a cold start.
+- The startup banner now logs `escalate_model` and `escalate_timeout`, so a
+  configured second opinion is visible in the log.
+
 ## [0.6.6] - 2026-06-09
 
 A reliability fix for session binding. When a project directory accumulates many

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.7-dev.1",
+  "version": "0.6.7-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.7-dev.2",
+  "version": "0.6.7-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.6",
+  "version": "0.6.7-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -10,7 +10,8 @@
  */
 
 import { errorToString } from '@remi/shared';
-import { chatCompletion, resolveProviderUrl } from './llm-client.ts';
+import { extractJsonObject } from './json-extract.ts';
+import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
 import {
   buildMultiChoicePrompt,
@@ -54,27 +55,22 @@ export function normalisePermissionSuggestion(entry: unknown): string | null {
  * Exported for unit testing.
  */
 export function parseDecision(raw: string): { decision: BinaryDecision; reasoning: string } {
-  let parseErr: unknown = null;
-  try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed === 'object' && parsed !== null) {
-      const decisionStr = String(parsed.decision ?? '').toLowerCase();
-      const reasoning = String(parsed.reasoning ?? '');
-      if (VALID_DECISIONS.has(decisionStr as BinaryDecision)) {
-        return { decision: decisionStr as BinaryDecision, reasoning };
-      }
+  // extractJsonObject tolerates a markdown code fence or a short preamble around
+  // the JSON (deterministic, string-aware — never a free-text keyword guess).
+  // Many reasoning-tuned local models, notably qwen3.6:35b-mlx, fence every
+  // response; without this they escalate every safe verdict on formatting alone.
+  const parsed = extractJsonObject(raw);
+  if (parsed !== null) {
+    const decisionStr = String(parsed['decision'] ?? '').toLowerCase();
+    const reasoning = String(parsed['reasoning'] ?? '');
+    if (VALID_DECISIONS.has(decisionStr as BinaryDecision)) {
+      return { decision: decisionStr as BinaryDecision, reasoning };
     }
-  } catch (err) {
-    // Capture the SyntaxError so the escalation reasoning explains WHY the
-    // raw text could not be parsed (markdown fences, "json\n{...}\n" prefix,
-    // etc. are common with local LLMs and benefit from a class hint).
-    parseErr = err;
   }
 
-  const errHint = parseErr ? ` [${(parseErr as Error).name}: ${(parseErr as Error).message}]` : '';
   return {
     decision: 'escalate',
-    reasoning: `Unparsable LLM response: ${raw.slice(0, 100)}${errHint}`,
+    reasoning: `Unparsable LLM response: ${raw.slice(0, 100)}`,
   };
 }
 
@@ -93,6 +89,12 @@ export class AutoApproveService {
   /** Second-opinion model on a primary 'escalate' (#522); empty = none. Public
    *  so the gate can read it without re-threading the config. */
   readonly escalateModel: string;
+  /** Dedicated timeout (ms) for escalate_model calls; 0 => fall back to the
+   *  fast model's timeout. The heavy model is usually cold, so it needs a longer
+   *  budget than the fast path. */
+  private readonly escalateTimeoutMs: number;
+  /** True when the provider is Ollama (enables the native warm-up load). */
+  private readonly providerIsOllama: boolean;
   /** Prevents concurrent evaluations. Second request escalates immediately. */
   private evaluating = false;
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
@@ -125,6 +127,27 @@ export class AutoApproveService {
     this.multichoiceMode = config.multichoice;
     this.multichoiceModel = config.multichoice_model;
     this.escalateModel = config.escalate_model;
+    this.escalateTimeoutMs = config.escalate_timeout > 0 ? config.escalate_timeout * 1000 : 0;
+    this.providerIsOllama = config.provider === 'ollama';
+  }
+
+  /**
+   * Warm-load the escalate_model so the FIRST second opinion does not pay a
+   * cold model-load (15s+ for a 35B). Ollama only (the native /api/generate
+   * empty-prompt load with a long keep_alive); a no-op otherwise or when no
+   * escalate_model is configured. Best-effort and never throws — a failed warm
+   * just means the first real consult loads the model itself.
+   */
+  async warmEscalateModel(): Promise<void> {
+    if (!this.escalateModel || !this.providerIsOllama) return;
+    try {
+      await warmModel(this.llmConfig.baseUrl, this.escalateModel);
+      this.logFn(`[AutoApprove] Warmed escalate_model ${this.escalateModel} (kept resident 30m)`);
+    } catch (err) {
+      this.logFn(
+        `[AutoApprove] escalate_model warm-up failed (will load on first consult): ${errorToString(err)}`,
+      );
+    }
   }
 
   /**
@@ -242,7 +265,14 @@ export class AutoApproveService {
       this.evaluating = true;
       this.currentAbortController = new AbortController();
       const externalSignal = this.currentAbortController.signal;
-      const timeoutMs = this.llmConfig.timeoutMs;
+      // The heavy escalate_model gets its dedicated (longer) budget when set, so
+      // a cold model-load does not abort the fast model's shorter timeout.
+      const isEscalateModelCall =
+        modelOverride !== undefined && modelOverride === this.escalateModel;
+      const timeoutMs =
+        isEscalateModelCall && this.escalateTimeoutMs > 0
+          ? this.escalateTimeoutMs
+          : this.llmConfig.timeoutMs;
       // Hold the race timer handle so we can clear it whichever side wins.
       // Without clearTimeout, a successful chatCompletion at t=200ms would
       // leave a timer scheduled at t=timeoutMs that fires on the NEXT eval
@@ -255,10 +285,12 @@ export class AutoApproveService {
         const useMultiChoice = isMultiChoice && this.multichoiceMode === 'evaluate';
         const callModel =
           useMultiChoice && this.multichoiceModel ? this.multichoiceModel : baseModel;
+        // Reuse the base config only when neither the model nor the timeout
+        // differs; the escalate_model path overrides both.
         const callConfig: LLMClientConfig =
-          callModel === this.llmConfig.model
+          callModel === this.llmConfig.model && timeoutMs === this.llmConfig.timeoutMs
             ? this.llmConfig
-            : { ...this.llmConfig, model: callModel };
+            : { ...this.llmConfig, model: callModel, timeoutMs };
         const messages = useMultiChoice
           ? buildMultiChoicePrompt(
               toolName,

--- a/packages/daemon/src/auto-approve/json-extract.ts
+++ b/packages/daemon/src/auto-approve/json-extract.ts
@@ -1,0 +1,123 @@
+/**
+ * Tolerant JSON extraction for local-LLM verdicts.
+ *
+ * Small instruct models (notably qwen3.6:35b-mlx, but most reasoning-tuned
+ * models intermittently) wrap their JSON answer in a markdown code fence
+ * (```json … ```), emit a leading language tag, or prepend a short preamble
+ * before the object even when asked for raw JSON. A strict `JSON.parse` of the
+ * whole response then throws, and the auto-approve service escalates EVERY such
+ * verdict to the user — which made qwen3.6:35b-mlx (the second-opinion model)
+ * escalate 13/38 safe-read scenarios in the sweep purely on formatting.
+ *
+ * This helper performs a DETERMINISTIC, SAFE recovery: it strips a recognised
+ * code-fence wrapper and, failing that, extracts the first balanced top-level
+ * `{ … }` object, then parses THAT strictly. It never guesses a decision from
+ * free text — if no parseable object is present the caller still escalates. The
+ * historical "no guessing" caution (a substring `approve` in free text must not
+ * approve) is preserved: we only ever return a parsed JSON object, never a
+ * keyword match.
+ */
+
+/**
+ * Extract and parse the first JSON object from a raw LLM response.
+ *
+ * Returns the parsed object, or null when no balanced `{…}` object parses.
+ * Order of attempts:
+ *   1. Parse the whole string (the fast, well-behaved path).
+ *   2. Strip a leading/trailing markdown code fence (``` or ```json) and parse.
+ *   3. Scan for the first balanced top-level `{…}` (brace-aware, string- and
+ *      escape-aware so braces inside string values do not miscount) and parse.
+ *
+ * Only object literals are accepted; arrays, numbers, and `null` return null so
+ * the caller's "must be a JSON object with a decision field" contract is
+ * unchanged.
+ */
+export function extractJsonObject(raw: string): Record<string, unknown> | null {
+  const tryParse = (s: string): Record<string, unknown> | null => {
+    try {
+      const parsed = JSON.parse(s);
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const whole = tryParse(raw.trim());
+  if (whole !== null) return whole;
+
+  const defenced = stripCodeFence(raw);
+  if (defenced !== null) {
+    const parsed = tryParse(defenced);
+    if (parsed !== null) return parsed;
+    // A fence around an array/preamble: fall through to balanced-object scan on
+    // the de-fenced text rather than the raw (so the fence markers don't count).
+    const inner = firstBalancedObject(defenced);
+    if (inner !== null) {
+      const innerParsed = tryParse(inner);
+      if (innerParsed !== null) return innerParsed;
+    }
+    return null;
+  }
+
+  // Preamble case ("Here it is: {…}"). Deliberately NOT applied when the
+  // response is array-shaped: a top-level `[ … ]` must escalate rather than
+  // have an object silently lifted out of it (conservative for an approve path).
+  if (!raw.trim().startsWith('[')) {
+    const candidate = firstBalancedObject(raw);
+    if (candidate !== null) {
+      const parsed = tryParse(candidate);
+      if (parsed !== null) return parsed;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Strip one surrounding markdown code fence, returning the inner text, or null
+ * when the input is not fenced. Handles an optional language tag (```json) and
+ * leading/trailing whitespace around the fences.
+ */
+function stripCodeFence(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('```')) return null;
+  // Drop the opening fence line (``` or ```json plus the rest of that line).
+  const firstNewline = trimmed.indexOf('\n');
+  if (firstNewline === -1) return null;
+  const afterOpen = trimmed.slice(firstNewline + 1);
+  const closeIdx = afterOpen.lastIndexOf('```');
+  const inner = closeIdx === -1 ? afterOpen : afterOpen.slice(0, closeIdx);
+  return inner.trim();
+}
+
+/**
+ * Return the first balanced top-level `{…}` substring, or null. String-literal
+ * aware: braces and the closing scan ignore `{`/`}` that appear inside double-
+ * quoted strings, and honour backslash escapes, so a brace inside a reasoning
+ * value does not prematurely close the object.
+ */
+function firstBalancedObject(raw: string): string | null {
+  const start = raw.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null;
+}

--- a/packages/daemon/src/auto-approve/json-extract.ts
+++ b/packages/daemon/src/auto-approve/json-extract.ts
@@ -55,7 +55,7 @@ export function extractJsonObject(raw: string): Record<string, unknown> | null {
     // (so the fence markers don't count). Deliberately NOT applied when the
     // de-fenced content is array-shaped — a `[ … ]` must escalate, never have an
     // inner object lifted out of it (same conservatism as the preamble branch).
-    if (!defenced.startsWith('[')) {
+    if (!isArrayShaped(defenced)) {
       const inner = firstBalancedObject(defenced);
       if (inner !== null) {
         const innerParsed = tryParse(inner);
@@ -68,7 +68,9 @@ export function extractJsonObject(raw: string): Record<string, unknown> | null {
   // Preamble case ("Here it is: {…}"). Deliberately NOT applied when the
   // response is array-shaped: a top-level `[ … ]` must escalate rather than
   // have an object silently lifted out of it (conservative for an approve path).
-  if (!raw.trim().startsWith('[')) {
+  // isArrayShaped also catches a preamble BEFORE an array ("Here: [ {…} ]") so
+  // an object nested inside an array is never lifted out as the verdict.
+  if (!isArrayShaped(raw)) {
     const candidate = firstBalancedObject(raw);
     if (candidate !== null) {
       const parsed = tryParse(candidate);
@@ -77,6 +79,22 @@ export function extractJsonObject(raw: string): Record<string, unknown> | null {
   }
 
   return null;
+}
+
+/**
+ * True when the response is array-shaped at the top level: the first structural
+ * bracket is a `[` (or there is a `[` but no `{` at all). Such a response must
+ * escalate — an object nested inside an array must never be lifted out and
+ * treated as the verdict (conservative for an approve path). Erring toward
+ * "array-shaped" (e.g. prose that happens to contain a `[` before the object)
+ * over-escalates to the user, which is the safe direction.
+ */
+function isArrayShaped(raw: string): boolean {
+  const obj = raw.indexOf('{');
+  const arr = raw.indexOf('[');
+  if (arr === -1) return false; // no array bracket → object/preamble path is safe
+  if (obj === -1) return true; // an array and no object → array-shaped
+  return arr < obj; // whichever bracket opens first decides the shape
 }
 
 /**

--- a/packages/daemon/src/auto-approve/json-extract.ts
+++ b/packages/daemon/src/auto-approve/json-extract.ts
@@ -51,12 +51,16 @@ export function extractJsonObject(raw: string): Record<string, unknown> | null {
   if (defenced !== null) {
     const parsed = tryParse(defenced);
     if (parsed !== null) return parsed;
-    // A fence around an array/preamble: fall through to balanced-object scan on
-    // the de-fenced text rather than the raw (so the fence markers don't count).
-    const inner = firstBalancedObject(defenced);
-    if (inner !== null) {
-      const innerParsed = tryParse(inner);
-      if (innerParsed !== null) return innerParsed;
+    // A fence around a preamble: scan the de-fenced text for a balanced object
+    // (so the fence markers don't count). Deliberately NOT applied when the
+    // de-fenced content is array-shaped — a `[ … ]` must escalate, never have an
+    // inner object lifted out of it (same conservatism as the preamble branch).
+    if (!defenced.startsWith('[')) {
+      const inner = firstBalancedObject(defenced);
+      if (inner !== null) {
+        const innerParsed = tryParse(inner);
+        if (innerParsed !== null) return innerParsed;
+      }
     }
     return null;
   }

--- a/packages/daemon/src/auto-approve/llm-client.ts
+++ b/packages/daemon/src/auto-approve/llm-client.ts
@@ -71,6 +71,40 @@ export function ollamaNativeBase(baseUrl: string): string {
 }
 
 /**
+ * Warm-load an Ollama model so a later request does not pay the cold model-load
+ * penalty. Uses the native /api/generate with an EMPTY prompt (the documented
+ * load-only call) and a long `keep_alive` so the model stays resident. Throws on
+ * network errors or non-200 responses; the caller treats it as best-effort.
+ *
+ * `keepAlive` accepts Ollama's duration string ("30m", "-1" for forever).
+ */
+export async function warmModel(
+  baseUrl: string,
+  model: string,
+  keepAlive = '30m',
+  timeoutMs = 120_000,
+): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${ollamaNativeBase(baseUrl)}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, prompt: '', keep_alive: keepAlive, stream: false }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`warm-up failed ${response.status}: ${body.slice(0, 200)}`);
+    }
+    // Drain the body so the connection is released promptly.
+    await response.json().catch(() => undefined);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Send a chat completion request. Throws on network errors, timeouts, or
  * non-200 responses.
  *

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -27,6 +27,7 @@
  * string labels — the UI prompt is the default Yes/Yes-always/No.
  */
 
+import { extractJsonObject } from './json-extract.ts';
 import type { ChatMessage } from './llm-client.ts';
 
 /**
@@ -149,25 +150,16 @@ export function parseMultiChoiceDecision(
 ):
   | { decision: 'pick'; index: number; reasoning: string }
   | { decision: 'escalate'; reasoning: string } {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    const e = err as Error;
+  // Tolerate a code fence / short preamble around the JSON (deterministic,
+  // string-aware — see json-extract.ts). Models that fence every response would
+  // otherwise escalate every multi-choice prompt on formatting alone.
+  const obj = extractJsonObject(raw);
+  if (obj === null) {
     return {
       decision: 'escalate',
-      reasoning: `Unparsable multi-choice response (${e.name}: ${e.message}): ${raw.slice(0, 100)}`,
+      reasoning: `Unparsable multi-choice response (no JSON object): ${raw.slice(0, 100)}`,
     };
   }
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    return {
-      decision: 'escalate',
-      reasoning: `Multi-choice response was not a JSON object: ${raw.slice(0, 100)}`,
-    };
-  }
-
-  const obj = parsed as Record<string, unknown>;
   const decisionStr = String(obj['decision'] ?? '').toLowerCase();
   const reasoning = String(obj['reasoning'] ?? '');
 

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -134,6 +134,16 @@ export interface AutoApproveConfig {
    */
   readonly escalate_model: string;
   /**
+   * Timeout (seconds) for the `escalate_model` second opinion specifically. The
+   * heavy model is larger and frequently COLD (escalations are sporadic, so it
+   * has usually been unloaded by the host), so its first call pays a model-load
+   * penalty that easily exceeds the fast model's `timeout`. Without a dedicated,
+   * longer budget the cold load aborts and the second opinion degrades to an
+   * error->escalate, adding latency without ever acting. 0 (default) means "use
+   * `timeout`". Ignored when `escalate_model` is empty.
+   */
+  readonly escalate_timeout: number;
+  /**
    * Ollama only: route through the native /api/chat with `think: false` to
    * turn OFF the model's reasoning. This is FASTER but lowers decision quality
    * — live testing showed the chain-of-thought is load-bearing for following

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.7-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.7-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.7-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.7-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.7-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.7-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.7-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.7-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.6'; // REMI_COMPILED_VERSION
+      return '0.6.7-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.6'; // REMI_COMPILED_VERSION
+    return '0.6.7-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -777,9 +777,15 @@ let autoApproveService: AutoApproveService | null = null;
     );
     const rulesSummary = `allow=${allow.length} deny=${deny.length} instructions=${instructions ? 'yes' : 'no'}`;
     const mcSummary = `multichoice=${multichoice}${multichoiceModel ? ` mc_model=${multichoiceModel}` : ''}`;
+    const escalateSummary = aaCfg.escalate_model
+      ? `escalate_model=${aaCfg.escalate_model}${aaCfg.escalate_timeout > 0 ? ` (timeout=${aaCfg.escalate_timeout}s)` : ''}`
+      : 'escalate_model=none';
     writeToLog(
-      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}, ${mcSummary}`,
+      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}, ${mcSummary}, ${escalateSummary}`,
     );
+    // Warm-load the heavy second-opinion model so the first escalation is not a
+    // cold start. Best-effort, fire-and-forget (never blocks daemon startup).
+    void autoApproveService.warmEscalateModel();
   }
 }
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -160,6 +160,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // no second opinion. Put a heavy model here (e.g. qwen3.5:35b) to honor a
     // broad approve policy without paying its latency on every permission.
     escalate_model: '',
+    // Dedicated timeout (seconds) for the heavy escalate_model. 0 = use
+    // `timeout`. Set higher (e.g. 90) when escalate_model is a large, often-cold
+    // model so its first-call load penalty does not abort into an error.
+    escalate_timeout: 0,
     // Keep the model's reasoning ON by default: live testing showed it is
     // load-bearing for following broad user instructions. Opt in (Ollama only)
     // for raw speed over decision nuance.
@@ -293,6 +297,16 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   if (typeof cfg.timeout !== 'number' || !Number.isFinite(cfg.timeout) || cfg.timeout <= 0) {
     throw new Error(
       `Invalid auto_approve.timeout in ${configPath}: must be a positive number (seconds), got ${typeof cfg.timeout === 'string' ? `string "${cfg.timeout}"` : typeof cfg.timeout}. Example: timeout = 10`,
+    );
+  }
+
+  if (
+    typeof cfg.escalate_timeout !== 'number' ||
+    !Number.isFinite(cfg.escalate_timeout) ||
+    cfg.escalate_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.escalate_timeout in ${configPath}: must be a non-negative number (seconds; 0 = use timeout), got ${typeof cfg.escalate_timeout === 'string' ? `string "${cfg.escalate_timeout}"` : typeof cfg.escalate_timeout}. Example: escalate_timeout = 90`,
     );
   }
 
@@ -483,6 +497,12 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     (auto_approve as { escalate_model: string }).escalate_model =
       env['REMI_AUTO_APPROVE_ESCALATE_MODEL'];
   }
+  if (env['REMI_AUTO_APPROVE_ESCALATE_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_ESCALATE_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { escalate_timeout: number }).escalate_timeout = parsed;
+    }
+  }
 
   // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
   const features = { ...config.features };
@@ -582,6 +602,10 @@ authorized_user_ids = []
 #                                  # (main context only). Put a heavy model here
 #                                  # (e.g. qwen3.5:35b) to honor a broad approve
 #                                  # policy without its latency on every prompt.
+# escalate_timeout = 0             # Seconds for escalate_model; 0 = use timeout.
+#                                  # Raise (e.g. 90) for a large, often-cold
+#                                  # second-opinion model so its first-call load
+#                                  # does not abort into an error->escalate.
 # disable_thinking = false         # Ollama only: native /api/chat with
 #                                  # think:false (no reasoning). Faster but
 #                                  # lowers decision quality (reasoning helps
@@ -669,6 +693,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  multichoice = "${config.auto_approve.multichoice}"`);
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
   lines.push(`  escalate_model = "${config.auto_approve.escalate_model}"`);
+  lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -50,6 +50,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     multichoice: 'skip',
     multichoice_model: '',
     escalate_model: '',
+    escalate_timeout: 0,
     disable_thinking: false,
     ...overrides,
   };
@@ -118,8 +119,30 @@ describe('parseDecision', () => {
     expect(r.decision).toBe('escalate');
   });
 
-  test('markdown-wrapped JSON escalates (no guessing)', () => {
+  test('markdown-fenced JSON is parsed (qwen3.6:35b emits ```json fences)', () => {
     const r = parseDecision('```json\n{"decision":"approve","reasoning":"safe"}\n```');
+    expect(r.decision).toBe('approve');
+    expect(r.reasoning).toBe('safe');
+  });
+
+  test('bare ``` fence (no language tag) is parsed', () => {
+    const r = parseDecision('```\n{"decision":"deny","reasoning":"destructive"}\n```');
+    expect(r.decision).toBe('deny');
+  });
+
+  test('JSON with a short preamble before the object is parsed', () => {
+    const r = parseDecision('Here is my verdict:\n{"decision":"escalate","reasoning":"unsure"}');
+    expect(r.decision).toBe('escalate');
+  });
+
+  test('fenced object whose reasoning contains braces parses without miscounting', () => {
+    const r = parseDecision('```json\n{"decision":"deny","reasoning":"matches rm -rf {a,b}"}\n```');
+    expect(r.decision).toBe('deny');
+    expect(r.reasoning).toContain('{a,b}');
+  });
+
+  test('free text mentioning a decision word still escalates (no keyword guessing)', () => {
+    const r = parseDecision('```\nI would approve this but it is risky\n```');
     expect(r.decision).toBe('escalate');
   });
 

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -115,6 +115,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     multichoice: 'skip',
     multichoice_model: '',
     escalate_model: '',
+    escalate_timeout: 0,
     disable_thinking: false,
   };
 }

--- a/packages/daemon/tests/auto-approve/json-extract.test.ts
+++ b/packages/daemon/tests/auto-approve/json-extract.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { extractJsonObject } from '../../src/auto-approve/json-extract.ts';
+
+describe('extractJsonObject', () => {
+  test('parses a bare object', () => {
+    expect(extractJsonObject('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  test('parses an object with surrounding whitespace', () => {
+    expect(extractJsonObject('  \n {"a":1}\n ')).toEqual({ a: 1 });
+  });
+
+  test('strips a ```json code fence', () => {
+    expect(extractJsonObject('```json\n{"decision":"approve"}\n```')).toEqual({
+      decision: 'approve',
+    });
+  });
+
+  test('strips a bare ``` fence with no language tag', () => {
+    expect(extractJsonObject('```\n{"decision":"deny"}\n```')).toEqual({ decision: 'deny' });
+  });
+
+  test('extracts the first balanced object after a preamble', () => {
+    expect(extractJsonObject('Sure, here it is: {"decision":"escalate"} done')).toEqual({
+      decision: 'escalate',
+    });
+  });
+
+  test('is string-aware: braces inside a string value do not miscount', () => {
+    expect(extractJsonObject('{"reasoning":"glob {a,b} and a } brace","decision":"deny"}')).toEqual(
+      {
+        reasoning: 'glob {a,b} and a } brace',
+        decision: 'deny',
+      },
+    );
+  });
+
+  test('honours escaped quotes inside string values', () => {
+    expect(extractJsonObject('{"reasoning":"a \\"quoted\\" word","decision":"approve"}')).toEqual({
+      reasoning: 'a "quoted" word',
+      decision: 'approve',
+    });
+  });
+
+  test('returns null for free text with no object', () => {
+    expect(extractJsonObject('I would approve this but it is risky')).toBeNull();
+  });
+
+  test('returns null for a JSON array (must be an object)', () => {
+    expect(extractJsonObject('[{"decision":"approve"}]')).toBeNull();
+  });
+
+  test('returns null for a JSON null/number literal', () => {
+    expect(extractJsonObject('null')).toBeNull();
+    expect(extractJsonObject('42')).toBeNull();
+  });
+
+  test('returns null for an unbalanced/truncated object', () => {
+    expect(extractJsonObject('{"decision":"approve"')).toBeNull();
+  });
+
+  test('parses a fenced object whose reasoning carries newlines', () => {
+    const raw = '```json\n{\n  "decision": "approve",\n  "reasoning": "safe\\nread"\n}\n```';
+    expect(extractJsonObject(raw)).toEqual({ decision: 'approve', reasoning: 'safe\nread' });
+  });
+});

--- a/packages/daemon/tests/auto-approve/json-extract.test.ts
+++ b/packages/daemon/tests/auto-approve/json-extract.test.ts
@@ -56,6 +56,21 @@ describe('extractJsonObject', () => {
     expect(extractJsonObject('```json\n[{"decision":"approve","reasoning":"x"}]\n```')).toBeNull();
   });
 
+  test('returns null for a PREAMBLE before an array (must not lift the inner object)', () => {
+    // Security guard (symmetric to the bare/fenced array cases): a preamble that
+    // precedes an array must escalate, never have the array's first object lifted
+    // out as the verdict.
+    expect(
+      extractJsonObject('Here is my answer: [{"decision":"approve","reasoning":"safe"}]'),
+    ).toBeNull();
+  });
+
+  test('returns null for a FENCED preamble before an array', () => {
+    expect(
+      extractJsonObject('```json\nResult: [{"decision":"approve","reasoning":"x"}]\n```'),
+    ).toBeNull();
+  });
+
   test('returns null for a JSON null/number literal', () => {
     expect(extractJsonObject('null')).toBeNull();
     expect(extractJsonObject('42')).toBeNull();

--- a/packages/daemon/tests/auto-approve/json-extract.test.ts
+++ b/packages/daemon/tests/auto-approve/json-extract.test.ts
@@ -50,6 +50,12 @@ describe('extractJsonObject', () => {
     expect(extractJsonObject('[{"decision":"approve"}]')).toBeNull();
   });
 
+  test('returns null for a FENCED JSON array (must not lift the inner object)', () => {
+    // Security guard: a fenced array must escalate, never have its first object
+    // extracted (which would flip escalate->approve on a crafted response).
+    expect(extractJsonObject('```json\n[{"decision":"approve","reasoning":"x"}]\n```')).toBeNull();
+  });
+
   test('returns null for a JSON null/number literal', () => {
     expect(extractJsonObject('null')).toBeNull();
     expect(extractJsonObject('42')).toBeNull();

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -65,6 +65,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     multichoice: 'skip',
     multichoice_model: '',
     escalate_model: '',
+    escalate_timeout: 0,
     disable_thinking: false,
     ...overrides,
   };

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -276,6 +276,15 @@ describe('parseMultiChoiceDecision', () => {
   test('escalates on JSON that is not an object', () => {
     const r = parseMultiChoiceDecision('"just a string"', 4);
     expect(r.decision).toBe('escalate');
-    expect(r.reasoning).toContain('not a JSON object');
+    expect(r.reasoning).toContain('no JSON object');
+  });
+
+  test('parses a markdown-fenced pick (qwen3.6:35b emits ```json fences)', () => {
+    const r = parseMultiChoiceDecision(
+      '```json\n{"decision":"pick","index":2,"reasoning":"opt 2"}\n```',
+      4,
+    );
+    expect(r.decision).toBe('pick');
+    if (r.decision === 'pick') expect(r.index).toBe(2);
   });
 });

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -330,6 +330,7 @@ function makeConfig(model: string): AutoApproveConfig {
     multichoice: 'skip',
     multichoice_model: '',
     escalate_model: '',
+    escalate_timeout: 0,
     disable_thinking: false,
   };
 }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -340,6 +340,7 @@ describe('auto_approve config', () => {
       multichoice: 'skip',
       multichoice_model: '',
       escalate_model: '',
+      escalate_timeout: 0,
       disable_thinking: false,
     });
   });


### PR DESCRIPTION
## Release 0.6.7

Makes auto-approve actually work with reasoning-tuned local models that fence
their JSON output (notably `qwen3.6:35b-mlx`). Found while diagnosing a live
session where a configured 35B second opinion escalated **every** permission,
including a plain `git commit`, despite the model returning `approve`.

### Fixed
- **Fenced-JSON verdicts are parsed, not escalated** (#533): `qwen3.6:35b-mlx`
  wraps every verdict in a ` ```json ` fence; the old strict `JSON.parse` threw
  on the backtick and fell back to escalate, so the model's `approve` became a
  question. New deterministic, string-aware `extractJsonObject` strips a fence or
  short preamble and parses the inner object, wired into both `parseDecision` and
  the multi-choice parser. Conservatism preserved: free text still escalates (no
  keyword guessing); a top-level array still escalates rather than lifting an
  inner object out as the verdict, including a preamble-before-array and a
  fenced array (the preamble-array hole was closed in review). Model sweep for
  `qwen3.6:35b-mlx`: **25/38 -> 37/38**, parse-fix only.

### Added
- **`escalate_timeout`** (`[auto_approve]`, seconds; `0` = reuse `timeout`): a
  longer budget for the usually-cold heavy second-opinion model so it no longer
  degrades into timeout-then-escalate.
- **Second-opinion warm-up**: on Ollama the daemon pre-loads `escalate_model` at
  startup (best-effort, `keep_alive` 30m) so the first escalation isn't cold.
- Startup banner logs `escalate_model` + `escalate_timeout` (a configured second
  opinion was previously invisible in the log).

### Review / validation
- PR #533 sonnet-reviewed (approve-path safety focus): the one finding (a
  preamble-before-array could lift an inner `approve`) was fixed + regression
  tested before merge; bare/fenced/preamble arrays and free text all escalate.
- All gates green on #533 and the changelog PR #549. json-extract: 15 tests.

Merge with a merge commit to trigger auto-release -> tag v0.6.7 -> npm + Homebrew
+ GitHub release; sync-develop bumps develop to the next dev line.

Note: watch the post-merge `main` run — the Test gate has flaked twice recently
(#532 isPortAvailable, #528 binder-teardown) and a flake there SKIPS auto-release
until a `gh run rerun <mainRunId> --failed`.