### PR TITLE
Phase 2: Hold the hook (Model B) + cancel + slow-eval push

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -31,6 +31,7 @@ import type { QuestionPresenceTracker } from '../api/question-presence-tracker.t
 import { log, logError } from '../cli/logger.ts';
 import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
 import type { SessionRegistry } from '../session/index.ts';
+import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
 
 /**
@@ -65,11 +66,14 @@ export interface AutoApproveGateDeps {
   tracker: QuestionPresenceTracker;
   /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
   isInSubagentContext: () => boolean;
-  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate wraps
-   *  every call in a try/catch, so an implementation that throws is logged and
-   *  absorbed rather than propagated; implementations should still prefer to
-   *  handle their own errors. */
-  escalate: (input: PermissionRequestHookInput) => void;
+  /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
+   *  of the `Question` it created (#573), so a binary escalation can hold the
+   *  hook keyed by that id and resolve it when the user answers; `undefined`
+   *  means no question was created (e.g. the push failed) and the gate must
+   *  fall open to passthrough rather than hold a hook nobody can answer. The
+   *  gate wraps every call in a try/catch, so an implementation that throws is
+   *  logged and absorbed (treated as `undefined`) rather than propagated. */
+  escalate: (input: PermissionRequestHookInput) => UUID | undefined;
   /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
    *  prompt until the verdict (don't push an auto-approved permission). #484. */
   onEvalStart?: () => void;
@@ -85,10 +89,44 @@ export interface AutoApproveGateDeps {
   /** Second-opinion model consulted on a primary 'escalate' in main context
    *  (#522). Empty/absent => no second opinion (escalate straight to the user). */
   escalateModel?: string;
+  /** Tools that ALWAYS escalate to the user, never auto-decided (#572). Used by
+   *  the gate to classify an escalation as binary (holdable) vs design (#573):
+   *  a design/plan-mode tool's pick cannot be expressed by the hook response, so
+   *  it passes through instead of holding. Absent => empty set (no extra tools). */
+  alwaysEscalateTools?: ReadonlySet<string>;
+  /** Milliseconds to HOLD a binary main-context PermissionRequest hook open
+   *  after escalating, until the user answers (Model B, #573). On expiry the
+   *  hold resolves 'passthrough' (fail open -> native prompt). <=0 (or absent)
+   *  disables holding: escalations return 'passthrough' immediately as before. */
+  holdMs?: number;
+  /** Milliseconds before a SLOW binary main-context eval triggers an early
+   *  push + hold (Part B, #573). If the eval has not produced a verdict within
+   *  this window, the gate pushes + holds the hook so the user can step in; a
+   *  late verdict then resolves the held hook. <=0 (or absent) disables Part B
+   *  entirely — the eval/timer race never arms, so behavior reverts to A+C. */
+  pushHoldMs?: number;
+}
+
+/** A held PermissionRequest hook awaiting a user answer (#573). The `resolve`
+ *  fulfills the promise the hook server is blocked on; the `timer` fails it open
+ *  to passthrough on hold-timeout. Keyed by the escalated `Question.id`. */
+interface PendingHold {
+  resolve: (decision: PermissionDecision) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 export class AutoApproveGate {
   private readonly sessionTag: string;
+
+  /**
+   * Binary main-context escalations currently holding their PermissionRequest
+   * hook open, keyed by the escalated `Question.id` (#573). Per-gate, so each
+   * session's holds are isolated. An entry lives from `escalateAndHold` until it
+   * is resolved by `resolveHeld` (the user answered), by the hold-timeout timer
+   * (fail open -> passthrough), or by `cancelStale` (session ended). Every exit
+   * path clears the timer and deletes the entry, so it never leaks.
+   */
+  private readonly pendingHolds = new Map<UUID, PendingHold>();
 
   constructor(
     private readonly deps: AutoApproveGateDeps,
@@ -109,10 +147,148 @@ export class AutoApproveGate {
    * service is configured.
    */
   cancelStale(reason: string): void {
+    // Release any held hooks first (#573): a Stop/SessionEnd means the session
+    // is going away, so a hook blocked on a human answer must fail open to
+    // passthrough rather than hang. A held hook cannot normally co-occur with
+    // Stop (Claude is blocked on the permission), but this is defensive.
+    this.releaseAllHolds('passthrough', reason);
     if (this.deps.service === null) return;
     if (this.deps.service.cancel(reason)) {
       log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
     }
+  }
+
+  /**
+   * Resolve a held PermissionRequest hook (#573). Called when the user answers
+   * from any channel (input-events.ts maps the picked option to allow/deny).
+   * Returns true when a hold for `questionId` existed and was resolved (the
+   * caller then skips the PTY inject — Claude is blocked on the hook, not
+   * rendering a prompt); false when no such hold exists (a non-held answer, e.g.
+   * a multi-choice pick or a non-auto-approve session, takes the PTY path).
+   * Clears the hold's timer and marks the permission handled so the #484 buffer
+   * + #513 cue close exactly as for a silent auto-decision.
+   */
+  resolveHeld(questionId: UUID, decision: 'allow' | 'deny'): boolean {
+    const hold = this.pendingHolds.get(questionId);
+    if (!hold) return false;
+    clearTimeout(hold.timer);
+    this.pendingHolds.delete(questionId);
+    this.markHandled();
+    hold.resolve(decision);
+    log(
+      `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)} resolved: ${decision}`,
+    );
+    return true;
+  }
+
+  /**
+   * Release a held hook to 'passthrough' so Claude renders its native numbered
+   * prompt (#573). Used when the user's answer cannot be expressed by the binary
+   * hook response — a "Yes, always" or a multi-choice pick — so the daemon pops
+   * the hold and the caller then injects the digit into the freshly-rendered
+   * prompt. Returns true iff a hold for `questionId` existed. Public wrapper over
+   * the private `releaseHeld(qid, 'passthrough')`; no markHandled (the user is
+   * about to answer the native prompt, not a silent auto-decision).
+   */
+  releaseHeldAsPassthrough(questionId: UUID): boolean {
+    return this.releaseHeld(questionId, 'passthrough');
+  }
+
+  /** Resolve every pending hold with one decision + reason, clearing timers and
+   *  emptying the map. Used by `cancelStale` (session teardown). */
+  private releaseAllHolds(decision: PermissionDecision, reason: string): void {
+    if (this.pendingHolds.size === 0) return;
+    log(
+      `[AutoApprove ${this.sessionTag}] Releasing ${this.pendingHolds.size} held hook(s) as ${decision} (${reason})`,
+    );
+    for (const [, hold] of this.pendingHolds) {
+      clearTimeout(hold.timer);
+      hold.resolve(decision);
+    }
+    this.pendingHolds.clear();
+  }
+
+  /**
+   * Escalate a binary main-context PermissionRequest to the user AND hold the
+   * hook open until the user answers (Model B, #573). `escalate()` stashes the
+   * hook record + pushes (returning the created `Question.id`); `onEscalate`
+   * releases the #484 buffer. Then:
+   *   - no question id (push failed) or holding disabled (holdMs <= 0) ->
+   *     'passthrough' (today's behavior: Claude renders its native prompt).
+   *   - else return a promise that stays PENDING until `resolveHeld` fulfills it
+   *     with allow/deny, or the hold-timeout fires and fails it open to
+   *     'passthrough' (so the terminal is never permanently stuck).
+   * The returned promise is what the hook server is blocked on.
+   */
+  private escalateAndHold(input: PermissionRequestHookInput): Promise<PermissionDecision> {
+    return this.createHold(input).decision;
+  }
+
+  /**
+   * Escalate (push) a binary main-context permission and register a hold,
+   * returning BOTH the held promise the hook server blocks on AND the created
+   * `Question.id` (so Part B can reconcile a late verdict into the same hold).
+   * `questionId` is undefined when no question was created (push failed) or
+   * holding is disabled — in which case `decision` is an immediate 'passthrough'
+   * (today's behavior) and no hold is registered.
+   */
+  private createHold(input: PermissionRequestHookInput): {
+    decision: Promise<PermissionDecision>;
+    questionId: UUID | undefined;
+  } {
+    const qid = this.escalateToUser(input);
+    const holdMs = this.deps.holdMs ?? 0;
+    if (!qid || holdMs <= 0) return { decision: Promise.resolve('passthrough'), questionId: qid };
+    const decision = new Promise<PermissionDecision>((resolve) => {
+      const timer = setTimeout(() => {
+        // Fail open: the user did not answer within the hold window, so let
+        // Claude render its native prompt (the local terminal can take over).
+        this.pendingHolds.delete(qid);
+        log(
+          `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
+        );
+        resolve('passthrough');
+      }, holdMs);
+      // setTimeout keeps the event loop alive for the whole human-paced hold;
+      // unref so a held hook never blocks daemon shutdown.
+      timer.unref?.();
+      this.pendingHolds.set(qid, { resolve, timer });
+    });
+    return { decision, questionId: qid };
+  }
+
+  /**
+   * Escalate a main-context permission to the user (#573). A BINARY escalation
+   * holds the hook open (`escalateAndHold`) so the user's answer resolves it via
+   * the hook response with no PTY render; a multi-choice / design escalation
+   * cannot be expressed by the binary response, so it escalates + returns
+   * 'passthrough' immediately (Claude renders the native prompt and the pick is
+   * delivered by the legacy PTY path / a later phase). Always main context — the
+   * subagent escalate paths default-deny and never reach here.
+   */
+  private escalateMain(input: PermissionRequestHookInput): Promise<PermissionDecision> {
+    if (this.isBinaryEscalation(input)) {
+      return this.escalateAndHold(input);
+    }
+    this.escalateToUser(input);
+    return Promise.resolve('passthrough');
+  }
+
+  /**
+   * Whether an escalated permission is BINARY (answerable allow/deny via the
+   * hook response) and therefore holdable (#573). Multi-choice prompts and
+   * design / plan-mode / long-form questions cannot be expressed by the binary
+   * response, so they always passthrough (their pick delivery is a later phase).
+   * Mirrors the service's own structural classifiers so the gate and the service
+   * agree on what "binary" means.
+   */
+  private isBinaryEscalation(input: PermissionRequestHookInput): boolean {
+    const suggestions = input.permission_suggestions as readonly unknown[] | undefined;
+    const alwaysEscalate = this.deps.alwaysEscalateTools ?? new Set<string>();
+    return (
+      !isMultiChoicePermission(input.tool_name, suggestions) &&
+      !isDesignQuestion(input.tool_name, input.tool_input, suggestions, alwaysEscalate)
+    );
   }
 
   /**
@@ -139,14 +315,13 @@ export class AutoApproveGate {
     }
 
     // No auto-approve: subagent default-denies via the response (no PTY, no
-    // leak); main escalates to the user.
+    // leak); main escalates to the user (holding the hook when binary, #573).
     if (!service) {
       if (isInSubagentContext()) {
         log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
         return 'deny';
       }
-      this.escalateToUser(input);
-      return 'passthrough';
+      return this.escalateMain(input);
     }
 
     // Open the buffer/cue window (#484/#513). With synchronous decisions Claude
@@ -154,25 +329,36 @@ export class AutoApproveGate {
     // PTY prompt now; the cue lifecycle still rides these signals.
     this.safeCue('onEvalStart', this.deps.onEvalStart);
 
+    // Raw suggestions: the service does its own strict-string filtering; we
+    // forward the raw shape so the multi-choice classifier can route a
+    // non-string entry through escalate instead of crashing.
+    const evalPromise = service.evaluate(
+      input.tool_name,
+      input.tool_input,
+      this.sessionTag,
+      input.permission_suggestions as readonly unknown[] | undefined,
+    );
+
+    // Part B (#573, ISOLATED behind push_hold_timeout): if the eval is still
+    // running after push_hold_timeout AND this is a binary main-context
+    // permission, push + hold the hook early so the user can step in while the
+    // model keeps thinking; the late verdict then reconciles into that hold.
+    // When push_hold_timeout <= 0 this never arms and the eval is awaited as
+    // usual (Parts A + C only). A non-null result means the early hold fired and
+    // the returned decision is what the hook server is blocked on.
+    const earlyHold = await this.maybePushOnSlowEval(input, evalPromise);
+    if (earlyHold !== null) return earlyHold;
+
     let result: AutoApproveResult;
     try {
-      // Raw suggestions: the service does its own strict-string filtering; we
-      // forward the raw shape so the multi-choice classifier can route a
-      // non-string entry through escalate instead of crashing.
-      result = await service.evaluate(
-        input.tool_name,
-        input.tool_input,
-        this.sessionTag,
-        input.permission_suggestions as readonly unknown[] | undefined,
-      );
+      result = await evalPromise;
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
       if (isInSubagentContext()) {
         this.markHandled();
         return 'deny';
       }
-      this.escalateToUser(input);
-      return 'passthrough';
+      return this.escalateMain(input);
     }
 
     if (result.decision === 'cancelled') {
@@ -270,8 +456,127 @@ export class AutoApproveGate {
       }
       // second opinion still unsure (escalate/pick) -> ask the user.
     }
-    this.escalateToUser(input);
-    return 'passthrough';
+    return this.escalateMain(input);
+  }
+
+  // -------------------------------------------------------------------------
+  // Part B (#573): slow-eval early push + hold. ISOLATED behind push_hold_timeout.
+  // Everything below is gated by `pushHoldMs > 0`; when it is <= 0 the method
+  // returns null without arming any timer, so removing this block (delete the
+  // method + its single call site, and the call site's `await ... ?? null`
+  // collapses to the plain `await evalPromise`) reverts the gate to A + C only
+  // with no other change.
+  // -------------------------------------------------------------------------
+
+  /**
+   * If a binary main-context eval is slow, push + hold the hook EARLY so the
+   * user can decide while the model keeps thinking (Part B). Returns:
+   *   - null  -> Part B did not fire (disabled, non-binary, subagent context, or
+   *              the eval settled before push_hold_timeout). The caller awaits
+   *              the eval and handles the verdict normally.
+   *   - a resolved PermissionDecision (from the held promise) -> the early hold
+   *     fired; the returned promise is what the hook server is blocked on, and
+   *     the late verdict has been reconciled into that same hold here. The caller
+   *     returns it WITHOUT also awaiting the eval (avoids a double decision).
+   *
+   * The eval/timer race is entirely self-contained so it cannot disturb the A/C
+   * paths: it only ever calls `escalateAndHold` (the shared hold primitive) and
+   * `resolveHeld` / `releaseHeld` to reconcile, with a `pushed` guard so a late
+   * escalate verdict never pushes a second time.
+   */
+  private async maybePushOnSlowEval(
+    input: PermissionRequestHookInput,
+    evalPromise: Promise<AutoApproveResult>,
+  ): Promise<PermissionDecision | null> {
+    const pushHoldMs = this.deps.pushHoldMs ?? 0;
+    // Disabled, or this escalation could not be answered via the hook response
+    // anyway (multi-choice/design), or a subagent prompt the user can't answer:
+    // do not arm the race. Subagent context is read live (it may close before
+    // the verdict), but arming an early USER push for a subagent prompt would be
+    // wrong, so gate on the current value here.
+    if (pushHoldMs <= 0 || !this.isBinaryEscalation(input) || this.deps.isInSubagentContext()) {
+      return null;
+    }
+
+    // Suppress the eval promise's own unhandled-rejection while it races the
+    // timer (we attach the real handler only on the timer-wins branch). The
+    // eval-wins branch returns null and the caller awaits + handles it.
+    const safeEval = evalPromise.then(
+      (r) => ({ ok: true as const, result: r }),
+      (err) => ({ ok: false as const, err }),
+    );
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), pushHoldMs);
+      timer.unref?.();
+    });
+
+    const winner = await Promise.race([safeEval, timeout]);
+    if (winner !== 'timeout') {
+      // The eval settled first: no early push. Clear the timer and let the
+      // caller take the normal path (it re-awaits evalPromise, already resolved).
+      clearTimeout(timer);
+      return null;
+    }
+
+    // The timer won: the eval is still running. Push + hold the hook now so the
+    // user can step in. createHold returns the pending promise the hook server
+    // will block on AND the question id (or passthrough if the push failed /
+    // holding is off).
+    log(`[AutoApprove ${this.sessionTag}] Slow eval (>${pushHoldMs}ms); pushing + holding early`);
+    const { decision: heldDecision, questionId } = this.createHold(input);
+    // We have already pushed. The reconciliation NEVER pushes again — a late
+    // escalate just leaves the existing hold in place (guarded by the
+    // pendingHolds membership check inside reconcileLateVerdict).
+    void this.reconcileLateVerdict(safeEval, questionId);
+    return heldDecision;
+  }
+
+  /**
+   * Reconcile the late verdict of a slow eval into the already-pushed hold
+   * (Part B). The hold was created with `escalateAndHold`; here we resolve it:
+   * approve -> allow, deny -> deny, cancelled -> passthrough. An escalate/pick
+   * verdict (or an eval error) leaves the hold in place — the user is already
+   * looking at the pushed question, so no second push and no change. No-op when
+   * the hold is already gone (the user answered, or it timed out) so there is no
+   * double-resolve.
+   */
+  private async reconcileLateVerdict(
+    safeEval: Promise<{ ok: true; result: AutoApproveResult } | { ok: false; err: unknown }>,
+    qid: UUID | undefined,
+  ): Promise<void> {
+    const outcome = await safeEval;
+    if (!qid || !this.pendingHolds.has(qid)) return; // already resolved/timed out
+    if (!outcome.ok) {
+      // Eval threw: the user is already looking at the pushed question; leave the
+      // hold in place (it fails open on its own timeout if the user never answers).
+      logError(`[AutoApprove ${this.sessionTag}] Slow-eval late error (hold kept):`, outcome.err);
+      return;
+    }
+    const result = outcome.result;
+    if (result.decision === 'approve') {
+      this.resolveHeld(qid, 'allow');
+    } else if (result.decision === 'deny') {
+      this.resolveHeld(qid, 'deny');
+    } else if (result.decision === 'cancelled') {
+      // Claude advanced past the prompt during the slow eval; fail the hold open.
+      this.deps.tracker.clearPending();
+      this.releaseHeld(qid, 'passthrough');
+    }
+    // escalate / pick: already pushed + holding; no double-push, leave as-is.
+  }
+
+  /** Resolve a held hook with an arbitrary decision (incl. passthrough) WITHOUT
+   *  markHandled (used by Part B's cancelled reconciliation, where the verdict
+   *  was not a silent auto-decision). Returns true when a hold existed. */
+  private releaseHeld(questionId: UUID, decision: PermissionDecision): boolean {
+    const hold = this.pendingHolds.get(questionId);
+    if (!hold) return false;
+    clearTimeout(hold.timer);
+    this.pendingHolds.delete(questionId);
+    hold.resolve(decision);
+    return true;
   }
 
   /**
@@ -354,14 +659,18 @@ export class AutoApproveGate {
   /**
    * Safe escalation to the user. Used when inject fails or when auto-approve is off
    * and we're in main context. Wrapped so a bridge/push failure does not leave a
-   * dangling unhandled rejection in the hook handler.
+   * dangling unhandled rejection in the hook handler. Returns the created
+   * `Question.id` so a binary escalation can hold the hook keyed by it (#573);
+   * `undefined` when no question was created (the escalate threw / push failed),
+   * in which case `escalateAndHold` falls open to passthrough.
    */
-  private escalateToUser(input: PermissionRequestHookInput): void {
+  private escalateToUser(input: PermissionRequestHookInput): UUID | undefined {
+    let questionId: UUID | undefined;
     try {
       // escalate() stashes the hook record (onPermissionRequest -> recordPendingHook)
       // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
       // finds that record. Order matters; do not reorder. #484.
-      this.deps.escalate(input);
+      questionId = this.deps.escalate(input);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
     } finally {
@@ -372,5 +681,6 @@ export class AutoApproveGate {
       // terminal cue (#513, cosmetic); a cue throw must not break the finally.
       this.safeCue('onEscalate', this.deps.onEscalate);
     }
+    return questionId;
   }
 }

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -186,4 +186,30 @@ export interface AutoApproveConfig {
    * non-binary suggestions. See `DEFAULT_ALWAYS_ESCALATE_TOOLS`.
    */
   readonly always_escalate_tools: readonly string[];
+  /**
+   * Seconds the daemon HOLDS a BINARY main-context PermissionRequest hook open
+   * after escalating to the user, instead of returning passthrough immediately
+   * (Model B, #573). Claude blocks on the held hook (no native prompt rendered)
+   * until the user answers from any channel — the answer resolves the hook to
+   * allow/deny with no PTY render and no warm-connection race. On expiry the
+   * hold fails open to passthrough (Claude renders its native prompt), so the
+   * terminal is never permanently stuck. A human answers here and may be busy,
+   * so the default is large + human-paced (1800s). 0 disables holding entirely
+   * (escalate -> passthrough, the pre-#573 behavior). Only binary main-context
+   * escalations hold; multi-choice / design escalations always passthrough (the
+   * hook response cannot express a pick). The registered PermissionRequest hook
+   * timeout (hook-config-manager.ts) is kept >= this so Claude does not give up
+   * on the hook before the hold does.
+   */
+  readonly hold_timeout: number;
+  /**
+   * Seconds before a SLOW eval triggers an early push + hold (Part B, #573). If
+   * a binary main-context eval has not produced a verdict within this window,
+   * the daemon pushes the question and holds the hook so the user can step in
+   * while the model keeps thinking; a late approve/deny then resolves the held
+   * hook (no double-push). 0 disables Part B entirely — behavior reverts to the
+   * plain hold-on-escalate path (A+C only). Default 60. Kept well below
+   * `hold_timeout` so the early-push window opens before the hold itself expires.
+   */
+  readonly push_hold_timeout: number;
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -131,6 +131,7 @@ import {
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { setupHookBridge } from './cli/session-phases/hook-bridge-setup.ts';
+import type { SessionGateHandle } from './cli/session-phases/hook-bridge-setup.ts';
 import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
 import { StatusBar, childRows } from './cli/status-bar.ts';
@@ -795,6 +796,18 @@ let autoApproveService: AutoApproveService | null = null;
 // the StatusWriter (see the gate cue wiring in setupHookBridge); it replaced the
 // shared title-bar TerminalIndicator, which raced under concurrent evals.
 
+/**
+ * Seconds to pass HookConfigManager as the PermissionRequest hold budget (#573):
+ * the configured `hold_timeout` when auto-approve is actually enabled (so the
+ * registered hook timeout outlasts a long human-paced hold), else 0 (the
+ * baseline 600s ceiling, since a non-AA daemon never holds — it passes through
+ * near-instantly). Keeps the hook timeout from being needlessly inflated when
+ * holding can't happen.
+ */
+function permissionHookHoldTimeoutSec(): number {
+  return autoApproveService ? remiConfig.auto_approve.hold_timeout : 0;
+}
+
 // ---------------------------------------------------------------------------
 // SIGTSTP / Ctrl+Z handling.
 //
@@ -836,6 +849,11 @@ const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new 
 // interval (it lives inside the binder); close() reaches all three. Empty when
 // transcript_binder_enabled is off (no binder is ever constructed).
 const binderClosers: Map<UUID, () => void> = new Map();
+// Per-session auto-approve gate handles (#573): resolveHeld + cancelStale, keyed
+// by sessionId, so the WebSocket answer handler reaches the RIGHT session's gate
+// (multi-session daemons). Populated in createNewSession after setupHookBridge;
+// removed on session close. Empty when no hookServer is configured.
+const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
 const sessionStore = new SessionStore();
 // Tracks the subagent chats the primary session spawns, so the client can
 // switch the displayed view to a subagent (epic #499 phase 3). Shared by the
@@ -866,6 +884,9 @@ const sessionRegistry = new SessionRegistry(
       // for the rest of the daemon's life across resumes (#463 phase 3 review).
       binderClosers.get(sessionId)?.();
       binderClosers.delete(sessionId);
+      // Drop the per-session gate handle (#573); any held hook was already
+      // released by the gate's closeBinder/cancelStale on teardown.
+      sessionGateHandles.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();
@@ -1150,6 +1171,11 @@ async function createNewSession(
         transcriptDiscovery,
         subagentViews,
         statusWriter,
+        // #573: classify holdable escalations + the hold / slow-eval-push budgets
+        // (seconds; the gate converts to ms and treats <=0 as disabled).
+        alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),
+        holdTimeoutSec: remiConfig.auto_approve.hold_timeout,
+        pushHoldTimeoutSec: remiConfig.auto_approve.push_hold_timeout,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1157,6 +1183,9 @@ async function createNewSession(
     // its start() inside setupHookBridge); record its teardown so cleanup()
     // reaches the rotation dir-poll interval the shared maps below cannot.
     if (binderEnabled) binderClosers.set(sessionId, hookBridgeHandle.closeBinder);
+    // Register the per-session gate handle (#573) so the WebSocket answer path
+    // can resolve a held permission / cancel the eval for this exact session.
+    sessionGateHandles.set(sessionId, hookBridgeHandle.gate);
   }
 
   const ptySession = createPtySessionForSession(
@@ -1264,6 +1293,14 @@ const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
   bindingStore,
   send: sendToConnection,
+  // #573: route a held-permission answer / release-to-passthrough / eval-cancel
+  // to the RIGHT session's gate (the map is populated per session in
+  // createNewSession).
+  resolveHeldPermission: (sessionId, questionId, decision) =>
+    sessionGateHandles.get(sessionId)?.resolveHeld(questionId, decision) ?? false,
+  releaseHeldAsPassthrough: (sessionId, questionId) =>
+    sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
+  cancelAutoApprove: (sessionId, reason) => sessionGateHandles.get(sessionId)?.cancelStale(reason),
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({
@@ -1672,7 +1709,11 @@ if (cliDaemonMode) {
 
   if (hookServer) {
     try {
-      hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
+      hookConfigManager = new HookConfigManager(
+        workingDirectory,
+        hookServer.url,
+        permissionHookHoldTimeoutSec(),
+      );
       await hookConfigManager.install();
     } catch (err) {
       const msg = errorToString(err);
@@ -1865,7 +1906,11 @@ if (cliDaemonMode) {
     log(`Hook server listening on ${hookServer.url} (port ${HOOK_PORT})`);
 
     // Configure Claude Code hooks to POST to our server
-    hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
+    hookConfigManager = new HookConfigManager(
+      workingDirectory,
+      hookServer.url,
+      permissionHookHoldTimeoutSec(),
+    );
     await hookConfigManager.install();
     log('[Hooks] Claude Code hooks configured');
   } catch (err) {

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -10,7 +10,7 @@
  */
 
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
-import type { UUID } from '@remi/shared';
+import type { QuestionOption, UUID } from '@remi/shared';
 
 import type { SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
@@ -20,6 +20,37 @@ export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
   bindingStore: SessionBindingStore;
   send: SendToConnection;
+  /**
+   * Resolve a HELD binary PermissionRequest hook with the user's answer (Model
+   * B, #573), routed to the gate for `sessionId`. Returns true when a hold
+   * existed and was resolved — `onAnswer` then SKIPS the PTY inject (Claude is
+   * blocked on the hook, not rendering a prompt). Absent / false => the answer
+   * takes the existing PTY-submit path (multi-choice pick, non-AA session, or
+   * Part-B-disabled escalation that passed through). Session-keyed by cli.ts.
+   */
+  resolveHeldPermission?: (
+    sessionId: UUID,
+    questionId: UUID,
+    decision: 'allow' | 'deny',
+  ) => boolean;
+  /**
+   * Release a HELD binary PermissionRequest hook to 'passthrough' for `sessionId`
+   * (#573) when the user's answer cannot be expressed by the binary hook
+   * response — a "Yes, always" or a multi-choice pick. Claude then renders its
+   * native numbered prompt and `onAnswer` submits the digit (the only way to
+   * express "always" / a specific pick). Returns true iff a hold existed.
+   * Session-keyed by cli.ts.
+   */
+  releaseHeldAsPassthrough?: (sessionId: UUID, questionId: UUID) => boolean;
+  /**
+   * Cancel the in-flight auto-approve eval (and release holds) for `sessionId`
+   * when the user answers a HELD permission from any channel (#573, issue 2): a
+   * stale eval would otherwise keep running and could inject a phantom decision.
+   * Fired ONLY when a hold was actually resolved/released, so answering an
+   * unrelated passthrough question does not abort a different binary permission's
+   * in-flight eval. Session-keyed.
+   */
+  cancelAutoApprove?: (sessionId: UUID, reason: string) => void;
 }
 
 /**
@@ -80,8 +111,42 @@ function guardBinding(
 
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
+/**
+ * Map a chosen answer string to a binary allow/deny decision via the active
+ * Question's options (#573). The answer the client sends is an option `value`
+ * (e.g. "1"/"2"/"3" or "y"/"n"); we find the matching option and read its
+ * `isYes` / `isNo` flags. Returns:
+ *   - 'deny' for a no-shaped option;
+ *   - 'allow' for a yes-shaped option ONLY when it is a one-time "Yes" — an
+ *     "always"-shaped label ("Yes, always") is NOT mapped, because the binary
+ *     PermissionRequest hook response can only express allow/deny, never the
+ *     session-wide "always" the user picked. Downgrading it to a one-time allow
+ *     would silently lose that choice, so it returns null and the caller takes
+ *     the native PTY path (which can express "always" via the digit);
+ *   - null otherwise (always-shaped, unknown value, or free text) -> PTY path.
+ */
+function mapAnswerToDecision(
+  options: readonly QuestionOption[],
+  answer: string,
+): 'allow' | 'deny' | null {
+  const option = options.find((o) => o.value === answer);
+  if (!option) return null;
+  if (option.isNo) return 'deny';
+  // "always" cannot be expressed in the binary hook response, so a yes-shaped
+  // "always" option must NOT collapse to a one-time allow.
+  if (option.isYes && !option.label.toLowerCase().includes('always')) return 'allow';
+  return null;
+}
+
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, bindingStore, send } = deps;
+  const {
+    sessionRegistry,
+    bindingStore,
+    send,
+    resolveHeldPermission,
+    releaseHeldAsPassthrough,
+    cancelAutoApprove,
+  } = deps;
 
   return {
     onUserInput: async (
@@ -168,7 +233,39 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      await session.pty.submitInput(answer);
+      // Model B (#573): if the auto-approve gate is HOLDING this permission's
+      // hook, a binary (one-time Yes / No) answer resolves it via the hook
+      // response — Claude is blocked on the hook and is NOT rendering a prompt,
+      // so a PTY submit would land in the wrong place. An answer the binary
+      // response cannot express ("Yes, always", a multi-choice pick, free text)
+      // first RELEASES the held hook to passthrough so Claude renders its native
+      // numbered prompt, then submits the digit (the only way to express
+      // "always" / a specific pick).
+      const decision = mapAnswerToDecision(active.options, answer);
+      let hadHold = false;
+      if (decision !== null) {
+        hadHold = resolveHeldPermission?.(session.sessionId, questionId, decision) ?? false;
+      }
+      if (!hadHold) {
+        // decision === null (always/pick/free-text) OR no hold for this question:
+        // if a hold exists, pop it to passthrough so the native prompt renders,
+        // then submit the digit. If no hold, this is the normal PTY path.
+        const released = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
+        hadHold = hadHold || released;
+        await session.pty.submitInput(answer);
+      } else {
+        log(
+          `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,
+        );
+      }
+
+      // Cancel the in-flight eval ONLY when a held permission was actually
+      // resolved/released (#573, issue 2): a stale verdict for THIS permission
+      // must not inject a phantom decision. Answering an unrelated passthrough
+      // question must NOT abort a different binary permission's eval, so this is
+      // gated on hadHold rather than firing on every answer.
+      if (hadHold) cancelAutoApprove?.(session.sessionId, 'user-answered');
+
       // Remove only the answered question; sibling prompts remain answerable.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
     },

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -116,6 +116,25 @@ export interface HookBridgeDeps {
    * all sessions (one terminal). Optional; inert when absent or headless.
    */
   statusWriter?: StatusWriter | undefined;
+  /**
+   * Tools that always escalate to the user (#572). Passed to the gate so it
+   * classifies an escalation as binary (holdable, #573) vs design/plan-mode
+   * (passthrough). From `config.auto_approve.always_escalate_tools`. Absent =>
+   * empty set (tests / no-AA callers).
+   */
+  alwaysEscalateTools?: ReadonlySet<string>;
+  /**
+   * Seconds to HOLD a binary main-context PermissionRequest hook open until the
+   * user answers (Model B, #573). From `config.auto_approve.hold_timeout`. 0 /
+   * absent => no holding (escalate -> passthrough as before).
+   */
+  holdTimeoutSec?: number;
+  /**
+   * Seconds before a slow binary main-context eval triggers an early push + hold
+   * (Part B, #573). From `config.auto_approve.push_hold_timeout`. 0 / absent =>
+   * Part B disabled (the eval/timer race never arms).
+   */
+  pushHoldTimeoutSec?: number;
 }
 
 export interface HookBridgeArgs {
@@ -133,6 +152,32 @@ export interface HookBridgeArgs {
   tracker: QuestionPresenceTracker;
 }
 
+/**
+ * Per-session control surface for the auto-approve gate (#573). Registered by
+ * cli.ts keyed by `sessionId` so the WebSocket answer handler reaches the RIGHT
+ * session's gate when the user answers a held permission.
+ */
+export interface SessionGateHandle {
+  /**
+   * Resolve a held binary PermissionRequest hook with the user's answer (Model
+   * B). Returns true when a hold for `questionId` existed and was resolved (the
+   * caller then SKIPS the PTY inject — Claude is blocked on the hook, not
+   * rendering); false when no hold exists (the answer takes the PTY path, e.g. a
+   * multi-choice pick or a non-AA session).
+   */
+  resolveHeld: (questionId: UUID, decision: 'allow' | 'deny') => boolean;
+  /**
+   * Release a held hook to 'passthrough' so Claude renders its native numbered
+   * prompt (#573), for answers the binary hook response cannot express ("Yes,
+   * always", a multi-choice pick). Returns true iff a hold existed; the caller
+   * then injects the digit into the rendered prompt.
+   */
+  releaseHeldAsPassthrough: (questionId: UUID) => boolean;
+  /** Cancel any in-flight eval AND release pending holds for this session (the
+   *  user answered / advanced). Forwards to the gate's `cancelStale`. */
+  cancelStale: (reason: string) => void;
+}
+
 export interface HookBridgeHandle {
   /** Live bridge instance. Callers can read `isInSubagentContext()` to gate
    *  alternate question sources (e.g. PTY parser) so subagent prompts are
@@ -147,6 +192,12 @@ export interface HookBridgeHandle {
    * reach — never outlives the session.
    */
   closeBinder: () => void;
+  /**
+   * Per-session auto-approve gate handle (#573): `resolveHeld` + `cancelStale`,
+   * so the WebSocket answer path can resolve a held hook / cancel the eval for
+   * this exact session. Always present (the gate is constructed unconditionally).
+   */
+  gate: SessionGateHandle;
 }
 
 export function setupHookBridge(
@@ -662,7 +713,11 @@ export function setupHookBridge(
       sessionRegistry,
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
-      escalate: (i) => handlers.onPermissionRequest?.(i),
+      // Call the bridge DIRECTLY (not via the void-typed handlers map) so the
+      // created Question.id flows back to the gate; a binary escalation holds
+      // the hook keyed by it (#573). The bridge still does the onQuestion +
+      // status side effects exactly as before.
+      escalate: (i) => hookBridge.handlePermissionRequest(i),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native
@@ -681,6 +736,13 @@ export function setupHookBridge(
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.
       escalateModel: autoApproveService?.escalateModel ?? '',
+      // #573: classify an escalation as binary (holdable) vs design/multi-choice
+      // (passthrough) the same way the service does; hold binary main-context
+      // hooks open until the user answers (holdMs) and optionally push early on a
+      // slow eval (pushHoldMs). Seconds -> ms; 0 disables (gate treats <=0 as off).
+      alwaysEscalateTools: deps.alwaysEscalateTools ?? new Set<string>(),
+      holdMs: (deps.holdTimeoutSec ?? 0) * 1000,
+      pushHoldMs: (deps.pushHoldTimeoutSec ?? 0) * 1000,
     },
     sessionId,
   );
@@ -1164,6 +1226,12 @@ export function setupHookBridge(
       // Drop the per-session PermissionRequest resolver (#496) so a stale
       // closure (over this session's gate/tracker) can't fire after teardown.
       hookServer.setPermissionResolver(null);
+    },
+    gate: {
+      resolveHeld: (questionId, decision) => autoApproveGate.resolveHeld(questionId, decision),
+      releaseHeldAsPassthrough: (questionId) =>
+        autoApproveGate.releaseHeldAsPassthrough(questionId),
+      cancelStale: (reason) => autoApproveGate.cancelStale(reason),
     },
   };
 }

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -187,6 +187,13 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Always escalate these to the user; never auto-decided by the LLM (#572):
     // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
     always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
+    // Hold a binary main-context PermissionRequest hook open until the user
+    // answers (Model B, #573). Large + human-paced; on expiry it fails open to
+    // the native prompt. 0 disables holding (escalate -> passthrough as before).
+    hold_timeout: 1800,
+    // Push + hold early if a binary main-context eval is still running after
+    // this many seconds (Part B, #573). 0 disables Part B (A+C only).
+    push_hold_timeout: 60,
   },
   features: {
     transcript_binder_shadow: false,
@@ -336,6 +343,35 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   ) {
     throw new Error(
       `Invalid auto_approve.queue_timeout in ${configPath}: must be a non-negative number (seconds; 0 = no bound), got ${typeof cfg.queue_timeout === 'string' ? `string "${cfg.queue_timeout}"` : typeof cfg.queue_timeout}. Example: queue_timeout = 240`,
+    );
+  }
+
+  if (
+    typeof cfg.hold_timeout !== 'number' ||
+    !Number.isFinite(cfg.hold_timeout) ||
+    cfg.hold_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable holding), got ${typeof cfg.hold_timeout === 'string' ? `string "${cfg.hold_timeout}"` : typeof cfg.hold_timeout}. Example: hold_timeout = 1800`,
+    );
+  }
+
+  if (
+    typeof cfg.push_hold_timeout !== 'number' ||
+    !Number.isFinite(cfg.push_hold_timeout) ||
+    cfg.push_hold_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.push_hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable slow-eval push), got ${typeof cfg.push_hold_timeout === 'string' ? `string "${cfg.push_hold_timeout}"` : typeof cfg.push_hold_timeout}. Example: push_hold_timeout = 60`,
+    );
+  }
+
+  // Contradictory pairing: Part B pushes + holds early on a slow eval, but with
+  // holding disabled the held hook immediately falls through to passthrough, so
+  // the early push buys nothing. Warn (not throw) so the daemon still starts.
+  if (cfg.push_hold_timeout > 0 && cfg.hold_timeout === 0) {
+    console.warn(
+      `[AutoApprove] Warning: push_hold_timeout (${cfg.push_hold_timeout}s) > 0 but hold_timeout = 0 in ${configPath}: the slow-eval early push cannot hold the hook (holding is disabled), so it falls through to passthrough immediately. Set hold_timeout > 0 to actually hold, or push_hold_timeout = 0 to disable the early push.`,
     );
   }
 
@@ -574,6 +610,18 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       (auto_approve as { queue_timeout: number }).queue_timeout = parsed;
     }
   }
+  if (env['REMI_AUTO_APPROVE_HOLD_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { hold_timeout: number }).hold_timeout = parsed;
+    }
+  }
+  if (env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { push_hold_timeout: number }).push_hold_timeout = parsed;
+    }
+  }
 
   // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
   const features = { ...config.features };
@@ -682,6 +730,18 @@ authorized_user_ids = []
 #                                  # queue before escalating. Concurrent evals
 #                                  # run one at a time; a deep burst could risk
 #                                  # the ~600s hook budget. 0 = no bound.
+# hold_timeout = 1800              # Seconds to HOLD a binary permission hook
+#                                  # open after escalating, so the user answers
+#                                  # it via the hook response (Model B, #573) —
+#                                  # no native prompt, no warm-connection race.
+#                                  # Large + human-paced; fails open to the
+#                                  # native prompt on expiry. 0 = no hold
+#                                  # (escalate -> passthrough as before).
+# push_hold_timeout = 60           # Push + hold early if a binary main-context
+#                                  # eval is still running after this many
+#                                  # seconds, so the user can step in while the
+#                                  # model keeps thinking (Part B, #573). A late
+#                                  # verdict resolves the held hook. 0 = off.
 # disable_thinking = false         # Ollama only: native /api/chat with
 #                                  # think:false (no reasoning). Faster but
 #                                  # lowers decision quality (reasoning helps
@@ -777,6 +837,8 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  escalate_model = "${config.auto_approve.escalate_model}"`);
   lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
+  lines.push(`  hold_timeout = ${config.auto_approve.hold_timeout}`);
+  lines.push(`  push_hold_timeout = ${config.auto_approve.push_hold_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push(
     `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -47,10 +47,6 @@ interface HookMatcher {
 const PERMISSION_REQUEST_HOOK_TIMEOUT = 600;
 const DEFAULT_HOOK_TIMEOUT = 5;
 
-function hookTimeoutFor(event: string): number {
-  return event === 'PermissionRequest' ? PERMISSION_REQUEST_HOOK_TIMEOUT : DEFAULT_HOOK_TIMEOUT;
-}
-
 interface ClaudeSettings {
   hooks?: Record<string, HookMatcher[]>;
   [key: string]: unknown;
@@ -60,10 +56,34 @@ export class HookConfigManager {
   private readonly settingsPath: string;
   private readonly hookUrl: string;
   private hasWritten = false;
+  /**
+   * Seconds the daemon may HOLD a PermissionRequest hook open before answering
+   * (Model B, #573). The registered PermissionRequest hook timeout must be >=
+   * this, or Claude Code gives up on the hook and renders its native prompt
+   * BEFORE the hold's own fail-open fires — so the registered timeout is
+   * `max(PERMISSION_REQUEST_HOOK_TIMEOUT, holdTimeoutSec)`. 0 / omitted keeps the
+   * baseline ceiling (the pre-#573 behavior).
+   */
+  private readonly permissionHoldTimeoutSec: number;
 
-  constructor(projectDir: string, hookServerUrl: string) {
+  constructor(projectDir: string, hookServerUrl: string, permissionHoldTimeoutSec = 0) {
     this.settingsPath = path.join(projectDir, '.claude', 'settings.local.json');
     this.hookUrl = hookServerUrl;
+    this.permissionHoldTimeoutSec =
+      Number.isFinite(permissionHoldTimeoutSec) && permissionHoldTimeoutSec > 0
+        ? permissionHoldTimeoutSec
+        : 0;
+  }
+
+  /**
+   * Seconds Claude Code waits for this hook's HTTP response. PermissionRequest
+   * gets the long budget (baseline 600s ceiling, raised to the configured hold
+   * timeout when larger so a long human-paced hold is not cut short, #573); all
+   * other hooks keep the short fail-fast timeout (#203).
+   */
+  private hookTimeoutFor(event: string): number {
+    if (event !== 'PermissionRequest') return DEFAULT_HOOK_TIMEOUT;
+    return Math.max(PERMISSION_REQUEST_HOOK_TIMEOUT, this.permissionHoldTimeoutSec);
   }
 
   /**
@@ -117,7 +137,7 @@ export class HookConfigManager {
       }
 
       const matchers = settings.hooks[event];
-      const desiredTimeout = hookTimeoutFor(event);
+      const desiredTimeout = this.hookTimeoutFor(event);
       // Reconcile any existing remi hook for this event to the desired timeout
       // (so an upgrade — e.g. the #537 PermissionRequest bump — takes effect for
       // an already-registered hook), and add it when missing.
@@ -193,7 +213,8 @@ export class HookConfigManager {
       // a reconcile on the next install() (#537).
       return matchers?.some((m) =>
         m.hooks.some(
-          (h) => h.type === 'http' && h.url === this.hookUrl && h.timeout === hookTimeoutFor(event),
+          (h) =>
+            h.type === 'http' && h.url === this.hookUrl && h.timeout === this.hookTimeoutFor(event),
         ),
       );
     });

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -180,7 +180,13 @@ export class HookEventBridge {
     this.events.onSessionInfo(input.session_id, input.transcript_path);
   }
 
-  handlePermissionRequest(input: PermissionRequestHookInput): void {
+  /**
+   * Build + emit the escalation Question for a PermissionRequest and return its
+   * id (#573). The id lets the auto-approve gate HOLD the binary hook keyed by
+   * this question, so the user's answer resolves the hook via the response
+   * (Model B) instead of a PTY inject. Always returns an id today.
+   */
+  handlePermissionRequest(input: PermissionRequestHookInput): UUID {
     // Phase 4 (#419): the subagentContext drop previously sat here.
     // After phase 3 wired in the QuestionPresenceTracker, push semantics
     // are presence-gated regardless of subagent context — a subagent
@@ -224,8 +230,9 @@ export class HookEventBridge {
       options = [...DEFAULT_PERMISSION_OPTIONS];
     }
 
+    const questionId = generateId();
     this.events.onQuestion({
-      id: generateId(),
+      id: questionId,
       text: promptText,
       options,
       allowsFreeText: false,
@@ -233,6 +240,7 @@ export class HookEventBridge {
       agentId: input.agent_id,
     });
     this.events.onStatusChange('waiting');
+    return questionId;
   }
 
   handlePostToolUseFailure(input: PostToolUseFailureHookInput): void {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -88,7 +88,10 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: (i) => escalations.push(i),
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
       },
       SID,
     );
@@ -113,7 +116,10 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: (i) => escalations.push(i),
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
         escalateModel: 'big-model',
       },
       SID,
@@ -400,7 +406,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: () => {},
+        escalate: () => undefined,
         onEvalStart: () => events.push('start'),
         onEscalate: () => events.push('escalate'),
         onHandled: () => events.push('handled'),
@@ -489,6 +495,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
         isInSubagentContext: () => false,
         escalate: () => {
           escalations++;
+          return undefined;
         },
         onHandled: () => {
           throw new Error('test: cue boom');
@@ -498,5 +505,403 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     );
     expect(await g.resolvePermission(pr())).toBe('allow'); // approved once, verdict intact
     expect(escalations).toBe(0); // no re-escalation
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2 (#573): hold the hook (Model B) + resolve-on-answer + slow-eval push.
+// All real objects (no mock framework): a plain evaluator literal returns real
+// AutoApproveResult values, and the held hook is a real pending promise.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  /** A gate that escalates (recording the created Question.id) and holds binary
+   *  main-context hooks for `holdMs`. The created id is exposed via
+   *  `lastQuestionId` so tests can resolve the hold. */
+  function holdGate(
+    service: AutoApproveEvaluator | null,
+    opts: { holdMs?: number; subagent?: boolean; alwaysEscalateTools?: ReadonlySet<string> } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const tracker = new QuestionPresenceTracker(() => {});
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => opts.subagent ?? false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        alwaysEscalateTools:
+          opts.alwaysEscalateTools ?? new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('binary escalate WITHHOLDS the decision until resolveHeld -> allow', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    // Give the eval + escalate a tick; the promise must still be pending (held).
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false);
+    expect(escalations).toHaveLength(1);
+    expect(lastQuestionId).toBeDefined();
+
+    // The user answers Yes -> the held hook resolves 'allow'.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('binary escalate held -> deny when the user answers No', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'deny')).toBe(true);
+    expect(await pending).toBe('deny');
+  });
+
+  test('resolveHeld for an unknown id returns false (non-held answer)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.resolveHeld(generateId() as UUID, 'allow')).toBe(false);
+    // The real hold is still pending; resolve it to avoid a dangling promise.
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('multi-choice escalate returns passthrough immediately (NO hold)', async () => {
+    // 4+ string suggestions => multi-choice; the hook response cannot pick.
+    const gate = holdGate(evaluator(escalate));
+    const d = await gate.resolvePermission(
+      pr({ permission_suggestions: ['Alpha', 'Beta', 'Gamma', 'Delta'] }),
+    );
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('design question escalate returns passthrough immediately (NO hold)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    // AskUserQuestion is in always_escalate_tools -> design -> not binary.
+    const d = await gate.resolvePermission(
+      pr({ tool_name: 'AskUserQuestion', tool_input: { question: 'Which approach?' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('hold timeout -> passthrough and the pending map is cleaned', async () => {
+    const gate = holdGate(evaluator(escalate), { holdMs: 30 });
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough'); // failed open after 30ms
+    // The hold timed out; a late answer for the same id must report "no hold".
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('holdMs <= 0 disables holding: binary escalate -> passthrough', async () => {
+    const gate = holdGate(evaluator(escalate), { holdMs: 0 });
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('releaseHeldAsPassthrough pops a held hook to passthrough (FIX 1)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qid = lastQuestionId as UUID;
+    // The user picked "Yes, always": the binary response can't express it, so the
+    // hook is released to passthrough (Claude renders its native prompt).
+    expect(gate.releaseHeldAsPassthrough(qid)).toBe(true);
+    expect(await pending).toBe('passthrough');
+    // The hold is gone; a second release reports no hold.
+    expect(gate.releaseHeldAsPassthrough(qid)).toBe(false);
+  });
+
+  test('releaseHeldAsPassthrough returns false when no hold exists', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.releaseHeldAsPassthrough(generateId() as UUID)).toBe(false);
+    // Resolve the real hold to avoid a dangling promise.
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('cancelStale releases a pending hold to passthrough + cancels the eval', async () => {
+    const cancels: string[] = [];
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const tracker = new QuestionPresenceTracker(() => {});
+    const gate = new AutoApproveGate(
+      {
+        service: {
+          evaluate: async () => escalate,
+          cancel: (reason: string) => {
+            cancels.push(reason);
+            return true;
+          },
+        },
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(),
+      },
+      SID,
+    );
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    gate.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough'); // hold released by teardown
+    expect(cancels).toContain('SessionEnd'); // eval also cancelled
+    // The hold is gone.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('per-session isolation: resolving session A does not touch session B', async () => {
+    const SID_B = generateId() as UUID;
+    const registryB = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registryB.registerSession(SID_B, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    let qidB: UUID | undefined;
+    const gateB = new AutoApproveGate(
+      {
+        service: { evaluate: async () => escalate, cancel: () => true },
+        sessionRegistry: registryB,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          qidB = generateId();
+          return qidB;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(),
+      },
+      SID_B,
+    );
+
+    const gateA = holdGate(evaluator(escalate));
+    const pendingA = gateA.resolvePermission(pr());
+    const pendingB = gateB.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qidA = lastQuestionId as UUID;
+
+    // Resolving A's question id on gate B finds no hold; A's own hold is intact.
+    expect(gateB.resolveHeld(qidA, 'allow')).toBe(false);
+    // Resolve each on its own gate.
+    expect(gateA.resolveHeld(qidA, 'allow')).toBe(true);
+    expect(gateB.resolveHeld(qidB as UUID, 'deny')).toBe(true);
+    expect(await pendingA).toBe('allow');
+    expect(await pendingB).toBe('deny');
+    await registryB.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B (#573): slow-eval early push + hold. ISOLATED behind push_hold_timeout.
+// A deferred eval lets the test control whether the eval or the push-hold timer
+// wins the race deterministically.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  /** An evaluator whose verdict is delayed until `release(result)` is called,
+   *  so the test decides when the eval finishes relative to push_hold_timeout. */
+  function deferredEvaluator(): {
+    service: AutoApproveEvaluator;
+    release: (r: AutoApproveResult) => void;
+  } {
+    let resolveEval: (r: AutoApproveResult) => void = () => {};
+    const pending = new Promise<AutoApproveResult>((res) => {
+      resolveEval = res;
+    });
+    return {
+      service: { evaluate: () => pending, cancel: () => true },
+      release: (r) => resolveEval(r),
+    };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: { holdMs?: number; pushHoldMs?: number } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
+        alwaysEscalateTools: new Set(),
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a slow eval pushes + holds early; a late approve resolves allow (no double push)', async () => {
+    const { service, release } = deferredEvaluator();
+    // push after 20ms; the eval has not finished yet -> early push + hold.
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+
+    await new Promise((r) => setTimeout(r, 40)); // let the push-hold timer fire
+    expect(escalations).toHaveLength(1); // pushed early exactly once
+    expect(lastQuestionId).toBeDefined();
+
+    // The late verdict arrives: approve -> the held hook resolves allow, and the
+    // reconciliation must NOT push a second time.
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(escalations).toHaveLength(1); // still one push (no double-push)
+  });
+
+  test('a slow eval whose late verdict is deny resolves the held hook deny', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    expect(escalations).toHaveLength(1);
+    release(deny);
+    expect(await pending).toBe('deny');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('a slow eval whose late verdict is escalate keeps the existing hold (no double push)', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20, holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    expect(escalations).toHaveLength(1);
+    // Late escalate: already pushed + holding, so no second push; the hold stays
+    // pending until the user answers.
+    release(escalate);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(escalations).toHaveLength(1);
+    // The user then answers the (single) held question.
+    expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('a fast eval (verdict before push_hold_timeout) never pushes early', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 200 });
+    const pending = g.resolvePermission(pr());
+    // Verdict arrives well before the 200ms push-hold timer.
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(escalations).toHaveLength(0); // no early push
+  });
+
+  test('push_hold_timeout = 0 disables Part B: a slow escalate just holds on verdict', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 0, holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    // No early push while the eval runs.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(escalations).toHaveLength(0);
+    // The eval escalates -> NOW it pushes + holds (Part A path), once.
+    release(escalate);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(escalations).toHaveLength(1);
+    g.resolveHeld(lastQuestionId as UUID, 'allow');
+    expect(await pending).toBe('allow');
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -54,6 +54,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -119,6 +119,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/hold-hook.test.ts
+++ b/packages/daemon/tests/auto-approve/hold-hook.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for Model B "hold the hook" (#573) over a REAL loopback
+ * HookServer wired to a REAL AutoApproveGate (no mocks). Asserts the HTTP
+ * response Claude blocks on is WITHHELD while the gate holds a binary
+ * escalation, then carries the allow/deny verdict once the user answers via
+ * `resolveHeld` — and that a multi-choice escalation passes through immediately.
+ *
+ * Mirrors the gated-server pattern in serialize.test.ts: a real Bun.serve fixture
+ * (here, the daemon's own HookServer) is driven over the loopback so timing is
+ * observed deterministically rather than stubbed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import { HookServer } from '../../src/hooks/hook-server.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+const escalate: AutoApproveResult = {
+  decision: 'escalate',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+
+function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+  return { evaluate: async () => result, cancel: () => true };
+}
+
+function permissionBody(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    session_id: 'claude-test',
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/d',
+    permission_mode: 'default',
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    ...over,
+  });
+}
+
+describe('Model B hold over a real HookServer (#573)', () => {
+  const SID = generateId() as UUID;
+  let server: HookServer;
+  let registry: SessionRegistry;
+  let gate: AutoApproveGate;
+  let lastQuestionId: UUID | undefined;
+
+  beforeEach(() => {
+    configureLogger({ writeLog: () => {} });
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    lastQuestionId = undefined;
+    gate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+    server = new HookServer({ port: 0 });
+    server.setPermissionResolver((input) => gate.resolvePermission(input));
+    server.start();
+  });
+
+  afterEach(async () => {
+    server.stop();
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('binary escalate WITHHOLDS the HTTP response until resolveHeld -> allow', async () => {
+    const post = fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody(),
+    });
+
+    // Wait for the gate to escalate (creates the question id) without the POST
+    // having resolved yet — the hook server is blocked on the held promise.
+    await waitFor(() => lastQuestionId !== undefined);
+    let responded = false;
+    void post.then(() => {
+      responded = true;
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(responded).toBe(false); // response is withheld (held hook)
+
+    // The user answers Yes -> the held hook resolves allow and the POST returns
+    // the allow decision body.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    const res = await post;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'allow' } },
+    });
+  });
+
+  test('held hook -> deny body when the user answers No', async () => {
+    const post = fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody(),
+    });
+    await waitFor(() => lastQuestionId !== undefined);
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'deny')).toBe(true);
+    const res = await post;
+    expect(await res.json()).toEqual({
+      hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'deny' } },
+    });
+  });
+
+  test('multi-choice escalate returns the passthrough body immediately (no hold)', async () => {
+    const res = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody({ permission_suggestions: ['Alpha', 'Beta', 'Gamma', 'Delta'] }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({}); // passthrough = bare {}
+  });
+});
+
+/** Poll `cond` up to ~1s; throw if it never becomes true (real timing, no mock). */
+async function waitFor(cond: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('waitFor: condition not met within 1s');
+}

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -69,6 +69,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -334,6 +334,8 @@ function makeConfig(model: string): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -106,6 +106,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -331,6 +331,209 @@ describe('createInputHandlers', () => {
     });
   });
 
+  describe('onAnswer held-permission resolution (Model B, #573)', () => {
+    function addYesNoQuestion(sessionId: UUID): void {
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+    }
+
+    test('Yes answer maps to allow, resolves the held hook, and SKIPS the PTY submit', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const held: Array<{ sessionId: UUID; questionId: UUID; decision: 'allow' | 'deny' }> = [];
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (s, q, d) => {
+          held.push({ sessionId: s, questionId: q, decision: d });
+          return true; // a hold existed and was resolved
+        },
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1'); // option 1 = Yes
+
+      expect(held).toEqual([{ sessionId, questionId: QID, decision: 'allow' }]);
+      expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('No answer maps to deny and resolves the held hook', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '3'); // option 3 = No
+
+      expect(held).toEqual(['deny']);
+      expect(ptyCapture.submits).toEqual([]);
+    });
+
+    test('"Yes, always" releases the held hook to passthrough and submits the digit (FIX 1)', async () => {
+      // "always" cannot be expressed by the binary hook response, so it must NOT
+      // resolve the hold as a one-time allow; instead the hook is released to
+      // passthrough and the digit is submitted into the native prompt.
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const resolveDecisions: Array<'allow' | 'deny'> = [];
+      const released: UUID[] = [];
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        // A held hook exists, but resolveHeldPermission must NOT be consulted for
+        // "always" (decision === null), so it would return true if wrongly called.
+        resolveHeldPermission: (_s, _q, d) => {
+          resolveDecisions.push(d);
+          return true;
+        },
+        releaseHeldAsPassthrough: (_s, q) => {
+          released.push(q);
+          return true; // a hold existed and was popped to passthrough
+        },
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '2'); // option 2 = Yes, always
+
+      expect(resolveDecisions).toEqual([]); // never resolved as a one-time allow
+      expect(released).toEqual([QID]); // hook released to passthrough
+      expect(ptyCapture.submits).toEqual(['2']); // digit submitted into the native prompt
+      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]); // hold was released
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a non-held answer does NOT cancel the eval and still submits to the PTY (FIX 3)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false, // no hold for this question
+        releaseHeldAsPassthrough: () => false, // no hold to release either
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']); // falls back to the PTY path
+      // FIX 3: no hold was resolved/released, so an unrelated eval must NOT be
+      // cancelled by this answer.
+      expect(cancels).toEqual([]);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a free-text answer (no yes/no option match) takes the PTY path', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'name?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      let resolveHeldCalled = false;
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => {
+          resolveHeldCalled = true;
+          return true;
+        },
+        releaseHeldAsPassthrough: () => false, // no hold for a free-text prompt
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Alice');
+
+      // No yes/no option matched -> decision is null -> resolveHeld not consulted.
+      expect(resolveHeldCalled).toBe(false);
+      expect(ptyCapture.submits).toEqual(['Alice']);
+    });
+
+    test('without the held-permission deps wired, onAnswer behaves exactly as before', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']); // PTY path, no held resolution
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+  });
+
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -346,6 +346,8 @@ describe('auto_approve config', () => {
       queue_timeout: 240,
       disable_thinking: false,
       always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
+      hold_timeout: 1800,
+      push_hold_timeout: 60,
     });
   });
 
@@ -523,6 +525,68 @@ Escalate anything touching secrets.
       const config = loadConfig(TEST_CONFIG);
       expect(config.auto_approve.approve_groups).toEqual(['read-only', 'bogus']);
       expect(warnings.some((w) => w.includes('unknown permission group "bogus"'))).toBe(true);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('loads hold_timeout / push_hold_timeout from TOML (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = 900\npush_hold_timeout = 45\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.hold_timeout).toBe(900);
+    expect(config.auto_approve.push_hold_timeout).toBe(45);
+  });
+
+  test('rejects a negative hold_timeout (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/hold_timeout/);
+  });
+
+  test('rejects a negative push_hold_timeout (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\npush_hold_timeout = -5\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/push_hold_timeout/);
+  });
+
+  test('REMI_AUTO_APPROVE_HOLD_TIMEOUT / PUSH_HOLD_TIMEOUT env overrides (#573)', () => {
+    process.env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'] = '1200';
+    process.env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'] = '90';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.auto_approve.hold_timeout).toBe(1200);
+    expect(config.auto_approve.push_hold_timeout).toBe(90);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'];
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'];
+  });
+
+  test('warns (does not throw) when push_hold_timeout > 0 but hold_timeout = 0 (FIX 4 / #573)', () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg?: unknown) => warnings.push(String(msg));
+    try {
+      fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = 0\npush_hold_timeout = 60\n');
+      const config = loadConfig(TEST_CONFIG); // must NOT throw
+      expect(config.auto_approve.hold_timeout).toBe(0);
+      expect(config.auto_approve.push_hold_timeout).toBe(60);
+      expect(
+        warnings.some((w) => w.includes('push_hold_timeout') && w.includes('hold_timeout = 0')),
+      ).toBe(true);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('does NOT warn when both hold_timeout and push_hold_timeout are set (FIX 4 / #573)', () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg?: unknown) => warnings.push(String(msg));
+    try {
+      fs.writeFileSync(
+        TEST_CONFIG,
+        '[auto_approve]\nhold_timeout = 1800\npush_hold_timeout = 60\n',
+      );
+      loadConfig(TEST_CONFIG);
+      expect(warnings.some((w) => w.includes('push_hold_timeout'))).toBe(false);
     } finally {
       console.warn = original;
     }


### PR DESCRIPTION
## Summary

Phase 2 of epic #571 — **Model B "hold the hook"** + cancel-on-answer + slow-eval push. When auto-approve escalates a **binary** permission, the daemon now keeps Claude's `PermissionRequest` hook open and answers it with the `allow`/`deny` hook response (the durable, docs-verified contract) instead of relying on a PTY digit typed into a rendered prompt. No render race; no dependence on a warm connection at answer time (the connection-independent relay lands in Phase 4 / #575).

### Part A — hold (binary, main context)
- The gate keeps a per-session `pendingHolds` map. `escalateAndHold` pushes the question and returns the pending promise the hook server blocks on. It is settled by `resolveHeld` (user answered), the hold-timeout timer (fails open → `passthrough` → Claude's native prompt), or `cancelStale` (session end) — every path clears the timer and deletes the entry.
- Only binary escalations hold; multi-choice / design escalations (incl. all of Phase 1's) still return `passthrough` because the hook response can't express a pick.
- The registered `PermissionRequest` hook timeout is raised to `max(600, hold_timeout)` so the hook outlasts a human-paced hold.
- **"Yes, always"** can't be expressed by the binary response, so it releases the hold to `passthrough` and submits the native PTY digit rather than silently downgrading to a one-time allow.

### Part C — cancel on answer
- `onAnswer` resolves the held hook and cancels the in-flight eval — but only for the permission actually answered, so a concurrent unrelated eval isn't aborted. Queued waiters drain.

### Part B — slow-eval push (isolated behind `push_hold_timeout`)
- A timer racing `service.evaluate()` pushes + holds early if the eval runs past `push_hold_timeout`, so you can step in while the model keeps thinking; a late verdict reconciles into the same hold (approve→allow, deny→deny, cancelled→passthrough), with no double-push / double-resolve. `push_hold_timeout = 0` disables Part B entirely (the timer never arms) — the removable seam you asked for.

New config: `auto_approve.hold_timeout` (default 1800s; 0 disables holding) and `push_hold_timeout` (default 60s; 0 disables Part B).

Closes #573. Part of epic #571.

## Review (pr-review-toolkit, Sonnet — code-reviewer + silent-failure-hunter)

Both ran adversarially against the concurrency. **Cleared:** double-resolve (single-threaded + `pendingHolds` membership guards), permanent hang (the `unref`'d hold-timeout is the unconditional safety net), per-session isolation, Part B isolation, and the existing approve/deny/pick/subagent-deny/cancelled paths. **4 findings, all addressed** (one was a false positive):

| Finding | Resolution |
|---|---|
| HIGH — "Yes, always" silently downgraded to one-time allow | `mapAnswerToDecision` returns null for "always"-shaped options → `onAnswer` releases the hold to passthrough + submits the native PTY digit |
| `cancelAutoApprove` fired on every answer (aborted unrelated evals) | now fires only when a held permission was actually resolved/released (`hadHold` guard) |
| `hold_timeout=0` + `push_hold_timeout>0` contradictory | `validateAutoApprove` warns (no throw) |
| `releaseAllHolds` missing `clearTimeout` | false positive — it was already present (gate:192) |

## Test plan (NO MOCKS)

- Real loopback `HookServer` + real gate (`hold-hook.test.ts`): the HTTP response is withheld until `resolveHeld`, then carries `allow`/`deny`; multi-choice passes through immediately.
- Gate tests: binary hold→allow/deny, hold-timeout→passthrough + cleanup, `holdMs<=0` disables, `cancelStale` releases holds, per-session isolation; Part B slow-eval push+hold with late approve/deny/escalate reconcile, fast-eval no-push, `push_hold_timeout=0` disables.
- `onAnswer`: Yes→allow / No→deny resolve (no PTY submit); "Yes, always"→release+PTY digit; non-held answer still submits; cancel only on a held answer.
- Config: load/reject/env for both fields + the contradiction warning.
- `bun test` (auto-approve + hooks + config + cli/handlers): **597 pass / 69 skip / 0 fail**. Typecheck + biome clean.
