### PR TITLE
Phase 3: Faithful notification text + dynamic options

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -90,15 +90,35 @@ export class QuestionPresenceTracker {
    * confirms the prompt is visible, or never if status moves past 'waiting'
    * first.
    *
-   * Replacement policy: per agent, the newer hook wins (correct for the
-   * same-prompt double-fire: PermissionRequest then Notification). Different
-   * agents no longer overwrite each other (#425).
+   * Replacement policy: per agent, the newer hook normally wins. The one
+   * exception (#574): a pending rich `PermissionRequest` is authoritative and
+   * is NOT evicted by any other shape — only a NEWER `PermissionRequest` (a new
+   * permission cycle) may replace it. Claude fires both a PermissionRequest and
+   * a generic `Notification(permission_prompt)` for one prompt; the
+   * PermissionRequest carries the tool + command + real option labels ("Allow
+   * Bash: git push", Edit's Yes/Always/No), while the Notification is the bland
+   * "Claude needs your permission to use Bash" with the hardcoded 3-set.
+   * Letting the trailing notification win is exactly what garbled the push
+   * text/options (issues 3+4). A same-agent source-less question (e.g. a
+   * StopFailure "Retry?" card) must likewise not silently evict the pending
+   * permission request and leave the real prompt without a push. Different
+   * agents never overwrite each other (#425).
    */
   recordPendingHook(question: Question): void {
     const key = agentKey(question);
-    if (this.pending.has(key)) {
+    const existing = this.pending.get(key);
+    if (existing) {
+      // A pending rich permission request stays put unless the incoming is a
+      // newer permission request: a generic Notification or a source-less
+      // StopFailure-shaped question for the same agent must NOT evict it.
+      if (existing.source === 'permission_request' && question.source !== 'permission_request') {
+        console.debug(
+          `[QuestionPresenceTracker] Keeping richer pending permission_request for agent "${key}"; not evicting with source="${question.source ?? 'undefined'}" (kept="${existing.text.slice(0, 50)}", dropped="${question.text.slice(0, 50)}")`,
+        );
+        return;
+      }
       console.debug(
-        `[QuestionPresenceTracker] Replacing pending hook for agent "${key}" (old="${this.pending.get(key)?.text.slice(0, 50)}", new="${question.text.slice(0, 50)}")`,
+        `[QuestionPresenceTracker] Replacing pending hook for agent "${key}" (old="${existing.text.slice(0, 50)}", new="${question.text.slice(0, 50)}")`,
       );
     }
     // Re-insert so this agent's entry is the most recent (matters for the

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -112,10 +112,23 @@ function guardBinding(
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 /**
- * Map a chosen answer string to a binary allow/deny decision via the active
- * Question's options (#573). The answer the client sends is an option `value`
- * (e.g. "1"/"2"/"3" or "y"/"n"); we find the matching option and read its
- * `isYes` / `isNo` flags. Returns:
+ * Resolve an incoming answer string to the active Question's matching option
+ * (#574). The phone now sends the option LABEL for display (e.g. "Yes", "Yes,
+ * always", "No") rather than only the numeric `value` ("1"/"2"/"3"), so match
+ * EITHER field. The in-app WebSocket path may still send a `value`; both
+ * resolve to the same option. Returns the option, or undefined for a free-text
+ * answer that matches neither.
+ */
+function resolveOption(
+  options: readonly QuestionOption[],
+  answer: string,
+): QuestionOption | undefined {
+  return options.find((o) => o.value === answer || o.label === answer);
+}
+
+/**
+ * Map a resolved option to a binary allow/deny decision (#573). Reads the
+ * option's `isYes` / `isNo` flags. Returns:
  *   - 'deny' for a no-shaped option;
  *   - 'allow' for a yes-shaped option ONLY when it is a one-time "Yes" — an
  *     "always"-shaped label ("Yes, always") is NOT mapped, because the binary
@@ -123,13 +136,13 @@ export type InputHandlers = ReturnType<typeof createInputHandlers>;
  *     session-wide "always" the user picked. Downgrading it to a one-time allow
  *     would silently lose that choice, so it returns null and the caller takes
  *     the native PTY path (which can express "always" via the digit);
- *   - null otherwise (always-shaped, unknown value, or free text) -> PTY path.
+ *   - null otherwise (always-shaped, unknown value/label, or free text) -> PTY path.
  */
 function mapAnswerToDecision(
   options: readonly QuestionOption[],
   answer: string,
 ): 'allow' | 'deny' | null {
-  const option = options.find((o) => o.value === answer);
+  const option = resolveOption(options, answer);
   if (!option) return null;
   if (option.isNo) return 'deny';
   // "always" cannot be expressed in the binary hook response, so a yes-shaped
@@ -252,7 +265,22 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         // then submit the digit. If no hold, this is the normal PTY path.
         const released = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
         hadHold = hadHold || released;
-        await session.pty.submitInput(answer);
+        // The phone may send a label for display (#574), but Claude's native
+        // numbered prompt expects the option's VALUE (the 1-based index). Resolve
+        // the answer back to its option and submit the index; a free-text answer
+        // (no option match) is submitted verbatim.
+        const ptyInput = resolveOption(active.options, answer)?.value ?? answer;
+        if (ptyInput !== answer) {
+          log(`[Answer] resolved "${answer}" -> "${ptyInput}" for q ${questionId.slice(0, 8)}`);
+        } else if (
+          active.options.length > 0 &&
+          resolveOption(active.options, answer) === undefined
+        ) {
+          log(
+            `[Answer] "${answer}" matched no option (${active.options.length}); submitting verbatim`,
+          );
+        }
+        await session.pty.submitInput(ptyInput);
       } else {
         log(
           `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -145,6 +145,9 @@ export class HookEventBridge {
         allowsFreeText: false,
         isAnswered: false,
         agentId: input.agent_id,
+        // Generic fallback: the tracker must let a richer PermissionRequest
+        // for the same agent win over this text/options (#574).
+        source: 'notification',
       };
       this.events.onQuestion(question);
       this.events.onStatusChange('waiting');
@@ -238,6 +241,9 @@ export class HookEventBridge {
       allowsFreeText: false,
       isAnswered: false,
       agentId: input.agent_id,
+      // Rich source: carries tool + command + agent context. The tracker
+      // keeps this over a trailing generic notification for the same agent (#574).
+      source: 'permission_request',
     });
     this.events.onStatusChange('waiting');
     return questionId;

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -42,6 +42,58 @@ export function selectPushCategory(options: readonly QuestionOption[]): string |
   return undefined;
 }
 
+/** Cap for the APNS title; iOS truncates visually but a hard cap keeps the
+ *  payload bounded for long Bash commands. */
+const TITLE_MAX = 120;
+/** Cap for the APNS body (ask + option list). */
+const BODY_MAX = 200;
+
+/**
+ * Normalize text for the notification surface (#574, issue 3). Collapses every
+ * run of whitespace (including the zero-width gaps that the PTY's column-
+ * aligned permission box leaves after ANSI stripping, which produced the
+ * "Doyouwanttoproceed?" garble) into a single ASCII space, then trims. A bare
+ * run-together token with no separators (the worst PTY case) is left as-is by
+ * this pass — but the dispatcher prefers the clean hook text for the body, so
+ * the raw PTY string never reaches the user (see `buildPushText`).
+ */
+function normalizeNotificationText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The compact option list shown in the body, e.g. "1. Yes  2. Yes, always
+ * 3. No". Uses the real option LABELS (#574, issue 4) so the user sees what
+ * they are actually choosing. The prefix is the option's actual `value`, not
+ * its positional index, so it stays accurate for non-indexed values like the
+ * StopFailure y/n set ("y. Yes  n. No"). Empty when there are no options
+ * (free-text prompt) so the body is just the ask.
+ */
+function formatOptionList(options: readonly QuestionOption[]): string {
+  if (options.length === 0) return '';
+  return options.map((o) => `${o.value}. ${o.label || o.value}`).join('  ');
+}
+
+/**
+ * Build the APNS title + body from the question (#574, issues 3+4).
+ *   - title: session context + the clean hook ask (tool + command), never the
+ *     raw PTY screen text.
+ *   - body: the ask repeated as the leading line plus the real option labels,
+ *     so the lock screen shows the choices even where the static action-button
+ *     titles cannot (REMI_MULTI). Whitespace is normalized so a column-aligned
+ *     PTY prompt can never collapse into a run-together string.
+ */
+export function buildPushText(
+  sessionName: string,
+  question: Question,
+): { title: string; body: string } {
+  const ask = normalizeNotificationText(question.text) || 'Allow this action?';
+  const title = `${sessionName}: ${ask}`.slice(0, TITLE_MAX);
+  const optionList = formatOptionList(question.options);
+  const body = (optionList ? `${ask}\n${optionList}` : ask).slice(0, BODY_MAX);
+  return { title, body };
+}
+
 /** Signature of the APNS-relay push call; injectable so the push branch is
  *  observable in tests without mocking a network module. */
 export type PushFn = typeof sendPushTrigger;
@@ -108,12 +160,18 @@ export class NotificationDispatcher {
     const cfg = pushConfig();
     const pushSessionId = this.deps.getPrimarySessionId() ?? this.sessionId;
     const pushCategory = selectPushCategory(question.options);
-    const pushOptions = question.options.map((o) => o.value);
+    // Send the human-readable LABELS for DISPLAY (#574, issue 4); answer
+    // routing in input-events resolves an incoming label OR value back to the
+    // option, then submits the option's index when a PTY submit is required, so
+    // sending labels here does not break delivery. Fall back to the value when a
+    // label is empty so the button still carries something answerable.
+    const pushOptions = question.options.map((o) => o.label || o.value);
+    const { title, body } = buildPushText(sessionName, question);
 
     for (const dt of deviceTokens.values()) {
       this.pushFn(cfg.signalingUrl, dt.token, {
-        title: `${sessionName} needs input`,
-        body: question.text.slice(0, 100),
+        title,
+        body,
         ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
         sessionId: pushSessionId,
         questionId: question.id,

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -42,6 +42,27 @@ function makeHookQuestion(text = 'Allow Bash?'): Question {
   };
 }
 
+/** Rich PermissionRequest record: tool + command text, real labels (#574). */
+function makePermissionRequestHook(text = 'Allow Bash: git push origin main'): Question {
+  return { ...makeHookQuestion(text), source: 'permission_request' };
+}
+
+/** Generic Notification(permission_prompt) record: bland text, hardcoded 3-set (#574). */
+function makeNotificationHook(text = 'Claude needs your permission to use Bash'): Question {
+  return {
+    id: generateId(),
+    text,
+    options: [
+      makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+      makeOption('Yes, always', '2', { isYes: true }),
+      makeOption('No', '3', { isNo: true }),
+    ],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'notification',
+  };
+}
+
 describe('QuestionPresenceTracker', () => {
   it('PTY-only push (no preceding hook) — fires once with PTY question as-is', () => {
     // Covers anthropics/claude-code #23983: subagent permission requests
@@ -330,6 +351,116 @@ describe('QuestionPresenceTracker', () => {
       tracker.onPTYPromptVisible(makePTYQuestion());
       tracker.onStatusChange('idle');
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+  });
+
+  describe('PermissionRequest vs Notification merge policy (#574)', () => {
+    it('a trailing generic Notification does NOT overwrite a rich PermissionRequest for the same agent', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      // Claude fires both for one prompt: the rich request first, the bland
+      // notification second. The notification must be dropped.
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push origin main'));
+      tracker.recordPendingHook(makeNotificationHook());
+
+      // PTY confirms the prompt is on screen -> single push with the rich text.
+      const ptyQ = makePTYQuestion('Do you want to proceed?');
+      tracker.onPTYPromptVisible(ptyQ);
+
+      expect(pushes.length).toBe(1);
+      // The user sees the command, not "Claude needs your permission to use Bash"
+      // and never the bare PTY "Do you want to proceed?".
+      expect(pushes[0]?.text).toBe('Allow Bash: git push origin main');
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('a source-less (StopFailure-shaped) question does NOT evict a pending permission_request, but a newer permission_request DOES replace it (FIX 2A)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push'));
+
+      // A StopFailure "Retry?" card for the same agent carries no source; it
+      // must NOT silently evict the rich permission request (which would leave
+      // the real permission prompt without a push).
+      const stopFailureCard: Question = {
+        id: generateId(),
+        text: 'Session stop failed (timeout). Retry?',
+        options: [
+          makeOption('Yes', 'y', { isYes: true, isRecommended: true }),
+          makeOption('No', 'n', { isNo: true }),
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+        // source intentionally undefined (StopFailure does not set it)
+      };
+      tracker.recordPendingHook(stopFailureCard);
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1);
+      // The permission request survived the StopFailure arrival.
+      expect(pushes[0]?.text).toBe('Allow Bash: git push');
+
+      // A genuinely new permission cycle (another permission_request) DOES replace it.
+      const tracker2 = new QuestionPresenceTracker(() => {});
+      tracker2.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
+      tracker2.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
+      const pushes2: Question[] = [];
+      const tracker3 = new QuestionPresenceTracker((q) => pushes2.push(q));
+      tracker3.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
+      tracker3.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
+      tracker3.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes2[0]?.text).toBe('Allow Edit: new cmd');
+    });
+
+    it('a PermissionRequest arriving AFTER a Notification still wins (richer replaces generic)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makeNotificationHook());
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Edit: /tmp/foo.ts'));
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('Allow Edit: /tmp/foo.ts');
+    });
+
+    it('raw PTY text never wins over the hook text for the notification (#574 issue 3)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: rm -rf build'));
+      // The PTY's literal screen text is the bare prompt; it must not surface.
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+
+      expect(pushes[0]?.text).toBe('Allow Bash: rm -rf build');
+      expect(pushes[0]?.text).not.toBe('Do you want to proceed?');
+    });
+
+    it('subagent fallback: a Notification with no preceding PermissionRequest is still recorded', () => {
+      // Subagent / no-PermissionRequest escalations must keep a question record
+      // so they remain answerable; the drop only applies when a richer request
+      // for the SAME agent already exists.
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makeNotificationHook('Claude needs your permission to use Bash'));
+      expect(tracker.hasPendingForTest()).toBe(true);
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it("different agents: a notification for agent B does not touch agent A's request", () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.recordPendingHook({
+        ...makePermissionRequestHook('Allow Bash A'),
+        agentId: 'agent-A',
+      });
+      tracker.recordPendingHook({
+        ...makeNotificationHook(),
+        agentId: 'agent-B',
+      });
+      // Both kept: the per-agent merge policy only drops a same-agent generic.
+      expect(tracker.pendingCountForTest()).toBe(2);
     });
   });
 

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -534,6 +534,269 @@ describe('createInputHandlers', () => {
     });
   });
 
+  describe('onAnswer value-or-label resolution (#574)', () => {
+    function addYesNoAlwaysQuestion(sessionId: UUID): void {
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+    }
+
+    function makeSession(): UUID {
+      const sessionId = sessionRegistry.createSessionId();
+      return sessionId;
+    }
+
+    test('a label "No" (phone display) resolves to deny via the held hook', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      // The phone sent the LABEL, not the value.
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+
+      expect(held).toEqual(['deny']); // resolved by label
+      expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+    });
+
+    test('a label "Yes" resolves to allow via the held hook (no PTY submit)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+
+      expect(held).toEqual(['allow']);
+      expect(ptyCapture.submits).toEqual([]);
+    });
+
+    test('the label "Yes, always" releases to passthrough and submits the option VALUE (index), not the label', async () => {
+      // Phase-2 "always" rule preserved: a label-sent "always" still cannot be
+      // expressed by the binary response, so it pops to passthrough; the PTY
+      // submit must be the digit Claude's native prompt expects ("2"), NOT "Yes, always".
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const released: UUID[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => {
+          throw new Error('resolveHeldPermission must not be called for "always"');
+        },
+        releaseHeldAsPassthrough: (_s, q) => {
+          released.push(q);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes, always'); // sent as a LABEL
+
+      expect(released).toEqual([QID]);
+      expect(ptyCapture.submits).toEqual(['2']); // index, not the label
+    });
+
+    test('non-held PTY path: a label answer submits the option VALUE (index) into the native prompt', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        // No hold for this question on either path.
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // "No" is no-shaped -> decision 'deny', but no hold exists, so it falls to
+      // the PTY path; the digit "3" must be submitted, not the label "No".
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+
+      expect(ptyCapture.submits).toEqual(['3']);
+    });
+
+    test('non-held PTY path: a numeric value answer still submits that value (back-compat)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // A Telegram/in-app client still sends the value "1"; it resolves to the
+      // same option and submits "1".
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('multi-choice pick by label submits the picked index, not the label', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // A multi-choice prompt (ExitPlanMode-style) with non-binary labels.
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'How should I proceed?',
+        options: [
+          { value: '1', label: 'Keep planning', isRecommended: false, isYes: false, isNo: false },
+          { value: '2', label: 'Accept the plan', isRecommended: true, isYes: false, isNo: false },
+          { value: '3', label: 'Cancel', isRecommended: false, isYes: false, isNo: false },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false, // non-binary -> decision null -> not consulted
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Accept the plan'); // label pick
+
+      expect(ptyCapture.submits).toEqual(['2']); // index for Claude's native prompt
+    });
+
+    test('a free-text answer with no option match is submitted verbatim', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'What should I name it?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'my-widget');
+
+      expect(ptyCapture.submits).toEqual(['my-widget']);
+    });
+
+    test('logs a label->value resolution and an unresolved-label verbatim submit (FIX 1A)', async () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // Label resolves to a different value -> logged as a translation.
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+      expect(logs.some((m) => m.includes('[Answer] resolved "No" -> "3"'))).toBe(true);
+
+      // A label that matches no option (options present) -> logged as verbatim submit.
+      addYesNoAlwaysQuestion(sessionId);
+      logs.length = 0;
+      await handlers.onAnswer(CID, sessionId, QID, 'Maybe');
+      expect(logs.some((m) => m.includes('[Answer] "Maybe" matched no option (3)'))).toBe(true);
+      expect(ptyCapture.submits).toContain('Maybe');
+    });
+  });
+
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -423,6 +423,26 @@ describe('HookEventBridge', () => {
 
       expect(questions[0]?.text).toBe('Allow Bash: ssh hallu "uv run pytest"');
     });
+
+    it('stamps source so the tracker can prefer the rich request over the generic notification (#574)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      } as PermissionRequestHookInput);
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Claude needs your permission to use Bash',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.source).toBe('permission_request');
+      expect(questions[1]?.source).toBe('notification');
+    });
   });
 
   describe('subagent context filtering (issue #316, phase 4 #419)', () => {

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -5,6 +5,7 @@ import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts'
 import {
   NotificationDispatcher,
   type PushFn,
+  buildPushText,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -25,9 +26,22 @@ const noOpt: QuestionOption = {
   isNo: true,
 };
 
-function question(id: string, options: QuestionOption[]): Question {
-  return { id: id as UUID, text: 'proceed?', options, allowsFreeText: false, isAnswered: false };
+function question(id: string, options: QuestionOption[], text = 'proceed?'): Question {
+  return { id: id as UUID, text, options, allowsFreeText: false, isAnswered: false };
 }
+
+const yesAlwaysOpt: QuestionOption = {
+  value: '2',
+  label: 'Yes, always',
+  isRecommended: false,
+  isYes: true,
+  isNo: false,
+};
+const defaultThreeSet: QuestionOption[] = [
+  { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+  yesAlwaysOpt,
+  { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+];
 
 function fakePTY(): PTYSession {
   return {
@@ -45,6 +59,55 @@ describe('selectPushCategory', () => {
     expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt])).toBe('REMI_MULTI');
     expect(selectPushCategory([yesOpt])).toBeUndefined();
     expect(selectPushCategory([])).toBeUndefined();
+  });
+});
+
+describe('buildPushText (#574 issues 3+4)', () => {
+  test('title carries session + clean hook ask; body lists the real option labels', () => {
+    const { title, body } = buildPushText(
+      'my-project',
+      question('q', defaultThreeSet, 'Allow Bash: git push origin main'),
+    );
+    expect(title).toBe('my-project: Allow Bash: git push origin main');
+    // Body leads with the ask, then the real labels (not numeric indices).
+    expect(body).toBe('Allow Bash: git push origin main\n1. Yes  2. Yes, always  3. No');
+  });
+
+  test('regression: a raw collapsed PTY prompt is NEVER emitted as the body', () => {
+    // The PTY screen text collapses to a run-together string after ANSI strip
+    // ("Doyouwanttoproceed?"); normalization must keep word separators and the
+    // dispatcher must never surface that exact garble. Here the hook text is
+    // the clean source; even a garbled question.text must be whitespace-safe.
+    const { title, body } = buildPushText(
+      'agent',
+      question('q', defaultThreeSet, 'Do  you\twant\nto   proceed?'),
+    );
+    // Collapsed whitespace -> single spaces, never the no-space run-together form.
+    expect(body).not.toContain('Doyouwanttoproceed');
+    expect(title).not.toContain('Doyouwanttoproceed');
+    expect(body.startsWith('Do you want to proceed?')).toBe(true);
+  });
+
+  test('free-text prompt (no options): body is just the ask, no trailing list', () => {
+    const { body } = buildPushText('agent', question('q', [], 'What should I name it?'));
+    expect(body).toBe('What should I name it?');
+  });
+
+  test('empty question text falls back to a generic ask, never blank', () => {
+    const { title, body } = buildPushText('agent', question('q', defaultThreeSet, '   '));
+    expect(title).toBe('agent: Allow this action?');
+    expect(body.startsWith('Allow this action?')).toBe(true);
+  });
+
+  test('option prefix is the actual VALUE, not the positional index (FIX 3C)', () => {
+    // StopFailure-style y/n options carry non-index values; the prefix must
+    // reflect the real value ("y. Yes  n. No") so it stays accurate.
+    const ynOpts: QuestionOption[] = [
+      { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+      { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+    ];
+    const { body } = buildPushText('agent', question('q', ynOpts, 'Retry?'));
+    expect(body).toBe('Retry?\ny. Yes  n. No');
   });
 });
 
@@ -104,7 +167,9 @@ describe('NotificationDispatcher.maybePush', () => {
     // wss->https normalization downstream.
     expect(pushed[0]?.url).toBe('ws://x');
     expect(pushed[0]?.opts['category']).toBe('REMI_YN');
-    expect(pushed[0]?.opts['options']).toEqual(['y', 'n']);
+    // #574: options carry the human-readable LABELS for display, not the
+    // numeric values; answer routing resolves a label back to the option.
+    expect(pushed[0]?.opts['options']).toEqual(['Yes', 'No']);
   });
 
   test('does NOT push when a client is attached (it sees the question in-app)', () => {
@@ -134,5 +199,39 @@ describe('NotificationDispatcher.maybePush', () => {
     d.resetDedup(); // prompt cycle ended (status left 'waiting')
     d.maybePush(SID, question('q3', [yesOpt, noOpt]));
     expect(pushed).toHaveLength(2);
+  });
+
+  test('sends option LABELS for display, not numeric values (#574 issue 4)', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().maybePush(SID, question('q1', defaultThreeSet, 'Allow Bash: git push'));
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.opts['options']).toEqual(['Yes', 'Yes, always', 'No']);
+    expect(pushed[0]?.opts['category']).toBe('REMI_YNA');
+  });
+
+  test('body shows the ask + real labels and is never the collapsed PTY garble (#574 issue 3)', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    // A garbled PTY-derived text must not surface run-together on the wire.
+    make().maybePush(SID, question('q1', defaultThreeSet, 'Do  you\twant to proceed?'));
+
+    expect(pushed).toHaveLength(1);
+    const body = pushed[0]?.opts['body'] as string;
+    expect(body).not.toContain('Doyouwanttoproceed');
+    expect(body).toContain('1. Yes  2. Yes, always  3. No');
+  });
+
+  test('falls back to the option value when a label is empty', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    const blankLabel: QuestionOption = { ...yesOpt, label: '' };
+    make().maybePush(SID, question('q1', [blankLabel, noOpt]));
+
+    expect(pushed[0]?.opts['options']).toEqual(['y', 'No']);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export type {
   Acknowledgment,
   Question,
   QuestionOption,
+  QuestionSource,
   Session,
   ConnectionInfo,
   Result,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -157,7 +157,26 @@ export interface Question {
    * question id, so concurrency there holds regardless of this field.
    */
   readonly agentId?: string | undefined;
+
+  /**
+   * Where this question came from (#574). The daemon emits two hook-derived
+   * questions for one permission cycle: a rich `PermissionRequest` (tool +
+   * command + agent context) and a generic `Notification(permission_prompt)`
+   * ("Claude needs your permission to use Bash"). The
+   * QuestionPresenceTracker's merge policy uses this so a trailing generic
+   * notification never overwrites the richer permission-request text/options
+   * for the same agent. PTY-parsed prompts are `'pty'`. Optional and
+   * ignored on the wire; consumed only by the daemon's notification path.
+   */
+  readonly source?: QuestionSource | undefined;
 }
+
+/**
+ * Provenance of a {@link Question} (#574). Drives the daemon's
+ * QuestionPresenceTracker merge policy (richer hook text must win over the
+ * generic notification fallback) and is otherwise inert on the wire.
+ */
+export type QuestionSource = 'permission_request' | 'notification' | 'pty';
 
 /** Sentinel agent key for the primary (main) agent, whose questions carry no
  *  `agentId`. Normalize `agentId ?? MAIN_AGENT_ID` when building collection keys. */


### PR DESCRIPTION
## Summary

Phase 3 of epic #571 — **faithful notification**: fixes the garbled APNS body ("Doyouwanttoproceed?") and makes options reflect the real question (issues 3 + 4).

- **Text:** title/body built from the hook's clean rich text + whitespace-normalized, so the raw column-aligned PTY prompt can never surface as a run-together string; body lists the real option labels.
- **Single source of truth:** new optional `Question.source` (`permission_request`|`notification`|`pty`); the presence tracker keeps a pending rich `permission_request` over a generic `Notification` for the same agent, and only a newer `permission_request` evicts it (so a generic notification or a source-less `StopFailure` card can't strand the real prompt).
- **Dynamic options:** the push sends option **labels** for display; the daemon resolves an incoming answer by **value OR label** and the non-held PTY path submits the option's **value** (the index Claude's native prompt expects). Phase 2's held-hook resolution, "Yes, always" release-to-passthrough, and multi-choice picks are all preserved; in-app clients sending the numeric value still work. **Signaling worker untouched (no redeploy).**

Closes #574. Part of epic #571.

## Review (pr-review-toolkit, Sonnet — code-reviewer + silent-failure-hunter)

Code-reviewer: no high-confidence issues; traced every answer-routing branch and confirmed **Phase 2's held-hook invariants are preserved** under label resolution; merge policy cannot strand a subagent-only notification. silent-failure-hunter: 3 findings, **all fixed**:

| Finding | Resolution |
|---|---|
| HIGH — a source-less `StopFailure` could silently evict a pending `permission_request` (same `"main"` key) → wrong card, no push | guard broadened to keep `permission_request` unless replaced by a newer `permission_request`; + debug log |
| MEDIUM — no log on label→value answer translation / unresolved-label verbatim submit | added resolution logs |
| LOW — `formatOptionList` numbered positionally (misleading for y/n) | prefix uses the option's actual value |

## Test plan (NO MOCKS)

notification-dispatcher (title/body, no-garble regression, options labels, y/n rendering), hook-event-bridge + question-presence-tracker (PermissionRequest text wins; StopFailure doesn't evict; newer permission_request does), input-events (answer resolves by value AND label; held→decision; non-held→PTY submits the index even when a label was sent; "Yes, always" + pick paths intact; resolution logging). Full daemon suite: **2151 pass / 69 skip / 0 fail**. Typecheck + biome clean.
