### PR TITLE
Release 0.6.12: auto-approve notification rethink (epic #571) + reconnect-storm fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.12] - 2026-06-18
+
+The biggest auto-approve UX change: escalated permissions are now held on the
+hook and answered via the hook response (Model B), delivered and presented
+faithfully, and the local model never decides design/plan questions (epic #571).
+Plus a fix for a multi-host reconnect storm.
+
+### Added
+- **Hold the hook (Model B)** (#573): a binary permission the local model
+  escalates HOLDS its `PermissionRequest` hook open and is answered via the
+  `allow`/`deny` hook response — no PTY digit, no render race, no dependence on a
+  warm socket. A long human-paced `auto_approve.hold_timeout` (default 1800s)
+  fails open to the native prompt; a slow-eval fallback push fires at
+  `auto_approve.push_hold_timeout` (default 60s). Holding only engages when
+  auto-approve is on.
+- **Never auto-decide design / plan-mode / long-form questions** (#572):
+  `AskUserQuestion`, `ExitPlanMode`, and non-binary questions escalate to the
+  user before the LLM, at zero latency. New `auto_approve.always_escalate_tools`.
+- **Faithful notification** (#574): notification text comes from the hook
+  (no more run-together "Doyouwanttoproceed?"); the real option labels are shown.
+- **Connection-independent answer relay** (#575): a daemon `POST /answer`
+  endpoint (same auth as the WebSocket) lets a tapped answer reach the daemon
+  without a warm WebSocket; the iOS app gets a `content-available` pre-wake and
+  a longer, fail-fast answer deadline.
+- **Responsive status** (#576): `evaluating` / `approved` / `starting` states,
+  the blocked-on-you state surfaces distinctly, and a faster status bar.
+- **Cross-client question dismissal** (#585): answering on one device (or an
+  auto-resolve, or `/clear`) dismisses the card on every client and clears the
+  lock-screen push; duplicate device tokens are de-duplicated.
+
+### Fixed
+- **Held escalations now reach the phone** (#573): a held binary escalation was
+  registered/pushed only on a PTY render that a held hook prevents, so it could
+  sit unanswerable until the hold timeout — now pushed immediately.
+- **Recurring "Transcript for session not found"** (#577): a durable
+  transcript-index, client-side eviction of dead cached sessions, and a longer
+  first-transcript fallback window.
+- **Multi-host reconnect storm** (#586): `WebSocketClient` reset its reconnect
+  backoff on transport-open (before auth), so any open-but-fail connection
+  looped at ~1s forever and never escalated; the reset now happens only on a
+  fully-established connection.
+
+### Note
+- The `content-available` pre-wake and the dismissal/collapse-id pushes require a
+  Cloudflare **signaling worker redeploy** to take effect; without it they
+  degrade gracefully to 0.6.11 push behavior.
+- Native iOS Live Activities / Notification Service Extension are tracked
+  separately (#575) and are not part of this release.
+
 ## [0.6.11] - 2026-06-11
 
 A persistent remi status bar on the terminal's last row, visible even while

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.12-dev.3",
+  "version": "0.6.12-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.12-dev.1",
+  "version": "0.6.12-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.11",
+  "version": "0.6.12-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.12-dev.2",
+  "version": "0.6.12-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -81,6 +81,18 @@ export interface AdapterEvents {
     claudeSessionId?: UUID,
   ) => void;
 
+  /**
+   * Connection-independent answer relay (#575, P4a). Used by the HTTP /answer
+   * endpoint; returns a structured outcome so the route can JSON-encode it.
+   * Only the WebSocket adapter exposes a relay endpoint today.
+   */
+  onAnswerRelay?: (
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
+
   /** Bullet expand request received */
   onBulletExpandRequest: (
     connectionId: UUID,

--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -305,8 +305,10 @@ export class TelegramAdapter implements ConnectionAdapter {
       return false;
     }
 
-    // Show typing indicator for thinking/executing status
-    if (status === 'thinking' || status === 'executing') {
+    // Show typing indicator while the agent is busy: thinking, executing, or
+    // auto-approve evaluating a permission (#576). 'approved'/'starting' are
+    // transient/non-busy and intentionally produce no typing action.
+    if (status === 'thinking' || status === 'executing' || status === 'evaluating') {
       // Send typing indicator repeatedly while working
       this.bot.api
         .sendChatAction(session.chatId, 'typing', {

--- a/packages/daemon/src/adapters/telegram-ui.ts
+++ b/packages/daemon/src/adapters/telegram-ui.ts
@@ -147,6 +147,13 @@ export function formatStatusText(status: AgentStatus): string {
       return '⚡ Executing...';
     case 'waiting':
       return '⏳ Waiting for input';
+    // Auto-approve + session-lifecycle states (#576).
+    case 'evaluating':
+      return '⏳ Evaluating…';
+    case 'approved':
+      return '✓ Approved';
+    case 'starting':
+      return '⚡ Starting';
     default:
       return status;
   }

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -118,6 +118,12 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onAnswer?.(connectionId, sessionId, questionId, answer, claudeSessionId);
       },
 
+      onAnswerRelay: async (sessionId, questionId, answer, claudeSessionId) =>
+        // No relay handler wired => behave like an unknown session rather than
+        // throwing inside the HTTP route.
+        (await this.events.onAnswerRelay?.(sessionId, questionId, answer, claudeSessionId)) ??
+        'session-not-found',
+
       onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {
         this.events.onBulletExpandRequest?.(connectionId, sessionId, bulletId, requestId);
       },

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -90,15 +90,35 @@ export class QuestionPresenceTracker {
    * confirms the prompt is visible, or never if status moves past 'waiting'
    * first.
    *
-   * Replacement policy: per agent, the newer hook wins (correct for the
-   * same-prompt double-fire: PermissionRequest then Notification). Different
-   * agents no longer overwrite each other (#425).
+   * Replacement policy: per agent, the newer hook normally wins. The one
+   * exception (#574): a pending rich `PermissionRequest` is authoritative and
+   * is NOT evicted by any other shape — only a NEWER `PermissionRequest` (a new
+   * permission cycle) may replace it. Claude fires both a PermissionRequest and
+   * a generic `Notification(permission_prompt)` for one prompt; the
+   * PermissionRequest carries the tool + command + real option labels ("Allow
+   * Bash: git push", Edit's Yes/Always/No), while the Notification is the bland
+   * "Claude needs your permission to use Bash" with the hardcoded 3-set.
+   * Letting the trailing notification win is exactly what garbled the push
+   * text/options (issues 3+4). A same-agent source-less question (e.g. a
+   * StopFailure "Retry?" card) must likewise not silently evict the pending
+   * permission request and leave the real prompt without a push. Different
+   * agents never overwrite each other (#425).
    */
   recordPendingHook(question: Question): void {
     const key = agentKey(question);
-    if (this.pending.has(key)) {
+    const existing = this.pending.get(key);
+    if (existing) {
+      // A pending rich permission request stays put unless the incoming is a
+      // newer permission request: a generic Notification or a source-less
+      // StopFailure-shaped question for the same agent must NOT evict it.
+      if (existing.source === 'permission_request' && question.source !== 'permission_request') {
+        console.debug(
+          `[QuestionPresenceTracker] Keeping richer pending permission_request for agent "${key}"; not evicting with source="${question.source ?? 'undefined'}" (kept="${existing.text.slice(0, 50)}", dropped="${question.text.slice(0, 50)}")`,
+        );
+        return;
+      }
       console.debug(
-        `[QuestionPresenceTracker] Replacing pending hook for agent "${key}" (old="${this.pending.get(key)?.text.slice(0, 50)}", new="${question.text.slice(0, 50)}")`,
+        `[QuestionPresenceTracker] Replacing pending hook for agent "${key}" (old="${existing.text.slice(0, 50)}", new="${question.text.slice(0, 50)}")`,
       );
     }
     // Re-insert so this agent's entry is the most recent (matters for the

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -82,6 +82,17 @@ export class QuestionPresenceTracker {
    *  status/clearPending resets (verdict = handled, or the prompt is gone). */
   private bufferedDuringEval: Question | null = null;
 
+  /** Question ids already pushed via `pushHeldHook` (#573). A binary escalation
+   *  that HOLDS its PermissionRequest hook (Model B, #573) never lets Claude
+   *  render the native prompt, so `onPTYPromptVisible` cannot be the push
+   *  trigger; the gate pushes the held question immediately and idempotently
+   *  through here instead. Membership makes a repeat `pushHeldHook` for the same
+   *  id a no-op, and guards the (rare) hold-timeout fail-open case where the PTY
+   *  finally renders and would otherwise re-push the same prompt. Cleared on any
+   *  reset (status-out-of-waiting / clearPending) so a new prompt cycle starts
+   *  fresh. */
+  private pushedHeldIds = new Set<string>();
+
   constructor(private readonly push: PushQuestion) {}
 
   /**
@@ -125,6 +136,57 @@ export class QuestionPresenceTracker {
     // PTY-pairing fallback below).
     this.pending.delete(key);
     this.pending.set(key, question);
+  }
+
+  /**
+   * Push a held escalation's question IMMEDIATELY, without waiting for a PTY
+   * render (#573). A binary escalation that HOLDS its PermissionRequest hook
+   * (Model B, #573) blocks Claude's hook response, so Claude never renders the
+   * native numbered prompt and `onPTYPromptVisible` never fires — meaning the
+   * normal push trigger never runs and the question is never registered in
+   * `sessionRegistry` nor pushed to the phone, leaving it UNANSWERABLE. The gate
+   * decided the user MUST answer, so the PTY-presence gate (which exists only to
+   * avoid pushing a silently auto-approved permission that never rendered) does
+   * not apply: push now, under the SAME `questionId` the hold is keyed by.
+   *
+   * Locates the stashed hook record by id (the `pending` map is agent-keyed, so
+   * we scan its values for the matching `Question.id`), routes it through the
+   * same `push` sink as `onPTYPromptVisible` (-> MessageAPI.handleQuestion ->
+   * addQuestion + maybePush), and removes the consumed record so the normal
+   * pair-merge cannot push it a second time. Idempotent: a repeat call for the
+   * same id (or one whose record was already consumed) is a no-op, guarded by
+   * `pushedHeldIds`. Returns true iff a push fired.
+   */
+  pushHeldHook(questionId: string): boolean {
+    if (this.pushedHeldIds.has(questionId)) return false;
+    let recordKey: string | undefined;
+    for (const [key, q] of this.pending) {
+      if (q.id === questionId) {
+        recordKey = key;
+        break;
+      }
+    }
+    if (recordKey === undefined) {
+      // No stashed record for this id: the hook was never recorded (e.g. a
+      // restart cleared pending between escalate and this call). Nothing to push.
+      console.debug(
+        `[QuestionPresenceTracker] pushHeldHook: no pending record for question ${questionId.slice(0, 8)}`,
+      );
+      return false;
+    }
+    const question = this.pending.get(recordKey) as Question;
+    // Consume BEFORE the push so a re-entrant call cannot re-push the same
+    // record, and so a later onPTYPromptVisible has no record to merge.
+    this.pending.delete(recordKey);
+    this.pushedHeldIds.add(questionId);
+    try {
+      this.push(question);
+    } catch (err) {
+      console.error(
+        `[QuestionPresenceTracker] pushHeldHook push sink threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return true;
   }
 
   /**
@@ -222,6 +284,10 @@ export class QuestionPresenceTracker {
       // agent advanced) or left the screen. Discard it — do not ping the user.
       this.autoApproveInFlight = false;
       this.bufferedDuringEval = null;
+      // New prompt cycle starts fresh: a held push from the prior cycle must not
+      // suppress an identical id in a future one (ids are unique, so this is
+      // belt-and-suspenders, but keeps the set bounded). (#573)
+      this.pushedHeldIds.clear();
     }
   }
 
@@ -274,6 +340,7 @@ export class QuestionPresenceTracker {
     this.ptyShowingQuestion = false;
     this.autoApproveInFlight = false;
     this.bufferedDuringEval = null;
+    this.pushedHeldIds.clear();
   }
 
   /**

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -142,6 +142,45 @@ export class Authenticator {
   }
 
   /**
+   * Verify a detached, connection-independent signed request (#575, P4a).
+   *
+   * Used by the HTTP `/answer` relay, which cannot run the interactive
+   * challenge-response handshake but must still authenticate with the SAME
+   * trust model the WebSocket uses: (1) verify the client's Ed25519 signature
+   * over `message`, then (2) require the key to be in the authorized-keys store
+   * (the exact gate `verifyResponse` step 2 applies). Unlike the live handshake,
+   * this path does NOT TOFU-accept unknown keys — a relayed answer must come
+   * from an already-trusted client, never bootstrap trust.
+   *
+   * `message` is the canonical request string the client signed (the caller is
+   * responsible for binding it to the request, e.g. sessionId|questionId|answer).
+   * Returns true only when the signature verifies AND the key is authorized.
+   */
+  async verifyDetachedRequest(
+    message: string,
+    signatureBase64: string,
+    clientPublicKeyBase64: string,
+    clientFingerprint: string,
+  ): Promise<boolean> {
+    try {
+      const clientPublicKey = await importPublicKey(fromBase64(clientPublicKeyBase64));
+      const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+      const valid = await verify(clientPublicKey, data, signatureBase64);
+      if (!valid) return false;
+    } catch (err) {
+      console.error(`Detached request verification error: ${errorToString(err)}`);
+      return false;
+    }
+
+    try {
+      return this.store.isAuthorized(clientPublicKeyBase64, clientFingerprint);
+    } catch (err) {
+      console.error(`Auth store error during detached verification: ${errorToString(err)}`);
+      return false;
+    }
+  }
+
+  /**
    * Clean up a pending challenge (e.g., on connection close).
    */
   removePendingChallenge(connectionId: string): void {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -31,6 +31,7 @@ import type { QuestionPresenceTracker } from '../api/question-presence-tracker.t
 import { log, logError } from '../cli/logger.ts';
 import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
 import type { SessionRegistry } from '../session/index.ts';
+import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
 
 /**
@@ -65,11 +66,14 @@ export interface AutoApproveGateDeps {
   tracker: QuestionPresenceTracker;
   /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
   isInSubagentContext: () => boolean;
-  /** Escalate to the user (wraps `handlers.onPermissionRequest`). The gate wraps
-   *  every call in a try/catch, so an implementation that throws is logged and
-   *  absorbed rather than propagated; implementations should still prefer to
-   *  handle their own errors. */
-  escalate: (input: PermissionRequestHookInput) => void;
+  /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
+   *  of the `Question` it created (#573), so a binary escalation can hold the
+   *  hook keyed by that id and resolve it when the user answers; `undefined`
+   *  means no question was created (e.g. the push failed) and the gate must
+   *  fall open to passthrough rather than hold a hook nobody can answer. The
+   *  gate wraps every call in a try/catch, so an implementation that throws is
+   *  logged and absorbed (treated as `undefined`) rather than propagated. */
+  escalate: (input: PermissionRequestHookInput) => UUID | undefined;
   /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
    *  prompt until the verdict (don't push an auto-approved permission). #484. */
   onEvalStart?: () => void;
@@ -85,10 +89,44 @@ export interface AutoApproveGateDeps {
   /** Second-opinion model consulted on a primary 'escalate' in main context
    *  (#522). Empty/absent => no second opinion (escalate straight to the user). */
   escalateModel?: string;
+  /** Tools that ALWAYS escalate to the user, never auto-decided (#572). Used by
+   *  the gate to classify an escalation as binary (holdable) vs design (#573):
+   *  a design/plan-mode tool's pick cannot be expressed by the hook response, so
+   *  it passes through instead of holding. Absent => empty set (no extra tools). */
+  alwaysEscalateTools?: ReadonlySet<string>;
+  /** Milliseconds to HOLD a binary main-context PermissionRequest hook open
+   *  after escalating, until the user answers (Model B, #573). On expiry the
+   *  hold resolves 'passthrough' (fail open -> native prompt). <=0 (or absent)
+   *  disables holding: escalations return 'passthrough' immediately as before. */
+  holdMs?: number;
+  /** Milliseconds before a SLOW binary main-context eval triggers an early
+   *  push + hold (Part B, #573). If the eval has not produced a verdict within
+   *  this window, the gate pushes + holds the hook so the user can step in; a
+   *  late verdict then resolves the held hook. <=0 (or absent) disables Part B
+   *  entirely — the eval/timer race never arms, so behavior reverts to A+C. */
+  pushHoldMs?: number;
+}
+
+/** A held PermissionRequest hook awaiting a user answer (#573). The `resolve`
+ *  fulfills the promise the hook server is blocked on; the `timer` fails it open
+ *  to passthrough on hold-timeout. Keyed by the escalated `Question.id`. */
+interface PendingHold {
+  resolve: (decision: PermissionDecision) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 export class AutoApproveGate {
   private readonly sessionTag: string;
+
+  /**
+   * Binary main-context escalations currently holding their PermissionRequest
+   * hook open, keyed by the escalated `Question.id` (#573). Per-gate, so each
+   * session's holds are isolated. An entry lives from `escalateAndHold` until it
+   * is resolved by `resolveHeld` (the user answered), by the hold-timeout timer
+   * (fail open -> passthrough), or by `cancelStale` (session ended). Every exit
+   * path clears the timer and deletes the entry, so it never leaks.
+   */
+  private readonly pendingHolds = new Map<UUID, PendingHold>();
 
   constructor(
     private readonly deps: AutoApproveGateDeps,
@@ -109,10 +147,148 @@ export class AutoApproveGate {
    * service is configured.
    */
   cancelStale(reason: string): void {
+    // Release any held hooks first (#573): a Stop/SessionEnd means the session
+    // is going away, so a hook blocked on a human answer must fail open to
+    // passthrough rather than hang. A held hook cannot normally co-occur with
+    // Stop (Claude is blocked on the permission), but this is defensive.
+    this.releaseAllHolds('passthrough', reason);
     if (this.deps.service === null) return;
     if (this.deps.service.cancel(reason)) {
       log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
     }
+  }
+
+  /**
+   * Resolve a held PermissionRequest hook (#573). Called when the user answers
+   * from any channel (input-events.ts maps the picked option to allow/deny).
+   * Returns true when a hold for `questionId` existed and was resolved (the
+   * caller then skips the PTY inject — Claude is blocked on the hook, not
+   * rendering a prompt); false when no such hold exists (a non-held answer, e.g.
+   * a multi-choice pick or a non-auto-approve session, takes the PTY path).
+   * Clears the hold's timer and marks the permission handled so the #484 buffer
+   * + #513 cue close exactly as for a silent auto-decision.
+   */
+  resolveHeld(questionId: UUID, decision: 'allow' | 'deny'): boolean {
+    const hold = this.pendingHolds.get(questionId);
+    if (!hold) return false;
+    clearTimeout(hold.timer);
+    this.pendingHolds.delete(questionId);
+    this.markHandled();
+    hold.resolve(decision);
+    log(
+      `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)} resolved: ${decision}`,
+    );
+    return true;
+  }
+
+  /**
+   * Release a held hook to 'passthrough' so Claude renders its native numbered
+   * prompt (#573). Used when the user's answer cannot be expressed by the binary
+   * hook response — a "Yes, always" or a multi-choice pick — so the daemon pops
+   * the hold and the caller then injects the digit into the freshly-rendered
+   * prompt. Returns true iff a hold for `questionId` existed. Public wrapper over
+   * the private `releaseHeld(qid, 'passthrough')`; no markHandled (the user is
+   * about to answer the native prompt, not a silent auto-decision).
+   */
+  releaseHeldAsPassthrough(questionId: UUID): boolean {
+    return this.releaseHeld(questionId, 'passthrough');
+  }
+
+  /** Resolve every pending hold with one decision + reason, clearing timers and
+   *  emptying the map. Used by `cancelStale` (session teardown). */
+  private releaseAllHolds(decision: PermissionDecision, reason: string): void {
+    if (this.pendingHolds.size === 0) return;
+    log(
+      `[AutoApprove ${this.sessionTag}] Releasing ${this.pendingHolds.size} held hook(s) as ${decision} (${reason})`,
+    );
+    for (const [, hold] of this.pendingHolds) {
+      clearTimeout(hold.timer);
+      hold.resolve(decision);
+    }
+    this.pendingHolds.clear();
+  }
+
+  /**
+   * Escalate a binary main-context PermissionRequest to the user AND hold the
+   * hook open until the user answers (Model B, #573). `escalate()` stashes the
+   * hook record + pushes (returning the created `Question.id`); `onEscalate`
+   * releases the #484 buffer. Then:
+   *   - no question id (push failed) or holding disabled (holdMs <= 0) ->
+   *     'passthrough' (today's behavior: Claude renders its native prompt).
+   *   - else return a promise that stays PENDING until `resolveHeld` fulfills it
+   *     with allow/deny, or the hold-timeout fires and fails it open to
+   *     'passthrough' (so the terminal is never permanently stuck).
+   * The returned promise is what the hook server is blocked on.
+   */
+  private escalateAndHold(input: PermissionRequestHookInput): Promise<PermissionDecision> {
+    return this.createHold(input).decision;
+  }
+
+  /**
+   * Escalate (push) a binary main-context permission and register a hold,
+   * returning BOTH the held promise the hook server blocks on AND the created
+   * `Question.id` (so Part B can reconcile a late verdict into the same hold).
+   * `questionId` is undefined when no question was created (push failed) or
+   * holding is disabled — in which case `decision` is an immediate 'passthrough'
+   * (today's behavior) and no hold is registered.
+   */
+  private createHold(input: PermissionRequestHookInput): {
+    decision: Promise<PermissionDecision>;
+    questionId: UUID | undefined;
+  } {
+    const qid = this.escalateToUser(input);
+    const holdMs = this.deps.holdMs ?? 0;
+    if (!qid || holdMs <= 0) return { decision: Promise.resolve('passthrough'), questionId: qid };
+    const decision = new Promise<PermissionDecision>((resolve) => {
+      const timer = setTimeout(() => {
+        // Fail open: the user did not answer within the hold window, so let
+        // Claude render its native prompt (the local terminal can take over).
+        this.pendingHolds.delete(qid);
+        log(
+          `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
+        );
+        resolve('passthrough');
+      }, holdMs);
+      // setTimeout keeps the event loop alive for the whole human-paced hold;
+      // unref so a held hook never blocks daemon shutdown.
+      timer.unref?.();
+      this.pendingHolds.set(qid, { resolve, timer });
+    });
+    return { decision, questionId: qid };
+  }
+
+  /**
+   * Escalate a main-context permission to the user (#573). A BINARY escalation
+   * holds the hook open (`escalateAndHold`) so the user's answer resolves it via
+   * the hook response with no PTY render; a multi-choice / design escalation
+   * cannot be expressed by the binary response, so it escalates + returns
+   * 'passthrough' immediately (Claude renders the native prompt and the pick is
+   * delivered by the legacy PTY path / a later phase). Always main context — the
+   * subagent escalate paths default-deny and never reach here.
+   */
+  private escalateMain(input: PermissionRequestHookInput): Promise<PermissionDecision> {
+    if (this.isBinaryEscalation(input)) {
+      return this.escalateAndHold(input);
+    }
+    this.escalateToUser(input);
+    return Promise.resolve('passthrough');
+  }
+
+  /**
+   * Whether an escalated permission is BINARY (answerable allow/deny via the
+   * hook response) and therefore holdable (#573). Multi-choice prompts and
+   * design / plan-mode / long-form questions cannot be expressed by the binary
+   * response, so they always passthrough (their pick delivery is a later phase).
+   * Mirrors the service's own structural classifiers so the gate and the service
+   * agree on what "binary" means.
+   */
+  private isBinaryEscalation(input: PermissionRequestHookInput): boolean {
+    const suggestions = input.permission_suggestions as readonly unknown[] | undefined;
+    const alwaysEscalate = this.deps.alwaysEscalateTools ?? new Set<string>();
+    return (
+      !isMultiChoicePermission(input.tool_name, suggestions) &&
+      !isDesignQuestion(input.tool_name, input.tool_input, suggestions, alwaysEscalate)
+    );
   }
 
   /**
@@ -139,14 +315,13 @@ export class AutoApproveGate {
     }
 
     // No auto-approve: subagent default-denies via the response (no PTY, no
-    // leak); main escalates to the user.
+    // leak); main escalates to the user (holding the hook when binary, #573).
     if (!service) {
       if (isInSubagentContext()) {
         log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
         return 'deny';
       }
-      this.escalateToUser(input);
-      return 'passthrough';
+      return this.escalateMain(input);
     }
 
     // Open the buffer/cue window (#484/#513). With synchronous decisions Claude
@@ -154,25 +329,36 @@ export class AutoApproveGate {
     // PTY prompt now; the cue lifecycle still rides these signals.
     this.safeCue('onEvalStart', this.deps.onEvalStart);
 
+    // Raw suggestions: the service does its own strict-string filtering; we
+    // forward the raw shape so the multi-choice classifier can route a
+    // non-string entry through escalate instead of crashing.
+    const evalPromise = service.evaluate(
+      input.tool_name,
+      input.tool_input,
+      this.sessionTag,
+      input.permission_suggestions as readonly unknown[] | undefined,
+    );
+
+    // Part B (#573, ISOLATED behind push_hold_timeout): if the eval is still
+    // running after push_hold_timeout AND this is a binary main-context
+    // permission, push + hold the hook early so the user can step in while the
+    // model keeps thinking; the late verdict then reconciles into that hold.
+    // When push_hold_timeout <= 0 this never arms and the eval is awaited as
+    // usual (Parts A + C only). A non-null result means the early hold fired and
+    // the returned decision is what the hook server is blocked on.
+    const earlyHold = await this.maybePushOnSlowEval(input, evalPromise);
+    if (earlyHold !== null) return earlyHold;
+
     let result: AutoApproveResult;
     try {
-      // Raw suggestions: the service does its own strict-string filtering; we
-      // forward the raw shape so the multi-choice classifier can route a
-      // non-string entry through escalate instead of crashing.
-      result = await service.evaluate(
-        input.tool_name,
-        input.tool_input,
-        this.sessionTag,
-        input.permission_suggestions as readonly unknown[] | undefined,
-      );
+      result = await evalPromise;
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
       if (isInSubagentContext()) {
         this.markHandled();
         return 'deny';
       }
-      this.escalateToUser(input);
-      return 'passthrough';
+      return this.escalateMain(input);
     }
 
     if (result.decision === 'cancelled') {
@@ -270,8 +456,127 @@ export class AutoApproveGate {
       }
       // second opinion still unsure (escalate/pick) -> ask the user.
     }
-    this.escalateToUser(input);
-    return 'passthrough';
+    return this.escalateMain(input);
+  }
+
+  // -------------------------------------------------------------------------
+  // Part B (#573): slow-eval early push + hold. ISOLATED behind push_hold_timeout.
+  // Everything below is gated by `pushHoldMs > 0`; when it is <= 0 the method
+  // returns null without arming any timer, so removing this block (delete the
+  // method + its single call site, and the call site's `await ... ?? null`
+  // collapses to the plain `await evalPromise`) reverts the gate to A + C only
+  // with no other change.
+  // -------------------------------------------------------------------------
+
+  /**
+   * If a binary main-context eval is slow, push + hold the hook EARLY so the
+   * user can decide while the model keeps thinking (Part B). Returns:
+   *   - null  -> Part B did not fire (disabled, non-binary, subagent context, or
+   *              the eval settled before push_hold_timeout). The caller awaits
+   *              the eval and handles the verdict normally.
+   *   - a resolved PermissionDecision (from the held promise) -> the early hold
+   *     fired; the returned promise is what the hook server is blocked on, and
+   *     the late verdict has been reconciled into that same hold here. The caller
+   *     returns it WITHOUT also awaiting the eval (avoids a double decision).
+   *
+   * The eval/timer race is entirely self-contained so it cannot disturb the A/C
+   * paths: it only ever calls `escalateAndHold` (the shared hold primitive) and
+   * `resolveHeld` / `releaseHeld` to reconcile, with a `pushed` guard so a late
+   * escalate verdict never pushes a second time.
+   */
+  private async maybePushOnSlowEval(
+    input: PermissionRequestHookInput,
+    evalPromise: Promise<AutoApproveResult>,
+  ): Promise<PermissionDecision | null> {
+    const pushHoldMs = this.deps.pushHoldMs ?? 0;
+    // Disabled, or this escalation could not be answered via the hook response
+    // anyway (multi-choice/design), or a subagent prompt the user can't answer:
+    // do not arm the race. Subagent context is read live (it may close before
+    // the verdict), but arming an early USER push for a subagent prompt would be
+    // wrong, so gate on the current value here.
+    if (pushHoldMs <= 0 || !this.isBinaryEscalation(input) || this.deps.isInSubagentContext()) {
+      return null;
+    }
+
+    // Suppress the eval promise's own unhandled-rejection while it races the
+    // timer (we attach the real handler only on the timer-wins branch). The
+    // eval-wins branch returns null and the caller awaits + handles it.
+    const safeEval = evalPromise.then(
+      (r) => ({ ok: true as const, result: r }),
+      (err) => ({ ok: false as const, err }),
+    );
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), pushHoldMs);
+      timer.unref?.();
+    });
+
+    const winner = await Promise.race([safeEval, timeout]);
+    if (winner !== 'timeout') {
+      // The eval settled first: no early push. Clear the timer and let the
+      // caller take the normal path (it re-awaits evalPromise, already resolved).
+      clearTimeout(timer);
+      return null;
+    }
+
+    // The timer won: the eval is still running. Push + hold the hook now so the
+    // user can step in. createHold returns the pending promise the hook server
+    // will block on AND the question id (or passthrough if the push failed /
+    // holding is off).
+    log(`[AutoApprove ${this.sessionTag}] Slow eval (>${pushHoldMs}ms); pushing + holding early`);
+    const { decision: heldDecision, questionId } = this.createHold(input);
+    // We have already pushed. The reconciliation NEVER pushes again — a late
+    // escalate just leaves the existing hold in place (guarded by the
+    // pendingHolds membership check inside reconcileLateVerdict).
+    void this.reconcileLateVerdict(safeEval, questionId);
+    return heldDecision;
+  }
+
+  /**
+   * Reconcile the late verdict of a slow eval into the already-pushed hold
+   * (Part B). The hold was created with `escalateAndHold`; here we resolve it:
+   * approve -> allow, deny -> deny, cancelled -> passthrough. An escalate/pick
+   * verdict (or an eval error) leaves the hold in place — the user is already
+   * looking at the pushed question, so no second push and no change. No-op when
+   * the hold is already gone (the user answered, or it timed out) so there is no
+   * double-resolve.
+   */
+  private async reconcileLateVerdict(
+    safeEval: Promise<{ ok: true; result: AutoApproveResult } | { ok: false; err: unknown }>,
+    qid: UUID | undefined,
+  ): Promise<void> {
+    const outcome = await safeEval;
+    if (!qid || !this.pendingHolds.has(qid)) return; // already resolved/timed out
+    if (!outcome.ok) {
+      // Eval threw: the user is already looking at the pushed question; leave the
+      // hold in place (it fails open on its own timeout if the user never answers).
+      logError(`[AutoApprove ${this.sessionTag}] Slow-eval late error (hold kept):`, outcome.err);
+      return;
+    }
+    const result = outcome.result;
+    if (result.decision === 'approve') {
+      this.resolveHeld(qid, 'allow');
+    } else if (result.decision === 'deny') {
+      this.resolveHeld(qid, 'deny');
+    } else if (result.decision === 'cancelled') {
+      // Claude advanced past the prompt during the slow eval; fail the hold open.
+      this.deps.tracker.clearPending();
+      this.releaseHeld(qid, 'passthrough');
+    }
+    // escalate / pick: already pushed + holding; no double-push, leave as-is.
+  }
+
+  /** Resolve a held hook with an arbitrary decision (incl. passthrough) WITHOUT
+   *  markHandled (used by Part B's cancelled reconciliation, where the verdict
+   *  was not a silent auto-decision). Returns true when a hold existed. */
+  private releaseHeld(questionId: UUID, decision: PermissionDecision): boolean {
+    const hold = this.pendingHolds.get(questionId);
+    if (!hold) return false;
+    clearTimeout(hold.timer);
+    this.pendingHolds.delete(questionId);
+    hold.resolve(decision);
+    return true;
   }
 
   /**
@@ -354,14 +659,18 @@ export class AutoApproveGate {
   /**
    * Safe escalation to the user. Used when inject fails or when auto-approve is off
    * and we're in main context. Wrapped so a bridge/push failure does not leave a
-   * dangling unhandled rejection in the hook handler.
+   * dangling unhandled rejection in the hook handler. Returns the created
+   * `Question.id` so a binary escalation can hold the hook keyed by it (#573);
+   * `undefined` when no question was created (the escalate threw / push failed),
+   * in which case `escalateAndHold` falls open to passthrough.
    */
-  private escalateToUser(input: PermissionRequestHookInput): void {
+  private escalateToUser(input: PermissionRequestHookInput): UUID | undefined {
+    let questionId: UUID | undefined;
     try {
       // escalate() stashes the hook record (onPermissionRequest -> recordPendingHook)
       // FIRST, then onEscalate releases the buffered PTY prompt so the pair+push
       // finds that record. Order matters; do not reorder. #484.
-      this.deps.escalate(input);
+      questionId = this.deps.escalate(input);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalateToUser threw:`, err);
     } finally {
@@ -372,5 +681,6 @@ export class AutoApproveGate {
       // terminal cue (#513, cosmetic); a cue throw must not break the finally.
       this.safeCue('onEscalate', this.deps.onEscalate);
     }
+    return questionId;
   }
 }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -80,6 +80,15 @@ export interface AutoApproveGateDeps {
   /** Called when the verdict is escalate (the user must answer), so the tracker
    *  releases the buffered PTY prompt. #484. */
   onEscalate?: () => void;
+  /** Called when a BINARY escalation HOLDS its hook open (Model B, #573):
+   *  Claude blocks on the hook response, so it never renders the native prompt
+   *  and the tracker's PTY-render push trigger never fires. The gate calls this
+   *  with the held `Question.id` so the tracker pushes that question IMMEDIATELY
+   *  (-> sessionRegistry.addQuestion + APNS), making it answerable. Called ONLY
+   *  in the held branch — passthrough / multi-choice escalations still render the
+   *  PTY and push via `onPTYPromptVisible`, so calling it for them would
+   *  double-push. Absent => no immediate held push (tests / no-AA callers). #573 */
+  onHeldEscalate?: (questionId: UUID) => void;
   /** Called when the permission was auto-approved/denied silently (inject
    *  succeeded; the user never sees it). Drives the terminal "done" cue. #513. */
   onHandled?: () => void;
@@ -239,6 +248,15 @@ export class AutoApproveGate {
     const qid = this.escalateToUser(input);
     const holdMs = this.deps.holdMs ?? 0;
     if (!qid || holdMs <= 0) return { decision: Promise.resolve('passthrough'), questionId: qid };
+    // A held binary escalation BLOCKS Claude's hook response, so Claude never
+    // renders the native prompt and the tracker's PTY-render push trigger never
+    // fires. Push the held question NOW so it is registered in sessionRegistry
+    // (answerable) and pushed to the phone, keyed by the SAME id the hold uses
+    // (#573). safeCue: cosmetic-shielded like the other lifecycle callbacks — a
+    // push failure here must not break the decision path. ONLY here (a real
+    // hold), never on the passthrough/multi-choice branches above (which push
+    // via onPTYPromptVisible and would double-push).
+    this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
     const decision = new Promise<PermissionDecision>((resolve) => {
       const timer = setTimeout(() => {
         // Fail open: the user did not answer within the hold window, so let
@@ -525,10 +543,12 @@ export class AutoApproveGate {
     // will block on AND the question id (or passthrough if the push failed /
     // holding is off).
     log(`[AutoApprove ${this.sessionTag}] Slow eval (>${pushHoldMs}ms); pushing + holding early`);
+    // createHold escalates AND (when a hold is registered) pushes the held
+    // question via onHeldEscalate (#573), so the user can step in immediately.
     const { decision: heldDecision, questionId } = this.createHold(input);
-    // We have already pushed. The reconciliation NEVER pushes again — a late
-    // escalate just leaves the existing hold in place (guarded by the
-    // pendingHolds membership check inside reconcileLateVerdict).
+    // The reconciliation NEVER pushes again — a late escalate just leaves the
+    // existing hold in place (guarded by the pendingHolds membership check
+    // inside reconcileLateVerdict), and pushHeldHook is itself idempotent.
     void this.reconcileLateVerdict(safeEval, questionId);
     return heldDecision;
   }
@@ -601,6 +621,23 @@ export class AutoApproveGate {
     if (!fn) return;
     try {
       fn();
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
+  }
+
+  /**
+   * `safeCue` for a single-argument lifecycle callback (e.g. `onHeldEscalate`,
+   * #573). Same contract: a throw is logged and absorbed so a held-push failure
+   * cannot propagate into the decision/hold path. NOTE the held push IS
+   * load-bearing for answerability, but absorbing a throw here only means the
+   * push is lost — the hold still fails open on its own timeout, which is
+   * strictly safer than letting the throw escape into the hook dispatch loop.
+   */
+  private safeCueWithArg<T>(label: string, fn: ((arg: T) => void) | undefined, arg: T): void {
+    if (!fn) return;
+    try {
+      fn(arg);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
     }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -95,6 +95,18 @@ export interface AutoApproveGateDeps {
   /** Called when the eval ended without a verdict (cancelled — the user already
    *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
   onCancelled?: () => void;
+  /**
+   * Called when a HELD question resolved WITHOUT the user answering it through
+   * the WebSocket/relay answer path (#585, P7): a Part-B slow-eval verdict landed
+   * after the early push (auto_approved/auto_denied), the hold timed out, or
+   * cancelStale released it (cancelled). The daemon broadcasts a `question_resolved`
+   * + fires the APNS dismissal so the pushed card clears on every client. NOT
+   * called for a user answer — that path (input-events.handleAnswer) broadcasts
+   * its own 'answered' resolution, so wiring it here too would double-fire.
+   * Throw-safe at the call site (routed through `safeCueWithArg`), so a broadcast
+   * failure can never break the decision/hold path. Absent => no resolution
+   * broadcast (tests / no-AA callers). */
+  onResolved?: (questionId: UUID, reason: 'auto_approved' | 'auto_denied' | 'cancelled') => void;
   /** Second-opinion model consulted on a primary 'escalate' in main context
    *  (#522). Empty/absent => no second opinion (escalate straight to the user). */
   escalateModel?: string;
@@ -182,6 +194,12 @@ export class AutoApproveGate {
     if (!hold) return false;
     clearTimeout(hold.timer);
     this.pendingHolds.delete(questionId);
+    // Remove the registry entry too (#585, P7 FIX 2): the held question was
+    // registered via pushHeldHook -> addQuestion, so resolving the hold without
+    // this leaves a ghost card that replays on reconnect and lets a late
+    // handleAnswer find it "live" and misroute. The user-answer path also
+    // removes it in handleAnswer's finally; a double-remove is idempotent.
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
     this.markHandled();
     hold.resolve(decision);
     log(
@@ -210,8 +228,13 @@ export class AutoApproveGate {
     log(
       `[AutoApprove ${this.sessionTag}] Releasing ${this.pendingHolds.size} held hook(s) as ${decision} (${reason})`,
     );
-    for (const [, hold] of this.pendingHolds) {
+    for (const [qid, hold] of this.pendingHolds) {
       clearTimeout(hold.timer);
+      // The session is going away (Stop/SessionEnd); dismiss the pushed card on
+      // every client BEFORE resolving so it does not linger after the prompt is
+      // gone (#585, P7), and drop the registry entry so no ghost card replays.
+      this.notifyResolved(qid, 'cancelled');
+      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
       hold.resolve(decision);
     }
     this.pendingHolds.clear();
@@ -265,6 +288,11 @@ export class AutoApproveGate {
         log(
           `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
         );
+        // The pushed card is now stale (Claude will render its own prompt); tell
+        // every client to dismiss it BEFORE failing open (#585, P7), and drop the
+        // registry entry so no ghost card replays. Throw-safe.
+        this.notifyResolved(qid, 'cancelled');
+        this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
         resolve('passthrough');
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;
@@ -575,13 +603,22 @@ export class AutoApproveGate {
       return;
     }
     const result = outcome.result;
+    // Dismiss BEFORE resolving (#585, P7 FIX 5): the broadcast races ahead of
+    // Claude proceeding on the verdict, shrinking the window where Claude has
+    // executed but the card still shows. resolveHeld/releaseHeld then resolve the
+    // hook + drop the registry entry (FIX 2).
     if (result.decision === 'approve') {
+      // The slow verdict landed AFTER the early push, so the card is on screens
+      // the user never needs to act on — dismiss it everywhere (#585, P7).
+      this.notifyResolved(qid, 'auto_approved');
       this.resolveHeld(qid, 'allow');
     } else if (result.decision === 'deny') {
+      this.notifyResolved(qid, 'auto_denied');
       this.resolveHeld(qid, 'deny');
     } else if (result.decision === 'cancelled') {
       // Claude advanced past the prompt during the slow eval; fail the hold open.
       this.deps.tracker.clearPending();
+      this.notifyResolved(qid, 'cancelled');
       this.releaseHeld(qid, 'passthrough');
     }
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
@@ -595,6 +632,10 @@ export class AutoApproveGate {
     if (!hold) return false;
     clearTimeout(hold.timer);
     this.pendingHolds.delete(questionId);
+    // Drop the registry entry so no ghost card replays (#585, P7 FIX 2). The
+    // user-answer path (releaseHeldAsPassthrough -> handleAnswer finally) also
+    // removes it; a double-remove is idempotent.
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
     hold.resolve(decision);
     return true;
   }
@@ -640,6 +681,26 @@ export class AutoApproveGate {
       fn(arg);
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
+  }
+
+  /**
+   * Notify the daemon that a HELD question resolved without a user answer (#585,
+   * P7), so it can broadcast `question_resolved` + dismiss the pushed card on
+   * every client. Throw-safe like the cosmetic cues: a broadcast/push failure is
+   * logged and absorbed so it can never propagate into the decision/hold path.
+   * No-op when no `onResolved` is wired.
+   */
+  private notifyResolved(
+    questionId: UUID,
+    reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+  ): void {
+    const fn = this.deps.onResolved;
+    if (!fn) return;
+    try {
+      fn(questionId, reason);
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] onResolved threw (ignored):`, err);
     }
   }
 

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -15,6 +15,7 @@ import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
 import {
   buildMultiChoicePrompt,
+  isDesignQuestion,
   isMultiChoicePermission,
   parseMultiChoiceDecision,
 } from './multichoice.ts';
@@ -84,6 +85,8 @@ export class AutoApproveService {
   private readonly denyGroups: readonly string[];
   private readonly instructions: string;
   private readonly multichoiceMode: MultiChoiceMode;
+  /** Tool names that always escalate to the user, never auto-decided (#572). */
+  private readonly alwaysEscalateTools: ReadonlySet<string>;
   /** Falls back to llmConfig.model when empty. */
   private readonly multichoiceModel: string;
   /** Second-opinion model on a primary 'escalate' (#522); empty = none. Public
@@ -133,6 +136,7 @@ export class AutoApproveService {
     this.denyGroups = config.deny_groups;
     this.instructions = config.instructions;
     this.multichoiceMode = config.multichoice;
+    this.alwaysEscalateTools = new Set(config.always_escalate_tools);
     this.multichoiceModel = config.multichoice_model;
     this.escalateModel = config.escalate_model;
     this.escalateTimeoutMs = config.escalate_timeout > 0 ? config.escalate_timeout * 1000 : 0;
@@ -272,6 +276,20 @@ export class AutoApproveService {
           this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
         }
         return { decision: 'approve', reasoning, durationMs: 0, model };
+      }
+
+      // Design / plan-mode / long-form questions are never auto-decided by the
+      // LLM (#572): AskUserQuestion, ExitPlanMode, or any tool that structurally
+      // poses a non-binary question. Runs AFTER the deny/allow/group checks
+      // (those are deterministic, explicit user rules and intentionally win),
+      // but BEFORE the queue and the LLM, so it costs zero latency, takes no
+      // eval-queue slot, and never triggers the escalate_model second opinion.
+      // Logged unconditionally (like the deny branches): a structural router
+      // that bypasses the LLM must be traceable even when log_decisions is off.
+      if (isDesignQuestion(toolName, toolInput, permissionSuggestions, this.alwaysEscalateTools)) {
+        const reasoning = `always-escalate (design/plan/long-form), tool=${toolName}; never auto-decided by LLM`;
+        this.logFn(`${prefix} ${toolName}: escalate (0ms) - ${reasoning}`);
+        return { decision: 'escalate', reasoning, durationMs: 0, model };
       }
 
       const isMultiChoice = isMultiChoicePermission(toolName, permissionSuggestions);

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -11,7 +11,11 @@
  *
  * 1. Tool name. `ExitPlanMode` is always multi-choice: the user's intent
  *    (continue planning, accept plan, accept and stop asking) cannot be
- *    derived from tool input, so the LLM should never auto-pick.
+ *    derived from tool input, so the LLM should never auto-pick. (Under the
+ *    default config `ExitPlanMode` is pre-empted even earlier by
+ *    `isDesignQuestion` / `always_escalate_tools` in auto-approve-service.ts;
+ *    this `ALWAYS_MULTI_CHOICE_TOOLS` entry is the fallback if a user removes
+ *    it from that list.)
  * 2. String-label count > 3: a custom plugin tool with 4+ string choices
  *    cannot be expressed in the approve/deny mapping at all.
  * 3. String-label shape: any 2- or 3-label set whose labels are not all
@@ -82,6 +86,76 @@ export function isMultiChoicePermission(
   // the safe escalate path runs.
   // 2- or 3-label lists: binary only when every label is yes/no-shaped.
   return !stringLabels.every(isBinaryShapedLabel);
+}
+
+/**
+ * Keys under which a tool carries a user-facing question in its `tool_input`.
+ * Deliberately narrow — only structured question fields, never a Bash command
+ * string — so a `Bash` command ending in "?" is not mistaken for a question.
+ */
+const QUESTION_INPUT_FIELDS: readonly string[] = ['question', 'questions'];
+
+function isNonEmptyString(v: unknown): boolean {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+/**
+ * A question-bearing value: a non-empty string, or a non-empty array whose
+ * elements are question strings or `{question: string}` objects (the real
+ * AskUserQuestion shape). A bare array of numbers / null / `{}` is NOT a
+ * question, so a custom tool with an unrelated field named `questions` is not
+ * mis-escalated.
+ */
+function isQuestionLike(v: unknown): boolean {
+  if (isNonEmptyString(v)) return true;
+  if (Array.isArray(v)) {
+    return v.some(
+      (item) =>
+        isNonEmptyString(item) ||
+        (item !== null &&
+          typeof item === 'object' &&
+          isNonEmptyString((item as { question?: unknown }).question)),
+    );
+  }
+  return false;
+}
+
+function hasQuestionField(toolInput: Record<string, unknown> | null | undefined): boolean {
+  if (!toolInput) return false;
+  return QUESTION_INPUT_FIELDS.some((key) => isQuestionLike(toolInput[key]));
+}
+
+/**
+ * True when a permission must ALWAYS go to the human — a design / plan-mode /
+ * long-form question the binary approve/deny path cannot answer and the LLM
+ * must never auto-decide (#572). Two layers:
+ *
+ * 1. Tool-name allowlist (`alwaysEscalateTools`, default
+ *    `DEFAULT_ALWAYS_ESCALATE_TOOLS` in types.ts plus any user-configured
+ *    names): definitionally user-intent tools. Immune to tool_input shape drift.
+ * 2. Free-text heuristic: a tool that structurally carries a question field
+ *    (see `QUESTION_INPUT_FIELDS`) whose suggestions are not all yes/no-shaped
+ *    is a long-form question with no binary mapping. Catches MCP / custom tools
+ *    that mimic AskUserQuestion without being on the allowlist.
+ *
+ * Evaluated BEFORE any LLM call so the outcome is structural (not a model
+ * guess), costs zero latency, takes no eval-queue slot, and never triggers the
+ * escalate_model second opinion.
+ */
+export function isDesignQuestion(
+  toolName: string,
+  toolInput: Record<string, unknown> | null | undefined,
+  permissionSuggestions: readonly unknown[] | null | undefined,
+  alwaysEscalateTools: ReadonlySet<string>,
+): boolean {
+  if (alwaysEscalateTools.has(toolName)) return true;
+  if (!hasQuestionField(toolInput)) return false;
+  const stringLabels = Array.isArray(permissionSuggestions)
+    ? permissionSuggestions.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  // A question with no binary-shaped suggestions has no approve/deny mapping —
+  // the user must select or type a long-form answer.
+  return stringLabels.length === 0 || !stringLabels.every(isBinaryShapedLabel);
 }
 
 const MULTI_CHOICE_SYSTEM_PROMPT = `You are a permission evaluator for Claude Code, an AI coding assistant running inside Remi (a remote monitoring tool).

--- a/packages/daemon/src/auto-approve/multichoice.ts
+++ b/packages/daemon/src/auto-approve/multichoice.ts
@@ -12,7 +12,7 @@
  * 1. Tool name. `ExitPlanMode` is always multi-choice: the user's intent
  *    (continue planning, accept plan, accept and stop asking) cannot be
  *    derived from tool input, so the LLM should never auto-pick. (Under the
- *    default config `ExitPlanMode` is pre-empted even earlier by
+ *    default config `ExitPlanMode` is preempted even earlier by
  *    `isDesignQuestion` / `always_escalate_tools` in auto-approve-service.ts;
  *    this `ALWAYS_MULTI_CHOICE_TOOLS` entry is the fallback if a user removes
  *    it from that list.)
@@ -104,7 +104,7 @@ function isNonEmptyString(v: unknown): boolean {
  * elements are question strings or `{question: string}` objects (the real
  * AskUserQuestion shape). A bare array of numbers / null / `{}` is NOT a
  * question, so a custom tool with an unrelated field named `questions` is not
- * mis-escalated.
+ * wrongly escalated.
  */
 function isQuestionLike(v: unknown): boolean {
   if (isNonEmptyString(v)) return true;

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -186,4 +186,30 @@ export interface AutoApproveConfig {
    * non-binary suggestions. See `DEFAULT_ALWAYS_ESCALATE_TOOLS`.
    */
   readonly always_escalate_tools: readonly string[];
+  /**
+   * Seconds the daemon HOLDS a BINARY main-context PermissionRequest hook open
+   * after escalating to the user, instead of returning passthrough immediately
+   * (Model B, #573). Claude blocks on the held hook (no native prompt rendered)
+   * until the user answers from any channel — the answer resolves the hook to
+   * allow/deny with no PTY render and no warm-connection race. On expiry the
+   * hold fails open to passthrough (Claude renders its native prompt), so the
+   * terminal is never permanently stuck. A human answers here and may be busy,
+   * so the default is large + human-paced (1800s). 0 disables holding entirely
+   * (escalate -> passthrough, the pre-#573 behavior). Only binary main-context
+   * escalations hold; multi-choice / design escalations always passthrough (the
+   * hook response cannot express a pick). The registered PermissionRequest hook
+   * timeout (hook-config-manager.ts) is kept >= this so Claude does not give up
+   * on the hook before the hold does.
+   */
+  readonly hold_timeout: number;
+  /**
+   * Seconds before a SLOW eval triggers an early push + hold (Part B, #573). If
+   * a binary main-context eval has not produced a verdict within this window,
+   * the daemon pushes the question and holds the hook so the user can step in
+   * while the model keeps thinking; a late approve/deny then resolves the held
+   * hook (no double-push). 0 disables Part B entirely — behavior reverts to the
+   * plain hold-on-escalate path (A+C only). Default 60. Kept well below
+   * `hold_timeout` so the early-push window opens before the hold itself expires.
+   */
+  readonly push_hold_timeout: number;
 }

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -59,6 +59,15 @@ export type AutoApproveResult = AutoApproveDecisionResult | AutoApproveCancelled
 /** How auto-approve treats multi-choice permission prompts (#399). */
 export type MultiChoiceMode = 'skip' | 'evaluate';
 
+/**
+ * Tools whose invocation is, by definition, a request for user intent the
+ * auto-approve LLM must never answer (#572): `AskUserQuestion` (Claude
+ * explicitly solicited the user) and `ExitPlanMode` (plan-mode accept /
+ * keep-planning is a direction decision). Default for
+ * `AutoApproveConfig.always_escalate_tools`.
+ */
+export const DEFAULT_ALWAYS_ESCALATE_TOOLS: readonly string[] = ['AskUserQuestion', 'ExitPlanMode'];
+
 /** Configuration for the auto-approve feature */
 export interface AutoApproveConfig {
   readonly enabled: boolean;
@@ -164,4 +173,17 @@ export interface AutoApproveConfig {
    * has no knob to disable reasoning).
    */
   readonly disable_thinking: boolean;
+  /**
+   * Tool names that ALWAYS escalate to the user and are NEVER auto-decided by
+   * the LLM (#572) — design / plan-mode / long-form questions whose answers are
+   * not yes/no. Matched by tool name BEFORE any LLM call, so it costs zero
+   * latency, takes no eval-queue slot, and never triggers the escalate_model
+   * second opinion. Explicit `deny`/`allow` rules are deterministic and still
+   * checked first, so a user can override this for a specific tool.
+   * Default: ["AskUserQuestion", "ExitPlanMode"]. Extend with
+   * custom MCP tools that solicit user intent. A free-text heuristic also
+   * escalates any tool that structurally carries a question field with
+   * non-binary suggestions. See `DEFAULT_ALWAYS_ESCALATE_TOOLS`.
+   */
+  readonly always_escalate_tools: readonly string[];
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -95,6 +95,7 @@ loadDotenvFile();
 import {
   createDaemonUpdateAvailable,
   createHelloAck,
+  createQuestionResolved,
   createReplayBatch,
   createSessionListResponse,
   createSessionUpdate,
@@ -143,6 +144,7 @@ import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookServer } from './hooks/index.ts';
+import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
@@ -856,6 +858,11 @@ const binderClosers: Map<UUID, () => void> = new Map();
 // (multi-session daemons). Populated in createNewSession after setupHookBridge;
 // removed on session close. Empty when no hookServer is configured.
 const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
+// Per-session APNS dispatchers (#585, P7), keyed by sessionId, so the
+// question-resolved path can fire a quiet lock-screen dismissal through the same
+// device-token fan-out that pushed the card. Populated in createNewSession;
+// removed on session close.
+const sessionNotifiers: Map<UUID, NotificationDispatcher> = new Map();
 const sessionStore = new SessionStore();
 // Tracks the subagent chats the primary session spawns, so the client can
 // switch the displayed view to a subagent (epic #499 phase 3). Shared by the
@@ -894,6 +901,8 @@ const sessionRegistry = new SessionRegistry(
       // Drop the per-session gate handle (#573); any held hook was already
       // released by the gate's closeBinder/cancelStale on teardown.
       sessionGateHandles.delete(sessionId);
+      // Drop the per-session APNS dispatcher (#585, P7).
+      sessionNotifiers.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();
@@ -1081,7 +1090,7 @@ async function createNewSession(
   passThrough = false,
   reservedRows = 0,
 ): Promise<PTYSession> {
-  const { messageApi, sendAndRecord } = createMessageApiForSession(
+  const { messageApi, sendAndRecord, notifications } = createMessageApiForSession(
     {
       sessionRegistry,
       transcriptWatchers,
@@ -1109,6 +1118,9 @@ async function createNewSession(
     },
     sessionId,
   );
+  // Register this session's APNS dispatcher so the question-resolved path can
+  // dismiss a pushed card through the same device-token fan-out (#585, P7).
+  sessionNotifiers.set(sessionId, notifications);
 
   // PTY output parser: streamStatusOnly suppresses regular agent content (comes
   // from transcript). Tool-output errors (e.g. "OAuth token revoked") bypass the
@@ -1183,6 +1195,9 @@ async function createNewSession(
         alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),
         holdTimeoutSec: remiConfig.auto_approve.hold_timeout,
         pushHoldTimeoutSec: remiConfig.auto_approve.push_hold_timeout,
+        // #585: a held question the gate resolves without a user answer dismisses
+        // its pushed card on every client.
+        broadcastQuestionResolved: onQuestionResolved,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1294,6 +1309,37 @@ const registry = new AdapterRegistry({
   },
 });
 
+/**
+ * Cross-client question dismissal (#585, P7). Fired when a pending question stops
+ * being pending on ANY channel: (a) answered locally (input-events.handleAnswer,
+ * reason 'answered'), or (b) resolved by the auto-approve gate without a user
+ * answer (Part-B late verdict / hold timeout / cancelStale, reason
+ * 'auto_approved'/'auto_denied'/'cancelled'). It does TWO throw-safe things:
+ *   1. Broadcast `question_resolved` to every connected client so each dismisses
+ *      its card (in-app, over the WebSocket / Telegram via the AdapterRegistry).
+ *   2. Fire a quiet APNS dismissal through this session's NotificationDispatcher
+ *      (apns-collapse-id = questionId, content-available) so a suspended device's
+ *      lock-screen card is cleared.
+ * Each step is independently guarded so a failure in one never blocks the other,
+ * and neither can propagate into the answer handler or the gate decision.
+ */
+const onQuestionResolved = (
+  sessionId: UUID,
+  questionId: UUID,
+  reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled',
+): void => {
+  try {
+    registry.broadcast(createQuestionResolved(sessionId, questionId, reason));
+  } catch (err) {
+    logError(`[QuestionResolved] broadcast failed for ${questionId}: ${errorToString(err)}`);
+  }
+  try {
+    sessionNotifiers.get(sessionId)?.dismiss(sessionId, questionId);
+  } catch (err) {
+    logError(`[QuestionResolved] APNS dismissal failed for ${questionId}: ${errorToString(err)}`);
+  }
+};
+
 import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
@@ -1319,6 +1365,10 @@ const inputHandlers: InputHandlers = createInputHandlers({
   releaseHeldAsPassthrough: (sessionId, questionId) =>
     sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
   cancelAutoApprove: (sessionId, reason) => sessionGateHandles.get(sessionId)?.cancelStale(reason),
+  // #585: a locally answered question dismisses its card + lock-screen push on
+  // every other client.
+  onQuestionResolved: (sessionId, questionId) =>
+    onQuestionResolved(sessionId, questionId, 'answered'),
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.11'; // REMI_COMPILED_VERSION
+      return '0.6.12-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.11'; // REMI_COMPILED_VERSION
+    return '0.6.12-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -97,6 +97,7 @@ import {
   createHelloAck,
   createReplayBatch,
   createSessionListResponse,
+  createSessionUpdate,
   generateId,
 } from '@remi/shared';
 import type { ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
@@ -1209,6 +1210,17 @@ async function createNewSession(
     messageApi,
     locallyOwned,
   );
+
+  // #576: give clients a defined pill state from the first hello_ack. Without
+  // this, no status reaches the client until the first hook fires (Claude can
+  // take tens of seconds to its first PreToolUse), so the session shows no
+  // signal. Recorded via sendAndRecord so a client that connects later replays
+  // it. Wrapped so a send hiccup can never abort session creation.
+  try {
+    sendAndRecord(createSessionUpdate(sessionId, 'starting'));
+  } catch (err) {
+    logError(`[Session ${sessionId}] Failed to emit starting status:`, err);
+  }
 
   // If the spawn or any post-spawn wiring throws, mark the pre-saved
   // store entry as exited so sibling daemons reading the store don't

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.12-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.12-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.12-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.12-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.12-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.12-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.12-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.12-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1380,6 +1380,11 @@ const sharedEvents = {
   ...transcriptHandlers,
   ...createSessionHandlers_,
   ...resumeSessionHandlers,
+  // Expose the shared answer core under the adapter's relay event name (#575,
+  // P4a). The HTTP /answer endpoint routes through the SAME logic as the
+  // WebSocket onAnswer, just reporting a structured outcome instead of an
+  // over-the-connection error frame.
+  onAnswerRelay: inputHandlers.relayAnswer,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.12-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.12-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.12-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.12-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -153,6 +153,7 @@ import {
   SessionRegistryFile,
   SessionStore,
   type StoredSession,
+  TranscriptIndex,
 } from './session/index.ts';
 import { findAvailableTcpPort } from './session/port-utils.ts';
 import { TranscriptDiscovery, type TranscriptWatcher } from './transcript/index.ts';
@@ -863,7 +864,12 @@ const subagentViews = new SubagentViewRegistry();
 // Single binding accessor for the whole daemon (#460 phase 2): the one typed,
 // disk-backed surface for remiUUID<->claudeSessionId. Every binding read/write +
 // both resume resolvers route through it. No cache — see session-binding-store.ts.
-const bindingStore = new SessionBindingStore(sessionStore);
+// Durable, long-TTL remiUUID -> {claudeSessionId, projectPath} index (#577). Not
+// subject to sessions.json's 100-entry cap or 7-day purge, so a transcript_load
+// for an older session still resolves after the liveness store has dropped it.
+// The binding store mirrors every preAssign/update write into it.
+const transcriptIndex = new TranscriptIndex();
+const bindingStore = new SessionBindingStore(sessionStore, transcriptIndex);
 
 const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
@@ -1339,6 +1345,7 @@ const transcriptHandlers: TranscriptHandlers = createTranscriptHandlers({
   transcriptDiscovery,
   transcriptWatchers,
   bindingStore,
+  transcriptIndex,
   currentOwnedSession,
   subagentViews,
   send: sendToConnection,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1193,8 +1193,12 @@ async function createNewSession(
         // #573: classify holdable escalations + the hold / slow-eval-push budgets
         // (seconds; the gate converts to ms and treats <=0 as disabled).
         alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),
-        holdTimeoutSec: remiConfig.auto_approve.hold_timeout,
-        pushHoldTimeoutSec: remiConfig.auto_approve.push_hold_timeout,
+        // Guard on AA being enabled (mirrors permissionHookHoldTimeoutSec): with
+        // no auto-approve service the gate must NOT hold a binary escalation —
+        // that would block Claude until the hook timeout instead of rendering the
+        // native prompt immediately (the pre-0.6.12 behavior). 0 => no hold.
+        holdTimeoutSec: autoApproveService ? remiConfig.auto_approve.hold_timeout : 0,
+        pushHoldTimeoutSec: autoApproveService ? remiConfig.auto_approve.push_hold_timeout : 0,
         // #585: a held question the gate resolves without a user answer dismisses
         // its pushed card on every client.
         broadcastQuestionResolved: onQuestionResolved,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -131,6 +131,7 @@ import {
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { setupHookBridge } from './cli/session-phases/hook-bridge-setup.ts';
+import type { SessionGateHandle } from './cli/session-phases/hook-bridge-setup.ts';
 import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
 import { createPtySessionForSession } from './cli/session-phases/pty-session-setup.ts';
 import { StatusBar, childRows } from './cli/status-bar.ts';
@@ -795,6 +796,18 @@ let autoApproveService: AutoApproveService | null = null;
 // the StatusWriter (see the gate cue wiring in setupHookBridge); it replaced the
 // shared title-bar TerminalIndicator, which raced under concurrent evals.
 
+/**
+ * Seconds to pass HookConfigManager as the PermissionRequest hold budget (#573):
+ * the configured `hold_timeout` when auto-approve is actually enabled (so the
+ * registered hook timeout outlasts a long human-paced hold), else 0 (the
+ * baseline 600s ceiling, since a non-AA daemon never holds — it passes through
+ * near-instantly). Keeps the hook timeout from being needlessly inflated when
+ * holding can't happen.
+ */
+function permissionHookHoldTimeoutSec(): number {
+  return autoApproveService ? remiConfig.auto_approve.hold_timeout : 0;
+}
+
 // ---------------------------------------------------------------------------
 // SIGTSTP / Ctrl+Z handling.
 //
@@ -836,6 +849,11 @@ const transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>> = new 
 // interval (it lives inside the binder); close() reaches all three. Empty when
 // transcript_binder_enabled is off (no binder is ever constructed).
 const binderClosers: Map<UUID, () => void> = new Map();
+// Per-session auto-approve gate handles (#573): resolveHeld + cancelStale, keyed
+// by sessionId, so the WebSocket answer handler reaches the RIGHT session's gate
+// (multi-session daemons). Populated in createNewSession after setupHookBridge;
+// removed on session close. Empty when no hookServer is configured.
+const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
 const sessionStore = new SessionStore();
 // Tracks the subagent chats the primary session spawns, so the client can
 // switch the displayed view to a subagent (epic #499 phase 3). Shared by the
@@ -866,6 +884,9 @@ const sessionRegistry = new SessionRegistry(
       // for the rest of the daemon's life across resumes (#463 phase 3 review).
       binderClosers.get(sessionId)?.();
       binderClosers.delete(sessionId);
+      // Drop the per-session gate handle (#573); any held hook was already
+      // released by the gate's closeBinder/cancelStale on teardown.
+      sessionGateHandles.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
       if (watcher) {
         watcher.stop();
@@ -1150,6 +1171,11 @@ async function createNewSession(
         transcriptDiscovery,
         subagentViews,
         statusWriter,
+        // #573: classify holdable escalations + the hold / slow-eval-push budgets
+        // (seconds; the gate converts to ms and treats <=0 as disabled).
+        alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),
+        holdTimeoutSec: remiConfig.auto_approve.hold_timeout,
+        pushHoldTimeoutSec: remiConfig.auto_approve.push_hold_timeout,
       },
       { hookServer, sessionId, workingDirectory, messageApi, sendAndRecord, tracker },
     );
@@ -1157,6 +1183,9 @@ async function createNewSession(
     // its start() inside setupHookBridge); record its teardown so cleanup()
     // reaches the rotation dir-poll interval the shared maps below cannot.
     if (binderEnabled) binderClosers.set(sessionId, hookBridgeHandle.closeBinder);
+    // Register the per-session gate handle (#573) so the WebSocket answer path
+    // can resolve a held permission / cancel the eval for this exact session.
+    sessionGateHandles.set(sessionId, hookBridgeHandle.gate);
   }
 
   const ptySession = createPtySessionForSession(
@@ -1264,6 +1293,14 @@ const inputHandlers: InputHandlers = createInputHandlers({
   sessionRegistry,
   bindingStore,
   send: sendToConnection,
+  // #573: route a held-permission answer / release-to-passthrough / eval-cancel
+  // to the RIGHT session's gate (the map is populated per session in
+  // createNewSession).
+  resolveHeldPermission: (sessionId, questionId, decision) =>
+    sessionGateHandles.get(sessionId)?.resolveHeld(questionId, decision) ?? false,
+  releaseHeldAsPassthrough: (sessionId, questionId) =>
+    sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
+  cancelAutoApprove: (sessionId, reason) => sessionGateHandles.get(sessionId)?.cancelStale(reason),
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({
@@ -1672,7 +1709,11 @@ if (cliDaemonMode) {
 
   if (hookServer) {
     try {
-      hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
+      hookConfigManager = new HookConfigManager(
+        workingDirectory,
+        hookServer.url,
+        permissionHookHoldTimeoutSec(),
+      );
       await hookConfigManager.install();
     } catch (err) {
       const msg = errorToString(err);
@@ -1865,7 +1906,11 @@ if (cliDaemonMode) {
     log(`Hook server listening on ${hookServer.url} (port ${HOOK_PORT})`);
 
     // Configure Claude Code hooks to POST to our server
-    hookConfigManager = new HookConfigManager(workingDirectory, hookServer.url);
+    hookConfigManager = new HookConfigManager(
+      workingDirectory,
+      hookServer.url,
+      permissionHookHoldTimeoutSec(),
+    );
     await hookConfigManager.install();
     log('[Hooks] Claude Code hooks configured');
   } catch (err) {

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -51,6 +51,16 @@ export interface InputHandlerDeps {
    * in-flight eval. Session-keyed.
    */
   cancelAutoApprove?: (sessionId: UUID, reason: string) => void;
+  /**
+   * Cross-client question dismissal (#585, P7). Called after a question is
+   * answered here so the daemon broadcasts `question_resolved` to every client and
+   * fires the APNS dismissal — answering on one device clears the card (and the
+   * lock-screen notification) on the others. Fired ONCE per answered question, on
+   * the delivered path only (not for stale/session-not-found/stale-binding, where
+   * nothing was consumed). Must be throw-safe: a broadcast failure must never
+   * break answer handling. Absent => no dismissal broadcast (tests/old callers).
+   */
+  onQuestionResolved?: (sessionId: UUID, questionId: UUID) => void;
 }
 
 /**
@@ -177,6 +187,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     resolveHeldPermission,
     releaseHeldAsPassthrough,
     cancelAutoApprove,
+    onQuestionResolved,
   } = deps;
 
   /**
@@ -310,6 +321,16 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // Remove only the answered question; sibling prompts remain answerable.
       // In `finally` so a throwing submit cannot leave a zombie question.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
+      // Cross-client dismissal (#585, P7): tell every client this question is
+      // resolved so its card clears and the lock-screen push is dismissed.
+      // Throw-safe: a broadcast/push failure must never break answer handling,
+      // and it lives in `finally` so even a throwing submit still clears the card
+      // (the question was consumed). Idempotent on the client side.
+      try {
+        onQuestionResolved?.(session.sessionId, questionId);
+      } catch (err) {
+        logError(`[Answer] question_resolved broadcast failed: ${errorToString(err)}`);
+      }
     }
     return 'delivered';
   }

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -112,10 +112,23 @@ function guardBinding(
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 /**
- * Map a chosen answer string to a binary allow/deny decision via the active
- * Question's options (#573). The answer the client sends is an option `value`
- * (e.g. "1"/"2"/"3" or "y"/"n"); we find the matching option and read its
- * `isYes` / `isNo` flags. Returns:
+ * Resolve an incoming answer string to the active Question's matching option
+ * (#574). The phone now sends the option LABEL for display (e.g. "Yes", "Yes,
+ * always", "No") rather than only the numeric `value` ("1"/"2"/"3"), so match
+ * EITHER field. The in-app WebSocket path may still send a `value`; both
+ * resolve to the same option. Returns the option, or undefined for a free-text
+ * answer that matches neither.
+ */
+function resolveOption(
+  options: readonly QuestionOption[],
+  answer: string,
+): QuestionOption | undefined {
+  return options.find((o) => o.value === answer || o.label === answer);
+}
+
+/**
+ * Map a resolved option to a binary allow/deny decision (#573). Reads the
+ * option's `isYes` / `isNo` flags. Returns:
  *   - 'deny' for a no-shaped option;
  *   - 'allow' for a yes-shaped option ONLY when it is a one-time "Yes" — an
  *     "always"-shaped label ("Yes, always") is NOT mapped, because the binary
@@ -123,13 +136,13 @@ export type InputHandlers = ReturnType<typeof createInputHandlers>;
  *     session-wide "always" the user picked. Downgrading it to a one-time allow
  *     would silently lose that choice, so it returns null and the caller takes
  *     the native PTY path (which can express "always" via the digit);
- *   - null otherwise (always-shaped, unknown value, or free text) -> PTY path.
+ *   - null otherwise (always-shaped, unknown value/label, or free text) -> PTY path.
  */
 function mapAnswerToDecision(
   options: readonly QuestionOption[],
   answer: string,
 ): 'allow' | 'deny' | null {
-  const option = options.find((o) => o.value === answer);
+  const option = resolveOption(options, answer);
   if (!option) return null;
   if (option.isNo) return 'deny';
   // "always" cannot be expressed in the binary hook response, so a yes-shaped
@@ -252,7 +265,22 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         // then submit the digit. If no hold, this is the normal PTY path.
         const released = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
         hadHold = hadHold || released;
-        await session.pty.submitInput(answer);
+        // The phone may send a label for display (#574), but Claude's native
+        // numbered prompt expects the option's VALUE (the 1-based index). Resolve
+        // the answer back to its option and submit the index; a free-text answer
+        // (no option match) is submitted verbatim.
+        const ptyInput = resolveOption(active.options, answer)?.value ?? answer;
+        if (ptyInput !== answer) {
+          log(`[Answer] resolved "${answer}" -> "${ptyInput}" for q ${questionId.slice(0, 8)}`);
+        } else if (
+          active.options.length > 0 &&
+          resolveOption(active.options, answer) === undefined
+        ) {
+          log(
+            `[Answer] "${answer}" matched no option (${active.options.length}); submitting verbatim`,
+          );
+        }
+        await session.pty.submitInput(ptyInput);
       } else {
         log(
           `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -10,7 +10,7 @@
  */
 
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
-import type { UUID } from '@remi/shared';
+import type { QuestionOption, UUID } from '@remi/shared';
 
 import type { SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
@@ -20,6 +20,37 @@ export interface InputHandlerDeps {
   sessionRegistry: SessionRegistry;
   bindingStore: SessionBindingStore;
   send: SendToConnection;
+  /**
+   * Resolve a HELD binary PermissionRequest hook with the user's answer (Model
+   * B, #573), routed to the gate for `sessionId`. Returns true when a hold
+   * existed and was resolved — `onAnswer` then SKIPS the PTY inject (Claude is
+   * blocked on the hook, not rendering a prompt). Absent / false => the answer
+   * takes the existing PTY-submit path (multi-choice pick, non-AA session, or
+   * Part-B-disabled escalation that passed through). Session-keyed by cli.ts.
+   */
+  resolveHeldPermission?: (
+    sessionId: UUID,
+    questionId: UUID,
+    decision: 'allow' | 'deny',
+  ) => boolean;
+  /**
+   * Release a HELD binary PermissionRequest hook to 'passthrough' for `sessionId`
+   * (#573) when the user's answer cannot be expressed by the binary hook
+   * response — a "Yes, always" or a multi-choice pick. Claude then renders its
+   * native numbered prompt and `onAnswer` submits the digit (the only way to
+   * express "always" / a specific pick). Returns true iff a hold existed.
+   * Session-keyed by cli.ts.
+   */
+  releaseHeldAsPassthrough?: (sessionId: UUID, questionId: UUID) => boolean;
+  /**
+   * Cancel the in-flight auto-approve eval (and release holds) for `sessionId`
+   * when the user answers a HELD permission from any channel (#573, issue 2): a
+   * stale eval would otherwise keep running and could inject a phantom decision.
+   * Fired ONLY when a hold was actually resolved/released, so answering an
+   * unrelated passthrough question does not abort a different binary permission's
+   * in-flight eval. Session-keyed.
+   */
+  cancelAutoApprove?: (sessionId: UUID, reason: string) => void;
 }
 
 /**
@@ -80,8 +111,42 @@ function guardBinding(
 
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
+/**
+ * Map a chosen answer string to a binary allow/deny decision via the active
+ * Question's options (#573). The answer the client sends is an option `value`
+ * (e.g. "1"/"2"/"3" or "y"/"n"); we find the matching option and read its
+ * `isYes` / `isNo` flags. Returns:
+ *   - 'deny' for a no-shaped option;
+ *   - 'allow' for a yes-shaped option ONLY when it is a one-time "Yes" — an
+ *     "always"-shaped label ("Yes, always") is NOT mapped, because the binary
+ *     PermissionRequest hook response can only express allow/deny, never the
+ *     session-wide "always" the user picked. Downgrading it to a one-time allow
+ *     would silently lose that choice, so it returns null and the caller takes
+ *     the native PTY path (which can express "always" via the digit);
+ *   - null otherwise (always-shaped, unknown value, or free text) -> PTY path.
+ */
+function mapAnswerToDecision(
+  options: readonly QuestionOption[],
+  answer: string,
+): 'allow' | 'deny' | null {
+  const option = options.find((o) => o.value === answer);
+  if (!option) return null;
+  if (option.isNo) return 'deny';
+  // "always" cannot be expressed in the binary hook response, so a yes-shaped
+  // "always" option must NOT collapse to a one-time allow.
+  if (option.isYes && !option.label.toLowerCase().includes('always')) return 'allow';
+  return null;
+}
+
 export function createInputHandlers(deps: InputHandlerDeps) {
-  const { sessionRegistry, bindingStore, send } = deps;
+  const {
+    sessionRegistry,
+    bindingStore,
+    send,
+    resolveHeldPermission,
+    releaseHeldAsPassthrough,
+    cancelAutoApprove,
+  } = deps;
 
   return {
     onUserInput: async (
@@ -168,7 +233,39 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         return;
       }
 
-      await session.pty.submitInput(answer);
+      // Model B (#573): if the auto-approve gate is HOLDING this permission's
+      // hook, a binary (one-time Yes / No) answer resolves it via the hook
+      // response — Claude is blocked on the hook and is NOT rendering a prompt,
+      // so a PTY submit would land in the wrong place. An answer the binary
+      // response cannot express ("Yes, always", a multi-choice pick, free text)
+      // first RELEASES the held hook to passthrough so Claude renders its native
+      // numbered prompt, then submits the digit (the only way to express
+      // "always" / a specific pick).
+      const decision = mapAnswerToDecision(active.options, answer);
+      let hadHold = false;
+      if (decision !== null) {
+        hadHold = resolveHeldPermission?.(session.sessionId, questionId, decision) ?? false;
+      }
+      if (!hadHold) {
+        // decision === null (always/pick/free-text) OR no hold for this question:
+        // if a hold exists, pop it to passthrough so the native prompt renders,
+        // then submit the digit. If no hold, this is the normal PTY path.
+        const released = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
+        hadHold = hadHold || released;
+        await session.pty.submitInput(answer);
+      } else {
+        log(
+          `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,
+        );
+      }
+
+      // Cancel the in-flight eval ONLY when a held permission was actually
+      // resolved/released (#573, issue 2): a stale verdict for THIS permission
+      // must not inject a phantom decision. Answering an unrelated passthrough
+      // question must NOT abort a different binary permission's eval, so this is
+      // gated on hadHold rather than firing on every answer.
+      if (hadHold) cancelAutoApprove?.(session.sessionId, 'user-answered');
+
       // Remove only the answered question; sibling prompts remain answerable.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
     },

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -109,6 +109,17 @@ function guardBinding(
   return false;
 }
 
+/**
+ * Outcome of routing an answer to a pending Question. Returned by the shared
+ * answer core so the connection-independent HTTP `/answer` relay (#575, P4a)
+ * can map it to a clear JSON status without re-implementing the routing logic.
+ *   - `delivered`     — the answer was resolved via the held hook OR submitted to the PTY.
+ *   - `session-not-found` — no session matched the sessionId/connectionId.
+ *   - `stale-binding` — the Claude session this answer targeted has rotated.
+ *   - `stale`         — the question is no longer active (already answered/auto-approved).
+ */
+export type AnswerOutcome = 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+
 export type InputHandlers = ReturnType<typeof createInputHandlers>;
 
 /**
@@ -125,6 +136,13 @@ function resolveOption(
 ): QuestionOption | undefined {
   return options.find((o) => o.value === answer || o.label === answer);
 }
+
+/**
+ * No-op `send` for the connection-independent `/answer` relay (#575, P4a),
+ * which has no WebSocket connection to write error frames to. The relay reports
+ * status via its `AnswerOutcome` return value instead.
+ */
+const noopSend: SendToConnection = () => false;
 
 /**
  * Map a resolved option to a binary allow/deny decision (#573). Reads the
@@ -161,80 +179,68 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     cancelAutoApprove,
   } = deps;
 
-  return {
-    onUserInput: async (
-      connectionId: UUID,
-      sessionId: UUID,
-      content: string,
-      raw?: boolean,
-      claudeSessionId?: UUID,
-    ): Promise<void> => {
-      log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
+  /**
+   * Shared answer-routing core for both the WebSocket `onAnswer` event and the
+   * HTTP `/answer` relay (#575, P4a). Resolves a held permission hook (Model B),
+   * releases to passthrough + submits a PTY digit for picks / "always", or
+   * submits free text — then cancels the in-flight eval and removes the
+   * question. Returns the outcome; the WebSocket path additionally surfaces
+   * errors over the connection via `send` (suppressed when `viaRelay`).
+   */
+  async function handleAnswer(
+    connectionId: UUID,
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId: UUID | undefined,
+    viaRelay = false,
+  ): Promise<AnswerOutcome> {
+    log(
+      `Answer ${viaRelay ? '(relay) ' : ''}from ${connectionId} for session ${sessionId}: ${answer}`,
+    );
 
-      const session = sessionRegistry.getSessionForConnection(connectionId);
-      if (!session) {
-        log(`No session found for connection ${connectionId}`);
-        return;
-      }
-
-      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
-        return;
-      }
-
-      if (raw) {
-        // Raw terminal input from attach client: write directly without Enter
-        try {
-          session.pty.write(content);
-        } catch (err) {
-          log(`[PTY] raw write failed: ${errorToString(err)}`);
-        }
-        return;
-      }
-
-      // Structured input from web/mobile client: append Enter
-      await session.pty.submitInput(content);
-    },
-
-    onAnswer: async (
-      connectionId: UUID,
-      sessionId: UUID,
-      questionId: UUID,
-      answer: string,
-      claudeSessionId?: UUID,
-    ): Promise<void> => {
-      log(`Answer from ${connectionId} for session ${sessionId}: ${answer}`);
-
-      // Prefer lookup by sessionId (from push-action answers) so reconnected clients
-      // can answer even before the connection is fully mapped in the registry.
-      const session =
-        sessionRegistry.getSession(sessionId) ??
-        sessionRegistry.getSessionForConnection(connectionId);
-      if (!session) {
-        log(`No session found for connection ${connectionId} or session ${sessionId}`);
+    // Prefer lookup by sessionId (from push-action answers) so reconnected clients
+    // can answer even before the connection is fully mapped in the registry.
+    const session =
+      sessionRegistry.getSession(sessionId) ??
+      sessionRegistry.getSessionForConnection(connectionId);
+    if (!session) {
+      log(`No session found for connection ${connectionId} or session ${sessionId}`);
+      if (!viaRelay) {
         send(
           connectionId,
           createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
         );
-        return;
       }
+      return 'session-not-found';
+    }
 
-      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
-        return;
-      }
+    if (
+      !guardBinding(
+        bindingStore,
+        viaRelay ? noopSend : send,
+        connectionId,
+        sessionId,
+        claudeSessionId,
+      )
+    ) {
+      return 'stale-binding';
+    }
 
-      // Drop stale answers. APNS tokens persist across disconnect (#286), so a
-      // delayed lock-screen tap can deliver an answer for a question that has
-      // since been auto-approved or resolved. Membership in the pending set
-      // (not equality with a single slot) is the check, so answering one of
-      // several concurrent prompts (main + subagent, #419) never invalidates
-      // the others. Surface the drop so the iOS user gets a "not delivered"
-      // signal instead of silent failure.
-      const active = sessionRegistry.getQuestion(session.sessionId, questionId);
-      if (active === null) {
-        const pendingIds = [...session.currentQuestions.keys()];
-        log(
-          `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
-        );
+    // Drop stale answers. APNS tokens persist across disconnect (#286), so a
+    // delayed lock-screen tap can deliver an answer for a question that has
+    // since been auto-approved or resolved. Membership in the pending set
+    // (not equality with a single slot) is the check, so answering one of
+    // several concurrent prompts (main + subagent, #419) never invalidates
+    // the others. Surface the drop so the iOS user gets a "not delivered"
+    // signal instead of silent failure.
+    const active = sessionRegistry.getQuestion(session.sessionId, questionId);
+    if (active === null) {
+      const pendingIds = [...session.currentQuestions.keys()];
+      log(
+        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
+      );
+      if (!viaRelay) {
         send(
           connectionId,
           createError('STALE_ANSWER', 'The question this answer was for is no longer active', {
@@ -243,19 +249,26 @@ export function createInputHandlers(deps: InputHandlerDeps) {
             pendingQuestionIds: pendingIds,
           }),
         );
-        return;
       }
+      return 'stale';
+    }
 
-      // Model B (#573): if the auto-approve gate is HOLDING this permission's
-      // hook, a binary (one-time Yes / No) answer resolves it via the hook
-      // response — Claude is blocked on the hook and is NOT rendering a prompt,
-      // so a PTY submit would land in the wrong place. An answer the binary
-      // response cannot express ("Yes, always", a multi-choice pick, free text)
-      // first RELEASES the held hook to passthrough so Claude renders its native
-      // numbered prompt, then submits the digit (the only way to express
-      // "always" / a specific pick).
-      const decision = mapAnswerToDecision(active.options, answer);
-      let hadHold = false;
+    // Model B (#573): if the auto-approve gate is HOLDING this permission's
+    // hook, a binary (one-time Yes / No) answer resolves it via the hook
+    // response — Claude is blocked on the hook and is NOT rendering a prompt,
+    // so a PTY submit would land in the wrong place. An answer the binary
+    // response cannot express ("Yes, always", a multi-choice pick, free text)
+    // first RELEASES the held hook to passthrough so Claude renders its native
+    // numbered prompt, then submits the digit (the only way to express
+    // "always" / a specific pick).
+    //
+    // The submit/hold-resolution + question removal are wrapped so the question
+    // is ALWAYS consumed exactly once: if `submitInput` throws, the `finally`
+    // still removes it (no zombie question that a retry could double-submit),
+    // and the throw still propagates (relay -> HTTP 500, WS -> caller-logged).
+    const decision = mapAnswerToDecision(active.options, answer);
+    let hadHold = false;
+    try {
       if (decision !== null) {
         hadHold = resolveHeldPermission?.(session.sessionId, questionId, decision) ?? false;
       }
@@ -293,9 +306,79 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // question must NOT abort a different binary permission's eval, so this is
       // gated on hadHold rather than firing on every answer.
       if (hadHold) cancelAutoApprove?.(session.sessionId, 'user-answered');
-
+    } finally {
       // Remove only the answered question; sibling prompts remain answerable.
+      // In `finally` so a throwing submit cannot leave a zombie question.
       sessionRegistry.removeQuestion(session.sessionId, questionId);
+    }
+    return 'delivered';
+  }
+
+  return {
+    onUserInput: async (
+      connectionId: UUID,
+      sessionId: UUID,
+      content: string,
+      raw?: boolean,
+      claudeSessionId?: UUID,
+    ): Promise<void> => {
+      log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
+
+      const session = sessionRegistry.getSessionForConnection(connectionId);
+      if (!session) {
+        log(`No session found for connection ${connectionId}`);
+        return;
+      }
+
+      if (!guardBinding(bindingStore, send, connectionId, sessionId, claudeSessionId)) {
+        return;
+      }
+
+      if (raw) {
+        // Raw terminal input from attach client: write directly without Enter
+        try {
+          session.pty.write(content);
+        } catch (err) {
+          log(`[PTY] raw write failed: ${errorToString(err)}`);
+        }
+        return;
+      }
+
+      // Structured input from web/mobile client: append Enter
+      await session.pty.submitInput(content);
+    },
+
+    // The WebSocket path: route the answer and reply over the connection on
+    // error. Returns void to match the adapter event signature. The HTTP
+    // `/answer` relay (#575, P4a) calls `relayAnswer` instead, which shares the
+    // exact same routing core but reports a structured outcome.
+    onAnswer: async (
+      connectionId: UUID,
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): Promise<void> => {
+      await handleAnswer(connectionId, sessionId, questionId, answer, claudeSessionId);
+    },
+
+    /**
+     * Connection-independent answer relay (#575, P4a). Routes an answer through
+     * the SAME core as the WebSocket `onAnswer` so a cold-start push tap can
+     * deliver a held-hook decision / PTY pick over plain HTTP, then returns the
+     * structured outcome for the caller to JSON-encode. There is no WebSocket
+     * connection to reply on, so `send` error frames are suppressed here; the
+     * outcome carries the same information.
+     */
+    relayAnswer: async (
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ): Promise<AnswerOutcome> => {
+      // The relay has no connection; use the sessionId as the synthetic id so
+      // logging stays meaningful and the registry's sessionId-first lookup wins.
+      return handleAnswer(sessionId as UUID, sessionId, questionId, answer, claudeSessionId, true);
     },
 
     onBulletExpandRequest: (

--- a/packages/daemon/src/cli/handlers/transcript-events.ts
+++ b/packages/daemon/src/cli/handlers/transcript-events.ts
@@ -17,7 +17,7 @@ import type { StaleSessionErrorDetails, UUID } from '@remi/shared';
 
 import { MessageAPI } from '../../api/message-api.ts';
 import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
-import type { SessionBindingStore } from '../../session/index.ts';
+import type { SessionBindingStore, TranscriptIndex } from '../../session/index.ts';
 import type {
   TranscriptDiscovery,
   TranscriptWatcher as TranscriptWatcherType,
@@ -35,6 +35,10 @@ export interface TranscriptHandlerDeps {
   /** Authoritative Remi-UUID -> claudeSessionId binding, used as a last-resort
    *  resolver when no live watcher exists (e.g. a wedged/rotated session). */
   bindingStore: SessionBindingStore;
+  /** Durable, long-TTL remiUUID -> {claudeSessionId, projectPath} index that
+   *  outlives sessions.json's 100-entry cap / 7-day purge, so an old session's
+   *  transcript still resolves after the liveness store has dropped it (#577). */
+  transcriptIndex: TranscriptIndex;
   /** Resolves the daemon's current owned session, so a stale/unknown request is
    *  redirected to the current session instead of dead-ending on NOT_FOUND (#499). */
   currentOwnedSession: () => CurrentOwnedSession | null;
@@ -51,6 +55,7 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
     transcriptDiscovery,
     transcriptWatchers,
     bindingStore,
+    transcriptIndex,
     currentOwnedSession,
     subagentViews,
     send,
@@ -95,6 +100,40 @@ export function createTranscriptHandlers(deps: TranscriptHandlerDeps) {
         } catch (err) {
           logError(
             `[TranscriptLoad] binding lookup failed for ${sessionId}; proceeding without store resolution: ${errorToString(err)}`,
+          );
+        }
+      }
+
+      // Durable index fallback (#577): the session was purged from sessions.json
+      // (100-entry cap or 7-day TTL), so bindingStore.get returned null, but the
+      // long-TTL transcript-index still holds its claude id + project path. Rebuild
+      // the deterministic transcript path and load it from disk if it exists. This
+      // is what stops the recurring "Transcript for session <id> not found" for an
+      // old-but-still-on-disk session.
+      if (!filePath) {
+        try {
+          const indexed = transcriptIndex.get(sessionId as UUID);
+          if (indexed) {
+            const candidate = `${transcriptDiscovery.getProjectTranscriptDir(indexed.projectPath)}/${indexed.claudeSessionId}.jsonl`;
+            if (fs.existsSync(candidate)) {
+              filePath = candidate;
+              log(
+                `[TranscriptLoad] Resolved Remi UUID ${sessionId} to path via durable index ${indexed.claudeSessionId.slice(0, 8)}`,
+              );
+            } else {
+              // Indexed but the .jsonl is gone (Claude transcript deleted/moved).
+              // Distinct from "never indexed" so the failure is diagnosable: the
+              // binding survived but the content did not.
+              log(
+                `[TranscriptLoad] Durable index hit for ${sessionId} (claude=${indexed.claudeSessionId.slice(0, 8)}) but transcript is absent on disk: ${candidate}`,
+              );
+            }
+          } else {
+            log(`[TranscriptLoad] No durable index entry for ${sessionId}`);
+          }
+        } catch (err) {
+          logError(
+            `[TranscriptLoad] transcript-index lookup failed for ${sessionId}; proceeding: ${errorToString(err)}`,
           );
         }
       }

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -35,6 +35,23 @@ export function createTrivialHandlers(deps: TrivialHandlerDeps) {
   return {
     onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string): void => {
       log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
+      // Dedup (#585, P7): the map is already keyed by token, so re-registering an
+      // identical token collapses to one entry (no duplicate push). The remaining
+      // duplicate-push case is APNS token ROTATION — the same physical device
+      // hands the daemon a NEW token while the old one is still registered, so a
+      // push fans out to BOTH (the user's reported 2x). The connection that
+      // re-registers is the same client session, so prune any OTHER token
+      // previously registered from THIS connectionId before recording the new one.
+      // This is conservative: it only drops a stale token tied to the same client,
+      // never a genuinely distinct device on another connection.
+      for (const [existingToken, entry] of deviceTokens) {
+        if (existingToken !== token && entry.connectionId === connectionId) {
+          deviceTokens.delete(existingToken);
+          log(
+            `Pruned stale device token from ${connectionId} (rotated): ${existingToken.slice(0, 20)}...`,
+          );
+        }
+      }
       deviceTokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
     },
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -116,6 +116,25 @@ export interface HookBridgeDeps {
    * all sessions (one terminal). Optional; inert when absent or headless.
    */
   statusWriter?: StatusWriter | undefined;
+  /**
+   * Tools that always escalate to the user (#572). Passed to the gate so it
+   * classifies an escalation as binary (holdable, #573) vs design/plan-mode
+   * (passthrough). From `config.auto_approve.always_escalate_tools`. Absent =>
+   * empty set (tests / no-AA callers).
+   */
+  alwaysEscalateTools?: ReadonlySet<string>;
+  /**
+   * Seconds to HOLD a binary main-context PermissionRequest hook open until the
+   * user answers (Model B, #573). From `config.auto_approve.hold_timeout`. 0 /
+   * absent => no holding (escalate -> passthrough as before).
+   */
+  holdTimeoutSec?: number;
+  /**
+   * Seconds before a slow binary main-context eval triggers an early push + hold
+   * (Part B, #573). From `config.auto_approve.push_hold_timeout`. 0 / absent =>
+   * Part B disabled (the eval/timer race never arms).
+   */
+  pushHoldTimeoutSec?: number;
 }
 
 export interface HookBridgeArgs {
@@ -133,6 +152,32 @@ export interface HookBridgeArgs {
   tracker: QuestionPresenceTracker;
 }
 
+/**
+ * Per-session control surface for the auto-approve gate (#573). Registered by
+ * cli.ts keyed by `sessionId` so the WebSocket answer handler reaches the RIGHT
+ * session's gate when the user answers a held permission.
+ */
+export interface SessionGateHandle {
+  /**
+   * Resolve a held binary PermissionRequest hook with the user's answer (Model
+   * B). Returns true when a hold for `questionId` existed and was resolved (the
+   * caller then SKIPS the PTY inject — Claude is blocked on the hook, not
+   * rendering); false when no hold exists (the answer takes the PTY path, e.g. a
+   * multi-choice pick or a non-AA session).
+   */
+  resolveHeld: (questionId: UUID, decision: 'allow' | 'deny') => boolean;
+  /**
+   * Release a held hook to 'passthrough' so Claude renders its native numbered
+   * prompt (#573), for answers the binary hook response cannot express ("Yes,
+   * always", a multi-choice pick). Returns true iff a hold existed; the caller
+   * then injects the digit into the rendered prompt.
+   */
+  releaseHeldAsPassthrough: (questionId: UUID) => boolean;
+  /** Cancel any in-flight eval AND release pending holds for this session (the
+   *  user answered / advanced). Forwards to the gate's `cancelStale`. */
+  cancelStale: (reason: string) => void;
+}
+
 export interface HookBridgeHandle {
   /** Live bridge instance. Callers can read `isInSubagentContext()` to gate
    *  alternate question sources (e.g. PTY parser) so subagent prompts are
@@ -147,6 +192,12 @@ export interface HookBridgeHandle {
    * reach — never outlives the session.
    */
   closeBinder: () => void;
+  /**
+   * Per-session auto-approve gate handle (#573): `resolveHeld` + `cancelStale`,
+   * so the WebSocket answer path can resolve a held hook / cancel the eval for
+   * this exact session. Always present (the gate is constructed unconditionally).
+   */
+  gate: SessionGateHandle;
 }
 
 export function setupHookBridge(
@@ -662,7 +713,11 @@ export function setupHookBridge(
       sessionRegistry,
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
-      escalate: (i) => handlers.onPermissionRequest?.(i),
+      // Call the bridge DIRECTLY (not via the void-typed handlers map) so the
+      // created Question.id flows back to the gate; a binary escalation holds
+      // the hook keyed by it (#573). The bridge still does the onQuestion +
+      // status side effects exactly as before.
+      escalate: (i) => hookBridge.handlePermissionRequest(i),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native
@@ -681,6 +736,13 @@ export function setupHookBridge(
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.
       escalateModel: autoApproveService?.escalateModel ?? '',
+      // #573: classify an escalation as binary (holdable) vs design/multi-choice
+      // (passthrough) the same way the service does; hold binary main-context
+      // hooks open until the user answers (holdMs) and optionally push early on a
+      // slow eval (pushHoldMs). Seconds -> ms; 0 disables (gate treats <=0 as off).
+      alwaysEscalateTools: deps.alwaysEscalateTools ?? new Set<string>(),
+      holdMs: (deps.holdTimeoutSec ?? 0) * 1000,
+      pushHoldMs: (deps.pushHoldTimeoutSec ?? 0) * 1000,
     },
     sessionId,
   );
@@ -1164,6 +1226,12 @@ export function setupHookBridge(
       // Drop the per-session PermissionRequest resolver (#496) so a stale
       // closure (over this session's gate/tracker) can't fire after teardown.
       hookServer.setPermissionResolver(null);
+    },
+    gate: {
+      resolveHeld: (questionId, decision) => autoApproveGate.resolveHeld(questionId, decision),
+      releaseHeldAsPassthrough: (questionId) =>
+        autoApproveGate.releaseHeldAsPassthrough(questionId),
+      cancelStale: (reason) => autoApproveGate.cancelStale(reason),
     },
   };
 }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -763,6 +763,15 @@ export function setupHookBridge(
         // handlePermissionRequest -> onStatusChange('waiting'), which broadcasts
         // the 'waiting' session_update. Re-emitting would double-emit.
       },
+      // #573: a binary escalation that HOLDS its hook blocks Claude's response,
+      // so Claude never renders the native prompt and the tracker's PTY-render
+      // push trigger (onPTYPromptVisible) never fires. Without this, the held
+      // question is stashed via recordPendingHook but never registered in
+      // sessionRegistry nor pushed -> the user cannot answer it and the hold sits
+      // until hold_timeout. The gate calls this ONLY in the held branch with the
+      // held Question.id, so the tracker pushes that exact question immediately
+      // (-> addQuestion + maybePush) under the id the hold is keyed by.
+      onHeldEscalate: (questionId) => tracker.pushHeldHook(questionId),
       onHandled: () => {
         deps.statusWriter?.autoApproveEnd('approved', Date.now());
         // #576: the permission was silently allowed; tell clients so the pill

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -39,7 +39,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createSessionRotated, createSessionViews, errorToString } from '@remi/shared';
+import {
+  createSessionRotated,
+  createSessionUpdate,
+  createSessionViews,
+  errorToString,
+} from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../../api/message-api.ts';
@@ -703,6 +708,28 @@ export function setupHookBridge(
 
   const handlers = hookBridge.hookHandlers();
 
+  // #576: push an auto-approve lifecycle status to clients so the pill reflects
+  // `evaluating` -> `approved` promptly, instead of waiting for the next hook.
+  //
+  // CRITICAL: the gate invokes the cue callbacks below through its `safeCue`
+  // wrapper (cosmetic; a throw there is logged and absorbed so it can never
+  // re-enter the decision/buffer path). This helper adds its OWN try/catch so a
+  // broadcast send error can never propagate into the gate even if the call site
+  // changes. It emits a client-only `session_update` and deliberately does NOT
+  // touch the StatusWriter `sessionStatus` (the wrapper bar + native statusline
+  // already cue the AA state from the `autoApprove` sub-field) nor the existing
+  // hook-driven onStatusChange path, so it neither double-emits nor fights the
+  // real PreToolUse/PermissionRequest status that follows.
+  const broadcastAutoApproveStatus = (status: AgentStatus): void => {
+    try {
+      sendAndRecord(createSessionUpdate(sessionId, status));
+    } catch (err) {
+      logError(
+        `[Hooks] auto-approve status broadcast failed for ${sessionId}: ${errorToString(err)}`,
+      );
+    }
+  };
+
   // Auto-approve control plane (#453 phase 1): owns the PermissionRequest eval +
   // inject + escalate + cancelStale. Constructed after the bridge + handlers so it
   // can wrap the two outward couplings (isInSubagentContext, onPermissionRequest) as
@@ -726,12 +753,22 @@ export function setupHookBridge(
       onEvalStart: () => {
         tracker.onAutoApproveStart();
         deps.statusWriter?.autoApproveStart(Date.now());
+        // #576: surface the in-flight eval on the client pill ('working').
+        broadcastAutoApproveStatus('evaluating');
       },
       onEscalate: () => {
         tracker.onAutoApproveEscalate();
         deps.statusWriter?.autoApproveEnd('escalated', Date.now());
+        // No status broadcast here: escalate already routes through
+        // handlePermissionRequest -> onStatusChange('waiting'), which broadcasts
+        // the 'waiting' session_update. Re-emitting would double-emit.
       },
-      onHandled: () => deps.statusWriter?.autoApproveEnd('approved', Date.now()),
+      onHandled: () => {
+        deps.statusWriter?.autoApproveEnd('approved', Date.now());
+        // #576: the permission was silently allowed; tell clients so the pill
+        // doesn't sit stale on 'evaluating' until the next hook fires.
+        broadcastAutoApproveStatus('approved');
+      },
       onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -140,6 +140,18 @@ export interface HookBridgeDeps {
    * Part B disabled (the eval/timer race never arms).
    */
   pushHoldTimeoutSec?: number;
+  /**
+   * Cross-client question dismissal (#585, P7). Called by the gate when a HELD
+   * question resolves WITHOUT a user answer (Part-B late verdict, hold timeout,
+   * or cancelStale): the daemon broadcasts `question_resolved` to every client and
+   * fires the APNS dismissal so the pushed card clears everywhere. Must be
+   * throw-safe (the gate also guards the call). Absent => no dismissal broadcast.
+   */
+  broadcastQuestionResolved?: (
+    sessionId: UUID,
+    questionId: UUID,
+    reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+  ) => void;
 }
 
 export interface HookBridgeArgs {
@@ -261,6 +273,37 @@ export function setupHookBridge(
         })),
       ),
     );
+  };
+
+  /**
+   * Dismiss every pending question for this session on a Claude restart
+   * (/clear, /compact, /resume), THEN clear the registry collection (#585, P7).
+   * A card pushed before the restart would otherwise linger on every device
+   * forever — the most common dismissal case. Broadcasts
+   * `question_resolved(..., 'cancelled')` for each pending id so all clients drop
+   * the card and the lock-screen push is dismissed, mirroring the gate's own
+   * held-resolution dismissal. Used at all three restart sites
+   * (initFromHookEvent, onSessionInfo, drive-binder onRotation) so none is
+   * missed. Throw-safe: a broadcast failure for one question must never block
+   * clearing the rest, and the clear always runs.
+   */
+  const resolveAndClearQuestions = (): void => {
+    const broadcast = deps.broadcastQuestionResolved;
+    if (broadcast) {
+      const pendingIds = [
+        ...(sessionRegistry.getSession(sessionId)?.currentQuestions.keys() ?? []),
+      ];
+      for (const questionId of pendingIds) {
+        try {
+          broadcast(sessionId, questionId, 'cancelled');
+        } catch (err) {
+          logError(
+            `[Hooks] question_resolved broadcast (restart) failed for ${questionId}: ${errorToString(err)}`,
+          );
+        }
+      }
+    }
+    sessionRegistry.clearQuestions(sessionId);
   };
 
   // ---- Per-session locks (mutable across event callbacks) -----------------
@@ -484,10 +527,11 @@ export function setupHookBridge(
       teardownWatcher('restart');
       // Drop any hook record stashed before /clear or /compact: the new
       // Claude session's first PTY prompt must not merge stale option
-      // labels from the dying session. Also drop the pending-question
-      // collection so answers to the dead session's prompts are refused.
+      // labels from the dying session. Also dismiss + drop the pending-question
+      // collection so cards clear on every device (#585) and answers to the dead
+      // session's prompts are refused.
       tracker.clearPending();
-      sessionRegistry.clearQuestions(sessionId);
+      resolveAndClearQuestions();
       // Announce the rotation NOW, before the sibling / no-transcript_path
       // guards below can early-return. teardownWatcher already reset the
       // client's view, so the client must learn of the rotation (clear +
@@ -648,11 +692,11 @@ export function setupHookBridge(
         );
         teardownWatcher('restart-sessioninfo');
         // Mirror the initFromHookEvent restart branch: drop any hook
-        // record and the pending-question collection so the new session's
-        // first PTY prompt cannot merge stale options, and stale answers
-        // are refused.
+        // record, dismiss + drop the pending-question collection (so cards clear
+        // on every device, #585) so the new session's first PTY prompt cannot
+        // merge stale options, and stale answers are refused.
         tracker.clearPending();
-        sessionRegistry.clearQuestions(sessionId);
+        resolveAndClearQuestions();
         claudeSessionId = null;
         mainSessionEnded = false;
         isRotation = previousClaudeSessionId !== null;
@@ -779,6 +823,11 @@ export function setupHookBridge(
         broadcastAutoApproveStatus('approved');
       },
       onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
+      // #585: a held question that resolves without a user answer (Part-B late
+      // verdict / hold timeout / cancelStale) tells the daemon to dismiss the
+      // pushed card on every client. Forwarded with this session's id.
+      onResolved: (questionId, reason) =>
+        deps.broadcastQuestionResolved?.(sessionId, questionId, reason),
       // #522: second-opinion model on a primary escalate (read from the service's
       // config). Empty when unset -> escalate straight to the user.
       escalateModel: autoApproveService?.escalateModel ?? '',
@@ -919,10 +968,11 @@ export function setupHookBridge(
             onRotation: () => {
               // The old restart branch's injected side effects: drop any hook
               // record stashed before the rotation so the new session's first
-              // PTY prompt cannot merge stale option labels, and drop the
-              // pending-question collection so stale answers are refused.
+              // PTY prompt cannot merge stale option labels, and dismiss + drop
+              // the pending-question collection (cards clear on every device,
+              // #585) so stale answers are refused.
               tracker.clearPending();
-              sessionRegistry.clearQuestions(sessionId);
+              resolveAndClearQuestions();
               // The new session starts with no subagents (#499 phase 3).
               if (subagentViews) {
                 subagentViews.clear();

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -60,6 +60,12 @@ export interface MessageApiSetupDeps {
 export interface MessageApiHandle {
   messageApi: MessageAPI;
   sendAndRecord: (message: ProtocolMessage) => void;
+  /**
+   * This session's APNS dispatcher (#585, P7). Exposed so the daemon's
+   * question-resolved path can fire a quiet lock-screen dismissal for a resolved
+   * question through the SAME device-token fan-out that pushed it.
+   */
+  notifications: NotificationDispatcher;
 }
 
 export function createMessageApiForSession(
@@ -166,5 +172,5 @@ export function createMessageApiForSession(
 
   const messageApi = new MessageAPI({ sessionId, initialBulletId: 1, maxBulletLength }, callbacks);
 
-  return { messageApi, sendAndRecord };
+  return { messageApi, sendAndRecord, notifications };
 }

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -139,16 +139,18 @@ export interface StatusBarDeps {
   /** Logger for render-failure notes. Required so a draw failure is never
    *  silently swallowed by an accidental no-op default. */
   readonly log: (msg: string) => void;
-  /** Refresh cadence in ms. Default 1000 (the `evaluating Ns` counter ticks 1Hz). */
+  /** Refresh cadence in ms. Default 250 so the `evaluating Ns` counter and AA
+   *  state changes feel smooth (#576). The repaint reads in-memory status only —
+   *  no disk I/O — so a faster cadence costs just one small fd write per tick. */
   readonly intervalMs?: number;
 }
 
 /**
  * Owns the reserved-row redraw loop. `start()` paints immediately and then on a
- * 1Hz timer; the unconditional periodic repaint keeps the bar asserted even if
- * Claude's output scrolled it (inline mode) since the last tick. `stop()` clears
- * the row and halts the loop. All draws are no-ops unless `isEnabled()` and a
- * live fd and enough rows.
+ * ~250ms timer (#576); the unconditional periodic repaint keeps the bar asserted
+ * even if Claude's output scrolled it (inline mode) since the last tick and keeps
+ * the `evaluating Ns` counter smooth. `stop()` clears the row and halts the loop.
+ * All draws are no-ops unless `isEnabled()` and a live fd and enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -175,7 +177,7 @@ export class StatusBar {
     this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
     this.now = deps.now ?? (() => Date.now());
     this.log = deps.log;
-    this.intervalMs = deps.intervalMs ?? 1000;
+    this.intervalMs = deps.intervalMs ?? 250;
   }
 
   /** Begin the redraw loop (idempotent). Paints once immediately. */

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -20,7 +20,9 @@
 import * as fs from 'node:fs';
 import type { AgentStatus, UUID } from '@remi/shared';
 
-export type RemiSessionStatus = AgentStatus | 'starting';
+/** Session status surfaced in the status file. `starting` now lives in the
+ *  shared `AgentStatus` (#576), so this is just an alias kept for callers. */
+export type RemiSessionStatus = AgentStatus;
 
 /**
  * Auto-approve eval state surfaced in Claude's native status line (#560).

--- a/packages/daemon/src/cli/transcript-fallback.ts
+++ b/packages/daemon/src/cli/transcript-fallback.ts
@@ -14,7 +14,11 @@
  * settings.local.json absent, hook server disabled, or in the sibling-in-dir
  * case where the bridge defers to filesystem ground-truth).
  *
- * Poll every 2 seconds. Give up after 30 seconds and log the reason.
+ * Poll every 2 seconds. Give up after 120 seconds and log the reason. Claude
+ * routinely takes 30-90s to write its first transcript line on a large context,
+ * so a 30s window timed out on nearly every session (the self-heal path still
+ * covered it, but noisily, and left a race window for a client that loaded
+ * during startup). 120s covers the common slow-start case (#577).
  */
 
 import * as fs from 'node:fs';
@@ -29,7 +33,7 @@ import { log, logError } from './logger.ts';
 import { startTranscriptWatcher } from './transcript-watcher-setup.ts';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
-const DEFAULT_POLL_TIMEOUT_MS = 30000;
+const DEFAULT_POLL_TIMEOUT_MS = 120000;
 
 export interface TranscriptFallbackDeps {
   sessionRegistry: SessionRegistry;
@@ -38,7 +42,7 @@ export interface TranscriptFallbackDeps {
   transcriptFallbackTimers: Map<UUID, ReturnType<typeof setInterval>>;
   /** Override for tests. Defaults to 2000ms. */
   pollIntervalMs?: number;
-  /** Override for tests. Defaults to 30000ms. */
+  /** Override for tests. Defaults to 120000ms. */
   pollTimeoutMs?: number;
 }
 
@@ -84,6 +88,10 @@ export function startTranscriptFallback(
     claudeSessionId,
   );
 
+  // Emit one "still waiting" log at the halfway mark so a genuine early failure
+  // is visible during the longer 120s window instead of an ~85s silent gap (#577).
+  let midLogged = false;
+
   const stopPoll = (): void => {
     clearInterval(fallbackInterval);
     transcriptFallbackTimers.delete(sessionId);
@@ -97,6 +105,14 @@ export function startTranscriptFallback(
     if (!sessionRegistry.hasSession(sessionId)) {
       stopPoll();
       return;
+    }
+
+    const elapsed = Date.now() - startupTime;
+    if (!midLogged && elapsed >= pollTimeoutMs / 2) {
+      midLogged = true;
+      log(
+        `[Fallback] Still waiting for transcript after ${Math.round(elapsed / 1000)}s: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude is likely still loading context; self-heal via hooks remains primary.`,
+      );
     }
 
     if (fs.existsSync(expectedPath)) {
@@ -125,7 +141,7 @@ export function startTranscriptFallback(
       return;
     }
 
-    if (Date.now() - startupTime > pollTimeoutMs) {
+    if (elapsed > pollTimeoutMs) {
       stopPoll();
       logError(
         `[Fallback] Timed out waiting for transcript: ${expectedPath} (claude=${claudeSessionId.slice(0, 8)}). Claude may have failed to start, or wrote to an unexpected path.`,

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -187,6 +187,13 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Always escalate these to the user; never auto-decided by the LLM (#572):
     // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
     always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
+    // Hold a binary main-context PermissionRequest hook open until the user
+    // answers (Model B, #573). Large + human-paced; on expiry it fails open to
+    // the native prompt. 0 disables holding (escalate -> passthrough as before).
+    hold_timeout: 1800,
+    // Push + hold early if a binary main-context eval is still running after
+    // this many seconds (Part B, #573). 0 disables Part B (A+C only).
+    push_hold_timeout: 60,
   },
   features: {
     transcript_binder_shadow: false,
@@ -336,6 +343,35 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   ) {
     throw new Error(
       `Invalid auto_approve.queue_timeout in ${configPath}: must be a non-negative number (seconds; 0 = no bound), got ${typeof cfg.queue_timeout === 'string' ? `string "${cfg.queue_timeout}"` : typeof cfg.queue_timeout}. Example: queue_timeout = 240`,
+    );
+  }
+
+  if (
+    typeof cfg.hold_timeout !== 'number' ||
+    !Number.isFinite(cfg.hold_timeout) ||
+    cfg.hold_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable holding), got ${typeof cfg.hold_timeout === 'string' ? `string "${cfg.hold_timeout}"` : typeof cfg.hold_timeout}. Example: hold_timeout = 1800`,
+    );
+  }
+
+  if (
+    typeof cfg.push_hold_timeout !== 'number' ||
+    !Number.isFinite(cfg.push_hold_timeout) ||
+    cfg.push_hold_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.push_hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable slow-eval push), got ${typeof cfg.push_hold_timeout === 'string' ? `string "${cfg.push_hold_timeout}"` : typeof cfg.push_hold_timeout}. Example: push_hold_timeout = 60`,
+    );
+  }
+
+  // Contradictory pairing: Part B pushes + holds early on a slow eval, but with
+  // holding disabled the held hook immediately falls through to passthrough, so
+  // the early push buys nothing. Warn (not throw) so the daemon still starts.
+  if (cfg.push_hold_timeout > 0 && cfg.hold_timeout === 0) {
+    console.warn(
+      `[AutoApprove] Warning: push_hold_timeout (${cfg.push_hold_timeout}s) > 0 but hold_timeout = 0 in ${configPath}: the slow-eval early push cannot hold the hook (holding is disabled), so it falls through to passthrough immediately. Set hold_timeout > 0 to actually hold, or push_hold_timeout = 0 to disable the early push.`,
     );
   }
 
@@ -574,6 +610,18 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       (auto_approve as { queue_timeout: number }).queue_timeout = parsed;
     }
   }
+  if (env['REMI_AUTO_APPROVE_HOLD_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { hold_timeout: number }).hold_timeout = parsed;
+    }
+  }
+  if (env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT']) {
+    const parsed = Number.parseInt(env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'], 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      (auto_approve as { push_hold_timeout: number }).push_hold_timeout = parsed;
+    }
+  }
 
   // Experimental feature flags (#453 phase 3). Default OFF; env opt-in only.
   const features = { ...config.features };
@@ -682,6 +730,18 @@ authorized_user_ids = []
 #                                  # queue before escalating. Concurrent evals
 #                                  # run one at a time; a deep burst could risk
 #                                  # the ~600s hook budget. 0 = no bound.
+# hold_timeout = 1800              # Seconds to HOLD a binary permission hook
+#                                  # open after escalating, so the user answers
+#                                  # it via the hook response (Model B, #573) —
+#                                  # no native prompt, no warm-connection race.
+#                                  # Large + human-paced; fails open to the
+#                                  # native prompt on expiry. 0 = no hold
+#                                  # (escalate -> passthrough as before).
+# push_hold_timeout = 60           # Push + hold early if a binary main-context
+#                                  # eval is still running after this many
+#                                  # seconds, so the user can step in while the
+#                                  # model keeps thinking (Part B, #573). A late
+#                                  # verdict resolves the held hook. 0 = off.
 # disable_thinking = false         # Ollama only: native /api/chat with
 #                                  # think:false (no reasoning). Faster but
 #                                  # lowers decision quality (reasoning helps
@@ -777,6 +837,8 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  escalate_model = "${config.auto_approve.escalate_model}"`);
   lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
+  lines.push(`  hold_timeout = ${config.auto_approve.hold_timeout}`);
+  lines.push(`  push_hold_timeout = ${config.auto_approve.push_hold_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push(
     `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
 import { parse as parseToml } from 'smol-toml';
 import { isKnownGroup, knownGroupNames } from '../auto-approve/permission-groups.ts';
+import { DEFAULT_ALWAYS_ESCALATE_TOOLS } from '../auto-approve/types.ts';
 import type { AutoApproveConfig } from '../auto-approve/types.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
@@ -183,6 +184,9 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // load-bearing for following broad user instructions. Opt in (Ollama only)
     // for raw speed over decision nuance.
     disable_thinking: false,
+    // Always escalate these to the user; never auto-decided by the LLM (#572):
+    // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
+    always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
   },
   features: {
     transcript_binder_shadow: false,
@@ -375,6 +379,18 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   }
   expectString('multichoice_model', cfg.multichoice_model);
   expectString('escalate_model', cfg.escalate_model);
+  if (!isStringArray(cfg.always_escalate_tools)) {
+    throw new Error(
+      `Invalid auto_approve.always_escalate_tools in ${configPath}: must be an array of tool names. Example: always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]`,
+    );
+  }
+  for (const t of cfg.always_escalate_tools) {
+    if (t.trim().length === 0) {
+      console.warn(
+        `[AutoApprove] Warning: always_escalate_tools entry "${t}" in ${configPath} is empty/whitespace and will never match a tool name.`,
+      );
+    }
+  }
 
   // Warn about dangerously short patterns that would match too broadly.
   const MIN_PATTERN_LENGTH = 2;
@@ -520,6 +536,20 @@ export function applyEnvOverrides(config: RemiConfig): RemiConfig {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
   }
+  if (env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE']) {
+    const tools = env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE']
+      .split(/[\n,]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (tools.length === 0) {
+      console.warn(
+        '[AutoApprove] REMI_AUTO_APPROVE_ALWAYS_ESCALATE resolved to an empty list; ' +
+          'AskUserQuestion and ExitPlanMode will no longer be structurally escalated. ' +
+          'Set it to "AskUserQuestion,ExitPlanMode" to keep the default safety net.',
+      );
+    }
+    (auto_approve as { always_escalate_tools: readonly string[] }).always_escalate_tools = tools;
+  }
   const mc = env['REMI_AUTO_APPROVE_MULTICHOICE'];
   if (mc === 'skip' || mc === 'evaluate') {
     (auto_approve as { multichoice: 'skip' | 'evaluate' }).multichoice = mc;
@@ -657,6 +687,11 @@ authorized_user_ids = []
 #                                  # lowers decision quality (reasoning helps
 #                                  # the model follow broad instructions), so
 #                                  # default off. Opt in for raw speed.
+# always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]
+#                                  # Tools that ALWAYS go to the user, never
+#                                  # auto-decided by the LLM (design / plan-mode
+#                                  # / long-form questions). Add custom MCP tools
+#                                  # that solicit user intent.
 `;
 }
 
@@ -743,6 +778,9 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  escalate_timeout = ${config.auto_approve.escalate_timeout}`);
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
+  lines.push(
+    `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,
+  );
   lines.push('');
   lines.push('# Experimental (epic #453). Default off; flip = restart (no hot reload).');
   lines.push('[features]');

--- a/packages/daemon/src/hooks/hook-config-manager.ts
+++ b/packages/daemon/src/hooks/hook-config-manager.ts
@@ -47,10 +47,6 @@ interface HookMatcher {
 const PERMISSION_REQUEST_HOOK_TIMEOUT = 600;
 const DEFAULT_HOOK_TIMEOUT = 5;
 
-function hookTimeoutFor(event: string): number {
-  return event === 'PermissionRequest' ? PERMISSION_REQUEST_HOOK_TIMEOUT : DEFAULT_HOOK_TIMEOUT;
-}
-
 interface ClaudeSettings {
   hooks?: Record<string, HookMatcher[]>;
   [key: string]: unknown;
@@ -60,10 +56,34 @@ export class HookConfigManager {
   private readonly settingsPath: string;
   private readonly hookUrl: string;
   private hasWritten = false;
+  /**
+   * Seconds the daemon may HOLD a PermissionRequest hook open before answering
+   * (Model B, #573). The registered PermissionRequest hook timeout must be >=
+   * this, or Claude Code gives up on the hook and renders its native prompt
+   * BEFORE the hold's own fail-open fires — so the registered timeout is
+   * `max(PERMISSION_REQUEST_HOOK_TIMEOUT, holdTimeoutSec)`. 0 / omitted keeps the
+   * baseline ceiling (the pre-#573 behavior).
+   */
+  private readonly permissionHoldTimeoutSec: number;
 
-  constructor(projectDir: string, hookServerUrl: string) {
+  constructor(projectDir: string, hookServerUrl: string, permissionHoldTimeoutSec = 0) {
     this.settingsPath = path.join(projectDir, '.claude', 'settings.local.json');
     this.hookUrl = hookServerUrl;
+    this.permissionHoldTimeoutSec =
+      Number.isFinite(permissionHoldTimeoutSec) && permissionHoldTimeoutSec > 0
+        ? permissionHoldTimeoutSec
+        : 0;
+  }
+
+  /**
+   * Seconds Claude Code waits for this hook's HTTP response. PermissionRequest
+   * gets the long budget (baseline 600s ceiling, raised to the configured hold
+   * timeout when larger so a long human-paced hold is not cut short, #573); all
+   * other hooks keep the short fail-fast timeout (#203).
+   */
+  private hookTimeoutFor(event: string): number {
+    if (event !== 'PermissionRequest') return DEFAULT_HOOK_TIMEOUT;
+    return Math.max(PERMISSION_REQUEST_HOOK_TIMEOUT, this.permissionHoldTimeoutSec);
   }
 
   /**
@@ -117,7 +137,7 @@ export class HookConfigManager {
       }
 
       const matchers = settings.hooks[event];
-      const desiredTimeout = hookTimeoutFor(event);
+      const desiredTimeout = this.hookTimeoutFor(event);
       // Reconcile any existing remi hook for this event to the desired timeout
       // (so an upgrade — e.g. the #537 PermissionRequest bump — takes effect for
       // an already-registered hook), and add it when missing.
@@ -193,7 +213,8 @@ export class HookConfigManager {
       // a reconcile on the next install() (#537).
       return matchers?.some((m) =>
         m.hooks.some(
-          (h) => h.type === 'http' && h.url === this.hookUrl && h.timeout === hookTimeoutFor(event),
+          (h) =>
+            h.type === 'http' && h.url === this.hookUrl && h.timeout === this.hookTimeoutFor(event),
         ),
       );
     });

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -145,6 +145,9 @@ export class HookEventBridge {
         allowsFreeText: false,
         isAnswered: false,
         agentId: input.agent_id,
+        // Generic fallback: the tracker must let a richer PermissionRequest
+        // for the same agent win over this text/options (#574).
+        source: 'notification',
       };
       this.events.onQuestion(question);
       this.events.onStatusChange('waiting');
@@ -238,6 +241,9 @@ export class HookEventBridge {
       allowsFreeText: false,
       isAnswered: false,
       agentId: input.agent_id,
+      // Rich source: carries tool + command + agent context. The tracker
+      // keeps this over a trailing generic notification for the same agent (#574).
+      source: 'permission_request',
     });
     this.events.onStatusChange('waiting');
     return questionId;

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -180,7 +180,13 @@ export class HookEventBridge {
     this.events.onSessionInfo(input.session_id, input.transcript_path);
   }
 
-  handlePermissionRequest(input: PermissionRequestHookInput): void {
+  /**
+   * Build + emit the escalation Question for a PermissionRequest and return its
+   * id (#573). The id lets the auto-approve gate HOLD the binary hook keyed by
+   * this question, so the user's answer resolves the hook via the response
+   * (Model B) instead of a PTY inject. Always returns an id today.
+   */
+  handlePermissionRequest(input: PermissionRequestHookInput): UUID {
     // Phase 4 (#419): the subagentContext drop previously sat here.
     // After phase 3 wired in the QuestionPresenceTracker, push semantics
     // are presence-gated regardless of subagent context — a subagent
@@ -224,8 +230,9 @@ export class HookEventBridge {
       options = [...DEFAULT_PERMISSION_OPTIONS];
     }
 
+    const questionId = generateId();
     this.events.onQuestion({
-      id: generateId(),
+      id: questionId,
       text: promptText,
       options,
       allowsFreeText: false,
@@ -233,6 +240,7 @@ export class HookEventBridge {
       agentId: input.agent_id,
     });
     this.events.onStatusChange('waiting');
+    return questionId;
   }
 
   handlePostToolUseFailure(input: PostToolUseFailureHookInput): void {

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -182,4 +182,36 @@ export class NotificationDispatcher {
         .catch((err) => log(`Push notification failed: ${err}`));
     }
   }
+
+  /**
+   * Fire a QUIET APNS dismissal for a resolved question (#585, P7). Sends a
+   * `content-available` push (no alert, no sound) keyed by `apns-collapse-id` =
+   * questionId so a suspended device replaces/clears the earlier lock-screen card
+   * for that exact question. Fans out to every registered device — unlike
+   * `maybePush`, it deliberately does NOT skip when a client is attached: the
+   * card may still sit on another device's lock screen, and the collapse-id makes
+   * a no-op dismissal harmless. No dedup gate (a repeat dismissal is idempotent at
+   * the device). No-op when no tokens are registered.
+   *
+   * `questionSessionId` is the primary id the client knows (from hello_ack), kept
+   * symmetric with `maybePush` so the dismissal carries the same routing id.
+   */
+  dismiss(questionSessionId: UUID, questionId: UUID): void {
+    const { deviceTokens, pushConfig } = this.deps;
+    if (deviceTokens.size === 0) return;
+    const cfg = pushConfig();
+    const pushSessionId = this.deps.getPrimarySessionId() ?? questionSessionId;
+    for (const dt of deviceTokens.values()) {
+      this.pushFn(cfg.signalingUrl, dt.token, {
+        // No title/body: a dismissal is a silent content-available push, and the
+        // relay skips the title/body requirement for it (#585, P7).
+        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+        sessionId: pushSessionId,
+        questionId,
+        dismiss: true,
+      })
+        .then(() => log(`Push dismissal sent for question ${questionId}`))
+        .catch((err) => log(`Push dismissal failed: ${err}`));
+    }
+  }
 }

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -42,6 +42,58 @@ export function selectPushCategory(options: readonly QuestionOption[]): string |
   return undefined;
 }
 
+/** Cap for the APNS title; iOS truncates visually but a hard cap keeps the
+ *  payload bounded for long Bash commands. */
+const TITLE_MAX = 120;
+/** Cap for the APNS body (ask + option list). */
+const BODY_MAX = 200;
+
+/**
+ * Normalize text for the notification surface (#574, issue 3). Collapses every
+ * run of whitespace (including the zero-width gaps that the PTY's column-
+ * aligned permission box leaves after ANSI stripping, which produced the
+ * "Doyouwanttoproceed?" garble) into a single ASCII space, then trims. A bare
+ * run-together token with no separators (the worst PTY case) is left as-is by
+ * this pass — but the dispatcher prefers the clean hook text for the body, so
+ * the raw PTY string never reaches the user (see `buildPushText`).
+ */
+function normalizeNotificationText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The compact option list shown in the body, e.g. "1. Yes  2. Yes, always
+ * 3. No". Uses the real option LABELS (#574, issue 4) so the user sees what
+ * they are actually choosing. The prefix is the option's actual `value`, not
+ * its positional index, so it stays accurate for non-indexed values like the
+ * StopFailure y/n set ("y. Yes  n. No"). Empty when there are no options
+ * (free-text prompt) so the body is just the ask.
+ */
+function formatOptionList(options: readonly QuestionOption[]): string {
+  if (options.length === 0) return '';
+  return options.map((o) => `${o.value}. ${o.label || o.value}`).join('  ');
+}
+
+/**
+ * Build the APNS title + body from the question (#574, issues 3+4).
+ *   - title: session context + the clean hook ask (tool + command), never the
+ *     raw PTY screen text.
+ *   - body: the ask repeated as the leading line plus the real option labels,
+ *     so the lock screen shows the choices even where the static action-button
+ *     titles cannot (REMI_MULTI). Whitespace is normalized so a column-aligned
+ *     PTY prompt can never collapse into a run-together string.
+ */
+export function buildPushText(
+  sessionName: string,
+  question: Question,
+): { title: string; body: string } {
+  const ask = normalizeNotificationText(question.text) || 'Allow this action?';
+  const title = `${sessionName}: ${ask}`.slice(0, TITLE_MAX);
+  const optionList = formatOptionList(question.options);
+  const body = (optionList ? `${ask}\n${optionList}` : ask).slice(0, BODY_MAX);
+  return { title, body };
+}
+
 /** Signature of the APNS-relay push call; injectable so the push branch is
  *  observable in tests without mocking a network module. */
 export type PushFn = typeof sendPushTrigger;
@@ -108,12 +160,18 @@ export class NotificationDispatcher {
     const cfg = pushConfig();
     const pushSessionId = this.deps.getPrimarySessionId() ?? this.sessionId;
     const pushCategory = selectPushCategory(question.options);
-    const pushOptions = question.options.map((o) => o.value);
+    // Send the human-readable LABELS for DISPLAY (#574, issue 4); answer
+    // routing in input-events resolves an incoming label OR value back to the
+    // option, then submits the option's index when a PTY submit is required, so
+    // sending labels here does not break delivery. Fall back to the value when a
+    // label is empty so the button still carries something answerable.
+    const pushOptions = question.options.map((o) => o.label || o.value);
+    const { title, body } = buildPushText(sessionName, question);
 
     for (const dt of deviceTokens.values()) {
       this.pushFn(cfg.signalingUrl, dt.token, {
-        title: `${sessionName} needs input`,
-        body: question.text.slice(0, 100),
+        title,
+        body,
         ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
         sessionId: pushSessionId,
         questionId: question.id,

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -16,7 +16,7 @@
 import type { Question, QuestionOption, UUID } from '@remi/shared';
 
 import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
-import { log } from '../cli/logger.ts';
+import { log, logError } from '../cli/logger.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import { sendPushTrigger } from './push-client.ts';
 import { PushDedup } from './push-dedup.ts';
@@ -211,7 +211,9 @@ export class NotificationDispatcher {
         dismiss: true,
       })
         .then(() => log(`Push dismissal sent for question ${questionId}`))
-        .catch((err) => log(`Push dismissal failed: ${err}`));
+        .catch((err) =>
+          logError(`Push dismissal failed (signaling worker redeploy needed?): ${err}`),
+        );
     }
   }
 }

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -8,10 +8,12 @@ const DEFAULT_SIGNALING_URL = 'https://remi-signaling.yooz.workers.dev';
 
 /** Options for sendPushTrigger */
 export interface PushTriggerOptions {
-  /** Title shown in the notification banner */
-  title: string;
-  /** Body text shown in the notification banner */
-  body: string;
+  /** Title shown in the notification banner. Optional only for a `dismiss`
+   *  push (#585, P7), which is silent (content-available) and has no text. */
+  title?: string;
+  /** Body text shown in the notification banner. Optional only for a `dismiss`
+   *  push (#585, P7). */
+  body?: string;
   /** Bearer token for signaling server auth (REMI_PUSH_SECRET) */
   pushSecret?: string;
   /** Remi session UUID included in APNS custom data for tap-to-navigate */
@@ -22,6 +24,14 @@ export interface PushTriggerOptions {
   category?: string;
   /** Answer values for action buttons: opt_0, opt_1, ... */
   options?: string[];
+  /**
+   * Dismissal trigger (#585, P7). When true the signaling server sends a QUIET
+   * `content-available` push (no alert) carrying the same `apns-collapse-id` =
+   * questionId, so the device replaces/clears the lock-screen card for an
+   * already-resolved question instead of buzzing again. The relay skips the
+   * title/body requirement for a dismiss, so the dispatcher omits them entirely.
+   */
+  dismiss?: boolean;
 }
 
 /**
@@ -47,8 +57,9 @@ export async function sendPushTrigger(
   }
   const payload: Record<string, unknown> = {
     token: deviceToken,
-    title: opts.title,
-    body: opts.body,
+    // Omitted for a dismiss push (#585, P7): silent, no user-visible text.
+    ...(opts.title !== undefined ? { title: opts.title } : {}),
+    ...(opts.body !== undefined ? { body: opts.body } : {}),
   };
   if (opts.sessionId) {
     payload['sessionId'] = opts.sessionId;
@@ -61,6 +72,9 @@ export async function sendPushTrigger(
   }
   if (opts.options && opts.options.length > 0) {
     payload['options'] = opts.options;
+  }
+  if (opts.dismiss) {
+    payload['dismiss'] = true;
   }
   const response = await fetch(url, {
     method: 'POST',

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -60,6 +60,19 @@ export interface ServerEvents {
     claudeSessionId?: UUID,
   ) => void;
 
+  /**
+   * Connection-independent answer relay over HTTP POST /answer (#575, P4a).
+   * Resolves to a structured outcome so the route can report delivered / stale /
+   * session-not-found. Distinct from `onAnswer` because the HTTP path has no
+   * connection to reply on and must surface the result in the HTTP response.
+   */
+  onAnswerRelay: (
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+  ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
+
   /** Bullet expand request from client */
   onBulletExpandRequest: (
     connectionId: UUID,
@@ -262,6 +275,32 @@ export class WebSocketServer {
           );
         }
 
+        // Connection-independent answer relay (#575, P4a). Lets a cold-start
+        // push tap deliver an answer over plain HTTP before any WebSocket is
+        // warm. Authenticated with the SAME trust model as the WebSocket
+        // (loopback bypass + Ed25519 signature over an authorized key); routes
+        // through the SAME answer core as the WebSocket `onAnswer`.
+        if (url.pathname === '/answer') {
+          if (req.method === 'OPTIONS') {
+            return new Response(null, {
+              status: 204,
+              headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'POST, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+              },
+            });
+          }
+          if (req.method !== 'POST') {
+            return new Response(JSON.stringify({ result: 'method-not-allowed' }), {
+              status: 405,
+              headers: jsonCorsHeaders,
+            });
+          }
+          const peer = server.requestIP(req);
+          return self.handleAnswerRelay(req, peer?.address ?? null, jsonCorsHeaders);
+        }
+
         return new Response('Not found', {
           status: 404,
           headers: { 'Access-Control-Allow-Origin': '*' },
@@ -333,6 +372,118 @@ export class WebSocketServer {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Handle a POST /answer relay request (#575, P4a).
+   *
+   * Auth reuses the WebSocket trust model: loopback peers are exempt (same
+   * `shouldSkipAuthForPeer` bypass as the WS upgrade); networked peers must
+   * sign the canonical request string `sessionId|questionId|answer` with a key
+   * already in the daemon's authorized-keys store (the exact gate the WS
+   * handshake applies). The answer is then routed through the SAME core as the
+   * WebSocket `onAnswer`, so held-hook resolution / pick injection are identical.
+   */
+  private async handleAnswerRelay(
+    req: Request,
+    peerAddress: string | null,
+    corsHeaders: Record<string, string>,
+  ): Promise<Response> {
+    const reply = (status: number, result: string, extra?: Record<string, unknown>): Response =>
+      new Response(JSON.stringify({ result, ...extra }), { status, headers: corsHeaders });
+
+    // Defense-in-depth on a LAN-facing endpoint: cap the body before parsing.
+    // Bun.serve defaults to a 128MB body limit; a permission answer is tiny, so
+    // reject anything over 64KiB outright (before req.json() allocates).
+    const MAX_BODY_BYTES = 64 * 1024;
+    const contentLength = Number.parseInt(req.headers.get('content-length') ?? '', 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      console.warn(
+        `[answer-relay] rejected oversized body (${contentLength} bytes) from peer ${peerAddress ?? 'unknown'}`,
+      );
+      return reply(413, 'payload-too-large', { error: 'request body too large' });
+    }
+
+    let body: {
+      sessionId?: unknown;
+      questionId?: unknown;
+      answer?: unknown;
+      claudeSessionId?: unknown;
+      auth?: {
+        signature?: unknown;
+        clientPublicKey?: unknown;
+        clientFingerprint?: unknown;
+      };
+    };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return reply(400, 'bad-request', { error: 'invalid JSON body' });
+    }
+
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : '';
+    const questionId = typeof body.questionId === 'string' ? body.questionId : '';
+    const answer = typeof body.answer === 'string' ? body.answer : '';
+    const claudeSessionId =
+      typeof body.claudeSessionId === 'string' ? body.claudeSessionId : undefined;
+    if (!sessionId || !questionId || !answer) {
+      return reply(400, 'bad-request', {
+        error: 'sessionId, questionId, and answer are required',
+      });
+    }
+
+    // Authenticate with the same trust model as the WebSocket.
+    const authenticator = this.config.connection?.authenticator;
+    if (authenticator && !shouldSkipAuthForPeer(true, peerAddress)) {
+      const auth = body.auth;
+      const signature = typeof auth?.signature === 'string' ? auth.signature : '';
+      const clientPublicKey = typeof auth?.clientPublicKey === 'string' ? auth.clientPublicKey : '';
+      const clientFingerprint =
+        typeof auth?.clientFingerprint === 'string' ? auth.clientFingerprint : '';
+      if (!signature || !clientPublicKey || !clientFingerprint) {
+        console.warn(
+          `[answer-relay] auth rejected: missing signature from peer ${peerAddress ?? 'unknown'}`,
+        );
+        return reply(401, 'unauthorized', { error: 'missing auth signature' });
+      }
+      // Bind the signature to this exact answer so it cannot be replayed for a
+      // different question. Matches the client-side canonicalization.
+      const message = `${sessionId}|${questionId}|${answer}`;
+      const ok = await authenticator.verifyDetachedRequest(
+        message,
+        signature,
+        clientPublicKey,
+        clientFingerprint,
+      );
+      if (!ok) {
+        console.warn(
+          `[answer-relay] auth rejected: signature verification failed from peer ${peerAddress ?? 'unknown'} (key ${clientPublicKey.slice(0, 12)}…)`,
+        );
+        return reply(401, 'unauthorized', { error: 'signature verification failed' });
+      }
+    }
+
+    if (!this.events.onAnswerRelay) {
+      return reply(503, 'unavailable', { error: 'answer relay not wired' });
+    }
+
+    let outcome: 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+    try {
+      outcome = await this.events.onAnswerRelay(
+        sessionId as UUID,
+        questionId as UUID,
+        answer,
+        claudeSessionId as UUID | undefined,
+      );
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+      return reply(500, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const status = outcome === 'delivered' ? 200 : outcome === 'session-not-found' ? 404 : 409;
+    return reply(status, outcome);
   }
 
   private handleOpen(ws: { data: WSData }): void {

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -15,6 +15,8 @@ export { SessionStore, type StoredSession } from './session-store.ts';
 
 export { SessionBindingStore, type SessionBinding } from './session-binding-store.ts';
 
+export { TranscriptIndex, type TranscriptIndexEntry } from './transcript-index.ts';
+
 export {
   SessionRegistryFile,
   type LiveSessionEntry,

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -22,14 +22,26 @@
 
 import type { UUID } from '@remi/shared';
 
+import { log } from '../cli/logger.ts';
 import type { SessionStore, StoredSession } from './session-store.ts';
+import type { TranscriptIndex } from './transcript-index.ts';
 
 export interface SessionBinding {
   claudeSessionId: string | null;
 }
 
 export class SessionBindingStore {
-  constructor(private readonly store: SessionStore) {}
+  /**
+   * Optional durable mirror (#577). Every binding write (preAssign + update)
+   * also records {remiUUID -> claudeSessionId, projectPath} here so the
+   * transcript handler can rebuild an old session's on-disk path after
+   * sessions.json purges it. Co-located on the single binding accessor so a
+   * rotation that updates the binding can never forget to refresh the index.
+   */
+  constructor(
+    private readonly store: SessionStore,
+    private readonly transcriptIndex?: TranscriptIndex,
+  ) {}
 
   /**
    * Current durable binding for this Remi session, or null when no record exists.
@@ -55,7 +67,15 @@ export class SessionBindingStore {
    * today). Together with preAssign, the ONLY claudeSessionId writer.
    */
   update(remiSessionId: UUID, claudeSessionId: string): void {
-    this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+    const updated = this.store.updateClaudeSessionId(remiSessionId, claudeSessionId);
+    // Refresh the durable mirror with the (possibly rotated) claude id so a
+    // later transcript load resolves the CURRENT transcript, not a stale one.
+    // Mirror from the SAME record the write produced — a second
+    // findByRemiSessionId read could race a concurrent purgeStale() and observe
+    // a null record, leaving the index pinned to the pre-rotation id (#577).
+    if (updated) {
+      this.transcriptIndex?.record(remiSessionId, claudeSessionId, updated.projectPath);
+    }
   }
 
   /**
@@ -66,5 +86,20 @@ export class SessionBindingStore {
    */
   preAssign(session: StoredSession): void {
     this.store.save(session);
+    // Seed the durable mirror at spawn so the binding is recoverable even if the
+    // session never rotates and is later purged from sessions.json (#577).
+    if (session.claudeSessionId) {
+      this.transcriptIndex?.record(
+        session.remiSessionId,
+        session.claudeSessionId,
+        session.projectPath,
+      );
+    } else if (this.transcriptIndex) {
+      // No claude id yet (deferred to the first update() on hook adopt/rotation).
+      // Log so the deferred index seed is traceable rather than silently skipped.
+      log(
+        `[transcript-index] preAssign for ${session.remiSessionId} has no claudeSessionId yet; index seed deferred to update()`,
+      );
+    }
   }
 }

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -211,13 +211,21 @@ export class SessionStore {
     }
   }
 
-  /** Update the Claude session ID (extracted from transcript after startup). */
-  updateClaudeSessionId(remiSessionId: UUID, claudeSessionId: string): void {
+  /**
+   * Update the Claude session ID (extracted from transcript after startup).
+   * Returns the updated record (already in memory from the read-modify-write) so
+   * callers that mirror the binding elsewhere don't need a second disk read — a
+   * separate read could race a concurrent purgeStale() and observe a null record
+   * mid-rotation (#577). Returns null when no record exists (a no-op, as before).
+   */
+  updateClaudeSessionId(remiSessionId: UUID, claudeSessionId: string): StoredSession | null {
     const sessions = this.read();
     const session = sessions.find((s) => s.remiSessionId === remiSessionId);
     if (session) {
       session.claudeSessionId = claudeSessionId;
       this.write(sessions);
+      return session;
     }
+    return null;
   }
 }

--- a/packages/daemon/src/session/transcript-index.ts
+++ b/packages/daemon/src/session/transcript-index.ts
@@ -108,7 +108,7 @@ export class TranscriptIndex {
     }
   }
 
-  /** Parse updatedAt to epoch ms; NaN (unparseable) becomes 0 = oldest. */
+  /** Parse updatedAt to epoch ms; NaN (unparsable) becomes 0 = oldest. */
   private static updatedAtMs(entry: TranscriptIndexEntry): number {
     const t = new Date(entry.updatedAt).getTime();
     return Number.isNaN(t) ? 0 : t;
@@ -130,7 +130,7 @@ export class TranscriptIndex {
     });
     if (sawBadTimestamp) {
       logError(
-        '[transcript-index] Found entry with unparseable updatedAt; treating as oldest for cap trimming',
+        '[transcript-index] Found entry with unparsable updatedAt; treating as oldest for cap trimming',
       );
     }
     if (kept.length > this.maxEntries) {

--- a/packages/daemon/src/session/transcript-index.ts
+++ b/packages/daemon/src/session/transcript-index.ts
@@ -1,0 +1,189 @@
+/**
+ * TranscriptIndex — a durable, append-only remiUUID -> {claudeSessionId,
+ * projectPath} map persisted at ~/.remi/transcript-index.json.
+ *
+ * Phase 6 (#577). The `remiUUID <-> claudeSessionId` binding lives in
+ * sessions.json (SessionStore), but that store is bounded two ways that both
+ * lose old bindings: MAX_SESSIONS=100 trims the oldest exited rows, and
+ * STALE_AGE_MS=7d purges exited rows. For a user running Claude across many
+ * worktrees the 100-entry cap fills fast, so a transcript_load_request for an
+ * older session resolves to nothing and returns NOT_FOUND ("Transcript for
+ * session <id> not found").
+ *
+ * This index decouples binding durability from the liveness store: it is NOT
+ * subject to the 100-entry cap and uses a much longer TTL (90 days). It stores
+ * only what the transcript handler needs to RECONSTRUCT the on-disk path
+ * (claudeSessionId + projectPath, fed through TranscriptDiscovery's
+ * deterministic encoding) — no liveness, no pid, no port churn.
+ *
+ * Atomic writes use the same per-process `.<pid>.tmp` pattern as SessionStore
+ * (#461) so two daemons sharing ~/.remi never race on a shared tmp path.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { logError } from '../cli/logger.ts';
+
+export interface TranscriptIndexEntry {
+  remiSessionId: UUID;
+  claudeSessionId: string;
+  projectPath: string;
+  /** ISO timestamp of the most recent write for this entry; drives TTL pruning. */
+  updatedAt: string;
+}
+
+interface TranscriptIndexFile {
+  version: 1;
+  entries: TranscriptIndexEntry[];
+}
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+const INDEX_FILE = path.join(REMI_DIR, 'transcript-index.json');
+/** Far longer than SessionStore's 7d so old transcripts stay loadable (#577). */
+const INDEX_STALE_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+/** Hard ceiling so a long-lived heavy-worktree machine cannot grow unbounded. */
+const DEFAULT_MAX_INDEX_ENTRIES = 2000;
+
+export class TranscriptIndex {
+  private filePath: string;
+  private maxEntries: number;
+
+  /** `maxEntries` is overridable for tests; production uses the 2000 default. */
+  constructor(filePath?: string, maxEntries: number = DEFAULT_MAX_INDEX_ENTRIES) {
+    this.filePath = filePath ?? INDEX_FILE;
+    this.maxEntries = maxEntries;
+  }
+
+  private ensureDir(): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  /** Read the index, returning [] on a missing/corrupt file (never throws on parse). */
+  private read(): TranscriptIndexEntry[] {
+    if (!fs.existsSync(this.filePath)) return [];
+    const raw = fs.readFileSync(this.filePath, 'utf-8');
+    try {
+      const data = JSON.parse(raw) as TranscriptIndexFile;
+      if (data.version !== 1 || !Array.isArray(data.entries)) {
+        // A future-version or malformed index is discarded, not merged. Log it
+        // so the silent drop is visible (a recovery index must be debuggable);
+        // an unknown version usually means a newer daemon wrote this file.
+        logError(
+          `[transcript-index] Ignoring index with unexpected shape (version=${String(
+            (data as { version?: unknown }).version,
+          )}); recovery lookups will miss until it is rewritten`,
+        );
+        return [];
+      }
+      return data.entries;
+    } catch (err) {
+      if (!(err instanceof SyntaxError)) {
+        logError(`[transcript-index] Unexpected error reading index: ${errorToString(err)}`);
+      }
+      return [];
+    }
+  }
+
+  /** Write the index atomically (per-process tmp + rename), same as SessionStore (#461). */
+  private write(entries: TranscriptIndexEntry[]): void {
+    this.ensureDir();
+    const data: TranscriptIndexFile = { version: 1, entries };
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    try {
+      fs.renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        // best-effort cleanup; surface the original error
+      }
+      throw err;
+    }
+  }
+
+  /** Parse updatedAt to epoch ms; NaN (unparseable) becomes 0 = oldest. */
+  private static updatedAtMs(entry: TranscriptIndexEntry): number {
+    const t = new Date(entry.updatedAt).getTime();
+    return Number.isNaN(t) ? 0 : t;
+  }
+
+  /** Drop entries older than the TTL, then trim oldest if over the hard cap. */
+  private prune(entries: TranscriptIndexEntry[]): TranscriptIndexEntry[] {
+    const now = Date.now();
+    let sawBadTimestamp = false;
+    let kept = entries.filter((e) => {
+      const t = new Date(e.updatedAt).getTime();
+      if (Number.isNaN(t)) {
+        // Keep on NaN here (conservative: never TTL-drop on bad data alone), but
+        // flag it so the cap step below treats it as oldest and trims it first.
+        sawBadTimestamp = true;
+        return true;
+      }
+      return now - t < INDEX_STALE_AGE_MS;
+    });
+    if (sawBadTimestamp) {
+      logError(
+        '[transcript-index] Found entry with unparseable updatedAt; treating as oldest for cap trimming',
+      );
+    }
+    if (kept.length > this.maxEntries) {
+      // Sort numerically with NaN -> 0 (oldest). A string compare here would
+      // sort a NaN/garbage timestamp to the FRONT and the cap would then trim
+      // the NEWEST valid entries first, looping forever on a bad file (#577).
+      kept = [...kept]
+        .sort((a, b) => TranscriptIndex.updatedAtMs(a) - TranscriptIndex.updatedAtMs(b))
+        .slice(kept.length - this.maxEntries);
+    }
+    return kept;
+  }
+
+  /**
+   * Record (or refresh) the binding for a session. Upserts by remiSessionId and
+   * bumps updatedAt; prunes stale/overflow entries on every write so the file
+   * self-maintains. Fails soft: a disk error is logged, not thrown, so a
+   * persistence hiccup never aborts session creation (the index is an
+   * optimization on top of sessions.json, not the authority).
+   */
+  record(remiSessionId: UUID, claudeSessionId: string, projectPath: string): void {
+    try {
+      const entries = this.read();
+      const idx = entries.findIndex((e) => e.remiSessionId === remiSessionId);
+      const entry: TranscriptIndexEntry = {
+        remiSessionId,
+        claudeSessionId,
+        projectPath,
+        updatedAt: new Date().toISOString(),
+      };
+      if (idx >= 0) {
+        entries[idx] = entry;
+      } else {
+        entries.push(entry);
+      }
+      this.write(this.prune(entries));
+    } catch (err) {
+      logError(
+        `[transcript-index] Failed to record binding for ${remiSessionId}: ${errorToString(err)}`,
+      );
+    }
+  }
+
+  /** Resolve a remi session id to its durable binding, or null. Never throws. */
+  get(remiSessionId: UUID): TranscriptIndexEntry | null {
+    try {
+      const entries = this.read();
+      return entries.find((e) => e.remiSessionId === remiSessionId) ?? null;
+    } catch (err) {
+      logError(
+        `[transcript-index] Failed to read binding for ${remiSessionId}: ${errorToString(err)}`,
+      );
+      return null;
+    }
+  }
+}

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -42,6 +42,27 @@ function makeHookQuestion(text = 'Allow Bash?'): Question {
   };
 }
 
+/** Rich PermissionRequest record: tool + command text, real labels (#574). */
+function makePermissionRequestHook(text = 'Allow Bash: git push origin main'): Question {
+  return { ...makeHookQuestion(text), source: 'permission_request' };
+}
+
+/** Generic Notification(permission_prompt) record: bland text, hardcoded 3-set (#574). */
+function makeNotificationHook(text = 'Claude needs your permission to use Bash'): Question {
+  return {
+    id: generateId(),
+    text,
+    options: [
+      makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+      makeOption('Yes, always', '2', { isYes: true }),
+      makeOption('No', '3', { isNo: true }),
+    ],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'notification',
+  };
+}
+
 describe('QuestionPresenceTracker', () => {
   it('PTY-only push (no preceding hook) — fires once with PTY question as-is', () => {
     // Covers anthropics/claude-code #23983: subagent permission requests
@@ -330,6 +351,116 @@ describe('QuestionPresenceTracker', () => {
       tracker.onPTYPromptVisible(makePTYQuestion());
       tracker.onStatusChange('idle');
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    });
+  });
+
+  describe('PermissionRequest vs Notification merge policy (#574)', () => {
+    it('a trailing generic Notification does NOT overwrite a rich PermissionRequest for the same agent', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      // Claude fires both for one prompt: the rich request first, the bland
+      // notification second. The notification must be dropped.
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push origin main'));
+      tracker.recordPendingHook(makeNotificationHook());
+
+      // PTY confirms the prompt is on screen -> single push with the rich text.
+      const ptyQ = makePTYQuestion('Do you want to proceed?');
+      tracker.onPTYPromptVisible(ptyQ);
+
+      expect(pushes.length).toBe(1);
+      // The user sees the command, not "Claude needs your permission to use Bash"
+      // and never the bare PTY "Do you want to proceed?".
+      expect(pushes[0]?.text).toBe('Allow Bash: git push origin main');
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('a source-less (StopFailure-shaped) question does NOT evict a pending permission_request, but a newer permission_request DOES replace it (FIX 2A)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push'));
+
+      // A StopFailure "Retry?" card for the same agent carries no source; it
+      // must NOT silently evict the rich permission request (which would leave
+      // the real permission prompt without a push).
+      const stopFailureCard: Question = {
+        id: generateId(),
+        text: 'Session stop failed (timeout). Retry?',
+        options: [
+          makeOption('Yes', 'y', { isYes: true, isRecommended: true }),
+          makeOption('No', 'n', { isNo: true }),
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+        // source intentionally undefined (StopFailure does not set it)
+      };
+      tracker.recordPendingHook(stopFailureCard);
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1);
+      // The permission request survived the StopFailure arrival.
+      expect(pushes[0]?.text).toBe('Allow Bash: git push');
+
+      // A genuinely new permission cycle (another permission_request) DOES replace it.
+      const tracker2 = new QuestionPresenceTracker(() => {});
+      tracker2.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
+      tracker2.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
+      const pushes2: Question[] = [];
+      const tracker3 = new QuestionPresenceTracker((q) => pushes2.push(q));
+      tracker3.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
+      tracker3.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
+      tracker3.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes2[0]?.text).toBe('Allow Edit: new cmd');
+    });
+
+    it('a PermissionRequest arriving AFTER a Notification still wins (richer replaces generic)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makeNotificationHook());
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Edit: /tmp/foo.ts'));
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('Allow Edit: /tmp/foo.ts');
+    });
+
+    it('raw PTY text never wins over the hook text for the notification (#574 issue 3)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: rm -rf build'));
+      // The PTY's literal screen text is the bare prompt; it must not surface.
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+
+      expect(pushes[0]?.text).toBe('Allow Bash: rm -rf build');
+      expect(pushes[0]?.text).not.toBe('Do you want to proceed?');
+    });
+
+    it('subagent fallback: a Notification with no preceding PermissionRequest is still recorded', () => {
+      // Subagent / no-PermissionRequest escalations must keep a question record
+      // so they remain answerable; the drop only applies when a richer request
+      // for the SAME agent already exists.
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.recordPendingHook(makeNotificationHook('Claude needs your permission to use Bash'));
+      expect(tracker.hasPendingForTest()).toBe(true);
+
+      tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it("different agents: a notification for agent B does not touch agent A's request", () => {
+      const tracker = new QuestionPresenceTracker(() => {});
+      tracker.recordPendingHook({
+        ...makePermissionRequestHook('Allow Bash A'),
+        agentId: 'agent-A',
+      });
+      tracker.recordPendingHook({
+        ...makeNotificationHook(),
+        agentId: 'agent-B',
+      });
+      // Both kept: the per-agent merge policy only drops a same-agent generic.
+      expect(tracker.pendingCountForTest()).toBe(2);
     });
   });
 

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -905,3 +905,207 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
     expect(await pending).toBe('allow');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #585 (P7): onResolved fires when a HELD question resolves WITHOUT a user
+// answer, so the daemon can dismiss the pushed card on every client. It must NOT
+// fire for a user-driven resolveHeld (the answer path broadcasts its own
+// 'answered'), and a throw must be absorbed.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+  let resolved: Array<{ questionId: UUID; reason: string }>;
+
+  function deferredEvaluator(): {
+    service: AutoApproveEvaluator;
+    release: (r: AutoApproveResult) => void;
+  } {
+    let resolveEval: (r: AutoApproveResult) => void = () => {};
+    const pending = new Promise<AutoApproveResult>((res) => {
+      resolveEval = res;
+    });
+    return {
+      service: { evaluate: () => pending, cancel: () => true },
+      release: (r) => resolveEval(r),
+    };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: { holdMs?: number; pushHoldMs?: number; onResolvedThrows?: boolean } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
+        alwaysEscalateTools: new Set(),
+        onResolved: (questionId, reason) => {
+          if (opts.onResolvedThrows) throw new Error('test: onResolved synthetic failure');
+          resolved.push({ questionId, reason });
+        },
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    lastQuestionId = undefined;
+    resolved = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('Part-B late approve fires onResolved auto_approved', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'auto_approved' }]);
+  });
+
+  test('Part-B late deny fires onResolved auto_denied', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    release(deny);
+    expect(await pending).toBe('deny');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'auto_denied' }]);
+  });
+
+  test('cancelStale on a held hook fires onResolved cancelled', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    g.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough');
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'cancelled' }]);
+  });
+
+  test('hold timeout fires onResolved cancelled', async () => {
+    const { service } = deferredEvaluator();
+    // Short hold so the timeout fail-open fires during the test.
+    const g = gate(service, { pushHoldMs: 10, holdMs: 30 });
+    const pending = g.resolvePermission(pr());
+    expect(await pending).toBe('passthrough'); // failed open on hold timeout
+    expect(resolved).toEqual([{ questionId: lastQuestionId as UUID, reason: 'cancelled' }]);
+  });
+
+  test('a user-driven resolveHeld does NOT fire onResolved (no double-broadcast)', async () => {
+    // Part A: a normal binary escalate holds; the user answers via resolveHeld.
+    // The answer path (input-events) broadcasts 'answered' itself, so the gate
+    // must stay silent here.
+    const service: AutoApproveEvaluator = { evaluate: async () => escalate, cancel: () => true };
+    const g = gate(service, { holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+    expect(resolved).toEqual([]);
+  });
+
+  test('a throwing onResolved never breaks the decision path', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20, onResolvedThrows: true });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    release(approve);
+    // Despite the throwing onResolved, the held hook still resolves allow.
+    expect(await pending).toBe('allow');
+  });
+
+  // #585 P7 FIX 2: a Part-B held question is registered (pushHeldHook ->
+  // addQuestion); the gate-side resolution must drop it from the registry so no
+  // ghost card replays and a late handleAnswer can't find it "live".
+  test('Part-B auto-approve removes the held question from sessionRegistry', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40)); // early push + hold
+    // Simulate the real push having registered the question under the held id.
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    release(approve);
+    expect(await pending).toBe('allow');
+    // The held question is gone from the registry (no ghost card / misroute).
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+
+  test('hold timeout removes the held question from sessionRegistry', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 10, holdMs: 30 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 15)); // after the early push, before timeout
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(await pending).toBe('passthrough'); // failed open on hold timeout
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+
+  test('cancelStale removes the held question from sessionRegistry', async () => {
+    const { service } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    g.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough');
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -88,7 +88,10 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: (i) => escalations.push(i),
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
       },
       SID,
     );
@@ -113,7 +116,10 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: (i) => escalations.push(i),
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
         escalateModel: 'big-model',
       },
       SID,
@@ -400,7 +406,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
-        escalate: () => {},
+        escalate: () => undefined,
         onEvalStart: () => events.push('start'),
         onEscalate: () => events.push('escalate'),
         onHandled: () => events.push('handled'),
@@ -489,6 +495,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
         isInSubagentContext: () => false,
         escalate: () => {
           escalations++;
+          return undefined;
         },
         onHandled: () => {
           throw new Error('test: cue boom');
@@ -498,5 +505,403 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     );
     expect(await g.resolvePermission(pr())).toBe('allow'); // approved once, verdict intact
     expect(escalations).toBe(0); // no re-escalation
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2 (#573): hold the hook (Model B) + resolve-on-answer + slow-eval push.
+// All real objects (no mock framework): a plain evaluator literal returns real
+// AutoApproveResult values, and the held hook is a real pending promise.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  /** A gate that escalates (recording the created Question.id) and holds binary
+   *  main-context hooks for `holdMs`. The created id is exposed via
+   *  `lastQuestionId` so tests can resolve the hold. */
+  function holdGate(
+    service: AutoApproveEvaluator | null,
+    opts: { holdMs?: number; subagent?: boolean; alwaysEscalateTools?: ReadonlySet<string> } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const tracker = new QuestionPresenceTracker(() => {});
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => opts.subagent ?? false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        alwaysEscalateTools:
+          opts.alwaysEscalateTools ?? new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('binary escalate WITHHOLDS the decision until resolveHeld -> allow', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    // Give the eval + escalate a tick; the promise must still be pending (held).
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false);
+    expect(escalations).toHaveLength(1);
+    expect(lastQuestionId).toBeDefined();
+
+    // The user answers Yes -> the held hook resolves 'allow'.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('binary escalate held -> deny when the user answers No', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'deny')).toBe(true);
+    expect(await pending).toBe('deny');
+  });
+
+  test('resolveHeld for an unknown id returns false (non-held answer)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.resolveHeld(generateId() as UUID, 'allow')).toBe(false);
+    // The real hold is still pending; resolve it to avoid a dangling promise.
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('multi-choice escalate returns passthrough immediately (NO hold)', async () => {
+    // 4+ string suggestions => multi-choice; the hook response cannot pick.
+    const gate = holdGate(evaluator(escalate));
+    const d = await gate.resolvePermission(
+      pr({ permission_suggestions: ['Alpha', 'Beta', 'Gamma', 'Delta'] }),
+    );
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('design question escalate returns passthrough immediately (NO hold)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    // AskUserQuestion is in always_escalate_tools -> design -> not binary.
+    const d = await gate.resolvePermission(
+      pr({ tool_name: 'AskUserQuestion', tool_input: { question: 'Which approach?' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('hold timeout -> passthrough and the pending map is cleaned', async () => {
+    const gate = holdGate(evaluator(escalate), { holdMs: 30 });
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough'); // failed open after 30ms
+    // The hold timed out; a late answer for the same id must report "no hold".
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('holdMs <= 0 disables holding: binary escalate -> passthrough', async () => {
+    const gate = holdGate(evaluator(escalate), { holdMs: 0 });
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('releaseHeldAsPassthrough pops a held hook to passthrough (FIX 1)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qid = lastQuestionId as UUID;
+    // The user picked "Yes, always": the binary response can't express it, so the
+    // hook is released to passthrough (Claude renders its native prompt).
+    expect(gate.releaseHeldAsPassthrough(qid)).toBe(true);
+    expect(await pending).toBe('passthrough');
+    // The hold is gone; a second release reports no hold.
+    expect(gate.releaseHeldAsPassthrough(qid)).toBe(false);
+  });
+
+  test('releaseHeldAsPassthrough returns false when no hold exists', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gate.releaseHeldAsPassthrough(generateId() as UUID)).toBe(false);
+    // Resolve the real hold to avoid a dangling promise.
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('cancelStale releases a pending hold to passthrough + cancels the eval', async () => {
+    const cancels: string[] = [];
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const tracker = new QuestionPresenceTracker(() => {});
+    const gate = new AutoApproveGate(
+      {
+        service: {
+          evaluate: async () => escalate,
+          cancel: (reason: string) => {
+            cancels.push(reason);
+            return true;
+          },
+        },
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(),
+      },
+      SID,
+    );
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    gate.cancelStale('SessionEnd');
+    expect(await pending).toBe('passthrough'); // hold released by teardown
+    expect(cancels).toContain('SessionEnd'); // eval also cancelled
+    // The hold is gone.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('per-session isolation: resolving session A does not touch session B', async () => {
+    const SID_B = generateId() as UUID;
+    const registryB = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registryB.registerSession(SID_B, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    let qidB: UUID | undefined;
+    const gateB = new AutoApproveGate(
+      {
+        service: { evaluate: async () => escalate, cancel: () => true },
+        sessionRegistry: registryB,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          qidB = generateId();
+          return qidB;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(),
+      },
+      SID_B,
+    );
+
+    const gateA = holdGate(evaluator(escalate));
+    const pendingA = gateA.resolvePermission(pr());
+    const pendingB = gateB.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qidA = lastQuestionId as UUID;
+
+    // Resolving A's question id on gate B finds no hold; A's own hold is intact.
+    expect(gateB.resolveHeld(qidA, 'allow')).toBe(false);
+    // Resolve each on its own gate.
+    expect(gateA.resolveHeld(qidA, 'allow')).toBe(true);
+    expect(gateB.resolveHeld(qidB as UUID, 'deny')).toBe(true);
+    expect(await pendingA).toBe('allow');
+    expect(await pendingB).toBe('deny');
+    await registryB.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B (#573): slow-eval early push + hold. ISOLATED behind push_hold_timeout.
+// A deferred eval lets the test control whether the eval or the push-hold timer
+// wins the race deterministically.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  /** An evaluator whose verdict is delayed until `release(result)` is called,
+   *  so the test decides when the eval finishes relative to push_hold_timeout. */
+  function deferredEvaluator(): {
+    service: AutoApproveEvaluator;
+    release: (r: AutoApproveResult) => void;
+  } {
+    let resolveEval: (r: AutoApproveResult) => void = () => {};
+    const pending = new Promise<AutoApproveResult>((res) => {
+      resolveEval = res;
+    });
+    return {
+      service: { evaluate: () => pending, cancel: () => true },
+      release: (r) => resolveEval(r),
+    };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: { holdMs?: number; pushHoldMs?: number } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
+        alwaysEscalateTools: new Set(),
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a slow eval pushes + holds early; a late approve resolves allow (no double push)', async () => {
+    const { service, release } = deferredEvaluator();
+    // push after 20ms; the eval has not finished yet -> early push + hold.
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+
+    await new Promise((r) => setTimeout(r, 40)); // let the push-hold timer fire
+    expect(escalations).toHaveLength(1); // pushed early exactly once
+    expect(lastQuestionId).toBeDefined();
+
+    // The late verdict arrives: approve -> the held hook resolves allow, and the
+    // reconciliation must NOT push a second time.
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(escalations).toHaveLength(1); // still one push (no double-push)
+  });
+
+  test('a slow eval whose late verdict is deny resolves the held hook deny', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    expect(escalations).toHaveLength(1);
+    release(deny);
+    expect(await pending).toBe('deny');
+    expect(escalations).toHaveLength(1);
+  });
+
+  test('a slow eval whose late verdict is escalate keeps the existing hold (no double push)', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20, holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    expect(escalations).toHaveLength(1);
+    // Late escalate: already pushed + holding, so no second push; the hold stays
+    // pending until the user answers.
+    release(escalate);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(escalations).toHaveLength(1);
+    // The user then answers the (single) held question.
+    expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('a fast eval (verdict before push_hold_timeout) never pushes early', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 200 });
+    const pending = g.resolvePermission(pr());
+    // Verdict arrives well before the 200ms push-hold timer.
+    release(approve);
+    expect(await pending).toBe('allow');
+    expect(escalations).toHaveLength(0); // no early push
+  });
+
+  test('push_hold_timeout = 0 disables Part B: a slow escalate just holds on verdict', async () => {
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 0, holdMs: 60_000 });
+    const pending = g.resolvePermission(pr());
+    // No early push while the eval runs.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(escalations).toHaveLength(0);
+    // The eval escalates -> NOW it pushes + holds (Part A path), once.
+    release(escalate);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(escalations).toHaveLength(1);
+    g.resolveHeld(lastQuestionId as UUID, 'allow');
+    expect(await pending).toBe('allow');
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -53,6 +53,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }
@@ -1294,5 +1295,81 @@ describe('AutoApproveService - multichoice regression guards', () => {
     } finally {
       server.stop();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design / plan-mode / long-form always-escalate (#572) - deterministic.
+// These never call the LLM, so they run without Ollama. base_url points at a
+// closed port: any regression that reached the LLM would yield durationMs > 0.
+// ---------------------------------------------------------------------------
+describe('design/plan-mode always-escalate (#572)', () => {
+  const offline = { base_url: 'http://127.0.0.1:1/v1', provider: 'http://127.0.0.1:1/v1' };
+
+  test('AskUserQuestion escalates structurally, with no LLM call (0ms)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({ ...offline, always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'] }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'Which DB?' }] });
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+    expect(r.reasoning).toContain('always-escalate');
+  });
+
+  test('ExitPlanMode escalates structurally even in multichoice=evaluate mode', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        multichoice: 'evaluate',
+        always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('ExitPlanMode', { plan: 'ship it' });
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('free-text heuristic escalates a question-posing tool not on the allowlist', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({ ...offline, always_escalate_tools: [] }),
+      logFn,
+    );
+    const r = await svc.evaluate('mcp__ask', { question: 'Which approach?' }, undefined, [
+      'Alpha',
+      'Beta',
+      'Gamma',
+    ]);
+    expect(r.decision).toBe('escalate');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('deny list is still checked first (explicit user rule wins over the classifier)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        deny: ['AskUserQuestion'],
+        always_escalate_tools: ['AskUserQuestion'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'x' }] });
+    expect(r.decision).toBe('deny');
+    expect(r.durationMs).toBe(0);
+  });
+
+  test('allow list is still checked first (explicit allow overrides the classifier)', async () => {
+    const svc = new AutoApproveService(
+      makeConfig({
+        ...offline,
+        allow: ['AskUserQuestion'],
+        always_escalate_tools: ['AskUserQuestion'],
+      }),
+      logFn,
+    );
+    const r = await svc.evaluate('AskUserQuestion', { questions: [{ question: 'x' }] });
+    expect(r.decision).toBe('approve');
+    expect(r.durationMs).toBe(0);
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -54,6 +54,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -119,6 +119,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -118,6 +118,7 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
   };
 }
 

--- a/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
+++ b/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
@@ -1,0 +1,309 @@
+/**
+ * End-to-end round-trip for the Model B held-escalation push gap (#573).
+ *
+ * THE BUG (found by two holistic reviewers, hidden by the gap in this very
+ * suite): when the gate HOLDS a binary escalation's PermissionRequest hook,
+ * Claude blocks on the hook response and never renders its native numbered
+ * prompt, so the tracker's `onPTYPromptVisible` push trigger NEVER fires. With
+ * the pre-#573 wiring the question was only STASHED via `recordPendingHook` —
+ * never registered in `sessionRegistry` and never pushed — so it was
+ * unanswerable: the shared `handleAnswer` looked it up via `getQuestion`, got
+ * null, and returned `'stale'` before ever reaching `resolveHeld`. The hold sat
+ * in `pendingHolds` for the full `hold_timeout` then failed open.
+ *
+ * The pre-existing `hold-hook.test.ts` missed this because its `escalate` stub
+ * synthesised a question id WITHOUT going through the bridge -> tracker ->
+ * registry chain, and its push sink was a no-op; it then called `resolveHeld`
+ * DIRECTLY, bypassing the `getQuestion` round-trip that was actually broken.
+ *
+ * This test assembles the REAL gate + tracker + sessionRegistry + the REAL
+ * shared `handleAnswer` (the input-events core used by both the WebSocket
+ * `onAnswer` and the HTTP `/answer` relay), wires the tracker's push sink to
+ * `sessionRegistry.addQuestion` exactly as production's `onQuestion` callback
+ * does, and proves the question is REGISTERED + PUSHED on a held escalation and
+ * that the shared answer path resolves the hold to allow/deny (not 'stale').
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateId } from '@remi/shared';
+import type { Question, UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { createInputHandlers } from '../../src/cli/handlers/input-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+
+/** Real-enough PTY that records every submitInput so the test can assert the
+ *  held path does NOT type into the PTY (Claude is blocked on the hook). */
+function fakePTY(submits: string[]): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async (content: string) => {
+      submits.push(content);
+    },
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+const escalate: AutoApproveResult = {
+  decision: 'escalate',
+  reasoning: 'test',
+  durationMs: 0,
+  model: 'm',
+};
+
+function evaluator(result: AutoApproveResult, delayMs = 0): AutoApproveEvaluator {
+  return {
+    evaluate: async () => {
+      if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+      return result;
+    },
+    cancel: () => true,
+  };
+}
+
+/** A binary (Bash) PermissionRequest — no multi-choice suggestions, so the gate
+ *  classifies it as holdable. */
+function binaryPermission(over: Record<string, unknown> = {}): PermissionRequestHookInput {
+  return {
+    session_id: 'claude-test',
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/d',
+    permission_mode: 'default',
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    ...over,
+  } as unknown as PermissionRequestHookInput;
+}
+
+/** Default 3-option permission set (Yes / Yes always / No) with the binary
+ *  flags the answer-mapper reads. Mirrors the bridge's DEFAULT_PERMISSION_OPTIONS
+ *  shape closely enough for the round-trip. */
+function defaultOptions() {
+  return [
+    { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+    { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+    { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+  ];
+}
+
+describe('Held escalation round-trip — register + push + shared answer (#573)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
+  let tmpDir: string;
+  let tracker: QuestionPresenceTracker;
+  let pushes: Question[];
+  let ptySubmits: string[];
+
+  beforeEach(() => {
+    configureLogger({ writeLog: () => {} });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-held-roundtrip-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    ptySubmits = [];
+    registry.registerSession(SID, '/d', fakePTY(ptySubmits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+
+    // Production push sink: push -> messageApi.handleQuestion -> onQuestion ->
+    // sessionRegistry.addQuestion (+ maybePush). We collapse that into the sink
+    // here: record the push (the APNS/in-app signal) AND register the question
+    // in the registry, exactly as message-api-setup's onQuestion does.
+    pushes = [];
+    tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      registry.addQuestion(SID, q);
+    });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build a gate wired EXACTLY like hook-bridge-setup.ts:
+   *   - escalate -> a real Question is built (with a stable id), stashed via
+   *     tracker.recordPendingHook (NO push, like the real bridge), and the id
+   *     returned;
+   *   - onHeldEscalate -> tracker.pushHeldHook (the #573 fix).
+   * Captures the id the escalate produced so the test can answer it.
+   */
+  function makeGate(
+    service: AutoApproveEvaluator | null,
+    pushHoldMs = 0,
+  ): {
+    gate: AutoApproveGate;
+    lastQid: () => UUID | undefined;
+  } {
+    let lastQid: UUID | undefined;
+    const gate = new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (input) => {
+          const qid = generateId() as UUID;
+          // Mirror HookEventBridge.handlePermissionRequest: build the question,
+          // stash it (recordPendingHook = onQuestion), return the id. No push.
+          tracker.recordPendingHook({
+            id: qid,
+            text: `Allow Bash: ${(input.tool_input as { command?: string }).command ?? ''}`,
+            options: defaultOptions(),
+            allowsFreeText: false,
+            isAnswered: false,
+            source: 'permission_request',
+          });
+          lastQid = qid;
+          return qid;
+        },
+        onHeldEscalate: (qid) => tracker.pushHeldHook(qid),
+        holdMs: 60_000,
+        pushHoldMs,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+    return { gate, lastQid: () => lastQid };
+  }
+
+  /** Input handlers wired to resolve/release the gate's held hook, mirroring
+   *  cli.ts's session-keyed gate handles. */
+  function makeHandlers(gate: AutoApproveGate, sendCalls: unknown[] = []) {
+    return createInputHandlers({
+      sessionRegistry: registry,
+      bindingStore,
+      send: ((_c: UUID, m: unknown) => {
+        sendCalls.push(m);
+        return true;
+      }) as never,
+      resolveHeldPermission: (_s, q, d) => gate.resolveHeld(q, d),
+      releaseHeldAsPassthrough: (_s, q) => gate.releaseHeldAsPassthrough(q),
+      cancelAutoApprove: (_s, reason) => gate.cancelStale(reason),
+    });
+  }
+
+  test('binary escalate (no service) REGISTERS + PUSHES, then "No" -> deny via shared handleAnswer', async () => {
+    const { gate, lastQid } = makeGate(null); // no-service main escalates
+
+    // The hook server blocks on this promise; the gate holds it.
+    const decisionPromise = gate.resolvePermission(binaryPermission());
+
+    // Let the synchronous escalate + onHeldEscalate run.
+    await Promise.resolve();
+    const qid = lastQid();
+    expect(qid).toBeDefined();
+
+    // (a) REGISTERED — this is what was broken: getQuestion must find it.
+    const registered = registry.getQuestion(SID, qid as UUID);
+    expect(registered).not.toBeNull();
+    expect(registered?.id).toBe(qid as UUID);
+
+    // (b) the push sink fired for that exact qid.
+    expect(pushes.map((p) => p.id)).toContain(qid as UUID);
+
+    // The hook is still HELD (no decision yet) and nothing typed into the PTY.
+    let resolved = false;
+    void decisionPromise.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolved).toBe(false);
+    expect(ptySubmits).toEqual([]);
+
+    // Answer "No" through the SHARED handleAnswer (WS onAnswer / relay core).
+    const handlers = makeHandlers(gate);
+    const outcome = await handlers.relayAnswer(SID, qid as UUID, 'No', undefined);
+    expect(outcome).toBe('delivered'); // NOT 'stale'
+
+    // The held hook resolved to 'deny' (the value Claude is unblocked with).
+    await expect(decisionPromise).resolves.toBe('deny');
+    // No PTY submit — Claude was blocked on the hook, not rendering a prompt.
+    expect(ptySubmits).toEqual([]);
+    // The answered question was consumed.
+    expect(registry.getQuestion(SID, qid as UUID)).toBeNull();
+  });
+
+  test('"Yes" -> allow via shared handleAnswer (no PTY submit)', async () => {
+    const { gate, lastQid } = makeGate(evaluator(escalate));
+    const decisionPromise = gate.resolvePermission(binaryPermission());
+
+    // Wait for the (async) eval to resolve escalate and the hold to register.
+    await waitFor(
+      () => lastQid() !== undefined && registry.getQuestion(SID, lastQid() as UUID) !== null,
+    );
+    const qid = lastQid() as UUID;
+    expect(pushes.map((p) => p.id)).toContain(qid);
+
+    const handlers = makeHandlers(gate);
+    const outcome = await handlers.relayAnswer(SID, qid, 'Yes', undefined);
+    expect(outcome).toBe('delivered');
+    await expect(decisionPromise).resolves.toBe('allow');
+    expect(ptySubmits).toEqual([]);
+  });
+
+  test('pushHeldHook is idempotent: a second call for the same qid does not double-register/push', async () => {
+    const { gate, lastQid } = makeGate(null);
+    void gate.resolvePermission(binaryPermission());
+    await Promise.resolve();
+    const qid = lastQid() as UUID;
+
+    expect(pushes.filter((p) => p.id === qid).length).toBe(1);
+    // Re-invoke the tracker method directly (simulating a stray re-fire): no-op.
+    expect(tracker.pushHeldHook(qid)).toBe(false);
+    expect(pushes.filter((p) => p.id === qid).length).toBe(1);
+  });
+
+  test('Part B early push (slow eval) also REGISTERS + PUSHES the held question', async () => {
+    // Eval is slower (50ms) than push_hold_timeout (10ms): the slow-eval path
+    // fires createHold early, which must push + register via onHeldEscalate.
+    const { gate, lastQid } = makeGate(evaluator(escalate, 50), 10);
+    const decisionPromise = gate.resolvePermission(binaryPermission());
+
+    // The early push fires after ~10ms, before the 50ms eval settles.
+    await waitFor(
+      () => lastQid() !== undefined && registry.getQuestion(SID, lastQid() as UUID) !== null,
+    );
+    const qid = lastQid() as UUID;
+    expect(pushes.map((p) => p.id)).toContain(qid);
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    // The user answers before / around the late verdict; the shared path resolves
+    // the held hook to deny regardless of the late escalate verdict.
+    const handlers = makeHandlers(gate);
+    const outcome = await handlers.relayAnswer(SID, qid, 'No', undefined);
+    expect(outcome).toBe('delivered');
+    await expect(decisionPromise).resolves.toBe('deny');
+    expect(ptySubmits).toEqual([]);
+  });
+});
+
+/** Poll `cond` up to ~1s; throw if it never becomes true (real timing, no mock). */
+async function waitFor(cond: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('waitFor: condition not met within 1s');
+}

--- a/packages/daemon/tests/auto-approve/hold-hook.test.ts
+++ b/packages/daemon/tests/auto-approve/hold-hook.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for Model B "hold the hook" (#573) over a REAL loopback
+ * HookServer wired to a REAL AutoApproveGate (no mocks). Asserts the HTTP
+ * response Claude blocks on is WITHHELD while the gate holds a binary
+ * escalation, then carries the allow/deny verdict once the user answers via
+ * `resolveHeld` — and that a multi-choice escalation passes through immediately.
+ *
+ * Mirrors the gated-server pattern in serialize.test.ts: a real Bun.serve fixture
+ * (here, the daemon's own HookServer) is driven over the loopback so timing is
+ * observed deterministically rather than stubbed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import { HookServer } from '../../src/hooks/hook-server.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+const escalate: AutoApproveResult = {
+  decision: 'escalate',
+  reasoning: 't',
+  durationMs: 0,
+  model: 'm',
+};
+
+function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+  return { evaluate: async () => result, cancel: () => true };
+}
+
+function permissionBody(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    session_id: 'claude-test',
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/d',
+    permission_mode: 'default',
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    ...over,
+  });
+}
+
+describe('Model B hold over a real HookServer (#573)', () => {
+  const SID = generateId() as UUID;
+  let server: HookServer;
+  let registry: SessionRegistry;
+  let gate: AutoApproveGate;
+  let lastQuestionId: UUID | undefined;
+
+  beforeEach(() => {
+    configureLogger({ writeLog: () => {} });
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    lastQuestionId = undefined;
+    gate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+    server = new HookServer({ port: 0 });
+    server.setPermissionResolver((input) => gate.resolvePermission(input));
+    server.start();
+  });
+
+  afterEach(async () => {
+    server.stop();
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('binary escalate WITHHOLDS the HTTP response until resolveHeld -> allow', async () => {
+    const post = fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody(),
+    });
+
+    // Wait for the gate to escalate (creates the question id) without the POST
+    // having resolved yet — the hook server is blocked on the held promise.
+    await waitFor(() => lastQuestionId !== undefined);
+    let responded = false;
+    void post.then(() => {
+      responded = true;
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(responded).toBe(false); // response is withheld (held hook)
+
+    // The user answers Yes -> the held hook resolves allow and the POST returns
+    // the allow decision body.
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    const res = await post;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'allow' } },
+    });
+  });
+
+  test('held hook -> deny body when the user answers No', async () => {
+    const post = fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody(),
+    });
+    await waitFor(() => lastQuestionId !== undefined);
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'deny')).toBe(true);
+    const res = await post;
+    expect(await res.json()).toEqual({
+      hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'deny' } },
+    });
+  });
+
+  test('multi-choice escalate returns the passthrough body immediately (no hold)', async () => {
+    const res = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: permissionBody({ permission_suggestions: ['Alpha', 'Beta', 'Gamma', 'Delta'] }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({}); // passthrough = bare {}
+  });
+});
+
+/** Poll `cond` up to ~1s; throw if it never becomes true (real timing, no mock). */
+async function waitFor(cond: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('waitFor: condition not met within 1s');
+}

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -68,6 +68,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -69,6 +69,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/multichoice.test.ts
+++ b/packages/daemon/tests/auto-approve/multichoice.test.ts
@@ -5,9 +5,11 @@
 import { describe, expect, test } from 'bun:test';
 import {
   buildMultiChoicePrompt,
+  isDesignQuestion,
   isMultiChoicePermission,
   parseMultiChoiceDecision,
 } from '../../src/auto-approve/multichoice.ts';
+import { DEFAULT_ALWAYS_ESCALATE_TOOLS } from '../../src/auto-approve/types.ts';
 
 describe('isMultiChoicePermission', () => {
   test('returns false for null/undefined/empty (default 3-set substitutes)', () => {
@@ -286,5 +288,102 @@ describe('parseMultiChoiceDecision', () => {
     );
     expect(r.decision).toBe('pick');
     if (r.decision === 'pick') expect(r.index).toBe(2);
+  });
+});
+
+describe('isDesignQuestion (#572)', () => {
+  const DEFAULTS = new Set(DEFAULT_ALWAYS_ESCALATE_TOOLS);
+
+  test('AskUserQuestion always escalates by tool name, even with binary suggestions', () => {
+    expect(
+      isDesignQuestion(
+        'AskUserQuestion',
+        { questions: [{ question: 'Which?' }] },
+        undefined,
+        DEFAULTS,
+      ),
+    ).toBe(true);
+    // Tool name wins even when the suggestions look binary.
+    expect(isDesignQuestion('AskUserQuestion', {}, ['Yes', 'No'], DEFAULTS)).toBe(true);
+  });
+
+  test('ExitPlanMode always escalates by tool name', () => {
+    expect(isDesignQuestion('ExitPlanMode', { plan: 'do the thing' }, undefined, DEFAULTS)).toBe(
+      true,
+    );
+  });
+
+  test('Bash is never a design question, even when the command ends in "?"', () => {
+    // The free-text heuristic must NOT inspect the Bash command string.
+    expect(isDesignQuestion('Bash', { command: 'echo are we sure?' }, undefined, DEFAULTS)).toBe(
+      false,
+    );
+  });
+
+  test('Edit with the standard Yes/Always/No suggestions is not a design question', () => {
+    expect(
+      isDesignQuestion(
+        'Edit',
+        { file_path: '/x', old_string: 'a', new_string: 'b' },
+        ['Yes', 'Always', 'No'],
+        DEFAULTS,
+      ),
+    ).toBe(false);
+  });
+
+  test('free-text heuristic: a custom tool posing a question with no binary suggestions escalates', () => {
+    expect(
+      isDesignQuestion(
+        'mcp__ask',
+        { question: 'Which database should we use?' },
+        undefined,
+        DEFAULTS,
+      ),
+    ).toBe(true);
+    expect(isDesignQuestion('mcp__ask', { questions: ['a', 'b'] }, undefined, DEFAULTS)).toBe(true);
+  });
+
+  test('free-text heuristic: a question with binary suggestions has a yes/no mapping, does NOT escalate', () => {
+    expect(
+      isDesignQuestion('mcp__confirm', { question: 'Proceed?' }, ['Yes', 'No'], DEFAULTS),
+    ).toBe(false);
+  });
+
+  test('free-text heuristic: a question with non-binary suggestions escalates', () => {
+    expect(
+      isDesignQuestion('mcp__pick', { question: 'Which?' }, ['Alpha', 'Beta', 'Gamma'], DEFAULTS),
+    ).toBe(true);
+  });
+
+  test('a tool with no question field and not on the allowlist is not a design question', () => {
+    expect(isDesignQuestion('mcp__do', { path: '/x' }, undefined, DEFAULTS)).toBe(false);
+  });
+
+  test('whitespace-only question field does not trigger the heuristic', () => {
+    expect(isDesignQuestion('mcp__ask', { question: '   ' }, undefined, DEFAULTS)).toBe(false);
+  });
+
+  test('config-extensible: a user-listed tool escalates by name', () => {
+    expect(isDesignQuestion('mcp__myAsk', {}, undefined, new Set(['mcp__myAsk']))).toBe(true);
+  });
+
+  test('empty allowlist: the free-text heuristic still backs up AskUserQuestion-shaped input', () => {
+    expect(
+      isDesignQuestion('AskUserQuestion', { questions: [{ question: 'x' }] }, undefined, new Set()),
+    ).toBe(true);
+    // ...but a tool with neither a listed name nor a question field does not escalate.
+    expect(isDesignQuestion('Bash', { command: 'ls' }, undefined, new Set())).toBe(false);
+  });
+
+  test('a "questions" array of non-question elements does not trigger the heuristic', () => {
+    // Only strings or {question: string} objects count; bare numbers/null/{}
+    // must not over-escalate a custom tool with an unrelated `questions` field.
+    expect(isDesignQuestion('mcp__x', { questions: [42] }, undefined, DEFAULTS)).toBe(false);
+    expect(isDesignQuestion('mcp__x', { questions: [null] }, undefined, DEFAULTS)).toBe(false);
+    expect(isDesignQuestion('mcp__x', { questions: [{}] }, undefined, DEFAULTS)).toBe(false);
+    // ...but the real AskUserQuestion-style {question: string} element does.
+    expect(
+      isDesignQuestion('mcp__x', { questions: [{ question: 'Pick?' }] }, undefined, DEFAULTS),
+    ).toBe(true);
   });
 });

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -333,6 +333,7 @@ function makeConfig(model: string): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
   };
 }
 

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -334,6 +334,8 @@ function makeConfig(model: string): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -106,6 +106,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     queue_timeout: 240,
     disable_thinking: false,
     always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -105,6 +105,7 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     escalate_timeout: 0,
     queue_timeout: 240,
     disable_thinking: false,
+    always_escalate_tools: [],
     ...overrides,
   };
 }

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1185,4 +1185,83 @@ describe('createInputHandlers', () => {
       expect(ptyCapture.submits).toEqual([]);
     });
   });
+
+  describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {
+    function registerWithQuestion(questionId: UUID): UUID {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: questionId,
+        text: 'proceed?',
+        options: [
+          { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      return sessionId;
+    }
+
+    test('fires onQuestionResolved once with the answered ids on the delivered path', async () => {
+      const sessionId = registerWithQuestion(QID);
+      const resolved: Array<{ sessionId: UUID; questionId: UUID }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: (s, q) => resolved.push({ sessionId: s, questionId: q }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(resolved).toEqual([{ sessionId, questionId: QID }]);
+    });
+
+    test('does NOT fire for a stale answer (nothing was consumed)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // No question registered -> the answer is stale.
+      const resolved: UUID[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: (_s, q) => resolved.push(q),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+      expect(resolved).toEqual([]);
+    });
+
+    test('a throwing onQuestionResolved never breaks answer handling', async () => {
+      const sessionId = registerWithQuestion(QID);
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        onQuestionResolved: () => {
+          throw new Error('broadcast boom');
+        },
+      });
+
+      // The answer still delivers and the question is still consumed despite the
+      // throwing broadcast (it is guarded in the finally).
+      await expect(handlers.onAnswer(CID, sessionId, QID, 'y')).resolves.toBe(undefined);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -331,6 +331,209 @@ describe('createInputHandlers', () => {
     });
   });
 
+  describe('onAnswer held-permission resolution (Model B, #573)', () => {
+    function addYesNoQuestion(sessionId: UUID): void {
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+    }
+
+    test('Yes answer maps to allow, resolves the held hook, and SKIPS the PTY submit', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const held: Array<{ sessionId: UUID; questionId: UUID; decision: 'allow' | 'deny' }> = [];
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (s, q, d) => {
+          held.push({ sessionId: s, questionId: q, decision: d });
+          return true; // a hold existed and was resolved
+        },
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1'); // option 1 = Yes
+
+      expect(held).toEqual([{ sessionId, questionId: QID, decision: 'allow' }]);
+      expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('No answer maps to deny and resolves the held hook', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '3'); // option 3 = No
+
+      expect(held).toEqual(['deny']);
+      expect(ptyCapture.submits).toEqual([]);
+    });
+
+    test('"Yes, always" releases the held hook to passthrough and submits the digit (FIX 1)', async () => {
+      // "always" cannot be expressed by the binary hook response, so it must NOT
+      // resolve the hold as a one-time allow; instead the hook is released to
+      // passthrough and the digit is submitted into the native prompt.
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const resolveDecisions: Array<'allow' | 'deny'> = [];
+      const released: UUID[] = [];
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        // A held hook exists, but resolveHeldPermission must NOT be consulted for
+        // "always" (decision === null), so it would return true if wrongly called.
+        resolveHeldPermission: (_s, _q, d) => {
+          resolveDecisions.push(d);
+          return true;
+        },
+        releaseHeldAsPassthrough: (_s, q) => {
+          released.push(q);
+          return true; // a hold existed and was popped to passthrough
+        },
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '2'); // option 2 = Yes, always
+
+      expect(resolveDecisions).toEqual([]); // never resolved as a one-time allow
+      expect(released).toEqual([QID]); // hook released to passthrough
+      expect(ptyCapture.submits).toEqual(['2']); // digit submitted into the native prompt
+      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]); // hold was released
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a non-held answer does NOT cancel the eval and still submits to the PTY (FIX 3)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false, // no hold for this question
+        releaseHeldAsPassthrough: () => false, // no hold to release either
+        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']); // falls back to the PTY path
+      // FIX 3: no hold was resolved/released, so an unrelated eval must NOT be
+      // cancelled by this answer.
+      expect(cancels).toEqual([]);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a free-text answer (no yes/no option match) takes the PTY path', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'name?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      let resolveHeldCalled = false;
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => {
+          resolveHeldCalled = true;
+          return true;
+        },
+        releaseHeldAsPassthrough: () => false, // no hold for a free-text prompt
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Alice');
+
+      // No yes/no option matched -> decision is null -> resolveHeld not consulted.
+      expect(resolveHeldCalled).toBe(false);
+      expect(ptyCapture.submits).toEqual(['Alice']);
+    });
+
+    test('without the held-permission deps wired, onAnswer behaves exactly as before', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoQuestion(sessionId);
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']); // PTY path, no held resolution
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+  });
+
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -25,6 +25,7 @@ function fakePTY(capture: {
   writes: string[];
   submits: string[];
   writeError?: Error;
+  submitError?: Error;
 }): PTYSession {
   return {
     id: generateId(),
@@ -33,6 +34,7 @@ function fakePTY(capture: {
       capture.writes.push(content);
     },
     submitInput: async (content: string) => {
+      if (capture.submitError) throw capture.submitError;
       capture.submits.push(content);
     },
     close: async () => {},
@@ -180,6 +182,40 @@ describe('createInputHandlers', () => {
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a throwing submitInput still consumes the question (no zombie) and propagates the error', async () => {
+      // Defense against double-submit on retry: even if the PTY submit throws,
+      // the question must be removed exactly once (finally), and the error must
+      // surface to the caller rather than being swallowed.
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [
+          { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await expect(handlers.onAnswer(CID, sessionId, QID, 'y')).rejects.toThrow('pty closed');
+
+      // No zombie question left behind for a retry to double-submit.
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
@@ -972,6 +1008,181 @@ describe('createInputHandlers', () => {
 
       expect(capture.submits).toEqual(['y']);
       expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+  });
+
+  // The connection-independent HTTP /answer relay (#575, P4a) shares the exact
+  // same routing core as onAnswer, but reports a structured outcome instead of
+  // sending error frames over a (non-existent) connection.
+  describe('relayAnswer (HTTP /answer relay, #575 P4a)', () => {
+    test('routes a free-text answer through the same PTY-submit core and returns delivered', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
+
+      expect(outcome).toBe('delivered');
+      // The phone sends the label; the relay resolves it back to the option value.
+      expect(ptyCapture.submits).toEqual(['1']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+      // No connection, so no error frames are ever sent over the relay path.
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('resolves a HELD binary permission via the hook response (no PTY submit)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const held: Array<{ decision: 'allow' | 'deny' }> = [];
+      const cancels: string[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push({ decision: d });
+          return true;
+        },
+        cancelAutoApprove: (_s, reason) => cancels.push(reason),
+      });
+
+      const outcome = await handlers.relayAnswer(sessionId, QID, '1');
+
+      expect(outcome).toBe('delivered');
+      expect(held).toEqual([{ decision: 'allow' }]); // resolved via the held hook
+      expect(ptyCapture.submits).toEqual([]); // held => no PTY submit
+      expect(cancels).toEqual(['user-answered']);
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('a throwing submit still consumes the question and propagates (route maps to 500)', async () => {
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [{ value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      // The relay surfaces the throw (the HTTP route turns it into a 500).
+      await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
+      // Question consumed exactly once despite the throw.
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+    });
+
+    test('returns session-not-found for an unknown session (no error frame)', async () => {
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(
+        'unknown0-0000-0000-0000-000000000000' as UUID,
+        QID,
+        'Yes',
+      );
+      expect(outcome).toBe('session-not-found');
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('returns stale when the question is no longer active (delayed lock-screen tap)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // No question added: the relay must report stale rather than submitting.
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
+
+      expect(outcome).toBe('stale');
+      expect(ptyCapture.submits).toEqual([]);
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('returns stale-binding when the claudeSessionId has rotated', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionStore.save({
+        remiSessionId: sessionId,
+        claudeSessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        projectPath: '/test/dir',
+        port: 18765,
+        pid: null,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const outcome = await handlers.relayAnswer(
+        sessionId,
+        QID,
+        'Yes',
+        '99999999-8888-7777-6666-555555555555' as UUID,
+      );
+
+      expect(outcome).toBe('stale-binding');
+      expect(ptyCapture.submits).toEqual([]);
     });
   });
 });

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -534,6 +534,269 @@ describe('createInputHandlers', () => {
     });
   });
 
+  describe('onAnswer value-or-label resolution (#574)', () => {
+    function addYesNoAlwaysQuestion(sessionId: UUID): void {
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'Yes, always', isRecommended: false, isYes: true, isNo: false },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+    }
+
+    function makeSession(): UUID {
+      const sessionId = sessionRegistry.createSessionId();
+      return sessionId;
+    }
+
+    test('a label "No" (phone display) resolves to deny via the held hook', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      // The phone sent the LABEL, not the value.
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+
+      expect(held).toEqual(['deny']); // resolved by label
+      expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+    });
+
+    test('a label "Yes" resolves to allow via the held hook (no PTY submit)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+
+      expect(held).toEqual(['allow']);
+      expect(ptyCapture.submits).toEqual([]);
+    });
+
+    test('the label "Yes, always" releases to passthrough and submits the option VALUE (index), not the label', async () => {
+      // Phase-2 "always" rule preserved: a label-sent "always" still cannot be
+      // expressed by the binary response, so it pops to passthrough; the PTY
+      // submit must be the digit Claude's native prompt expects ("2"), NOT "Yes, always".
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const released: UUID[] = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => {
+          throw new Error('resolveHeldPermission must not be called for "always"');
+        },
+        releaseHeldAsPassthrough: (_s, q) => {
+          released.push(q);
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes, always'); // sent as a LABEL
+
+      expect(released).toEqual([QID]);
+      expect(ptyCapture.submits).toEqual(['2']); // index, not the label
+    });
+
+    test('non-held PTY path: a label answer submits the option VALUE (index) into the native prompt', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        // No hold for this question on either path.
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // "No" is no-shaped -> decision 'deny', but no hold exists, so it falls to
+      // the PTY path; the digit "3" must be submitted, not the label "No".
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+
+      expect(ptyCapture.submits).toEqual(['3']);
+    });
+
+    test('non-held PTY path: a numeric value answer still submits that value (back-compat)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // A Telegram/in-app client still sends the value "1"; it resolves to the
+      // same option and submits "1".
+      await handlers.onAnswer(CID, sessionId, QID, '1');
+
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('multi-choice pick by label submits the picked index, not the label', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      // A multi-choice prompt (ExitPlanMode-style) with non-binary labels.
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'How should I proceed?',
+        options: [
+          { value: '1', label: 'Keep planning', isRecommended: false, isYes: false, isNo: false },
+          { value: '2', label: 'Accept the plan', isRecommended: true, isYes: false, isNo: false },
+          { value: '3', label: 'Cancel', isRecommended: false, isYes: false, isNo: false },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false, // non-binary -> decision null -> not consulted
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Accept the plan'); // label pick
+
+      expect(ptyCapture.submits).toEqual(['2']); // index for Claude's native prompt
+    });
+
+    test('a free-text answer with no option match is submitted verbatim', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'What should I name it?',
+        options: [],
+        allowsFreeText: true,
+        isAnswered: false,
+      });
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'my-widget');
+
+      expect(ptyCapture.submits).toEqual(['my-widget']);
+    });
+
+    test('logs a label->value resolution and an unresolved-label verbatim submit (FIX 1A)', async () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = makeSession();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      addYesNoAlwaysQuestion(sessionId);
+
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: () => false,
+        releaseHeldAsPassthrough: () => false,
+      });
+
+      // Label resolves to a different value -> logged as a translation.
+      await handlers.onAnswer(CID, sessionId, QID, 'No');
+      expect(logs.some((m) => m.includes('[Answer] resolved "No" -> "3"'))).toBe(true);
+
+      // A label that matches no option (options present) -> logged as verbatim submit.
+      addYesNoAlwaysQuestion(sessionId);
+      logs.length = 0;
+      await handlers.onAnswer(CID, sessionId, QID, 'Maybe');
+      expect(logs.some((m) => m.includes('[Answer] "Maybe" matched no option (3)'))).toBe(true);
+      expect(ptyCapture.submits).toContain('Maybe');
+    });
+  });
+
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });

--- a/packages/daemon/tests/cli/handlers/transcript-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/transcript-events.test.ts
@@ -9,6 +9,7 @@ import { createTranscriptHandlers } from '../../../src/cli/handlers/transcript-e
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionBindingStore } from '../../../src/session/session-binding-store.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
+import { TranscriptIndex } from '../../../src/session/transcript-index.ts';
 import { TranscriptDiscovery } from '../../../src/transcript/transcript-discovery.ts';
 import { TranscriptWatcher } from '../../../src/transcript/transcript-watcher.ts';
 
@@ -47,6 +48,7 @@ describe('createTranscriptHandlers', () => {
   let transcriptWatchers: Map<UUID, TranscriptWatcher>;
   let sessionStore: SessionStore;
   let bindingStore: SessionBindingStore;
+  let transcriptIndex: TranscriptIndex;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
 
   function send(connectionId: UUID, message: ProtocolMessage): boolean {
@@ -61,7 +63,8 @@ describe('createTranscriptHandlers', () => {
     transcriptDiscovery = new TranscriptDiscovery({ projectsDir });
     transcriptWatchers = new Map();
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
-    bindingStore = new SessionBindingStore(sessionStore);
+    transcriptIndex = new TranscriptIndex(path.join(tmpDir, 'transcript-index.json'));
+    bindingStore = new SessionBindingStore(sessionStore, transcriptIndex);
     sendCalls = [];
     configureLogger({ writeLog: () => {} });
   });
@@ -79,6 +82,7 @@ describe('createTranscriptHandlers', () => {
       transcriptDiscovery,
       transcriptWatchers,
       bindingStore,
+      transcriptIndex,
       currentOwnedSession,
       subagentViews,
       send,
@@ -271,6 +275,51 @@ describe('createTranscriptHandlers', () => {
     expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
       false,
     );
+  });
+
+  test('resolves a purged session via the durable transcript-index (#577)', async () => {
+    // The session was dropped from sessions.json (100-cap / 7-day TTL), so the
+    // store binding is gone, but the durable index still holds {claudeId,
+    // projectPath} and the .jsonl is still on disk. The handler must rebuild the
+    // path from the index instead of returning NOT_FOUND.
+    const claudeSessionId = '66666666-6666-6666-6666-666666666666';
+    writeTranscript(claudeSessionId, [
+      {
+        type: 'user',
+        uuid: 'u1',
+        sessionId: claudeSessionId,
+        cwd: '/Users/test/project',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: 'old history' },
+      },
+    ]);
+
+    const remiUuid = '77777777-7777-7777-7777-777777777777' as UUID;
+    // Record into the durable index ONLY (sessions.json deliberately empty, as
+    // it would be after a purge); bindingStore.get(remiUuid) therefore returns null.
+    transcriptIndex.record(remiUuid, claudeSessionId, '/Users/test/project');
+    expect(bindingStore.get(remiUuid)).toBeNull();
+
+    makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+    await waitForMessages(sendCalls, (calls) =>
+      calls.some((c) => c.message.type === 'transcript_load_complete'),
+    );
+    expect(sendCalls.some((c) => (c.message as { code?: string }).code === 'NOT_FOUND')).toBe(
+      false,
+    );
+  });
+
+  test('durable index resolves nothing when the .jsonl is gone -> NOT_FOUND', async () => {
+    // Index has the binding but the transcript file was deleted from disk. The
+    // existsSync guard must keep us from claiming a path that does not exist.
+    const remiUuid = '88888888-8888-8888-8888-888888888888' as UUID;
+    transcriptIndex.record(remiUuid, '99999999-9999-9999-9999-999999999999', '/Users/test/project');
+
+    makeHandlers().onTranscriptLoadRequest(CID, remiUuid, REQ);
+
+    expect(sendCalls).toHaveLength(1);
+    expect((sendCalls[0]?.message as { code?: string }).code).toBe('NOT_FOUND');
   });
 
   test('falls back to the active watcher when the id is a Remi UUID', async () => {

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -70,6 +70,53 @@ describe('createTrivialHandlers', () => {
     expect(typeof entry?.registeredAt).toBe('number');
   });
 
+  test('onRegisterDeviceToken: registering the same token twice yields ONE entry (#585 P7)', () => {
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
+    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
+
+    expect(deviceTokens.size).toBe(1);
+    expect(deviceTokens.has('same-token')).toBe(true);
+  });
+
+  test('onRegisterDeviceToken: a rotated token from the same connection prunes the old one (#585 P7)', () => {
+    // APNS token rotation: the same physical device (same client connection)
+    // re-registers a NEW token while the old one is still live -> a push would
+    // otherwise fan out to BOTH (the 2x duplicate). The old token from this
+    // connection is pruned, leaving only the new one.
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'old-token', 'ios');
+    handlers.onRegisterDeviceToken(CID, 'new-token', 'ios');
+
+    expect(deviceTokens.size).toBe(1);
+    expect(deviceTokens.has('new-token')).toBe(true);
+    expect(deviceTokens.has('old-token')).toBe(false);
+  });
+
+  test('onRegisterDeviceToken: a different connection keeps its own token (no cross-device prune)', () => {
+    const OTHER = 'conn1111-1111-1111-1111-111111111111' as UUID;
+    const deviceTokens = new Map<string, DeviceTokenEntry>();
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
+    configureLogger({ writeLog: () => {} });
+
+    handlers.onRegisterDeviceToken(CID, 'token-a', 'ios');
+    handlers.onRegisterDeviceToken(OTHER, 'token-b', 'ios');
+
+    // Two genuinely distinct devices on different connections must both survive.
+    expect(deviceTokens.size).toBe(2);
+    expect(deviceTokens.has('token-a')).toBe(true);
+    expect(deviceTokens.has('token-b')).toBe(true);
+  });
+
   test('onTerminalResize logs and returns when no session is attached', () => {
     const logs: string[] = [];
     const { send } = makeSend();

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { Question, UUID } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
@@ -191,6 +191,9 @@ describe('setupHookBridge', () => {
        *  contract through the bridge wiring. Defaults to the passthrough
        *  tracker used by the legacy assertion-style tests. */
       realTracker?: boolean;
+      /** Capture every message the bridge sends via sendAndRecord (#576: the
+       *  auto-approve status broadcasts). Defaults to a no-op send. */
+      sendLog?: ProtocolMessage[];
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -268,7 +271,7 @@ describe('setupHookBridge', () => {
         sessionId: SID,
         workingDirectory: tmpDir,
         messageApi: localMessageApi,
-        sendAndRecord: () => {},
+        sendAndRecord: opts.sendLog ? (m) => opts.sendLog?.push(m) : () => {},
         // PassthroughTracker is the default: it collapses
         // recordPendingHook into an immediate push so the legacy
         // "bridge emitted a question to the consumer" assertions via
@@ -2365,6 +2368,142 @@ describe('setupHookBridge', () => {
       } as unknown as Question);
 
       expect(messageApiLog.questionCalls).toBe(1);
+    });
+  });
+
+  describe('#576 auto-approve status broadcasts', () => {
+    /** Pull the AgentStatus values out of the session_update messages a run sent. */
+    function sessionUpdateStatuses(log: ProtocolMessage[]): string[] {
+      return log
+        .filter(
+          (m): m is Extract<ProtocolMessage, { type: 'session_update' }> =>
+            m.type === 'session_update',
+        )
+        .map((m) => m.session.status);
+    }
+
+    test('an APPROVE eval broadcasts "evaluating" then "approved" session_updates', async () => {
+      const sendLog: ProtocolMessage[] = [];
+      // A small eval delay guarantees onEvalStart fires before onHandled.
+      build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 10, sendLog });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-aa-status',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'aa-status.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-aa-status',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      expect(decision).toBe('allow');
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      // evaluating (onEvalStart) must precede approved (onHandled).
+      expect(statuses).toContain('evaluating');
+      expect(statuses).toContain('approved');
+      expect(statuses.indexOf('evaluating')).toBeLessThan(statuses.indexOf('approved'));
+    });
+
+    test('an ESCALATE eval broadcasts "evaluating" but NOT "approved" (no double-emit)', async () => {
+      const sendLog: ProtocolMessage[] = [];
+      build({
+        autoApprove: true,
+        autoApproveDecision: 'escalate',
+        autoApproveDelayMs: 10,
+        sendLog,
+      });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-aa-esc',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'aa-esc.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      await hookServer.firePermission({
+        session_id: 'claude-aa-esc',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      expect(statuses).toContain('evaluating');
+      // onEscalate deliberately does NOT broadcast (the bridge's
+      // handlePermissionRequest -> onStatusChange('waiting') already does);
+      // and onHandled is not reached on an escalate verdict.
+      expect(statuses).not.toContain('approved');
+    });
+
+    test('a status-broadcast send error never propagates into the gate decision', async () => {
+      // The broadcast helper wraps its own send in try/catch so a throwing
+      // sendAndRecord cannot break the allow/deny decision or the buffer path.
+      // A fresh setup wires a sender that records then throws on every send.
+      const throwingLog: ProtocolMessage[] = [];
+      const localApi = fakeMessageAPI({ resetCalls: { n: 0 }, statusCalls: [], questionCalls: 0 });
+      const freshSid = generateId();
+      sessionRegistry.registerSession(freshSid, tmpDir, fakePTY([]), localApi);
+      const autoApproveService = {
+        evaluate: async () => ({
+          decision: 'approve' as const,
+          reasoning: 'test',
+          durationMs: 0,
+          model: 'test-model',
+        }),
+        cancel: () => false,
+      } as unknown as import('../../../src/auto-approve/index.ts').AutoApproveService;
+      const freshHook = new RecordingHookServer();
+      setupHookBridge(
+        {
+          sessionRegistry,
+          bindingStore,
+          liveSessionsRegistry,
+          transcriptWatchers: transcriptWatchers as unknown as Map<
+            UUID,
+            import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
+          >,
+          transcriptFallbackTimers,
+          autoApproveService,
+          currentPort: () => 8765,
+        },
+        {
+          hookServer: freshHook as unknown as HookServer,
+          sessionId: freshSid,
+          workingDirectory: tmpDir,
+          messageApi: localApi,
+          sendAndRecord: (m) => {
+            throwingLog.push(m);
+            throw new Error('test: send blew up');
+          },
+          tracker: makePassthroughTracker(localApi),
+        },
+      );
+
+      freshHook.fire('SessionStart', {
+        session_id: 'claude-throw-broadcast',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'throw-bc.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      // The decision must still resolve to 'allow' despite the throwing sender.
+      const decision = await freshHook.firePermission({
+        session_id: 'claude-throw-broadcast',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      expect(decision).toBe('allow');
+      // And the broadcast was at least attempted (proving the throw path ran).
+      expect(throwingLog.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -194,6 +194,10 @@ describe('setupHookBridge', () => {
       /** Capture every message the bridge sends via sendAndRecord (#576: the
        *  auto-approve status broadcasts). Defaults to a no-op send. */
       sendLog?: ProtocolMessage[];
+      /** Capture every broadcastQuestionResolved call (#585, P7). Each entry is
+       *  the (questionId, reason) the bridge forwarded. Defaults to undefined
+       *  (dep not wired). */
+      broadcastResolvedLog?: Array<{ questionId: UUID; reason: string }>;
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -265,6 +269,15 @@ describe('setupHookBridge', () => {
         transcriptFallbackTimers,
         autoApproveService,
         currentPort: () => 8765,
+        ...(opts.broadcastResolvedLog
+          ? {
+              broadcastQuestionResolved: (
+                _sid: UUID,
+                questionId: UUID,
+                reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+              ) => opts.broadcastResolvedLog?.push({ questionId, reason }),
+            }
+          : {}),
       },
       {
         hookServer: hookServer as unknown as HookServer,
@@ -860,6 +873,45 @@ describe('setupHookBridge', () => {
     // assert only the tear-down signals, not the final map state.
     expect(stopCalls.length).toBeGreaterThanOrEqual(1);
     expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
+  });
+
+  test('restart (/clear) broadcasts question_resolved for each pending question and clears them (#585 P7)', () => {
+    const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+    build({ broadcastResolvedLog });
+
+    // Lock onto claude-A.
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-A',
+      transcript_path: path.join(tmpDir, 'a.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    // A question was pushed before the restart (held-hook or hook+PTY path).
+    const QID = 'q1111111-1111-1111-1111-111111111111' as UUID;
+    sessionRegistry.addQuestion(SID, {
+      id: QID,
+      text: 'proceed?',
+      options: [
+        { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+        { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+    // /clear: a new session_id rotates the binding (restart classification).
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-B',
+      transcript_path: path.join(tmpDir, 'b.jsonl'),
+      hook_event_name: 'SessionStart',
+      source: 'clear',
+    });
+
+    // The pending card is dismissed on every client (broadcast) AND dropped from
+    // the registry, so nothing lingers across the rotation.
+    expect(broadcastResolvedLog).toEqual([{ questionId: QID, reason: 'cancelled' }]);
+    expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
   });
 
   // SessionStart restart pre-empt is source-agnostic: any rotation of

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -225,6 +225,29 @@ describe('StatusBar', () => {
     expect(writes.length).toBeGreaterThan(2);
   });
 
+  test('the default interval is ~250ms so the evaluating counter is smooth (#576)', async () => {
+    // No explicit intervalMs: exercise the constructor default. Within 320ms a
+    // 250ms timer must have ticked at least once past the immediate paint
+    // (the old 1000ms default would not have). Kept comfortably above 250ms to
+    // avoid CI timer jitter flaking the assertion.
+    const writes: string[] = [];
+    const bar = new StatusBar({
+      getStdoutFd: () => 1,
+      getStatus: () => mkStatus(),
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => NOW_MS,
+      log: () => {},
+      // intervalMs intentionally omitted to test the default.
+    });
+    bar.start();
+    expect(writes).toHaveLength(1); // immediate paint
+    await new Promise((r) => setTimeout(r, 320));
+    bar.stop();
+    expect(writes.length).toBeGreaterThan(1); // at least one timer repaint
+  });
+
   test('a persistent render error never throws, logs once, and backs off after the threshold', async () => {
     let calls = 0;
     const { bar, writes, logs } = harness({

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -291,6 +291,8 @@ describe('formatConfig', () => {
     expect(output).toContain('deny_groups = []');
     // escalate_model visible (#522).
     expect(output).toContain('escalate_model = ""');
+    // always_escalate_tools visible (#572).
+    expect(output).toContain('always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]');
   });
 
   test('default model is a fast 4b; escalate_model empty (#522)', () => {
@@ -343,6 +345,7 @@ describe('auto_approve config', () => {
       escalate_timeout: 0,
       queue_timeout: 240,
       disable_thinking: false,
+      always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
     });
   });
 
@@ -368,6 +371,25 @@ timeout = 5
     // Defaults preserved for unset fields
     expect(config.auto_approve.base_url).toBe('http://localhost:11434/v1');
     expect(config.auto_approve.log_decisions).toBe(true);
+  });
+
+  test('loads always_escalate_tools from TOML (#572)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nalways_escalate_tools = ["MyTool"]\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.always_escalate_tools).toEqual(['MyTool']);
+  });
+
+  test('rejects always_escalate_tools as a non-array (#572)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nalways_escalate_tools = "AskUserQuestion"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/always_escalate_tools/);
+  });
+
+  test('REMI_AUTO_APPROVE_ALWAYS_ESCALATE env override trims and drops empties (#572)', () => {
+    process.env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE'] = 'AskUserQuestion, mcp__custom , ';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.auto_approve.always_escalate_tools).toEqual(['AskUserQuestion', 'mcp__custom']);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_ALWAYS_ESCALATE'];
   });
 
   test('preserves auto_approve defaults when section missing', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -346,6 +346,8 @@ describe('auto_approve config', () => {
       queue_timeout: 240,
       disable_thinking: false,
       always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
+      hold_timeout: 1800,
+      push_hold_timeout: 60,
     });
   });
 
@@ -523,6 +525,68 @@ Escalate anything touching secrets.
       const config = loadConfig(TEST_CONFIG);
       expect(config.auto_approve.approve_groups).toEqual(['read-only', 'bogus']);
       expect(warnings.some((w) => w.includes('unknown permission group "bogus"'))).toBe(true);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('loads hold_timeout / push_hold_timeout from TOML (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = 900\npush_hold_timeout = 45\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.hold_timeout).toBe(900);
+    expect(config.auto_approve.push_hold_timeout).toBe(45);
+  });
+
+  test('rejects a negative hold_timeout (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/hold_timeout/);
+  });
+
+  test('rejects a negative push_hold_timeout (#573)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\npush_hold_timeout = -5\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/push_hold_timeout/);
+  });
+
+  test('REMI_AUTO_APPROVE_HOLD_TIMEOUT / PUSH_HOLD_TIMEOUT env overrides (#573)', () => {
+    process.env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'] = '1200';
+    process.env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'] = '90';
+    const config = applyEnvOverrides(DEFAULT_CONFIG);
+    expect(config.auto_approve.hold_timeout).toBe(1200);
+    expect(config.auto_approve.push_hold_timeout).toBe(90);
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_HOLD_TIMEOUT'];
+    // biome-ignore lint/performance/noDelete: test isolation
+    delete process.env['REMI_AUTO_APPROVE_PUSH_HOLD_TIMEOUT'];
+  });
+
+  test('warns (does not throw) when push_hold_timeout > 0 but hold_timeout = 0 (FIX 4 / #573)', () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg?: unknown) => warnings.push(String(msg));
+    try {
+      fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_timeout = 0\npush_hold_timeout = 60\n');
+      const config = loadConfig(TEST_CONFIG); // must NOT throw
+      expect(config.auto_approve.hold_timeout).toBe(0);
+      expect(config.auto_approve.push_hold_timeout).toBe(60);
+      expect(
+        warnings.some((w) => w.includes('push_hold_timeout') && w.includes('hold_timeout = 0')),
+      ).toBe(true);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('does NOT warn when both hold_timeout and push_hold_timeout are set (FIX 4 / #573)', () => {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg?: unknown) => warnings.push(String(msg));
+    try {
+      fs.writeFileSync(
+        TEST_CONFIG,
+        '[auto_approve]\nhold_timeout = 1800\npush_hold_timeout = 60\n',
+      );
+      loadConfig(TEST_CONFIG);
+      expect(warnings.some((w) => w.includes('push_hold_timeout'))).toBe(false);
     } finally {
       console.warn = original;
     }

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -423,6 +423,26 @@ describe('HookEventBridge', () => {
 
       expect(questions[0]?.text).toBe('Allow Bash: ssh hallu "uv run pytest"');
     });
+
+    it('stamps source so the tracker can prefer the rich request over the generic notification (#574)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      } as PermissionRequestHookInput);
+      bridge.handleNotification({
+        ...makeCommon(),
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        message: 'Claude needs your permission to use Bash',
+      } as NotificationHookInput);
+
+      expect(questions[0]?.source).toBe('permission_request');
+      expect(questions[1]?.source).toBe('notification');
+    });
   });
 
   describe('subagent context filtering (issue #316, phase 4 #419)', () => {

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -5,6 +5,7 @@ import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts'
 import {
   NotificationDispatcher,
   type PushFn,
+  buildPushText,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -25,9 +26,22 @@ const noOpt: QuestionOption = {
   isNo: true,
 };
 
-function question(id: string, options: QuestionOption[]): Question {
-  return { id: id as UUID, text: 'proceed?', options, allowsFreeText: false, isAnswered: false };
+function question(id: string, options: QuestionOption[], text = 'proceed?'): Question {
+  return { id: id as UUID, text, options, allowsFreeText: false, isAnswered: false };
 }
+
+const yesAlwaysOpt: QuestionOption = {
+  value: '2',
+  label: 'Yes, always',
+  isRecommended: false,
+  isYes: true,
+  isNo: false,
+};
+const defaultThreeSet: QuestionOption[] = [
+  { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+  yesAlwaysOpt,
+  { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+];
 
 function fakePTY(): PTYSession {
   return {
@@ -45,6 +59,55 @@ describe('selectPushCategory', () => {
     expect(selectPushCategory([yesOpt, noOpt, yesOpt, noOpt])).toBe('REMI_MULTI');
     expect(selectPushCategory([yesOpt])).toBeUndefined();
     expect(selectPushCategory([])).toBeUndefined();
+  });
+});
+
+describe('buildPushText (#574 issues 3+4)', () => {
+  test('title carries session + clean hook ask; body lists the real option labels', () => {
+    const { title, body } = buildPushText(
+      'my-project',
+      question('q', defaultThreeSet, 'Allow Bash: git push origin main'),
+    );
+    expect(title).toBe('my-project: Allow Bash: git push origin main');
+    // Body leads with the ask, then the real labels (not numeric indices).
+    expect(body).toBe('Allow Bash: git push origin main\n1. Yes  2. Yes, always  3. No');
+  });
+
+  test('regression: a raw collapsed PTY prompt is NEVER emitted as the body', () => {
+    // The PTY screen text collapses to a run-together string after ANSI strip
+    // ("Doyouwanttoproceed?"); normalization must keep word separators and the
+    // dispatcher must never surface that exact garble. Here the hook text is
+    // the clean source; even a garbled question.text must be whitespace-safe.
+    const { title, body } = buildPushText(
+      'agent',
+      question('q', defaultThreeSet, 'Do  you\twant\nto   proceed?'),
+    );
+    // Collapsed whitespace -> single spaces, never the no-space run-together form.
+    expect(body).not.toContain('Doyouwanttoproceed');
+    expect(title).not.toContain('Doyouwanttoproceed');
+    expect(body.startsWith('Do you want to proceed?')).toBe(true);
+  });
+
+  test('free-text prompt (no options): body is just the ask, no trailing list', () => {
+    const { body } = buildPushText('agent', question('q', [], 'What should I name it?'));
+    expect(body).toBe('What should I name it?');
+  });
+
+  test('empty question text falls back to a generic ask, never blank', () => {
+    const { title, body } = buildPushText('agent', question('q', defaultThreeSet, '   '));
+    expect(title).toBe('agent: Allow this action?');
+    expect(body.startsWith('Allow this action?')).toBe(true);
+  });
+
+  test('option prefix is the actual VALUE, not the positional index (FIX 3C)', () => {
+    // StopFailure-style y/n options carry non-index values; the prefix must
+    // reflect the real value ("y. Yes  n. No") so it stays accurate.
+    const ynOpts: QuestionOption[] = [
+      { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+      { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+    ];
+    const { body } = buildPushText('agent', question('q', ynOpts, 'Retry?'));
+    expect(body).toBe('Retry?\ny. Yes  n. No');
   });
 });
 
@@ -104,7 +167,9 @@ describe('NotificationDispatcher.maybePush', () => {
     // wss->https normalization downstream.
     expect(pushed[0]?.url).toBe('ws://x');
     expect(pushed[0]?.opts['category']).toBe('REMI_YN');
-    expect(pushed[0]?.opts['options']).toEqual(['y', 'n']);
+    // #574: options carry the human-readable LABELS for display, not the
+    // numeric values; answer routing resolves a label back to the option.
+    expect(pushed[0]?.opts['options']).toEqual(['Yes', 'No']);
   });
 
   test('does NOT push when a client is attached (it sees the question in-app)', () => {
@@ -134,5 +199,39 @@ describe('NotificationDispatcher.maybePush', () => {
     d.resetDedup(); // prompt cycle ended (status left 'waiting')
     d.maybePush(SID, question('q3', [yesOpt, noOpt]));
     expect(pushed).toHaveLength(2);
+  });
+
+  test('sends option LABELS for display, not numeric values (#574 issue 4)', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().maybePush(SID, question('q1', defaultThreeSet, 'Allow Bash: git push'));
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.opts['options']).toEqual(['Yes', 'Yes, always', 'No']);
+    expect(pushed[0]?.opts['category']).toBe('REMI_YNA');
+  });
+
+  test('body shows the ask + real labels and is never the collapsed PTY garble (#574 issue 3)', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    // A garbled PTY-derived text must not surface run-together on the wire.
+    make().maybePush(SID, question('q1', defaultThreeSet, 'Do  you\twant to proceed?'));
+
+    expect(pushed).toHaveLength(1);
+    const body = pushed[0]?.opts['body'] as string;
+    expect(body).not.toContain('Doyouwanttoproceed');
+    expect(body).toContain('1. Yes  2. Yes, always  3. No');
+  });
+
+  test('falls back to the option value when a label is empty', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    const blankLabel: QuestionOption = { ...yesOpt, label: '' };
+    make().maybePush(SID, question('q1', [blankLabel, noOpt]));
+
+    expect(pushed[0]?.opts['options']).toEqual(['y', 'No']);
   });
 });

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -235,3 +235,69 @@ describe('NotificationDispatcher.maybePush', () => {
     expect(pushed[0]?.opts['options']).toEqual(['y', 'No']);
   });
 });
+
+describe('NotificationDispatcher.dismiss (#585 P7)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+  const QID = 'q0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (_url, token, opts) => {
+    pushed.push({ token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('fires a dismiss push (dismiss flag + questionId) to every device', () => {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    // Attach a client: dismiss must STILL fire (unlike maybePush) — the card may
+    // be on another device's lock screen.
+    registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    deviceTokens.set('b', { token: 'b', platform: 'ios', registeredAt: 2, connectionId: SID });
+
+    make().dismiss(SID, QID);
+
+    expect(pushed.map((p) => p.token).sort()).toEqual(['a', 'b']);
+    expect(pushed[0]?.opts['dismiss']).toBe(true);
+    expect(pushed[0]?.opts['questionId']).toBe(QID);
+  });
+
+  test('no-op when no device tokens are registered', () => {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    make().dismiss(SID, QID);
+    expect(pushed).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/session/session-binding-store.test.ts
+++ b/packages/daemon/tests/session/session-binding-store.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { UUID } from '@remi/shared';
 import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
 import { SessionStore, type StoredSession } from '../../src/session/session-store.ts';
+import { TranscriptIndex } from '../../src/session/transcript-index.ts';
 
 function makeTmpPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-binding-test-'));
@@ -123,5 +124,25 @@ describe('SessionBindingStore', () => {
     expect(binding.get(session.remiSessionId)?.claudeSessionId).toBe('claude-3');
     expect(binding.getByClaudeSessionId('claude-3')?.remiSessionId).toBe(session.remiSessionId);
     expect(binding.getByClaudeSessionId('claude-1')).toBeNull();
+  });
+
+  test('rotation mirrors the NEW claudeSessionId into the durable index (#577)', () => {
+    // The transcript-index must follow a rotation; otherwise the purged-binding
+    // fallback would load the STALE pre-rotation transcript. Mirroring from the
+    // record returned by updateClaudeSessionId (not a second read) closes the
+    // race where a concurrent purge could null the row between write and mirror.
+    const indexPath = path.join(path.dirname(filePath), 'transcript-index.json');
+    const index = new TranscriptIndex(indexPath);
+    const withIndex = new SessionBindingStore(store, index);
+
+    const session = makeSession({ claudeSessionId: 'claude-old' });
+    withIndex.preAssign(session);
+    expect(index.get(session.remiSessionId)?.claudeSessionId).toBe('claude-old');
+
+    withIndex.update(session.remiSessionId, 'claude-new');
+    // The index now points at the rotated id with the same project path.
+    const entry = index.get(session.remiSessionId);
+    expect(entry?.claudeSessionId).toBe('claude-new');
+    expect(entry?.projectPath).toBe(session.projectPath);
   });
 });

--- a/packages/daemon/tests/session/transcript-index.test.ts
+++ b/packages/daemon/tests/session/transcript-index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { TranscriptIndex } from '../../src/session/transcript-index.ts';
+
+function makeTmpPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tidx-'));
+  return path.join(dir, 'transcript-index.json');
+}
+
+const remi = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, '0')}` as UUID;
+
+describe('TranscriptIndex (#577)', () => {
+  let filePath: string;
+  let index: TranscriptIndex;
+
+  beforeEach(() => {
+    filePath = makeTmpPath();
+    index = new TranscriptIndex(filePath);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('get returns null when nothing recorded', () => {
+    expect(index.get(remi(1))).toBeNull();
+  });
+
+  test('record then get round-trips the binding', () => {
+    index.record(remi(1), 'claude-abc', '/Users/me/project');
+    const entry = index.get(remi(1));
+    expect(entry?.claudeSessionId).toBe('claude-abc');
+    expect(entry?.projectPath).toBe('/Users/me/project');
+    expect(entry?.remiSessionId).toBe(remi(1));
+  });
+
+  test('record upserts by remiSessionId (rotation refresh)', () => {
+    index.record(remi(1), 'claude-old', '/proj');
+    index.record(remi(1), 'claude-new', '/proj');
+    const all = index.get(remi(1));
+    expect(all?.claudeSessionId).toBe('claude-new');
+    // Still a single entry (upsert, not append).
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(raw.entries).toHaveLength(1);
+  });
+
+  test('persists across a fresh instance (durability beyond process)', () => {
+    index.record(remi(7), 'claude-7', '/p7');
+    const reopened = new TranscriptIndex(filePath);
+    expect(reopened.get(remi(7))?.claudeSessionId).toBe('claude-7');
+  });
+
+  test('outlives many recordings (no 100-entry cap like sessions.json)', () => {
+    for (let i = 0; i < 250; i++) {
+      index.record(remi(i), `claude-${i}`, `/p/${i}`);
+    }
+    // The oldest entry is still resolvable; sessions.json would have trimmed it.
+    expect(index.get(remi(0))?.claudeSessionId).toBe('claude-0');
+    expect(index.get(remi(249))?.claudeSessionId).toBe('claude-249');
+  });
+
+  test('prunes entries older than the 90-day TTL on write', () => {
+    // Seed an entry whose updatedAt is 100 days old by writing the file directly.
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { remiSessionId: remi(1), claudeSessionId: 'old', projectPath: '/p', updatedAt: old },
+        ],
+      }),
+    );
+    // A new record triggers prune; the 100-day-old entry should be dropped.
+    index.record(remi(2), 'fresh', '/p2');
+    expect(index.get(remi(1))).toBeNull();
+    expect(index.get(remi(2))?.claudeSessionId).toBe('fresh');
+  });
+
+  test('keeps entries within the TTL', () => {
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            remiSessionId: remi(1),
+            claudeSessionId: 'recent',
+            projectPath: '/p',
+            updatedAt: recent,
+          },
+        ],
+      }),
+    );
+    index.record(remi(2), 'fresh', '/p2');
+    expect(index.get(remi(1))?.claudeSessionId).toBe('recent');
+  });
+
+  test('handles corrupt JSON gracefully', () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'not json', 'utf-8');
+    expect(index.get(remi(1))).toBeNull();
+    // Can still record after corruption.
+    index.record(remi(1), 'after', '/p');
+    expect(index.get(remi(1))?.claudeSessionId).toBe('after');
+  });
+
+  test('ignores a wrong-version file', () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify({ version: 99, entries: [] }), 'utf-8');
+    expect(index.get(remi(1))).toBeNull();
+  });
+
+  test('over cap: NaN-timestamp entries are trimmed BEFORE valid ones (#577 FIX 2)', () => {
+    // Regression for the prune sort defect: a string compare sorted an
+    // unparseable updatedAt to the FRONT, so the cap trimmed the newest VALID
+    // entries first and a NaN-heavy file looped forever. Numeric NaN->0 (oldest)
+    // makes the cap drop the bad entries first.
+    const capped = new TranscriptIndex(filePath, 2); // maxEntries = 2
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const valid1 = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { remiSessionId: remi(1), claudeSessionId: 'bad-a', projectPath: '/p', updatedAt: 'NaN' },
+          {
+            remiSessionId: remi(2),
+            claudeSessionId: 'bad-b',
+            projectPath: '/p',
+            updatedAt: 'garbage',
+          },
+          {
+            remiSessionId: remi(3),
+            claudeSessionId: 'valid-1',
+            projectPath: '/p',
+            updatedAt: valid1,
+          },
+        ],
+      }),
+    );
+    // record() (with cap=2) triggers prune. After the new entry there are 4;
+    // trimming to 2 must drop the two NaN entries first, keeping the valid ones.
+    capped.record(remi(4), 'valid-2', '/p');
+
+    expect(capped.get(remi(1))).toBeNull(); // NaN -> trimmed
+    expect(capped.get(remi(2))).toBeNull(); // NaN -> trimmed
+    expect(capped.get(remi(3))?.claudeSessionId).toBe('valid-1'); // valid -> kept
+    expect(capped.get(remi(4))?.claudeSessionId).toBe('valid-2'); // valid -> kept
+  });
+});

--- a/packages/daemon/tests/session/transcript-index.test.ts
+++ b/packages/daemon/tests/session/transcript-index.test.ts
@@ -123,7 +123,7 @@ describe('TranscriptIndex (#577)', () => {
 
   test('over cap: NaN-timestamp entries are trimmed BEFORE valid ones (#577 FIX 2)', () => {
     // Regression for the prune sort defect: a string compare sorted an
-    // unparseable updatedAt to the FRONT, so the cap trimmed the newest VALID
+    // unparsable updatedAt to the FRONT, so the cap trimmed the newest VALID
     // entries first and a NaN-heavy file looped forever. Numeric NaN->0 (oldest)
     // makes the cap drop the bad entries first.
     const capped = new TranscriptIndex(filePath, 2); // maxEntries = 2

--- a/packages/daemon/tests/telegram-ui.test.ts
+++ b/packages/daemon/tests/telegram-ui.test.ts
@@ -189,6 +189,13 @@ describe('formatStatusText', () => {
     expect(formatStatusText('waiting')).toContain('Waiting');
   });
 
+  test('formats the auto-approve + lifecycle statuses with human labels (#576)', () => {
+    // No raw "evaluating"/"approved"/"starting" leaking through the default arm.
+    expect(formatStatusText('evaluating')).toContain('Evaluating');
+    expect(formatStatusText('approved')).toContain('Approved');
+    expect(formatStatusText('starting')).toContain('Starting');
+  });
+
   test('returns raw string for unknown status', () => {
     expect(formatStatusText('custom' as AgentStatus)).toBe('custom');
   });

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -3,14 +3,22 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   type UUID,
   createCreateSessionRequest,
   createHello,
+  createIdentity,
   createPing,
   createUserInput,
   serialize,
+  sign,
+  unlockIdentity,
 } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
 import { WebSocketServer } from '../src/server/websocket-server.ts';
 
 describe('WebSocketServer', () => {
@@ -594,6 +602,199 @@ describe('WebSocketServer', () => {
 
       ws.close();
       await server.stop();
+    });
+  });
+
+  // Connection-independent answer relay (#575, P4a). Real HTTP requests; real
+  // Ed25519 auth via a real IdentityStore + Authenticator (no mocks).
+  describe('POST /answer relay', () => {
+    // Each startServer() call binds a fresh port so a not-yet-released listener
+    // from a prior server in the same/previous test cannot answer this request.
+    let nextAnswerPort = testPort + 30;
+    let answerPort = nextAnswerPort;
+
+    async function startServer(opts: {
+      authenticator?: Authenticator;
+      relayResult?: 'delivered' | 'session-not-found' | 'stale-binding' | 'stale';
+      captureRelay?: (args: { sessionId: string; questionId: string; answer: string }) => void;
+    }): Promise<WebSocketServer> {
+      if (server?.running) await server.stop();
+      answerPort = nextAnswerPort++;
+      const s = new WebSocketServer(
+        {
+          port: answerPort,
+          connection: opts.authenticator ? { authenticator: opts.authenticator } : {},
+        },
+        {
+          onAnswerRelay: async (sessionId, questionId, answer) => {
+            opts.captureRelay?.({ sessionId, questionId, answer });
+            return opts.relayResult ?? 'delivered';
+          },
+        },
+      );
+      await s.start();
+      server = s; // so afterEach stops it
+      return s;
+    }
+
+    function makeAuthDir(): { store: IdentityStore; dir: string } {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-answer-relay-'));
+      return { store: new IdentityStore(dir), dir };
+    }
+
+    test('routes a loopback (no-auth) answer through onAnswerRelay and returns delivered', async () => {
+      const captured: Array<{ sessionId: string; questionId: string; answer: string }> = [];
+      await startServer({ captureRelay: (a) => captured.push(a) });
+
+      const res = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'sess-1', questionId: 'q-1', answer: 'Yes' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result: string };
+      expect(body.result).toBe('delivered');
+      expect(captured).toEqual([{ sessionId: 'sess-1', questionId: 'q-1', answer: 'Yes' }]);
+    });
+
+    test('maps session-not-found to 404 and stale to 409', async () => {
+      await startServer({ relayResult: 'session-not-found' });
+      const r1 = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+      });
+      expect(r1.status).toBe(404);
+      expect(((await r1.json()) as { result: string }).result).toBe('session-not-found');
+
+      await startServer({ relayResult: 'stale' });
+      const r2 = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+      });
+      expect(r2.status).toBe(409);
+      expect(((await r2.json()) as { result: string }).result).toBe('stale');
+    });
+
+    test('returns 400 for missing fields and bad JSON', async () => {
+      await startServer({});
+      const bad = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      });
+      expect(bad.status).toBe(400);
+
+      const missing = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's' }),
+      });
+      expect(missing.status).toBe(400);
+    });
+
+    test('rejects an oversized body with 413 before parsing', async () => {
+      await startServer({});
+      // 64KiB + 1: just over the guard.
+      const huge = 'x'.repeat(64 * 1024 + 1);
+      const res = await fetch(`http://localhost:${answerPort}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: huge }),
+      });
+      expect(res.status).toBe(413);
+      expect(((await res.json()) as { result: string }).result).toBe('payload-too-large');
+    });
+
+    test('loopback peer is exempt from auth even when an authenticator is configured', async () => {
+      // Mirrors the WebSocket loopback bypass: a same-machine peer is trusted
+      // by virtue of the OS, so the route does not require a signature. The test
+      // client connects over 127.0.0.1, so this proves the route is reachable
+      // (and auth-exempt) for loopback even with auth on.
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+        await startServer({ authenticator });
+
+        const res = await fetch(`http://localhost:${answerPort}/answer`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: 's', questionId: 'q', answer: 'Yes' }),
+        });
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { result: string }).result).toBe('delivered');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    // The route's networked-peer auth gate calls Authenticator.verifyDetachedRequest;
+    // since loopback peers (the only peer a local test can present) are exempt,
+    // the auth-rejection path is exercised directly against that method — the
+    // exact same gate the route uses (verify signature, then require an
+    // authorized key). This is the SAME trust model the WebSocket handshake uses.
+    test('verifyDetachedRequest rejects a valid signature from an UNAUTHORIZED key', async () => {
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+
+        const stranger = await createIdentity();
+        const strangerUnlocked = await unlockIdentity(stranger);
+        const msg = 'sess|q|Yes';
+        const data = new TextEncoder().encode(msg).buffer as ArrayBuffer;
+        const sig = await sign(strangerUnlocked.privateKey, data);
+        // Signature is cryptographically valid, but the key was never authorized.
+        expect(
+          await authenticator.verifyDetachedRequest(
+            msg,
+            sig,
+            stranger.publicKey,
+            stranger.fingerprint,
+          ),
+        ).toBe(false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    test('verifyDetachedRequest accepts an authorized key with a valid signature, rejects a tampered message', async () => {
+      const { store, dir } = makeAuthDir();
+      try {
+        await store.generate();
+        const serverIdentity = await store.unlock();
+        const authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+
+        const client = await createIdentity();
+        const clientUnlocked = await unlockIdentity(client);
+        await store.addAuthorizedKey(client.publicKey, 'Test Client');
+
+        const msg = 'sess|q|Yes';
+        const data = new TextEncoder().encode(msg).buffer as ArrayBuffer;
+        const sig = await sign(clientUnlocked.privateKey, data);
+
+        // Authorized key + matching signature => accepted.
+        expect(
+          await authenticator.verifyDetachedRequest(msg, sig, client.publicKey, client.fingerprint),
+        ).toBe(true);
+
+        // Same signature over a DIFFERENT message (replay for another answer) => rejected.
+        expect(
+          await authenticator.verifyDetachedRequest(
+            'sess|q|No',
+            sig,
+            client.publicKey,
+            client.fingerprint,
+          ),
+        ).toBe(false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -91,6 +91,7 @@ export type {
   SessionRotatedMessage,
   SessionViewsMessage,
   SessionViewMeta,
+  QuestionResolvedMessage,
   CreateHelloOptions,
 } from './protocol.ts';
 
@@ -139,6 +140,7 @@ export {
   createDaemonUpdateAvailable,
   createSessionRotated,
   createSessionViews,
+  createQuestionResolved,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export type {
   Acknowledgment,
   Question,
   QuestionOption,
+  QuestionSource,
   Session,
   ConnectionInfo,
   Result,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -101,7 +101,8 @@ export type ProtocolMessage =
   | RegisterDeviceTokenMessage
   | DaemonUpdateAvailableMessage
   | SessionRotatedMessage
-  | SessionViewsMessage;
+  | SessionViewsMessage
+  | QuestionResolvedMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -243,6 +244,30 @@ export interface AnswerMessage {
    * Omitted by pre-#429 clients.
    */
   readonly claudeSessionId?: UUID | undefined;
+}
+
+/**
+ * Daemon -> client broadcast: a pending question stopped being pending, so every
+ * client should dismiss its card and clear any local/lock-screen notification for
+ * it (#585, P7). Sent to ALL connected clients (cross-client dismissal) the moment
+ * a question resolves on ANY channel — answered from one device, auto-approved/denied
+ * by the gate, or cancelled because Claude advanced past the prompt. Idempotent: a
+ * client that no longer holds the question simply ignores it.
+ *
+ * The daemon also fires a quiet APNS dismissal (apns-collapse-id = questionId,
+ * content-available) so a suspended device replaces/clears the lock-screen card; this
+ * WebSocket message is the in-app counterpart for connected clients.
+ */
+export interface QuestionResolvedMessage {
+  readonly type: 'question_resolved';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session that owned the question (the id the client keys cards by). */
+  readonly sessionId: UUID;
+  /** The resolved question's id; clients remove the card carrying it. */
+  readonly questionId: UUID;
+  /** Why it resolved, for diagnostics + client UX (all dismiss the card the same). */
+  readonly reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
 }
 
 /** Session state update */
@@ -779,6 +804,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'daemon_update_available',
     'session_rotated',
     'session_views',
+    'question_resolved',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1006,6 +1032,26 @@ export function createAnswer(
     questionId,
     answer,
     ...(claudeSessionId !== undefined && { claudeSessionId }),
+  };
+}
+
+/**
+ * Create a question-resolved broadcast (#585, P7). Fired by the daemon to ALL
+ * clients when a pending question stops being pending so every client dismisses
+ * its card; `reason` records how it resolved (all clients dismiss identically).
+ */
+export function createQuestionResolved(
+  sessionId: UUID,
+  questionId: UUID,
+  reason: QuestionResolvedMessage['reason'],
+): QuestionResolvedMessage {
+  return {
+    type: 'question_resolved',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    questionId,
+    reason,
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -157,7 +157,26 @@ export interface Question {
    * question id, so concurrency there holds regardless of this field.
    */
   readonly agentId?: string | undefined;
+
+  /**
+   * Where this question came from (#574). The daemon emits two hook-derived
+   * questions for one permission cycle: a rich `PermissionRequest` (tool +
+   * command + agent context) and a generic `Notification(permission_prompt)`
+   * ("Claude needs your permission to use Bash"). The
+   * QuestionPresenceTracker's merge policy uses this so a trailing generic
+   * notification never overwrites the richer permission-request text/options
+   * for the same agent. PTY-parsed prompts are `'pty'`. Optional and
+   * ignored on the wire; consumed only by the daemon's notification path.
+   */
+  readonly source?: QuestionSource | undefined;
 }
+
+/**
+ * Provenance of a {@link Question} (#574). Drives the daemon's
+ * QuestionPresenceTracker merge policy (richer hook text must win over the
+ * generic notification fallback) and is otherwise inert on the wire.
+ */
+export type QuestionSource = 'permission_request' | 'notification' | 'pty';
 
 /** Sentinel agent key for the primary (main) agent, whose questions carry no
  *  `agentId`. Normalize `agentId ?? MAIN_AGENT_ID` when building collection keys. */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -20,8 +20,25 @@ export type MessageState = 'sending' | 'sent' | 'delivered' | 'read';
 /** Who sent the message */
 export type MessageSender = 'agent' | 'user' | 'system';
 
-/** Agent status while working */
-export type AgentStatus = 'idle' | 'thinking' | 'executing' | 'waiting';
+/**
+ * Agent status while working.
+ *
+ * Hook- and auto-approve-sourced lifecycle states (#576):
+ *   - `waiting`     — blocked on the user (a permission/question is open).
+ *   - `evaluating`  — auto-approve is deciding a permission right now.
+ *   - `approved`    — auto-approve just allowed a permission (transient; the
+ *                     next hook moves the session back to executing/thinking).
+ *   - `starting`    — the session is spinning up before its first hook fires,
+ *                     so clients have a defined pill state from hello_ack.
+ */
+export type AgentStatus =
+  | 'idle'
+  | 'thinking'
+  | 'executing'
+  | 'waiting'
+  | 'evaluating'
+  | 'approved'
+  | 'starting';
 
 /**
  * Core message type.

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -18,6 +18,7 @@ import {
   createPing,
   createPong,
   createQuestion,
+  createQuestionResolved,
   createReplayBatch,
   createResumeSessionRequest,
   createResumeSessionResponse,
@@ -270,6 +271,7 @@ describe('deserialize()', () => {
       'session_list_request',
       'session_list_response',
       'transcript_content',
+      'question_resolved',
     ] as const;
 
     for (const type of validTypes) {
@@ -307,6 +309,37 @@ describe('deserialize()', () => {
     expect(parsed.message.content).toBe(message.content);
     expect(parsed.message.tool).toBe(message.tool);
     expect(parsed.message.isEditing).toBe(message.isEditing);
+  });
+});
+
+describe('createQuestionResolved() (#585 P7)', () => {
+  test('builds a well-formed question_resolved message', () => {
+    const sessionId = generateId();
+    const questionId = generateId();
+    const msg = createQuestionResolved(sessionId, questionId, 'answered');
+    expect(msg.type).toBe('question_resolved');
+    expect(msg.sessionId).toBe(sessionId);
+    expect(msg.questionId).toBe(questionId);
+    expect(msg.reason).toBe('answered');
+    expect(typeof msg.id).toBe('string');
+    expect(typeof msg.timestamp).toBe('string');
+  });
+
+  test('round-trips through serialize/deserialize for every reason', () => {
+    const reasons = ['answered', 'auto_approved', 'auto_denied', 'cancelled'] as const;
+    for (const reason of reasons) {
+      const sessionId = generateId();
+      const questionId = generateId();
+      const original = createQuestionResolved(sessionId, questionId, reason);
+      const parsed = deserialize(serialize(original));
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('question_resolved');
+      if (parsed?.type === 'question_resolved') {
+        expect(parsed.sessionId).toBe(sessionId);
+        expect(parsed.questionId).toBe(questionId);
+        expect(parsed.reason).toBe(reason);
+      }
+    }
   });
 });
 

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -22,6 +22,17 @@ interface ApnsPayload {
    * bytes; callers pass a questionId (a UUID, well within the limit).
    */
   collapseId?: string;
+  /**
+   * Dismissal push (#585, P7). When true the push is QUIET: no `alert`, no
+   * `sound`, no `badge` bump — only `content-available: 1` plus the
+   * `apns-collapse-id` header. iOS replaces the earlier notification for the same
+   * collapse-id with this contentless update, so the lock-screen card for an
+   * already-resolved question is cleared/superseded. The app's
+   * `didReceiveRemoteNotification` handler then calls
+   * `removeDeliveredNotifications(withIdentifiers:)` to drop it entirely
+   * (native-only; see web/Capacitor handler).
+   */
+  dismiss?: boolean;
 }
 
 interface ApnsConfig {
@@ -64,30 +75,43 @@ export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest
       ? payload.collapseId.slice(0, 64)
       : undefined;
 
+  // A dismissal (#585, P7) is a QUIET background push: it carries no alert and
+  // must use the `background` push type at low priority, or APNS rejects a
+  // content-available-only payload sent as `alert`. The collapse-id ties it to
+  // the original card so iOS supersedes it; the app then removes the delivered
+  // notification on receipt.
   const headers: Record<string, string> = {
     authorization: `bearer ${jwt}`,
     'apns-topic': payload.bundleId,
-    'apns-push-type': 'alert',
-    'apns-priority': '10',
+    'apns-push-type': payload.dismiss ? 'background' : 'alert',
+    'apns-priority': payload.dismiss ? '5' : '10',
     ...(collapseId ? { 'apns-collapse-id': collapseId } : {}),
   };
 
+  const aps: Record<string, unknown> = payload.dismiss
+    ? {
+        // Quiet update only: no alert, no sound, no badge bump. iOS replaces the
+        // earlier collapse-id card and wakes the app to remove it.
+        'content-available': 1,
+      }
+    : {
+        alert: {
+          title: payload.title,
+          body: payload.body,
+        },
+        sound: 'default',
+        badge: 1,
+        // content-available pre-wakes the app in the background so the
+        // WebSocket can start reconnecting before the user taps (#575, P4a).
+        // Kept alongside the alert so the interactive notification still
+        // renders; iOS treats this as a normal alert push with a background
+        // wake opportunity.
+        'content-available': 1,
+        ...(payload.category ? { category: payload.category } : {}),
+      };
+
   const body = JSON.stringify({
-    aps: {
-      alert: {
-        title: payload.title,
-        body: payload.body,
-      },
-      sound: 'default',
-      badge: 1,
-      // content-available pre-wakes the app in the background so the
-      // WebSocket can start reconnecting before the user taps (#575, P4a).
-      // Kept alongside the alert so the interactive notification still
-      // renders; iOS treats this as a normal alert push with a background
-      // wake opportunity.
-      'content-available': 1,
-      ...(payload.category ? { category: payload.category } : {}),
-    },
+    aps,
     ...(payload.data ? payload.data : {}),
   });
 

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -15,12 +15,83 @@ interface ApnsPayload {
   sandbox?: boolean;
   /** UNNotificationCategory identifier for action buttons (lock screen / Watch) */
   category?: string;
+  /**
+   * Collapse identifier (#575, P4a). Sent as the `apns-collapse-id` header AND
+   * used to de-dup at the device. A re-push for the same questionId replaces the
+   * earlier notification instead of stacking a duplicate. Apple caps this at 64
+   * bytes; callers pass a questionId (a UUID, well within the limit).
+   */
+  collapseId?: string;
 }
 
 interface ApnsConfig {
   keyId: string;
   teamId: string;
   privateKey: string;
+}
+
+/** The fully-resolved APNS HTTP/2 request (URL + headers + JSON body string). */
+export interface ApnsRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Build the APNS HTTP/2 request (URL, headers, body) from a payload + JWT.
+ *
+ * Extracted as a pure function so the payload shape — including the #575 P4a
+ * `content-available` pre-wake flag and the `apns-collapse-id` header — can be
+ * asserted directly in tests without intercepting the network.
+ *
+ * Throws if `payload.data` contains the reserved `aps` key (would clobber the
+ * APNS dictionary).
+ */
+export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest {
+  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
+  const url = `https://${apnsHost}/3/device/${payload.token}`;
+
+  // Guard against reserved APNS key collision in custom data
+  if (payload.data && 'aps' in payload.data) {
+    throw new Error('ApnsPayload.data must not contain reserved key "aps"');
+  }
+
+  // apns-collapse-id (#575, P4a): a re-push for the same question replaces the
+  // prior notification on the device instead of stacking a duplicate. Apple
+  // caps the value at 64 bytes; a questionId UUID is well within that.
+  const collapseId =
+    payload.collapseId && payload.collapseId.length > 0
+      ? payload.collapseId.slice(0, 64)
+      : undefined;
+
+  const headers: Record<string, string> = {
+    authorization: `bearer ${jwt}`,
+    'apns-topic': payload.bundleId,
+    'apns-push-type': 'alert',
+    'apns-priority': '10',
+    ...(collapseId ? { 'apns-collapse-id': collapseId } : {}),
+  };
+
+  const body = JSON.stringify({
+    aps: {
+      alert: {
+        title: payload.title,
+        body: payload.body,
+      },
+      sound: 'default',
+      badge: 1,
+      // content-available pre-wakes the app in the background so the
+      // WebSocket can start reconnecting before the user taps (#575, P4a).
+      // Kept alongside the alert so the interactive notification still
+      // renders; iOS treats this as a normal alert push with a background
+      // wake opportunity.
+      'content-available': 1,
+      ...(payload.category ? { category: payload.category } : {}),
+    },
+    ...(payload.data ? payload.data : {}),
+  });
+
+  return { url, headers, body };
 }
 
 /**
@@ -32,36 +103,9 @@ export async function sendApnsPush(
   config: ApnsConfig,
 ): Promise<{ success: boolean; error?: string }> {
   const jwt = await createApnsJwt(config);
+  const { url, headers, body } = buildApnsRequest(payload, jwt);
 
-  const apnsHost = payload.sandbox ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
-  const apnsUrl = `https://${apnsHost}/3/device/${payload.token}`;
-
-  // Guard against reserved APNS key collision in custom data
-  if (payload.data && 'aps' in payload.data) {
-    throw new Error('ApnsPayload.data must not contain reserved key "aps"');
-  }
-
-  const response = await fetch(apnsUrl, {
-    method: 'POST',
-    headers: {
-      authorization: `bearer ${jwt}`,
-      'apns-topic': payload.bundleId,
-      'apns-push-type': 'alert',
-      'apns-priority': '10',
-    },
-    body: JSON.stringify({
-      aps: {
-        alert: {
-          title: payload.title,
-          body: payload.body,
-        },
-        sound: 'default',
-        badge: 1,
-        ...(payload.category ? { category: payload.category } : {}),
-      },
-      ...(payload.data ? payload.data : {}),
-    }),
-  });
+  const response = await fetch(url, { method: 'POST', headers, body });
 
   if (response.ok) {
     return { success: true };

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -48,6 +48,12 @@ interface PushRequestBody {
   options?: string[];
   /** Reserved for future per-request sandbox override; daemon does not send this today */
   sandbox?: boolean;
+  /**
+   * Dismissal trigger (#585, P7). When true, send a QUIET background push (no
+   * alert) keyed by `apns-collapse-id` = questionId so the device clears the
+   * lock-screen card for an already-resolved question.
+   */
+  dismiss?: boolean;
 }
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
@@ -153,11 +159,17 @@ export default {
         );
       }
 
-      if (!body.token || !body.title || !body.body) {
+      // A dismissal (#585, P7) is a quiet content-available push with no
+      // user-visible text, so title/body are not required for it — only the
+      // token (the device) and the questionId (the collapse-id target, validated
+      // below by buildApnsRequest's collapse-id handling). An alert push still
+      // requires all three.
+      const isDismiss = body.dismiss === true;
+      if (!body.token || (!isDismiss && (!body.title || !body.body))) {
         return new Response(
           JSON.stringify({
             error: 'MISSING_FIELDS',
-            message: 'token, title, and body are required',
+            message: isDismiss ? 'token is required' : 'token, title, and body are required',
           }),
           { status: 400, headers: corsHeaders },
         );
@@ -189,8 +201,11 @@ export default {
         result = await sendApnsPush(
           {
             token: body.token,
-            title: body.title,
-            body: body.body,
+            // For a dismissal these are absent; buildApnsRequest ignores them in
+            // dismiss mode (no alert), so default to empty strings to satisfy the
+            // ApnsPayload shape without surfacing any text.
+            title: body.title ?? '',
+            body: body.body ?? '',
             bundleId,
             sandbox,
             data: Object.keys(data).length > 0 ? data : undefined,
@@ -199,6 +214,8 @@ export default {
             ...(body.questionId && body.questionId.length > 0
               ? { collapseId: body.questionId }
               : {}),
+            // Quiet dismissal of an already-resolved question (#585, P7).
+            ...(body.dismiss === true ? { dismiss: true } : {}),
           },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -195,6 +195,10 @@ export default {
             sandbox,
             data: Object.keys(data).length > 0 ? data : undefined,
             category,
+            // Collapse repeated pushes for the same question (#575, P4a).
+            ...(body.questionId && body.questionId.length > 0
+              ? { collapseId: body.questionId }
+              : {}),
           },
           { keyId: env.APNS_KEY_ID, teamId: env.APNS_TEAM_ID, privateKey: env.APNS_PRIVATE_KEY },
         );

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the APNS request builder (#575, P4a).
+ *
+ * `buildApnsRequest` is a pure function (URL + headers + JSON body), so the
+ * payload shape is asserted directly — no network, no mocks. These cover the
+ * P4a additions: `content-available: 1` pre-wake and the `apns-collapse-id`
+ * header keyed by questionId, while confirming the interactive alert stays
+ * well-formed.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { buildApnsRequest } from '../src/apns.ts';
+
+const BASE = {
+  token: 'device-token-abc',
+  title: 'remi-phase4 needs input',
+  body: 'Allow Bash: git push',
+  bundleId: 'live.yooz.remi',
+};
+
+function parseBody(body: string): {
+  aps: {
+    alert?: { title?: string; body?: string };
+    sound?: string;
+    badge?: number;
+    'content-available'?: number;
+    category?: string;
+  };
+  [key: string]: unknown;
+} {
+  return JSON.parse(body);
+}
+
+describe('buildApnsRequest (#575 P4a)', () => {
+  test('includes content-available: 1 for background pre-wake', () => {
+    const req = buildApnsRequest(BASE, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('keeps the interactive alert well-formed alongside content-available', () => {
+    const req = buildApnsRequest({ ...BASE, category: 'REMI_YNA' }, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps.alert?.title).toBe(BASE.title);
+    expect(payload.aps.alert?.body).toBe(BASE.body);
+    expect(payload.aps.sound).toBe('default');
+    expect(payload.aps.badge).toBe(1);
+    expect(payload.aps.category).toBe('REMI_YNA');
+    // content-available coexists with the alert (not a silent push).
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('sets apns-collapse-id header from the collapseId (questionId)', () => {
+    const req = buildApnsRequest({ ...BASE, collapseId: 'question-uuid-1234' }, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toBe('question-uuid-1234');
+  });
+
+  test('omits apns-collapse-id when no collapseId is provided', () => {
+    const req = buildApnsRequest(BASE, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toBeUndefined();
+  });
+
+  test('truncates a collapseId longer than 64 bytes (APNS limit)', () => {
+    const longId = 'x'.repeat(100);
+    const req = buildApnsRequest({ ...BASE, collapseId: longId }, 'jwt-token');
+    expect(req.headers['apns-collapse-id']).toHaveLength(64);
+  });
+
+  test('carries custom data fields (sessionId / opt_N) as siblings to aps', () => {
+    const req = buildApnsRequest(
+      { ...BASE, data: { sessionId: 's1', questionId: 'q1', opt_0: 'Yes', opt_1: 'No' } },
+      'jwt-token',
+    );
+    const payload = parseBody(req.body);
+    expect(payload['sessionId']).toBe('s1');
+    expect(payload['opt_0']).toBe('Yes');
+    expect(payload['opt_1']).toBe('No');
+    // Custom data does not clobber the aps dictionary.
+    expect(payload.aps['content-available']).toBe(1);
+  });
+
+  test('throws if custom data tries to override the reserved aps key', () => {
+    expect(() => buildApnsRequest({ ...BASE, data: { aps: 'malicious' } }, 'jwt-token')).toThrow(
+      'reserved key "aps"',
+    );
+  });
+
+  test('uses the production APNS host by default and sandbox when requested', () => {
+    expect(buildApnsRequest(BASE, 'jwt').url).toContain('api.push.apple.com');
+    expect(buildApnsRequest({ ...BASE, sandbox: true }, 'jwt').url).toContain(
+      'api.sandbox.push.apple.com',
+    );
+  });
+
+  test('always sets the standard APNS headers', () => {
+    const req = buildApnsRequest(BASE, 'jwt-xyz');
+    expect(req.headers['authorization']).toBe('bearer jwt-xyz');
+    expect(req.headers['apns-topic']).toBe('live.yooz.remi');
+    expect(req.headers['apns-push-type']).toBe('alert');
+    expect(req.headers['apns-priority']).toBe('10');
+  });
+});

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -100,3 +100,46 @@ describe('buildApnsRequest (#575 P4a)', () => {
     expect(req.headers['apns-priority']).toBe('10');
   });
 });
+
+describe('buildApnsRequest dismissal (#585 P7)', () => {
+  const DISMISS = {
+    token: 'device-token-abc',
+    title: ' ',
+    body: ' ',
+    bundleId: 'live.yooz.remi',
+    collapseId: 'question-uuid-1234',
+    dismiss: true,
+  };
+
+  test('quiet dismissal: content-available only, no alert/sound/badge', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    const payload = parseBody(req.body);
+    expect(payload.aps['content-available']).toBe(1);
+    expect(payload.aps.alert).toBeUndefined();
+    expect(payload.aps.sound).toBeUndefined();
+    expect(payload.aps.badge).toBeUndefined();
+    expect(payload.aps.category).toBeUndefined();
+  });
+
+  test('carries the apns-collapse-id (questionId) so it supersedes the original card', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    expect(req.headers['apns-collapse-id']).toBe('question-uuid-1234');
+  });
+
+  test('uses the background push type at low priority (a content-available push)', () => {
+    const req = buildApnsRequest(DISMISS, 'jwt');
+    expect(req.headers['apns-push-type']).toBe('background');
+    expect(req.headers['apns-priority']).toBe('5');
+  });
+
+  test('carries custom data (sessionId/questionId) as siblings to aps', () => {
+    const req = buildApnsRequest(
+      { ...DISMISS, data: { sessionId: 's1', questionId: 'q1' } },
+      'jwt',
+    );
+    const payload = parseBody(req.body);
+    expect(payload['sessionId']).toBe('s1');
+    expect(payload['questionId']).toBe('q1');
+    expect(payload.aps['content-available']).toBe(1);
+  });
+});

--- a/packages/signaling/tests/push-dismiss.test.ts
+++ b/packages/signaling/tests/push-dismiss.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Worker-level tests for the /push dismissal contract (#585, P7).
+ *
+ * Drives the worker's `fetch` directly (no miniflare; bun's runtime provides
+ * `crypto.subtle` and `fetch`, which we stub for the Apple call). Confirms FIX 4:
+ * a `dismiss` push is accepted WITHOUT title/body (skips MISSING_FIELDS), while a
+ * dismiss still requires `token`. Each test uses a unique CF-Connecting-IP to
+ * dodge the module-level per-IP push rate limiter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+// A real EC P-256 PKCS8 key so createApnsJwt's crypto.subtle.importKey/sign
+// succeed (the JWT itself is never verified here — we stub the Apple fetch).
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+}
+
+describe('/push dismissal contract (#585 P7 FIX 4)', () => {
+  let env: TestEnv;
+  let realFetch: typeof globalThis.fetch;
+  let appleRequests: Array<{ url: string; headers: Headers; body: string }>;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    env = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleRequests = [];
+    realFetch = globalThis.fetch;
+    // Stub only the Apple APNS host; everything else is unused in these tests.
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        appleRequests.push({
+          url,
+          headers: new Headers(init?.headers),
+          body: String(init?.body ?? ''),
+        });
+        return new Response('', { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function pushRequest(body: Record<string, unknown>): Request {
+    ipCounter += 1;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': `203.0.113.${ipCounter}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('a dismiss push WITHOUT title/body is accepted (skips MISSING_FIELDS)', async () => {
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    // It reached APNS: a single background dismissal with the collapse-id.
+    expect(appleRequests).toHaveLength(1);
+    expect(appleRequests[0]?.headers.get('apns-push-type')).toBe('background');
+    expect(appleRequests[0]?.headers.get('apns-collapse-id')).toBe('q-1');
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['content-available']).toBe(1);
+    expect(parsed.aps.alert).toBeUndefined();
+  });
+
+  test('a dismiss push still requires a token (MISSING_FIELDS otherwise)', async () => {
+    const res = await worker.fetch(pushRequest({ questionId: 'q-1', dismiss: true }), env as never);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('MISSING_FIELDS');
+    expect(appleRequests).toHaveLength(0);
+  });
+
+  test('a normal (non-dismiss) push still requires title and body', async () => {
+    const res = await worker.fetch(pushRequest({ token: 'device-abc' }), env as never);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('MISSING_FIELDS');
+  });
+});

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -85,6 +85,57 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
     }
 
+    // Background pre-wake for escalated-question pushes (#575, P4a).
+    //
+    // The signaling worker now sends `content-available: 1`, so iOS calls this
+    // BEFORE the user taps the notification, giving the app a short background
+    // window. We use it to nudge the WebView into re-establishing the WebSocket
+    // so the connection is closer to ready by the time the user acts — and so
+    // the direct /answer relay has a warm route on LAN/Tailscale.
+    //
+    // We forward the SAME DOM CustomEvents the web app already listens for on
+    // foreground (`app-resume` / `app-force-reconnect`, dispatched from
+    // main.tsx), rather than inventing a native message channel. Capacitor owns
+    // the WKWebView and its push delegate, so we reach the web layer by
+    // evaluating JS on the bridge's webView.
+    //
+    // NOTE: This path CANNOT be verified headlessly — it depends on APNS
+    // delivering a content-available push to a real device and the WKWebView
+    // running JS while backgrounded. Verify on-device:
+    //   1. Background the app, trigger an escalated permission, confirm the
+    //      Xcode console logs "[remi] background pre-wake" before any tap.
+    //   2. Confirm the WebSocket shows a reconnect attempt in the web logs
+    //      while the app is still backgrounded.
+    //   3. Confirm `completionHandler` is always called (no background-budget
+    //      warnings in the console).
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        let js = """
+        (function() {
+          try {
+            document.dispatchEvent(new CustomEvent('app-resume'));
+            document.dispatchEvent(new CustomEvent('app-force-reconnect'));
+            console.debug('[remi] background pre-wake: dispatched app-force-reconnect');
+          } catch (e) {
+            console.warn('[remi] background pre-wake failed', e);
+          }
+        })();
+        """
+
+        // Reach the WKWebView through the Capacitor bridge view controller.
+        if let bridgeVC = window?.rootViewController as? CAPBridgeViewController {
+            bridgeVC.webView?.evaluateJavaScript(js, completionHandler: nil)
+        }
+
+        // Always call the completion handler so iOS does not throttle future
+        // background wakes. `.newData` keeps the background-refresh budget warm
+        // for this remote-notification use case.
+        completionHandler(.newData)
+    }
+
     // Keep WebSocket alive when app enters background.
     // iOS grants ~30 seconds of background execution time.
     // During this window, the WebSocket stays connected and can

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -9,10 +9,12 @@ import { AppLayout } from '@/components/layout';
 import { ConnectModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
-import { hasIdentity, unlockStoredIdentity } from '@/lib/identity-client';
+import { probeAuthInfo } from '@/lib/auth-probe';
+import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { setSoundEnabled } from '@/lib/notifications';
+import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import {
   clearSessionQuestions,
@@ -1283,13 +1285,74 @@ function App() {
         return;
       }
 
+      // Fast path (#575, P4a): deliver the answer over a plain HTTPS POST to the
+      // daemon's /answer endpoint, bypassing the WebSocket and its handshake.
+      // This is the only reliable path on a cold-start wake where the WS is not
+      // warm. Probe whether the daemon requires auth so we can sign when needed
+      // (loopback daemons skip the probe-derived signature; the daemon exempts
+      // them anyway). probeAuthInfo never throws — it returns null on any
+      // failure — so a null probe means "assume no auth" and let the daemon
+      // reject if it disagrees (a 401 then falls back to WS).
+      const targetUrl = target.url;
+      const authInfo = await probeAuthInfo(targetUrl);
+      const authRequired = authInfo?.authRequired ?? false;
+
+      const relay = await relayAnswerDirect({
+        wsUrl: targetUrl,
+        sessionId,
+        questionId,
+        answer,
+        claudeSessionId: boundId,
+        authRequired,
+      });
+
+      if (relay.kind === 'delivered') return;
+      if (relay.kind === 'rejected') {
+        // The daemon refused as stale (409) or unknown (404). The WebSocket
+        // would refuse identically; tell the user instead of retrying.
+        console.warn('[App] direct relay rejected:', relay.result);
+        notifyFailure();
+        return;
+      }
+      if (relay.kind === 'needs-passphrase') {
+        // No unlocked identity, so neither the relay nor the WebSocket can
+        // authenticate without a prompt. Fail fast rather than waiting out the
+        // (now longer) deadline on a connection that will never complete.
+        console.warn('[App] direct relay blocked: identity needs passphrase');
+        notifyFailure();
+        return;
+      }
+      // relay.kind === 'unreachable' (network / WebRTC-relay-only daemon) or
+      // 'auth-failed' (HTTP 401 — no/invalid detached signature, but the WS
+      // challenge-response may still succeed). Both fall back to the WebSocket
+      // reconnect path.
+      console.debug(
+        `[App] direct relay ${relay.kind}, falling back to WS:`,
+        relay.kind === 'unreachable' ? relay.reason : relay.result,
+      );
+
+      // If auth is required but there is no usable (unlocked) identity, the
+      // WebSocket would stall at auth_challenge forever — fail fast rather than
+      // waiting out the 25s deadline. Covers both "no identity" and "encrypted
+      // identity" (isIdentityEncrypted() is false when none is stored, so both
+      // are checked).
+      if (authRequired && (!hasIdentity() || isIdentityEncrypted())) {
+        console.warn('[App] WS fallback blocked: identity missing or needs passphrase');
+        notifyFailure();
+        return;
+      }
+
       const targetConnId: ConnectionId =
         target.kind === 'pending' && target.connectionId
           ? (target.connectionId as ConnectionId)
-          : connectDirectRef.current(target.url);
+          : connectDirectRef.current(targetUrl);
 
-      // Wait for connection with 10s timeout, then send answer
-      const ANSWER_TIMEOUT_MS = 10_000;
+      // Wait for the connection, then send. Raised from 10s to 25s (#575, P4a):
+      // a cold-start wake includes process resume + TCP/TLS + the Ed25519
+      // handshake, which routinely exceeds 10s; 25s stays within the iOS
+      // background-task window. The loop sends the instant status hits
+      // 'connected', so a fast connect is not penalized by the larger deadline.
+      const ANSWER_TIMEOUT_MS = 25_000;
       const deadline = Date.now() + ANSWER_TIMEOUT_MS;
       const delivered = await new Promise<boolean>((resolve) => {
         const check = setInterval(() => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,8 +20,10 @@ import {
   clearSessionQuestions,
   getSessionQuestions,
   questionKey,
+  removeQuestionById,
   statusClearsMainQuestion,
 } from '@/lib/question-collection';
+import { dismissDeliveredNotification } from '@/lib/notifications';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
 import { shouldEvictCachedSession } from '@/lib/session-eviction';
@@ -653,6 +655,39 @@ function App() {
         );
 
         // Push (APNS) is the notification channel — no local notification from WebSocket
+        break;
+      }
+
+      case 'question_resolved': {
+        // Cross-client dismissal (#585, P7): the question resolved on some
+        // channel (answered elsewhere, auto-approved/denied, or cancelled), so
+        // drop its card and clear any lock-screen notification for it here.
+        // Idempotent — if we never held it (or already dropped it), this is a
+        // no-op. The message carries no agentId, so locate the card by question
+        // id within the session.
+        const resolvedSessionId = message.sessionId;
+        const resolvedQuestionId = message.questionId;
+        // Compute the post-removal map from the CURRENT committed ref, then drive
+        // both setters from that one value (#585, P7 FIX 3). Reading the updated
+        // map (not the pre-removal ref) is what prevents two concurrent
+        // resolutions from leaving the badge stuck `questionPending: true`. The
+        // ref is the latest committed map (kept in sync by the effect below), so
+        // the second resolution sees the first's removal.
+        const updatedQuestions = removeQuestionById(
+          questionsRef.current,
+          resolvedSessionId,
+          resolvedQuestionId,
+        );
+        const stillPending = getSessionQuestions(updatedQuestions, resolvedSessionId).some(
+          (q) => q.answeredWith === undefined,
+        );
+        questionsRef.current = updatedQuestions;
+        setQuestions(updatedQuestions);
+        setSessions((prev) =>
+          prev.map((s) => (s.id === resolvedSessionId ? { ...s, questionPending: stillPending } : s)),
+        );
+        // Clear the matching delivered lock-screen / in-app notification (native).
+        dismissDeliveredNotification(resolvedQuestionId);
         break;
       }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
+import { shouldEvictCachedSession } from '@/lib/session-eviction';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
@@ -76,6 +77,35 @@ function rememberSessionDaemon(sessionId: string, url: string): void {
     localStorage.setItem(LOCALSTORAGE_SESSION_DAEMONS_KEY, JSON.stringify(map));
   } catch (err) {
     console.warn('[App] Failed to persist session-daemon map:', err);
+  }
+}
+
+/**
+ * Forget evicted phantom sessions in localStorage so they don't resurface on a
+ * cold start (#577). Drops them from the session->daemon map and clears
+ * remi-last-session if it points at one. Best-effort; storage errors are logged,
+ * never thrown, so a quota/parse hiccup can't break the message handler.
+ */
+function forgetEvictedSessions(evictedIds: readonly string[]): void {
+  if (evictedIds.length === 0) return;
+  const evicted = new Set(evictedIds);
+  try {
+    const stored = localStorage.getItem(LOCALSTORAGE_SESSION_DAEMONS_KEY);
+    if (stored) {
+      const map = JSON.parse(stored) as Record<string, string>;
+      let changed = false;
+      for (const id of evictedIds) {
+        if (id in map) {
+          delete map[id];
+          changed = true;
+        }
+      }
+      if (changed) localStorage.setItem(LOCALSTORAGE_SESSION_DAEMONS_KEY, JSON.stringify(map));
+    }
+    const last = localStorage.getItem(LOCALSTORAGE_SESSION_KEY);
+    if (last && evicted.has(last)) localStorage.removeItem(LOCALSTORAGE_SESSION_KEY);
+  } catch (err) {
+    console.warn('[App] Failed to forget evicted sessions:', err);
   }
 }
 
@@ -704,13 +734,59 @@ function App() {
             return new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime();
           });
 
+        // Phantom eviction (#577 Fix A): drop long-dead sessions this daemon no
+        // longer knows, which is what stops the recurring NOT_FOUND retry loop
+        // for a session purged from sessions.json. Computed from the synchronous
+        // sessionsRef snapshot (not inside setSessions) so it stays pure +
+        // StrictMode-safe and we can do the localStorage/ref cleanup after.
+        //
+        // Authoritative known set for THIS connection: the daemon's own
+        // daemon-sourced sessions + the attached hello_ack session. mDNS
+        // 'transcript' discoveries are excluded — they don't prove this daemon
+        // still manages the session, so they must not keep a phantom alive.
+        const knownIds = new Set<string>(
+          message.sessions
+            .filter((ds: DiscoverableSession) => ds.source === 'daemon')
+            .map((ds: DiscoverableSession) => ds.sessionId),
+        );
+        if (helloAckSessionId) knownIds.add(helloAckSessionId);
+        const evictionCtx = { knownIds, connectionAuthoritative: connectionId };
+        const evictionNow = Date.now();
+        // Compute the evicted set ONCE from the synchronous snapshot, then reuse
+        // the SAME set for the state filter, the loadedTranscriptsRef cleanup,
+        // and the active-session reset so there is no two-snapshot drift (every
+        // side effect acts on exactly what the list filter removes).
+        const evictedSet = new Set(
+          sessionsRef.current
+            .filter((s) =>
+              shouldEvictCachedSession(
+                { id: s.id, lastActiveAt: s.lastActiveAt, connectionId: s.connectionId },
+                evictionCtx,
+                evictionNow,
+              ),
+            )
+            .map((s) => s.id),
+        );
+        if (evictedSet.size > 0) {
+          const evictedIds = [...evictedSet];
+          forgetEvictedSessions(evictedIds);
+          for (const id of evictedIds) loadedTranscriptsRef.current.delete(id);
+          // If the active session was evicted, clear it so the UI doesn't sit on
+          // a dead session and re-request its (gone) transcript.
+          if (activeSessionIdRef.current && evictedSet.has(activeSessionIdRef.current)) {
+            setActiveSessionId(null);
+          }
+          console.warn('[App] Evicted stale phantom sessions (#577):', evictedIds);
+        }
+
         // Multi-daemon merge: keep sessions from other connections, preserve attached session
         // for this connection if not in discovered list, add all newly discovered sessions,
         // sort live-first then by recency.
         setSessions((prev) => {
-          const otherConnSessions = prev.filter((s) => s.connectionId !== connectionId);
+          const live = prev.filter((s) => !evictedSet.has(s.id));
+          const otherConnSessions = live.filter((s) => s.connectionId !== connectionId);
           // Keep the attached session for this connection (from hello_ack)
-          const attachedSession = prev.find(
+          const attachedSession = live.find(
             (s) => s.connectionId === connectionId && s.connectionStatus === 'connected',
           );
           const discoveredIds = new Set(discovered.map((s) => s.id));

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
   clearSessionQuestions,
   getSessionQuestions,
   questionKey,
+  statusClearsMainQuestion,
 } from '@/lib/question-collection';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
@@ -454,11 +455,14 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === sessionData.id ? { ...s, status: sessionData.status } : s)),
         );
-        // If status moved from 'waiting', the MAIN agent's prompt resolved
-        // (auto-approved, answered in terminal, etc.). Session status tracks
-        // the main agent only (subagent events don't change it), so clear just
-        // the main-agent slot — a concurrent subagent prompt must survive.
-        if (sessionData.status !== 'waiting') {
+        // If status moved to a non-waiting, non-transient state, the MAIN
+        // agent's prompt resolved (auto-approved, answered in terminal, etc.).
+        // Session status tracks the main agent only (subagent events don't
+        // change it), so clear just the main-agent slot; a concurrent subagent
+        // prompt must survive. The transient auto-approve broadcasts
+        // ('evaluating'/'approved', #576) must NOT clear a pending card; see
+        // statusClearsMainQuestion for the rationale.
+        if (statusClearsMainQuestion(sessionData.status)) {
           setQuestions((prev) => {
             const key = questionKey(sessionData.id);
             if (!prev.has(key)) return prev;

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -85,7 +85,12 @@ export function ChatView({
   // grouping, pinned question cards). The legacy compact toggle was removed.
   const [viewMode] = useState<ViewMode>('chat');
   const { isVisible: keyboardVisible, height: keyboardHeight } = useKeyboard();
-  const isAgentBusy = session.status === 'thinking' || session.status === 'executing';
+  // 'evaluating' (auto-approve deciding a permission, #576) counts as busy so
+  // the in-chat typing indicator stays consistent with the "Working" pill.
+  const isAgentBusy =
+    session.status === 'thinking' ||
+    session.status === 'executing' ||
+    session.status === 'evaluating';
   const isConnected = session.connectionStatus === 'connected';
 
   // Render a stack of QuestionCards (main + any subagent prompts, #437) pinned

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -177,8 +177,11 @@ export function MessageList({
     }
   }, [keyboardVisible]);
 
-  // Show typing indicator when agent is thinking/executing
-  const showTyping = agentStatus === 'thinking' || agentStatus === 'executing';
+  // Show typing indicator when the agent is busy: thinking, executing, or
+  // auto-approve evaluating a permission (#576). Kept in lockstep with
+  // ChatView's isAgentBusy so the dots and the "Working" pill never disagree.
+  const showTyping =
+    agentStatus === 'thinking' || agentStatus === 'executing' || agentStatus === 'evaluating';
 
   // In chat mode, collapse tool messages into inline summaries
   const filterTools = viewMode === 'chat';

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -150,6 +150,40 @@ export function openNotificationSettings(): void {
   window.open('app-settings:', '_system');
 }
 
+/**
+ * Clear the delivered lock-screen / notification-center notification for a
+ * resolved question (#585, P7). Called from the `question_resolved` handler so
+ * answering on one device clears the lock-screen card on this one too.
+ *
+ * NATIVE-ONLY: this is meaningful only on iOS/Android. On web there is no
+ * notification center to clear, so it is a no-op. The daemon ALSO sends a quiet
+ * APNS dismissal (apns-collapse-id = questionId) that supersedes the card while
+ * the app is suspended; this handler covers the foreground/just-woken case by
+ * removing any delivered notification whose payload carries the same questionId.
+ *
+ * APNS pushes are delivered through @capacitor/push-notifications, so the
+ * delivered list is queried there and matched on `data.questionId`. Local
+ * notifications scheduled by `pushNotificationReceived` (foreground mirror) carry
+ * no questionId, so they cannot be matched precisely; they auto-clear when the
+ * user opens the app. Errors are swallowed — a failed dismissal must never break
+ * message handling.
+ */
+export async function dismissDeliveredNotification(questionId: string): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const delivered = await PushNotifications.getDeliveredNotifications();
+    const matches = (delivered.notifications ?? []).filter((n) => {
+      const data = (n.data ?? {}) as Record<string, unknown>;
+      return data['questionId'] === questionId;
+    });
+    if (matches.length > 0) {
+      await PushNotifications.removeDeliveredNotifications({ notifications: matches });
+    }
+  } catch (err) {
+    console.warn('[Notifications] Failed to dismiss delivered notification:', err);
+  }
+}
+
 /** Send a local notification for a question/permission prompt. */
 export async function notifyQuestion(sessionName: string, prompt: string): Promise<void> {
   if (!localPermissionGranted) return;

--- a/packages/web/src/lib/push-answer-relay.ts
+++ b/packages/web/src/lib/push-answer-relay.ts
@@ -1,0 +1,192 @@
+/**
+ * Connection-independent answer relay (#575, P4a).
+ *
+ * On a cold-start push tap the WebSocket is not warm and the reconnect +
+ * Ed25519 handshake can take longer than the answer deadline (or never
+ * complete when the identity needs a passphrase). This module delivers the
+ * answer over a plain HTTPS POST to the daemon's `/answer` endpoint — the
+ * fast path — bypassing the WebSocket entirely.
+ *
+ * The daemon authenticates the POST with the SAME trust model as the
+ * WebSocket: loopback peers are exempt; networked peers must sign the
+ * canonical request string with a key already in the daemon's
+ * authorized-keys store. The signature is produced here from the locally
+ * stored identity. If the identity is encrypted (passphrase) the relay
+ * cannot sign without a prompt, so the caller falls back to the WebSocket
+ * path (which has the same limitation) or surfaces an "open the app" failure.
+ */
+
+import { sign } from '@remi/shared';
+import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from './identity-client';
+
+/** Outcome of a direct-relay attempt. */
+export type RelayResult =
+  | { kind: 'delivered' }
+  /**
+   * The daemon refused the answer as stale (409) or unknown (404). The
+   * WebSocket would refuse identically, so the caller should NOT fall back —
+   * surface an "open the app" failure instead.
+   */
+  | { kind: 'rejected'; result: string }
+  /**
+   * The relay could not be attempted or did not reach the daemon — network
+   * error, timeout, or WebRTC-relay-only daemon. The caller MAY fall back to
+   * the WebSocket reconnect path.
+   */
+  | { kind: 'unreachable'; reason: string }
+  /**
+   * The daemon returned HTTP 401 (the detached signature was missing/invalid,
+   * e.g. the /auth-info probe timed out so no signature was sent). This does
+   * NOT mean the WebSocket would fail — the WS uses an interactive
+   * challenge-response handshake — so the caller should fall back to WS, same
+   * as `unreachable`.
+   */
+  | { kind: 'auth-failed'; result: string }
+  /**
+   * Auth is required but no usable local identity can sign without a prompt
+   * (the identity is passphrase-encrypted, or there is no stored identity at
+   * all). The WebSocket path is equally blocked, so the caller should fail fast
+   * and tell the user to open the app.
+   */
+  | { kind: 'needs-passphrase' };
+
+/**
+ * Convert a `ws(s)://host:port/path` daemon URL to its `http(s)://host:port/answer`
+ * form. Throws if the input cannot be parsed. (Mirrors `authInfoUrl` in
+ * auth-probe.ts, kept separate so the two endpoints can diverge.)
+ */
+export function answerUrl(wsUrl: string): string {
+  const u = new URL(wsUrl);
+  let scheme: string;
+  if (u.protocol === 'wss:') scheme = 'https:';
+  else if (u.protocol === 'ws:') scheme = 'http:';
+  else throw new Error(`Unsupported scheme: ${u.protocol}`);
+  return `${scheme}//${u.host}/answer`;
+}
+
+/** Default timeout for the direct relay; keep it well under the WS deadline. */
+const DEFAULT_TIMEOUT_MS = 6000;
+
+interface RelayInput {
+  readonly wsUrl: string;
+  readonly sessionId: string;
+  readonly questionId: string;
+  readonly answer: string;
+  readonly claudeSessionId?: string | undefined;
+  /** When true the daemon will require a signed request (networked, auth on). */
+  readonly authRequired: boolean;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Build the signed auth block for a `/answer` POST when the daemon requires it.
+ * Returns null when we cannot sign without a passphrase prompt — either because
+ * there is NO stored identity, or the stored identity is encrypted.
+ */
+async function buildAuth(
+  message: string,
+): Promise<{ signature: string; clientPublicKey: string; clientFingerprint: string } | null> {
+  // No identity at all (isIdentityEncrypted() returns false in this case, so it
+  // must be checked separately) OR an encrypted identity: cannot sign here.
+  if (!hasIdentity() || isIdentityEncrypted()) return null;
+  // `unlockStoredIdentity()` with no passphrase succeeds only for an
+  // unencrypted identity (the encrypted/missing cases are filtered above); it
+  // returns usable CryptoKey objects, so sign directly.
+  const identity = await unlockStoredIdentity();
+  const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+  const signature = await sign(identity.privateKey, data);
+  return {
+    signature,
+    clientPublicKey: identity.publicKeyRaw,
+    clientFingerprint: identity.fingerprint,
+  };
+}
+
+/**
+ * Attempt to deliver an answer directly to the daemon over HTTPS.
+ *
+ * Returns:
+ *   - `delivered`        — the daemon accepted and routed the answer.
+ *   - `delivered`        — the daemon accepted and routed the answer.
+ *   - `rejected`         — the daemon refused as stale (409) / unknown (404); the
+ *                          WebSocket would refuse identically, so do NOT retry.
+ *   - `auth-failed`      — HTTP 401 (missing/invalid detached signature); the WS
+ *                          handshake may still succeed, so the caller MAY fall back.
+ *   - `unreachable`      — network error / not directly reachable; caller may fall
+ *                          back to the WebSocket reconnect path.
+ *   - `needs-passphrase` — auth required but no usable (unlocked) identity to sign.
+ */
+export async function relayAnswerDirect(input: RelayInput): Promise<RelayResult> {
+  const { wsUrl, sessionId, questionId, answer, claudeSessionId, authRequired } = input;
+
+  let httpUrl: string;
+  try {
+    httpUrl = answerUrl(wsUrl);
+  } catch {
+    return { kind: 'unreachable', reason: 'bad daemon url' };
+  }
+
+  // Canonical message the daemon binds the signature to.
+  const message = `${sessionId}|${questionId}|${answer}`;
+
+  let auth: { signature: string; clientPublicKey: string; clientFingerprint: string } | undefined;
+  if (authRequired) {
+    let built: Awaited<ReturnType<typeof buildAuth>>;
+    try {
+      built = await buildAuth(message);
+    } catch (err) {
+      return { kind: 'unreachable', reason: `sign failed: ${(err as Error).message ?? err}` };
+    }
+    if (built === null) {
+      // Encrypted identity: cannot sign without a passphrase prompt.
+      return { kind: 'needs-passphrase' };
+    }
+    auth = built;
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(httpUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId,
+        questionId,
+        answer,
+        ...(claudeSessionId ? { claudeSessionId } : {}),
+        ...(auth ? { auth } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    let parsed: { result?: string } = {};
+    try {
+      parsed = (await res.json()) as { result?: string };
+    } catch {
+      // Non-JSON body; fall through to status-based handling.
+    }
+
+    if (res.ok && parsed.result === 'delivered') {
+      return { kind: 'delivered' };
+    }
+    // HTTP 401: the detached signature was missing/invalid (e.g. the /auth-info
+    // probe timed out so no signature was sent). The WebSocket uses an
+    // interactive challenge-response, so it may still succeed — let the caller
+    // fall back to WS rather than giving up.
+    if (res.status === 401) {
+      return { kind: 'auth-failed', result: parsed.result ?? 'unauthorized' };
+    }
+    // A definitive refusal (stale=409, session-not-found=404, bad-request=400)
+    // means the WebSocket would refuse identically — do not fall back.
+    return { kind: 'rejected', result: parsed.result ?? `http ${res.status}` };
+  } catch (err) {
+    // Network error / timeout / daemon not directly reachable (e.g. WebRTC-only).
+    const reason = (err as { name?: string })?.name === 'AbortError' ? 'timeout' : 'network error';
+    return { kind: 'unreachable', reason };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -8,7 +8,7 @@
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';
-import type { UIQuestion } from '@/types';
+import type { AgentStatus, UIQuestion } from '@/types';
 
 /** Composite map key: a session's prompt, scoped to its agent (main default). */
 export function questionKey(sessionId: string, agentId?: string | undefined): string {
@@ -55,4 +55,20 @@ export function clearSessionQuestions(
   const next = new Map(questions);
   for (const key of keys) next.delete(key);
   return next;
+}
+
+/**
+ * Whether a `session_update` status means the MAIN agent's prompt resolved and
+ * its pending card should be cleared.
+ *
+ * 'waiting' is the blocked state (the prompt is open), so it never clears.
+ * 'evaluating' and 'approved' are TRANSIENT auto-approve broadcasts (#576) that
+ * must NOT clear a pending card: a second permission's onEvalStart
+ * ('evaluating') would otherwise delete the first card the user is still
+ * looking at, and a Part-B early-push question the gate later auto-approves
+ * ('approved') would vanish silently. The card clears on the next real hook
+ * status ('thinking'/'executing'/'idle'/'starting') or when answered.
+ */
+export function statusClearsMainQuestion(status: AgentStatus): boolean {
+  return status !== 'waiting' && status !== 'evaluating' && status !== 'approved';
 }

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -58,6 +58,32 @@ export function clearSessionQuestions(
 }
 
 /**
+ * Return a map with the single question matching (sessionId, questionId) removed
+ * (#585, P7). Used by the `question_resolved` broadcast handler: the message
+ * carries no agentId, so the entry is located by its question `id` within the
+ * session rather than by composite key. Returns the SAME reference when nothing
+ * matched, so callers keep React's no-op-update optimization. Idempotent — a
+ * client that already dropped the card simply gets the same map back.
+ */
+export function removeQuestionById(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+  questionId: string,
+): Map<string, UIQuestion> {
+  let foundKey: string | undefined;
+  for (const [key, q] of questions) {
+    if (q.sessionId === sessionId && q.id === questionId) {
+      foundKey = key;
+      break;
+    }
+  }
+  if (foundKey === undefined) return questions;
+  const next = new Map(questions);
+  next.delete(foundKey);
+  return next;
+}
+
+/**
  * Whether a `session_update` status means the MAIN agent's prompt resolved and
  * its pending card should be cleared.
  *

--- a/packages/web/src/lib/session-display.ts
+++ b/packages/web/src/lib/session-display.ts
@@ -35,10 +35,26 @@ export function sessionPillState(
       void _exhaustive;
     }
   }
-  // A pending question always wins. Note: the 'waiting' AgentStatus has no
-  // distinct pill and intentionally collapses to 'idle'.
+  // A pending question always wins.
   if (session.questionPending) return 'asking';
-  if (session.status === 'thinking' || session.status === 'executing') return 'working';
+  // 'waiting' used to collapse to 'idle' (a blocked agent looked idle). Now
+  // that hook events (PreToolUse / PermissionRequest) drive 'waiting'
+  // authoritatively, surface it as 'asking' — the agent is blocked on the user
+  // even before a discrete question record arrives (#576).
+  if (session.status === 'waiting') return 'asking';
+  // The agent is busy: thinking, executing a tool, auto-approve evaluating a
+  // permission, or just-approved one (transient before the next hook).
+  if (
+    session.status === 'thinking' ||
+    session.status === 'executing' ||
+    session.status === 'evaluating' ||
+    session.status === 'approved'
+  ) {
+    return 'working';
+  }
+  // 'starting' = session spinning up before its first hook; show it like a
+  // connection coming up (non-interactive spinner), not idle.
+  if (session.status === 'starting') return 'connecting';
   return 'idle';
 }
 

--- a/packages/web/src/lib/session-eviction.ts
+++ b/packages/web/src/lib/session-eviction.ts
@@ -24,7 +24,7 @@
  *     recent session is never a candidate; the minimum-age guard makes that
  *     explicit and independent of the staleness window so a session younger
  *     than MIN_EVICT_AGE_MS is always kept even if STALE_EVICT_AGE_MS were
- *     mis-set.
+ *     set incorrectly.
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -72,7 +72,7 @@ export function shouldEvictCachedSession(
   if (ctx.knownIds.has(cached.id)) return false;
 
   const last = new Date(cached.lastActiveAt).getTime();
-  // Unparseable timestamp: keep it (conservative — never evict on bad data).
+  // Unparsable timestamp: keep it (conservative — never evict on bad data).
   if (Number.isNaN(last)) return false;
 
   const age = now - last;

--- a/packages/web/src/lib/session-eviction.ts
+++ b/packages/web/src/lib/session-eviction.ts
@@ -1,0 +1,96 @@
+/**
+ * Phantom-session eviction (#577, Fix A — the primary fix for the recurring
+ * "Transcript for session <id> not found").
+ *
+ * The bug: the iOS/web client caches sessions in its in-memory list (rehydrated
+ * across reconnects). When a session dies and the daemon purges it from
+ * sessions.json (100-entry cap / 7-day TTL), the daemon stops listing it — but
+ * the client keeps the dead remi UUID and re-requests its transcript on every
+ * reconnect, producing NOT_FOUND each time (the `b7f8d9af` loop).
+ *
+ * The fix evicts a cached session ONLY when it is, conservatively, both:
+ *   1. unknown to the daemon that owns it (absent from that connection's fresh
+ *      session_list_response / hello_ack), AND
+ *   2. stale — its lastActivity is older than STALE_EVICT_AGE_MS (~14 days).
+ *
+ * Two guards keep eviction from ever wiping a still-valid session:
+ *   - Per-connection scoping: a session is only a candidate when we have just
+ *     heard the AUTHORITATIVE list for ITS OWN connection. A session belonging
+ *     to connection B is never evicted because connection A's list omits it
+ *     (multi-daemon), and a session whose connection has not (re)listed this
+ *     cycle is never touched.
+ *   - Minimum-age guard: a freshly restarted daemon may reconnect and ack
+ *     before it has re-listed older sessions. The staleness threshold means a
+ *     recent session is never a candidate; the minimum-age guard makes that
+ *     explicit and independent of the staleness window so a session younger
+ *     than MIN_EVICT_AGE_MS is always kept even if STALE_EVICT_AGE_MS were
+ *     mis-set.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** A cached session is only evictable once its lastActivity is older than this. */
+export const STALE_EVICT_AGE_MS = 14 * DAY_MS;
+/** Hard floor: never evict anything more recent than this, regardless of config. */
+export const MIN_EVICT_AGE_MS = 1 * DAY_MS;
+
+export interface EvictableSession {
+  readonly id: string;
+  /** ISO timestamp of the session's last activity. */
+  readonly lastActiveAt: string;
+  /** The connection (daemon) this cached session belongs to. */
+  readonly connectionId: string;
+}
+
+export interface EvictionContext {
+  /** Session ids the daemon for `connectionAuthoritative` just reported as known. */
+  readonly knownIds: ReadonlySet<string>;
+  /**
+   * The connection whose authoritative list we just received. Only sessions on
+   * THIS connection are eviction candidates this cycle; sessions on other
+   * connections are out of scope (their daemon has not spoken).
+   */
+  readonly connectionAuthoritative: string;
+}
+
+/**
+ * Decide whether a single cached session should be evicted from the client's
+ * list. Pure — no clock, no storage, no React. `now` is injected so callers
+ * (and tests) control the staleness comparison.
+ *
+ * Returns true ONLY when the session belongs to the connection that just
+ * listed, is absent from that daemon's known set, and is both older than the
+ * staleness threshold and older than the minimum-age floor.
+ */
+export function shouldEvictCachedSession(
+  cached: EvictableSession,
+  ctx: EvictionContext,
+  now: number,
+): boolean {
+  // Scope: only act on the connection that just gave us an authoritative list.
+  if (cached.connectionId !== ctx.connectionAuthoritative) return false;
+  // Known to the daemon -> definitely keep.
+  if (ctx.knownIds.has(cached.id)) return false;
+
+  const last = new Date(cached.lastActiveAt).getTime();
+  // Unparseable timestamp: keep it (conservative — never evict on bad data).
+  if (Number.isNaN(last)) return false;
+
+  const age = now - last;
+  // Minimum-age floor: a fresh/recent session is never evicted, even if the
+  // daemon just restarted and has not re-listed it yet.
+  if (age < MIN_EVICT_AGE_MS) return false;
+  // Staleness threshold: only long-dead unknown sessions are evicted.
+  return age >= STALE_EVICT_AGE_MS;
+}
+
+/**
+ * Apply {@link shouldEvictCachedSession} across a list, returning the sessions
+ * to KEEP. Convenience wrapper so callers express the filter once.
+ */
+export function evictPhantomSessions<T extends EvictableSession>(
+  sessions: readonly T[],
+  ctx: EvictionContext,
+  now: number,
+): T[] {
+  return sessions.filter((s) => !shouldEvictCachedSession(s, ctx, now));
+}

--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -204,10 +204,17 @@ export class WebSocketClient {
   /** Handle WebSocket open */
   private handleOpen(): void {
     this.clearConnectionTimer();
-    this.reconnectAttempts = 0;
     this.lastDataReceived = Date.now();
     this.missedHeartbeats = 0;
     this.startHeartbeat();
+    // Don't reset reconnectAttempts here: the transport opening is not a
+    // fully-established connection. Resetting on open would pin a connection
+    // that opens but never authenticates (auth fail/timeout, post-auth drop,
+    // heartbeat miss) to the base reconnectDelay forever, so the backoff never
+    // grows and onReconnectExhausted never fires (a ~1s reconnect storm).
+    // The counter is reset in setConnected(), the post-auth 'connected'
+    // transition. See #586.
+    //
     // Don't set 'connected' yet; wait for auth handshake or hello_ack.
     // Set 'authenticating' to signal that the transport is open but auth is pending.
     this.setStatus('authenticating');
@@ -215,6 +222,11 @@ export class WebSocketClient {
 
   /** Transition to connected state (called after auth completes) */
   setConnected(): void {
+    // Only a fully-established (authenticated) connection clears the reconnect
+    // counter, so a healthy connection that drops on a network blip and
+    // reconnects successfully resets here, while an open-but-never-connected
+    // connection keeps its growing backoff toward onReconnectExhausted (#586).
+    this.reconnectAttempts = 0;
     this.setStatus('connected');
   }
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -41,8 +41,17 @@ export interface ConnectionState {
   readonly sessionId: string | null;
 }
 
-/** Agent status as displayed in the UI */
-export type AgentStatus = 'idle' | 'thinking' | 'executing' | 'waiting';
+/** Agent status as displayed in the UI. Mirrors the daemon's `AgentStatus`
+ *  (@remi/shared); `evaluating`/`approved`/`starting` are auto-approve and
+ *  session-lifecycle states surfaced on the pill (#576). */
+export type AgentStatus =
+  | 'idle'
+  | 'thinking'
+  | 'executing'
+  | 'waiting'
+  | 'evaluating'
+  | 'approved'
+  | 'starting';
 
 /** Message sender type */
 export type MessageSender = 'user' | 'agent' | 'system';

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the connection-independent answer relay (#575, P4a).
+ *
+ * `relayAnswerDirect` is exercised against a REAL Bun HTTP server (no network
+ * mocks). The auth branches need a real identity in localStorage, so a tiny
+ * in-memory Storage shim is installed (an environment shim, not a logic mock);
+ * real Ed25519 keys are generated via the shared crypto.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createIdentity, serializeIdentity } from '@remi/shared';
+import { answerUrl, relayAnswerDirect } from '../../src/lib/push-answer-relay';
+
+// Minimal in-memory localStorage so identity-client can read/write a real
+// identity. This is the runtime environment, not a stub of any logic under test.
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.m.has(k) ? (this.m.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.m.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.m.delete(k);
+  }
+  clear(): void {
+    this.m.clear();
+  }
+}
+
+const store = new MemStorage();
+(globalThis as unknown as { localStorage: MemStorage }).localStorage = store;
+
+describe('answerUrl', () => {
+  test('converts ws:// to http:// and targets /answer', () => {
+    expect(answerUrl('ws://localhost:18765/ws')).toBe('http://localhost:18765/answer');
+  });
+
+  test('converts wss:// to https://', () => {
+    expect(answerUrl('wss://example.com:8443/ws')).toBe('https://example.com:8443/answer');
+  });
+
+  test('throws on unsupported scheme', () => {
+    expect(() => answerUrl('http://localhost:18765/ws')).toThrow();
+  });
+});
+
+describe('relayAnswerDirect (#575 P4a)', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+  afterEach(() => {
+    store.clear();
+  });
+
+  function startServer(handler: (req: Request) => Response | Promise<Response>) {
+    return Bun.serve({ port: 0, fetch: handler });
+  }
+
+  test('no-auth daemon: posts the answer and returns delivered', async () => {
+    let received: { sessionId: string; questionId: string; answer: string } | null = null;
+    const server = startServer(async (req) => {
+      const u = new URL(req.url);
+      if (u.pathname === '/answer' && req.method === 'POST') {
+        received = (await req.json()) as typeof received;
+        return new Response(JSON.stringify({ result: 'delivered' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('nope', { status: 404 });
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(received).toEqual({ sessionId: 's1', questionId: 'q1', answer: 'Yes' });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('daemon refusal (stale) returns rejected — caller must NOT fall back', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'stale' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('rejected');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('HTTP 401 returns auth-failed (NOT rejected) so the caller can fall back to the WS handshake', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('auth-failed');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('daemon not directly reachable returns unreachable (caller may fall back to WS)', async () => {
+    // Port 1 is virtually never open.
+    const result = await relayAnswerDirect({
+      wsUrl: 'ws://127.0.0.1:1/ws',
+      sessionId: 's1',
+      questionId: 'q1',
+      answer: 'Yes',
+      authRequired: false,
+      timeoutMs: 400,
+    });
+    expect(result.kind).toBe('unreachable');
+  });
+
+  test('auth required + encrypted identity => needs-passphrase, no request sent', async () => {
+    // Store a passphrase-encrypted identity; the relay cannot sign without a prompt.
+    const encrypted = await createIdentity('correct horse battery staple');
+    store.setItem('remi-identity', serializeIdentity(encrypted));
+
+    let hit = false;
+    const server = startServer(() => {
+      hit = true;
+      return new Response(JSON.stringify({ result: 'delivered' }));
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result.kind).toBe('needs-passphrase');
+      expect(hit).toBe(false); // failed fast, never reached the daemon
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('auth required + NO stored identity => needs-passphrase, no request sent (FIX 5)', async () => {
+    // store is cleared in beforeEach; no identity exists. isIdentityEncrypted()
+    // returns false in this case, so the relay must check hasIdentity() too.
+    let hit = false;
+    const server = startServer(() => {
+      hit = true;
+      return new Response(JSON.stringify({ result: 'delivered' }));
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result.kind).toBe('needs-passphrase');
+      expect(hit).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('auth required + unencrypted identity: signs and the daemon receives the auth block', async () => {
+    const unencrypted = await createIdentity(); // no passphrase => signable without a prompt
+    store.setItem('remi-identity', serializeIdentity(unencrypted));
+
+    let body: {
+      sessionId?: string;
+      auth?: { signature?: string; clientPublicKey?: string; clientFingerprint?: string };
+    } | null = null;
+    const server = startServer(async (req) => {
+      body = (await req.json()) as typeof body;
+      return new Response(JSON.stringify({ result: 'delivered' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    try {
+      const result = await relayAnswerDirect({
+        wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
+      expect(body?.auth?.clientFingerprint).toBe(unencrypted.fingerprint);
+      expect(typeof body?.auth?.signature).toBe('string');
+      expect((body?.auth?.signature ?? '').length).toBeGreaterThan(0);
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -9,6 +9,7 @@ import {
   getSessionQuestions,
   hasSessionQuestion,
   questionKey,
+  removeQuestionById,
   statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
@@ -73,6 +74,28 @@ describe('clearSessionQuestions', () => {
   test('returns the same reference when nothing matched (no-op update)', () => {
     const map = build(q('s1', undefined, 'a'));
     expect(clearSessionQuestions(map, 's2')).toBe(map);
+  });
+});
+
+describe('removeQuestionById (#585 P7)', () => {
+  test('removes the matching question by id within the session, keeps siblings', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'), q('s2', undefined, 'c'));
+    const next = removeQuestionById(map, 's1', 'b');
+    // The subagent prompt 'b' is gone; the main 'a' and the other session 'c' remain.
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['c']);
+  });
+
+  test('returns the same reference when the id is not present (idempotent / no-op)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(removeQuestionById(map, 's1', 'nope')).toBe(map);
+  });
+
+  test('does not remove a same-id question belonging to a different session', () => {
+    const map = build(q('s1', undefined, 'dup'), q('s2', undefined, 'dup'));
+    const next = removeQuestionById(map, 's1', 'dup');
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['dup']);
   });
 });
 

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -9,6 +9,7 @@ import {
   getSessionQuestions,
   hasSessionQuestion,
   questionKey,
+  statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
 
@@ -72,5 +73,26 @@ describe('clearSessionQuestions', () => {
   test('returns the same reference when nothing matched (no-op update)', () => {
     const map = build(q('s1', undefined, 'a'));
     expect(clearSessionQuestions(map, 's2')).toBe(map);
+  });
+});
+
+describe('statusClearsMainQuestion (#576)', () => {
+  test("'waiting' never clears (the prompt is still open)", () => {
+    expect(statusClearsMainQuestion('waiting')).toBe(false);
+  });
+
+  test("transient auto-approve states 'evaluating'/'approved' do NOT clear the card", () => {
+    // Regression: a second permission's onEvalStart ('evaluating') or a
+    // gate auto-approval ('approved') must not delete a card the user is
+    // still looking at.
+    expect(statusClearsMainQuestion('evaluating')).toBe(false);
+    expect(statusClearsMainQuestion('approved')).toBe(false);
+  });
+
+  test("real hook statuses still clear the resolved main-agent card", () => {
+    expect(statusClearsMainQuestion('thinking')).toBe(true);
+    expect(statusClearsMainQuestion('executing')).toBe(true);
+    expect(statusClearsMainQuestion('idle')).toBe(true);
+    expect(statusClearsMainQuestion('starting')).toBe(true);
   });
 });

--- a/packages/web/tests/lib/session-display.test.ts
+++ b/packages/web/tests/lib/session-display.test.ts
@@ -86,8 +86,31 @@ describe('sessionPillState', () => {
     expect(sessionPillState({ connectionStatus: 'connected', status: 'executing' })).toBe('working');
   });
 
-  test('connected + idle (or waiting) is idle', () => {
+  test('connected + idle is idle', () => {
     expect(sessionPillState({ connectionStatus: 'connected', status: 'idle' })).toBe('idle');
-    expect(sessionPillState({ connectionStatus: 'connected', status: 'waiting' })).toBe('idle');
+  });
+
+  test('connected + waiting is asking (no longer collapses to idle) (#576)', () => {
+    // A blocked agent (PreToolUse / PermissionRequest -> 'waiting') must surface
+    // as "Needs you", even before a discrete question record arrives.
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'waiting' })).toBe('asking');
+  });
+
+  test('connected + evaluating/approved is working (#576)', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'evaluating' })).toBe('working');
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'approved' })).toBe('working');
+  });
+
+  test('connected + starting is connecting (session spinning up) (#576)', () => {
+    expect(sessionPillState({ connectionStatus: 'connected', status: 'starting' })).toBe('connecting');
+  });
+
+  test('a pending question still wins over a busy/waiting agent status', () => {
+    expect(
+      sessionPillState({ connectionStatus: 'connected', status: 'evaluating', questionPending: true }),
+    ).toBe('asking');
+    expect(
+      sessionPillState({ connectionStatus: 'connected', status: 'waiting', questionPending: true }),
+    ).toBe('asking');
   });
 });

--- a/packages/web/tests/lib/session-eviction.test.ts
+++ b/packages/web/tests/lib/session-eviction.test.ts
@@ -60,7 +60,7 @@ describe('shouldEvictCachedSession (#577 Fix A)', () => {
     ).toBe(false);
   });
 
-  test('keeps a session with an unparseable timestamp (conservative)', () => {
+  test('keeps a session with an unparsable timestamp (conservative)', () => {
     expect(shouldEvictCachedSession(session('bad', 'not-a-date'), ctx([]), NOW)).toBe(false);
   });
 

--- a/packages/web/tests/lib/session-eviction.test.ts
+++ b/packages/web/tests/lib/session-eviction.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  evictPhantomSessions,
+  MIN_EVICT_AGE_MS,
+  shouldEvictCachedSession,
+  STALE_EVICT_AGE_MS,
+} from '../../src/lib/session-eviction';
+
+const NOW = Date.parse('2026-06-18T00:00:00Z');
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+const DAY = 24 * 60 * 60 * 1000;
+
+const session = (id: string, lastActiveAt: string, connectionId = 'conn-A') => ({
+  id,
+  lastActiveAt,
+  connectionId,
+});
+
+const ctx = (knownIds: string[], connectionAuthoritative = 'conn-A') => ({
+  knownIds: new Set(knownIds),
+  connectionAuthoritative,
+});
+
+describe('shouldEvictCachedSession (#577 Fix A)', () => {
+  test('evicts a stale + unknown session on the authoritative connection', () => {
+    // 20 days old, not in the daemon's known set, same connection -> phantom.
+    expect(
+      shouldEvictCachedSession(session('b7f8d9af', ago(20 * DAY)), ctx(['live-1']), NOW),
+    ).toBe(true);
+  });
+
+  test('keeps a session the daemon still knows, however old', () => {
+    expect(
+      shouldEvictCachedSession(session('known', ago(100 * DAY)), ctx(['known']), NOW),
+    ).toBe(false);
+  });
+
+  test('keeps a recent unknown session (minimum-age guard)', () => {
+    // Daemon restarted and acked before re-listing; the session is only 2h old,
+    // well under the minimum-age floor -> never evict.
+    expect(
+      shouldEvictCachedSession(session('fresh', ago(2 * 60 * 60 * 1000)), ctx([]), NOW),
+    ).toBe(false);
+  });
+
+  test('keeps an unknown session that is between min-age and the staleness threshold', () => {
+    // 3 days old: past the 1-day floor but well under the 14-day staleness
+    // threshold. A daemon that hasn't re-listed must not lose it.
+    expect(shouldEvictCachedSession(session('mid', ago(3 * DAY)), ctx([]), NOW)).toBe(false);
+  });
+
+  test('does not evict a session belonging to a different connection', () => {
+    // Stale + unknown, but it lives on conn-B; conn-A's list says nothing about it.
+    expect(
+      shouldEvictCachedSession(
+        session('other', ago(30 * DAY), 'conn-B'),
+        ctx([], 'conn-A'),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  test('keeps a session with an unparseable timestamp (conservative)', () => {
+    expect(shouldEvictCachedSession(session('bad', 'not-a-date'), ctx([]), NOW)).toBe(false);
+  });
+
+  test('boundary: exactly at the staleness threshold evicts', () => {
+    expect(
+      shouldEvictCachedSession(session('edge', ago(STALE_EVICT_AGE_MS)), ctx([]), NOW),
+    ).toBe(true);
+  });
+
+  test('boundary: one ms under the staleness threshold is kept', () => {
+    expect(
+      shouldEvictCachedSession(session('edge', ago(STALE_EVICT_AGE_MS - 1)), ctx([]), NOW),
+    ).toBe(false);
+  });
+
+  test('minimum-age floor is below the staleness threshold (sanity)', () => {
+    expect(MIN_EVICT_AGE_MS).toBeLessThan(STALE_EVICT_AGE_MS);
+  });
+});
+
+describe('evictPhantomSessions', () => {
+  test('returns only the sessions to keep', () => {
+    const sessions = [
+      session('phantom', ago(30 * DAY)), // stale + unknown -> evict
+      session('known', ago(30 * DAY)), // unknown-age but known -> keep
+      session('fresh', ago(60 * 60 * 1000)), // recent -> keep
+      session('other-conn', ago(30 * DAY), 'conn-B'), // other connection -> keep
+    ];
+    const kept = evictPhantomSessions(sessions, ctx(['known'], 'conn-A'), NOW);
+    expect(kept.map((s) => s.id).sort()).toEqual(['fresh', 'known', 'other-conn']);
+  });
+
+  test('returns the list unchanged when nothing is evictable', () => {
+    const sessions = [session('a', ago(60 * 60 * 1000)), session('b', ago(2 * DAY))];
+    const kept = evictPhantomSessions(sessions, ctx(['a', 'b']), NOW);
+    expect(kept).toHaveLength(2);
+  });
+});

--- a/packages/web/tests/lib/websocket-client.test.ts
+++ b/packages/web/tests/lib/websocket-client.test.ts
@@ -27,6 +27,31 @@ function liveWsServer() {
   });
 }
 
+/**
+ * A real WebSocket server that accepts the upgrade (the transport opens, so the
+ * client reaches 'authenticating') but closes the socket shortly after without
+ * ever letting it reach 'connected'. Models an auth fail / post-open drop, the
+ * #586 reconnect-storm trigger.
+ */
+function openThenCloseServer() {
+  return Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return undefined;
+      return new Response('no upgrade', { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        // Close right after open: the transport opened but auth never completes,
+        // so the client never reaches 'connected'.
+        ws.close();
+      },
+      message() {},
+      close() {},
+    },
+  });
+}
+
 /** A loopback port with nothing listening (connections are refused). */
 const DEAD_URL_A = 'ws://127.0.0.1:49250/ws';
 const DEAD_URL_B = 'ws://127.0.0.1:49251/ws';
@@ -95,6 +120,104 @@ describe('WebSocketClient reconnect ceiling', () => {
     client.disconnect();
     await wait(300);
     expect(exhausted).toBe(false);
+  });
+});
+
+describe('WebSocketClient open-but-not-connected (#586 reconnect storm)', () => {
+  test('reconnect counter grows across opens and exhaustion fires (not pinned)', async () => {
+    const server = openThenCloseServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const MAX = 3;
+    let authenticatingCount = 0;
+    let exhausted = false;
+
+    const client = track(
+      new WebSocketClient(
+        {
+          url,
+          autoReconnect: true,
+          maxReconnectAttempts: MAX,
+          reconnectDelay: 10,
+          connectionTimeout: 500,
+          heartbeatInterval: 0,
+        },
+        {
+          onStatusChange: (s) => {
+            // Each successful transport open lands here. The owner never calls
+            // setConnected(), so the connection never reaches 'connected'.
+            if (s === 'authenticating') authenticatingCount++;
+          },
+          onReconnectExhausted: () => {
+            exhausted = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      const start = Date.now();
+      while (!exhausted && Date.now() - start < 6000) await wait(25);
+
+      // Exhaustion proves the loop is bounded: the counter survived each open
+      // and climbed to the ceiling. Before the fix, handleOpen reset it to 0 on
+      // every open, so the ceiling was never reached and this never fired.
+      expect(exhausted).toBe(true);
+      // The client opened (reached 'authenticating') more than once: it is not
+      // pinned at a single attempt, and it stopped at the ceiling rather than
+      // looping forever (initial connect + MAX reconnects = MAX + 1 opens).
+      expect(authenticatingCount).toBeGreaterThan(1);
+      expect(authenticatingCount).toBe(MAX + 1);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('reaching connected resets the reconnect counter', async () => {
+    const server = openThenCloseServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const MAX = 3;
+    let authenticatingCount = 0;
+    let exhausted = false;
+
+    const client = track(
+      new WebSocketClient(
+        {
+          url,
+          autoReconnect: true,
+          maxReconnectAttempts: MAX,
+          reconnectDelay: 10,
+          connectionTimeout: 500,
+          heartbeatInterval: 0,
+        },
+        {
+          onStatusChange: (s) => {
+            if (s === 'authenticating') {
+              authenticatingCount++;
+              // Simulate the owner completing auth on every open: each open
+              // becomes a fully-established connection, so the counter resets.
+              client.setConnected();
+            }
+          },
+          onReconnectExhausted: () => {
+            exhausted = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      // Let it churn well past MAX opens. Because every open reaches 'connected'
+      // and resets the counter, the ceiling is never hit.
+      const start = Date.now();
+      while (authenticatingCount <= MAX + 2 && Date.now() - start < 6000) await wait(25);
+
+      expect(authenticatingCount).toBeGreaterThan(MAX + 1);
+      expect(exhausted).toBe(false);
+    } finally {
+      server.stop();
+    }
   });
 });
 


### PR DESCRIPTION
## Release 0.6.12 — auto-approve notification pipeline rethink + reconnect-storm fix

develop → main. Auto-release strips `-dev`, tags `v0.6.12`, publishes npm `@yooz-labs/remi` + platform pkgs + Homebrew + GitHub release, then syncs develop.

### Headline — Epic #571 (notification → answer pipeline, Model B hooks)
Escalated permissions are now delivered, presented, and answered faithfully on the durable hooks contract.

- **Hold the hook (Model B, #573):** a binary permission the local model escalates HOLDS its `PermissionRequest` hook open and is answered via the `allow`/`deny` hook response — no PTY digit, no render race, no dependence on a warm socket. Long human-paced `hold_timeout` fails open to the native prompt. Slow-eval fallback push behind `push_hold_timeout`.
- **Never auto-decide design questions (#572):** `AskUserQuestion`, `ExitPlanMode`, and non-binary/long-form questions are escalated structurally before the LLM (config `always_escalate_tools`).
- **Faithful notification (#574):** text comes from the hook (kills the `Doyouwanttoproceed?` garble); real option labels shown; answer resolves by value-or-label.
- **Connection-independent answer relay (#575/4a):** daemon `POST /answer` (WS-equivalent auth) + web direct-relay + 25s deadline + fail-fast; APNS `content-available` pre-wake + `collapse-id`.
- **Responsive status (#576):** `evaluating`/`approved`/`starting`, un-collapsed `waiting`, 250ms status bar.
- **Transcript durability + phantom eviction (#577):** durable `transcript-index.json` + client eviction + longer fallback — fixes the recurring "Transcript for session not found".
- **Cross-client dismissal + token dedup (#585):** answering anywhere dismisses the card everywhere (`question_resolved` broadcast + collapse-id dismiss push), incl. on `/clear`; duplicate device tokens deduped.

### Also
- **Reconnect-storm fix (#586):** `WebSocketClient` reset its reconnect backoff on transport-open (pre-auth), so any open-but-fail connection looped at ~1s forever across all hosts; reset moved to full (post-auth) connection.

### New config
`auto_approve.hold_timeout` (1800s; 0=off), `push_hold_timeout` (60s; 0=off Part B), `always_escalate_tools` (["AskUserQuestion","ExitPlanMode"]).

### Review status
Each phase + the storm fix adversarially reviewed (code + silent-failure); the epic got a holistic cross-phase pass that caught a critical held-escalation-never-pushed bug (fixed) and the dismissal review caught the `/clear`-doesn't-dismiss + gate-registry gaps (fixed). Daemon-side live-validated on the real binary. **All CI green on #584 and #587.**

### Ops / not in this binary release
- The APNS `content-available`/`collapse-id`/dismiss features need a **Cloudflare signaling worker redeploy** to function.
- Native iOS (Live Activities / NSE) tracked on #575 — separate Xcode work, not shipped here.
