### PR TITLE
fix(auto-approve): long PermissionRequest hook timeout + stop dropping verdicts on PostToolUse (#537)

### DIFF
--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -23,8 +23,9 @@
  * auto-approve eval and injects "1"/"3"/pick into the PTY, escalates to the user,
  * or default-denies a subagent prompt no one can answer. The gate is wired with
  * the bridge's `isInSubagentContext` + the router's `onPermissionRequest` as
- * callbacks; Pre/PostToolUse/Stop/SessionEnd call `gate.cancelStale()` to abort a
- * stale in-flight eval once Claude has advanced past the prompt.
+ * callbacks; Stop/SessionEnd call `gate.cancelStale()` to abort an in-flight eval
+ * when the Claude session actually ends. (Pre/PostToolUse deliberately do NOT
+ * cancel — under synchronous decisions the eval is never stale; see #537.)
  *
  * This listener block IS the per-session hook router (admit-then-fan-out); a
  * formal HookRouter class is deferred until the shadow/drive dual path is
@@ -983,7 +984,13 @@ export function setupHookBridge(
     shadowDecide('PreToolUse', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
-    autoApproveGate.cancelStale('PreToolUse');
+    // NB: do NOT cancel the in-flight auto-approve eval here (#537). Under
+    // synchronous decisions (#496) Claude BLOCKS on the PermissionRequest until
+    // the daemon answers, so a running eval is never stale — it is the verdict
+    // Claude is waiting for. A PreToolUse/PostToolUse for a PREVIOUS tool would
+    // otherwise abort the NEXT permission's eval mid-flight ("Decision dropped"),
+    // dropping a decision that was about to approve. Only Stop/SessionEnd (a real
+    // session-end) cancel an eval now.
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
@@ -993,7 +1000,8 @@ export function setupHookBridge(
     shadowDecide('PostToolUse', input);
     if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return;
     if (isSubagentEvent(input)) return;
-    autoApproveGate.cancelStale('PostToolUse');
+    // See the PreToolUse note above: no cancelStale here (#537). The previous
+    // tool's PostToolUse must not abort the next permission's in-flight eval.
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -26,6 +26,24 @@ interface HookMatcher {
   hooks: HookEntry[];
 }
 
+/**
+ * Seconds Claude Code waits for a hook's HTTP response before proceeding
+ * WITHOUT it. PermissionRequest must outlast the synchronous auto-approve eval
+ * (#496/#537): a heavy local model plus the serialization queue can take far
+ * longer than a few seconds, and at the old blanket 5s Claude Code gave up and
+ * showed its own prompt before the daemon's verdict arrived (so a decision that
+ * WOULD approve landed too late). A dead daemon still fails fast (connection
+ * refused), so the long timeout only delays while the daemon is actively
+ * deciding. Every other hook keeps the short timeout so a slow/dead daemon never
+ * gates worktree creation / prompt submission / compaction (#203).
+ */
+const PERMISSION_REQUEST_HOOK_TIMEOUT = 300;
+const DEFAULT_HOOK_TIMEOUT = 5;
+
+function hookTimeoutFor(event: string): number {
+  return event === 'PermissionRequest' ? PERMISSION_REQUEST_HOOK_TIMEOUT : DEFAULT_HOOK_TIMEOUT;
+}
+
 interface ClaudeSettings {
   hooks?: Record<string, HookMatcher[]>;
   [key: string]: unknown;
@@ -80,12 +98,6 @@ export class HookConfigManager {
       settings.hooks = {};
     }
 
-    const remiHookEntry: HookEntry = {
-      type: 'http',
-      url: this.hookUrl,
-      timeout: 5,
-    };
-
     // Register only the subset of events remi actually consumes. Registering
     // every event in HOOK_EVENT_NAMES forces Claude Code into a synchronous
     // HTTP call to remi for every Worktree/UserPrompt/etc. event — and a
@@ -98,14 +110,23 @@ export class HookConfigManager {
       }
 
       const matchers = settings.hooks[event];
-      const alreadyInstalled = matchers.some(
-        (m) =>
-          Array.isArray(m.hooks) &&
-          m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
-      );
+      const desiredTimeout = hookTimeoutFor(event);
+      // Reconcile any existing remi hook for this event to the desired timeout
+      // (so an upgrade — e.g. the #537 PermissionRequest bump — takes effect for
+      // an already-registered hook), and add it when missing.
+      let installed = false;
+      for (const m of matchers) {
+        if (!Array.isArray(m.hooks)) continue;
+        for (const h of m.hooks) {
+          if (h.type === 'http' && h.url === this.hookUrl) {
+            installed = true;
+            h.timeout = desiredTimeout;
+          }
+        }
+      }
 
-      if (!alreadyInstalled) {
-        matchers.push({ hooks: [{ ...remiHookEntry }] });
+      if (!installed) {
+        matchers.push({ hooks: [{ type: 'http', url: this.hookUrl, timeout: desiredTimeout }] });
       }
     }
 
@@ -160,8 +181,13 @@ export class HookConfigManager {
 
     return REMI_REGISTERED_HOOK_EVENTS.every((event) => {
       const matchers = settings.hooks?.[event];
+      // Require the correct timeout too, so a stale registration (e.g. the old
+      // blanket 5s PermissionRequest hook) reports as not-installed and triggers
+      // a reconcile on the next install() (#537).
       return matchers?.some((m) =>
-        m.hooks.some((h) => h.type === 'http' && h.url === this.hookUrl),
+        m.hooks.some(
+          (h) => h.type === 'http' && h.url === this.hookUrl && h.timeout === hookTimeoutFor(event),
+        ),
       );
     });
   }

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -36,8 +36,15 @@ interface HookMatcher {
  * refused), so the long timeout only delays while the daemon is actively
  * deciding. Every other hook keeps the short timeout so a slow/dead daemon never
  * gates worktree creation / prompt submission / compaction (#203).
+ *
+ * 600s = Claude Code's hook-budget ceiling, chosen so a verdict is never dropped
+ * even for the heaviest realistic config: the auto-approve worst case is roughly
+ * `queue_timeout` (default 240s) + `timeout` (user-configurable, e.g. 120s) =
+ * 360s, which a 300s ceiling would still drop. The eval itself self-limits
+ * (`timeout`) and queued requests escalate at `queue_timeout`, so the daemon
+ * always answers well within 600s; this is a ceiling, not a typical wait.
  */
-const PERMISSION_REQUEST_HOOK_TIMEOUT = 300;
+const PERMISSION_REQUEST_HOOK_TIMEOUT = 600;
 const DEFAULT_HOOK_TIMEOUT = 5;
 
 function hookTimeoutFor(event: string): number {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1713,7 +1713,10 @@ describe('setupHookBridge', () => {
   // Issue #387: cancel stale auto-approve LLM eval on advance signals
   // -------------------------------------------------------------------------
 
-  test('PreToolUse cancels stale auto-approve LLM eval', () => {
+  test('#537: PreToolUse does NOT cancel the in-flight auto-approve eval', () => {
+    // Under synchronous decisions Claude blocks on the PermissionRequest, so a
+    // running eval is the verdict it is waiting for — a previous tool's
+    // PreToolUse must not abort it (that dropped decisions about to approve).
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
     hookServer.fire('SessionStart', {
@@ -1729,10 +1732,10 @@ describe('setupHookBridge', () => {
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
     });
-    expect(cancelLog).toContain('PreToolUse');
+    expect(cancelLog).not.toContain('PreToolUse');
   });
 
-  test('PostToolUse cancels stale auto-approve LLM eval', () => {
+  test('#537: PostToolUse does NOT cancel the in-flight auto-approve eval', () => {
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
     hookServer.fire('SessionStart', {
@@ -1749,7 +1752,7 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
       tool_response: 'ok',
     });
-    expect(cancelLog).toContain('PostToolUse');
+    expect(cancelLog).not.toContain('PostToolUse');
   });
 
   test('Stop cancels stale auto-approve LLM eval', () => {

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -77,8 +77,46 @@ describe('HookConfigManager', () => {
       expect(hooks?.length).toBe(1);
       expect(hooks?.[0]?.type).toBe('http');
       expect(hooks?.[0]?.url).toBe(hookUrl);
-      expect(hooks?.[0]?.timeout).toBe(5);
+      // PermissionRequest must outlast the synchronous auto-approve eval (#537);
+      // every other hook keeps the short fail-fast timeout (#203).
+      expect(hooks?.[0]?.timeout).toBe(event === 'PermissionRequest' ? 300 : 5);
     }
+  });
+
+  it('#537: PermissionRequest gets a long timeout; other hooks stay short', async () => {
+    await manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, Array<{ hooks: Array<{ url: string; timeout: number }> }>>;
+    };
+    const permHook = settings.hooks['PermissionRequest']
+      ?.find((m) => m.hooks.some((h) => h.url === hookUrl))
+      ?.hooks.find((h) => h.url === hookUrl);
+    expect(permHook?.timeout).toBe(300);
+    // A representative non-permission hook keeps the short timeout.
+    const stopHook = settings.hooks['Stop']
+      ?.find((m) => m.hooks.some((h) => h.url === hookUrl))
+      ?.hooks.find((h) => h.url === hookUrl);
+    expect(stopHook?.timeout).toBe(5);
+  });
+
+  it('#537: install() reconciles a stale 5s PermissionRequest hook up to the long timeout', async () => {
+    // Simulate a settings file from a pre-#537 remi: PermissionRequest registered
+    // with the old blanket 5s. install() must update it in place, not duplicate.
+    const stale = {
+      hooks: { PermissionRequest: [{ hooks: [{ type: 'http', url: hookUrl, timeout: 5 }] }] },
+    };
+    writeSettings(stale);
+    expect(manager.isInstalled()).toBe(false); // stale timeout reports not-installed
+
+    await manager.install();
+    const settings = readSettings() as {
+      hooks: Record<string, Array<{ hooks: Array<{ url: string; timeout: number }> }>>;
+    };
+    const permMatchers = settings.hooks['PermissionRequest'];
+    const remiHooks = permMatchers?.flatMap((m) => m.hooks.filter((h) => h.url === hookUrl)) ?? [];
+    expect(remiHooks.length).toBe(1); // reconciled in place, not duplicated
+    expect(remiHooks[0]?.timeout).toBe(300);
+    expect(manager.isInstalled()).toBe(true);
   });
 
   it('regression #203: install() drops legacy remi entries for events it no longer registers', async () => {

--- a/packages/daemon/tests/hooks/hook-config-manager.test.ts
+++ b/packages/daemon/tests/hooks/hook-config-manager.test.ts
@@ -79,7 +79,7 @@ describe('HookConfigManager', () => {
       expect(hooks?.[0]?.url).toBe(hookUrl);
       // PermissionRequest must outlast the synchronous auto-approve eval (#537);
       // every other hook keeps the short fail-fast timeout (#203).
-      expect(hooks?.[0]?.timeout).toBe(event === 'PermissionRequest' ? 300 : 5);
+      expect(hooks?.[0]?.timeout).toBe(event === 'PermissionRequest' ? 600 : 5);
     }
   });
 
@@ -91,7 +91,7 @@ describe('HookConfigManager', () => {
     const permHook = settings.hooks['PermissionRequest']
       ?.find((m) => m.hooks.some((h) => h.url === hookUrl))
       ?.hooks.find((h) => h.url === hookUrl);
-    expect(permHook?.timeout).toBe(300);
+    expect(permHook?.timeout).toBe(600);
     // A representative non-permission hook keeps the short timeout.
     const stopHook = settings.hooks['Stop']
       ?.find((m) => m.hooks.some((h) => h.url === hookUrl))
@@ -115,7 +115,7 @@ describe('HookConfigManager', () => {
     const permMatchers = settings.hooks['PermissionRequest'];
     const remiHooks = permMatchers?.flatMap((m) => m.hooks.filter((h) => h.url === hookUrl)) ?? [];
     expect(remiHooks.length).toBe(1); // reconciled in place, not duplicated
-    expect(remiHooks[0]?.timeout).toBe(300);
+    expect(remiHooks[0]?.timeout).toBe(600);
     expect(manager.isInstalled()).toBe(true);
   });
 


### PR DESCRIPTION
Closes #537.

## Problem

Auto-approve computes the right verdict but it never reaches Claude when the eval
is slow — the user hand-approves safe commands. Two causes, both surfaced by a
heavy local model (qwen3.6:35b, 4-23s evals):

1. **Hook timeout 5s < eval time.** Remi registered EVERY hook with `timeout: 5`
   (`hook-config-manager.ts`). Claude Code waits 5s for the PermissionRequest
   hook, then gives up and shows its native prompt. The daemon's eval finishes at
   ~6s and logs `approve`, but too late. (This is why `auto_approve.timeout=120`
   didn't help — that's how long the eval RUNS, not how long Claude WAITS.)
2. **PostToolUse cancels the in-flight eval.** A previous tool's `PostToolUse`
   arrives mid-eval and `cancelStale('PostToolUse')` aborts the NEXT permission's
   eval → `Decision dropped` → native prompt. (86 such drops in a 400-line live
   log window.) This is a holdover from the PTY-injection era; under synchronous
   decisions (#496) Claude blocks on the prompt, so the eval is never stale.

## Fix

- **Per-event hook timeout** (`hook-config-manager.ts`): PermissionRequest gets a
  long timeout (300s, covers the eval + serialization-queue budget); every other
  hook keeps 5s so a slow/dead daemon never gates worktree/prompt/compaction
  (#203). A dead daemon still fails fast (connection refused), so the long timeout
  only applies while the daemon is actively deciding. `install()` now RECONCILES
  an existing hook's timeout in place (so an upgrade fixes the stale 5s), and
  `isInstalled()` treats a stale timeout as not-installed to force the reconcile.
- **No more Pre/PostToolUse eval cancellation** (`hook-bridge-setup.ts`): only
  `Stop`/`SessionEnd` (a real session end) cancel an in-flight eval now. The
  running eval is the verdict Claude is blocked waiting for.

## Tests

- `hook-config-manager.test.ts`: PermissionRequest=300 / others=5; reconcile a
  stale 5s PermissionRequest in place (no duplicate); per-event assertion in the
  existing all-events test.
- `hook-bridge-setup.test.ts`: Pre/PostToolUse do NOT cancel the in-flight eval
  (rewritten from the old assert-they-do); Stop/SessionEnd still cancel.
- typecheck + biome clean; 83 tests across the 3 affected suites pass.