### PR TITLE
Phase 4a: Connection-independent answer relay

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -81,6 +81,18 @@ export interface AdapterEvents {
     claudeSessionId?: UUID,
   ) => void;
 
+  /**
+   * Connection-independent answer relay (#575, P4a). Used by the HTTP /answer
+   * endpoint; returns a structured outcome so the route can JSON-encode it.
+   * Only the WebSocket adapter exposes a relay endpoint today.
+   */
+  onAnswerRelay?: (
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
+
   /** Bullet expand request received */
   onBulletExpandRequest: (
     connectionId: UUID,

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -118,6 +118,12 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onAnswer?.(connectionId, sessionId, questionId, answer, claudeSessionId);
       },
 
+      onAnswerRelay: async (sessionId, questionId, answer, claudeSessionId) =>
+        // No relay handler wired => behave like an unknown session rather than
+        // throwing inside the HTTP route.
+        (await this.events.onAnswerRelay?.(sessionId, questionId, answer, claudeSessionId)) ??
+        'session-not-found',
+
       onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {
         this.events.onBulletExpandRequest?.(connectionId, sessionId, bulletId, requestId);
       },

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -142,6 +142,45 @@ export class Authenticator {
   }
 
   /**
+   * Verify a detached, connection-independent signed request (#575, P4a).
+   *
+   * Used by the HTTP `/answer` relay, which cannot run the interactive
+   * challenge-response handshake but must still authenticate with the SAME
+   * trust model the WebSocket uses: (1) verify the client's Ed25519 signature
+   * over `message`, then (2) require the key to be in the authorized-keys store
+   * (the exact gate `verifyResponse` step 2 applies). Unlike the live handshake,
+   * this path does NOT TOFU-accept unknown keys — a relayed answer must come
+   * from an already-trusted client, never bootstrap trust.
+   *
+   * `message` is the canonical request string the client signed (the caller is
+   * responsible for binding it to the request, e.g. sessionId|questionId|answer).
+   * Returns true only when the signature verifies AND the key is authorized.
+   */
+  async verifyDetachedRequest(
+    message: string,
+    signatureBase64: string,
+    clientPublicKeyBase64: string,
+    clientFingerprint: string,
+  ): Promise<boolean> {
+    try {
+      const clientPublicKey = await importPublicKey(fromBase64(clientPublicKeyBase64));
+      const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+      const valid = await verify(clientPublicKey, data, signatureBase64);
+      if (!valid) return false;
+    } catch (err) {
+      console.error(`Detached request verification error: ${errorToString(err)}`);
+      return false;
+    }
+
+    try {
+      return this.store.isAuthorized(clientPublicKeyBase64, clientFingerprint);
+    } catch (err) {
+      console.error(`Auth store error during detached verification: ${errorToString(err)}`);
+      return false;
+    }
+  }
+
+  /**
    * Clean up a pending challenge (e.g., on connection close).
    */
   removePendingChallenge(connectionId: string): void {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1380,6 +1380,11 @@ const sharedEvents = {
   ...transcriptHandlers,
   ...createSessionHandlers_,
   ...resumeSessionHandlers,
+  // Expose the shared answer core under the adapter's relay event name (#575,
+  // P4a). The HTTP /answer endpoint routes through the SAME logic as the
+  // WebSocket onAnswer, just reporting a structured outcome instead of an
+  // over-the-connection error frame.
+  onAnswerRelay: inputHandlers.relayAnswer,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -109,6 +109,17 @@ function guardBinding(
   return false;
 }
 
+/**
+ * Outcome of routing an answer to a pending Question. Returned by the shared
+ * answer core so the connection-independent HTTP `/answer` relay (#575, P4a)
+ * can map it to a clear JSON status without re-implementing the routing logic.
+ *   - `delivered`     — the answer was resolved via the held hook OR submitted to the PTY.
+ *   - `session-not-found` — no session matched the sessionId/connectionId.
+ *   - `stale-binding` — the Claude session this answer targeted has rotated.
+ *   - `stale`         — the question is no longer active (already answered/auto-approved).
+ */
+export type AnswerOutcome = 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 /**
@@ -125,6 +136,13 @@ function resolveOption(
 ): QuestionOption | undefined {
   return options.find((o) => o.value === answer || o.label === answer);
 }
+
+/**
+ * No-op `send` for the connection-independent `/answer` relay (#575, P4a),
+ * which has no WebSocket connection to write error frames to. The relay reports
+ * status via its `AnswerOutcome` return value instead.
+ */
+const noopSend: SendToConnection = () => false;
 
 /**
  * Map a resolved option to a binary allow/deny decision (#573). Reads the
@@ -161,80 +179,68 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     cancelAutoApprove,
   } = deps;
 
-  return {
-    onUserInput: async (
-      connectionId: UUID,
-      sessionId: UUID,
-      content: string,
-      raw?: boolean,
-      claudeSessionId?: UUID,
-    ): Promise<void> => {
-      log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
+  /**
+   * Shared answer-routing core for both the WebSocket `onAnswer` event and the
+   * HTTP `/answer` relay (#575, P4a). Resolves a held permission hook (Model B),
+   * releases to passthrough + submits a PTY digit for picks / "always", or
+   * submits free text — then cancels the in-flight eval and removes the
+   * question. Returns the outcome; the WebSocket path additionally surfaces
+   * errors over the connection via `send` (suppressed when `viaRelay`).
+   */
+  async function handleAnswer(
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId: UUID | undefined,
+    viaRelay = false,
+  ): Promise<AnswerOutcome> {
+    log(
+      `Answer ${viaRelay ? '(relay) ' : ''}from ${connectionId} for session ${sessionId}: ${answer}`,
+    );
 
-      const session = sessionRegistry.getSessionForConnection(connectionId);
-      if (!session) {
-        log(`No session found for connection ${connectionId}`);
-        return;
-      }
-
-      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
-        return;
-      }
-
-      if (raw) {
-        // Raw terminal input from attach client: write directly without Enter
-        try {
-          session.pty.write(content);
-        } catch (err) {
-          log(`[PTY] raw write failed: ${errorToString(err)}`);
-        }
-        return;
-      }
-
-      // Structured input from web/mobile client: append Enter
-      await session.pty.submitInput(content);
-    },
-
-    onAnswer: async (
-      connectionId: UUID,
-      sessionId: UUID,
-      questionId: UUID,
-      answer: string,
-      claudeSessionId?: UUID,
-    ): Promise<void> => {
-      log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
-
-      // Prefer lookup by sessionId (from push-action answers) so reconnected clients
-      // can answer even before the connection is fully mapped in the registry.
-      const session =
-        sessionRegistry.getSession(sessionId) ??
-        sessionRegistry.getSessionForConnection(connectionId);
-      if (!session) {
-        log(`No session found for connection ${connectionId} or session ${sessionId}`);
+    // Prefer lookup by sessionId (from push-action answers) so reconnected clients
+    // can answer even before the connection is fully mapped in the registry.
+    const session =
+      sessionRegistry.getSession(sessionId) ??
+      sessionRegistry.getSessionForConnection(connectionId);
+    if (!session) {
+      log(`No session found for connection ${connectionId} or session ${sessionId}`);
+      if (!viaRelay) {
         send(
           connectionId,
           createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
         );
-        return;
       }
+      return 'session-not-found';
+    }
 
-      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
-        return;
-      }
+    if (
+      !guardBinding(
+        bindingStore,
+        viaRelay ? noopSend : send,
+        connectionId,
+        sessionId,
+        claudeSessionId,
+      )
+    ) {
+      return 'stale-binding';
+    }
 
-      // Drop stale answers. APNS tokens persist across disconnect (#286), so a
-      // delayed lock-screen tap can deliver an answer for a question that has
-      // since been auto-approved or resolved. Membership in the pending set
-      // (not equality with a single slot) is the check, so answering one of
-      // several concurrent prompts (main + subagent, #419) never invalidates
-      // the others. Surface the drop so the iOS user gets a "not delivered"
-      // signal instead of silent failure.
-      const active = sessionRegistry.getQuestion(session.sessionId, questionId);
-      if (active === null) {
-        const pendingIds = [...session.currentQuestions.keys()];
-        log(
-          `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
-        );
+    // Drop stale answers. APNS tokens persist across disconnect (#286), so a
+    // delayed lock-screen tap can deliver an answer for a question that has
+    // since been auto-approved or resolved. Membership in the pending set
+    // (not equality with a single slot) is the check, so answering one of
+    // several concurrent prompts (main + subagent, #419) never invalidates
+    // the others. Surface the drop so the iOS user gets a "not delivered"
+    // signal instead of silent failure.
+    const active = sessionRegistry.getQuestion(session.sessionId, questionId);
+    if (active === null) {
+      const pendingIds = [...session.currentQuestions.keys()];
+      log(
+        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
+      );
+      if (!viaRelay) {
         send(
           connectionId,
           createError('STALE_ANSWER', 'The question this answer was for is no longer active', {
@@ -243,19 +249,26 @@ export function createInputHandlers(deps: InputHandlerDeps) {
             pendingQuestionIds: pendingIds,
           }),
         );
-        return;
       }
+      return 'stale';
+    }
 
-      // Model B (#573): if the auto-approve gate is HOLDING this permission's
-      // hook, a binary (one-time Yes / No) answer resolves it via the hook
-      // response — Claude is blocked on the hook and is NOT rendering a prompt,
-      // so a PTY submit would land in the wrong place. An answer the binary
-      // response cannot express ("Yes, always", a multi-choice pick, free text)
-      // first RELEASES the held hook to passthrough so Claude renders its native
-      // numbered prompt, then submits the digit (the only way to express
-      // "always" / a specific pick).
-      const decision = mapAnswerToDecision(active.options, answer);
-      let hadHold = false;
+    // Model B (#573): if the auto-approve gate is HOLDING this permission's
+    // hook, a binary (one-time Yes / No) answer resolves it via the hook
+    // response — Claude is blocked on the hook and is NOT rendering a prompt,
+    // so a PTY submit would land in the wrong place. An answer the binary
+    // response cannot express ("Yes, always", a multi-choice pick, free text)
+    // first RELEASES the held hook to passthrough so Claude renders its native
+    // numbered prompt, then submits the digit (the only way to express
+    // "always" / a specific pick).
+    //
+    // The submit/hold-resolution + question removal are wrapped so the question
+    // is ALWAYS consumed exactly once: if `submitInput` throws, the `finally`
+    // still removes it (no zombie question that a retry could double-submit),
+    // and the throw still propagates (relay -> HTTP 500, WS -> caller-logged).
+    const decision = mapAnswerToDecision(active.options, answer);
+    let hadHold = false;
+    try {
       if (decision !== null) {
         hadHold = resolveHeldPermission?.(session.sessionId, questionId, decision) ?? false;
       }
@@ -293,9 +306,79 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // question must NOT abort a different binary permission's eval, so this is
       // gated on hadHold rather than firing on every answer.
       if (hadHold) cancelAutoApprove?.(session.sessionId, 'user-answered');
-
+    } finally {
       // Remove only the answered question; sibling prompts remain answerable.
+      // In `finally` so a throwing submit cannot leave a zombie question.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
+    }
+    return 'delivered';
+  }
+
+  return {
+    onUserInput: async (
+      connectionId: UUID,
+      sessionId: UUID,
+      content: string,
+      raw?: boolean,
+      claudeSessionId?: UUID,
+    ): Promise<void> => {
+      log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
+
+      const session = sessionRegistry.getSessionForConnection(connectionId);
+      if (!session) {
+        log(`No session found for connection ${connectionId}`);
+        return;
+      }
+
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
+        return;
+      }
+
+      if (raw) {
+        // Raw terminal input from attach client: write directly without Enter
+        try {
+          session.pty.write(content);
+        } catch (err) {
+          log(`[PTY] raw write failed: ${errorToString(err)}`);
+        }
+        return;
+      }
+
+      // Structured input from web/mobile client: append Enter
+      await session.pty.submitInput(content);
+    },
+
+    // The WebSocket path: route the answer and reply over the connection on
+    // error. Returns void to match the adapter event signature. The HTTP
+    // `/answer` relay (#575, P4a) calls `relayAnswer` instead, which shares the
+    // exact same routing core but reports a structured outcome.
+    onAnswer: async (
+      connectionId: UUID,
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): Promise<void> => {
+      await handleAnswer(connectionId, sessionId, questionId, answer, claudeSessionId);
+    },
+
+    /**
+     * Connection-independent answer relay (#575, P4a). Routes an answer through
+     * the SAME core as the WebSocket `onAnswer` so a cold-start push tap can
+     * deliver a held-hook decision / PTY pick over plain HTTP, then returns the
+     * structured outcome for the caller to JSON-encode. There is no WebSocket
+     * connection to reply on, so `send` error frames are suppressed here; the
+     * outcome carries the same information.
+     */
+    relayAnswer: async (
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): Promise<AnswerOutcome> => {
+      // The relay has no connection; use the sessionId as the synthetic id so
+      // logging stays meaningful and the registry's sessionId-first lookup wins.
+      return handleAnswer(sessionId as UUID, sessionId, questionId, answer, claudeSessionId, true);
     },
 
     onBulletExpandRequest: (

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -60,6 +60,19 @@ export interface ServerEvents {
     claudeSessionId?: UUID,
   ) => void;
 
+  /**
+   * Connection-independent answer relay over HTTP POST /answer (#575, P4a).
+   * Resolves to a structured outcome so the route can report delivered / stale /
+   * session-not-found. Distinct from `onAnswer` because the HTTP path has no
+   * connection to reply on and must surface the result in the HTTP response.
+   */
+  onAnswerRelay: (
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
+
   /** Bullet expand request from client */
   onBulletExpandRequest: (
     connectionId: UUID,
@@ -262,6 +275,32 @@ export class WebSocketServer {
           );
         }
 
+        // Connection-independent answer relay (#575, P4a). Lets a cold-start
+        // push tap deliver an answer over plain HTTP before any WebSocket is
+        // warm. Authenticated with the SAME trust model as the WebSocket
+        // (loopback bypass + Ed25519 signature over an authorized key); routes
+        // through the SAME answer core as the WebSocket `onAnswer`.
+        if (url.pathname === '/answer') {
+          if (req.method === 'OPTIONS') {
+            return new Response(null, {
+              status: 204,
+              headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'POST, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+              },
+            });
+          }
+          if (req.method !== 'POST') {
+            return new Response(JSON.stringify({ result: 'method-not-allowed' }), {
+              status: 405,
+              headers: jsonCorsHeaders,
+            });
+          }
+          const peer = server.requestIP(req);
+          return self.handleAnswerRelay(req, peer?.address ?? null, jsonCorsHeaders);
+        }
+
         return new Response('Not found', {
           status: 404,
           headers: { 'Access-Control-Allow-Origin': '*' },
@@ -333,6 +372,118 @@ export class WebSocketServer {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Handle a POST /answer relay request (#575, P4a).
+   *
+   * Auth reuses the WebSocket trust model: loopback peers are exempt (same
+   * `shouldSkipAuthForPeer` bypass as the WS upgrade); networked peers must
+   * sign the canonical request string `sessionId|questionId|answer` with a key
+   * already in the daemon's authorized-keys store (the exact gate the WS
+   * handshake applies). The answer is then routed through the SAME core as the
+   * WebSocket `onAnswer`, so held-hook resolution / pick injection are identical.
+   */
+  private async handleAnswerRelay(
+    req: Request,
+    peerAddress: string | null,
+    corsHeaders: Record<string, string>,
+  ): Promise<Response> {
+    const reply = (status: number, result: string, extra?: Record<string, unknown>): Response =>
+      new Response(JSON.stringify({ result, ...extra }), { status, headers: corsHeaders });
+
+    // Defense-in-depth on a LAN-facing endpoint: cap the body before parsing.
+    // Bun.serve defaults to a 128MB body limit; a permission answer is tiny, so
+    // reject anything over 64KiB outright (before req.json() allocates).
+    const MAX_BODY_BYTES = 64 * 1024;
+    const contentLength = Number.parseInt(req.headers.get('content-length') ?? '', 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      console.warn(
+        `[answer-relay] rejected oversized body (${contentLength} bytes) from peer ${peerAddress ?? 'unknown'}`,
+      );
+      return reply(413, 'payload-too-large', { error: 'request body too large' });
+    }
+
+    let body: {
+      sessionId?: unknown;
+      questionId?: unknown;
+      answer?: unknown;
+      claudeSessionId?: unknown;
+      auth?: {
+        signature?: unknown;
+        clientPublicKey?: unknown;
+        clientFingerprint?: unknown;
+      };
+    };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return reply(400, 'bad-request', { error: 'invalid JSON body' });
+    }
+
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : '';
+    const questionId = typeof body.questionId === 'string' ? body.questionId : '';
+    const answer = typeof body.answer === 'string' ? body.answer : '';
+    const claudeSessionId =
+      typeof body.claudeSessionId === 'string' ? body.claudeSessionId : undefined;
+    if (!sessionId || !questionId || !answer) {
+      return reply(400, 'bad-request', {
+        error: 'sessionId, questionId, and answer are required',
+      });
+    }
+
+    // Authenticate with the same trust model as the WebSocket.
+    const authenticator = this.config.connection?.authenticator;
+    if (authenticator && !shouldSkipAuthForPeer(true, peerAddress)) {
+      const auth = body.auth;
+      const signature = typeof auth?.signature === 'string' ? auth.signature : '';
+      const clientPublicKey = typeof auth?.clientPublicKey === 'string' ? auth.clientPublicKey : '';
+      const clientFingerprint =
+        typeof auth?.clientFingerprint === 'string' ? auth.clientFingerprint : '';
+      if (!signature || !clientPublicKey || !clientFingerprint) {
+        console.warn(
+          `[answer-relay] auth rejected: missing signature from peer ${peerAddress ?? 'unknown'}`,
+        );
+        return reply(401, 'unauthorized', { error: 'missing auth signature' });
+      }
+      // Bind the signature to this exact answer so it cannot be replayed for a
+      // different question. Matches the client-side canonicalization.
+      const message = `${sessionId}|${questionId}|${answer}`;
+      const ok = await authenticator.verifyDetachedRequest(
+        message,
+        signature,
+        clientPublicKey,
+        clientFingerprint,
+      );
+      if (!ok) {
+        console.warn(
+          `[answer-relay] auth rejected: signature verification failed from peer ${peerAddress ?? 'unknown'} (key ${clientPublicKey.slice(0, 12)}…)`,
+        );
+        return reply(401, 'unauthorized', { error: 'signature verification failed' });
+      }
+    }
+
+    if (!this.events.onAnswerRelay) {
+      return reply(503, 'unavailable', { error: 'answer relay not wired' });
+    }
+
+    let outcome: 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+    try {
+      outcome = await this.events.onAnswerRelay(
+        sessionId as UUID,
+        questionId as UUID,
+        answer,
+        claudeSessionId as UUID | undefined,
+      );
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+      return reply(500, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const status = outcome === 'delivered' ? 200 : outcome === 'session-not-found' ? 404 : 409;
+    return reply(status, outcome);
   }
 
   private handleOpen(ws: { data: WSData }): void {

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -25,6 +25,7 @@ function fakePTY(capture: {
   writes: string[];
   submits: string[];
   writeError?: Error;
+  submitError?: Error;
 }): PTYSession {
   return {
     id: generateId(),
@@ -33,6 +34,7 @@ function fakePTY(capture: {
       capture.writes.push(content);
     },
     submitInput: async (content: string) => {
+      if (capture.submitError) throw capture.submitError;
       capture.submits.push(content);
     },
     close: async () => {},
@@ -180,6 +182,40 @@ describe('createInputHandlers', () => {
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a throwing submitInput still consumes the question (no zombie) and propagates the error', async () => {
+      // Defense against double-submit on retry: even if the PTY submit throws,
+      // the question must be removed exactly once (finally), and the error must
+      // surface to the caller rather than being swallowed.
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [
+          { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await expect(handlers.onAnswer(CID, sessionId, QID, 'y')).rejects.toThrow('pty closed');
+
+      // No zombie question left behind for a retry to double-submit.
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
@@ -972,6 +1008,181 @@ describe('createInputHandlers', () => {
 
       expect(capture.submits).toEqual(['y']);
       expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+  });
+
+  // The connection-independent HTTP /answer relay (#575, P4a) shares the exact
+  // same routing core as onAnswer, but reports a structured outcome instead of
+  // sending error frames over a (non-existent) connection.
+  describe('relayAnswer (HTTP /answer relay, #575 P4a)', () => {
+    test('routes a free-text answer through the same PTY-submit core and returns delivered', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
+
+      expect(outcome).toBe('delivered');
+      // The phone sends the label; the relay resolves it back to the option value.
+      expect(ptyCapture.submits).toEqual(['1']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+      // No connection, so no error frames are ever sent over the relay path.
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('resolves a HELD binary permission via the hook response (no PTY submit)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const held: Array<{ decision: 'allow' | 'deny' }> = [];
+      const cancels: string[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push({ decision: d });
+          return true;
+        },
+        cancelAutoApprove: (_s, reason) => cancels.push(reason),
+      });
+
+      const outcome = await handlers.relayAnswer(sessionId, QID, '1');
+
+      expect(outcome).toBe('delivered');
+      expect(held).toEqual([{ decision: 'allow' }]); // resolved via the held hook
+      expect(ptyCapture.submits).toEqual([]); // held => no PTY submit
+      expect(cancels).toEqual(['user-answered']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a throwing submit still consumes the question and propagates (route maps to 500)', async () => {
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [{ value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      // The relay surfaces the throw (the HTTP route turns it into a 500).
+      await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
+      // Question consumed exactly once despite the throw.
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('returns session-not-found for an unknown session (no error frame)', async () => {
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(
+        'unknown0-0000-0000-0000-000000000000' as UUID,
+        QID,
+        'Yes',
+      );
+      expect(outcome).toBe('session-not-found');
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('returns stale when the question is no longer active (delayed lock-screen tap)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // No question added: the relay must report stale rather than submitting.
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
+
+      expect(outcome).toBe('stale');
+      expect(ptyCapture.submits).toEqual([]);
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('returns stale-binding when the claudeSessionId has rotated', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        projectPath: '/test/dir',
+        port: 18765,
+        pid: null,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(
+        sessionId,
+        QID,
+        'Yes',
+        '99999999-8888-7777-6666-555555555555' as UUID,
+      );
+
+      expect(outcome).toBe('stale-binding');
+      expect(ptyCapture.submits).toEqual([]);
     });
   });
 });

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -3,14 +3,22 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   type UUID,
   createCreateSessionRequest,
   createHello,
+  createIdentity,
   createPing,
   createUserInput,
   serialize,
+  sign,
+  unlockIdentity,
 } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
 import { WebSocketServer } from '../src/server/websocket-server.ts';
 
 describe('WebSocketServer', () => {
@@ -594,6 +602,199 @@ describe('WebSocketServer', () => {
 
       ws.close();
       await server.stop();
+    });
+  });
+
+  // Connection-independent answer relay (#575, P4a). Real HTTP requests; real
+  // Ed25519 auth via a real IdentityStore + Authenticator (no mocks).
+  describe('POST /answer relay', () => {
+    // Each startServer() call binds a fresh port so a not-yet-released listener
+    // from a prior server in the same/previous test cannot answer this request.
+    let nextAnswerPort = testPort + 30;
+    let answerPort = nextAnswerPort;
+
+    async function startServer(opts: {
+      authenticator?: Authenticator;
+      relayResult?: 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+      captureRelay?: (args: { sessionId: string; questionId: string; answer: string }) => void;
+    }): Promise<WebSocketServer> {
+      if (server?.running) await server.stop();
+      answerPort = nextAnswerPort++;
+      const s = new WebSocketServer(
+        {
+          port: answerPort,
+          connection: opts.authenticator ? { authenticator: opts.authenticator } : {},
+        },
+        {
+          onAnswerRelay: async (sessionId, questionId, answer) => {
+            opts.captureRelay?.({ sessionId, questionId, answer });
+            return opts.relayResult ?? 'delivered';
+          },
+        },
+      );
+      await s.start();
+      server = s; // so afterEach stops it
+      return s;
+    }
+
+    function makeAuthDir(): { store: IdentityStore; dir: string } {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-answer-relay-'));
+      return { store: new IdentityStore(dir), dir };
+    }
+
+    test('routes a loopback (no-auth) answer through onAnswerRelay and returns delivered', async () => {
+      const captured: Array<{ sessionId: string; questionId: string; answer: string }> = [];
+      await startServer({ captureRelay: (a) => captured.push(a) });
+
+      const res = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'sess-1', questionId: 'q-1', answer: 'Yes' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result: string };
+      expect(body.result).toBe('delivered');
+      expect(captured).toEqual([{ sessionId: 'sess-1', questionId: 'q-1', answer: 'Yes' }]);
+    });
+
+    test('maps session-not-found to 404 and stale to 409', async () => {
+      await startServer({ relayResult: 'session-not-found' });
+      const r1 = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+      });
+      expect(r1.status).toBe(404);
+      expect(((await r1.json()) as { result: string }).result).toBe('session-not-found');
+
+      await startServer({ relayResult: 'stale' });
+      const r2 = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+      });
+      expect(r2.status).toBe(409);
+      expect(((await r2.json()) as { result: string }).result).toBe('stale');
+    });
+
+    test('returns 400 for missing fields and bad JSON', async () => {
+      await startServer({});
+      const bad = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      });
+      expect(bad.status).toBe(400);
+
+      const missing = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's' }),
+      });
+      expect(missing.status).toBe(400);
+    });
+
+    test('rejects an oversized body with 413 before parsing', async () => {
+      await startServer({});
+      // 64KiB + 1: just over the guard.
+      const huge = 'x'.repeat(64 * 1024 + 1);
+      const res = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: huge }),
+      });
+      expect(res.status).toBe(413);
+      expect(((await res.json()) as { result: string }).result).toBe('payload-too-large');
+    });
+
+    test('loopback peer is exempt from auth even when an authenticator is configured', async () => {
+      // Mirrors the WebSocket loopback bypass: a same-machine peer is trusted
+      // by virtue of the OS, so the route does not require a signature. The test
+      // client connects over 127.0.0.1, so this proves the route is reachable
+      // (and auth-exempt) for loopback even with auth on.
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+        await startServer({ authenticator });
+
+        const res = await fetch(`http://localhost:${answerPort}/answer`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+        });
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { result: string }).result).toBe('delivered');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    // The route's networked-peer auth gate calls Authenticator.verifyDetachedRequest;
+    // since loopback peers (the only peer a local test can present) are exempt,
+    // the auth-rejection path is exercised directly against that method — the
+    // exact same gate the route uses (verify signature, then require an
+    // authorized key). This is the SAME trust model the WebSocket handshake uses.
+    test('verifyDetachedRequest rejects a valid signature from an UNAUTHORIZED key', async () => {
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+
+        const stranger = await createIdentity();
+        const strangerUnlocked = await unlockIdentity(stranger);
+        const msg = 'sess|q|Yes';
+        const data = new TextEncoder().encode(msg).buffer as ArrayBuffer;
+        const sig = await sign(strangerUnlocked.privateKey, data);
+        // Signature is cryptographically valid, but the key was never authorized.
+        expect(
+          await authenticator.verifyDetachedRequest(
+            msg,
+            sig,
+            stranger.publicKey,
+            stranger.fingerprint,
+          ),
+        ).toBe(false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    test('verifyDetachedRequest accepts an authorized key with a valid signature, rejects a tampered message', async () => {
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+
+        const client = await createIdentity();
+        const clientUnlocked = await unlockIdentity(client);
+        await store.addAuthorizedKey(client.publicKey, 'Test Client');
+
+        const msg = 'sess|q|Yes';
+        const data = new TextEncoder().encode(msg).buffer as ArrayBuffer;
+        const sig = await sign(clientUnlocked.privateKey, data);
+
+        // Authorized key + matching signature => accepted.
+        expect(
+          await authenticator.verifyDetachedRequest(msg, sig, client.publicKey, client.fingerprint),
+        ).toBe(true);
+
+        // Same signature over a DIFFERENT message (replay for another answer) => rejected.
+        expect(
+          await authenticator.verifyDetachedRequest(
+            'sess|q|No',
+            sig,
+            client.publicKey,
+            client.fingerprint,
+          ),
+        ).toBe(false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -15,12 +15,83 @@ interface ApnsPayload {
   sandbox?: boolean;
   /** UNNotificationCategory identifier for action buttons (lock screen / Watch) */
   category?: string;
+  /**
+   * Collapse identifier (#575, P4a). Sent as the `apns-collapse-id` header AND
+   * used to de-dup at the device. A re-push for the same questionId replaces the
+   * earlier notification instead of stacking a duplicate. Apple caps this at 64
+   * bytes; callers pass a questionId (a UUID, well within the limit).
+   */
+  collapseId?: string;
 }
 
 interface ApnsConfig {
   keyId: string;
   teamId: string;
   privateKey: string;
+}
+
+/** The fully-resolved APNS HTTP/2 request (URL + headers + JSON body string). */
+export interface ApnsRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Build the APNS HTTP/2 request (URL, headers, body) from a payload + JWT.
+ *
+ * Extracted as a pure function so the payload shape — including the #575 P4a
+ * `content-available` pre-wake flag and the `apns-collapse-id` header — can be
+ * asserted directly in tests without intercepting the network.
+ *
+ * Throws if `payload.data` contains the reserved `aps` key (would clobber the
+ * APNS dictionary).
+ */
+export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest {
+  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
+  const url = `https://${apnsHost}/3/device/${payload.token}`;
+
+  // Guard against reserved APNS key collision in custom data
+  if (payload.data && 'aps' in payload.data) {
+    throw new Error('ApnsPayload.data must not contain reserved key "aps"');
+  }
+
+  // apns-collapse-id (#575, P4a): a re-push for the same question replaces the
+  // prior notification on the device instead of stacking a duplicate. Apple
+  // caps the value at 64 bytes; a questionId UUID is well within that.
+  const collapseId =
+    payload.collapseId && payload.collapseId.length > 0
+      ? payload.collapseId.slice(0, 64)
+      : undefined;
+
+  const headers: Record<string, string> = {
+    authorization: `bearer ${jwt}`,
+    'apns-topic': payload.bundleId,
+    'apns-push-type': 'alert',
+    'apns-priority': '10',
+    ...(collapseId ? { 'apns-collapse-id': collapseId } : {}),
+  };
+
+  const body = JSON.stringify({
+    aps: {
+      alert: {
+        title: payload.title,
+        body: payload.body,
+      },
+      sound: 'default',
+      badge: 1,
+      // content-available pre-wakes the app in the background so the
+      // WebSocket can start reconnecting before the user taps (#575, P4a).
+      // Kept alongside the alert so the interactive notification still
+      // renders; iOS treats this as a normal alert push with a background
+      // wake opportunity.
+      'content-available': 1,
+      ...(payload.category ? { category: payload.category } : {}),
+    },
+    ...(payload.data ? payload.data : {}),
+  });
+
+  return { url, headers, body };
 }
 
 /**
@@ -32,36 +103,9 @@ export async function sendApnsPush(
   config: ApnsConfig,
 ): Promise<{ success: boolean; error?: string }> {
   const jwt = await createApnsJwt(config);
+  const { url, headers, body } = buildApnsRequest(payload, jwt);
 
-  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
-  const apnsUrl = `https://${apnsHost}/3/device/${payload.token}`;
-
-  // Guard against reserved APNS key collision in custom data
-  if (payload.data && 'aps' in payload.data) {
-    throw new Error('ApnsPayload.data must not contain reserved key "aps"');
-  }
-
-  const response = await fetch(apnsUrl, {
-    method: 'POST',
-    headers: {
-      authorization: `bearer ${jwt}`,
-      'apns-topic': payload.bundleId,
-      'apns-push-type': 'alert',
-      'apns-priority': '10',
-    },
-    body: JSON.stringify({
-      aps: {
-        alert: {
-          title: payload.title,
-          body: payload.body,
-        },
-        sound: 'default',
-        badge: 1,
-        ...(payload.category ? { category: payload.category } : {}),
-      },
-      ...(payload.data ? payload.data : {}),
-    }),
-  });
+  const response = await fetch(url, { method: 'POST', headers, body });
 
   if (response.ok) {
     return { success: true };

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -195,6 +195,10 @@ export default {
             sandbox,
             data: Object.keys(data).length > 0 ? data : undefined,
             category,
+            // Collapse repeated pushes for the same question (#575, P4a).
+            ...(body.questionId && body.questionId.length > 0
+              ? { collapseId: body.questionId }
+              : {}),
           },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the APNS request builder (#575, P4a).
+ *
+ * `buildApnsRequest` is a pure function (URL + headers + JSON body), so the
+ * payload shape is asserted directly — no network, no mocks. These cover the
+ * P4a additions: `content-available: 1` pre-wake and the `apns-collapse-id`
+ * header keyed by questionId, while confirming the interactive alert stays
+ * well-formed.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { buildApnsRequest } from '../src/apns.ts';
+
+const BASE = {
+  token: 'device-token-abc',
+  title: 'remi-phase4 needs input',
+  body: 'Allow Bash: git push',
+  bundleId: 'live.yooz.remi',
+};
+
+function parseBody(body: string): {
+  aps: {
+    alert?: { title?: string; body?: string };
+    sound?: string;
+    badge?: number;
+    'content-available'?: number;
+    category?: string;
+  };
+  [key: string]: unknown;
+} {
+  return JSON.parse(body);
+}
+
+describe('buildApnsRequest (#575 P4a)', () => {
+  test('includes content-available: 1 for background pre-wake', () => {
+    const req = buildApnsRequest(BASE, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('keeps the interactive alert well-formed alongside content-available', () => {
+    const req = buildApnsRequest({ ...BASE, category: 'REMI_YNA' }, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps.alert?.title).toBe(BASE.title);
+    expect(payload.aps.alert?.body).toBe(BASE.body);
+    expect(payload.aps.sound).toBe('default');
+    expect(payload.aps.badge).toBe(1);
+    expect(payload.aps.category).toBe('REMI_YNA');
+    // content-available coexists with the alert (not a silent push).
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('sets apns-collapse-id header from the collapseId (questionId)', () => {
+    const req = buildApnsRequest({ ...BASE, collapseId: 'question-uuid-1234' }, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toBe('question-uuid-1234');
+  });
+
+  test('omits apns-collapse-id when no collapseId is provided', () => {
+    const req = buildApnsRequest(BASE, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toBeUndefined();
+  });
+
+  test('truncates a collapseId longer than 64 bytes (APNS limit)', () => {
+    const longId = 'x'.repeat(100);
+    const req = buildApnsRequest({ ...BASE, collapseId: longId }, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toHaveLength(64);
+  });
+
+  test('carries custom data fields (sessionId / opt_N) as siblings to aps', () => {
+    const req = buildApnsRequest(
+      { ...BASE, data: { sessionId: 's1', questionId: 'q1', opt_0: 'Yes', opt_1: 'No' } },
+      'jwt-token',
+    );
+    const payload = parseBody(req.body);
+    expect(payload['sessionId']).toBe('s1');
+    expect(payload['opt_0']).toBe('Yes');
+    expect(payload['opt_1']).toBe('No');
+    // Custom data does not clobber the aps dictionary.
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('throws if custom data tries to override the reserved aps key', () => {
+    expect(() => buildApnsRequest({ ...BASE, data: { aps: 'malicious' } }, 'jwt-token')).toThrow(
+      'reserved key "aps"',
+    );
+  });
+
+  test('uses the production APNS host by default and sandbox when requested', () => {
+    expect(buildApnsRequest(BASE, 'jwt').url).toContain('api.push.apple.com');
+    expect(buildApnsRequest({ ...BASE, sandbox: true }, 'jwt').url).toContain(
+      'api.sandbox.push.apple.com',
+    );
+  });
+
+  test('always sets the standard APNS headers', () => {
+    const req = buildApnsRequest(BASE, 'jwt-xyz');
+    expect(req.headers['authorization']).toBe('bearer jwt-xyz');
+    expect(req.headers['apns-topic']).toBe('live.yooz.remi');
+    expect(req.headers['apns-push-type']).toBe('alert');
+    expect(req.headers['apns-priority']).toBe('10');
+  });
+});

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -85,6 +85,57 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
     }
 
+    // Background pre-wake for escalated-question pushes (#575, P4a).
+    //
+    // The signaling worker now sends `content-available: 1`, so iOS calls this
+    // BEFORE the user taps the notification, giving the app a short background
+    // window. We use it to nudge the WebView into re-establishing the WebSocket
+    // so the connection is closer to ready by the time the user acts — and so
+    // the direct /answer relay has a warm route on LAN/Tailscale.
+    //
+    // We forward the SAME DOM CustomEvents the web app already listens for on
+    // foreground (`app-resume` / `app-force-reconnect`, dispatched from
+    // main.tsx), rather than inventing a native message channel. Capacitor owns
+    // the WKWebView and its push delegate, so we reach the web layer by
+    // evaluating JS on the bridge's webView.
+    //
+    // NOTE: This path CANNOT be verified headlessly — it depends on APNS
+    // delivering a content-available push to a real device and the WKWebView
+    // running JS while backgrounded. Verify on-device:
+    //   1. Background the app, trigger an escalated permission, confirm the
+    //      Xcode console logs "[remi] background pre-wake" before any tap.
+    //   2. Confirm the WebSocket shows a reconnect attempt in the web logs
+    //      while the app is still backgrounded.
+    //   3. Confirm `completionHandler` is always called (no background-budget
+    //      warnings in the console).
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        let js = """
+        (function() {
+          try {
+            document.dispatchEvent(new CustomEvent('app-resume'));
+            document.dispatchEvent(new CustomEvent('app-force-reconnect'));
+            console.debug('[remi] background pre-wake: dispatched app-force-reconnect');
+          } catch (e) {
+            console.warn('[remi] background pre-wake failed', e);
+          }
+        })();
+        """
+
+        // Reach the WKWebView through the Capacitor bridge view controller.
+        if let bridgeVC = window?.rootViewController as? CAPBridgeViewController {
+            bridgeVC.webView?.evaluateJavaScript(js, completionHandler: nil)
+        }
+
+        // Always call the completion handler so iOS does not throttle future
+        // background wakes. `.newData` keeps the background-refresh budget warm
+        // for this remote-notification use case.
+        completionHandler(.newData)
+    }
+
     // Keep WebSocket alive when app enters background.
     // iOS grants ~30 seconds of background execution time.
     // During this window, the WebSocket stays connected and can

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -9,10 +9,12 @@ import { AppLayout } from '@/components/layout';
 import { ConnectModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
-import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
+import { probeAuthInfo } from '@/lib/auth-probe';
+import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
+import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import {
   clearSessionQuestions,
@@ -1283,13 +1285,74 @@ function App() {
         return;
       }
 
+      // Fast path (#575, P4a): deliver the answer over a plain HTTPS POST to the
+      // daemon's /answer endpoint, bypassing the WebSocket and its handshake.
+      // This is the only reliable path on a cold-start wake where the WS is not
+      // warm. Probe whether the daemon requires auth so we can sign when needed
+      // (loopback daemons skip the probe-derived signature; the daemon exempts
+      // them anyway). probeAuthInfo never throws — it returns null on any
+      // failure — so a null probe means "assume no auth" and let the daemon
+      // reject if it disagrees (a 401 then falls back to WS).
+      const targetUrl = target.url;
+      const authInfo = await probeAuthInfo(targetUrl);
+      const authRequired = authInfo?.authRequired ?? false;
+
+      const relay = await relayAnswerDirect({
+        wsUrl: targetUrl,
+        sessionId,
+        questionId,
+        answer,
+        claudeSessionId: boundId,
+        authRequired,
+      });
+
+      if (relay.kind === 'delivered') return;
+      if (relay.kind === 'rejected') {
+        // The daemon refused as stale (409) or unknown (404). The WebSocket
+        // would refuse identically; tell the user instead of retrying.
+        console.warn('[App] direct relay rejected:', relay.result);
+        notifyFailure();
+        return;
+      }
+      if (relay.kind === 'needs-passphrase') {
+        // No unlocked identity, so neither the relay nor the WebSocket can
+        // authenticate without a prompt. Fail fast rather than waiting out the
+        // (now longer) deadline on a connection that will never complete.
+        console.warn('[App] direct relay blocked: identity needs passphrase');
+        notifyFailure();
+        return;
+      }
+      // relay.kind === 'unreachable' (network / WebRTC-relay-only daemon) or
+      // 'auth-failed' (HTTP 401 — no/invalid detached signature, but the WS
+      // challenge-response may still succeed). Both fall back to the WebSocket
+      // reconnect path.
+      console.debug(
+        `[App] direct relay ${relay.kind}, falling back to WS:`,
+        relay.kind === 'unreachable' ? relay.reason : relay.result,
+      );
+
+      // If auth is required but there is no usable (unlocked) identity, the
+      // WebSocket would stall at auth_challenge forever — fail fast rather than
+      // waiting out the 25s deadline. Covers both "no identity" and "encrypted
+      // identity" (isIdentityEncrypted() is false when none is stored, so both
+      // are checked).
+      if (authRequired && (!hasIdentity() || isIdentityEncrypted())) {
+        console.warn('[App] WS fallback blocked: identity missing or needs passphrase');
+        notifyFailure();
+        return;
+      }
+
       const targetConnId: ConnectionId =
         target.kind === 'pending' && target.connectionId
           ? (target.connectionId as ConnectionId)
-          : connectDirectRef.current(target.url);
+          : connectDirectRef.current(targetUrl);
 
-      // Wait for connection with 10s timeout, then send answer
-      const ANSWER_TIMEOUT_MS = 10_000;
+      // Wait for the connection, then send. Raised from 10s to 25s (#575, P4a):
+      // a cold-start wake includes process resume + TCP/TLS + the Ed25519
+      // handshake, which routinely exceeds 10s; 25s stays within the iOS
+      // background-task window. The loop sends the instant status hits
+      // 'connected', so a fast connect is not penalized by the larger deadline.
+      const ANSWER_TIMEOUT_MS = 25_000;
       const deadline = Date.now() + ANSWER_TIMEOUT_MS;
       const delivered = await new Promise<boolean>((resolve) => {
         const check = setInterval(() => {

--- a/packages/web/src/lib/push-answer-relay.ts
+++ b/packages/web/src/lib/push-answer-relay.ts
@@ -1,0 +1,192 @@
+/**
+ * Connection-independent answer relay (#575, P4a).
+ *
+ * On a cold-start push tap the WebSocket is not warm and the reconnect +
+ * Ed25519 handshake can take longer than the answer deadline (or never
+ * complete when the identity needs a passphrase). This module delivers the
+ * answer over a plain HTTPS POST to the daemon's `/answer` endpoint — the
+ * fast path — bypassing the WebSocket entirely.
+ *
+ * The daemon authenticates the POST with the SAME trust model as the
+ * WebSocket: loopback peers are exempt; networked peers must sign the
+ * canonical request string with a key already in the daemon's
+ * authorized-keys store. The signature is produced here from the locally
+ * stored identity. If the identity is encrypted (passphrase) the relay
+ * cannot sign without a prompt, so the caller falls back to the WebSocket
+ * path (which has the same limitation) or surfaces an "open the app" failure.
+ */
+
+import { sign } from '@remi/shared';
+import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from './identity-client';
+
+/** Outcome of a direct-relay attempt. */
+export type RelayResult =
+  | { kind: 'delivered' }
+  /**
+   * The daemon refused the answer as stale (409) or unknown (404). The
+   * WebSocket would refuse identically, so the caller should NOT fall back —
+   * surface an "open the app" failure instead.
+   */
+  | { kind: 'rejected'; result: string }
+  /**
+   * The relay could not be attempted or did not reach the daemon — network
+   * error, timeout, or WebRTC-relay-only daemon. The caller MAY fall back to
+   * the WebSocket reconnect path.
+   */
+  | { kind: 'unreachable'; reason: string }
+  /**
+   * The daemon returned HTTP 401 (the detached signature was missing/invalid,
+   * e.g. the /auth-info probe timed out so no signature was sent). This does
+   * NOT mean the WebSocket would fail — the WS uses an interactive
+   * challenge-response handshake — so the caller should fall back to WS, same
+   * as `unreachable`.
+   */
+  | { kind: 'auth-failed'; result: string }
+  /**
+   * Auth is required but no usable local identity can sign without a prompt
+   * (the identity is passphrase-encrypted, or there is no stored identity at
+   * all). The WebSocket path is equally blocked, so the caller should fail fast
+   * and tell the user to open the app.
+   */
+  | { kind: 'needs-passphrase' };
+
+/**
+ * Convert a `ws(s)://host:port/path` daemon URL to its `http(s)://host:port/answer`
+ * form. Throws if the input cannot be parsed. (Mirrors `authInfoUrl` in
+ * auth-probe.ts, kept separate so the two endpoints can diverge.)
+ */
+export function answerUrl(wsUrl: string): string {
+  const u = new URL(wsUrl);
+  let scheme: string;
+  if (u.protocol === 'wss:') scheme = 'https:';
+  else if (u.protocol === 'ws:') scheme = 'http:';
+  else throw new Error(`Unsupported scheme: ${u.protocol}`);
+  return `${scheme}//${u.host}/answer`;
+}
+
+/** Default timeout for the direct relay; keep it well under the WS deadline. */
+const DEFAULT_TIMEOUT_MS = 6000;
+
+interface RelayInput {
+  readonly wsUrl: string;
+  readonly sessionId: string;
+  readonly questionId: string;
+  readonly answer: string;
+  readonly claudeSessionId?: string | undefined;
+  /** When true the daemon will require a signed request (networked, auth on). */
+  readonly authRequired: boolean;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Build the signed auth block for a `/answer` POST when the daemon requires it.
+ * Returns null when we cannot sign without a passphrase prompt — either because
+ * there is NO stored identity, or the stored identity is encrypted.
+ */
+async function buildAuth(
+  message: string,
+): Promise<{ signature: string; clientPublicKey: string; clientFingerprint: string } | null> {
+  // No identity at all (isIdentityEncrypted() returns false in this case, so it
+  // must be checked separately) OR an encrypted identity: cannot sign here.
+  if (!hasIdentity() || isIdentityEncrypted()) return null;
+  // `unlockStoredIdentity()` with no passphrase succeeds only for an
+  // unencrypted identity (the encrypted/missing cases are filtered above); it
+  // returns usable CryptoKey objects, so sign directly.
+  const identity = await unlockStoredIdentity();
+  const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+  const signature = await sign(identity.privateKey, data);
+  return {
+    signature,
+    clientPublicKey: identity.publicKeyRaw,
+    clientFingerprint: identity.fingerprint,
+  };
+}
+
+/**
+ * Attempt to deliver an answer directly to the daemon over HTTPS.
+ *
+ * Returns:
+ *   - `delivered`        — the daemon accepted and routed the answer.
+ *   - `delivered`        — the daemon accepted and routed the answer.
+ *   - `rejected`         — the daemon refused as stale (409) / unknown (404); the
+ *                          WebSocket would refuse identically, so do NOT retry.
+ *   - `auth-failed`      — HTTP 401 (missing/invalid detached signature); the WS
+ *                          handshake may still succeed, so the caller MAY fall back.
+ *   - `unreachable`      — network error / not directly reachable; caller may fall
+ *                          back to the WebSocket reconnect path.
+ *   - `needs-passphrase` — auth required but no usable (unlocked) identity to sign.
+ */
+export async function relayAnswerDirect(input: RelayInput): Promise<RelayResult> {
+  const { wsUrl, sessionId, questionId, answer, claudeSessionId, authRequired } = input;
+
+  let httpUrl: string;
+  try {
+    httpUrl = answerUrl(wsUrl);
+  } catch {
+    return { kind: 'unreachable', reason: 'bad daemon url' };
+  }
+
+  // Canonical message the daemon binds the signature to.
+  const message = `${sessionId}|${questionId}|${answer}`;
+
+  let auth: { signature: string; clientPublicKey: string; clientFingerprint: string } | undefined;
+  if (authRequired) {
+    let built: Awaited<ReturnType<typeof buildAuth>>;
+    try {
+      built = await buildAuth(message);
+    } catch (err) {
+      return { kind: 'unreachable', reason: `sign failed: ${(err as Error).message ?? err}` };
+    }
+    if (built === null) {
+      // Encrypted identity: cannot sign without a passphrase prompt.
+      return { kind: 'needs-passphrase' };
+    }
+    auth = built;
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(httpUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId,
+        questionId,
+        answer,
+        ...(claudeSessionId ? { claudeSessionId } : {}),
+        ...(auth ? { auth } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    let parsed: { result?: string } = {};
+    try {
+      parsed = (await res.json()) as { result?: string };
+    } catch {
+      // Non-JSON body; fall through to status-based handling.
+    }
+
+    if (res.ok && parsed.result === 'delivered') {
+      return { kind: 'delivered' };
+    }
+    // HTTP 401: the detached signature was missing/invalid (e.g. the /auth-info
+    // probe timed out so no signature was sent). The WebSocket uses an
+    // interactive challenge-response, so it may still succeed — let the caller
+    // fall back to WS rather than giving up.
+    if (res.status === 401) {
+      return { kind: 'auth-failed', result: parsed.result ?? 'unauthorized' };
+    }
+    // A definitive refusal (stale=409, session-not-found=404, bad-request=400)
+    // means the WebSocket would refuse identically — do not fall back.
+    return { kind: 'rejected', result: parsed.result ?? `http ${res.status}` };
+  } catch (err) {
+    // Network error / timeout / daemon not directly reachable (e.g. WebRTC-only).
+    const reason = (err as { name?: string })?.name === 'AbortError' ? 'timeout' : 'network error';
+    return { kind: 'unreachable', reason };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the connection-independent answer relay (#575, P4a).
+ *
+ * `relayAnswerDirect` is exercised against a REAL Bun HTTP server (no network
+ * mocks). The auth branches need a real identity in localStorage, so a tiny
+ * in-memory Storage shim is installed (an environment shim, not a logic mock);
+ * real Ed25519 keys are generated via the shared crypto.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createIdentity, serializeIdentity } from '@remi/shared';
+import { answerUrl, relayAnswerDirect } from '../../src/lib/push-answer-relay';
+
+// Minimal in-memory localStorage so identity-client can read/write a real
+// identity. This is the runtime environment, not a stub of any logic under test.
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.m.has(k) ? (this.m.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.m.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.m.delete(k);
+  }
+  clear(): void {
+    this.m.clear();
+  }
+}
+
+const store = new MemStorage();
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = store;
+
+describe('answerUrl', () => {
+  test('converts ws:// to http:// and targets /answer', () => {
+    expect(answerUrl('ws://localhost:18765/ws')).toBe('http://localhost:18765/answer');
+  });
+
+  test('converts wss:// to https://', () => {
+    expect(answerUrl('wss://example.com:8443/ws')).toBe('https://example.com:8443/answer');
+  });
+
+  test('throws on unsupported scheme', () => {
+    expect(() => answerUrl('http://localhost:18765/ws')).toThrow();
+  });
+});
+
+describe('relayAnswerDirect (#575 P4a)', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+  afterEach(() => {
+    store.clear();
+  });
+
+  function startServer(handler: (req: Request) => Response | Promise<Response>) {
+    return Bun.serve({ port: 0, fetch: handler });
+  }
+
+  test('no-auth daemon: posts the answer and returns delivered', async () => {
+    let received: { sessionId: string; questionId: string; answer: string } | null = null;
+    const server = startServer(async (req) => {
+      const u = new URL(req.url);
+      if (u.pathname === '/answer' && req.method === 'POST') {
+        received = (await req.json()) as typeof received;
+        return new Response(JSON.stringify({ result: 'delivered' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('nope', { status: 404 });
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(received).toEqual({ sessionId: 's1', questionId: 'q1', answer: 'Yes' });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('daemon refusal (stale) returns rejected — caller must NOT fall back', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'stale' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('rejected');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('HTTP 401 returns auth-failed (NOT rejected) so the caller can fall back to the WS handshake', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('auth-failed');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('daemon not directly reachable returns unreachable (caller may fall back to WS)', async () => {
+    // Port 1 is virtually never open.
+    const result = await relayAnswerDirect({
+      wsUrl: 'ws://127.0.0.1:1/ws',
+      sessionId: 's1',
+      questionId: 'q1',
+      answer: 'Yes',
+      authRequired: false,
+      timeoutMs: 400,
+    });
+    expect(result.kind).toBe('unreachable');
+  });
+
+  test('auth required + encrypted identity => needs-passphrase, no request sent', async () => {
+    // Store a passphrase-encrypted identity; the relay cannot sign without a prompt.
+    const encrypted = await createIdentity('correct horse battery staple');
+    store.setItem('remi-identity', serializeIdentity(encrypted));
+
+    let hit = false;
+    const server = startServer(() => {
+      hit = true;
+      return new Response(JSON.stringify({ result: 'delivered' }));
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result.kind).toBe('needs-passphrase');
+      expect(hit).toBe(false); // failed fast, never reached the daemon
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('auth required + NO stored identity => needs-passphrase, no request sent (FIX 5)', async () => {
+    // store is cleared in beforeEach; no identity exists. isIdentityEncrypted()
+    // returns false in this case, so the relay must check hasIdentity() too.
+    let hit = false;
+    const server = startServer(() => {
+      hit = true;
+      return new Response(JSON.stringify({ result: 'delivered' }));
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result.kind).toBe('needs-passphrase');
+      expect(hit).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('auth required + unencrypted identity: signs and the daemon receives the auth block', async () => {
+    const unencrypted = await createIdentity(); // no passphrase => signable without a prompt
+    store.setItem('remi-identity', serializeIdentity(unencrypted));
+
+    let body: {
+      sessionId?: string;
+      auth?: { signature?: string; clientPublicKey?: string; clientFingerprint?: string };
+    } | null = null;
+    const server = startServer(async (req) => {
+      body = (await req.json()) as typeof body;
+      return new Response(JSON.stringify({ result: 'delivered' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
+      expect(body?.auth?.clientFingerprint).toBe(unencrypted.fingerprint);
+      expect(typeof body?.auth?.signature).toBe('string');
+      expect((body?.auth?.signature ?? '').length).toBeGreaterThan(0);
+    } finally {
+      server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4a of epic #571 (partial #575) — **connection-independent answer relay**, the core of issue 6: an escalated permission answer now reaches the daemon on a cold-start wake without depending on a warm WebSocket.

- **Daemon `POST /answer`** on the client-facing server: authenticated with the **same gates as the WebSocket** (loopback bypass via the kernel peer IP — not a header; networked peers sign `sessionId|questionId|answer`, verified via `verifyDetachedRequest` → `isAuthorized`, **no TOFU**). Routes through the **shared `handleAnswer`** core that WS `onAnswer` also uses (held-hook resolve / "Yes, always" passthrough / pick / PTY submit / cancel) — Phases 1–3 behavior unchanged. A throwing PTY submit removes the question in a `finally` (consumed once; no zombie/double-submit). Body capped (413 > 64KiB) before parse; 401s logged.
- **Web** (`push-answer-relay.ts`, `App.tsx`): direct HTTPS relay to `/answer` as the fast path (ws→http normalized), WS fallback on `unreachable` OR `auth-failed` (a 401 ≠ a WS refusal). Deadline 10s → 25s; **fail-fast** when the identity is missing/passphrase-locked instead of waiting out the deadline.
- **APNS** (`signaling/apns.ts`): `content-available: 1` (background pre-wake) + `apns-collapse-id` keyed by questionId. **Requires a worker redeploy** (not deployed here).
- **iOS** (`AppDelegate.swift`): `didReceiveRemoteNotification` fires the Capacitor reconnect events so the connection re-establishes before the user taps. Swift not verifiable headlessly — carries an on-device checklist comment.

**Deferred to follow-ups (not in this PR):** Notification Service Extension (dynamic labels), Live Activities, cross-client `question_resolved` dismissal. #575 stays open for those.

Part of epic #571.

## Review (pr-review-toolkit, Sonnet — code-reviewer/security + silent-failure-hunter)

**Security cleared:** no auth bypass (loopback via kernel peer IP, not spoofable headers), no TOFU on the relay, replay effectively mitigated (questionId is single-use; replay → stale), shared-handler refactor preserves Phase 1–3. **6 findings, all fixed:**

| Finding | Resolution |
|---|---|
| HIGH — PTY-submit throw left a zombie question (double-submit risk) | `removeQuestion` moved into a `finally` (consumed once) |
| HIGH — a 401 from `/answer` blocked the WS fallback | 401 → `auth-failed` → WS fallback fires (404/409 still terminal) |
| HIGH-ish — `/answer` auth rejections unlogged | `console.warn` with peer addr at both 401 points |
| MED — no body-size guard before parse | Content-Length > 64KiB → 413 before `req.json()` |
| MED — no-identity case hung 25s | fail-fast for `!hasIdentity() || isIdentityEncrypted()` |
| cleanup — dead empty catch around `probeAuthInfo` | removed |

## Test plan (NO MOCKS)

daemon `/answer` (real HTTP: auth required/rejected, delivered routes through `handleAnswer`, stale/unknown, 413 oversized, throwing-submit consumes question); web (401→auth-failed, no-identity→needs-passphrase, deadline, relay→WS fallback) with real Ed25519 signing; signaling (miniflare: content-available + collapse-id present, alert well-formed). **daemon+signaling 2223 pass, web 189 pass, 0 fail.** Typecheck + biome clean.
