### PR TITLE
feat(wrapper): reserve last terminal row for a remi status bar (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.11] - 2026-06-11
+
+A persistent remi status bar on the terminal's last row, visible even while
+Claude shows a permission prompt — exactly when the native status line is hidden.
+
+### Added
+- **Reserved-row status bar in wrapper mode** (#565): remi reports `rows - 1` to
+  Claude and pins the terminal's scroll region to the rows above, so it owns the
+  bottom row exclusively and draws `remi:<port> <repo>:<branch> | <clients> |
+  <state>` there. The auto-approve cue (`evaluating <N>s` / `needs you`) stays
+  visible during prompts, when Claude's own status line is covered. Wrapper +
+  real-TTY only; on by default, off-able via `terminal.status_bar` (or
+  `REMI_TERMINAL_STATUS_BAR=false`). The native status line drops its remi prefix
+  while the bar is active to avoid a duplicate line.
+
 ## [0.6.10] - 2026-06-11
 
 The Claude Code status line now shows what auto-approve is doing, so you can tell

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2091,7 +2091,7 @@ if (cliDaemonMode) {
           rows: process.stdout.rows || 40,
         });
       } catch (err) {
-        log(`[Detach] winsize restore failed: ${errorToString(err)}`);
+        logError(`[Detach] winsize restore failed: ${errorToString(err)}`);
       }
     }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -133,6 +133,7 @@ import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-fi
 import { setupHookBridge } from './cli/session-phases/hook-bridge-setup.ts';
 import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
+import { StatusBar, childRows } from './cli/status-bar.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { installSuspendHandler } from './cli/suspend-handler.ts';
 import { startTranscriptFallback } from './cli/transcript-fallback.ts';
@@ -1014,6 +1015,11 @@ function startBinaryUpdateWatcher(): void {
 let liveSessionsWatcher: import('node:fs').FSWatcher | null = null;
 let liveWatchDebounce: ReturnType<typeof setTimeout> | null = null;
 
+// Reserved-row status bar (#565). Assigned in wrapper mode; stays null in
+// daemon mode. Module-level so cleanup() (defined outside the wrapper block)
+// can clear the row on shutdown.
+let statusBar: StatusBar | null = null;
+
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
 ): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
@@ -1045,6 +1051,7 @@ async function createNewSession(
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void,
   extraArgs: string[] = [],
   passThrough = false,
+  reservedRows = 0,
 ): Promise<PTYSession> {
   const { messageApi, sendAndRecord } = createMessageApiForSession(
     {
@@ -1162,7 +1169,7 @@ async function createNewSession(
       sendMessage,
       cleanup,
     },
-    { sessionId, workingDirectory, extraArgs: binding.args, passThrough },
+    { sessionId, workingDirectory, extraArgs: binding.args, passThrough, reservedRows },
   );
 
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
@@ -1497,6 +1504,11 @@ async function cleanup(): Promise<void> {
   cleanupRunning = true;
 
   cancelOrphanTimeout();
+
+  // Stop and clear the reserved-row status bar (#565) before the rest of
+  // teardown so the terminal is left clean. No-op in daemon mode (null).
+  statusBar?.stop();
+  statusBar = null;
 
   // Restore terminal state before shutting down
   if (process.stdin.isTTY) {
@@ -1920,6 +1932,13 @@ if (cliDaemonMode) {
     }
   }
 
+  // Reserved-row status bar (#565). Only in wrapper mode with a real TTY, and
+  // off-able via config. When active, Claude is reported `rows - 1` so it never
+  // touches the bottom row, which remi draws into. A non-TTY stdout (piped) has
+  // no row to reserve, so it fails safe to off.
+  const statusBarActive = remiConfig.terminal.status_bar && Boolean(process.stdout.isTTY);
+  const reservedRows = statusBarActive ? 1 : 0;
+
   // Create and start the primary PTY session
   const ptySession = await createNewSession(
     sessionId,
@@ -1936,7 +1955,26 @@ if (cliDaemonMode) {
     },
     claudeArgs,
     true, // pass-through mode
+    reservedRows,
   );
+
+  // Start drawing the reserved-row bar now that the PTY is up. Reads the live
+  // StatusWriter state and repaints on a 1Hz timer (the cadence of the
+  // `evaluating Ns` counter), which also re-asserts the bar if Claude's output
+  // scrolled it. Inert until started, and a no-op when detached.
+  if (statusBarActive) {
+    statusBar = new StatusBar({
+      getStdoutFd: getPtyStdoutFd,
+      getStatus: () => statusWriter.state,
+      getSize: () => ({
+        cols: process.stdout.columns || 120,
+        rows: process.stdout.rows || 40,
+      }),
+      isEnabled: () => !isWrapperDetached(),
+      log: (m) => log(m),
+    });
+    statusBar.start();
+  }
 
   // Print session name to terminal (useful for 'remi new' and general awareness)
   {
@@ -2012,7 +2050,11 @@ if (cliDaemonMode) {
   // Handle terminal resize
   process.stdout.on('resize', () => {
     const cols = process.stdout.columns || 120;
-    const rows = process.stdout.rows || 40;
+    const realRows = process.stdout.rows || 40;
+    // Keep reserving the bottom row for the bar (#565): Claude still sees one
+    // row fewer so it never reflows over the reserved row. Once detached, give
+    // Claude the full height back (the bar is gone).
+    const rows = childRows(realRows, statusBarActive && !isWrapperDetached());
     try {
       if (ptySession.isRunning) {
         ptySession.resize({ cols, rows });
@@ -2020,6 +2062,8 @@ if (cliDaemonMode) {
     } catch (err) {
       log(`[PTY] resize failed: ${errorToString(err)}`);
     }
+    // Repaint the bar at the new last row after the child has reflowed.
+    statusBar?.render();
   });
 
   // Detach local terminal.
@@ -2034,6 +2078,22 @@ if (cliDaemonMode) {
     // Tear down the wrapper-mode SIGTSTP/SIGCONT listeners; once the local
     // terminal is gone there is no value in suspending the process.
     suspendController.dispose();
+
+    // Stop the reserved-row bar and clear it while the real fd is still valid
+    // (the sighup branch nulls it below). Restore Claude's full winsize so the
+    // lingering PTY isn't stuck a row short before a remote client re-attaches.
+    statusBar?.stop();
+    statusBar = null;
+    if (statusBarActive && ptySession.isRunning) {
+      try {
+        ptySession.resize({
+          cols: process.stdout.columns || 120,
+          rows: process.stdout.rows || 40,
+        });
+      } catch (err) {
+        log(`[Detach] winsize restore failed: ${errorToString(err)}`);
+      }
+    }
 
     // Stop reading from stdin
     if (process.stdin.isTTY) {

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -26,6 +26,7 @@ import type { OutputProcessor } from '../../parser/output-processor.ts';
 import { PTYSession } from '../../pty/index.ts';
 import type { SessionRegistry, SessionRegistryFile, SessionStore } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
+import { childRows } from '../status-bar.ts';
 import {
   getPtyStdoutFd,
   isWrapperDetached,
@@ -61,6 +62,12 @@ export interface PtySessionSetupArgs {
   extraArgs: readonly string[];
   /** True when the PTY is attached to a local terminal (wrapper mode). */
   passThrough: boolean;
+  /**
+   * Rows the wrapper reserves for its own status bar (#565). When > 0 the child
+   * PTY is reported `rows - reservedRows` so Claude never touches the reserved
+   * row(s). 0 (default) gives Claude the full terminal height.
+   */
+  reservedRows?: number;
 }
 
 /**
@@ -68,12 +75,20 @@ export interface PtySessionSetupArgs {
  * 120x40 so output parsing is reproducible; wrapper-mode PTYs prefer the
  * host terminal's `stdout.columns`/`rows` and fall back to 120x40 if those
  * are unavailable (e.g., stdout not a TTY).
+ *
+ * `reservedRows` (#565) shrinks the reported height so the wrapper can own the
+ * bottom row(s); it only applies in pass-through mode and only when the
+ * terminal is tall enough to spare the row (see `childRows`).
  */
-export function computeTermSize(passThrough: boolean): { cols: number; rows: number } {
+export function computeTermSize(
+  passThrough: boolean,
+  reservedRows = 0,
+): { cols: number; rows: number } {
   if (!passThrough) return { cols: 120, rows: 40 };
+  const realRows = process.stdout.rows || 40;
   return {
     cols: process.stdout.columns || 120,
-    rows: process.stdout.rows || 40,
+    rows: childRows(realRows, reservedRows > 0),
   };
 }
 
@@ -90,13 +105,13 @@ export function createPtySessionForSession(
     sendMessage,
     cleanup,
   } = deps;
-  const { sessionId, workingDirectory, extraArgs, passThrough } = args;
+  const { sessionId, workingDirectory, extraArgs, passThrough, reservedRows = 0 } = args;
 
   if (!Number.isInteger(wsPort) || wsPort <= 0) {
     throw new Error(`Invalid wsPort: ${wsPort}. Must be a positive integer.`);
   }
 
-  const termSize = computeTermSize(passThrough);
+  const termSize = computeTermSize(passThrough, reservedRows);
 
   const ptySession: PTYSession = new PTYSession(
     {

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -118,13 +118,20 @@ export function createPtySessionForSession(
 
   const termSize = computeTermSize(passThrough, reservedRows);
 
+  // When the reserved-row status bar is active (#565), tell Claude's statusLine
+  // script via REMI_STATUS_BAR so it drops the remi prefix and shows only
+  // model/context — the bar already renders the remi fields, avoiding a
+  // duplicate line just above the bar.
+  const env: Record<string, string> = { REMI_PORT: String(wsPort) };
+  if (reservedRows > 0) env['REMI_STATUS_BAR'] = '1';
+
   const ptySession: PTYSession = new PTYSession(
     {
       command: 'claude',
       args: [...extraArgs],
       cwd: workingDirectory,
       size: termSize,
-      env: { REMI_PORT: String(wsPort) },
+      env,
     },
     {
       onRawData: (data: Uint8Array) => {

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -79,6 +79,11 @@ export interface PtySessionSetupArgs {
  * `reservedRows` (#565) shrinks the reported height so the wrapper can own the
  * bottom row(s); it only applies in pass-through mode and only when the
  * terminal is tall enough to spare the row (see `childRows`).
+ *
+ * Caller invariant: pass `reservedRows > 0` only when stdout is a real TTY.
+ * The sole caller (the wrapper block in cli.ts) derives it from
+ * `statusBarActive`, which already requires `process.stdout.isTTY`, so a
+ * non-TTY stdout (no real row count) never reserves a row here.
  */
 export function computeTermSize(
   passThrough: boolean,

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -35,6 +35,10 @@ export const EVALUATING_CAP_S = 600;
 /** An 'approved' verdict fades from the bar after this many seconds (mirrors the
  *  5s in statusline-installer.ts). */
 export const APPROVED_FRESH_S = 5;
+/** Consecutive render failures tolerated before the bar backs off for good. A
+ *  single transient write error (e.g. an interrupted syscall) must not silence
+ *  the bar for the whole session; a genuinely dead fd trips this within seconds. */
+export const MAX_RENDER_ERRORS = 3;
 
 /**
  * Rows to report to the child PTY given the real terminal height and whether
@@ -110,8 +114,9 @@ export interface StatusBarDeps {
   readonly writeToFd?: (fd: number, data: string) => void;
   /** Current epoch ms. Injectable for tests; defaults to Date.now. */
   readonly now?: () => number;
-  /** Logger for a one-shot render-failure note. */
-  readonly log?: (msg: string) => void;
+  /** Logger for render-failure notes. Required so a draw failure is never
+   *  silently swallowed by an accidental no-op default. */
+  readonly log: (msg: string) => void;
   /** Refresh cadence in ms. Default 1000 (the `evaluating Ns` counter ticks 1Hz). */
   readonly intervalMs?: number;
 }
@@ -126,7 +131,10 @@ export interface StatusBarDeps {
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
   private errorLogged = false;
-  /** Set once a render fails; the bar backs off permanently (the fd is bad). */
+  /** Consecutive render failures; reset to 0 on any success. */
+  private consecutiveErrors = 0;
+  /** Set after MAX_RENDER_ERRORS consecutive failures; the bar backs off for
+   *  good (the fd has gone bad). A success before then clears the streak. */
   private disabled = false;
   private readonly getStdoutFd: () => number | null;
   private readonly getStatus: () => Readonly<RemiStatus>;
@@ -144,7 +152,7 @@ export class StatusBar {
     this.isEnabled = deps.isEnabled;
     this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
     this.now = deps.now ?? (() => Date.now());
-    this.log = deps.log ?? (() => {});
+    this.log = deps.log;
     this.intervalMs = deps.intervalMs ?? 1000;
   }
 
@@ -152,7 +160,8 @@ export class StatusBar {
   start(): void {
     if (this.timer || this.disabled) return;
     this.render();
-    // If the initial paint failed, render() set `disabled`; don't arm the loop.
+    // A single failing initial paint does not disable the bar (the loop retries
+    // up to MAX_RENDER_ERRORS); only a prior permanent back-off skips the timer.
     if (this.disabled) return;
     this.timer = setInterval(() => this.render(), this.intervalMs);
     // The bar must never, on its own, keep the process alive.
@@ -175,21 +184,33 @@ export class StatusBar {
     if (fd === null) return;
     const { cols, rows } = this.getSize();
     if (rows < MIN_ROWS_FOR_BAR || cols < 1) return;
+    // The whole draw stays inside the try: an exception escaping into the
+    // setInterval callback would surface as an uncaughtException and could take
+    // the wrapper down — the one thing a cosmetic bar must never do. The
+    // accessors and pure builders don't throw over a well-typed status, so in
+    // practice only the fd write can fail here.
     try {
       const text = formatStatusBar(this.getStatus(), this.now());
       this.writeToFd(fd, buildBarSequence(rows, cols, text));
+      this.consecutiveErrors = 0;
       this.errorLogged = false;
     } catch (err) {
-      // A cosmetic draw must never crash the wrapper. Back off permanently on
-      // failure (the fd has gone bad) and log exactly once.
+      // Log the first failure of a streak (a later success clears it, so a new
+      // streak logs again). Back off for good only after repeated failures so a
+      // single transient error doesn't silence the bar for the whole session.
+      this.consecutiveErrors += 1;
       if (!this.errorLogged) {
-        this.log(`[status-bar] render failed, disabling bar: ${errorToString(err)}`);
+        this.log(
+          `[status-bar] render failed (backs off after ${MAX_RENDER_ERRORS}): ${errorToString(err)}`,
+        );
         this.errorLogged = true;
       }
-      this.disabled = true;
-      if (this.timer) {
-        clearInterval(this.timer);
-        this.timer = null;
+      if (this.consecutiveErrors >= MAX_RENDER_ERRORS) {
+        this.disabled = true;
+        if (this.timer) {
+          clearInterval(this.timer);
+          this.timer = null;
+        }
       }
     }
   }
@@ -202,8 +223,11 @@ export class StatusBar {
     if (rows < MIN_ROWS_FOR_BAR) return;
     try {
       this.writeToFd(fd, buildClearSequence(rows));
-    } catch {
-      // Teardown path: the terminal may already be gone. Nothing to recover.
+    } catch (err) {
+      // Teardown path: the terminal may already be gone on SIGHUP. Nothing to
+      // recover, but on a keybinding-detach with a live fd a failed clear leaves
+      // a stale row in the returned shell, so leave a diagnostic.
+      this.log(`[status-bar] clear failed on teardown: ${errorToString(err)}`);
     }
   }
 }

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -1,12 +1,19 @@
 /**
  * Reserved last-row status bar for wrapper mode (#565).
  *
- * remi is the PTY wrapper; Claude is its child. By reporting `rows - 1` to
- * Claude's PTY winsize (see `computeTermSize` / the resize handler), Claude
- * lays out entirely within rows `1..N-1` and never touches the real terminal's
- * last row. remi then owns row `N` exclusively and draws a persistent status
- * bar there — visible even while Claude shows a permission/question prompt,
- * which is exactly when the native `statusLine` cue (#560) is hidden.
+ * remi is the PTY wrapper; Claude is its child. Two mechanisms together keep
+ * the last row remi's alone:
+ *   1. **winsize** — report `rows - 1` to Claude's PTY (see `computeTermSize` /
+ *      the resize handler) so Claude lays out within rows `1..N-1`.
+ *   2. **scroll region** — set DECSTBM to `1..N-1` (in every bar paint) so the
+ *      terminal can only scroll the rows above the bar. The winsize trick alone
+ *      is insufficient because Claude renders inline (no alternate screen): on
+ *      output the terminal would scroll the whole screen and the bar would
+ *      bleed up into Claude's content. The region pins row `N` fixed.
+ *
+ * remi then owns row `N` exclusively and draws a persistent status bar there —
+ * visible even while Claude shows a permission/question prompt, which is exactly
+ * when the native `statusLine` cue (#560) is hidden.
  *
  * The draw is bracketed by DECSC/DECRC (ESC7/ESC8) save/restore so it never
  * disturbs Claude's cursor position or character rendition. Origin mode is
@@ -85,20 +92,35 @@ export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): st
  * full-width reverse-video bar, then restores the prior cursor + rendition.
  * `text` is truncated to `cols` and padded with spaces so the bar spans the
  * full width.
+ *
+ * Crucially it also sets the **scroll region** (DECSTBM) to rows `1..row-1`.
+ * The winsize trick alone is not enough: Claude renders inline (no alternate
+ * screen), so without a scroll region the terminal scrolls the *whole* screen
+ * on output and the bar bleeds up into Claude's content (#565). With the region
+ * pinned to `1..row-1`, the terminal can only scroll the rows above the bar, so
+ * `row` stays fixed. The region is re-asserted on every paint in case Claude
+ * ever resets it. DECSTBM homes the cursor, but DECSC/DECRC (ESC7/ESC8) restore
+ * it, and DECRC does not touch the region, so the region persists after.
  */
 export function buildBarSequence(row: number, cols: number, text: string): string {
   const visible = text.length > cols ? text.slice(0, cols) : text;
   const padded = visible.padEnd(cols, ' ');
-  // ESC7   DECSC: save cursor, rendition, charset, origin mode
-  // ESC[?6l DECOM off: absolute addressing, immune to a scroll region
-  // ESC[r;1H CUP to the reserved row   ESC[2K erase line   ESC[7m reverse video
-  // ESC[0m reset rendition             ESC8 DECRC: restore everything DECSC saved
-  return `\x1b7\x1b[?6l\x1b[${row};1H\x1b[2K\x1b[7m${padded}\x1b[0m\x1b8`;
+  // ESC7     DECSC: save cursor, rendition, charset, origin mode
+  // ESC[?6l  DECOM off: absolute addressing, so CUP can reach row `row`
+  // ESC[1;Nr DECSTBM: scroll region = rows 1..row-1 (protects the bar row)
+  // ESC[r;1H CUP to the bar row   ESC[2K erase line   ESC[7m reverse video
+  // ESC[0m   reset rendition      ESC8 DECRC: restore cursor (region persists)
+  return `\x1b7\x1b[?6l\x1b[1;${row - 1}r\x1b[${row};1H\x1b[2K\x1b[7m${padded}\x1b[0m\x1b8`;
 }
 
-/** Build the escape sequence that clears `row` (on teardown). */
+/**
+ * Build the escape sequence that resets the scroll region to the full screen
+ * (ESC[r) and clears `row`, handing the terminal back clean on teardown.
+ * Bracketed by DECSC/DECRC so Claude's cursor is preserved; DECRC does not
+ * restore the region, so the full-screen region persists.
+ */
 export function buildClearSequence(row: number): string {
-  return `\x1b7\x1b[?6l\x1b[${row};1H\x1b[2K\x1b8`;
+  return `\x1b7\x1b[?6l\x1b[r\x1b[${row};1H\x1b[2K\x1b8`;
 }
 
 export interface StatusBarDeps {

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -1,0 +1,209 @@
+/**
+ * Reserved last-row status bar for wrapper mode (#565).
+ *
+ * remi is the PTY wrapper; Claude is its child. By reporting `rows - 1` to
+ * Claude's PTY winsize (see `computeTermSize` / the resize handler), Claude
+ * lays out entirely within rows `1..N-1` and never touches the real terminal's
+ * last row. remi then owns row `N` exclusively and draws a persistent status
+ * bar there — visible even while Claude shows a permission/question prompt,
+ * which is exactly when the native `statusLine` cue (#560) is hidden.
+ *
+ * The draw is bracketed by DECSC/DECRC (ESC7/ESC8) save/restore so it never
+ * disturbs Claude's cursor position or character rendition. Origin mode is
+ * forced off (`ESC[?6l`) for the absolute cursor move so that any scroll region
+ * Claude may have set (DECSTBM) cannot clamp the write up into Claude's content
+ * area. DECSC also saves/restores origin mode, so forcing it off is transparent
+ * to Claude.
+ *
+ * Every path fails safe to "no bar": the renderer no-ops when disabled, when
+ * the wrapper has detached (stdout fd is null), or when the terminal is too
+ * short to spare a row. A render error backs the bar off rather than crashing
+ * the wrapper.
+ */
+
+import * as fs from 'node:fs';
+import { errorToString } from '@remi/shared';
+import { ESCALATE_FRESH_S, type RemiStatus } from './status-writer.ts';
+
+/** Rows reserved for the status bar. */
+export const RESERVED_ROWS = 1;
+/** A bar needs at least one row for Claude plus one for itself. */
+export const MIN_ROWS_FOR_BAR = 2;
+/** Leak-safety cap: a stuck `inFlight` stops reading as "evaluating" after this
+ *  many seconds (mirrors the 600s in statusline-installer.ts). */
+export const EVALUATING_CAP_S = 600;
+/** An 'approved' verdict fades from the bar after this many seconds (mirrors the
+ *  5s in statusline-installer.ts). */
+export const APPROVED_FRESH_S = 5;
+
+/**
+ * Rows to report to the child PTY given the real terminal height and whether
+ * the status bar is reserving its row. Reserves only when there is room — a
+ * 1-row terminal gives every row to Claude (no bar).
+ */
+export function childRows(realRows: number, reserve: boolean): number {
+  return reserve && realRows >= MIN_ROWS_FOR_BAR ? realRows - RESERVED_ROWS : realRows;
+}
+
+/**
+ * Build the human-readable status string (no styling, no truncation). Mirrors
+ * the render logic in `statusline-installer.ts` so the reserved-row bar and the
+ * native statusLine agree on what the auto-approve state reads as.
+ *
+ *   remi:<port> <repo>:<branch> | <N> client(s) | <state>
+ *
+ * `state` is the live auto-approve cue when a permission is being decided
+ * (`evaluating Ns` / `needs you` / `approved`), otherwise Claude's agent status.
+ */
+export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): string {
+  const nowS = Math.floor(nowMs / 1000);
+  const aa = status.autoApprove;
+  const elapsed = nowS - aa.sinceS;
+  const age = nowS - aa.lastVerdictAtS;
+
+  let state: string = status.sessionStatus;
+  if (aa.inFlight > 0 && elapsed >= 0 && elapsed < EVALUATING_CAP_S) {
+    state = `evaluating ${elapsed}s`;
+  } else if (aa.lastVerdict === 'escalated' && age >= 0 && age < ESCALATE_FRESH_S) {
+    state = 'needs you';
+  } else if (aa.lastVerdict === 'approved' && age >= 0 && age < APPROVED_FRESH_S) {
+    state = 'approved';
+  }
+
+  const clients = status.connections > 0 ? `${status.connections} client(s)` : 'no clients';
+  const repoBranch = status.repo ? `${status.repo}:${status.branch}` : status.branch;
+  const head = repoBranch ? `remi:${status.wsPort} ${repoBranch}` : `remi:${status.wsPort}`;
+  return `${head} | ${clients} | ${state}`;
+}
+
+/**
+ * Build the escape sequence that paints `text` on `row` (1-based) as a
+ * full-width reverse-video bar, then restores the prior cursor + rendition.
+ * `text` is truncated to `cols` and padded with spaces so the bar spans the
+ * full width.
+ */
+export function buildBarSequence(row: number, cols: number, text: string): string {
+  const visible = text.length > cols ? text.slice(0, cols) : text;
+  const padded = visible.padEnd(cols, ' ');
+  // ESC7   DECSC: save cursor, rendition, charset, origin mode
+  // ESC[?6l DECOM off: absolute addressing, immune to a scroll region
+  // ESC[r;1H CUP to the reserved row   ESC[2K erase line   ESC[7m reverse video
+  // ESC[0m reset rendition             ESC8 DECRC: restore everything DECSC saved
+  return `\x1b7\x1b[?6l\x1b[${row};1H\x1b[2K\x1b[7m${padded}\x1b[0m\x1b8`;
+}
+
+/** Build the escape sequence that clears `row` (on teardown). */
+export function buildClearSequence(row: number): string {
+  return `\x1b7\x1b[?6l\x1b[${row};1H\x1b[2K\x1b8`;
+}
+
+export interface StatusBarDeps {
+  /** Real terminal stdout fd, or null once the wrapper has detached. */
+  readonly getStdoutFd: () => number | null;
+  /** Live status snapshot (the StatusWriter's in-memory object). */
+  readonly getStatus: () => Readonly<RemiStatus>;
+  /** Real terminal size (the full height, including the reserved row). */
+  readonly getSize: () => { cols: number; rows: number };
+  /** Master enable (config flag + wrapper mode + a real TTY). */
+  readonly isEnabled: () => boolean;
+  /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
+  readonly writeToFd?: (fd: number, data: string) => void;
+  /** Current epoch ms. Injectable for tests; defaults to Date.now. */
+  readonly now?: () => number;
+  /** Logger for a one-shot render-failure note. */
+  readonly log?: (msg: string) => void;
+  /** Refresh cadence in ms. Default 1000 (the `evaluating Ns` counter ticks 1Hz). */
+  readonly intervalMs?: number;
+}
+
+/**
+ * Owns the reserved-row redraw loop. `start()` paints immediately and then on a
+ * 1Hz timer; the unconditional periodic repaint keeps the bar asserted even if
+ * Claude's output scrolled it (inline mode) since the last tick. `stop()` clears
+ * the row and halts the loop. All draws are no-ops unless `isEnabled()` and a
+ * live fd and enough rows.
+ */
+export class StatusBar {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private errorLogged = false;
+  /** Set once a render fails; the bar backs off permanently (the fd is bad). */
+  private disabled = false;
+  private readonly getStdoutFd: () => number | null;
+  private readonly getStatus: () => Readonly<RemiStatus>;
+  private readonly getSize: () => { cols: number; rows: number };
+  private readonly isEnabled: () => boolean;
+  private readonly writeToFd: (fd: number, data: string) => void;
+  private readonly now: () => number;
+  private readonly log: (msg: string) => void;
+  private readonly intervalMs: number;
+
+  constructor(deps: StatusBarDeps) {
+    this.getStdoutFd = deps.getStdoutFd;
+    this.getStatus = deps.getStatus;
+    this.getSize = deps.getSize;
+    this.isEnabled = deps.isEnabled;
+    this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
+    this.now = deps.now ?? (() => Date.now());
+    this.log = deps.log ?? (() => {});
+    this.intervalMs = deps.intervalMs ?? 1000;
+  }
+
+  /** Begin the redraw loop (idempotent). Paints once immediately. */
+  start(): void {
+    if (this.timer || this.disabled) return;
+    this.render();
+    // If the initial paint failed, render() set `disabled`; don't arm the loop.
+    if (this.disabled) return;
+    this.timer = setInterval(() => this.render(), this.intervalMs);
+    // The bar must never, on its own, keep the process alive.
+    this.timer.unref?.();
+  }
+
+  /** Halt the redraw loop and clear the reserved row (idempotent). */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.clearRow();
+  }
+
+  /** Paint the reserved row now. Safe no-op when disabled / detached / no room. */
+  render(): void {
+    if (this.disabled || !this.isEnabled()) return;
+    const fd = this.getStdoutFd();
+    if (fd === null) return;
+    const { cols, rows } = this.getSize();
+    if (rows < MIN_ROWS_FOR_BAR || cols < 1) return;
+    try {
+      const text = formatStatusBar(this.getStatus(), this.now());
+      this.writeToFd(fd, buildBarSequence(rows, cols, text));
+      this.errorLogged = false;
+    } catch (err) {
+      // A cosmetic draw must never crash the wrapper. Back off permanently on
+      // failure (the fd has gone bad) and log exactly once.
+      if (!this.errorLogged) {
+        this.log(`[status-bar] render failed, disabling bar: ${errorToString(err)}`);
+        this.errorLogged = true;
+      }
+      this.disabled = true;
+      if (this.timer) {
+        clearInterval(this.timer);
+        this.timer = null;
+      }
+    }
+  }
+
+  private clearRow(): void {
+    if (this.disabled) return;
+    const fd = this.getStdoutFd();
+    if (fd === null) return;
+    const { rows } = this.getSize();
+    if (rows < MIN_ROWS_FOR_BAR) return;
+    try {
+      this.writeToFd(fd, buildClearSequence(rows));
+    } catch {
+      // Teardown path: the terminal may already be gone. Nothing to recover.
+    }
+  }
+}

--- a/packages/daemon/src/cli/statusline-installer.ts
+++ b/packages/daemon/src/cli/statusline-installer.ts
@@ -28,9 +28,12 @@ export function buildStatuslineScript(remiDir: string): string {
   return `#!/bin/bash
 input=\$(cat)
 REMI=""
-# REMI_PORT is set by remi when spawning Claude; status file is per-port
+# REMI_PORT is set by remi when spawning Claude; status file is per-port.
+# REMI_STATUS_BAR=1 means remi draws its own reserved-row status bar (#565), so
+# the native statusLine drops the remi prefix and shows only model/context to
+# avoid duplicating the remi fields just above the bar.
 REMI_STATUS_FILE="${remiDir}/status-\$REMI_PORT.json"
-if [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
+if [ "\$REMI_STATUS_BAR" != "1" ] && [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
   IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH AA_INFLIGHT AA_SINCE AA_LASTV AA_LASTAT < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // "", .autoApprove.inFlight // 0, .autoApprove.sinceS // 0, .autoApprove.lastVerdict // "none", .autoApprove.lastVerdictAtS // 0] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
   if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
     CLIENT_INFO="no clients"

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -58,6 +58,14 @@ export interface TerminalConfig {
    * The title bar is the only cue channel that does not fight Claude's renderer.
    */
   readonly status_cue: boolean;
+  /**
+   * Reserve the wrapper terminal's last row for a persistent remi status bar
+   * (#565). remi reports `rows - 1` to Claude so Claude never touches the last
+   * row, which remi then owns — visible even while Claude shows a prompt (when
+   * the native statusLine cue is hidden). Wrapper mode + a real TTY only;
+   * inert otherwise. Default on; set false to keep the full height for Claude.
+   */
+  readonly status_bar: boolean;
 }
 
 /** Telegram settings */
@@ -121,6 +129,9 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // iTerm2/Ghostty. The animated title is a subtle in-terminal cue.
     notify: 'osc9',
     status_cue: true,
+    // Reserve the last terminal row for an always-visible remi status bar in
+    // wrapper mode (#565). Default on; off-able for users who want every row.
+    status_bar: true,
   },
   telegram: {
     enabled: false,
@@ -396,6 +407,11 @@ function validateTerminal(cfg: TerminalConfig, configPath: string): void {
       `Invalid terminal.status_cue in ${configPath}: must be a boolean (true/false), got ${typeof cfg.status_cue === 'string' ? `string "${cfg.status_cue}"` : typeof cfg.status_cue}.`,
     );
   }
+  if (typeof cfg.status_bar !== 'boolean') {
+    throw new Error(
+      `Invalid terminal.status_bar in ${configPath}: must be a boolean (true/false), got ${typeof cfg.status_bar === 'string' ? `string "${cfg.status_bar}"` : typeof cfg.status_bar}.`,
+    );
+  }
 }
 
 /**
@@ -436,6 +452,11 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
     (terminal as { status_cue: boolean }).status_cue = true;
   } else if (env['REMI_TERMINAL_STATUS_CUE'] === 'false') {
     (terminal as { status_cue: boolean }).status_cue = false;
+  }
+  if (env['REMI_TERMINAL_STATUS_BAR'] === 'true') {
+    (terminal as { status_bar: boolean }).status_bar = true;
+  } else if (env['REMI_TERMINAL_STATUS_BAR'] === 'false') {
+    (terminal as { status_bar: boolean }).status_bar = false;
   }
 
   // Telegram env vars
@@ -579,6 +600,7 @@ max_bullet_length = ${DEFAULT_CONFIG.display.max_bullet_length}  # 0 = disabled
 # auto_approve is enabled). notify fires when a permission ESCALATES to you.
 notify = "${DEFAULT_CONFIG.terminal.notify}"        # osc9 | osc777 | bell | off
 status_cue = ${DEFAULT_CONFIG.terminal.status_cue}     # animate the title: evaluating -> done/needs-you
+status_bar = ${DEFAULT_CONFIG.terminal.status_bar}     # reserve the last terminal row for a remi status bar (#565)
 
 [telegram]
 enabled = ${DEFAULT_CONFIG.telegram.enabled}
@@ -688,6 +710,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push('[terminal]');
   lines.push(`  notify = "${config.terminal.notify}"`);
   lines.push(`  status_cue = ${config.terminal.status_cue}`);
+  lines.push(`  status_bar = ${config.terminal.status_bar}`);
   lines.push('');
   lines.push('[telegram]');
   lines.push(`  enabled = ${config.telegram.enabled}`);

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -46,6 +46,18 @@ describe('computeTermSize', () => {
       expect(size.rows).toBe(40);
     }
   });
+
+  test('reservedRows shrinks the pass-through height by one row (#565)', () => {
+    const full = computeTermSize(true, 0);
+    const reserved = computeTermSize(true, 1);
+    expect(reserved.cols).toBe(full.cols);
+    expect(reserved.rows).toBe(full.rows - 1);
+  });
+
+  test('reservedRows never affects the headless deterministic size', () => {
+    // Headless PTYs must stay a reproducible 120x40 regardless of reservedRows.
+    expect(computeTermSize(false, 1)).toEqual({ cols: 120, rows: 40 });
+  });
 });
 
 describe('createPtySessionForSession', () => {

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  MAX_RENDER_ERRORS,
   MIN_ROWS_FOR_BAR,
   StatusBar,
   type StatusBarDeps,
@@ -218,7 +219,7 @@ describe('StatusBar', () => {
     expect(writes.length).toBeGreaterThan(2);
   });
 
-  test('a render error never throws, logs once, and stops the loop', async () => {
+  test('a persistent render error never throws, logs once, and backs off after the threshold', async () => {
     let calls = 0;
     const { bar, writes, logs } = harness({
       writeToFd: () => {
@@ -227,10 +228,32 @@ describe('StatusBar', () => {
       },
     });
     expect(() => bar.start()).not.toThrow();
-    await new Promise((r) => setTimeout(r, 30));
-    // The loop backed off after the first failing paint; no repeated writes.
-    expect(calls).toBe(1);
-    expect(writes).toHaveLength(0);
+    await new Promise((r) => setTimeout(r, 60)); // well past MAX_RENDER_ERRORS ticks
+    // Backed off after MAX consecutive failures, then stopped retrying.
+    expect(calls).toBe(MAX_RENDER_ERRORS);
+    expect(writes).toHaveLength(0); // the throwing write never records a paint
+    expect(logs).toHaveLength(1); // first failure of the streak only
+    const settled = calls;
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls).toBe(settled); // no further attempts once disabled
+    bar.stop();
+  });
+
+  test('a transient render error does not disable the bar', async () => {
+    let attempts = 0;
+    const painted: string[] = [];
+    const { bar, logs } = harness({
+      writeToFd: (_fd, data) => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('EINTR'); // one transient blip
+        painted.push(data);
+      },
+    });
+    bar.start();
+    await new Promise((r) => setTimeout(r, 40)); // several ticks past the blip
+    // The streak reset on the first success, so the bar kept painting and never
+    // backed off. The single failure logged exactly once.
+    expect(painted.length).toBeGreaterThan(0);
     expect(logs).toHaveLength(1);
     bar.stop();
   });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MIN_ROWS_FOR_BAR,
+  StatusBar,
+  type StatusBarDeps,
+  buildBarSequence,
+  buildClearSequence,
+  childRows,
+  formatStatusBar,
+} from '../../src/cli/status-bar.ts';
+import type { RemiStatus } from '../../src/cli/status-writer.ts';
+
+const NOW_MS = 1_000_000_000; // fixed clock; NOW_MS/1000 = 1_000_000 s
+const NOW_S = Math.floor(NOW_MS / 1000);
+
+function mkStatus(overrides: Partial<RemiStatus> = {}): RemiStatus {
+  return {
+    pid: 123,
+    connections: 0,
+    sessionStatus: 'idle',
+    adapters: [],
+    wsPort: 19924,
+    sessionId: null,
+    repo: 'remi',
+    branch: 'develop',
+    autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'none', lastVerdictAtS: 0 },
+    ...overrides,
+  };
+}
+
+describe('childRows', () => {
+  test('reserves one row when reserve is on and there is room', () => {
+    expect(childRows(40, true)).toBe(39);
+    expect(childRows(MIN_ROWS_FOR_BAR, true)).toBe(MIN_ROWS_FOR_BAR - 1);
+  });
+
+  test('gives every row to the child when reserve is off', () => {
+    expect(childRows(40, false)).toBe(40);
+  });
+
+  test('does not reserve when the terminal is too short', () => {
+    expect(childRows(1, true)).toBe(1);
+    expect(childRows(0, true)).toBe(0);
+  });
+});
+
+describe('formatStatusBar', () => {
+  test('idle shows the session status as the state', () => {
+    const out = formatStatusBar(mkStatus({ sessionStatus: 'thinking' }), NOW_MS);
+    expect(out).toBe('remi:19924 remi:develop | no clients | thinking');
+  });
+
+  test('client count pluralizes', () => {
+    expect(formatStatusBar(mkStatus({ connections: 2 }), NOW_MS)).toContain('| 2 client(s) |');
+    expect(formatStatusBar(mkStatus({ connections: 0 }), NOW_MS)).toContain('| no clients |');
+  });
+
+  test('in-flight eval shows evaluating with elapsed seconds', () => {
+    const status = mkStatus({
+      autoApprove: { inFlight: 1, sinceS: NOW_S - 3, lastVerdict: 'none', lastVerdictAtS: 0 },
+    });
+    expect(formatStatusBar(status, NOW_MS)).toContain('| evaluating 3s');
+  });
+
+  test('a stuck eval past the cap falls back to the session status', () => {
+    const status = mkStatus({
+      sessionStatus: 'idle',
+      autoApprove: { inFlight: 1, sinceS: NOW_S - 601, lastVerdict: 'none', lastVerdictAtS: 0 },
+    });
+    expect(formatStatusBar(status, NOW_MS)).toContain('| idle');
+    expect(formatStatusBar(status, NOW_MS)).not.toContain('evaluating');
+  });
+
+  test('a fresh escalate shows needs you', () => {
+    const status = mkStatus({
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'escalated', lastVerdictAtS: NOW_S - 10 },
+    });
+    expect(formatStatusBar(status, NOW_MS)).toContain('| needs you');
+  });
+
+  test('an escalate older than the fresh window decays to the session status', () => {
+    const status = mkStatus({
+      sessionStatus: 'idle',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'escalated', lastVerdictAtS: NOW_S - 61 },
+    });
+    expect(formatStatusBar(status, NOW_MS)).not.toContain('needs you');
+    expect(formatStatusBar(status, NOW_MS)).toContain('| idle');
+  });
+
+  test('a fresh approve shows approved, then fades', () => {
+    const fresh = mkStatus({
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'approved', lastVerdictAtS: NOW_S - 2 },
+    });
+    expect(formatStatusBar(fresh, NOW_MS)).toContain('| approved');
+    const faded = mkStatus({
+      sessionStatus: 'idle',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'approved', lastVerdictAtS: NOW_S - 6 },
+    });
+    expect(formatStatusBar(faded, NOW_MS)).not.toContain('approved');
+  });
+
+  test('omits the repo:branch chunk when repo is empty', () => {
+    const out = formatStatusBar(mkStatus({ repo: '', branch: '' }), NOW_MS);
+    expect(out).toBe('remi:19924 | no clients | idle');
+  });
+
+  test('in-flight wins over a stale verdict', () => {
+    const status = mkStatus({
+      autoApprove: {
+        inFlight: 1,
+        sinceS: NOW_S - 1,
+        lastVerdict: 'escalated',
+        lastVerdictAtS: NOW_S - 5,
+      },
+    });
+    expect(formatStatusBar(status, NOW_MS)).toContain('evaluating 1s');
+    expect(formatStatusBar(status, NOW_MS)).not.toContain('needs you');
+  });
+});
+
+describe('buildBarSequence', () => {
+  test('brackets the draw with save/restore and positions the reserved row', () => {
+    const seq = buildBarSequence(40, 20, 'hi');
+    expect(seq.startsWith('\x1b7')).toBe(true); // DECSC
+    expect(seq.endsWith('\x1b8')).toBe(true); // DECRC
+    expect(seq).toContain('\x1b[?6l'); // origin mode off
+    expect(seq).toContain('\x1b[40;1H'); // CUP to row 40
+    expect(seq).toContain('\x1b[2K'); // erase line
+    expect(seq).toContain('\x1b[7m'); // reverse video
+    expect(seq).toContain('\x1b[0m'); // reset
+  });
+
+  test('pads the content to the full width', () => {
+    const seq = buildBarSequence(5, 10, 'abc');
+    expect(seq).toContain('abc       '); // 'abc' + 7 spaces = width 10
+  });
+
+  test('truncates content longer than the width', () => {
+    const seq = buildBarSequence(5, 4, 'abcdefgh');
+    expect(seq).toContain('abcd');
+    expect(seq).not.toContain('abcde');
+  });
+});
+
+describe('buildClearSequence', () => {
+  test('positions and erases the reserved row, bracketed by save/restore', () => {
+    const seq = buildClearSequence(24);
+    expect(seq).toBe('\x1b7\x1b[?6l\x1b[24;1H\x1b[2K\x1b8');
+  });
+});
+
+describe('StatusBar', () => {
+  function harness(overrides: Partial<StatusBarDeps> = {}) {
+    const writes: string[] = [];
+    const logs: string[] = [];
+    const deps: StatusBarDeps = {
+      getStdoutFd: () => 1,
+      getStatus: () => mkStatus(),
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => NOW_MS,
+      log: (m) => logs.push(m),
+      intervalMs: 5,
+      ...overrides,
+    };
+    return { bar: new StatusBar(deps), writes, logs };
+  }
+
+  test('render writes the bar when enabled with an fd and room', () => {
+    const { bar, writes } = harness();
+    bar.render();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain('\x1b[24;1H');
+  });
+
+  test('render no-ops when disabled', () => {
+    const { bar, writes } = harness({ isEnabled: () => false });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('render no-ops when the wrapper has detached (null fd)', () => {
+    const { bar, writes } = harness({ getStdoutFd: () => null });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('render no-ops when the terminal is too short to spare a row', () => {
+    const { bar, writes } = harness({ getSize: () => ({ cols: 80, rows: 1 }) });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('start paints immediately and stop clears the row', () => {
+    const { bar, writes } = harness();
+    bar.start();
+    expect(writes).toHaveLength(1); // immediate paint
+    bar.stop();
+    // stop() emits a clear sequence for the reserved row
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toBe(buildClearSequence(24));
+  });
+
+  test('start is idempotent', () => {
+    const { bar, writes } = harness();
+    bar.start();
+    bar.start();
+    expect(writes).toHaveLength(1); // second start does not repaint
+    bar.stop();
+  });
+
+  test('the timer repaints on its interval', async () => {
+    const { bar, writes } = harness();
+    bar.start();
+    await new Promise((r) => setTimeout(r, 30)); // a few 5ms ticks
+    bar.stop();
+    expect(writes.length).toBeGreaterThan(2);
+  });
+
+  test('a render error never throws, logs once, and stops the loop', async () => {
+    let calls = 0;
+    const { bar, writes, logs } = harness({
+      writeToFd: () => {
+        calls += 1;
+        throw new Error('EIO');
+      },
+    });
+    expect(() => bar.start()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 30));
+    // The loop backed off after the first failing paint; no repeated writes.
+    expect(calls).toBe(1);
+    expect(writes).toHaveLength(0);
+    expect(logs).toHaveLength(1);
+    bar.stop();
+  });
+});

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -125,10 +125,16 @@ describe('buildBarSequence', () => {
     expect(seq.startsWith('\x1b7')).toBe(true); // DECSC
     expect(seq.endsWith('\x1b8')).toBe(true); // DECRC
     expect(seq).toContain('\x1b[?6l'); // origin mode off
+    expect(seq).toContain('\x1b[1;39r'); // DECSTBM: scroll region rows 1..39
     expect(seq).toContain('\x1b[40;1H'); // CUP to row 40
     expect(seq).toContain('\x1b[2K'); // erase line
     expect(seq).toContain('\x1b[7m'); // reverse video
     expect(seq).toContain('\x1b[0m'); // reset
+  });
+
+  test('sets the scroll region to exclude exactly the bar row', () => {
+    // 24-row terminal -> region 1..23, bar on row 24.
+    expect(buildBarSequence(24, 80, 'x')).toContain('\x1b[1;23r');
   });
 
   test('pads the content to the full width', () => {
@@ -144,9 +150,9 @@ describe('buildBarSequence', () => {
 });
 
 describe('buildClearSequence', () => {
-  test('positions and erases the reserved row, bracketed by save/restore', () => {
+  test('resets the scroll region and erases the reserved row, bracketed by save/restore', () => {
     const seq = buildClearSequence(24);
-    expect(seq).toBe('\x1b7\x1b[?6l\x1b[24;1H\x1b[2K\x1b8');
+    expect(seq).toBe('\x1b7\x1b[?6l\x1b[r\x1b[24;1H\x1b[2K\x1b8');
   });
 });
 

--- a/packages/daemon/tests/cli/statusline-installer.test.ts
+++ b/packages/daemon/tests/cli/statusline-installer.test.ts
@@ -26,6 +26,13 @@ describe('buildStatuslineScript', () => {
     expect(script).not.toContain('remi :$REMI_PORT');
   });
 
+  test('drops the remi prefix when REMI_STATUS_BAR=1 (#565 de-dup)', () => {
+    const script = buildStatuslineScript('/x');
+    // The remi-fields branch is gated so it is skipped when remi draws its own
+    // reserved-row bar; model/context still renders unconditionally.
+    expect(script).toContain('"$REMI_STATUS_BAR" != "1"');
+  });
+
   test('surfaces auto-approve eval state in the status segment (#560)', () => {
     const script = buildStatuslineScript('/x');
     // reads the auto-approve fields from the per-port status JSON

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -539,8 +539,12 @@ Escalate anything touching secrets.
 });
 
 describe('terminal config (#513)', () => {
-  test('defaults: osc9 notify + status cue on', () => {
-    expect(DEFAULT_CONFIG.terminal).toEqual({ notify: 'osc9', status_cue: true });
+  test('defaults: osc9 notify + status cue on + status bar on', () => {
+    expect(DEFAULT_CONFIG.terminal).toEqual({
+      notify: 'osc9',
+      status_cue: true,
+      status_bar: true,
+    });
   });
 
   test('loads terminal from TOML', () => {
@@ -564,6 +568,25 @@ describe('terminal config (#513)', () => {
   test('rejects status_cue as a string', () => {
     fs.writeFileSync(TEST_CONFIG, '[terminal]\nstatus_cue = "yes"\n');
     expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.status_cue/);
+  });
+
+  test('loads status_bar from TOML', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nstatus_bar = false\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.terminal.status_bar).toBe(false);
+  });
+
+  test('rejects status_bar as a string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[terminal]\nstatus_bar = "yes"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/terminal\.status_bar/);
+  });
+
+  test('REMI_TERMINAL_STATUS_BAR=false disables the bar', () => {
+    process.env['REMI_TERMINAL_STATUS_BAR'] = 'false';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.terminal.status_bar).toBe(false);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_TERMINAL_STATUS_BAR'];
   });
 
   test('REMI_TERMINAL_NOTIFY env override', () => {
@@ -595,5 +618,6 @@ describe('terminal config (#513)', () => {
     expect(output).toContain('[terminal]');
     expect(output).toContain('notify = "osc9"');
     expect(output).toContain('status_cue = true');
+    expect(output).toContain('status_bar = true');
   });
 });


### PR DESCRIPTION
Closes #565.

## Problem

The native Claude `statusLine` cue (#560) is hidden exactly when it matters:
Claude takes over the bottom area when it shows a permission/question prompt, so
`evaluating Ns` / `needs you` can't be seen precisely while a prompt is up.

## Approach — reserve the last row via the PTY winsize

remi is the PTY wrapper (Claude is its child) and owns the PTY window size. We
report `rows - 1` to Claude, so Claude lays out entirely within rows `1..N-1`
and never touches the real terminal's last row. remi then owns row `N`
exclusively and draws a persistent status bar there, visible even during prompts.

## Changes

- **`status-bar.ts` (new)** — `StatusBar` 1 Hz redraw loop reading the live
  `StatusWriter` state; the unconditional periodic repaint also re-asserts the
  bar if Claude's output scrolled it. Pure, unit-tested helpers:
  `formatStatusBar` (mirrors the native statusline state logic), `childRows`,
  and the escape-sequence builders. The draw is bracketed by **DECSC/DECRC**
  (`ESC7`/`ESC8`) and forces **origin mode off** before the absolute cursor
  move, so a scroll region Claude may have set can't clamp the write into its
  content area.
- **winsize trick** — `computeTermSize` gains `reservedRows`; Claude is reported
  `rows - 1` on launch and on every SIGWINCH/resize.
- **teardown** — detach/exit/cleanup clears row `N` and restores Claude's full
  winsize so the terminal is left clean and a re-attaching client gets full height.
- **config** — `terminal.status_bar` (default **on**) + `REMI_TERMINAL_STATUS_BAR`.
  Wrapper + real-TTY only; inert (`reservedRows = 0`) otherwise.
- **fail-safe** — every render path no-ops when disabled/detached/too-short; a
  render error backs the bar off permanently rather than crashing the wrapper.

The native `statusLine` cue from #560 stays as the fallback for non-wrapper mode.
Content is duplicated between the bar and the native statusLine for now; dropping
the remi prefix from the native line when the bar is active is a noted follow-up
(the issue lists it as optional).

## Testing

- `bun test`: 95 pass across new `status-bar.test.ts` + updated `config.test.ts`
  and `pty-session-setup.test.ts`; broader CLI/config/session sweep 900 pass / 0 fail.
- `bun run typecheck` + `bunx biome check`: clean.

## Pending — live terminal validation (not CI-testable)

Terminal rendering in a live wrapper can't be CI-tested; the failure mode is a
corrupted Claude TUI. **Live sign-off pending** on a real `remi`-wrapped Claude
across: resize, suspend/resume (Ctrl+Z), tmux, and prompt display. Test binary
built at `dist/remi` (`0.6.11-p565.1`).

**Watch item:** if Claude renders inline (not alt-screen), the bar may briefly
scroll up before the next 1 Hz repaint reasserts it. If that's visible, the
follow-up is a DECSTBM scroll-region (belt-and-suspenders).
