### PR TITLE
Phase 7: Cross-client question dismissal + device-token dedup

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -194,6 +194,12 @@ export class AutoApproveGate {
     if (!hold) return false;
     clearTimeout(hold.timer);
     this.pendingHolds.delete(questionId);
+    // Remove the registry entry too (#585, P7 FIX 2): the held question was
+    // registered via pushHeldHook -> addQuestion, so resolving the hold without
+    // this leaves a ghost card that replays on reconnect and lets a late
+    // handleAnswer find it "live" and misroute. The user-answer path also
+    // removes it in handleAnswer's finally; a double-remove is idempotent.
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
     this.markHandled();
     hold.resolve(decision);
     log(
@@ -225,8 +231,10 @@ export class AutoApproveGate {
     for (const [qid, hold] of this.pendingHolds) {
       clearTimeout(hold.timer);
       // The session is going away (Stop/SessionEnd); dismiss the pushed card on
-      // every client so it does not linger after the prompt is gone (#585, P7).
+      // every client BEFORE resolving so it does not linger after the prompt is
+      // gone (#585, P7), and drop the registry entry so no ghost card replays.
       this.notifyResolved(qid, 'cancelled');
+      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
       hold.resolve(decision);
     }
     this.pendingHolds.clear();
@@ -281,8 +289,10 @@ export class AutoApproveGate {
           `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
         );
         // The pushed card is now stale (Claude will render its own prompt); tell
-        // every client to dismiss it (#585, P7). Throw-safe.
+        // every client to dismiss it BEFORE failing open (#585, P7), and drop the
+        // registry entry so no ghost card replays. Throw-safe.
         this.notifyResolved(qid, 'cancelled');
+        this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
         resolve('passthrough');
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;
@@ -593,19 +603,23 @@ export class AutoApproveGate {
       return;
     }
     const result = outcome.result;
+    // Dismiss BEFORE resolving (#585, P7 FIX 5): the broadcast races ahead of
+    // Claude proceeding on the verdict, shrinking the window where Claude has
+    // executed but the card still shows. resolveHeld/releaseHeld then resolve the
+    // hook + drop the registry entry (FIX 2).
     if (result.decision === 'approve') {
-      this.resolveHeld(qid, 'allow');
       // The slow verdict landed AFTER the early push, so the card is on screens
       // the user never needs to act on — dismiss it everywhere (#585, P7).
       this.notifyResolved(qid, 'auto_approved');
+      this.resolveHeld(qid, 'allow');
     } else if (result.decision === 'deny') {
-      this.resolveHeld(qid, 'deny');
       this.notifyResolved(qid, 'auto_denied');
+      this.resolveHeld(qid, 'deny');
     } else if (result.decision === 'cancelled') {
       // Claude advanced past the prompt during the slow eval; fail the hold open.
       this.deps.tracker.clearPending();
-      this.releaseHeld(qid, 'passthrough');
       this.notifyResolved(qid, 'cancelled');
+      this.releaseHeld(qid, 'passthrough');
     }
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
   }
@@ -618,6 +632,10 @@ export class AutoApproveGate {
     if (!hold) return false;
     clearTimeout(hold.timer);
     this.pendingHolds.delete(questionId);
+    // Drop the registry entry so no ghost card replays (#585, P7 FIX 2). The
+    // user-answer path (releaseHeldAsPassthrough -> handleAnswer finally) also
+    // removes it; a double-remove is idempotent.
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
     hold.resolve(decision);
     return true;
   }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -95,6 +95,18 @@ export interface AutoApproveGateDeps {
   /** Called when the eval ended without a verdict (cancelled — the user already
    *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
   onCancelled?: () => void;
+  /**
+   * Called when a HELD question resolved WITHOUT the user answering it through
+   * the WebSocket/relay answer path (#585, P7): a Part-B slow-eval verdict landed
+   * after the early push (auto_approved/auto_denied), the hold timed out, or
+   * cancelStale released it (cancelled). The daemon broadcasts a `question_resolved`
+   * + fires the APNS dismissal so the pushed card clears on every client. NOT
+   * called for a user answer — that path (input-events.handleAnswer) broadcasts
+   * its own 'answered' resolution, so wiring it here too would double-fire.
+   * Throw-safe at the call site (routed through `safeCueWithArg`), so a broadcast
+   * failure can never break the decision/hold path. Absent => no resolution
+   * broadcast (tests / no-AA callers). */
+  onResolved?: (questionId: UUID, reason: 'auto_approved' | 'auto_denied' | 'cancelled') => void;
   /** Second-opinion model consulted on a primary 'escalate' in main context
    *  (#522). Empty/absent => no second opinion (escalate straight to the user). */
   escalateModel?: string;
@@ -210,8 +222,11 @@ export class AutoApproveGate {
     log(
       `[AutoApprove ${this.sessionTag}] Releasing ${this.pendingHolds.size} held hook(s) as ${decision} (${reason})`,
     );
-    for (const [, hold] of this.pendingHolds) {
+    for (const [qid, hold] of this.pendingHolds) {
       clearTimeout(hold.timer);
+      // The session is going away (Stop/SessionEnd); dismiss the pushed card on
+      // every client so it does not linger after the prompt is gone (#585, P7).
+      this.notifyResolved(qid, 'cancelled');
       hold.resolve(decision);
     }
     this.pendingHolds.clear();
@@ -265,6 +280,9 @@ export class AutoApproveGate {
         log(
           `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
         );
+        // The pushed card is now stale (Claude will render its own prompt); tell
+        // every client to dismiss it (#585, P7). Throw-safe.
+        this.notifyResolved(qid, 'cancelled');
         resolve('passthrough');
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;
@@ -577,12 +595,17 @@ export class AutoApproveGate {
     const result = outcome.result;
     if (result.decision === 'approve') {
       this.resolveHeld(qid, 'allow');
+      // The slow verdict landed AFTER the early push, so the card is on screens
+      // the user never needs to act on — dismiss it everywhere (#585, P7).
+      this.notifyResolved(qid, 'auto_approved');
     } else if (result.decision === 'deny') {
       this.resolveHeld(qid, 'deny');
+      this.notifyResolved(qid, 'auto_denied');
     } else if (result.decision === 'cancelled') {
       // Claude advanced past the prompt during the slow eval; fail the hold open.
       this.deps.tracker.clearPending();
       this.releaseHeld(qid, 'passthrough');
+      this.notifyResolved(qid, 'cancelled');
     }
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
   }
@@ -640,6 +663,26 @@ export class AutoApproveGate {
       fn(arg);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
+  }
+
+  /**
+   * Notify the daemon that a HELD question resolved without a user answer (#585,
+   * P7), so it can broadcast `question_resolved` + dismiss the pushed card on
+   * every client. Throw-safe like the cosmetic cues: a broadcast/push failure is
+   * logged and absorbed so it can never propagate into the decision/hold path.
+   * No-op when no `onResolved` is wired.
+   */
+  private notifyResolved(
+    questionId: UUID,
+    reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+  ): void {
+    const fn = this.deps.onResolved;
+    if (!fn) return;
+    try {
+      fn(questionId, reason);
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] onResolved threw (ignored):`, err);
     }
   }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -95,6 +95,7 @@ loadDotenvFile();
 import {
   createDaemonUpdateAvailable,
   createHelloAck,
+  createQuestionResolved,
   createReplayBatch,
   createSessionListResponse,
   createSessionUpdate,
@@ -143,6 +144,7 @@ import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookServer } from './hooks/index.ts';
+import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
@@ -856,6 +858,11 @@ const binderClosers: Map<UUID, () => void> = new Map();
 // (multi-session daemons). Populated in createNewSession after setupHookBridge;
 // removed on session close. Empty when no hookServer is configured.
 const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
+// Per-session APNS dispatchers (#585, P7), keyed by sessionId, so the
+// question-resolved path can fire a quiet lock-screen dismissal through the same
+// device-token fan-out that pushed the card. Populated in createNewSession;
+// removed on session close.
+const sessionNotifiers: Map<UUID, NotificationDispatcher> = new Map();
 const sessionStore = new SessionStore();
 // Tracks the subagent chats the primary session spawns, so the client can
 // switch the displayed view to a subagent (epic #499 phase 3). Shared by the
@@ -894,6 +901,8 @@ const sessionRegistry = new SessionRegistry(
       // Drop the per-session gate handle (#573); any held hook was already
       // released by the gate's closeBinder/cancelStale on teardown.
       sessionGateHandles.delete(sessionId);
+      // Drop the per-session APNS dispatcher (#585, P7).
+      sessionNotifiers.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();
@@ -1081,7 +1090,7 @@ async function createNewSession(
   passThrough = false,
   reservedRows = 0,
 ): Promise<PTYSession> {
-  const { messageApi, sendAndRecord } = createMessageApiForSession(
+  const { messageApi, sendAndRecord, notifications } = createMessageApiForSession(
     {
       sessionRegistry,
       transcriptWatchers,
@@ -1109,6 +1118,9 @@ async function createNewSession(
     },
     sessionId,
   );
+  // Register this session's APNS dispatcher so the question-resolved path can
+  // dismiss a pushed card through the same device-token fan-out (#585, P7).
+  sessionNotifiers.set(sessionId, notifications);
 
   // PTY output parser: streamStatusOnly suppresses regular agent content (comes
   // from transcript). Tool-output errors (e.g. "OAuth token revoked") bypass the
@@ -1183,6 +1195,9 @@ async function createNewSession(
         alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),
         holdTimeoutSec: remiConfig.auto_approve.hold_timeout,
         pushHoldTimeoutSec: remiConfig.auto_approve.push_hold_timeout,
+        // #585: a held question the gate resolves without a user answer dismisses
+        // its pushed card on every client.
+        broadcastQuestionResolved: onQuestionResolved,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1294,6 +1309,37 @@ const registry = new AdapterRegistry({
   },
 });
 
+/**
+ * Cross-client question dismissal (#585, P7). Fired when a pending question stops
+ * being pending on ANY channel: (a) answered locally (input-events.handleAnswer,
+ * reason 'answered'), or (b) resolved by the auto-approve gate without a user
+ * answer (Part-B late verdict / hold timeout / cancelStale, reason
+ * 'auto_approved'/'auto_denied'/'cancelled'). It does TWO throw-safe things:
+ *   1. Broadcast `question_resolved` to every connected client so each dismisses
+ *      its card (in-app, over the WebSocket / Telegram via the AdapterRegistry).
+ *   2. Fire a quiet APNS dismissal through this session's NotificationDispatcher
+ *      (apns-collapse-id = questionId, content-available) so a suspended device's
+ *      lock-screen card is cleared.
+ * Each step is independently guarded so a failure in one never blocks the other,
+ * and neither can propagate into the answer handler or the gate decision.
+ */
+const onQuestionResolved = (
+  sessionId: UUID,
+  questionId: UUID,
+  reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled',
+): void => {
+  try {
+    registry.broadcast(createQuestionResolved(sessionId, questionId, reason));
+  } catch (err) {
+    logError(`[QuestionResolved] broadcast failed for ${questionId}: ${errorToString(err)}`);
+  }
+  try {
+    sessionNotifiers.get(sessionId)?.dismiss(sessionId, questionId);
+  } catch (err) {
+    logError(`[QuestionResolved] APNS dismissal failed for ${questionId}: ${errorToString(err)}`);
+  }
+};
+
 import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
@@ -1319,6 +1365,10 @@ const inputHandlers: InputHandlers = createInputHandlers({
   releaseHeldAsPassthrough: (sessionId, questionId) =>
     sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
   cancelAutoApprove: (sessionId, reason) => sessionGateHandles.get(sessionId)?.cancelStale(reason),
+  // #585: a locally answered question dismisses its card + lock-screen push on
+  // every other client.
+  onQuestionResolved: (sessionId, questionId) =>
+    onQuestionResolved(sessionId, questionId, 'answered'),
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -51,6 +51,16 @@ export interface InputHandlerDeps {
    * in-flight eval. Session-keyed.
    */
   cancelAutoApprove?: (sessionId: UUID, reason: string) => void;
+  /**
+   * Cross-client question dismissal (#585, P7). Called after a question is
+   * answered here so the daemon broadcasts `question_resolved` to every client and
+   * fires the APNS dismissal — answering on one device clears the card (and the
+   * lock-screen notification) on the others. Fired ONCE per answered question, on
+   * the delivered path only (not for stale/session-not-found/stale-binding, where
+   * nothing was consumed). Must be throw-safe: a broadcast failure must never
+   * break answer handling. Absent => no dismissal broadcast (tests/old callers).
+   */
+  onQuestionResolved?: (sessionId: UUID, questionId: UUID) => void;
 }
 
 /**
@@ -177,6 +187,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     resolveHeldPermission,
     releaseHeldAsPassthrough,
     cancelAutoApprove,
+    onQuestionResolved,
   } = deps;
 
   /**
@@ -310,6 +321,16 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // Remove only the answered question; sibling prompts remain answerable.
       // In `finally` so a throwing submit cannot leave a zombie question.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
+      // Cross-client dismissal (#585, P7): tell every client this question is
+      // resolved so its card clears and the lock-screen push is dismissed.
+      // Throw-safe: a broadcast/push failure must never break answer handling,
+      // and it lives in `finally` so even a throwing submit still clears the card
+      // (the question was consumed). Idempotent on the client side.
+      try {
+        onQuestionResolved?.(session.sessionId, questionId);
+      } catch (err) {
+        logError(`[Answer] question_resolved broadcast failed: ${errorToString(err)}`);
+      }
     }
     return 'delivered';
   }

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -35,6 +35,23 @@ export function createTrivialHandlers(deps: TrivialHandlerDeps) {
   return {
     onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string): void => {
       log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
+      // Dedup (#585, P7): the map is already keyed by token, so re-registering an
+      // identical token collapses to one entry (no duplicate push). The remaining
+      // duplicate-push case is APNS token ROTATION — the same physical device
+      // hands the daemon a NEW token while the old one is still registered, so a
+      // push fans out to BOTH (the user's reported 2x). The connection that
+      // re-registers is the same client session, so prune any OTHER token
+      // previously registered from THIS connectionId before recording the new one.
+      // This is conservative: it only drops a stale token tied to the same client,
+      // never a genuinely distinct device on another connection.
+      for (const [existingToken, entry] of deviceTokens) {
+        if (existingToken !== token && entry.connectionId === connectionId) {
+          deviceTokens.delete(existingToken);
+          log(
+            `Pruned stale device token from ${connectionId} (rotated): ${existingToken.slice(0, 20)}...`,
+          );
+        }
+      }
       deviceTokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
     },
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -140,6 +140,18 @@ export interface HookBridgeDeps {
    * Part B disabled (the eval/timer race never arms).
    */
   pushHoldTimeoutSec?: number;
+  /**
+   * Cross-client question dismissal (#585, P7). Called by the gate when a HELD
+   * question resolves WITHOUT a user answer (Part-B late verdict, hold timeout,
+   * or cancelStale): the daemon broadcasts `question_resolved` to every client and
+   * fires the APNS dismissal so the pushed card clears everywhere. Must be
+   * throw-safe (the gate also guards the call). Absent => no dismissal broadcast.
+   */
+  broadcastQuestionResolved?: (
+    sessionId: UUID,
+    questionId: UUID,
+    reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+  ) => void;
 }
 
 export interface HookBridgeArgs {
@@ -779,6 +791,11 @@ export function setupHookBridge(
         broadcastAutoApproveStatus('approved');
       },
       onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
+      // #585: a held question that resolves without a user answer (Part-B late
+      // verdict / hold timeout / cancelStale) tells the daemon to dismiss the
+      // pushed card on every client. Forwarded with this session's id.
+      onResolved: (questionId, reason) =>
+        deps.broadcastQuestionResolved?.(sessionId, questionId, reason),
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.
       escalateModel: autoApproveService?.escalateModel ?? '',

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -275,6 +275,37 @@ export function setupHookBridge(
     );
   };
 
+  /**
+   * Dismiss every pending question for this session on a Claude restart
+   * (/clear, /compact, /resume), THEN clear the registry collection (#585, P7).
+   * A card pushed before the restart would otherwise linger on every device
+   * forever — the most common dismissal case. Broadcasts
+   * `question_resolved(..., 'cancelled')` for each pending id so all clients drop
+   * the card and the lock-screen push is dismissed, mirroring the gate's own
+   * held-resolution dismissal. Used at all three restart sites
+   * (initFromHookEvent, onSessionInfo, drive-binder onRotation) so none is
+   * missed. Throw-safe: a broadcast failure for one question must never block
+   * clearing the rest, and the clear always runs.
+   */
+  const resolveAndClearQuestions = (): void => {
+    const broadcast = deps.broadcastQuestionResolved;
+    if (broadcast) {
+      const pendingIds = [
+        ...(sessionRegistry.getSession(sessionId)?.currentQuestions.keys() ?? []),
+      ];
+      for (const questionId of pendingIds) {
+        try {
+          broadcast(sessionId, questionId, 'cancelled');
+        } catch (err) {
+          logError(
+            `[Hooks] question_resolved broadcast (restart) failed for ${questionId}: ${errorToString(err)}`,
+          );
+        }
+      }
+    }
+    sessionRegistry.clearQuestions(sessionId);
+  };
+
   // ---- Per-session locks (mutable across event callbacks) -----------------
 
   // Track the Claude session ID so we can filter hook events by session.
@@ -496,10 +527,11 @@ export function setupHookBridge(
       teardownWatcher('restart');
       // Drop any hook record stashed before /clear or /compact: the new
       // Claude session's first PTY prompt must not merge stale option
-      // labels from the dying session. Also drop the pending-question
-      // collection so answers to the dead session's prompts are refused.
+      // labels from the dying session. Also dismiss + drop the pending-question
+      // collection so cards clear on every device (#585) and answers to the dead
+      // session's prompts are refused.
       tracker.clearPending();
-      sessionRegistry.clearQuestions(sessionId);
+      resolveAndClearQuestions();
       // Announce the rotation NOW, before the sibling / no-transcript_path
       // guards below can early-return. teardownWatcher already reset the
       // client's view, so the client must learn of the rotation (clear +
@@ -660,11 +692,11 @@ export function setupHookBridge(
         );
         teardownWatcher('restart-sessioninfo');
         // Mirror the initFromHookEvent restart branch: drop any hook
-        // record and the pending-question collection so the new session's
-        // first PTY prompt cannot merge stale options, and stale answers
-        // are refused.
+        // record, dismiss + drop the pending-question collection (so cards clear
+        // on every device, #585) so the new session's first PTY prompt cannot
+        // merge stale options, and stale answers are refused.
         tracker.clearPending();
-        sessionRegistry.clearQuestions(sessionId);
+        resolveAndClearQuestions();
         claudeSessionId = null;
         mainSessionEnded = false;
         isRotation = previousClaudeSessionId !== null;
@@ -936,10 +968,11 @@ export function setupHookBridge(
             onRotation: () => {
               // The old restart branch's injected side effects: drop any hook
               // record stashed before the rotation so the new session's first
-              // PTY prompt cannot merge stale option labels, and drop the
-              // pending-question collection so stale answers are refused.
+              // PTY prompt cannot merge stale option labels, and dismiss + drop
+              // the pending-question collection (cards clear on every device,
+              // #585) so stale answers are refused.
               tracker.clearPending();
-              sessionRegistry.clearQuestions(sessionId);
+              resolveAndClearQuestions();
               // The new session starts with no subagents (#499 phase 3).
               if (subagentViews) {
                 subagentViews.clear();

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -60,6 +60,12 @@ export interface MessageApiSetupDeps {
 export interface MessageApiHandle {
   messageApi: MessageAPI;
   sendAndRecord: (message: ProtocolMessage) => void;
+  /**
+   * This session's APNS dispatcher (#585, P7). Exposed so the daemon's
+   * question-resolved path can fire a quiet lock-screen dismissal for a resolved
+   * question through the SAME device-token fan-out that pushed it.
+   */
+  notifications: NotificationDispatcher;
 }
 
 export function createMessageApiForSession(
@@ -166,5 +172,5 @@ export function createMessageApiForSession(
 
   const messageApi = new MessageAPI({ sessionId, initialBulletId: 1, maxBulletLength }, callbacks);
 
-  return { messageApi, sendAndRecord };
+  return { messageApi, sendAndRecord, notifications };
 }

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -203,10 +203,8 @@ export class NotificationDispatcher {
     const pushSessionId = this.deps.getPrimarySessionId() ?? questionSessionId;
     for (const dt of deviceTokens.values()) {
       this.pushFn(cfg.signalingUrl, dt.token, {
-        // title/body are required by the relay's MISSING_FIELDS check but are
-        // never shown — the dismissal is a silent content-available push.
-        title: ' ',
-        body: ' ',
+        // No title/body: a dismissal is a silent content-available push, and the
+        // relay skips the title/body requirement for it (#585, P7).
         ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
         sessionId: pushSessionId,
         questionId,

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -182,4 +182,38 @@ export class NotificationDispatcher {
         .catch((err) => log(`Push notification failed: ${err}`));
     }
   }
+
+  /**
+   * Fire a QUIET APNS dismissal for a resolved question (#585, P7). Sends a
+   * `content-available` push (no alert, no sound) keyed by `apns-collapse-id` =
+   * questionId so a suspended device replaces/clears the earlier lock-screen card
+   * for that exact question. Fans out to every registered device — unlike
+   * `maybePush`, it deliberately does NOT skip when a client is attached: the
+   * card may still sit on another device's lock screen, and the collapse-id makes
+   * a no-op dismissal harmless. No dedup gate (a repeat dismissal is idempotent at
+   * the device). No-op when no tokens are registered.
+   *
+   * `questionSessionId` is the primary id the client knows (from hello_ack), kept
+   * symmetric with `maybePush` so the dismissal carries the same routing id.
+   */
+  dismiss(questionSessionId: UUID, questionId: UUID): void {
+    const { deviceTokens, pushConfig } = this.deps;
+    if (deviceTokens.size === 0) return;
+    const cfg = pushConfig();
+    const pushSessionId = this.deps.getPrimarySessionId() ?? questionSessionId;
+    for (const dt of deviceTokens.values()) {
+      this.pushFn(cfg.signalingUrl, dt.token, {
+        // title/body are required by the relay's MISSING_FIELDS check but are
+        // never shown — the dismissal is a silent content-available push.
+        title: ' ',
+        body: ' ',
+        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+        sessionId: pushSessionId,
+        questionId,
+        dismiss: true,
+      })
+        .then(() => log(`Push dismissal sent for question ${questionId}`))
+        .catch((err) => log(`Push dismissal failed: ${err}`));
+    }
+  }
 }

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -8,10 +8,12 @@ const DEFAULT_SIGNALING_URL = 'https://remi-signaling.yooz.workers.dev';
 
 /** Options for sendPushTrigger */
 export interface PushTriggerOptions {
-  /** Title shown in the notification banner */
-  title: string;
-  /** Body text shown in the notification banner */
-  body: string;
+  /** Title shown in the notification banner. Optional only for a `dismiss`
+   *  push (#585, P7), which is silent (content-available) and has no text. */
+  title?: string;
+  /** Body text shown in the notification banner. Optional only for a `dismiss`
+   *  push (#585, P7). */
+  body?: string;
   /** Bearer token for signaling server auth (REMI_PUSH_SECRET) */
   pushSecret?: string;
   /** Remi session UUID included in APNS custom data for tap-to-navigate */
@@ -26,9 +28,8 @@ export interface PushTriggerOptions {
    * Dismissal trigger (#585, P7). When true the signaling server sends a QUIET
    * `content-available` push (no alert) carrying the same `apns-collapse-id` =
    * questionId, so the device replaces/clears the lock-screen card for an
-   * already-resolved question instead of buzzing again. title/body are still
-   * required by the relay's MISSING_FIELDS check; the dispatcher passes short
-   * placeholders the user never sees (the push is silent).
+   * already-resolved question instead of buzzing again. The relay skips the
+   * title/body requirement for a dismiss, so the dispatcher omits them entirely.
    */
   dismiss?: boolean;
 }
@@ -56,8 +57,9 @@ export async function sendPushTrigger(
   }
   const payload: Record<string, unknown> = {
     token: deviceToken,
-    title: opts.title,
-    body: opts.body,
+    // Omitted for a dismiss push (#585, P7): silent, no user-visible text.
+    ...(opts.title !== undefined ? { title: opts.title } : {}),
+    ...(opts.body !== undefined ? { body: opts.body } : {}),
   };
   if (opts.sessionId) {
     payload['sessionId'] = opts.sessionId;

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -22,6 +22,15 @@ export interface PushTriggerOptions {
   category?: string;
   /** Answer values for action buttons: opt_0, opt_1, ... */
   options?: string[];
+  /**
+   * Dismissal trigger (#585, P7). When true the signaling server sends a QUIET
+   * `content-available` push (no alert) carrying the same `apns-collapse-id` =
+   * questionId, so the device replaces/clears the lock-screen card for an
+   * already-resolved question instead of buzzing again. title/body are still
+   * required by the relay's MISSING_FIELDS check; the dispatcher passes short
+   * placeholders the user never sees (the push is silent).
+   */
+  dismiss?: boolean;
 }
 
 /**
@@ -61,6 +70,9 @@ export async function sendPushTrigger(
   }
   if (opts.options && opts.options.length > 0) {
     payload['options'] = opts.options;
+  }
+  if (opts.dismiss) {
+    payload['dismiss'] = true;
   }
   const response = await fetch(url, {
     method: 'POST',

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -905,3 +905,147 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
     expect(await pending).toBe('allow');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #585 (P7): onResolved fires when a HELD question resolves WITHOUT a user
+// answer, so the daemon can dismiss the pushed card on every client. It must NOT
+// fire for a user-driven resolveHeld (the answer path broadcasts its own
+// 'answered'), and a throw must be absorbed.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+  let resolved: Array<{ questionId: UUID; reason: string }>;
+
+  function deferredEvaluator(): {
+    service: AutoApproveEvaluator;
+    release: (r: AutoApproveResult) => void;
+  } {
+    let resolveEval: (r: AutoApproveResult) => void = () => {};
+    const pending = new Promise<AutoApproveResult>((res) => {
+      resolveEval = res;
+    });
+    return {
+      service: { evaluate: () => pending, cancel: () => true },
+      release: (r) => resolveEval(r),
+    };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: { holdMs?: number; pushHoldMs?: number; onResolvedThrows?: boolean } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
+        alwaysEscalateTools: new Set(),
+        onResolved: (questionId, reason) => {
+          if (opts.onResolvedThrows) throw new Error('test: onResolved synthetic failure');
+          resolved.push({ questionId, reason });
+        },
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    lastQuestionId = undefined;
+    resolved = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('Part-B late approve fires onResolved auto_approved', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'auto_approved' }]);
+  });
+
+  test('Part-B late deny fires onResolved auto_denied', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    release(deny);
+    expect(await pending).toBe('deny');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'auto_denied' }]);
+  });
+
+  test('cancelStale on a held hook fires onResolved cancelled', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    g.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'cancelled' }]);
+  });
+
+  test('hold timeout fires onResolved cancelled', async () => {
+    const { service } = deferredEvaluator();
+    // Short hold so the timeout fail-open fires during the test.
+    const g = gate(service, { pushHoldMs: 10, holdMs: 30 });
+    const pending = g.resolvePermission(pr());
+    expect(await pending).toBe('passthrough'); // failed open on hold timeout
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'cancelled' }]);
+  });
+
+  test('a user-driven resolveHeld does NOT fire onResolved (no double-broadcast)', async () => {
+    // Part A: a normal binary escalate holds; the user answers via resolveHeld.
+    // The answer path (input-events) broadcasts 'answered' itself, so the gate
+    // must stay silent here.
+    const service: AutoApproveEvaluator = { evaluate: async () => escalate, cancel: () => true };
+    const g = gate(service, { holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+    expect(resolved).toEqual([]);
+  });
+
+  test('a throwing onResolved never breaks the decision path', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20, onResolvedThrows: true });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    release(approve);
+    // Despite the throwing onResolved, the held hook still resolves allow.
+    expect(await pending).toBe('allow');
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1048,4 +1048,64 @@ describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
     // Despite the throwing onResolved, the held hook still resolves allow.
     expect(await pending).toBe('allow');
   });
+
+  // #585 P7 FIX 2: a Part-B held question is registered (pushHeldHook ->
+  // addQuestion); the gate-side resolution must drop it from the registry so no
+  // ghost card replays and a late handleAnswer can't find it "live".
+  test('Part-B auto-approve removes the held question from sessionRegistry', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    // Simulate the real push having registered the question under the held id.
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    release(approve);
+    expect(await pending).toBe('allow');
+    // The held question is gone from the registry (no ghost card / misroute).
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+
+  test('hold timeout removes the held question from sessionRegistry', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 10, holdMs: 30 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 15)); // after the early push, before timeout
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(await pending).toBe('passthrough'); // failed open on hold timeout
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+
+  test('cancelStale removes the held question from sessionRegistry', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    g.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough');
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
 });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1185,4 +1185,83 @@ describe('createInputHandlers', () => {
       expect(ptyCapture.submits).toEqual([]);
     });
   });
+
+  describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {
+    function registerWithQuestion(questionId: UUID): UUID {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: questionId,
+        text: 'proceed?',
+        options: [
+          { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      return sessionId;
+    }
+
+    test('fires onQuestionResolved once with the answered ids on the delivered path', async () => {
+      const sessionId = registerWithQuestion(QID);
+      const resolved: Array<{ sessionId: UUID; questionId: UUID }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: (s, q) => resolved.push({ sessionId: s, questionId: q }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(resolved).toEqual([{ sessionId, questionId: QID }]);
+    });
+
+    test('does NOT fire for a stale answer (nothing was consumed)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // No question registered -> the answer is stale.
+      const resolved: UUID[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: (_s, q) => resolved.push(q),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(resolved).toEqual([]);
+    });
+
+    test('a throwing onQuestionResolved never breaks answer handling', async () => {
+      const sessionId = registerWithQuestion(QID);
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: () => {
+          throw new Error('broadcast boom');
+        },
+      });
+
+      // The answer still delivers and the question is still consumed despite the
+      // throwing broadcast (it is guarded in the finally).
+      await expect(handlers.onAnswer(CID, sessionId, QID, 'y')).resolves.toBe(undefined);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -70,6 +70,53 @@ describe('createTrivialHandlers', () => {
     expect(typeof entry?.registeredAt).toBe('number');
   });
 
+  test('onRegisterDeviceToken: registering the same token twice yields ONE entry (#585 P7)', () => {
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
+    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
+
+    expect(deviceTokens.size).toBe(1);
+    expect(deviceTokens.has('same-token')).toBe(true);
+  });
+
+  test('onRegisterDeviceToken: a rotated token from the same connection prunes the old one (#585 P7)', () => {
+    // APNS token rotation: the same physical device (same client connection)
+    // re-registers a NEW token while the old one is still live -> a push would
+    // otherwise fan out to BOTH (the 2x duplicate). The old token from this
+    // connection is pruned, leaving only the new one.
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'old-token', 'ios');
+    handlers.onRegisterDeviceToken(CID, 'new-token', 'ios');
+
+    expect(deviceTokens.size).toBe(1);
+    expect(deviceTokens.has('new-token')).toBe(true);
+    expect(deviceTokens.has('old-token')).toBe(false);
+  });
+
+  test('onRegisterDeviceToken: a different connection keeps its own token (no cross-device prune)', () => {
+    const OTHER = 'conn1111-1111-1111-1111-111111111111' as UUID;
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'token-a', 'ios');
+    handlers.onRegisterDeviceToken(OTHER, 'token-b', 'ios');
+
+    // Two genuinely distinct devices on different connections must both survive.
+    expect(deviceTokens.size).toBe(2);
+    expect(deviceTokens.has('token-a')).toBe(true);
+    expect(deviceTokens.has('token-b')).toBe(true);
+  });
+
   test('onTerminalResize logs and returns when no session is attached', () => {
     const logs: string[] = [];
     const { send } = makeSend();

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -194,6 +194,10 @@ describe('setupHookBridge', () => {
       /** Capture every message the bridge sends via sendAndRecord (#576: the
        *  auto-approve status broadcasts). Defaults to a no-op send. */
       sendLog?: ProtocolMessage[];
+      /** Capture every broadcastQuestionResolved call (#585, P7). Each entry is
+       *  the (questionId, reason) the bridge forwarded. Defaults to undefined
+       *  (dep not wired). */
+      broadcastResolvedLog?: Array<{ questionId: UUID; reason: string }>;
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -265,6 +269,15 @@ describe('setupHookBridge', () => {
         transcriptFallbackTimers,
         autoApproveService,
         currentPort: () => 8765,
+        ...(opts.broadcastResolvedLog
+          ? {
+              broadcastQuestionResolved: (
+                _sid: UUID,
+                questionId: UUID,
+                reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+              ) => opts.broadcastResolvedLog?.push({ questionId, reason }),
+            }
+          : {}),
       },
       {
         hookServer: hookServer as unknown as HookServer,
@@ -860,6 +873,45 @@ describe('setupHookBridge', () => {
     // assert only the tear-down signals, not the final map state.
     expect(stopCalls.length).toBeGreaterThanOrEqual(1);
     expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
+  });
+
+  test('restart (/clear) broadcasts question_resolved for each pending question and clears them (#585 P7)', () => {
+    const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+    build({ broadcastResolvedLog });
+
+    // Lock onto claude-A.
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    // A question was pushed before the restart (held-hook or hook+PTY path).
+    const QID = 'q1111111-1111-1111-1111-111111111111' as UUID;
+    sessionRegistry.addQuestion(SID, {
+      id: QID,
+      text: 'proceed?',
+      options: [
+        { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+        { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+    // /clear: a new session_id rotates the binding (restart classification).
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-B',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+      hook_event_name: 'SessionStart',
+      source: 'clear',
+    });
+
+    // The pending card is dismissed on every client (broadcast) AND dropped from
+    // the registry, so nothing lingers across the rotation.
+    expect(broadcastResolvedLog).toEqual([{ questionId: QID, reason: 'cancelled' }]);
+    expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
   });
 
   // SessionStart restart pre-empt is source-agnostic: any rotation of

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -235,3 +235,69 @@ describe('NotificationDispatcher.maybePush', () => {
     expect(pushed[0]?.opts['options']).toEqual(['y', 'No']);
   });
 });
+
+describe('NotificationDispatcher.dismiss (#585 P7)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+  const QID = 'q0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (_url, token, opts) => {
+    pushed.push({ token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('fires a dismiss push (dismiss flag + questionId) to every device', () => {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    // Attach a client: dismiss must STILL fire (unlike maybePush) — the card may
+    // be on another device's lock screen.
+    registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    deviceTokens.set('b', { token: 'b', platform: 'ios', registeredAt: 2, connectionId: SID });
+
+    make().dismiss(SID, QID);
+
+    expect(pushed.map((p) => p.token).sort()).toEqual(['a', 'b']);
+    expect(pushed[0]?.opts['dismiss']).toBe(true);
+    expect(pushed[0]?.opts['questionId']).toBe(QID);
+  });
+
+  test('no-op when no device tokens are registered', () => {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    make().dismiss(SID, QID);
+    expect(pushed).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -91,6 +91,7 @@ export type {
   SessionRotatedMessage,
   SessionViewsMessage,
   SessionViewMeta,
+  QuestionResolvedMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -139,6 +140,7 @@ export {
   createDaemonUpdateAvailable,
   createSessionRotated,
   createSessionViews,
+  createQuestionResolved,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -101,7 +101,8 @@ export type ProtocolMessage =
   | RegisterDeviceTokenMessage
   | DaemonUpdateAvailableMessage
   | SessionRotatedMessage
-  | SessionViewsMessage;
+  | SessionViewsMessage
+  | QuestionResolvedMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -243,6 +244,30 @@ export interface AnswerMessage {
    * Omitted by pre-#429 clients.
    */
   readonly claudeSessionId?: UUID | undefined;
+}
+
+/**
+ * Daemon -> client broadcast: a pending question stopped being pending, so every
+ * client should dismiss its card and clear any local/lock-screen notification for
+ * it (#585, P7). Sent to ALL connected clients (cross-client dismissal) the moment
+ * a question resolves on ANY channel — answered from one device, auto-approved/denied
+ * by the gate, or cancelled because Claude advanced past the prompt. Idempotent: a
+ * client that no longer holds the question simply ignores it.
+ *
+ * The daemon also fires a quiet APNS dismissal (apns-collapse-id = questionId,
+ * content-available) so a suspended device replaces/clears the lock-screen card; this
+ * WebSocket message is the in-app counterpart for connected clients.
+ */
+export interface QuestionResolvedMessage {
+  readonly type: 'question_resolved';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session that owned the question (the id the client keys cards by). */
+  readonly sessionId: UUID;
+  /** The resolved question's id; clients remove the card carrying it. */
+  readonly questionId: UUID;
+  /** Why it resolved, for diagnostics + client UX (all dismiss the card the same). */
+  readonly reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
 }
 
 /** Session state update */
@@ -779,6 +804,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'daemon_update_available',
     'session_rotated',
     'session_views',
+    'question_resolved',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1006,6 +1032,26 @@ export function createAnswer(
     questionId,
     answer,
     ...(claudeSessionId !== undefined && { claudeSessionId }),
+  };
+}
+
+/**
+ * Create a question-resolved broadcast (#585, P7). Fired by the daemon to ALL
+ * clients when a pending question stops being pending so every client dismisses
+ * its card; `reason` records how it resolved (all clients dismiss identically).
+ */
+export function createQuestionResolved(
+  sessionId: UUID,
+  questionId: UUID,
+  reason: QuestionResolvedMessage['reason'],
+): QuestionResolvedMessage {
+  return {
+    type: 'question_resolved',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    questionId,
+    reason,
   };
 }
 

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -18,6 +18,7 @@ import {
   createPing,
   createPong,
   createQuestion,
+  createQuestionResolved,
   createReplayBatch,
   createResumeSessionRequest,
   createResumeSessionResponse,
@@ -270,6 +271,7 @@ describe('deserialize()', () => {
       'session_list_request',
       'session_list_response',
       'transcript_content',
+      'question_resolved',
     ] as const;
 
     for (const type of validTypes) {
@@ -307,6 +309,37 @@ describe('deserialize()', () => {
     expect(parsed.message.content).toBe(message.content);
     expect(parsed.message.tool).toBe(message.tool);
     expect(parsed.message.isEditing).toBe(message.isEditing);
+  });
+});
+
+describe('createQuestionResolved() (#585 P7)', () => {
+  test('builds a well-formed question_resolved message', () => {
+    const sessionId = generateId();
+    const questionId = generateId();
+    const msg = createQuestionResolved(sessionId, questionId, 'answered');
+    expect(msg.type).toBe('question_resolved');
+    expect(msg.sessionId).toBe(sessionId);
+    expect(msg.questionId).toBe(questionId);
+    expect(msg.reason).toBe('answered');
+    expect(typeof msg.id).toBe('string');
+    expect(typeof msg.timestamp).toBe('string');
+  });
+
+  test('round-trips through serialize/deserialize for every reason', () => {
+    const reasons = ['answered', 'auto_approved', 'auto_denied', 'cancelled'] as const;
+    for (const reason of reasons) {
+      const sessionId = generateId();
+      const questionId = generateId();
+      const original = createQuestionResolved(sessionId, questionId, reason);
+      const parsed = deserialize(serialize(original));
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('question_resolved');
+      if (parsed?.type === 'question_resolved') {
+        expect(parsed.sessionId).toBe(sessionId);
+        expect(parsed.questionId).toBe(questionId);
+        expect(parsed.reason).toBe(reason);
+      }
+    }
   });
 });
 

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -22,6 +22,17 @@ interface ApnsPayload {
    * bytes; callers pass a questionId (a UUID, well within the limit).
    */
   collapseId?: string;
+  /**
+   * Dismissal push (#585, P7). When true the push is QUIET: no `alert`, no
+   * `sound`, no `badge` bump — only `content-available: 1` plus the
+   * `apns-collapse-id` header. iOS replaces the earlier notification for the same
+   * collapse-id with this contentless update, so the lock-screen card for an
+   * already-resolved question is cleared/superseded. The app's
+   * `didReceiveRemoteNotification` handler then calls
+   * `removeDeliveredNotifications(withIdentifiers:)` to drop it entirely
+   * (native-only; see web/Capacitor handler).
+   */
+  dismiss?: boolean;
 }
 
 interface ApnsConfig {
@@ -64,30 +75,43 @@ export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest
       ? payload.collapseId.slice(0, 64)
       : undefined;
 
+  // A dismissal (#585, P7) is a QUIET background push: it carries no alert and
+  // must use the `background` push type at low priority, or APNS rejects a
+  // content-available-only payload sent as `alert`. The collapse-id ties it to
+  // the original card so iOS supersedes it; the app then removes the delivered
+  // notification on receipt.
   const headers: Record<string, string> = {
     authorization: `bearer ${jwt}`,
     'apns-topic': payload.bundleId,
-    'apns-push-type': 'alert',
-    'apns-priority': '10',
+    'apns-push-type': payload.dismiss ? 'background' : 'alert',
+    'apns-priority': payload.dismiss ? '5' : '10',
     ...(collapseId ? { 'apns-collapse-id': collapseId } : {}),
   };
 
+  const aps: Record<string, unknown> = payload.dismiss
+    ? {
+        // Quiet update only: no alert, no sound, no badge bump. iOS replaces the
+        // earlier collapse-id card and wakes the app to remove it.
+        'content-available': 1,
+      }
+    : {
+        alert: {
+          title: payload.title,
+          body: payload.body,
+        },
+        sound: 'default',
+        badge: 1,
+        // content-available pre-wakes the app in the background so the
+        // WebSocket can start reconnecting before the user taps (#575, P4a).
+        // Kept alongside the alert so the interactive notification still
+        // renders; iOS treats this as a normal alert push with a background
+        // wake opportunity.
+        'content-available': 1,
+        ...(payload.category ? { category: payload.category } : {}),
+      };
+
   const body = JSON.stringify({
-    aps: {
-      alert: {
-        title: payload.title,
-        body: payload.body,
-      },
-      sound: 'default',
-      badge: 1,
-      // content-available pre-wakes the app in the background so the
-      // WebSocket can start reconnecting before the user taps (#575, P4a).
-      // Kept alongside the alert so the interactive notification still
-      // renders; iOS treats this as a normal alert push with a background
-      // wake opportunity.
-      'content-available': 1,
-      ...(payload.category ? { category: payload.category } : {}),
-    },
+    aps,
     ...(payload.data ? payload.data : {}),
   });
 

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -48,6 +48,12 @@ interface PushRequestBody {
   options?: string[];
   /** Reserved for future per-request sandbox override; daemon does not send this today */
   sandbox?: boolean;
+  /**
+   * Dismissal trigger (#585, P7). When true, send a QUIET background push (no
+   * alert) keyed by `apns-collapse-id` = questionId so the device clears the
+   * lock-screen card for an already-resolved question.
+   */
+  dismiss?: boolean;
 }
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
@@ -153,11 +159,17 @@ export default {
         );
       }
 
-      if (!body.token || !body.title || !body.body) {
+      // A dismissal (#585, P7) is a quiet content-available push with no
+      // user-visible text, so title/body are not required for it — only the
+      // token (the device) and the questionId (the collapse-id target, validated
+      // below by buildApnsRequest's collapse-id handling). An alert push still
+      // requires all three.
+      const isDismiss = body.dismiss === true;
+      if (!body.token || (!isDismiss && (!body.title || !body.body))) {
         return new Response(
           JSON.stringify({
             error: 'MISSING_FIELDS',
-            message: 'token, title, and body are required',
+            message: isDismiss ? 'token is required' : 'token, title, and body are required',
           }),
           { status: 400, headers: corsHeaders },
         );
@@ -189,8 +201,11 @@ export default {
         result = await sendApnsPush(
           {
             token: body.token,
-            title: body.title,
-            body: body.body,
+            // For a dismissal these are absent; buildApnsRequest ignores them in
+            // dismiss mode (no alert), so default to empty strings to satisfy the
+            // ApnsPayload shape without surfacing any text.
+            title: body.title ?? '',
+            body: body.body ?? '',
             bundleId,
             sandbox,
             data: Object.keys(data).length > 0 ? data : undefined,
@@ -199,6 +214,8 @@ export default {
             ...(body.questionId && body.questionId.length > 0
               ? { collapseId: body.questionId }
               : {}),
+            // Quiet dismissal of an already-resolved question (#585, P7).
+            ...(body.dismiss === true ? { dismiss: true } : {}),
           },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -100,3 +100,46 @@ describe('buildApnsRequest (#575 P4a)', () => {
     expect(req.headers['apns-priority']).toBe('10');
   });
 });
+
+describe('buildApnsRequest dismissal (#585 P7)', () => {
+  const DISMISS = {
+    token: 'device-token-abc',
+    title: ' ',
+    body: ' ',
+    bundleId: 'live.yooz.remi',
+    collapseId: 'question-uuid-1234',
+    dismiss: true,
+  };
+
+  test('quiet dismissal: content-available only, no alert/sound/badge', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    const payload = parseBody(req.body);
+    expect(payload.aps['content-available']).toBe(1);
+    expect(payload.aps.alert).toBeUndefined();
+    expect(payload.aps.sound).toBeUndefined();
+    expect(payload.aps.badge).toBeUndefined();
+    expect(payload.aps.category).toBeUndefined();
+  });
+
+  test('carries the apns-collapse-id (questionId) so it supersedes the original card', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    expect(req.headers['apns-collapse-id']).toBe('question-uuid-1234');
+  });
+
+  test('uses the background push type at low priority (a content-available push)', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    expect(req.headers['apns-push-type']).toBe('background');
+    expect(req.headers['apns-priority']).toBe('5');
+  });
+
+  test('carries custom data (sessionId/questionId) as siblings to aps', () => {
+    const req = buildApnsRequest(
+      { ...DISMISS, data: { sessionId: 's1', questionId: 'q1' } },
+      'jwt',
+    );
+    const payload = parseBody(req.body);
+    expect(payload['sessionId']).toBe('s1');
+    expect(payload['questionId']).toBe('q1');
+    expect(payload.aps['content-available']).toBe(1);
+  });
+});

--- a/packages/signaling/tests/push-dismiss.test.ts
+++ b/packages/signaling/tests/push-dismiss.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Worker-level tests for the /push dismissal contract (#585, P7).
+ *
+ * Drives the worker's `fetch` directly (no miniflare; bun's runtime provides
+ * `crypto.subtle` and `fetch`, which we stub for the Apple call). Confirms FIX 4:
+ * a `dismiss` push is accepted WITHOUT title/body (skips MISSING_FIELDS), while a
+ * dismiss still requires `token`. Each test uses a unique CF-Connecting-IP to
+ * dodge the module-level per-IP push rate limiter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+// A real EC P-256 PKCS8 key so createApnsJwt's crypto.subtle.importKey/sign
+// succeed (the JWT itself is never verified here — we stub the Apple fetch).
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+}
+
+describe('/push dismissal contract (#585 P7 FIX 4)', () => {
+  let env: TestEnv;
+  let realFetch: typeof globalThis.fetch;
+  let appleRequests: Array<{ url: string; headers: Headers; body: string }>;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    env = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleRequests = [];
+    realFetch = globalThis.fetch;
+    // Stub only the Apple APNS host; everything else is unused in these tests.
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        appleRequests.push({
+          url,
+          headers: new Headers(init?.headers),
+          body: String(init?.body ?? ''),
+        });
+        return new Response('', { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function pushRequest(body: Record<string, unknown>): Request {
+    ipCounter += 1;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': `203.0.113.${ipCounter}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('a dismiss push WITHOUT title/body is accepted (skips MISSING_FIELDS)', async () => {
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    // It reached APNS: a single background dismissal with the collapse-id.
+    expect(appleRequests).toHaveLength(1);
+    expect(appleRequests[0]?.headers.get('apns-push-type')).toBe('background');
+    expect(appleRequests[0]?.headers.get('apns-collapse-id')).toBe('q-1');
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['content-available']).toBe(1);
+    expect(parsed.aps.alert).toBeUndefined();
+  });
+
+  test('a dismiss push still requires a token (MISSING_FIELDS otherwise)', async () => {
+    const res = await worker.fetch(pushRequest({ questionId: 'q-1', dismiss: true }), env as never);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('MISSING_FIELDS');
+    expect(appleRequests).toHaveLength(0);
+  });
+
+  test('a normal (non-dismiss) push still requires title and body', async () => {
+    const res = await worker.fetch(pushRequest({ token: 'device-abc' }), env as never);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('MISSING_FIELDS');
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,8 +20,10 @@ import {
   clearSessionQuestions,
   getSessionQuestions,
   questionKey,
+  removeQuestionById,
   statusClearsMainQuestion,
 } from '@/lib/question-collection';
+import { dismissDeliveredNotification } from '@/lib/notifications';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
 import { shouldEvictCachedSession } from '@/lib/session-eviction';
@@ -653,6 +655,29 @@ function App() {
         );
 
         // Push (APNS) is the notification channel — no local notification from WebSocket
+        break;
+      }
+
+      case 'question_resolved': {
+        // Cross-client dismissal (#585, P7): the question resolved on some
+        // channel (answered elsewhere, auto-approved/denied, or cancelled), so
+        // drop its card and clear any lock-screen notification for it here.
+        // Idempotent — if we never held it (or already dropped it), this is a
+        // no-op. The message carries no agentId, so locate the card by question
+        // id within the session.
+        const resolvedSessionId = message.sessionId;
+        const resolvedQuestionId = message.questionId;
+        setQuestions((prev) => removeQuestionById(prev, resolvedSessionId, resolvedQuestionId));
+        // Recompute the session's pending badge from the latest committed map
+        // (the ref), since the card we just removed may have been the last one.
+        const stillPending = getSessionQuestions(questionsRef.current, resolvedSessionId).some(
+          (q) => q.id !== resolvedQuestionId && q.answeredWith === undefined,
+        );
+        setSessions((prev) =>
+          prev.map((s) => (s.id === resolvedSessionId ? { ...s, questionPending: stillPending } : s)),
+        );
+        // Clear the matching delivered lock-screen / in-app notification (native).
+        dismissDeliveredNotification(resolvedQuestionId);
         break;
       }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -667,12 +667,22 @@ function App() {
         // id within the session.
         const resolvedSessionId = message.sessionId;
         const resolvedQuestionId = message.questionId;
-        setQuestions((prev) => removeQuestionById(prev, resolvedSessionId, resolvedQuestionId));
-        // Recompute the session's pending badge from the latest committed map
-        // (the ref), since the card we just removed may have been the last one.
-        const stillPending = getSessionQuestions(questionsRef.current, resolvedSessionId).some(
-          (q) => q.id !== resolvedQuestionId && q.answeredWith === undefined,
+        // Compute the post-removal map from the CURRENT committed ref, then drive
+        // both setters from that one value (#585, P7 FIX 3). Reading the updated
+        // map (not the pre-removal ref) is what prevents two concurrent
+        // resolutions from leaving the badge stuck `questionPending: true`. The
+        // ref is the latest committed map (kept in sync by the effect below), so
+        // the second resolution sees the first's removal.
+        const updatedQuestions = removeQuestionById(
+          questionsRef.current,
+          resolvedSessionId,
+          resolvedQuestionId,
         );
+        const stillPending = getSessionQuestions(updatedQuestions, resolvedSessionId).some(
+          (q) => q.answeredWith === undefined,
+        );
+        questionsRef.current = updatedQuestions;
+        setQuestions(updatedQuestions);
         setSessions((prev) =>
           prev.map((s) => (s.id === resolvedSessionId ? { ...s, questionPending: stillPending } : s)),
         );

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -150,6 +150,40 @@ export function openNotificationSettings(): void {
   window.open('app-settings:', '_system');
 }
 
+/**
+ * Clear the delivered lock-screen / notification-center notification for a
+ * resolved question (#585, P7). Called from the `question_resolved` handler so
+ * answering on one device clears the lock-screen card on this one too.
+ *
+ * NATIVE-ONLY: this is meaningful only on iOS/Android. On web there is no
+ * notification center to clear, so it is a no-op. The daemon ALSO sends a quiet
+ * APNS dismissal (apns-collapse-id = questionId) that supersedes the card while
+ * the app is suspended; this handler covers the foreground/just-woken case by
+ * removing any delivered notification whose payload carries the same questionId.
+ *
+ * APNS pushes are delivered through @capacitor/push-notifications, so the
+ * delivered list is queried there and matched on `data.questionId`. Local
+ * notifications scheduled by `pushNotificationReceived` (foreground mirror) carry
+ * no questionId, so they cannot be matched precisely; they auto-clear when the
+ * user opens the app. Errors are swallowed — a failed dismissal must never break
+ * message handling.
+ */
+export async function dismissDeliveredNotification(questionId: string): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const delivered = await PushNotifications.getDeliveredNotifications();
+    const matches = (delivered.notifications ?? []).filter((n) => {
+      const data = (n.data ?? {}) as Record<string, unknown>;
+      return data['questionId'] === questionId;
+    });
+    if (matches.length > 0) {
+      await PushNotifications.removeDeliveredNotifications({ notifications: matches });
+    }
+  } catch (err) {
+    console.warn('[Notifications] Failed to dismiss delivered notification:', err);
+  }
+}
+
 /** Send a local notification for a question/permission prompt. */
 export async function notifyQuestion(sessionName: string, prompt: string): Promise<void> {
   if (!localPermissionGranted) return;

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -58,6 +58,32 @@ export function clearSessionQuestions(
 }
 
 /**
+ * Return a map with the single question matching (sessionId, questionId) removed
+ * (#585, P7). Used by the `question_resolved` broadcast handler: the message
+ * carries no agentId, so the entry is located by its question `id` within the
+ * session rather than by composite key. Returns the SAME reference when nothing
+ * matched, so callers keep React's no-op-update optimization. Idempotent — a
+ * client that already dropped the card simply gets the same map back.
+ */
+export function removeQuestionById(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+  questionId: string,
+): Map<string, UIQuestion> {
+  let foundKey: string | undefined;
+  for (const [key, q] of questions) {
+    if (q.sessionId === sessionId && q.id === questionId) {
+      foundKey = key;
+      break;
+    }
+  }
+  if (foundKey === undefined) return questions;
+  const next = new Map(questions);
+  next.delete(foundKey);
+  return next;
+}
+
+/**
  * Whether a `session_update` status means the MAIN agent's prompt resolved and
  * its pending card should be cleared.
  *

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -9,6 +9,7 @@ import {
   getSessionQuestions,
   hasSessionQuestion,
   questionKey,
+  removeQuestionById,
   statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
@@ -73,6 +74,28 @@ describe('clearSessionQuestions', () => {
   test('returns the same reference when nothing matched (no-op update)', () => {
     const map = build(q('s1', undefined, 'a'));
     expect(clearSessionQuestions(map, 's2')).toBe(map);
+  });
+});
+
+describe('removeQuestionById (#585 P7)', () => {
+  test('removes the matching question by id within the session, keeps siblings', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'), q('s2', undefined, 'c'));
+    const next = removeQuestionById(map, 's1', 'b');
+    // The subagent prompt 'b' is gone; the main 'a' and the other session 'c' remain.
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['c']);
+  });
+
+  test('returns the same reference when the id is not present (idempotent / no-op)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(removeQuestionById(map, 's1', 'nope')).toBe(map);
+  });
+
+  test('does not remove a same-id question belonging to a different session', () => {
+    const map = build(q('s1', undefined, 'dup'), q('s2', undefined, 'dup'));
+    const next = removeQuestionById(map, 's1', 'dup');
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['dup']);
   });
 });
 


### PR DESCRIPTION
Closes #585. Absorbs #481 items 5-6. Part of epic #571.

When a question resolves on any channel, every client dismisses its card and the lock-screen push clears; duplicate device tokens stop double-pushing.

- New `question_resolved` broadcast on all daemon resolution paths (answered / auto_approved / auto_denied / cancelled), throw-safe.
- Web removes the card everywhere + clears the delivered notification (native removeDeliveredNotifications).
- APNS dismissal: quiet content-available + collapse-id push (signaling 'dismiss' mode).
- Device-token dedup (identical=one; rotation prunes the prior).

Native boundary: the lock-screen `removeDeliveredNotifications` is app-side (guarded `isNative`). Signaling apns.ts change needs a worker redeploy.

Tests (no mocks): protocol round-trip, per-path broadcast + throw-safety, token dedup, dispatcher dismiss, signaling dismissal push, web removeQuestionById. daemon+shared+signaling 2549 pass, web 210 pass, 0 fail.