### PR TITLE
Phase 5: Responsive status states

### DIFF
--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -305,8 +305,10 @@ export class TelegramAdapter implements ConnectionAdapter {
       return false;
     }
 
-    // Show typing indicator for thinking/executing status
-    if (status === 'thinking' || status === 'executing') {
+    // Show typing indicator while the agent is busy: thinking, executing, or
+    // auto-approve evaluating a permission (#576). 'approved'/'starting' are
+    // transient/non-busy and intentionally produce no typing action.
+    if (status === 'thinking' || status === 'executing' || status === 'evaluating') {
       // Send typing indicator repeatedly while working
       this.bot.api
         .sendChatAction(session.chatId, 'typing', {

--- a/packages/daemon/src/adapters/telegram-ui.ts
+++ b/packages/daemon/src/adapters/telegram-ui.ts
@@ -147,6 +147,13 @@ export function formatStatusText(status: AgentStatus): string {
       return '⚡ Executing...';
     case 'waiting':
       return '⏳ Waiting for input';
+    // Auto-approve + session-lifecycle states (#576).
+    case 'evaluating':
+      return '⏳ Evaluating…';
+    case 'approved':
+      return '✓ Approved';
+    case 'starting':
+      return '⚡ Starting';
     default:
       return status;
   }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -97,6 +97,7 @@ import {
   createHelloAck,
   createReplayBatch,
   createSessionListResponse,
+  createSessionUpdate,
   generateId,
 } from '@remi/shared';
 import type { ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
@@ -1209,6 +1210,17 @@ async function createNewSession(
     messageApi,
     locallyOwned,
   );
+
+  // #576: give clients a defined pill state from the first hello_ack. Without
+  // this, no status reaches the client until the first hook fires (Claude can
+  // take tens of seconds to its first PreToolUse), so the session shows no
+  // signal. Recorded via sendAndRecord so a client that connects later replays
+  // it. Wrapped so a send hiccup can never abort session creation.
+  try {
+    sendAndRecord(createSessionUpdate(sessionId, 'starting'));
+  } catch (err) {
+    logError(`[Session ${sessionId}] Failed to emit starting status:`, err);
+  }
 
   // If the spawn or any post-spawn wiring throws, mark the pre-saved
   // store entry as exited so sibling daemons reading the store don't

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -39,7 +39,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionRotated, createSessionViews, errorToString } from '@remi/shared';
+import {
+  createSessionRotated,
+  createSessionUpdate,
+  createSessionViews,
+  errorToString,
+} from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
@@ -703,6 +708,28 @@ export function setupHookBridge(
 
   const handlers = hookBridge.hookHandlers();
 
+  // #576: push an auto-approve lifecycle status to clients so the pill reflects
+  // `evaluating` -> `approved` promptly, instead of waiting for the next hook.
+  //
+  // CRITICAL: the gate invokes the cue callbacks below through its `safeCue`
+  // wrapper (cosmetic; a throw there is logged and absorbed so it can never
+  // re-enter the decision/buffer path). This helper adds its OWN try/catch so a
+  // broadcast send error can never propagate into the gate even if the call site
+  // changes. It emits a client-only `session_update` and deliberately does NOT
+  // touch the StatusWriter `sessionStatus` (the wrapper bar + native statusline
+  // already cue the AA state from the `autoApprove` sub-field) nor the existing
+  // hook-driven onStatusChange path, so it neither double-emits nor fights the
+  // real PreToolUse/PermissionRequest status that follows.
+  const broadcastAutoApproveStatus = (status: AgentStatus): void => {
+    try {
+      sendAndRecord(createSessionUpdate(sessionId, status));
+    } catch (err) {
+      logError(
+        `[Hooks] auto-approve status broadcast failed for ${sessionId}: ${errorToString(err)}`,
+      );
+    }
+  };
+
   // Auto-approve control plane (#453 phase 1): owns the PermissionRequest eval +
   // inject + escalate + cancelStale. Constructed after the bridge + handlers so it
   // can wrap the two outward couplings (isInSubagentContext, onPermissionRequest) as
@@ -726,12 +753,22 @@ export function setupHookBridge(
       onEvalStart: () => {
         tracker.onAutoApproveStart();
         deps.statusWriter?.autoApproveStart(Date.now());
+        // #576: surface the in-flight eval on the client pill ('working').
+        broadcastAutoApproveStatus('evaluating');
       },
       onEscalate: () => {
         tracker.onAutoApproveEscalate();
         deps.statusWriter?.autoApproveEnd('escalated', Date.now());
+        // No status broadcast here: escalate already routes through
+        // handlePermissionRequest -> onStatusChange('waiting'), which broadcasts
+        // the 'waiting' session_update. Re-emitting would double-emit.
       },
-      onHandled: () => deps.statusWriter?.autoApproveEnd('approved', Date.now()),
+      onHandled: () => {
+        deps.statusWriter?.autoApproveEnd('approved', Date.now());
+        // #576: the permission was silently allowed; tell clients so the pill
+        // doesn't sit stale on 'evaluating' until the next hook fires.
+        broadcastAutoApproveStatus('approved');
+      },
       onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -139,16 +139,18 @@ export interface StatusBarDeps {
   /** Logger for render-failure notes. Required so a draw failure is never
    *  silently swallowed by an accidental no-op default. */
   readonly log: (msg: string) => void;
-  /** Refresh cadence in ms. Default 1000 (the `evaluating Ns` counter ticks 1Hz). */
+  /** Refresh cadence in ms. Default 250 so the `evaluating Ns` counter and AA
+   *  state changes feel smooth (#576). The repaint reads in-memory status only —
+   *  no disk I/O — so a faster cadence costs just one small fd write per tick. */
   readonly intervalMs?: number;
 }
 
 /**
  * Owns the reserved-row redraw loop. `start()` paints immediately and then on a
- * 1Hz timer; the unconditional periodic repaint keeps the bar asserted even if
- * Claude's output scrolled it (inline mode) since the last tick. `stop()` clears
- * the row and halts the loop. All draws are no-ops unless `isEnabled()` and a
- * live fd and enough rows.
+ * ~250ms timer (#576); the unconditional periodic repaint keeps the bar asserted
+ * even if Claude's output scrolled it (inline mode) since the last tick and keeps
+ * the `evaluating Ns` counter smooth. `stop()` clears the row and halts the loop.
+ * All draws are no-ops unless `isEnabled()` and a live fd and enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -175,7 +177,7 @@ export class StatusBar {
     this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
     this.now = deps.now ?? (() => Date.now());
     this.log = deps.log;
-    this.intervalMs = deps.intervalMs ?? 1000;
+    this.intervalMs = deps.intervalMs ?? 250;
   }
 
   /** Begin the redraw loop (idempotent). Paints once immediately. */

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -20,7 +20,9 @@
 import * as fs from 'node:fs';
 import type { AgentStatus, UUID } from '@remi/shared';
 
-export type RemiSessionStatus = AgentStatus | 'starting';
+/** Session status surfaced in the status file. `starting` now lives in the
+ *  shared `AgentStatus` (#576), so this is just an alias kept for callers. */
+export type RemiSessionStatus = AgentStatus;
 
 /**
  * Auto-approve eval state surfaced in Claude's native status line (#560).

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { Question, UUID } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
@@ -191,6 +191,9 @@ describe('setupHookBridge', () => {
        *  contract through the bridge wiring. Defaults to the passthrough
        *  tracker used by the legacy assertion-style tests. */
       realTracker?: boolean;
+      /** Capture every message the bridge sends via sendAndRecord (#576: the
+       *  auto-approve status broadcasts). Defaults to a no-op send. */
+      sendLog?: ProtocolMessage[];
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -268,7 +271,7 @@ describe('setupHookBridge', () => {
         sessionId: SID,
         workingDirectory: tmpDir,
         messageApi: localMessageApi,
-        sendAndRecord: () => {},
+        sendAndRecord: opts.sendLog ? (m) => opts.sendLog?.push(m) : () => {},
         // PassthroughTracker is the default: it collapses
         // recordPendingHook into an immediate push so the legacy
         // "bridge emitted a question to the consumer" assertions via
@@ -2365,6 +2368,142 @@ describe('setupHookBridge', () => {
       } as unknown as Question);
 
       expect(messageApiLog.questionCalls).toBe(1);
+    });
+  });
+
+  describe('#576 auto-approve status broadcasts', () => {
+    /** Pull the AgentStatus values out of the session_update messages a run sent. */
+    function sessionUpdateStatuses(log: ProtocolMessage[]): string[] {
+      return log
+        .filter(
+          (m): m is Extract<ProtocolMessage, { type: 'session_update' }> =>
+            m.type === 'session_update',
+        )
+        .map((m) => m.session.status);
+    }
+
+    test('an APPROVE eval broadcasts "evaluating" then "approved" session_updates', async () => {
+      const sendLog: ProtocolMessage[] = [];
+      // A small eval delay guarantees onEvalStart fires before onHandled.
+      build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 10, sendLog });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-aa-status',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'aa-status.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-aa-status',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      expect(decision).toBe('allow');
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      // evaluating (onEvalStart) must precede approved (onHandled).
+      expect(statuses).toContain('evaluating');
+      expect(statuses).toContain('approved');
+      expect(statuses.indexOf('evaluating')).toBeLessThan(statuses.indexOf('approved'));
+    });
+
+    test('an ESCALATE eval broadcasts "evaluating" but NOT "approved" (no double-emit)', async () => {
+      const sendLog: ProtocolMessage[] = [];
+      build({
+        autoApprove: true,
+        autoApproveDecision: 'escalate',
+        autoApproveDelayMs: 10,
+        sendLog,
+      });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-aa-esc',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'aa-esc.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      await hookServer.firePermission({
+        session_id: 'claude-aa-esc',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      expect(statuses).toContain('evaluating');
+      // onEscalate deliberately does NOT broadcast (the bridge's
+      // handlePermissionRequest -> onStatusChange('waiting') already does);
+      // and onHandled is not reached on an escalate verdict.
+      expect(statuses).not.toContain('approved');
+    });
+
+    test('a status-broadcast send error never propagates into the gate decision', async () => {
+      // The broadcast helper wraps its own send in try/catch so a throwing
+      // sendAndRecord cannot break the allow/deny decision or the buffer path.
+      // A fresh setup wires a sender that records then throws on every send.
+      const throwingLog: ProtocolMessage[] = [];
+      const localApi = fakeMessageAPI({ resetCalls: { n: 0 }, statusCalls: [], questionCalls: 0 });
+      const freshSid = generateId();
+      sessionRegistry.registerSession(freshSid, tmpDir, fakePTY([]), localApi);
+      const autoApproveService = {
+        evaluate: async () => ({
+          decision: 'approve' as const,
+          reasoning: 'test',
+          durationMs: 0,
+          model: 'test-model',
+        }),
+        cancel: () => false,
+      } as unknown as import('../../../src/auto-approve/index.ts').AutoApproveService;
+      const freshHook = new RecordingHookServer();
+      setupHookBridge(
+        {
+          sessionRegistry,
+          bindingStore,
+          liveSessionsRegistry,
+          transcriptWatchers: transcriptWatchers as unknown as Map<
+            UUID,
+            import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+          >,
+          transcriptFallbackTimers,
+          autoApproveService,
+          currentPort: () => 8765,
+        },
+        {
+          hookServer: freshHook as unknown as HookServer,
+          sessionId: freshSid,
+          workingDirectory: tmpDir,
+          messageApi: localApi,
+          sendAndRecord: (m) => {
+            throwingLog.push(m);
+            throw new Error('test: send blew up');
+          },
+          tracker: makePassthroughTracker(localApi),
+        },
+      );
+
+      freshHook.fire('SessionStart', {
+        session_id: 'claude-throw-broadcast',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'throw-bc.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      // The decision must still resolve to 'allow' despite the throwing sender.
+      const decision = await freshHook.firePermission({
+        session_id: 'claude-throw-broadcast',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      expect(decision).toBe('allow');
+      // And the broadcast was at least attempted (proving the throw path ran).
+      expect(throwingLog.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -225,6 +225,29 @@ describe('StatusBar', () => {
     expect(writes.length).toBeGreaterThan(2);
   });
 
+  test('the default interval is ~250ms so the evaluating counter is smooth (#576)', async () => {
+    // No explicit intervalMs: exercise the constructor default. Within 320ms a
+    // 250ms timer must have ticked at least once past the immediate paint
+    // (the old 1000ms default would not have). Kept comfortably above 250ms to
+    // avoid CI timer jitter flaking the assertion.
+    const writes: string[] = [];
+    const bar = new StatusBar({
+      getStdoutFd: () => 1,
+      getStatus: () => mkStatus(),
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => NOW_MS,
+      log: () => {},
+      // intervalMs intentionally omitted to test the default.
+    });
+    bar.start();
+    expect(writes).toHaveLength(1); // immediate paint
+    await new Promise((r) => setTimeout(r, 320));
+    bar.stop();
+    expect(writes.length).toBeGreaterThan(1); // at least one timer repaint
+  });
+
   test('a persistent render error never throws, logs once, and backs off after the threshold', async () => {
     let calls = 0;
     const { bar, writes, logs } = harness({

--- a/packages/daemon/tests/telegram-ui.test.ts
+++ b/packages/daemon/tests/telegram-ui.test.ts
@@ -189,6 +189,13 @@ describe('formatStatusText', () => {
     expect(formatStatusText('waiting')).toContain('Waiting');
   });
 
+  test('formats the auto-approve + lifecycle statuses with human labels (#576)', () => {
+    // No raw "evaluating"/"approved"/"starting" leaking through the default arm.
+    expect(formatStatusText('evaluating')).toContain('Evaluating');
+    expect(formatStatusText('approved')).toContain('Approved');
+    expect(formatStatusText('starting')).toContain('Starting');
+  });
+
   test('returns raw string for unknown status', () => {
     expect(formatStatusText('custom' as AgentStatus)).toBe('custom');
   });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -20,8 +20,25 @@ export type MessageState = 'sending' | 'sent' | 'delivered' | 'read';
 /** Who sent the message */
 export type MessageSender = 'agent' | 'user' | 'system';
 
-/** Agent status while working */
-export type AgentStatus = 'idle' | 'thinking' | 'executing' | 'waiting';
+/**
+ * Agent status while working.
+ *
+ * Hook- and auto-approve-sourced lifecycle states (#576):
+ *   - `waiting`     — blocked on the user (a permission/question is open).
+ *   - `evaluating`  — auto-approve is deciding a permission right now.
+ *   - `approved`    — auto-approve just allowed a permission (transient; the
+ *                     next hook moves the session back to executing/thinking).
+ *   - `starting`    — the session is spinning up before its first hook fires,
+ *                     so clients have a defined pill state from hello_ack.
+ */
+export type AgentStatus =
+  | 'idle'
+  | 'thinking'
+  | 'executing'
+  | 'waiting'
+  | 'evaluating'
+  | 'approved'
+  | 'starting';
 
 /**
  * Core message type.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
   clearSessionQuestions,
   getSessionQuestions,
   questionKey,
+  statusClearsMainQuestion,
 } from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
@@ -454,11 +455,14 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === sessionData.id ? { ...s, status: sessionData.status } : s)),
         );
-        // If status moved from 'waiting', the MAIN agent's prompt resolved
-        // (auto-approved, answered in terminal, etc.). Session status tracks
-        // the main agent only (subagent events don't change it), so clear just
-        // the main-agent slot — a concurrent subagent prompt must survive.
-        if (sessionData.status !== 'waiting') {
+        // If status moved to a non-waiting, non-transient state, the MAIN
+        // agent's prompt resolved (auto-approved, answered in terminal, etc.).
+        // Session status tracks the main agent only (subagent events don't
+        // change it), so clear just the main-agent slot; a concurrent subagent
+        // prompt must survive. The transient auto-approve broadcasts
+        // ('evaluating'/'approved', #576) must NOT clear a pending card; see
+        // statusClearsMainQuestion for the rationale.
+        if (statusClearsMainQuestion(sessionData.status)) {
           setQuestions((prev) => {
             const key = questionKey(sessionData.id);
             if (!prev.has(key)) return prev;

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -85,7 +85,12 @@ export function ChatView({
   // grouping, pinned question cards). The legacy compact toggle was removed.
   const [viewMode] = useState<ViewMode>('chat');
   const { isVisible: keyboardVisible, height: keyboardHeight } = useKeyboard();
-  const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
+  // 'evaluating' (auto-approve deciding a permission, #576) counts as busy so
+  // the in-chat typing indicator stays consistent with the "Working" pill.
+  const isAgentBusy =
+    session.status === 'thinking' ||
+    session.status === 'executing' ||
+    session.status === 'evaluating';
   const isConnected = session.connectionStatus === 'connected';
 
   // Render a stack of QuestionCards (main + any subagent prompts, #437) pinned

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -177,8 +177,11 @@ export function MessageList({
     }
   }, [keyboardVisible]);
 
-  // Show typing indicator when agent is thinking/executing
-  const showTyping = agentStatus === 'thinking' || agentStatus === 'executing';
+  // Show typing indicator when the agent is busy: thinking, executing, or
+  // auto-approve evaluating a permission (#576). Kept in lockstep with
+  // ChatView's isAgentBusy so the dots and the "Working" pill never disagree.
+  const showTyping =
+    agentStatus === 'thinking' || agentStatus === 'executing' || agentStatus === 'evaluating';
 
   // In chat mode, collapse tool messages into inline summaries
   const filterTools = viewMode === 'chat';

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -8,7 +8,7 @@
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';
-import type { UIQuestion } from '@/types';
+import type { AgentStatus, UIQuestion } from '@/types';
 
 /** Composite map key: a session's prompt, scoped to its agent (main default). */
 export function questionKey(sessionId: string, agentId?: string | undefined): string {
@@ -55,4 +55,20 @@ export function clearSessionQuestions(
   const next = new Map(questions);
   for (const key of keys) next.delete(key);
   return next;
+}
+
+/**
+ * Whether a `session_update` status means the MAIN agent's prompt resolved and
+ * its pending card should be cleared.
+ *
+ * 'waiting' is the blocked state (the prompt is open), so it never clears.
+ * 'evaluating' and 'approved' are TRANSIENT auto-approve broadcasts (#576) that
+ * must NOT clear a pending card: a second permission's onEvalStart
+ * ('evaluating') would otherwise delete the first card the user is still
+ * looking at, and a Part-B early-push question the gate later auto-approves
+ * ('approved') would vanish silently. The card clears on the next real hook
+ * status ('thinking'/'executing'/'idle'/'starting') or when answered.
+ */
+export function statusClearsMainQuestion(status: AgentStatus): boolean {
+  return status !== 'waiting' && status !== 'evaluating' && status !== 'approved';
 }

--- a/packages/web/src/lib/session-display.ts
+++ b/packages/web/src/lib/session-display.ts
@@ -35,10 +35,26 @@ export function sessionPillState(
       void _exhaustive;
     }
   }
-  // A pending question always wins. Note: the 'waiting' AgentStatus has no
-  // distinct pill and intentionally collapses to 'idle'.
+  // A pending question always wins.
   if (session.questionPending) return 'asking';
-  if (session.status === 'thinking' || session.status === 'executing') return 'working';
+  // 'waiting' used to collapse to 'idle' (a blocked agent looked idle). Now
+  // that hook events (PreToolUse / PermissionRequest) drive 'waiting'
+  // authoritatively, surface it as 'asking' — the agent is blocked on the user
+  // even before a discrete question record arrives (#576).
+  if (session.status === 'waiting') return 'asking';
+  // The agent is busy: thinking, executing a tool, auto-approve evaluating a
+  // permission, or just-approved one (transient before the next hook).
+  if (
+    session.status === 'thinking' ||
+    session.status === 'executing' ||
+    session.status === 'evaluating' ||
+    session.status === 'approved'
+  ) {
+    return 'working';
+  }
+  // 'starting' = session spinning up before its first hook; show it like a
+  // connection coming up (non-interactive spinner), not idle.
+  if (session.status === 'starting') return 'connecting';
   return 'idle';
 }
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -41,8 +41,17 @@ export interface ConnectionState {
   readonly sessionId: string | null;
 }
 
-/** Agent status as displayed in the UI */
-export type AgentStatus = 'idle' | 'thinking' | 'executing' | 'waiting';
+/** Agent status as displayed in the UI. Mirrors the daemon's `AgentStatus`
+ *  (@remi/shared); `evaluating`/`approved`/`starting` are auto-approve and
+ *  session-lifecycle states surfaced on the pill (#576). */
+export type AgentStatus =
+  | 'idle'
+  | 'thinking'
+  | 'executing'
+  | 'waiting'
+  | 'evaluating'
+  | 'approved'
+  | 'starting';
 
 /** Message sender type */
 export type MessageSender = 'user' | 'agent' | 'system';

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -9,6 +9,7 @@ import {
   getSessionQuestions,
   hasSessionQuestion,
   questionKey,
+  statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
 
@@ -72,5 +73,26 @@ describe('clearSessionQuestions', () => {
   test('returns the same reference when nothing matched (no-op update)', () => {
     const map = build(q('s1', undefined, 'a'));
     expect(clearSessionQuestions(map, 's2')).toBe(map);
+  });
+});
+
+describe('statusClearsMainQuestion (#576)', () => {
+  test("'waiting' never clears (the prompt is still open)", () => {
+    expect(statusClearsMainQuestion('waiting')).toBe(false);
+  });
+
+  test("transient auto-approve states 'evaluating'/'approved' do NOT clear the card", () => {
+    // Regression: a second permission's onEvalStart ('evaluating') or a
+    // gate auto-approval ('approved') must not delete a card the user is
+    // still looking at.
+    expect(statusClearsMainQuestion('evaluating')).toBe(false);
+    expect(statusClearsMainQuestion('approved')).toBe(false);
+  });
+
+  test("real hook statuses still clear the resolved main-agent card", () => {
+    expect(statusClearsMainQuestion('thinking')).toBe(true);
+    expect(statusClearsMainQuestion('executing')).toBe(true);
+    expect(statusClearsMainQuestion('idle')).toBe(true);
+    expect(statusClearsMainQuestion('starting')).toBe(true);
   });
 });

--- a/packages/web/tests/lib/session-display.test.ts
+++ b/packages/web/tests/lib/session-display.test.ts
@@ -86,8 +86,31 @@ describe('sessionPillState', () => {
     expect(sessionPillState({ connectionStatus: 'connected', status: 'executing' })).toBe('working');
   });
 
-  test('connected + idle (or waiting) is idle', () => {
+  test('connected + idle is idle', () => {
     expect(sessionPillState({ connectionStatus: 'connected', status: 'idle' })).toBe('idle');
-    expect(sessionPillState({ connectionStatus: 'connected', status: 'waiting' })).toBe('idle');
+  });
+
+  test('connected + waiting is asking (no longer collapses to idle) (#576)', () => {
+    // A blocked agent (PreToolUse / PermissionRequest -> 'waiting') must surface
+    // as "Needs you", even before a discrete question record arrives.
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'waiting' })).toBe('asking');
+  });
+
+  test('connected + evaluating/approved is working (#576)', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'evaluating' })).toBe('working');
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'approved' })).toBe('working');
+  });
+
+  test('connected + starting is connecting (session spinning up) (#576)', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'starting' })).toBe('connecting');
+  });
+
+  test('a pending question still wins over a busy/waiting agent status', () => {
+    expect(
+      sessionPillState({ connectionStatus: 'connected', status: 'evaluating', questionPending: true }),
+    ).toBe('asking');
+    expect(
+      sessionPillState({ connectionStatus: 'connected', status: 'waiting', questionPending: true }),
+    ).toBe('asking');
   });
 });


### PR DESCRIPTION
## Summary

Phase 5 of epic #571 (#576, P2) — status states surface promptly on the client.

- Added `evaluating`/`approved`/`starting` to the shared `AgentStatus` union (+ web mirror).
- Un-collapsed `waiting` on the pill (now `asking`; hook-sourced `waiting` is authoritative); `evaluating`/`approved`→working, `starting`→connecting.
- Daemon broadcasts `session_update` on auto-approve `evaluating` (onEvalStart) + `approved` (onHandled) via a **throw-safe** helper inside the gate's `safeCue` (a send error can't reach the decision/buffer path), and a `starting` update at session create.
- Status-bar render 1000ms→250ms.

Closes #576. Part of epic #571.

## Review (pr-review-toolkit, Sonnet)

Caught a real regression and a few consistency gaps — **all fixed**:

| Finding | Resolution |
|---|---|
| **Critical** — the new `evaluating`/`approved` broadcasts tripped App.tsx's `status !== 'waiting'` guard, making a **pending question card vanish** before the user answered | extracted a pure, tested `statusClearsMainQuestion` (false for waiting/evaluating/approved); card clears only on the next real hook status or on answer |
| typing indicator went dark during `evaluating` | `isAgentBusy`/`showTyping` include `evaluating` |
| Telegram showed raw "evaluating"/"approved"/"starting" | explicit human-readable labels |
| AgentStatus blast-radius sweep | swept all consumers; the rest confirmed safe (PillState switches, isActive, hook-only paths) |

Throw-safety confirmed: the gate-callback broadcast is double-guarded (safeCue + its own try/catch); a throwing sender still yields `allow`.

## Test plan (NO MOCKS)

`sessionPillState` (waiting/evaluating/approved/starting → pill states), `statusClearsMainQuestion` (evaluating/approved don't clear; thinking/executing/idle do), gate broadcast order (evaluating→approved on approve; none on escalate; throwing sender → still `allow`), telegram labels, status-bar cadence. **daemon 2170 pass, web 196 pass, 0 fail.** Typecheck + biome clean; web build ok.
