### PR TITLE
release prep: changelog 0.6.8 + fix env-fragile serialization test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-06-10
+
+Fixes the auto-approve regression where permissions piled up as questions
+whenever the model was busy. The evaluator was single-flight: any permission that
+arrived while another evaluation was already running escalated to the user with
+no model decision at all. During a burst (parallel subagents, fast tool
+sequences) or whenever the GPU was occupied with a slow model, this produced a
+flood of escalations even though the model's decisions were fine.
+
+### Fixed
+- **Concurrent permission evals now serialize instead of escalate-on-busy**
+  (#551): evaluations run one at a time (one GPU); a request that arrives while
+  another is in flight waits its turn and gets its own real decision rather than
+  being escalated. The deny / allow / group fast-paths stay instant and are never
+  queued.
+
+### Added
+- **`[auto_approve] queue_timeout`** (seconds, default 240; `0` = no bound): the
+  maximum a permission may wait in the serialization queue before escalating
+  gracefully, so a deep burst can never push a request toward the Claude Code
+  hook budget. Configurable via `REMI_AUTO_APPROVE_QUEUE_TIMEOUT`; shown in
+  `config show` and the startup banner.
+
 ## [0.6.7] - 2026-06-10
 
 Makes auto-approve actually work with reasoning-tuned local models. A model that

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -346,15 +346,17 @@ describe('AutoApproveService - concurrency serialization', () => {
       service.evaluate('Read', { file_path: '/tmp/test' }),
     ]);
 
-    // Neither carries the retired escalate-on-busy reasoning.
+    // The regression guard: under the OLD single-flight gate the second result
+    // carried 'Concurrent evaluation in progress' (an instant busy-bail). With
+    // serialization neither ever does — both take the real decision path and
+    // escalate via the failed LLM reach. (We do NOT assert durationMs: an
+    // unroutable IP hangs to the timeout on some networks but fails fast on
+    // others/CI. Deterministic serialization timing is covered in
+    // serialize.test.ts with a gated server.)
     expect(first.reasoning).not.toBe('Concurrent evaluation in progress');
     expect(second.reasoning).not.toBe('Concurrent evaluation in progress');
-    // Both actually ran the LLM (serialized), so both timed out -> escalate
-    // with a non-zero duration rather than an instant busy-bail.
     expect(first.decision).toBe('escalate');
     expect(second.decision).toBe('escalate');
-    expect(first.durationMs).toBeGreaterThan(0);
-    expect(second.durationMs).toBeGreaterThan(0);
   }, 15000);
 
   test('two independent service instances do not share a queue', async () => {


### PR DESCRIPTION
Changelog for 0.6.8 (auto-approve eval serialization + queue_timeout, #551), plus a fix to a #553 test whose durationMs assertion was environment-fragile (an unroutable IP hangs to timeout on some networks but fails fast on CI; serialization timing is deterministically covered in serialize.test.ts). Targets develop.