### PR TITLE
fix(web): reconnect storm - reset backoff only on full connection

### DIFF
--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -204,10 +204,17 @@ export class WebSocketClient {
   /** Handle WebSocket open */
   private handleOpen(): void {
     this.clearConnectionTimer();
-    this.reconnectAttempts = 0;
     this.lastDataReceived = Date.now();
     this.missedHeartbeats = 0;
     this.startHeartbeat();
+    // Don't reset reconnectAttempts here: the transport opening is not a
+    // fully-established connection. Resetting on open would pin a connection
+    // that opens but never authenticates (auth fail/timeout, post-auth drop,
+    // heartbeat miss) to the base reconnectDelay forever, so the backoff never
+    // grows and onReconnectExhausted never fires (a ~1s reconnect storm).
+    // The counter is reset in setConnected(), the post-auth 'connected'
+    // transition. See #586.
+    //
     // Don't set 'connected' yet; wait for auth handshake or hello_ack.
     // Set 'authenticating' to signal that the transport is open but auth is pending.
     this.setStatus('authenticating');
@@ -215,6 +222,11 @@ export class WebSocketClient {
 
   /** Transition to connected state (called after auth completes) */
   setConnected(): void {
+    // Only a fully-established (authenticated) connection clears the reconnect
+    // counter, so a healthy connection that drops on a network blip and
+    // reconnects successfully resets here, while an open-but-never-connected
+    // connection keeps its growing backoff toward onReconnectExhausted (#586).
+    this.reconnectAttempts = 0;
     this.setStatus('connected');
   }
 

--- a/packages/web/tests/lib/websocket-client.test.ts
+++ b/packages/web/tests/lib/websocket-client.test.ts
@@ -27,6 +27,31 @@ function liveWsServer() {
   });
 }
 
+/**
+ * A real WebSocket server that accepts the upgrade (the transport opens, so the
+ * client reaches 'authenticating') but closes the socket shortly after without
+ * ever letting it reach 'connected'. Models an auth fail / post-open drop, the
+ * #586 reconnect-storm trigger.
+ */
+function openThenCloseServer() {
+  return Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return undefined;
+      return new Response('no upgrade', { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        // Close right after open: the transport opened but auth never completes,
+        // so the client never reaches 'connected'.
+        ws.close();
+      },
+      message() {},
+      close() {},
+    },
+  });
+}
+
 /** A loopback port with nothing listening (connections are refused). */
 const DEAD_URL_A = 'ws://127.0.0.1:49250/ws';
 const DEAD_URL_B = 'ws://127.0.0.1:49251/ws';
@@ -95,6 +120,104 @@ describe('WebSocketClient reconnect ceiling', () => {
     client.disconnect();
     await wait(300);
     expect(exhausted).toBe(false);
+  });
+});
+
+describe('WebSocketClient open-but-not-connected (#586 reconnect storm)', () => {
+  test('reconnect counter grows across opens and exhaustion fires (not pinned)', async () => {
+    const server = openThenCloseServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const MAX = 3;
+    let authenticatingCount = 0;
+    let exhausted = false;
+
+    const client = track(
+      new WebSocketClient(
+        {
+          url,
+          autoReconnect: true,
+          maxReconnectAttempts: MAX,
+          reconnectDelay: 10,
+          connectionTimeout: 500,
+          heartbeatInterval: 0,
+        },
+        {
+          onStatusChange: (s) => {
+            // Each successful transport open lands here. The owner never calls
+            // setConnected(), so the connection never reaches 'connected'.
+            if (s === 'authenticating') authenticatingCount++;
+          },
+          onReconnectExhausted: () => {
+            exhausted = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      const start = Date.now();
+      while (!exhausted && Date.now() - start < 6000) await wait(25);
+
+      // Exhaustion proves the loop is bounded: the counter survived each open
+      // and climbed to the ceiling. Before the fix, handleOpen reset it to 0 on
+      // every open, so the ceiling was never reached and this never fired.
+      expect(exhausted).toBe(true);
+      // The client opened (reached 'authenticating') more than once: it is not
+      // pinned at a single attempt, and it stopped at the ceiling rather than
+      // looping forever (initial connect + MAX reconnects = MAX + 1 opens).
+      expect(authenticatingCount).toBeGreaterThan(1);
+      expect(authenticatingCount).toBe(MAX + 1);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('reaching connected resets the reconnect counter', async () => {
+    const server = openThenCloseServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const MAX = 3;
+    let authenticatingCount = 0;
+    let exhausted = false;
+
+    const client = track(
+      new WebSocketClient(
+        {
+          url,
+          autoReconnect: true,
+          maxReconnectAttempts: MAX,
+          reconnectDelay: 10,
+          connectionTimeout: 500,
+          heartbeatInterval: 0,
+        },
+        {
+          onStatusChange: (s) => {
+            if (s === 'authenticating') {
+              authenticatingCount++;
+              // Simulate the owner completing auth on every open: each open
+              // becomes a fully-established connection, so the counter resets.
+              client.setConnected();
+            }
+          },
+          onReconnectExhausted: () => {
+            exhausted = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      // Let it churn well past MAX opens. Because every open reaches 'connected'
+      // and resets the counter, the ceiling is never hit.
+      const start = Date.now();
+      while (authenticatingCount <= MAX + 2 && Date.now() - start < 6000) await wait(25);
+
+      expect(authenticatingCount).toBeGreaterThan(MAX + 1);
+      expect(exhausted).toBe(false);
+    } finally {
+      server.stop();
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #586. Root cause + fix in the commit. Independent of epic #571 (pre-existing bug; old-binary daemons storm too).

**Fix:** move `reconnectAttempts = 0` from `handleOpen()` (transport open, pre-auth) to `setConnected()` (post-auth 'connected'). An open-but-never-connected loop now backs off exponentially + escalates via `onReconnectExhausted` instead of storming at ~1s forever; a healthy drop+reconnect still resets once re-connected.

**Reviewed** (Sonnet): every 'connected' path calls setConnected (auth + no-auth/hello_ack); forceReconnect/reconnectWithUrl unaffected; tests non-flaky. **Tests:** real-server reproduction (no mocks); web 181 pass, 0 fail; typecheck + build clean.

Follow-ups documented on #586 (not in this surgical PR): client auth phase unbounded by connectionTimeout; borderline heartbeat/ping interval equality.