### PR TITLE
Phase 6: Transcript binding durability + phantom eviction

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -153,6 +153,7 @@ import {
   SessionRegistryFile,
   SessionStore,
   type StoredSession,
+  TranscriptIndex,
 } from './session/index.ts';
 import { findAvailableTcpPort } from './session/port-utils.ts';
 import { TranscriptDiscovery, type TranscriptWatcher } from './transcript/index.ts';
@@ -863,7 +864,12 @@ const subagentViews = new SubagentViewRegistry();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
 // both resume resolvers route through it. No cache — see session-binding-store.ts.
-const bindingStore = new SessionBindingStore(sessionStore);
+// Durable, long-TTL remiUUID -> {claudeSessionId, projectPath} index (#577). Not
+// subject to sessions.json's 100-entry cap or 7-day purge, so a transcript_load
+// for an older session still resolves after the liveness store has dropped it.
+// The binding store mirrors every preAssign/update write into it.
+const transcriptIndex = new TranscriptIndex();
+const bindingStore = new SessionBindingStore(sessionStore, transcriptIndex);
 
 const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
@@ -1339,6 +1345,7 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
   bindingStore,
+  transcriptIndex,
   currentOwnedSession,
   subagentViews,
   send: sendToConnection,

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -17,7 +17,7 @@ import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
 import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
-import type { SessionBindingStore } from '../../session/index.ts';
+import type { SessionBindingStore, TranscriptIndex } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
   TranscriptWatcher as TranscriptWatcherType,
@@ -35,6 +35,10 @@ export interface TranscriptHandlerDeps {
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
   bindingStore: SessionBindingStore;
+  /** Durable, long-TTL remiUUID -> {claudeSessionId, projectPath} index that
+   *  outlives sessions.json's 100-entry cap / 7-day purge, so an old session's
+   *  transcript still resolves after the liveness store has dropped it (#577). */
+  transcriptIndex: TranscriptIndex;
   /** Resolves the daemon's current owned session, so a stale/unknown request is
    *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
   currentOwnedSession: () => CurrentOwnedSession | null;
@@ -51,6 +55,7 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
     transcriptDiscovery,
     transcriptWatchers,
     bindingStore,
+    transcriptIndex,
     currentOwnedSession,
     subagentViews,
     send,
@@ -95,6 +100,40 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
         } catch (err) {
           logError(
             `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
+          );
+        }
+      }
+
+      // Durable index fallback (#577): the session was purged from sessions.json
+      // (100-entry cap or 7-day TTL), so bindingStore.get returned null, but the
+      // long-TTL transcript-index still holds its claude id + project path. Rebuild
+      // the deterministic transcript path and load it from disk if it exists. This
+      // is what stops the recurring "Transcript for session <id> not found" for an
+      // old-but-still-on-disk session.
+      if (!filePath) {
+        try {
+          const indexed = transcriptIndex.get(sessionId as UUID);
+          if (indexed) {
+            const candidate = `${transcriptDiscovery.getProjectTranscriptDir(indexed.projectPath)}/${indexed.claudeSessionId}.jsonl`;
+            if (fs.existsSync(candidate)) {
+              filePath = candidate;
+              log(
+                `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via durable index ${indexed.claudeSessionId.slice(0, 8)}`,
+              );
+            } else {
+              // Indexed but the .jsonl is gone (Claude transcript deleted/moved).
+              // Distinct from "never indexed" so the failure is diagnosable: the
+              // binding survived but the content did not.
+              log(
+                `[TranscriptLoad] Durable index hit for ${sessionId} (claude=${indexed.claudeSessionId.slice(0, 8)}) but transcript is absent on disk: ${candidate}`,
+              );
+            }
+          } else {
+            log(`[TranscriptLoad] No durable index entry for ${sessionId}`);
+          }
+        } catch (err) {
+          logError(
+            `[TranscriptLoad] transcript-index lookup failed for ${sessionId}; proceeding: ${errorToString(err)}`,
           );
         }
       }

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -14,7 +14,11 @@
  * settings.local.json absent, hook server disabled, or in the sibling-in-dir
  * case where the bridge defers to filesystem ground-truth).
  *
- * Poll every 2 seconds. Give up after 30 seconds and log the reason.
+ * Poll every 2 seconds. Give up after 120 seconds and log the reason. Claude
+ * routinely takes 30-90s to write its first transcript line on a large context,
+ * so a 30s window timed out on nearly every session (the self-heal path still
+ * covered it, but noisily, and left a race window for a client that loaded
+ * during startup). 120s covers the common slow-start case (#577).
  */
 
 import * as fs from 'node:fs';
@@ -29,7 +33,7 @@ import { log, logError } from './logger.ts';
 import { startTranscriptWatcher } from './transcript-watcher-setup.ts';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
-const DEFAULT_POLL_TIMEOUT_MS = 30000;
+const DEFAULT_POLL_TIMEOUT_MS = 120000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
@@ -38,7 +42,7 @@ export interface TranscriptFallbackDeps {
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
   /** Override for tests. Defaults to 2000ms. */
   pollIntervalMs?: number;
-  /** Override for tests. Defaults to 30000ms. */
+  /** Override for tests. Defaults to 120000ms. */
   pollTimeoutMs?: number;
 }
 
@@ -84,6 +88,10 @@ export function startTranscriptFallback(
     claudeSessionId,
   );
 
+  // Emit one "still waiting" log at the halfway mark so a genuine early failure
+  // is visible during the longer 120s window instead of an ~85s silent gap (#577).
+  let midLogged = false;
+
   const stopPoll = (): void => {
     clearInterval(fallbackInterval);
     transcriptFallbackTimers.delete(sessionId);
@@ -97,6 +105,14 @@ export function startTranscriptFallback(
     if (!sessionRegistry.hasSession(sessionId)) {
       stopPoll();
       return;
+    }
+
+    const elapsed = Date.now() - startupTime;
+    if (!midLogged && elapsed >= pollTimeoutMs / 2) {
+      midLogged = true;
+      log(
+        `[Fallback] Still waiting for transcript after ${Math.round(elapsed / 1000)}s: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude is likely still loading context; self-heal via hooks remains primary.`,
+      );
     }
 
     if (fs.existsSync(expectedPath)) {
@@ -125,7 +141,7 @@ export function startTranscriptFallback(
       return;
     }
 
-    if (Date.now() - startupTime > pollTimeoutMs) {
+    if (elapsed > pollTimeoutMs) {
       stopPoll();
       logError(
         `[Fallback] Timed out waiting for transcript: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude may have failed to start, or wrote to an unexpected path.`,

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -15,6 +15,8 @@ export { SessionStore, type StoredSession } from './session-store.ts';
 
 export { SessionBindingStore, type SessionBinding } from './session-binding-store.ts';
 
+export { TranscriptIndex, type TranscriptIndexEntry } from './transcript-index.ts';
+
 export {
   SessionRegistryFile,
   type LiveSessionEntry,

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -22,14 +22,26 @@
 
 import type { UUID } from '@remi/shared';
 
+import { log } from '../cli/logger.ts';
 import type { SessionStore, StoredSession } from './session-store.ts';
+import type { TranscriptIndex } from './transcript-index.ts';
 
 export interface SessionBinding {
   claudeSessionId: string | null;
 }
 
 export class SessionBindingStore {
-  constructor(private readonly store: SessionStore) {}
+  /**
+   * Optional durable mirror (#577). Every binding write (preAssign + update)
+   * also records {remiUUID -> claudeSessionId, projectPath} here so the
+   * transcript handler can rebuild an old session's on-disk path after
+   * sessions.json purges it. Co-located on the single binding accessor so a
+   * rotation that updates the binding can never forget to refresh the index.
+   */
+  constructor(
+    private readonly store: SessionStore,
+    private readonly transcriptIndex?: TranscriptIndex,
+  ) {}
 
   /**
    * Current durable binding for this Remi session, or null when no record exists.
@@ -55,7 +67,15 @@ export class SessionBindingStore {
    * today). Together with preAssign, the ONLY claudeSessionId writer.
    */
   update(remiSessionId: UUID, claudeSessionId: string): void {
-    this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+    const updated = this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+    // Refresh the durable mirror with the (possibly rotated) claude id so a
+    // later transcript load resolves the CURRENT transcript, not a stale one.
+    // Mirror from the SAME record the write produced — a second
+    // findByRemiSessionId read could race a concurrent purgeStale() and observe
+    // a null record, leaving the index pinned to the pre-rotation id (#577).
+    if (updated) {
+      this.transcriptIndex?.record(remiSessionId, claudeSessionId, updated.projectPath);
+    }
   }
 
   /**
@@ -66,5 +86,20 @@ export class SessionBindingStore {
    */
   preAssign(session: StoredSession): void {
     this.store.save(session);
+    // Seed the durable mirror at spawn so the binding is recoverable even if the
+    // session never rotates and is later purged from sessions.json (#577).
+    if (session.claudeSessionId) {
+      this.transcriptIndex?.record(
+        session.remiSessionId,
+        session.claudeSessionId,
+        session.projectPath,
+      );
+    } else if (this.transcriptIndex) {
+      // No claude id yet (deferred to the first update() on hook adopt/rotation).
+      // Log so the deferred index seed is traceable rather than silently skipped.
+      log(
+        `[transcript-index] preAssign for ${session.remiSessionId} has no claudeSessionId yet; index seed deferred to update()`,
+      );
+    }
   }
 }

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -211,13 +211,21 @@ export class SessionStore {
     }
   }
 
-  /** Update the Claude session ID (extracted from transcript after startup). */
-  updateClaudeSessionId(remiSessionId: UUID, claudeSessionId: string): void {
+  /**
+   * Update the Claude session ID (extracted from transcript after startup).
+   * Returns the updated record (already in memory from the read-modify-write) so
+   * callers that mirror the binding elsewhere don't need a second disk read — a
+   * separate read could race a concurrent purgeStale() and observe a null record
+   * mid-rotation (#577). Returns null when no record exists (a no-op, as before).
+   */
+  updateClaudeSessionId(remiSessionId: UUID, claudeSessionId: string): StoredSession | null {
     const sessions = this.read();
     const session = sessions.find((s) => s.remiSessionId === remiSessionId);
     if (session) {
       session.claudeSessionId = claudeSessionId;
       this.write(sessions);
+      return session;
     }
+    return null;
   }
 }

--- a/packages/daemon/src/session/transcript-index.ts
+++ b/packages/daemon/src/session/transcript-index.ts
@@ -1,0 +1,189 @@
+/**
+ * TranscriptIndex — a durable, append-only remiUUID -> {claudeSessionId,
+ * projectPath} map persisted at ~/.remi/transcript-index.json.
+ *
+ * Phase 6 (#577). The `remiUUID <-> claudeSessionId` binding lives in
+ * sessions.json (SessionStore), but that store is bounded two ways that both
+ * lose old bindings: MAX_SESSIONS=100 trims the oldest exited rows, and
+ * STALE_AGE_MS=7d purges exited rows. For a user running Claude across many
+ * worktrees the 100-entry cap fills fast, so a transcript_load_request for an
+ * older session resolves to nothing and returns NOT_FOUND ("Transcript for
+ * session <id> not found").
+ *
+ * This index decouples binding durability from the liveness store: it is NOT
+ * subject to the 100-entry cap and uses a much longer TTL (90 days). It stores
+ * only what the transcript handler needs to RECONSTRUCT the on-disk path
+ * (claudeSessionId + projectPath, fed through TranscriptDiscovery's
+ * deterministic encoding) — no liveness, no pid, no port churn.
+ *
+ * Atomic writes use the same per-process `.<pid>.tmp` pattern as SessionStore
+ * (#461) so two daemons sharing ~/.remi never race on a shared tmp path.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { logError } from '../cli/logger.ts';
+
+export interface TranscriptIndexEntry {
+  remiSessionId: UUID;
+  claudeSessionId: string;
+  projectPath: string;
+  /** ISO timestamp of the most recent write for this entry; drives TTL pruning. */
+  updatedAt: string;
+}
+
+interface TranscriptIndexFile {
+  version: 1;
+  entries: TranscriptIndexEntry[];
+}
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const INDEX_FILE = path.join(REMI_DIR, 'transcript-index.json');
+/** Far longer than SessionStore's 7d so old transcripts stay loadable (#577). */
+const INDEX_STALE_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+/** Hard ceiling so a long-lived heavy-worktree machine cannot grow unbounded. */
+const DEFAULT_MAX_INDEX_ENTRIES = 2000;
+
+export class TranscriptIndex {
+  private filePath: string;
+  private maxEntries: number;
+
+  /** `maxEntries` is overridable for tests; production uses the 2000 default. */
+  constructor(filePath?: string, maxEntries: number = DEFAULT_MAX_INDEX_ENTRIES) {
+    this.filePath = filePath ?? INDEX_FILE;
+    this.maxEntries = maxEntries;
+  }
+
+  private ensureDir(): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  /** Read the index, returning [] on a missing/corrupt file (never throws on parse). */
+  private read(): TranscriptIndexEntry[] {
+    if (!fs.existsSync(this.filePath)) return [];
+    const raw = fs.readFileSync(this.filePath, 'utf-8');
+    try {
+      const data = JSON.parse(raw) as TranscriptIndexFile;
+      if (data.version !== 1 || !Array.isArray(data.entries)) {
+        // A future-version or malformed index is discarded, not merged. Log it
+        // so the silent drop is visible (a recovery index must be debuggable);
+        // an unknown version usually means a newer daemon wrote this file.
+        logError(
+          `[transcript-index] Ignoring index with unexpected shape (version=${String(
+            (data as { version?: unknown }).version,
+          )}); recovery lookups will miss until it is rewritten`,
+        );
+        return [];
+      }
+      return data.entries;
+    } catch (err) {
+      if (!(err instanceof SyntaxError)) {
+        logError(`[transcript-index] Unexpected error reading index: ${errorToString(err)}`);
+      }
+      return [];
+    }
+  }
+
+  /** Write the index atomically (per-process tmp + rename), same as SessionStore (#461). */
+  private write(entries: TranscriptIndexEntry[]): void {
+    this.ensureDir();
+    const data: TranscriptIndexFile = { version: 1, entries };
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    try {
+      fs.renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        // best-effort cleanup; surface the original error
+      }
+      throw err;
+    }
+  }
+
+  /** Parse updatedAt to epoch ms; NaN (unparseable) becomes 0 = oldest. */
+  private static updatedAtMs(entry: TranscriptIndexEntry): number {
+    const t = new Date(entry.updatedAt).getTime();
+    return Number.isNaN(t) ? 0 : t;
+  }
+
+  /** Drop entries older than the TTL, then trim oldest if over the hard cap. */
+  private prune(entries: TranscriptIndexEntry[]): TranscriptIndexEntry[] {
+    const now = Date.now();
+    let sawBadTimestamp = false;
+    let kept = entries.filter((e) => {
+      const t = new Date(e.updatedAt).getTime();
+      if (Number.isNaN(t)) {
+        // Keep on NaN here (conservative: never TTL-drop on bad data alone), but
+        // flag it so the cap step below treats it as oldest and trims it first.
+        sawBadTimestamp = true;
+        return true;
+      }
+      return now - t < INDEX_STALE_AGE_MS;
+    });
+    if (sawBadTimestamp) {
+      logError(
+        '[transcript-index] Found entry with unparseable updatedAt; treating as oldest for cap trimming',
+      );
+    }
+    if (kept.length > this.maxEntries) {
+      // Sort numerically with NaN -> 0 (oldest). A string compare here would
+      // sort a NaN/garbage timestamp to the FRONT and the cap would then trim
+      // the NEWEST valid entries first, looping forever on a bad file (#577).
+      kept = [...kept]
+        .sort((a, b) => TranscriptIndex.updatedAtMs(a) - TranscriptIndex.updatedAtMs(b))
+        .slice(kept.length - this.maxEntries);
+    }
+    return kept;
+  }
+
+  /**
+   * Record (or refresh) the binding for a session. Upserts by remiSessionId and
+   * bumps updatedAt; prunes stale/overflow entries on every write so the file
+   * self-maintains. Fails soft: a disk error is logged, not thrown, so a
+   * persistence hiccup never aborts session creation (the index is an
+   * optimization on top of sessions.json, not the authority).
+   */
+  record(remiSessionId: UUID, claudeSessionId: string, projectPath: string): void {
+    try {
+      const entries = this.read();
+      const idx = entries.findIndex((e) => e.remiSessionId === remiSessionId);
+      const entry: TranscriptIndexEntry = {
+        remiSessionId,
+        claudeSessionId,
+        projectPath,
+        updatedAt: new Date().toISOString(),
+      };
+      if (idx >= 0) {
+        entries[idx] = entry;
+      } else {
+        entries.push(entry);
+      }
+      this.write(this.prune(entries));
+    } catch (err) {
+      logError(
+        `[transcript-index] Failed to record binding for ${remiSessionId}: ${errorToString(err)}`,
+      );
+    }
+  }
+
+  /** Resolve a remi session id to its durable binding, or null. Never throws. */
+  get(remiSessionId: UUID): TranscriptIndexEntry | null {
+    try {
+      const entries = this.read();
+      return entries.find((e) => e.remiSessionId === remiSessionId) ?? null;
+    } catch (err) {
+      logError(
+        `[transcript-index] Failed to read binding for ${remiSessionId}: ${errorToString(err)}`,
+      );
+      return null;
+    }
+  }
+}

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -9,6 +9,7 @@ import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-e
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptIndex } from '../../../src/session/transcript-index.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
 import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
 
@@ -47,6 +48,7 @@ describe('createTranscriptHandlers', () => {
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let sessionStore: SessionStore;
   let bindingStore: SessionBindingStore;
+  let transcriptIndex: TranscriptIndex;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
   function send(connectionId: UUID, message: ProtocolMessage): boolean {
@@ -61,7 +63,8 @@ describe('createTranscriptHandlers', () => {
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
-    bindingStore = new SessionBindingStore(sessionStore);
+    transcriptIndex = new TranscriptIndex(path.join(tmpDir, 'transcript-index.json'));
+    bindingStore = new SessionBindingStore(sessionStore, transcriptIndex);
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
   });
@@ -79,6 +82,7 @@ describe('createTranscriptHandlers', () => {
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
+      transcriptIndex,
       currentOwnedSession,
       subagentViews,
       send,
@@ -271,6 +275,51 @@ describe('createTranscriptHandlers', () => {
     expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
       false,
     );
+  });
+
+  test('resolves a purged session via the durable transcript-index (#577)', async () => {
+    // The session was dropped from sessions.json (100-cap / 7-day TTL), so the
+    // store binding is gone, but the durable index still holds {claudeId,
+    // projectPath} and the .jsonl is still on disk. The handler must rebuild the
+    // path from the index instead of returning NOT_FOUND.
+    const claudeSessionId = '66666666-6666-6666-6666-666666666666';
+    writeTranscript(claudeSessionId, [
+      {
+        type: 'user',
+        uuid: 'u1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'old history' },
+      },
+    ]);
+
+    const remiUuid = '77777777-7777-7777-7777-777777777777' as UUID;
+    // Record into the durable index ONLY (sessions.json deliberately empty, as
+    // it would be after a purge); bindingStore.get(remiUuid) therefore returns null.
+    transcriptIndex.record(remiUuid, claudeSessionId, '/Users/test/project');
+    expect(bindingStore.get(remiUuid)).toBeNull();
+
+    makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+    expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+      false,
+    );
+  });
+
+  test('durable index resolves nothing when the .jsonl is gone -> NOT_FOUND', async () => {
+    // Index has the binding but the transcript file was deleted from disk. The
+    // existsSync guard must keep us from claiming a path that does not exist.
+    const remiUuid = '88888888-8888-8888-8888-888888888888' as UUID;
+    transcriptIndex.record(remiUuid, '99999999-9999-9999-9999-999999999999', '/Users/test/project');
+
+    makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    expect((sendCalls[0]?.message as { code?: string }).code).toBe('NOT_FOUND');
   });
 
   test('falls back to the active watcher when the id is a Remi UUID', async () => {

--- a/packages/daemon/tests/session/session-binding-store.test.ts
+++ b/packages/daemon/tests/session/session-binding-store.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { UUID } from '@remi/shared';
 import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
 import { SessionStore, type StoredSession } from '../../src/session/session-store.ts';
+import { TranscriptIndex } from '../../src/session/transcript-index.ts';
 
 function makeTmpPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binding-test-'));
@@ -123,5 +124,25 @@ describe('SessionBindingStore', () => {
     expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-3');
     expect(binding.getByClaudeSessionId('claude-3')?.remiSessionId).toBe(session.remiSessionId);
     expect(binding.getByClaudeSessionId('claude-1')).toBeNull();
+  });
+
+  test('rotation mirrors the NEW claudeSessionId into the durable index (#577)', () => {
+    // The transcript-index must follow a rotation; otherwise the purged-binding
+    // fallback would load the STALE pre-rotation transcript. Mirroring from the
+    // record returned by updateClaudeSessionId (not a second read) closes the
+    // race where a concurrent purge could null the row between write and mirror.
+    const indexPath = path.join(path.dirname(filePath), 'transcript-index.json');
+    const index = new TranscriptIndex(indexPath);
+    const withIndex = new SessionBindingStore(store, index);
+
+    const session = makeSession({ claudeSessionId: 'claude-old' });
+    withIndex.preAssign(session);
+    expect(index.get(session.remiSessionId)?.claudeSessionId).toBe('claude-old');
+
+    withIndex.update(session.remiSessionId, 'claude-new');
+    // The index now points at the rotated id with the same project path.
+    const entry = index.get(session.remiSessionId);
+    expect(entry?.claudeSessionId).toBe('claude-new');
+    expect(entry?.projectPath).toBe(session.projectPath);
   });
 });

--- a/packages/daemon/tests/session/transcript-index.test.ts
+++ b/packages/daemon/tests/session/transcript-index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { TranscriptIndex } from '../../src/session/transcript-index.ts';
+
+function makeTmpPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tidx-'));
+  return path.join(dir, 'transcript-index.json');
+}
+
+const remi = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, '0')}` as UUID;
+
+describe('TranscriptIndex (#577)', () => {
+  let filePath: string;
+  let index: TranscriptIndex;
+
+  beforeEach(() => {
+    filePath = makeTmpPath();
+    index = new TranscriptIndex(filePath);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('get returns null when nothing recorded', () => {
+    expect(index.get(remi(1))).toBeNull();
+  });
+
+  test('record then get round-trips the binding', () => {
+    index.record(remi(1), 'claude-abc', '/Users/me/project');
+    const entry = index.get(remi(1));
+    expect(entry?.claudeSessionId).toBe('claude-abc');
+    expect(entry?.projectPath).toBe('/Users/me/project');
+    expect(entry?.remiSessionId).toBe(remi(1));
+  });
+
+  test('record upserts by remiSessionId (rotation refresh)', () => {
+    index.record(remi(1), 'claude-old', '/proj');
+    index.record(remi(1), 'claude-new', '/proj');
+    const all = index.get(remi(1));
+    expect(all?.claudeSessionId).toBe('claude-new');
+    // Still a single entry (upsert, not append).
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(raw.entries).toHaveLength(1);
+  });
+
+  test('persists across a fresh instance (durability beyond process)', () => {
+    index.record(remi(7), 'claude-7', '/p7');
+    const reopened = new TranscriptIndex(filePath);
+    expect(reopened.get(remi(7))?.claudeSessionId).toBe('claude-7');
+  });
+
+  test('outlives many recordings (no 100-entry cap like sessions.json)', () => {
+    for (let i = 0; i < 250; i++) {
+      index.record(remi(i), `claude-${i}`, `/p/${i}`);
+    }
+    // The oldest entry is still resolvable; sessions.json would have trimmed it.
+    expect(index.get(remi(0))?.claudeSessionId).toBe('claude-0');
+    expect(index.get(remi(249))?.claudeSessionId).toBe('claude-249');
+  });
+
+  test('prunes entries older than the 90-day TTL on write', () => {
+    // Seed an entry whose updatedAt is 100 days old by writing the file directly.
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { remiSessionId: remi(1), claudeSessionId: 'old', projectPath: '/p', updatedAt: old },
+        ],
+      }),
+    );
+    // A new record triggers prune; the 100-day-old entry should be dropped.
+    index.record(remi(2), 'fresh', '/p2');
+    expect(index.get(remi(1))).toBeNull();
+    expect(index.get(remi(2))?.claudeSessionId).toBe('fresh');
+  });
+
+  test('keeps entries within the TTL', () => {
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            remiSessionId: remi(1),
+            claudeSessionId: 'recent',
+            projectPath: '/p',
+            updatedAt: recent,
+          },
+        ],
+      }),
+    );
+    index.record(remi(2), 'fresh', '/p2');
+    expect(index.get(remi(1))?.claudeSessionId).toBe('recent');
+  });
+
+  test('handles corrupt JSON gracefully', () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'not json', 'utf-8');
+    expect(index.get(remi(1))).toBeNull();
+    // Can still record after corruption.
+    index.record(remi(1), 'after', '/p');
+    expect(index.get(remi(1))?.claudeSessionId).toBe('after');
+  });
+
+  test('ignores a wrong-version file', () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify({ version: 99, entries: [] }), 'utf-8');
+    expect(index.get(remi(1))).toBeNull();
+  });
+
+  test('over cap: NaN-timestamp entries are trimmed BEFORE valid ones (#577 FIX 2)', () => {
+    // Regression for the prune sort defect: a string compare sorted an
+    // unparseable updatedAt to the FRONT, so the cap trimmed the newest VALID
+    // entries first and a NaN-heavy file looped forever. Numeric NaN->0 (oldest)
+    // makes the cap drop the bad entries first.
+    const capped = new TranscriptIndex(filePath, 2); // maxEntries = 2
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const valid1 = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { remiSessionId: remi(1), claudeSessionId: 'bad-a', projectPath: '/p', updatedAt: 'NaN' },
+          {
+            remiSessionId: remi(2),
+            claudeSessionId: 'bad-b',
+            projectPath: '/p',
+            updatedAt: 'garbage',
+          },
+          {
+            remiSessionId: remi(3),
+            claudeSessionId: 'valid-1',
+            projectPath: '/p',
+            updatedAt: valid1,
+          },
+        ],
+      }),
+    );
+    // record() (with cap=2) triggers prune. After the new entry there are 4;
+    // trimming to 2 must drop the two NaN entries first, keeping the valid ones.
+    capped.record(remi(4), 'valid-2', '/p');
+
+    expect(capped.get(remi(1))).toBeNull(); // NaN -> trimmed
+    expect(capped.get(remi(2))).toBeNull(); // NaN -> trimmed
+    expect(capped.get(remi(3))?.claudeSessionId).toBe('valid-1'); // valid -> kept
+    expect(capped.get(remi(4))?.claudeSessionId).toBe('valid-2'); // valid -> kept
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
+import { shouldEvictCachedSession } from '@/lib/session-eviction';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
@@ -76,6 +77,35 @@ function rememberSessionDaemon(sessionId: string, url: string): void {
     localStorage.setItem(LOCALSTORAGE_SESSION_DAEMONS_KEY, JSON.stringify(map));
   } catch (err) {
     console.warn('[App] Failed to persist session-daemon map:', err);
+  }
+}
+
+/**
+ * Forget evicted phantom sessions in localStorage so they don't resurface on a
+ * cold start (#577). Drops them from the session->daemon map and clears
+ * remi-last-session if it points at one. Best-effort; storage errors are logged,
+ * never thrown, so a quota/parse hiccup can't break the message handler.
+ */
+function forgetEvictedSessions(evictedIds: readonly string[]): void {
+  if (evictedIds.length === 0) return;
+  const evicted = new Set(evictedIds);
+  try {
+    const stored = localStorage.getItem(LOCALSTORAGE_SESSION_DAEMONS_KEY);
+    if (stored) {
+      const map = JSON.parse(stored) as Record<string, string>;
+      let changed = false;
+      for (const id of evictedIds) {
+        if (id in map) {
+          delete map[id];
+          changed = true;
+        }
+      }
+      if (changed) localStorage.setItem(LOCALSTORAGE_SESSION_DAEMONS_KEY, JSON.stringify(map));
+    }
+    const last = localStorage.getItem(LOCALSTORAGE_SESSION_KEY);
+    if (last && evicted.has(last)) localStorage.removeItem(LOCALSTORAGE_SESSION_KEY);
+  } catch (err) {
+    console.warn('[App] Failed to forget evicted sessions:', err);
   }
 }
 
@@ -704,13 +734,59 @@ function App() {
             return new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime();
           });
 
+        // Phantom eviction (#577 Fix A): drop long-dead sessions this daemon no
+        // longer knows, which is what stops the recurring NOT_FOUND retry loop
+        // for a session purged from sessions.json. Computed from the synchronous
+        // sessionsRef snapshot (not inside setSessions) so it stays pure +
+        // StrictMode-safe and we can do the localStorage/ref cleanup after.
+        //
+        // Authoritative known set for THIS connection: the daemon's own
+        // daemon-sourced sessions + the attached hello_ack session. mDNS
+        // 'transcript' discoveries are excluded — they don't prove this daemon
+        // still manages the session, so they must not keep a phantom alive.
+        const knownIds = new Set<string>(
+          message.sessions
+            .filter((ds: DiscoverableSession) => ds.source === 'daemon')
+            .map((ds: DiscoverableSession) => ds.sessionId),
+        );
+        if (helloAckSessionId) knownIds.add(helloAckSessionId);
+        const evictionCtx = { knownIds, connectionAuthoritative: connectionId };
+        const evictionNow = Date.now();
+        // Compute the evicted set ONCE from the synchronous snapshot, then reuse
+        // the SAME set for the state filter, the loadedTranscriptsRef cleanup,
+        // and the active-session reset so there is no two-snapshot drift (every
+        // side effect acts on exactly what the list filter removes).
+        const evictedSet = new Set(
+          sessionsRef.current
+            .filter((s) =>
+              shouldEvictCachedSession(
+                { id: s.id, lastActiveAt: s.lastActiveAt, connectionId: s.connectionId },
+                evictionCtx,
+                evictionNow,
+              ),
+            )
+            .map((s) => s.id),
+        );
+        if (evictedSet.size > 0) {
+          const evictedIds = [...evictedSet];
+          forgetEvictedSessions(evictedIds);
+          for (const id of evictedIds) loadedTranscriptsRef.current.delete(id);
+          // If the active session was evicted, clear it so the UI doesn't sit on
+          // a dead session and re-request its (gone) transcript.
+          if (activeSessionIdRef.current && evictedSet.has(activeSessionIdRef.current)) {
+            setActiveSessionId(null);
+          }
+          console.warn('[App] Evicted stale phantom sessions (#577):', evictedIds);
+        }
+
         // Multi-daemon merge: keep sessions from other connections, preserve attached session
         // for this connection if not in discovered list, add all newly discovered sessions,
         // sort live-first then by recency.
         setSessions((prev) => {
-          const otherConnSessions = prev.filter((s) => s.connectionId !== connectionId);
+          const live = prev.filter((s) => !evictedSet.has(s.id));
+          const otherConnSessions = live.filter((s) => s.connectionId !== connectionId);
           // Keep the attached session for this connection (from hello_ack)
-          const attachedSession = prev.find(
+          const attachedSession = live.find(
             (s) => s.connectionId === connectionId && s.connectionStatus === 'connected',
           );
           const discoveredIds = new Set(discovered.map((s) => s.id));

--- a/packages/web/src/lib/session-eviction.ts
+++ b/packages/web/src/lib/session-eviction.ts
@@ -1,0 +1,96 @@
+/**
+ * Phantom-session eviction (#577, Fix A — the primary fix for the recurring
+ * "Transcript for session <id> not found").
+ *
+ * The bug: the iOS/web client caches sessions in its in-memory list (rehydrated
+ * across reconnects). When a session dies and the daemon purges it from
+ * sessions.json (100-entry cap / 7-day TTL), the daemon stops listing it — but
+ * the client keeps the dead remi UUID and re-requests its transcript on every
+ * reconnect, producing NOT_FOUND each time (the `b7f8d9af` loop).
+ *
+ * The fix evicts a cached session ONLY when it is, conservatively, both:
+ *   1. unknown to the daemon that owns it (absent from that connection's fresh
+ *      session_list_response / hello_ack), AND
+ *   2. stale — its lastActivity is older than STALE_EVICT_AGE_MS (~14 days).
+ *
+ * Two guards keep eviction from ever wiping a still-valid session:
+ *   - Per-connection scoping: a session is only a candidate when we have just
+ *     heard the AUTHORITATIVE list for ITS OWN connection. A session belonging
+ *     to connection B is never evicted because connection A's list omits it
+ *     (multi-daemon), and a session whose connection has not (re)listed this
+ *     cycle is never touched.
+ *   - Minimum-age guard: a freshly restarted daemon may reconnect and ack
+ *     before it has re-listed older sessions. The staleness threshold means a
+ *     recent session is never a candidate; the minimum-age guard makes that
+ *     explicit and independent of the staleness window so a session younger
+ *     than MIN_EVICT_AGE_MS is always kept even if STALE_EVICT_AGE_MS were
+ *     mis-set.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** A cached session is only evictable once its lastActivity is older than this. */
+export const STALE_EVICT_AGE_MS = 14 * DAY_MS;
+/** Hard floor: never evict anything more recent than this, regardless of config. */
+export const MIN_EVICT_AGE_MS = 1 * DAY_MS;
+
+export interface EvictableSession {
+  readonly id: string;
+  /** ISO timestamp of the session's last activity. */
+  readonly lastActiveAt: string;
+  /** The connection (daemon) this cached session belongs to. */
+  readonly connectionId: string;
+}
+
+export interface EvictionContext {
+  /** Session ids the daemon for `connectionAuthoritative` just reported as known. */
+  readonly knownIds: ReadonlySet<string>;
+  /**
+   * The connection whose authoritative list we just received. Only sessions on
+   * THIS connection are eviction candidates this cycle; sessions on other
+   * connections are out of scope (their daemon has not spoken).
+   */
+  readonly connectionAuthoritative: string;
+}
+
+/**
+ * Decide whether a single cached session should be evicted from the client's
+ * list. Pure — no clock, no storage, no React. `now` is injected so callers
+ * (and tests) control the staleness comparison.
+ *
+ * Returns true ONLY when the session belongs to the connection that just
+ * listed, is absent from that daemon's known set, and is both older than the
+ * staleness threshold and older than the minimum-age floor.
+ */
+export function shouldEvictCachedSession(
+  cached: EvictableSession,
+  ctx: EvictionContext,
+  now: number,
+): boolean {
+  // Scope: only act on the connection that just gave us an authoritative list.
+  if (cached.connectionId !== ctx.connectionAuthoritative) return false;
+  // Known to the daemon -> definitely keep.
+  if (ctx.knownIds.has(cached.id)) return false;
+
+  const last = new Date(cached.lastActiveAt).getTime();
+  // Unparseable timestamp: keep it (conservative — never evict on bad data).
+  if (Number.isNaN(last)) return false;
+
+  const age = now - last;
+  // Minimum-age floor: a fresh/recent session is never evicted, even if the
+  // daemon just restarted and has not re-listed it yet.
+  if (age < MIN_EVICT_AGE_MS) return false;
+  // Staleness threshold: only long-dead unknown sessions are evicted.
+  return age >= STALE_EVICT_AGE_MS;
+}
+
+/**
+ * Apply {@link shouldEvictCachedSession} across a list, returning the sessions
+ * to KEEP. Convenience wrapper so callers express the filter once.
+ */
+export function evictPhantomSessions<T extends EvictableSession>(
+  sessions: readonly T[],
+  ctx: EvictionContext,
+  now: number,
+): T[] {
+  return sessions.filter((s) => !shouldEvictCachedSession(s, ctx, now));
+}

--- a/packages/web/tests/lib/session-eviction.test.ts
+++ b/packages/web/tests/lib/session-eviction.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  evictPhantomSessions,
+  MIN_EVICT_AGE_MS,
+  shouldEvictCachedSession,
+  STALE_EVICT_AGE_MS,
+} from '../../src/lib/session-eviction';
+
+const NOW = Date.parse('2026-06-18T00:00:00Z');
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+const DAY = 24 * 60 * 60 * 1000;
+
+const session = (id: string, lastActiveAt: string, connectionId = 'conn-A') => ({
+  id,
+  lastActiveAt,
+  connectionId,
+});
+
+const ctx = (knownIds: string[], connectionAuthoritative = 'conn-A') => ({
+  knownIds: new Set(knownIds),
+  connectionAuthoritative,
+});
+
+describe('shouldEvictCachedSession (#577 Fix A)', () => {
+  test('evicts a stale + unknown session on the authoritative connection', () => {
+    // 20 days old, not in the daemon's known set, same connection -> phantom.
+    expect(
+      shouldEvictCachedSession(session('b7f8d9af', ago(20 * DAY)), ctx(['live-1']), NOW),
+    ).toBe(true);
+  });
+
+  test('keeps a session the daemon still knows, however old', () => {
+    expect(
+      shouldEvictCachedSession(session('known', ago(100 * DAY)), ctx(['known']), NOW),
+    ).toBe(false);
+  });
+
+  test('keeps a recent unknown session (minimum-age guard)', () => {
+    // Daemon restarted and acked before re-listing; the session is only 2h old,
+    // well under the minimum-age floor -> never evict.
+    expect(
+      shouldEvictCachedSession(session('fresh', ago(2 * 60 * 60 * 1000)), ctx([]), NOW),
+    ).toBe(false);
+  });
+
+  test('keeps an unknown session that is between min-age and the staleness threshold', () => {
+    // 3 days old: past the 1-day floor but well under the 14-day staleness
+    // threshold. A daemon that hasn't re-listed must not lose it.
+    expect(shouldEvictCachedSession(session('mid', ago(3 * DAY)), ctx([]), NOW)).toBe(false);
+  });
+
+  test('does not evict a session belonging to a different connection', () => {
+    // Stale + unknown, but it lives on conn-B; conn-A's list says nothing about it.
+    expect(
+      shouldEvictCachedSession(
+        session('other', ago(30 * DAY), 'conn-B'),
+        ctx([], 'conn-A'),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  test('keeps a session with an unparseable timestamp (conservative)', () => {
+    expect(shouldEvictCachedSession(session('bad', 'not-a-date'), ctx([]), NOW)).toBe(false);
+  });
+
+  test('boundary: exactly at the staleness threshold evicts', () => {
+    expect(
+      shouldEvictCachedSession(session('edge', ago(STALE_EVICT_AGE_MS)), ctx([]), NOW),
+    ).toBe(true);
+  });
+
+  test('boundary: one ms under the staleness threshold is kept', () => {
+    expect(
+      shouldEvictCachedSession(session('edge', ago(STALE_EVICT_AGE_MS - 1)), ctx([]), NOW),
+    ).toBe(false);
+  });
+
+  test('minimum-age floor is below the staleness threshold (sanity)', () => {
+    expect(MIN_EVICT_AGE_MS).toBeLessThan(STALE_EVICT_AGE_MS);
+  });
+});
+
+describe('evictPhantomSessions', () => {
+  test('returns only the sessions to keep', () => {
+    const sessions = [
+      session('phantom', ago(30 * DAY)), // stale + unknown -> evict
+      session('known', ago(30 * DAY)), // unknown-age but known -> keep
+      session('fresh', ago(60 * 60 * 1000)), // recent -> keep
+      session('other-conn', ago(30 * DAY), 'conn-B'), // other connection -> keep
+    ];
+    const kept = evictPhantomSessions(sessions, ctx(['known'], 'conn-A'), NOW);
+    expect(kept.map((s) => s.id).sort()).toEqual(['fresh', 'known', 'other-conn']);
+  });
+
+  test('returns the list unchanged when nothing is evictable', () => {
+    const sessions = [session('a', ago(60 * 60 * 1000)), session('b', ago(2 * DAY))];
+    const kept = evictPhantomSessions(sessions, ctx(['a', 'b']), NOW);
+    expect(kept).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6 of epic #571 (#577) — stops the recurring "Transcript for session not found".

- **Client phantom eviction** (the primary fix): pure, tested `shouldEvictCachedSession`/`evictPhantomSessions` drops a cached localStorage session only when it's on the connection that gave the authoritative list, absent from that daemon's known set, AND past BOTH a 14-day staleness and a 1-day min-age guard — never wipes a recent or not-yet-listed session.
- **Durable binding index**: uncapped, 90-day, atomically-written `~/.remi/transcript-index.json` (remiUUID→claudeSessionId+projectPath) mirrored by `SessionBindingStore` on every binding write (from the write's own returned record — no second read to race). `transcript-events` recovers a purged binding from it (disk-existence checked). Chosen over extending `STALE_AGE_MS` because the `MAX_SESSIONS=100` cap (many-worktree user) is the real durability killer.
- **Fallback timeout** 30s→120s + a mid-window "still waiting" log.

Closes #577. Part of epic #571.

## Review (pr-review-toolkit, Sonnet — code-reviewer + silent-failure-hunter)

No critical. 2 correctness + 6 robustness/logging, **all fixed**:

| Finding | Resolution |
|---|---|
| rotation race could mirror a STALE claudeSessionId → wrong transcript | `updateClaudeSessionId` returns the updated record; index mirrors from it (single read, no race) |
| NaN `updatedAt` defeated the 2000-cap (trimmed newest first) | sort treats NaN as oldest; cap trims bad entries first |
| index-hit-but-file-gone was silent | logged distinctly from "never indexed" |
| version/format mismatch silently discarded the index | logged |
| `console.warn` vs `logError` inconsistency | switched to `logError` |
| preAssign null-id / 85s fallback gap / eviction two-snapshot drift | debug log / mid-window log / single eviction set |

## Test plan (NO MOCKS)

`shouldEvictCachedSession` (11 cases: stale+unknown evicts; recent/known/mid-age/other-connection keep; bad timestamps conservative), `transcript-index` (round-trip, rotation updates to NEW id, cross-instance durability, 250-record no-cap, TTL prune, NaN-trim, corrupt/version handling), `transcript-events` (purged-binding recovery via index; NOT_FOUND when .jsonl gone). **daemon 2183 pass, web 207 pass, 0 fail.** Typecheck + biome clean; web build ok.
