### PR TITLE
Phase 1: Always-escalate design/plan-mode/long-form questions

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -278,17 +278,17 @@ export class AutoApproveService {
         return { decision: 'approve', reasoning, durationMs: 0, model };
       }
 
-      // Design / plan-mode / long-form questions are NEVER auto-decided (#572):
-      // the LLM must not answer something only the user can (AskUserQuestion,
-      // ExitPlanMode, or any tool that structurally poses a non-binary
-      // question). Structural check BEFORE the queue and the LLM, so it costs
-      // zero latency, takes no eval-queue slot, and never triggers the
-      // escalate_model second opinion.
+      // Design / plan-mode / long-form questions are never auto-decided by the
+      // LLM (#572): AskUserQuestion, ExitPlanMode, or any tool that structurally
+      // poses a non-binary question. Runs AFTER the deny/allow/group checks
+      // (those are deterministic, explicit user rules and intentionally win),
+      // but BEFORE the queue and the LLM, so it costs zero latency, takes no
+      // eval-queue slot, and never triggers the escalate_model second opinion.
+      // Logged unconditionally (like the deny branches): a structural router
+      // that bypasses the LLM must be traceable even when log_decisions is off.
       if (isDesignQuestion(toolName, toolInput, permissionSuggestions, this.alwaysEscalateTools)) {
-        const reasoning = `always-escalate (design/plan/long-form), tool=${toolName}; never auto-decided`;
-        if (this.logDecisions) {
-          this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
-        }
+        const reasoning = `always-escalate (design/plan/long-form), tool=${toolName}; never auto-decided by LLM`;
+        this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
         return { decision: 'escalate', reasoning, durationMs: 0, model };
       }
 

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -15,6 +15,7 @@ import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
 import {
   buildMultiChoicePrompt,
+  isDesignQuestion,
   isMultiChoicePermission,
   parseMultiChoiceDecision,
 } from './multichoice.ts';
@@ -84,6 +85,8 @@ export class AutoApproveService {
   private readonly denyGroups: readonly string[];
   private readonly instructions: string;
   private readonly multichoiceMode: MultiChoiceMode;
+  /** Tool names that always escalate to the user, never auto-decided (#572). */
+  private readonly alwaysEscalateTools: ReadonlySet<string>;
   /** Falls back to llmConfig.model when empty. */
   private readonly multichoiceModel: string;
   /** Second-opinion model on a primary 'escalate' (#522); empty = none. Public
@@ -133,6 +136,7 @@ export class AutoApproveService {
     this.denyGroups = config.deny_groups;
     this.instructions = config.instructions;
     this.multichoiceMode = config.multichoice;
+    this.alwaysEscalateTools = new Set(config.always_escalate_tools);
     this.multichoiceModel = config.multichoice_model;
     this.escalateModel = config.escalate_model;
     this.escalateTimeoutMs = config.escalate_timeout > 0 ? config.escalate_timeout * 1000 : 0;
@@ -272,6 +276,20 @@ export class AutoApproveService {
           this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
         }
         return { decision: 'approve', reasoning, durationMs: 0, model };
+      }
+
+      // Design / plan-mode / long-form questions are NEVER auto-decided (#572):
+      // the LLM must not answer something only the user can (AskUserQuestion,
+      // ExitPlanMode, or any tool that structurally poses a non-binary
+      // question). Structural check BEFORE the queue and the LLM, so it costs
+      // zero latency, takes no eval-queue slot, and never triggers the
+      // escalate_model second opinion.
+      if (isDesignQuestion(toolName, toolInput, permissionSuggestions, this.alwaysEscalateTools)) {
+        const reasoning = `always-escalate (design/plan/long-form), tool=${toolName}; never auto-decided`;
+        if (this.logDecisions) {
+          this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
+        }
+        return { decision: 'escalate', reasoning, durationMs: 0, model };
       }
 
       const isMultiChoice = isMultiChoicePermission(toolName, permissionSuggestions);

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -84,6 +84,56 @@ export function isMultiChoicePermission(
   return !stringLabels.every(isBinaryShapedLabel);
 }
 
+/**
+ * Keys under which a tool carries a user-facing question in its `tool_input`.
+ * Deliberately narrow — only structured question fields, never a Bash command
+ * string — so a `Bash` command ending in "?" is not mistaken for a question.
+ */
+const QUESTION_INPUT_FIELDS: readonly string[] = ['question', 'questions'];
+
+function hasQuestionField(toolInput: Record<string, unknown> | null | undefined): boolean {
+  if (!toolInput) return false;
+  for (const key of QUESTION_INPUT_FIELDS) {
+    const v = toolInput[key];
+    if (typeof v === 'string' && v.trim().length > 0) return true;
+    if (Array.isArray(v) && v.length > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * True when a permission must ALWAYS go to the human — a design / plan-mode /
+ * long-form question the binary approve/deny path cannot answer and the LLM
+ * must never auto-decide (#572). Two layers:
+ *
+ * 1. Tool-name allowlist (`alwaysEscalateTools`, default
+ *    `DEFAULT_ALWAYS_ESCALATE_TOOLS` in types.ts plus any user-configured
+ *    names): definitionally user-intent tools. Immune to tool_input shape drift.
+ * 2. Free-text heuristic: a tool that structurally carries a question field
+ *    (see `QUESTION_INPUT_FIELDS`) whose suggestions are not all yes/no-shaped
+ *    is a long-form question with no binary mapping. Catches MCP / custom tools
+ *    that mimic AskUserQuestion without being on the allowlist.
+ *
+ * Evaluated BEFORE any LLM call so the outcome is structural (not a model
+ * guess), costs zero latency, takes no eval-queue slot, and never triggers the
+ * escalate_model second opinion.
+ */
+export function isDesignQuestion(
+  toolName: string,
+  toolInput: Record<string, unknown> | null | undefined,
+  permissionSuggestions: readonly unknown[] | null | undefined,
+  alwaysEscalateTools: ReadonlySet<string>,
+): boolean {
+  if (alwaysEscalateTools.has(toolName)) return true;
+  if (!hasQuestionField(toolInput)) return false;
+  const stringLabels = Array.isArray(permissionSuggestions)
+    ? permissionSuggestions.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  // A question with no binary-shaped suggestions has no approve/deny mapping —
+  // the user must select or type a long-form answer.
+  return stringLabels.length === 0 || !stringLabels.every(isBinaryShapedLabel);
+}
+
 const MULTI_CHOICE_SYSTEM_PROMPT = `You are a permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).
 
 Claude Code is asking the user to PICK ONE option from a numbered list. Your job is to choose the most appropriate option, OR escalate to the user when you cannot decide confidently.

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -11,7 +11,11 @@
  *
  * 1. Tool name. `ExitPlanMode` is always multi-choice: the user's intent
  *    (continue planning, accept plan, accept and stop asking) cannot be
- *    derived from tool input, so the LLM should never auto-pick.
+ *    derived from tool input, so the LLM should never auto-pick. (Under the
+ *    default config `ExitPlanMode` is pre-empted even earlier by
+ *    `isDesignQuestion` / `always_escalate_tools` in auto-approve-service.ts;
+ *    this `ALWAYS_MULTI_CHOICE_TOOLS` entry is the fallback if a user removes
+ *    it from that list.)
  * 2. String-label count > 3: a custom plugin tool with 4+ string choices
  *    cannot be expressed in the approve/deny mapping at all.
  * 3. String-label shape: any 2- or 3-label set whose labels are not all
@@ -91,14 +95,34 @@ export function isMultiChoicePermission(
  */
 const QUESTION_INPUT_FIELDS: readonly string[] = ['question', 'questions'];
 
-function hasQuestionField(toolInput: Record<string, unknown> | null | undefined): boolean {
-  if (!toolInput) return false;
-  for (const key of QUESTION_INPUT_FIELDS) {
-    const v = toolInput[key];
-    if (typeof v === 'string' && v.trim().length > 0) return true;
-    if (Array.isArray(v) && v.length > 0) return true;
+function isNonEmptyString(v: unknown): boolean {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+/**
+ * A question-bearing value: a non-empty string, or a non-empty array whose
+ * elements are question strings or `{question: string}` objects (the real
+ * AskUserQuestion shape). A bare array of numbers / null / `{}` is NOT a
+ * question, so a custom tool with an unrelated field named `questions` is not
+ * mis-escalated.
+ */
+function isQuestionLike(v: unknown): boolean {
+  if (isNonEmptyString(v)) return true;
+  if (Array.isArray(v)) {
+    return v.some(
+      (item) =>
+        isNonEmptyString(item) ||
+        (item !== null &&
+          typeof item === 'object' &&
+          isNonEmptyString((item as { question?: unknown }).question)),
+    );
   }
   return false;
+}
+
+function hasQuestionField(toolInput: Record<string, unknown> | null | undefined): boolean {
+  if (!toolInput) return false;
+  return QUESTION_INPUT_FIELDS.some((key) => isQuestionLike(toolInput[key]));
 }
 
 /**

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -178,7 +178,9 @@ export interface AutoApproveConfig {
    * the LLM (#572) — design / plan-mode / long-form questions whose answers are
    * not yes/no. Matched by tool name BEFORE any LLM call, so it costs zero
    * latency, takes no eval-queue slot, and never triggers the escalate_model
-   * second opinion. Default: ["AskUserQuestion", "ExitPlanMode"]. Extend with
+   * second opinion. Explicit `deny`/`allow` rules are deterministic and still
+   * checked first, so a user can override this for a specific tool.
+   * Default: ["AskUserQuestion", "ExitPlanMode"]. Extend with
    * custom MCP tools that solicit user intent. A free-text heuristic also
    * escalates any tool that structurally carries a question field with
    * non-binary suggestions. See `DEFAULT_ALWAYS_ESCALATE_TOOLS`.

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -59,6 +59,15 @@ export type AutoApproveResult = AutoApproveDecisionResult | AutoApproveCancelled
 /** How auto-approve treats multi-choice permission prompts (#399). */
 export type MultiChoiceMode = 'skip' | 'evaluate';
 
+/**
+ * Tools whose invocation is, by definition, a request for user intent the
+ * auto-approve LLM must never answer (#572): `AskUserQuestion` (Claude
+ * explicitly solicited the user) and `ExitPlanMode` (plan-mode accept /
+ * keep-planning is a direction decision). Default for
+ * `AutoApproveConfig.always_escalate_tools`.
+ */
+export const DEFAULT_ALWAYS_ESCALATE_TOOLS: readonly string[] = ['AskUserQuestion', 'ExitPlanMode'];
+
 /** Configuration for the auto-approve feature */
 export interface AutoApproveConfig {
   readonly enabled: boolean;
@@ -164,4 +173,15 @@ export interface AutoApproveConfig {
    * has no knob to disable reasoning).
    */
   readonly disable_thinking: boolean;
+  /**
+   * Tool names that ALWAYS escalate to the user and are NEVER auto-decided by
+   * the LLM (#572) — design / plan-mode / long-form questions whose answers are
+   * not yes/no. Matched by tool name BEFORE any LLM call, so it costs zero
+   * latency, takes no eval-queue slot, and never triggers the escalate_model
+   * second opinion. Default: ["AskUserQuestion", "ExitPlanMode"]. Extend with
+   * custom MCP tools that solicit user intent. A free-text heuristic also
+   * escalates any tool that structurally carries a question field with
+   * non-binary suggestions. See `DEFAULT_ALWAYS_ESCALATE_TOOLS`.
+   */
+  readonly always_escalate_tools: readonly string[];
 }

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -384,6 +384,13 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
       `Invalid auto_approve.always_escalate_tools in ${configPath}: must be an array of tool names. Example: always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]`,
     );
   }
+  for (const t of cfg.always_escalate_tools) {
+    if (t.trim().length === 0) {
+      console.warn(
+        `[AutoApprove] Warning: always_escalate_tools entry "${t}" in ${configPath} is empty/whitespace and will never match a tool name.`,
+      );
+    }
+  }
 
   // Warn about dangerously short patterns that would match too broadly.
   const MIN_PATTERN_LENGTH = 2;
@@ -530,12 +537,18 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       .filter((s) => s.length > 0);
   }
   if (env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE']) {
-    (auto_approve as { always_escalate_tools: readonly string[] }).always_escalate_tools = env[
-      'REMI_AUTO_APPROVE_ALWAYS_ESCALATE'
-    ]
+    const tools = env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE']
       .split(/[\n,]/)
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
+    if (tools.length === 0) {
+      console.warn(
+        '[AutoApprove] REMI_AUTO_APPROVE_ALWAYS_ESCALATE resolved to an empty list; ' +
+          'AskUserQuestion and ExitPlanMode will no longer be structurally escalated. ' +
+          'Set it to "AskUserQuestion,ExitPlanMode" to keep the default safety net.',
+      );
+    }
+    (auto_approve as { always_escalate_tools: readonly string[] }).always_escalate_tools = tools;
   }
   const mc = env['REMI_AUTO_APPROVE_MULTICHOICE'];
   if (mc === 'skip' || mc === 'evaluate') {

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
 import { parse as parseToml } from 'smol-toml';
 import { isKnownGroup, knownGroupNames } from '../auto-approve/permission-groups.ts';
+import { DEFAULT_ALWAYS_ESCALATE_TOOLS } from '../auto-approve/types.ts';
 import type { AutoApproveConfig } from '../auto-approve/types.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
@@ -183,6 +184,9 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // load-bearing for following broad user instructions. Opt in (Ollama only)
     // for raw speed over decision nuance.
     disable_thinking: false,
+    // Always escalate these to the user; never auto-decided by the LLM (#572):
+    // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
+    always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
   },
   features: {
     transcript_binder_shadow: false,
@@ -375,6 +379,11 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   }
   expectString('multichoice_model', cfg.multichoice_model);
   expectString('escalate_model', cfg.escalate_model);
+  if (!isStringArray(cfg.always_escalate_tools)) {
+    throw new Error(
+      `Invalid auto_approve.always_escalate_tools in ${configPath}: must be an array of tool names. Example: always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]`,
+    );
+  }
 
   // Warn about dangerously short patterns that would match too broadly.
   const MIN_PATTERN_LENGTH = 2;
@@ -520,6 +529,14 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
   }
+  if (env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE']) {
+    (auto_approve as { always_escalate_tools: readonly string[] }).always_escalate_tools = env[
+      'REMI_AUTO_APPROVE_ALWAYS_ESCALATE'
+    ]
+      .split(/[\n,]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
   const mc = env['REMI_AUTO_APPROVE_MULTICHOICE'];
   if (mc === 'skip' || mc === 'evaluate') {
     (auto_approve as { multichoice: 'skip' | 'evaluate' }).multichoice = mc;
@@ -657,6 +674,11 @@ authorized_user_ids = []
 #                                  # lowers decision quality (reasoning helps
 #                                  # the model follow broad instructions), so
 #                                  # default off. Opt in for raw speed.
+# always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]
+#                                  # Tools that ALWAYS go to the user, never
+#                                  # auto-decided by the LLM (design / plan-mode
+#                                  # / long-form questions). Add custom MCP tools
+#                                  # that solicit user intent.
 `;
 }
 
@@ -743,6 +765,9 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
+  lines.push(
+    `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,
+  );
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
   lines.push('[features]');

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -1314,7 +1314,7 @@ describe('design/plan-mode always-escalate (#572)', () => {
     const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'Which DB?' }] });
     expect(r.decision).toBe('escalate');
     expect(r.durationMs).toBe(0);
-    if (r.decision !== 'cancelled') expect(r.reasoning).toContain('always-escalate');
+    expect(r.reasoning).toContain('always-escalate');
   });
 
   test('ExitPlanMode escalates structurally even in multichoice=evaluate mode', async () => {
@@ -1356,6 +1356,20 @@ describe('design/plan-mode always-escalate (#572)', () => {
     );
     const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'x' }] });
     expect(r.decision).toBe('deny');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('allow list is still checked first (explicit allow overrides the classifier)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        allow: ['AskUserQuestion'],
+        always_escalate_tools: ['AskUserQuestion'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'x' }] });
+    expect(r.decision).toBe('approve');
     expect(r.durationMs).toBe(0);
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -53,6 +53,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }
@@ -1294,5 +1295,67 @@ describe('AutoApproveService - multichoice regression guards', () => {
     } finally {
       server.stop();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design / plan-mode / long-form always-escalate (#572) - deterministic.
+// These never call the LLM, so they run without Ollama. base_url points at a
+// closed port: any regression that reached the LLM would yield durationMs > 0.
+// ---------------------------------------------------------------------------
+describe('design/plan-mode always-escalate (#572)', () => {
+  const offline = { base_url: 'http://127.0.0.1:1/v1', provider: 'http://127.0.0.1:1/v1' };
+
+  test('AskUserQuestion escalates structurally, with no LLM call (0ms)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({ ...offline, always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'] }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'Which DB?' }] });
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+    if (r.decision !== 'cancelled') expect(r.reasoning).toContain('always-escalate');
+  });
+
+  test('ExitPlanMode escalates structurally even in multichoice=evaluate mode', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        multichoice: 'evaluate',
+        always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('ExitPlanMode', { plan: 'ship it' });
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('free-text heuristic escalates a question-posing tool not on the allowlist', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({ ...offline, always_escalate_tools: [] }),
+      logFn,
+    );
+    const r = await svc.evaluate('mcp__ask', { question: 'Which approach?' }, undefined, [
+      'Alpha',
+      'Beta',
+      'Gamma',
+    ]);
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('deny list is still checked first (explicit user rule wins over the classifier)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        deny: ['AskUserQuestion'],
+        always_escalate_tools: ['AskUserQuestion'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'x' }] });
+    expect(r.decision).toBe('deny');
+    expect(r.durationMs).toBe(0);
   });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -118,6 +118,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
   };
 }
 

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -68,6 +68,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -374,4 +374,16 @@ describe('isDesignQuestion (#572)', () => {
     // ...but a tool with neither a listed name nor a question field does not escalate.
     expect(isDesignQuestion('Bash', { command: 'ls' }, undefined, new Set())).toBe(false);
   });
+
+  test('a "questions" array of non-question elements does not trigger the heuristic', () => {
+    // Only strings or {question: string} objects count; bare numbers/null/{}
+    // must not over-escalate a custom tool with an unrelated `questions` field.
+    expect(isDesignQuestion('mcp__x', { questions: [42] }, undefined, DEFAULTS)).toBe(false);
+    expect(isDesignQuestion('mcp__x', { questions: [null] }, undefined, DEFAULTS)).toBe(false);
+    expect(isDesignQuestion('mcp__x', { questions: [{}] }, undefined, DEFAULTS)).toBe(false);
+    // ...but the real AskUserQuestion-style {question: string} element does.
+    expect(
+      isDesignQuestion('mcp__x', { questions: [{ question: 'Pick?' }] }, undefined, DEFAULTS),
+    ).toBe(true);
+  });
 });

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -5,9 +5,11 @@
 import { describe, expect, test } from 'bun:test';
 import {
   buildMultiChoicePrompt,
+  isDesignQuestion,
   isMultiChoicePermission,
   parseMultiChoiceDecision,
 } from '../../src/auto-approve/multichoice.ts';
+import { DEFAULT_ALWAYS_ESCALATE_TOOLS } from '../../src/auto-approve/types.ts';
 
 describe('isMultiChoicePermission', () => {
   test('returns false for null/undefined/empty (default 3-set substitutes)', () => {
@@ -286,5 +288,90 @@ describe('parseMultiChoiceDecision', () => {
     );
     expect(r.decision).toBe('pick');
     if (r.decision === 'pick') expect(r.index).toBe(2);
+  });
+});
+
+describe('isDesignQuestion (#572)', () => {
+  const DEFAULTS = new Set(DEFAULT_ALWAYS_ESCALATE_TOOLS);
+
+  test('AskUserQuestion always escalates by tool name, even with binary suggestions', () => {
+    expect(
+      isDesignQuestion(
+        'AskUserQuestion',
+        { questions: [{ question: 'Which?' }] },
+        undefined,
+        DEFAULTS,
+      ),
+    ).toBe(true);
+    // Tool name wins even when the suggestions look binary.
+    expect(isDesignQuestion('AskUserQuestion', {}, ['Yes', 'No'], DEFAULTS)).toBe(true);
+  });
+
+  test('ExitPlanMode always escalates by tool name', () => {
+    expect(isDesignQuestion('ExitPlanMode', { plan: 'do the thing' }, undefined, DEFAULTS)).toBe(
+      true,
+    );
+  });
+
+  test('Bash is never a design question, even when the command ends in "?"', () => {
+    // The free-text heuristic must NOT inspect the Bash command string.
+    expect(isDesignQuestion('Bash', { command: 'echo are we sure?' }, undefined, DEFAULTS)).toBe(
+      false,
+    );
+  });
+
+  test('Edit with the standard Yes/Always/No suggestions is not a design question', () => {
+    expect(
+      isDesignQuestion(
+        'Edit',
+        { file_path: '/x', old_string: 'a', new_string: 'b' },
+        ['Yes', 'Always', 'No'],
+        DEFAULTS,
+      ),
+    ).toBe(false);
+  });
+
+  test('free-text heuristic: a custom tool posing a question with no binary suggestions escalates', () => {
+    expect(
+      isDesignQuestion(
+        'mcp__ask',
+        { question: 'Which database should we use?' },
+        undefined,
+        DEFAULTS,
+      ),
+    ).toBe(true);
+    expect(isDesignQuestion('mcp__ask', { questions: ['a', 'b'] }, undefined, DEFAULTS)).toBe(true);
+  });
+
+  test('free-text heuristic: a question with binary suggestions has a yes/no mapping, does NOT escalate', () => {
+    expect(
+      isDesignQuestion('mcp__confirm', { question: 'Proceed?' }, ['Yes', 'No'], DEFAULTS),
+    ).toBe(false);
+  });
+
+  test('free-text heuristic: a question with non-binary suggestions escalates', () => {
+    expect(
+      isDesignQuestion('mcp__pick', { question: 'Which?' }, ['Alpha', 'Beta', 'Gamma'], DEFAULTS),
+    ).toBe(true);
+  });
+
+  test('a tool with no question field and not on the allowlist is not a design question', () => {
+    expect(isDesignQuestion('mcp__do', { path: '/x' }, undefined, DEFAULTS)).toBe(false);
+  });
+
+  test('whitespace-only question field does not trigger the heuristic', () => {
+    expect(isDesignQuestion('mcp__ask', { question: '   ' }, undefined, DEFAULTS)).toBe(false);
+  });
+
+  test('config-extensible: a user-listed tool escalates by name', () => {
+    expect(isDesignQuestion('mcp__myAsk', {}, undefined, new Set(['mcp__myAsk']))).toBe(true);
+  });
+
+  test('empty allowlist: the free-text heuristic still backs up AskUserQuestion-shaped input', () => {
+    expect(
+      isDesignQuestion('AskUserQuestion', { questions: [{ question: 'x' }] }, undefined, new Set()),
+    ).toBe(true);
+    // ...but a tool with neither a listed name nor a question field does not escalate.
+    expect(isDesignQuestion('Bash', { command: 'ls' }, undefined, new Set())).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -333,6 +333,7 @@ function makeConfig(model: string): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
   };
 }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -105,6 +105,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -291,6 +291,8 @@ describe('formatConfig', () => {
     expect(output).toContain('deny_groups = []');
     // escalate_model visible (#522).
     expect(output).toContain('escalate_model = ""');
+    // always_escalate_tools visible (#572).
+    expect(output).toContain('always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]');
   });
 
   test('default model is a fast 4b; escalate_model empty (#522)', () => {
@@ -369,6 +371,25 @@ timeout = 5
     // Defaults preserved for unset fields
     expect(config.auto_approve.base_url).toBe('http://localhost:11434/v1');
     expect(config.auto_approve.log_decisions).toBe(true);
+  });
+
+  test('loads always_escalate_tools from TOML (#572)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nalways_escalate_tools = ["MyTool"]\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.always_escalate_tools).toEqual(['MyTool']);
+  });
+
+  test('rejects always_escalate_tools as a non-array (#572)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nalways_escalate_tools = "AskUserQuestion"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/always_escalate_tools/);
+  });
+
+  test('REMI_AUTO_APPROVE_ALWAYS_ESCALATE env override trims and drops empties (#572)', () => {
+    process.env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE'] = 'AskUserQuestion, mcp__custom , ';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.auto_approve.always_escalate_tools).toEqual(['AskUserQuestion', 'mcp__custom']);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE'];
   });
 
   test('preserves auto_approve defaults when section missing', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -343,6 +343,7 @@ describe('auto_approve config', () => {
       escalate_timeout: 0,
       queue_timeout: 240,
       disable_thinking: false,
+      always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 1 of epic #571 (rethink the auto-approve → notification → answer pipeline). The LLM must never auto-decide **design / plan-mode / long-form** questions — questions whose answers are not yes/no. This was biting live: auto-approve pressed "1" on an `AskUserQuestion` prompt, hijacking the user's own answer.

Adds a pre-LLM structural classifier `isDesignQuestion()` in `multichoice.ts`, called in `AutoApproveService.evaluate()` right after the deny/allow/group checks and **before** the eval queue and the LLM:

- **Layer 1 (tool name):** `always_escalate_tools` — default `["AskUserQuestion", "ExitPlanMode"]`. Immune to tool_input shape drift; escalates even in `multichoice = "evaluate"` mode.
- **Layer 2 (free-text heuristic):** any tool that structurally carries a `question`/`questions` field with no binary-shaped suggestions. Deliberately never inspects a Bash command string (so `echo ...?` is not mistaken for a question).

Returns `escalate` at zero latency, takes no eval-queue slot, and never triggers the `escalate_model` second opinion. Explicit `deny`/`allow` rules are still checked first (user's explicit config wins; not the LLM deciding).

New config `auto_approve.always_escalate_tools` (TOML + `REMI_AUTO_APPROVE_ALWAYS_ESCALATE` env), wired through defaults, validation, `config show`, and the example template.

Closes #572. Part of epic #571.

## Test plan (NO MOCKS)

- Unit `isDesignQuestion` over real payloads: AskUserQuestion (±choices), ExitPlanMode, Bash command ending in `?` (must NOT trigger), Edit with Yes/Always/No, custom MCP tools with/without question fields and binary/non-binary suggestions, config-extensible names, empty-allowlist fallback.
- Deterministic service integration (no Ollama): AskUserQuestion + ExitPlanMode (even in `evaluate` mode) escalate with `durationMs === 0` (proves no LLM call); free-text heuristic; deny-list-wins ordering. `base_url` points at a closed port so any regression that reached the LLM would surface as `durationMs > 0`.
- `bun test` (affected files): 188 pass, 7 skip (Ollama-gated), 0 fail. Typecheck + biome clean.
