### PR TITLE
Fix Quick Start package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ You start a Claude Code session on your workstation. It's working on a complex t
 
 ```bash
 # Install
-bun install -g remi
+bun install -g @yooz-labs/remi
+
+# The installed binary is still named `remi`
+# If you previously installed the unrelated unscoped package, remove it first:
+bun remove -g remi
 
 # Start Claude Code with Remi (session persists if terminal closes)
 remi -- claude


### PR DESCRIPTION
## Summary

Updates the Quick Start install command to use the published scoped package, `@yooz-labs/remi`, and notes that the installed binary remains `remi`.

## Why

The unscoped `remi` package on npm is a different third-party package. New users following the current Quick Start can install the wrong package before they ever reach the Remi daemon commands.

Fixes #547.

## Verification

```sh
npm view remi name description
npm view @yooz-labs/remi name description
```

The unscoped `remi` package resolves to a plugin registrator, while `@yooz-labs/remi` is the Remi package for this project.