### PR TITLE
Release 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-06-10
+
+Fixes the auto-approve regression where permissions piled up as questions
+whenever the model was busy. The evaluator was single-flight: any permission that
+arrived while another evaluation was already running escalated to the user with
+no model decision at all. During a burst (parallel subagents, fast tool
+sequences) or whenever the GPU was occupied with a slow model, this produced a
+flood of escalations even though the model's decisions were fine.
+
+### Fixed
+- **Concurrent permission evals now serialize instead of escalate-on-busy**
+  (#551): evaluations run one at a time (one GPU); a request that arrives while
+  another is in flight waits its turn and gets its own real decision rather than
+  being escalated. The deny / allow / group fast-paths stay instant and are never
+  queued.
+
+### Added
+- **`[auto_approve] queue_timeout`** (seconds, default 240; `0` = no bound): the
+  maximum a permission may wait in the serialization queue before escalating
+  gracefully, so a deep burst can never push a request toward the Claude Code
+  hook budget. Configurable via `REMI_AUTO_APPROVE_QUEUE_TIMEOUT`; shown in
+  `config show` and the startup banner.
+
 ## [0.6.7] - 2026-06-10
 
 Makes auto-approve actually work with reasoning-tuned local models. A model that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.7",
+  "version": "0.6.8-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.8-dev.1",
+  "version": "0.6.8-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.8-dev.2",
+  "version": "0.6.8-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -95,10 +95,18 @@ export class AutoApproveService {
   private readonly escalateTimeoutMs: number;
   /** True when the provider is Ollama (enables the native warm-up load). */
   private readonly providerIsOllama: boolean;
-  /** Prevents concurrent evaluations. Second request escalates immediately. */
-  private evaluating = false;
+  /** Max ms a permission eval may wait in the serialization queue before it
+   *  escalates gracefully (#551); 0 = no bound. */
+  private readonly queueTimeoutMs: number;
+  /** Serialize LLM evals: one runs at a time (one GPU). Concurrent requests
+   *  QUEUE here instead of escalating-on-busy (#551). `evalActive` is true while
+   *  a slot is held; `evalQueue` holds the FIFO waiters. The fast-path
+   *  deny/allow/group checks run BEFORE acquiring a slot, so they are never
+   *  queued. */
+  private evalActive = false;
+  private readonly evalQueue: Array<{ grant: () => void }> = [];
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
-   *  aborts via this. Held alongside `evaluating` so they share the same
+   *  aborts via this. Held alongside the active slot so they share the same
    *  lifecycle window. */
   private currentAbortController: AbortController | null = null;
   /** Set by cancel() so the catch block can distinguish a user-driven abort
@@ -128,7 +136,55 @@ export class AutoApproveService {
     this.multichoiceModel = config.multichoice_model;
     this.escalateModel = config.escalate_model;
     this.escalateTimeoutMs = config.escalate_timeout > 0 ? config.escalate_timeout * 1000 : 0;
+    this.queueTimeoutMs = config.queue_timeout > 0 ? config.queue_timeout * 1000 : 0;
     this.providerIsOllama = config.provider === 'ollama';
+  }
+
+  /**
+   * Acquire the single eval slot, serializing concurrent LLM evaluations (one
+   * GPU). Resolves true when the slot is held; resolves false if the wait
+   * exceeded `deadlineMs` (the caller then escalates gracefully rather than
+   * risking the ~600s hook budget). When the slot is free it is taken
+   * immediately; otherwise the caller is queued FIFO and granted by
+   * `releaseSlot`.
+   */
+  private acquireSlot(deadlineMs: number): Promise<boolean> {
+    if (!this.evalActive) {
+      this.evalActive = true;
+      return Promise.resolve(true);
+    }
+    return new Promise<boolean>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const waiter = {
+        grant: () => {
+          if (timer !== null) clearTimeout(timer);
+          resolve(true);
+        },
+      };
+      this.evalQueue.push(waiter);
+      if (deadlineMs > 0) {
+        timer = setTimeout(() => {
+          const i = this.evalQueue.indexOf(waiter);
+          if (i !== -1) {
+            this.evalQueue.splice(i, 1);
+            resolve(false);
+          }
+        }, deadlineMs);
+      }
+    });
+  }
+
+  /**
+   * Release the eval slot. Hands it to the next FIFO waiter (the slot stays
+   * active, just changes owner) or marks the evaluator idle when none wait.
+   */
+  private releaseSlot(): void {
+    const next = this.evalQueue.shift();
+    if (next) {
+      next.grant();
+    } else {
+      this.evalActive = false;
+    }
   }
 
   /**
@@ -252,17 +308,18 @@ export class AutoApproveService {
         return { decision: 'escalate', reasoning, durationMs: 0, model };
       }
 
-      if (this.evaluating) {
-        this.logFn(`${prefix} Concurrent evaluation blocked, escalating to user`);
-        return {
-          decision: 'escalate',
-          reasoning: 'Concurrent evaluation in progress',
-          durationMs: 0,
-          model,
-        };
+      // Serialize concurrent evals (#551): one LLM call at a time (one GPU).
+      // A second request QUEUES instead of escalating-on-busy; only a request
+      // that waits past queue_timeout escalates gracefully so a deep burst
+      // (parallel subagents) never risks the ~600s hook budget.
+      const acquired = await this.acquireSlot(this.queueTimeoutMs);
+      if (!acquired) {
+        const durationMs = Date.now() - start;
+        const reasoning = `eval queue wait exceeded ${this.queueTimeoutMs}ms; escalating to user`;
+        this.logFn(`${prefix} ${toolName}: escalate (${durationMs}ms) - ${reasoning}`);
+        return { decision: 'escalate', reasoning, durationMs, model };
       }
 
-      this.evaluating = true;
       this.currentAbortController = new AbortController();
       const externalSignal = this.currentAbortController.signal;
       // The heavy escalate_model gets its dedicated (longer) budget when set, so
@@ -362,8 +419,8 @@ export class AutoApproveService {
         return result;
       } finally {
         if (raceTimer !== null) clearTimeout(raceTimer);
-        this.evaluating = false;
         this.currentAbortController = null;
+        this.releaseSlot();
       }
     } catch (err) {
       const durationMs = Date.now() - start;

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -144,6 +144,15 @@ export interface AutoApproveConfig {
    */
   readonly escalate_timeout: number;
   /**
+   * Max seconds a permission eval may WAIT in the serialization queue before it
+   * escalates gracefully (#551). Evals run one at a time (one GPU); concurrent
+   * requests queue instead of escalating. Under a deep burst (parallel
+   * subagents) a request could otherwise wait long enough to risk the Claude
+   * Code hook budget (~600s). A waiter queued longer than this escalates to the
+   * user instead of hanging. 0 = no bound (wait until granted). Default 240.
+   */
+  readonly queue_timeout: number;
+  /**
    * Ollama only: route through the native /api/chat with `think: false` to
    * turn OFF the model's reasoning. This is FASTER but lowers decision quality
    * — live testing showed the chain-of-thought is load-bearing for following

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.8-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.8-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.8-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.8-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.7'; // REMI_COMPILED_VERSION
+      return '0.6.8-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.7'; // REMI_COMPILED_VERSION
+    return '0.6.8-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -780,8 +780,9 @@ let autoApproveService: AutoApproveService | null = null;
     const escalateSummary = aaCfg.escalate_model
       ? `escalate_model=${aaCfg.escalate_model}${aaCfg.escalate_timeout > 0 ? ` (timeout=${aaCfg.escalate_timeout}s)` : ''}`
       : 'escalate_model=none';
+    const queueSummary = `queue_timeout=${aaCfg.queue_timeout > 0 ? `${aaCfg.queue_timeout}s` : 'none'}`;
     writeToLog(
-      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}, ${mcSummary}, ${escalateSummary}`,
+      `[AutoApprove] Enabled: model=${model}, provider=${provider}, base_url=${baseUrl}, ${rulesSummary}, ${mcSummary}, ${escalateSummary}, ${queueSummary}`,
     );
     // Warm-load the heavy second-opinion model so the first escalation is not a
     // cold start. Best-effort, fire-and-forget (never blocks daemon startup).

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.8-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.8-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.8-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.8-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -164,6 +164,10 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // `timeout`. Set higher (e.g. 90) when escalate_model is a large, often-cold
     // model so its first-call load penalty does not abort into an error.
     escalate_timeout: 0,
+    // Max seconds a permission eval may wait in the serialization queue before
+    // escalating (#551). Concurrent evals run one at a time; a deep burst could
+    // otherwise wait long enough to risk the ~600s hook budget. 0 = no bound.
+    queue_timeout: 240,
     // Keep the model's reasoning ON by default: live testing showed it is
     // load-bearing for following broad user instructions. Opt in (Ollama only)
     // for raw speed over decision nuance.
@@ -307,6 +311,16 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   ) {
     throw new Error(
       `Invalid auto_approve.escalate_timeout in ${configPath}: must be a non-negative number (seconds; 0 = use timeout), got ${typeof cfg.escalate_timeout === 'string' ? `string "${cfg.escalate_timeout}"` : typeof cfg.escalate_timeout}. Example: escalate_timeout = 90`,
+    );
+  }
+
+  if (
+    typeof cfg.queue_timeout !== 'number' ||
+    !Number.isFinite(cfg.queue_timeout) ||
+    cfg.queue_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.queue_timeout in ${configPath}: must be a non-negative number (seconds; 0 = no bound), got ${typeof cfg.queue_timeout === 'string' ? `string "${cfg.queue_timeout}"` : typeof cfg.queue_timeout}. Example: queue_timeout = 240`,
     );
   }
 
@@ -503,6 +517,12 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       (auto_approve as { escalate_timeout: number }).escalate_timeout = parsed;
     }
   }
+  if (env['REMI_AUTO_APPROVE_QUEUE_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_QUEUE_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { queue_timeout: number }).queue_timeout = parsed;
+    }
+  }
 
   // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
   const features = { ...config.features };
@@ -606,6 +626,10 @@ authorized_user_ids = []
 #                                  # Raise (e.g. 90) for a large, often-cold
 #                                  # second-opinion model so its first-call load
 #                                  # does not abort into an error->escalate.
+# queue_timeout = 240              # Max seconds an eval waits in the serial
+#                                  # queue before escalating. Concurrent evals
+#                                  # run one at a time; a deep burst could risk
+#                                  # the ~600s hook budget. 0 = no bound.
 # disable_thinking = false         # Ollama only: native /api/chat with
 #                                  # think:false (no reasoning). Faster but
 #                                  # lowers decision quality (reasoning helps
@@ -694,6 +718,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  multichoice_model = "${config.auto_approve.multichoice_model}"`);
   lines.push(`  escalate_model = "${config.auto_approve.escalate_model}"`);
   lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
+  lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -51,6 +51,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     multichoice_model: '',
     escalate_model: '',
     escalate_timeout: 0,
+    queue_timeout: 240,
     disable_thinking: false,
     ...overrides,
   };
@@ -326,12 +327,15 @@ describe('AutoApproveService - error handling', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AutoApproveService - concurrency guard
+// AutoApproveService - concurrency serialization (#551)
 // ---------------------------------------------------------------------------
-describe('AutoApproveService - concurrency guard', () => {
-  test('second concurrent evaluation escalates immediately', async () => {
-    // Use an unroutable IP so the first request stays in-flight long enough
-    // for the second to race against the concurrency flag.
+describe('AutoApproveService - concurrency serialization', () => {
+  test('concurrent evaluations serialize instead of escalate-on-busy', async () => {
+    // #551: a second request that arrives while the first eval is in flight
+    // must QUEUE and get its own real decision, NOT escalate-on-busy. Use an
+    // unroutable IP so both calls reach the LLM path and time out; the old
+    // behavior gave the second an instant (0ms) "Concurrent evaluation in
+    // progress" escalate, the new behavior runs both (durationMs > 0).
     const service = new AutoApproveService(
       makeConfig({ base_url: 'http://10.255.255.1', timeout: 3 }),
       logFn,
@@ -342,18 +346,20 @@ describe('AutoApproveService - concurrency guard', () => {
       service.evaluate('Read', { file_path: '/tmp/test' }),
     ]);
 
-    const decisions = [first, second];
-    const concurrentResult = decisions.find(
-      (d) => d.reasoning === 'Concurrent evaluation in progress',
-    );
-    expect(concurrentResult).toBeDefined();
-    expect(concurrentResult?.decision).toBe('escalate');
-    expect(concurrentResult?.durationMs).toBe(0);
-  }, 10000);
+    // Neither carries the retired escalate-on-busy reasoning.
+    expect(first.reasoning).not.toBe('Concurrent evaluation in progress');
+    expect(second.reasoning).not.toBe('Concurrent evaluation in progress');
+    // Both actually ran the LLM (serialized), so both timed out -> escalate
+    // with a non-zero duration rather than an instant busy-bail.
+    expect(first.decision).toBe('escalate');
+    expect(second.decision).toBe('escalate');
+    expect(first.durationMs).toBeGreaterThan(0);
+    expect(second.durationMs).toBeGreaterThan(0);
+  }, 15000);
 
-  test('two independent service instances do not share state', async () => {
+  test('two independent service instances do not share a queue', async () => {
     // Regression: in a multi-session daemon, each session should have its own
-    // AutoApproveService instance so they do not serialize through one flag.
+    // AutoApproveService instance so they do not serialize through one queue.
     const serviceA = new AutoApproveService(
       makeConfig({ base_url: 'http://10.255.255.1', timeout: 3 }),
       logFn,
@@ -363,7 +369,7 @@ describe('AutoApproveService - concurrency guard', () => {
       logFn,
     );
 
-    // Both run concurrently; neither should trip the other's concurrency guard.
+    // Both run concurrently; neither should queue behind the other's slot.
     const [a, b] = await Promise.all([
       serviceA.evaluate('Bash', { command: 'ls' }, 'sessA'),
       serviceB.evaluate('Bash', { command: 'pwd' }, 'sessB'),
@@ -371,17 +377,17 @@ describe('AutoApproveService - concurrency guard', () => {
 
     expect(a.decision).toBe('escalate');
     expect(b.decision).toBe('escalate');
-    // Neither should hit the shared-state guard
+    // Neither should hit the retired shared-state busy guard
     expect(a.reasoning).not.toBe('Concurrent evaluation in progress');
     expect(b.reasoning).not.toBe('Concurrent evaluation in progress');
-  }, 10000);
+  }, 15000);
 });
 
 // ---------------------------------------------------------------------------
 // AutoApproveService - session tag in logs (multi-session visibility)
 // ---------------------------------------------------------------------------
 describe('AutoApproveService - session tag in logs', () => {
-  test('tag appears in concurrency-blocked log', async () => {
+  test('tag appears in logs for serialized concurrent evals', async () => {
     const logs: string[] = [];
     const tagLogFn = (msg: string) => logs.push(msg);
     const service = new AutoApproveService(
@@ -389,17 +395,15 @@ describe('AutoApproveService - session tag in logs', () => {
       tagLogFn,
     );
 
-    // Start one, race a second before it completes
+    // Start one, queue a second behind it; both produce tagged logs.
     const [,] = await Promise.all([
       service.evaluate('Bash', { command: 'first' }, 'abc12345'),
       service.evaluate('Bash', { command: 'second' }, 'abc12345'),
     ]);
 
-    const hasTaggedBlock = logs.some((l) =>
-      l.includes('[AutoApprove abc12345] Concurrent evaluation blocked'),
-    );
-    expect(hasTaggedBlock).toBe(true);
-  }, 10000);
+    const hasTagged = logs.some((l) => l.includes('[AutoApprove abc12345]'));
+    expect(hasTagged).toBe(true);
+  }, 15000);
 
   test('tag appears in error log on unreachable LLM', async () => {
     const logs: string[] = [];

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -346,15 +346,17 @@ describe('AutoApproveService - concurrency serialization', () => {
       service.evaluate('Read', { file_path: '/tmp/test' }),
     ]);
 
-    // Neither carries the retired escalate-on-busy reasoning.
+    // The regression guard: under the OLD single-flight gate the second result
+    // carried 'Concurrent evaluation in progress' (an instant busy-bail). With
+    // serialization neither ever does — both take the real decision path and
+    // escalate via the failed LLM reach. (We do NOT assert durationMs: an
+    // unroutable IP hangs to the timeout on some networks but fails fast on
+    // others/CI. Deterministic serialization timing is covered in
+    // serialize.test.ts with a gated server.)
     expect(first.reasoning).not.toBe('Concurrent evaluation in progress');
     expect(second.reasoning).not.toBe('Concurrent evaluation in progress');
-    // Both actually ran the LLM (serialized), so both timed out -> escalate
-    // with a non-zero duration rather than an instant busy-bail.
     expect(first.decision).toBe('escalate');
     expect(second.decision).toBe('escalate');
-    expect(first.durationMs).toBeGreaterThan(0);
-    expect(second.durationMs).toBeGreaterThan(0);
   }, 15000);
 
   test('two independent service instances do not share a queue', async () => {

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -116,6 +116,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     multichoice_model: '',
     escalate_model: '',
     escalate_timeout: 0,
+    queue_timeout: 240,
     disable_thinking: false,
   };
 }
@@ -215,19 +216,9 @@ describe('AutoApproveService.cancel()', () => {
     expect(result.reasoning).toContain('user-answered');
   });
 
-  test('concurrent eval: second call escalates while first is in flight', async () => {
-    const svc = new AutoApproveService(makeConfig(60), noLog);
-    const first = svc.evaluate('Bash', { command: 'ls' });
-    await hanging.awaitNextRequest();
-
-    const second = await svc.evaluate('Bash', { command: 'pwd' });
-    expect(second.decision).toBe('escalate');
-    expect(second.reasoning).toMatch(/concurrent/i);
-
-    svc.cancel('cleanup');
-    const firstResult = await first;
-    expect(firstResult.decision).toBe('cancelled');
-  });
+  // NOTE: escalate-on-busy was retired in #551 — concurrent evals now serialize
+  // (a second request queues instead of escalating). That behavior, including
+  // the cancel-drains-the-queue interaction, is covered in serialize.test.ts.
 
   test('hard-kill timer does not abort a subsequent successful eval', async () => {
     // Regression: prior implementation never cleared the race timer when

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -66,6 +66,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     multichoice_model: '',
     escalate_model: '',
     escalate_timeout: 0,
+    queue_timeout: 240,
     disable_thinking: false,
     ...overrides,
   };

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -331,6 +331,7 @@ function makeConfig(model: string): AutoApproveConfig {
     multichoice_model: '',
     escalate_model: '',
     escalate_timeout: 0,
+    queue_timeout: 240,
     disable_thinking: false,
   };
 }

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for AutoApproveService eval serialization (#551).
+ *
+ * Concurrent permission evals run ONE at a time (one GPU): a second request
+ * that arrives while the first is in flight QUEUES and gets its own real
+ * decision instead of escalating-on-busy (the regression that produced 496
+ * "Concurrent evaluation blocked" escalations in a live log). A waiter that
+ * sits in the queue past `queue_timeout` escalates gracefully so a deep burst
+ * never risks the Claude Code hook budget.
+ *
+ * Uses a local Bun.serve gate fixture that holds each request until released
+ * (a real server, no mocks) so serialization is observed deterministically by
+ * counting inbound LLM requests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+
+interface GatedServer {
+  url: string;
+  /** Count of inbound LLM requests seen so far. */
+  requestCount: () => number;
+  /** Resolves the next time a request enters the server. Grab BEFORE the call. */
+  awaitNextRequest: () => Promise<void>;
+  /** Release the oldest held request with a valid approve response. */
+  releaseNext: () => void;
+  /** Release ALL currently-held requests (incl. ones whose client aborted). */
+  releaseAll: () => void;
+  stop: () => void;
+}
+
+function startGatedServer(): GatedServer {
+  let count = 0;
+  const held: Array<(r: Response) => void> = [];
+  let nextResolver: (() => void) | null = null;
+  let next: Promise<void> = new Promise<void>((r) => {
+    nextResolver = r;
+  });
+  const approve = (): Response =>
+    new Response(
+      JSON.stringify({
+        choices: [{ message: { content: '{"decision":"approve","reasoning":"ok"}' } }],
+        model: 'test-model',
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  const server = Bun.serve({
+    port: 0,
+    fetch: (): Promise<Response> => {
+      count++;
+      nextResolver?.();
+      next = new Promise<void>((r) => {
+        nextResolver = r;
+      });
+      return new Promise<Response>((resolve) => {
+        held.push(resolve);
+      });
+    },
+  });
+  return {
+    url: `http://localhost:${server.port}/v1`,
+    requestCount: () => count,
+    awaitNextRequest: () => next,
+    releaseNext: () => {
+      const r = held.shift();
+      if (r) r(approve());
+    },
+    releaseAll: () => {
+      while (held.length > 0) {
+        held.shift()?.(approve());
+      }
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+let gate: GatedServer;
+beforeEach(() => {
+  gate = startGatedServer();
+});
+afterEach(() => {
+  gate.stop();
+});
+
+function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
+  return {
+    enabled: true,
+    // provider = the bare URL: resolveProviderUrl returns it as-is, so the
+    // OpenAI-compat path posts to the local gate (same trick as cancel.test).
+    provider: gate.url,
+    model: 'test-model',
+    api_key: '',
+    base_url: gate.url,
+    timeout: 30,
+    log_decisions: false,
+    allow: [],
+    deny: [],
+    approve_groups: [],
+    deny_groups: [],
+    instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
+    escalate_model: '',
+    escalate_timeout: 0,
+    queue_timeout: 240,
+    disable_thinking: false,
+    ...overrides,
+  };
+}
+
+const noLog = (_msg: string): void => {};
+
+describe('AutoApproveService - eval serialization (#551)', () => {
+  test('a second eval queues behind the first and runs only after it releases', async () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    const firstReq = gate.awaitNextRequest();
+    const aP = svc.evaluate('Bash', { command: 'cmdA' });
+    const bP = svc.evaluate('Bash', { command: 'cmdB' });
+
+    await firstReq; // A reached the LLM and holds the single slot
+    // Give B a chance to (wrongly) run concurrently. With serialization it
+    // stays queued, so the server has still only seen ONE request.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(gate.requestCount()).toBe(1);
+
+    const secondReq = gate.awaitNextRequest();
+    gate.releaseNext(); // A resolves -> releases its slot -> B is granted
+    const a = await aP;
+    await secondReq; // B reaches the LLM only AFTER A finished
+    expect(gate.requestCount()).toBe(2);
+
+    gate.releaseNext(); // B resolves
+    const b = await bP;
+
+    // Both got real decisions; B was never escalate-on-busy.
+    expect(a.decision).toBe('approve');
+    expect(b.decision).toBe('approve');
+    expect(b.reasoning).not.toBe('Concurrent evaluation in progress');
+  });
+
+  test('a waiter past queue_timeout escalates gracefully without hitting the LLM', async () => {
+    // 0.05s = 50ms queue deadline.
+    const svc = new AutoApproveService(makeConfig({ queue_timeout: 0.05 }), noLog);
+    const firstReq = gate.awaitNextRequest();
+    const aP = svc.evaluate('Bash', { command: 'cmdA' });
+    const bP = svc.evaluate('Bash', { command: 'cmdB' });
+
+    await firstReq; // A holds the slot (server keeps the request open)
+    const b = await bP; // B waits 50ms in the queue, then escalates
+    expect(b.decision).toBe('escalate');
+    expect(b.reasoning).toContain('queue wait exceeded');
+    expect(gate.requestCount()).toBe(1); // B never reached the LLM
+
+    gate.releaseNext(); // let A finish cleanly
+    const a = await aP;
+    expect(a.decision).toBe('approve');
+  });
+
+  test('three concurrent evals all get real decisions, draining FIFO', async () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    const r1 = gate.awaitNextRequest();
+    const p1 = svc.evaluate('Bash', { command: 'c1' });
+    const p2 = svc.evaluate('Bash', { command: 'c2' });
+    const p3 = svc.evaluate('Bash', { command: 'c3' });
+
+    await r1;
+    expect(gate.requestCount()).toBe(1); // only the first runs; 2 + 3 queued
+
+    const r2 = gate.awaitNextRequest();
+    gate.releaseNext();
+    expect((await p1).decision).toBe('approve');
+    await r2;
+    expect(gate.requestCount()).toBe(2);
+
+    const r3 = gate.awaitNextRequest();
+    gate.releaseNext();
+    expect((await p2).decision).toBe('approve');
+    await r3;
+    expect(gate.requestCount()).toBe(3);
+
+    gate.releaseNext();
+    expect((await p3).decision).toBe('approve');
+  });
+
+  test('cancel() during a queued burst aborts the in-flight eval and drains the rest', async () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    const r1 = gate.awaitNextRequest();
+    const p1 = svc.evaluate('Bash', { command: 'c1' });
+    const p2 = svc.evaluate('Bash', { command: 'c2' });
+
+    await r1; // c1 holds the slot
+    expect(svc.cancel('PostToolUse')).toBe(true); // abort the in-flight c1
+    const d1 = await p1;
+    expect(d1.decision).toBe('cancelled');
+
+    // c1's slot is released on cancel -> c2 is granted and reaches the LLM.
+    const r2 = gate.awaitNextRequest();
+    await r2;
+    expect(gate.requestCount()).toBe(2);
+    // releaseAll drains c1's orphaned (aborted) holder AND resolves c2.
+    gate.releaseAll();
+    expect((await p2).decision).toBe('approve');
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -341,6 +341,7 @@ describe('auto_approve config', () => {
       multichoice_model: '',
       escalate_model: '',
       escalate_timeout: 0,
+      queue_timeout: 240,
       disable_thinking: false,
     });
   });


### PR DESCRIPTION
## Release 0.6.8

Fixes the auto-approve regression where permissions piled up as questions
whenever the model was busy.

### Fixed
- **Concurrent permission evals serialize instead of escalate-on-busy** (#551,
  PR #553): the evaluator was single-flight, so any permission arriving while
  another eval ran escalated with NO model decision (a live log had 496
  `Concurrent evaluation blocked` lines; worst during parallel-subagent bursts
  or a busy GPU). Evals now run one at a time (one GPU) and a second request
  queues for its own real decision; the deny/allow/group fast-paths stay instant.

### Added
- **`[auto_approve] queue_timeout`** (seconds, default 240; `0` = no bound): max
  a permission may wait in the serialization queue before escalating gracefully,
  so a deep burst never risks the ~600s Claude Code hook budget. Env
  `REMI_AUTO_APPROVE_QUEUE_TIMEOUT`; shown in `config show` + the startup banner.

### Review / validation
- PR #553 sonnet-reviewed (concurrency safety): no slot leak/deadlock, atomic
  acquire, no deadline double-resolve, correct cancel/controller handoff,
  hook-budget safe.
- New `serialize.test.ts` (real Bun.serve gate, no mocks): queue-behind-first,
  deadline-escalate, FIFO drain, cancel-drains-queue. An env-fragile timing
  assertion from the first cut was removed before release.
- All gates green on #553 and #554.

Merge with a merge commit -> auto-release -> tag v0.6.8 -> npm + Homebrew +
GitHub. Watch the post-merge main run (Test gate has flaked: #532 / #528).