### PR TITLE
Phone->daemon answer relay: signaling Worker + daemon verify (#591 P1)

### DIFF
--- a/.context/native-lockscreen-answer-relay.md
+++ b/.context/native-lockscreen-answer-relay.md
@@ -1,0 +1,84 @@
+# Native lock-screen answer relay (Duo-style)
+
+Part of #575. Closes the remaining native-iOS gap found in the 0.6.12 live test:
+the Model B held-escalation round-trip works **in-app** (WebSocket answer resolves
+the held hook), but a **lock-screen answer never reaches the hook**.
+
+## Why it fails today
+
+1. The answer-send logic is JS-only: `notifications.ts` `pushNotificationActionPerformed`
+   -> `App.tsx` `handlePushAnswer` -> `/answer` relay. When iOS background-launches the
+   app for a non-`.foreground` action, the WKWebView/JS isn't running, so nothing sends.
+2. `push-answer-relay.ts` POSTs **directly to the daemon** (LAN/Tailscale only). The
+   lock-screen case is exactly the remote case, so direct-to-daemon can't reach the Mac.
+
+## The Cisco-Duo pattern (researched)
+
+Duo answers Approve/Deny from the lock screen without opening the app: iOS
+background-launches a **native** handler, which relays the verdict to Duo's **service**.
+- A `UNNotificationAction` **without** `.foreground` => iOS background-launches the app and
+  calls `userNotificationCenter(_:didReceive:withCompletionHandler:)` (no foreground).
+- ~30s background budget; wrap the network call in `beginBackgroundTask`; call
+  `completionHandler()` when the relay finishes.
+- `UNTextInputNotificationAction` gives a lock-screen text/number field (`userText`) for
+  free-text / numbered-pick questions.
+
+Our "service" is the **signaling Worker** (always reachable), not the daemon directly.
+
+## Architecture map (verified against the code)
+
+- **Daemon <-> signaling:** `packages/daemon/src/remote/relay-adapter.ts` (+ `signaling-client.ts`)
+  opens a WS to `wss://remi-signaling.yooz.workers.dev/connect/{code}`, registers as `host`,
+  sends/receives `{type:'relay', payload:<JSON string>}`. Inbound `relay` -> `routeMessage()`
+  -> for `answer` -> `this.events.onAnswer(connId, sessionId, questionId, answer, claudeId)`
+  (relay-adapter.ts ~266-280). **This already dispatches to `handleAnswer`.**
+- **Worker room:** `packages/signaling/src/connection-room.ts` is a Durable Object keyed by
+  the connection **code** (`idFromName(code)`); relays WS<->WS between `host` (daemon) and
+  `client` (phone). `index.ts` has `/connect/{code}` (WS upgrade) and `/push` (Bearer-auth,
+  daemon->APNS). No phone->daemon HTTP path yet.
+- **Answer -> hook:** `input-events.ts` `handleAnswer` -> `mapAnswerToDecision`
+  (isNo->deny, isYes-not-always->allow, else null) -> `resolveHeldPermission` ->
+  gate `resolveHeld(questionId, decision)`. Needs `{sessionId, questionId, answer}`.
+- **Direct `/answer` auth (the model to copy):** `push-answer-relay.ts` signs the canonical
+  message `${sessionId}|${questionId}|${answer}` with the phone's Ed25519 identity and sends
+  `auth:{signature, clientPublicKey, clientFingerprint}`. The daemon
+  (`websocket-server.ts` `handleAnswerRelay`) verifies via
+  `authenticator.verifyDetachedRequest(message, sig, pubKey, fingerprint)` (TOFU/authorized-keys).
+
+## The AUTH gap (must fix)
+
+The relay-adapter `onAnswer` path **trusts the relay peer** (the authenticated WS). An
+HTTP-injected answer has no WS peer, so we MUST verify the Ed25519 signature daemon-side
+before resolving — otherwise anyone with the room code could forge an answer. The relayed
+`answer` message therefore carries the same `auth` block, and the relay adapter verifies it
+(needs the `Authenticator` injected into the relay adapter).
+
+## Phases
+
+### P1 - backend reverse relay (device-independent, this PR)
+1. **Worker** (`index.ts` + `connection-room.ts`): `POST /answer/{code}` (or code in body).
+   Body `{sessionId, questionId, answer, claudeSessionId?, auth}`. Look up the room by code,
+   forward `{type:'relay', payload: JSON.stringify({type:'answer', ...rest, auth})}` to the
+   `host` WS. Add a DO method to forward to the host (today it only relays WS->peer).
+   Return delivered / no-peer (503) / not-found (404).
+2. **Daemon** (`relay-adapter.ts`): when an inbound relayed `answer` carries `auth`, verify it
+   with the injected `Authenticator` before `onAnswer`; reject on bad/missing sig when auth is
+   required. Inject the authenticator from `cli.ts`.
+3. **Web** (`push-answer-relay.ts`): add a signaling-relay fallback (try direct `/answer`,
+   then the Worker `/answer/{code}`) so the in-app-but-remote case also benefits.
+4. **Tests (NO MOCKS):** miniflare for the Worker route (forward-to-host + missing-peer);
+   real loopback daemon + real Ed25519 sign/verify for the relay-adapter auth path
+   (valid sig resolves a held hook; bad/missing sig rejected); web relay-fallback unit test.
+
+### P2 - native iOS (needs Xcode + device)
+- `UNTextInputNotificationAction` category for free-text/numbered questions.
+- Native `userNotificationCenter(_:didReceive:)` in `AppDelegate` (actions WITHOUT
+  `.foreground`): map `actionIdentifier`/`userText` -> answer; `beginBackgroundTask`;
+  native Ed25519 sign (device identity from Keychain) + POST to the Worker `/answer/{code}`;
+  call `completionHandler` when done.
+- Coordinate with Capacitor's `PushNotifications` delegate so the native handler runs even
+  when JS is asleep (chain/override).
+
+### P3 - on-device validation
+- Lock screen, app killed, cellular: tap Yes/No (and a text answer) -> Claude proceeds; card
+  dismisses across clients.

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -83,8 +83,9 @@ export interface AdapterEvents {
 
   /**
    * Connection-independent answer relay (#575, P4a). Used by the HTTP /answer
-   * endpoint; returns a structured outcome so the route can JSON-encode it.
-   * Only the WebSocket adapter exposes a relay endpoint today.
+   * endpoint (WebSocket adapter) and, for a lock-screen / backgrounded phone, by
+   * the relay adapter's self-authenticating answer path (#591). Returns a
+   * structured outcome so the caller can act on / encode it.
    */
   onAnswerRelay?: (
     sessionId: UUID,

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -164,9 +164,15 @@ export class RelayAdapter implements ConnectionAdapter {
         // #591: a connection-independent relayed answer (lock-screen / backgrounded
         // phone) is SELF-AUTHENTICATING — it carries an Ed25519 `auth` block and is
         // dispatched via the relayAnswer path, so it needs NO connected /
-        // handshake-authenticated WS peer (there is none). Verify + route it before
-        // the peer gates below.
-        if (message.type === 'answer' && message.auth && typeof message.auth === 'object') {
+        // handshake-authenticated WS peer (there is none). Gate on the ABSENCE of a
+        // connected peer so a normal connected peer's answer always uses the
+        // standard onAnswer routing even if a future client signs WS answers.
+        if (
+          !this.clientConnectionId &&
+          message.type === 'answer' &&
+          message.auth &&
+          typeof message.auth === 'object'
+        ) {
           this.handleRelayedAnswer(message).catch((err) =>
             console.warn('Relayed answer error:', err instanceof Error ? err.message : err),
           );
@@ -287,15 +293,22 @@ export class RelayAdapter implements ConnectionAdapter {
       }
     }
 
+    // Fail loud if the connection-independent relay handler is not wired (a
+    // partial events object) — otherwise a lock-screen answer would vanish with
+    // no trace and the permission would stay held forever.
+    if (!this.events.onAnswerRelay) {
+      console.warn('Relayed answer dropped: onAnswerRelay not wired on the relay adapter');
+      return;
+    }
     const claudeId =
       typeof msg['claudeSessionId'] === 'string' ? (msg['claudeSessionId'] as UUID) : undefined;
-    const outcome = await this.events.onAnswerRelay?.(
+    const outcome = await this.events.onAnswerRelay(
       sessionId as UUID,
       questionId as UUID,
       answer,
       claudeId,
     );
-    if (outcome && outcome !== 'delivered') {
+    if (outcome !== 'delivered') {
       console.warn(`Relayed answer not delivered: ${outcome}`);
     }
   }

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -154,15 +154,27 @@ export class RelayAdapter implements ConnectionAdapter {
     });
 
     this.client.on('relay', (payload: string) => {
-      if (!this.clientConnectionId) {
-        console.warn('Received relay message before client connection established');
-        return;
-      }
-
       try {
         const message = JSON.parse(payload);
         if (!message || typeof message !== 'object' || typeof message.type !== 'string') {
           console.warn('Relay payload missing required "type" field');
+          return;
+        }
+
+        // #591: a connection-independent relayed answer (lock-screen / backgrounded
+        // phone) is SELF-AUTHENTICATING — it carries an Ed25519 `auth` block and is
+        // dispatched via the relayAnswer path, so it needs NO connected /
+        // handshake-authenticated WS peer (there is none). Verify + route it before
+        // the peer gates below.
+        if (message.type === 'answer' && message.auth && typeof message.auth === 'object') {
+          this.handleRelayedAnswer(message).catch((err) =>
+            console.warn('Relayed answer error:', err instanceof Error ? err.message : err),
+          );
+          return;
+        }
+
+        if (!this.clientConnectionId) {
+          console.warn('Received relay message before client connection established');
           return;
         }
 
@@ -227,6 +239,64 @@ export class RelayAdapter implements ConnectionAdapter {
     } else {
       console.warn(`Relay auth failed: ${result.error}`);
       this.resetClient();
+    }
+  }
+
+  /**
+   * #591: handle a connection-independent relayed answer (a lock-screen /
+   * backgrounded phone) forwarded by the signaling Worker's `/answer/{code}`
+   * route. Unlike a peer's relay message there is no connected /
+   * handshake-authenticated WS peer, so the answer carries its own Ed25519 `auth`
+   * block which we verify here before dispatching via the relayAnswer path (the
+   * same one the HTTP /answer endpoint uses). When the adapter runs without an
+   * authenticator (rotating-code no-auth mode) the room code is the only gate,
+   * consistent with the relay's WS path.
+   */
+  private async handleRelayedAnswer(msg: Record<string, unknown>): Promise<void> {
+    const sessionId = typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '';
+    const questionId = typeof msg['questionId'] === 'string' ? msg['questionId'] : '';
+    const answer = typeof msg['answer'] === 'string' ? msg['answer'] : '';
+    if (!sessionId || !questionId || !answer) {
+      console.warn('Relayed answer dropped: missing sessionId, questionId, or answer');
+      return;
+    }
+
+    if (this.config.authenticator) {
+      const auth = msg['auth'] as Record<string, unknown>;
+      const signature = typeof auth['signature'] === 'string' ? auth['signature'] : '';
+      const clientPublicKey =
+        typeof auth['clientPublicKey'] === 'string' ? auth['clientPublicKey'] : '';
+      const clientFingerprint =
+        typeof auth['clientFingerprint'] === 'string' ? auth['clientFingerprint'] : '';
+      if (!signature || !clientPublicKey || !clientFingerprint) {
+        console.warn('Relayed answer rejected: missing auth signature');
+        return;
+      }
+      // Canonical message must match the phone's signing input and the daemon's
+      // HTTP /answer verification (push-answer-relay.ts / websocket-server.ts).
+      const message = `${sessionId}|${questionId}|${answer}`;
+      const ok = await this.config.authenticator.verifyDetachedRequest(
+        message,
+        signature,
+        clientPublicKey,
+        clientFingerprint,
+      );
+      if (!ok) {
+        console.warn('Relayed answer rejected: signature verification failed');
+        return;
+      }
+    }
+
+    const claudeId =
+      typeof msg['claudeSessionId'] === 'string' ? (msg['claudeSessionId'] as UUID) : undefined;
+    const outcome = await this.events.onAnswerRelay?.(
+      sessionId as UUID,
+      questionId as UUID,
+      answer,
+      claudeId,
+    );
+    if (outcome && outcome !== 'delivered') {
+      console.warn(`Relayed answer not delivered: ${outcome}`);
     }
   }
 

--- a/packages/daemon/tests/relay-adapter-answer.test.ts
+++ b/packages/daemon/tests/relay-adapter-answer.test.ts
@@ -1,0 +1,168 @@
+/**
+ * #591: the relay adapter routes a connection-independent (lock-screen) answer
+ * forwarded by the signaling Worker. Unlike a peer's relay message it carries its
+ * own Ed25519 `auth` block (there is no connected / handshake-authenticated WS
+ * peer), which the adapter verifies before dispatching via onAnswerRelay.
+ *
+ * Uses REAL Ed25519 keys + a real Authenticator + a real IdentityStore (no mocks).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createIdentity, sign, unlockIdentity } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { Authenticator } from '../src/auth/authenticator.ts';
+import { IdentityStore } from '../src/auth/identity-store.ts';
+import { RelayAdapter } from '../src/remote/relay-adapter.ts';
+
+const SID = 'aaaaaaaa-0000-0000-0000-000000000000' as UUID;
+const QID = 'bbbbbbbb-0000-0000-0000-000000000000' as UUID;
+const ANSWER = 'yes';
+
+interface Relayed {
+  sessionId: UUID;
+  questionId: UUID;
+  answer: string;
+  claudeSessionId?: UUID;
+}
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-relay-answer-test-'));
+}
+
+async function signAuth(
+  privateKey: CryptoKey,
+  pub: string,
+  fingerprint: string,
+  message: string,
+): Promise<{ signature: string; clientPublicKey: string; clientFingerprint: string }> {
+  const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+  const signature = await sign(privateKey, data);
+  return { signature, clientPublicKey: pub, clientFingerprint: fingerprint };
+}
+
+function handle(adapter: RelayAdapter, msg: Record<string, unknown>): Promise<void> {
+  return (
+    adapter as unknown as { handleRelayedAnswer: (m: Record<string, unknown>) => Promise<void> }
+  ).handleRelayedAnswer(msg);
+}
+
+function recordingEvents(calls: Relayed[]): object {
+  return {
+    onAnswerRelay: async (
+      sessionId: UUID,
+      questionId: UUID,
+      answer: string,
+      claudeSessionId?: UUID,
+    ) => {
+      calls.push({ sessionId, questionId, answer, claudeSessionId });
+      return 'delivered' as const;
+    },
+  };
+}
+
+describe('relay-adapter self-authenticating answer (#591)', () => {
+  let tmpDir: string;
+  let authenticator: Authenticator;
+  let clientPriv: CryptoKey;
+  let clientPub: string;
+  let clientFp: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    const store = new IdentityStore(tmpDir);
+    await store.generate();
+    const serverIdentity = await store.unlock();
+
+    const clientFile = await createIdentity();
+    const clientUnlocked = await unlockIdentity(clientFile);
+    clientPriv = clientUnlocked.privateKey;
+    clientPub = clientFile.publicKey;
+    clientFp = clientFile.fingerprint;
+    await store.addAuthorizedKey(clientPub, 'Test Phone');
+
+    authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function authedAdapter(calls: Relayed[]): RelayAdapter {
+    return new RelayAdapter(
+      {
+        signalingUrl: 'wss://ignored.example.com',
+        code: 'ABCD-1234',
+        rotateCode: false as const,
+        authenticator,
+      },
+      recordingEvents(calls),
+    );
+  }
+
+  test('valid signature -> dispatched via onAnswerRelay', async () => {
+    const calls: Relayed[] = [];
+    const auth = await signAuth(clientPriv, clientPub, clientFp, `${SID}|${QID}|${ANSWER}`);
+    await handle(authedAdapter(calls), {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: ANSWER,
+      claudeSessionId: 'cccccccc-0000-0000-0000-000000000000',
+      auth,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ sessionId: SID, questionId: QID, answer: ANSWER });
+    expect(calls[0]?.claudeSessionId).toBe('cccccccc-0000-0000-0000-000000000000' as UUID);
+  });
+
+  test('signature over a DIFFERENT answer -> rejected (no dispatch)', async () => {
+    const calls: Relayed[] = [];
+    // sign 'no' but submit 'yes' — the canonical message won't match
+    const auth = await signAuth(clientPriv, clientPub, clientFp, `${SID}|${QID}|no`);
+    await handle(authedAdapter(calls), {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: ANSWER,
+      auth,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test('missing auth block -> rejected when authenticator is configured', async () => {
+    const calls: Relayed[] = [];
+    await handle(authedAdapter(calls), {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: ANSWER,
+      auth: {},
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test('missing required fields -> dropped', async () => {
+    const calls: Relayed[] = [];
+    const auth = await signAuth(clientPriv, clientPub, clientFp, `${SID}||`);
+    await handle(authedAdapter(calls), { type: 'answer', sessionId: SID, auth });
+    expect(calls).toHaveLength(0);
+  });
+
+  test('no authenticator (rotating no-auth) -> dispatched code-gated, no signature needed', async () => {
+    const calls: Relayed[] = [];
+    const adapter = new RelayAdapter(
+      { signalingUrl: 'wss://ignored.example.com' },
+      recordingEvents(calls),
+    );
+    await handle(adapter, { type: 'answer', sessionId: SID, questionId: QID, answer: ANSWER });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ sessionId: SID, questionId: QID, answer: ANSWER });
+  });
+});

--- a/packages/daemon/tests/relay-adapter-answer.test.ts
+++ b/packages/daemon/tests/relay-adapter-answer.test.ts
@@ -25,7 +25,7 @@ interface Relayed {
   sessionId: UUID;
   questionId: UUID;
   answer: string;
-  claudeSessionId?: UUID;
+  claudeSessionId?: UUID | undefined;
 }
 
 function makeTmpDir(): string {

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -55,9 +55,15 @@ export class ConnectionRoom {
    * Handle HTTP requests (WebSocket upgrade).
    */
   async fetch(request: Request): Promise<Response> {
-    // Only accept WebSocket upgrade
+    // Non-upgrade requests: the phone -> daemon answer relay (#591). A POST
+    // forwards an answer for a held permission into the host (daemon) WebSocket
+    // when the phone has no live WebSocket of its own (lock-screen /
+    // backgrounded). Everything else must be a WebSocket upgrade.
     const upgradeHeader = request.headers.get('Upgrade');
     if (upgradeHeader !== 'websocket') {
+      if (request.method === 'POST') {
+        return this.handleAnswerRelay(request);
+      }
       return new Response('Expected WebSocket', { status: 426 });
     }
 
@@ -83,6 +89,67 @@ export class ConnectionRoom {
 
     // webSocket property is Cloudflare-specific ResponseInit extension
     return new Response(null, { status: 101, webSocket: clientWs } as ResponseInit);
+  }
+
+  /**
+   * Forward a phone -> daemon answer (#591) into the host (daemon) WebSocket.
+   *
+   * The phone POSTs `{sessionId, questionId, answer, claudeSessionId?, auth?}` to
+   * the Worker's `/answer/{code}` route when it has no live WebSocket (a
+   * lock-screen / backgrounded answer). We wrap it as a `relay` message carrying
+   * an `answer` protocol message and send it to the host, exactly as the phone's
+   * own relay WebSocket would. The daemon verifies the `auth` signature before
+   * acting (the relay path has no authenticated WS peer here), so this route only
+   * needs the room code — the room's existing join secret.
+   */
+  private async handleAnswerRelay(request: Request): Promise<Response> {
+    const cors = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
+    await this.restoreState();
+
+    let body: {
+      sessionId?: string;
+      questionId?: string;
+      answer?: string;
+      claudeSessionId?: string;
+      auth?: unknown;
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return new Response(JSON.stringify({ result: 'invalid-json' }), {
+        status: 400,
+        headers: cors,
+      });
+    }
+
+    const { sessionId, questionId, answer, claudeSessionId, auth } = body;
+    if (!sessionId || !questionId || !answer) {
+      return new Response(JSON.stringify({ result: 'missing-fields' }), {
+        status: 400,
+        headers: cors,
+      });
+    }
+
+    const hostWs = this.findByRole('host');
+    if (!hostWs) {
+      return new Response(JSON.stringify({ result: 'no-peer' }), { status: 503, headers: cors });
+    }
+
+    // Wrap as the daemon's relay envelope (payload is a JSON-encoded protocol
+    // message, matching what the phone's relay WebSocket sends for an answer).
+    const inner = JSON.stringify({
+      type: 'answer',
+      sessionId,
+      questionId,
+      answer,
+      ...(claudeSessionId ? { claudeSessionId } : {}),
+      ...(auth ? { auth } : {}),
+    });
+    const ok = this.send(hostWs, { type: 'relay', payload: inner });
+    return new Response(JSON.stringify({ result: ok ? 'delivered' : 'send-failed' }), {
+      status: ok ? 200 : 502,
+      headers: cors,
+    });
   }
 
   /**

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -106,6 +106,17 @@ export class ConnectionRoom {
     const cors = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
     await this.restoreState();
 
+    // A stale code whose cleanup alarm has not yet fired must not route an answer.
+    // Distinct 410 (vs the no-peer 503) tells the caller the code is dead, so it
+    // does not waste a WebSocket-reconnect fallback on a room that will never
+    // accept it.
+    if (this.code && Date.now() > this.expiresAt) {
+      return new Response(JSON.stringify({ result: 'room-expired' }), {
+        status: 410,
+        headers: cors,
+      });
+    }
+
     let body: {
       sessionId?: string;
       questionId?: string;

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -60,6 +60,8 @@ interface PushRequestBody {
 const rateLimiter = new RateLimiter(10, 60_000);
 /** Per-IP rate limiter for push: 5 pushes per 60 seconds */
 const pushRateLimiter = new RateLimiter(5, 60_000);
+/** Per-IP rate limiter for the answer relay: 10 answers per 60 seconds */
+const answerRateLimiter = new RateLimiter(10, 60_000);
 
 /** Main worker */
 export default {
@@ -113,6 +115,37 @@ export default {
 
       // Forward the WebSocket upgrade request (URL contains the code for the DO to extract)
       return room.fetch(request);
+    }
+
+    // Answer relay (#591): phone -> daemon answer for a held permission, used
+    // when the phone has no live WebSocket (lock-screen / backgrounded). Forwards
+    // the answer into the daemon's room WebSocket. Code-gated like joining the
+    // room; the daemon verifies the Ed25519 `auth` signature before acting.
+    const answerMatch = url.pathname.match(/^\/answer\/([A-Z0-9-]+)$/i);
+    if (answerMatch && request.method === 'POST') {
+      const corsHeaders = {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      };
+      const answerCode = normalizeCode(answerMatch[1] ?? '');
+      if (!answerCode) {
+        return new Response(
+          JSON.stringify({ error: 'INVALID_CODE', message: 'Invalid connection code format' }),
+          { status: 400, headers: corsHeaders },
+        );
+      }
+      const answerIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      if (!answerRateLimiter.check(answerIp)) {
+        return new Response(
+          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many answer requests' }),
+          { status: 429, headers: { ...corsHeaders, 'Retry-After': '60' } },
+        );
+      }
+      // Route to the same code-named room the daemon registered; the DO forwards
+      // the POST body to the host WebSocket (see ConnectionRoom.handleAnswerRelay).
+      const answerRoomId = env.CONNECTIONS.idFromName(answerCode);
+      const answerRoom = env.CONNECTIONS.get(answerRoomId);
+      return answerRoom.fetch(request);
     }
 
     // Push notification trigger endpoint (authenticated, rate-limited)

--- a/packages/signaling/tests/answer-relay.test.ts
+++ b/packages/signaling/tests/answer-relay.test.ts
@@ -125,6 +125,30 @@ describe('ConnectionRoom.handleAnswerRelay (#591)', () => {
     );
     expect(res.status).toBe(426);
   });
+
+  test('returns room-expired (410) when the restored code has expired', async () => {
+    const host = makeWs('host');
+    // restoreState() loads code + a PAST expiresAt (epoch 1 << now) from storage.
+    const expiredState = {
+      storage: {
+        get: async () =>
+          new Map<string, unknown>([
+            ['code', 'WXYZ-2345'],
+            ['expiresAt', 1],
+          ]),
+        put: async () => {},
+        deleteAll: async () => {},
+        setAlarm: () => {},
+      },
+      getWebSockets: () => [host],
+      acceptWebSocket: () => {},
+    };
+    const room = new ConnectionRoom(expiredState, ENV);
+    const res = await room.fetch(answerRequest('WXYZ-2345', VALID));
+    expect(res.status).toBe(410);
+    expect(((await res.json()) as { result: string }).result).toBe('room-expired');
+    expect(host.sent).toHaveLength(0);
+  });
 });
 
 describe('worker /answer/{code} route (#591)', () => {

--- a/packages/signaling/tests/answer-relay.test.ts
+++ b/packages/signaling/tests/answer-relay.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #591: the signaling Worker's phone -> daemon answer relay.
+ *
+ * Drives `worker.fetch` and `ConnectionRoom.fetch` directly with the real
+ * routing + forwarding logic. The Durable Object runtime (storage + hibernatable
+ * WebSockets) is supplied as a minimal harness — the host socket's `send` records
+ * the forwarded envelope, the same boundary-capture approach as push-dismiss.test.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { ConnectionRoom } from '../src/connection-room.ts';
+import worker from '../src/index.ts';
+
+/** A recording stand-in for a hibernatable Worker WebSocket of a given role. */
+function makeWs(role: string): {
+  sent: string[];
+  deserializeAttachment: () => unknown;
+  send: (s: string) => void;
+} {
+  const sent: string[] = [];
+  return {
+    sent,
+    deserializeAttachment: () => ({ role }),
+    send: (s: string) => sent.push(s),
+  };
+}
+
+/** Minimal DurableObjectState harness (storage + getWebSockets) for the answer path. */
+function makeState(sockets: unknown[]): unknown {
+  return {
+    storage: {
+      get: async () => undefined,
+      put: async () => {},
+      deleteAll: async () => {},
+      setAlarm: () => {},
+    },
+    getWebSockets: () => sockets,
+    acceptWebSocket: () => {},
+  };
+}
+
+const ENV = { CONNECTION_TIMEOUT_MS: '300000' };
+
+function answerRequest(code: string, body: unknown): Request {
+  return new Request(`https://signaling.example/answer/${code}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': '203.0.113.7' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+const VALID = {
+  sessionId: 'aaaaaaaa-0000-0000-0000-000000000000',
+  questionId: 'bbbbbbbb-0000-0000-0000-000000000000',
+  answer: 'yes',
+  auth: { signature: 'sig', clientPublicKey: 'pub', clientFingerprint: 'fp' },
+};
+
+describe('ConnectionRoom.handleAnswerRelay (#591)', () => {
+  test('forwards the answer to the host as a relay envelope', async () => {
+    const host = makeWs('host');
+    const room = new ConnectionRoom(makeState([host]), ENV);
+    const res = await room.fetch(answerRequest('ABCD-1234', VALID));
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { result: string }).result).toBe('delivered');
+    expect(host.sent).toHaveLength(1);
+
+    const envelope = JSON.parse(host.sent[0] ?? '') as { type: string; payload: string };
+    expect(envelope.type).toBe('relay');
+    const inner = JSON.parse(envelope.payload) as Record<string, unknown>;
+    expect(inner).toMatchObject({
+      type: 'answer',
+      sessionId: VALID.sessionId,
+      questionId: VALID.questionId,
+      answer: VALID.answer,
+    });
+    // the Ed25519 auth block must be carried through for daemon verification
+    expect(inner['auth']).toEqual(VALID.auth);
+  });
+
+  test('carries claudeSessionId through when present', async () => {
+    const host = makeWs('host');
+    const room = new ConnectionRoom(makeState([host]), ENV);
+    await room.fetch(
+      answerRequest('ABCD-1234', {
+        ...VALID,
+        claudeSessionId: 'cccccccc-0000-0000-0000-000000000000',
+      }),
+    );
+    const inner = JSON.parse(
+      (JSON.parse(host.sent[0] ?? '') as { payload: string }).payload,
+    ) as Record<string, unknown>;
+    expect(inner['claudeSessionId']).toBe('cccccccc-0000-0000-0000-000000000000');
+  });
+
+  test('returns no-peer (503) when no host is connected', async () => {
+    const room = new ConnectionRoom(makeState([makeWs('client')]), ENV);
+    const res = await room.fetch(answerRequest('ABCD-1234', VALID));
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { result: string }).result).toBe('no-peer');
+  });
+
+  test('rejects missing required fields (400)', async () => {
+    const host = makeWs('host');
+    const room = new ConnectionRoom(makeState([host]), ENV);
+    const res = await room.fetch(answerRequest('ABCD-1234', { sessionId: VALID.sessionId }));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { result: string }).result).toBe('missing-fields');
+    expect(host.sent).toHaveLength(0);
+  });
+
+  test('rejects invalid JSON (400)', async () => {
+    const host = makeWs('host');
+    const room = new ConnectionRoom(makeState([host]), ENV);
+    const res = await room.fetch(answerRequest('ABCD-1234', 'not json'));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { result: string }).result).toBe('invalid-json');
+  });
+
+  test('non-POST non-upgrade still rejected (426)', async () => {
+    const room = new ConnectionRoom(makeState([makeWs('host')]), ENV);
+    const res = await room.fetch(
+      new Request('https://signaling.example/answer/ABCD-1234', { method: 'GET' }),
+    );
+    expect(res.status).toBe(426);
+  });
+});
+
+describe('worker /answer/{code} route (#591)', () => {
+  test('routes a valid POST through to the room, which forwards to the host', async () => {
+    const host = makeWs('host');
+    const room = new ConnectionRoom(makeState([host]), ENV);
+    const env = {
+      ...ENV,
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTIONS: {
+        idFromName: (name: string) => name,
+        get: () => room,
+      },
+    };
+    const res = await worker.fetch(answerRequest('WXYZ-2345', VALID), env as never);
+    expect(res.status).toBe(200);
+    expect(host.sent).toHaveLength(1);
+  });
+
+  test('rejects a malformed code (400) before touching the room', async () => {
+    let gotRoom = false;
+    const env = {
+      ...ENV,
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTIONS: {
+        idFromName: (name: string) => name,
+        get: () => {
+          gotRoom = true;
+          return new ConnectionRoom(makeState([]), ENV);
+        },
+      },
+    };
+    // matches the [A-Z0-9-]+ route but fails the XXXX-9999 code format
+    const res = await worker.fetch(answerRequest('AB', VALID), env as never);
+    expect(res.status).toBe(400);
+    expect(gotRoom).toBe(false);
+  });
+});

--- a/packages/web/src/lib/push-answer-relay.ts
+++ b/packages/web/src/lib/push-answer-relay.ts
@@ -190,3 +190,107 @@ export async function relayAnswerDirect(input: RelayInput): Promise<RelayResult>
     clearTimeout(timeoutId);
   }
 }
+
+/**
+ * Convert the signaling base URL + room code to its `https://host/answer/{code}`
+ * form (#591). Accepts `ws(s)://` or `http(s)://`. Throws on an unsupported scheme.
+ */
+export function signalingAnswerUrl(signalingUrl: string, code: string): string {
+  const u = new URL(signalingUrl);
+  let scheme: string;
+  if (u.protocol === 'wss:') scheme = 'https:';
+  else if (u.protocol === 'ws:') scheme = 'http:';
+  else if (u.protocol === 'https:' || u.protocol === 'http:') scheme = u.protocol;
+  else throw new Error(`Unsupported scheme: ${u.protocol}`);
+  return `${scheme}//${u.host}/answer/${encodeURIComponent(code)}`;
+}
+
+interface SignalingRelayInput {
+  /** Signaling base URL (`wss://…workers.dev` or `https://…`). */
+  readonly signalingUrl: string;
+  /** Connection code naming the daemon's room. */
+  readonly code: string;
+  readonly sessionId: string;
+  readonly questionId: string;
+  readonly answer: string;
+  readonly claudeSessionId?: string | undefined;
+  /** When true, sign the request (the daemon verifies it on the relay path). */
+  readonly authRequired: boolean;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Deliver an answer via the signaling Worker's reverse relay (#591) — the path
+ * for a remote phone whose daemon is not directly reachable (WebRTC-relay case),
+ * where `relayAnswerDirect` returns `unreachable`. The Worker forwards the signed
+ * answer into the daemon's room WebSocket; the daemon verifies the signature, so
+ * we sign whenever an identity is available.
+ *
+ * Returns the same `RelayResult` shape as `relayAnswerDirect`. A 503 (`no-peer`,
+ * the daemon is not connected to the room) is reported as `unreachable` so the
+ * caller can still fall back to a WebSocket reconnect.
+ */
+export async function relayAnswerViaSignaling(input: SignalingRelayInput): Promise<RelayResult> {
+  let httpUrl: string;
+  try {
+    httpUrl = signalingAnswerUrl(input.signalingUrl, input.code);
+  } catch {
+    return { kind: 'unreachable', reason: 'bad signaling url' };
+  }
+
+  const message = `${input.sessionId}|${input.questionId}|${input.answer}`;
+  let auth: { signature: string; clientPublicKey: string; clientFingerprint: string } | undefined;
+  if (input.authRequired) {
+    let built: Awaited<ReturnType<typeof buildAuth>>;
+    try {
+      built = await buildAuth(message);
+    } catch (err) {
+      return { kind: 'unreachable', reason: `sign failed: ${(err as Error).message ?? err}` };
+    }
+    if (built === null) {
+      return { kind: 'needs-passphrase' };
+    }
+    auth = built;
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(httpUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId: input.sessionId,
+        questionId: input.questionId,
+        answer: input.answer,
+        ...(input.claudeSessionId ? { claudeSessionId: input.claudeSessionId } : {}),
+        ...(auth ? { auth } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    let parsed: { result?: string } = {};
+    try {
+      parsed = (await res.json()) as { result?: string };
+    } catch {
+      // Non-JSON body; fall through to status-based handling.
+    }
+
+    if (res.ok && parsed.result === 'delivered') {
+      return { kind: 'delivered' };
+    }
+    // 503 = the daemon is not connected to the room (no host peer). The caller
+    // may still fall back to a WebSocket reconnect, so report as unreachable.
+    if (res.status === 503) {
+      return { kind: 'unreachable', reason: parsed.result ?? 'no-peer' };
+    }
+    return { kind: 'rejected', result: parsed.result ?? `http ${res.status}` };
+  } catch (err) {
+    const reason = (err as { name?: string })?.name === 'AbortError' ? 'timeout' : 'network error';
+    return { kind: 'unreachable', reason };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/web/src/lib/push-answer-relay.ts
+++ b/packages/web/src/lib/push-answer-relay.ts
@@ -245,7 +245,8 @@ export async function relayAnswerViaSignaling(input: SignalingRelayInput): Promi
     try {
       built = await buildAuth(message);
     } catch (err) {
-      return { kind: 'unreachable', reason: `sign failed: ${(err as Error).message ?? err}` };
+      const detail = err instanceof Error ? err.message || err.name : String(err);
+      return { kind: 'unreachable', reason: `sign failed: ${detail}` };
     }
     if (built === null) {
       return { kind: 'needs-passphrase' };
@@ -281,10 +282,16 @@ export async function relayAnswerViaSignaling(input: SignalingRelayInput): Promi
     if (res.ok && parsed.result === 'delivered') {
       return { kind: 'delivered' };
     }
-    // 503 = the daemon is not connected to the room (no host peer). The caller
-    // may still fall back to a WebSocket reconnect, so report as unreachable.
-    if (res.status === 503) {
-      return { kind: 'unreachable', reason: parsed.result ?? 'no-peer' };
+    // 503 no-peer (daemon not connected to the room) or 502 send-failed (the
+    // daemon's room WS dropped at the moment of the relay) may still resolve via a
+    // WebSocket reconnect, so report as unreachable (caller MAY fall back).
+    if (res.status === 503 || res.status === 502) {
+      return { kind: 'unreachable', reason: parsed.result ?? `http ${res.status}` };
+    }
+    // 410 room-expired: the connection code is stale; a reconnect won't help, so
+    // surface as a definitive refusal like a stale answer.
+    if (res.status === 410) {
+      return { kind: 'rejected', result: parsed.result ?? 'room-expired' };
     }
     return { kind: 'rejected', result: parsed.result ?? `http ${res.status}` };
   } catch (err) {

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -352,4 +352,50 @@ describe('relayAnswerViaSignaling (#591)', () => {
     });
     expect(result.kind).toBe('unreachable');
   });
+
+  test('502 send-failed maps to unreachable (caller may fall back to WS)', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'send-failed' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerViaSignaling({
+        signalingUrl: `http://127.0.0.1:${server.port}`,
+        code: 'WXYZ-2345',
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('unreachable');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('410 room-expired maps to rejected (stale code, do not retry)', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'room-expired' }), {
+          status: 410,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerViaSignaling({
+        signalingUrl: `http://127.0.0.1:${server.port}`,
+        code: 'WXYZ-2345',
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('rejected');
+    } finally {
+      server.stop();
+    }
+  });
 });

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -9,7 +9,12 @@
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createIdentity, serializeIdentity } from '@remi/shared';
-import { answerUrl, relayAnswerDirect } from '../../src/lib/push-answer-relay';
+import {
+  answerUrl,
+  relayAnswerDirect,
+  relayAnswerViaSignaling,
+  signalingAnswerUrl,
+} from '../../src/lib/push-answer-relay';
 
 // Minimal in-memory localStorage so identity-client can read/write a real
 // identity. This is the runtime environment, not a stub of any logic under test.
@@ -220,5 +225,131 @@ describe('relayAnswerDirect (#575 P4a)', () => {
     } finally {
       server.stop();
     }
+  });
+});
+
+describe('signalingAnswerUrl (#591)', () => {
+  test('converts wss:// to https:// and targets /answer/{code}', () => {
+    expect(signalingAnswerUrl('wss://remi-signaling.example/', 'WXYZ-2345')).toBe(
+      'https://remi-signaling.example/answer/WXYZ-2345',
+    );
+  });
+
+  test('keeps https:// as-is', () => {
+    expect(signalingAnswerUrl('https://sig.example', 'WXYZ-2345')).toBe(
+      'https://sig.example/answer/WXYZ-2345',
+    );
+  });
+
+  test('throws on unsupported scheme', () => {
+    expect(() => signalingAnswerUrl('ftp://sig.example', 'WXYZ-2345')).toThrow();
+  });
+});
+
+describe('relayAnswerViaSignaling (#591)', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+  afterEach(() => {
+    store.clear();
+  });
+
+  function startServer(handler: (req: Request) => Response | Promise<Response>) {
+    return Bun.serve({ port: 0, fetch: handler });
+  }
+
+  test('no-auth: POSTs to /answer/{code} and returns delivered', async () => {
+    let path = '';
+    let received: { sessionId: string; questionId: string; answer: string } | null = null;
+    const server = startServer(async (req) => {
+      const u = new URL(req.url);
+      path = u.pathname;
+      if (req.method === 'POST') {
+        received = (await req.json()) as typeof received;
+        return new Response(JSON.stringify({ result: 'delivered' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('nope', { status: 404 });
+    });
+    try {
+      const result = await relayAnswerViaSignaling({
+        signalingUrl: `http://127.0.0.1:${server.port}`,
+        code: 'WXYZ-2345',
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(path).toBe('/answer/WXYZ-2345');
+      expect(received).toEqual({ sessionId: 's1', questionId: 'q1', answer: 'Yes' });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('503 no-peer maps to unreachable (caller may fall back to WS)', async () => {
+    const server = startServer(
+      () =>
+        new Response(JSON.stringify({ result: 'no-peer' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    try {
+      const result = await relayAnswerViaSignaling({
+        signalingUrl: `http://127.0.0.1:${server.port}`,
+        code: 'WXYZ-2345',
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: false,
+      });
+      expect(result.kind).toBe('unreachable');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('auth required + unencrypted identity: signs and the Worker receives the auth block', async () => {
+    const unencrypted = await createIdentity();
+    store.setItem('remi-identity', serializeIdentity(unencrypted));
+    let body: {
+      auth?: { signature?: string; clientPublicKey?: string; clientFingerprint?: string };
+    } | null = null;
+    const server = startServer(async (req) => {
+      body = (await req.json()) as typeof body;
+      return new Response(JSON.stringify({ result: 'delivered' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    try {
+      const result = await relayAnswerViaSignaling({
+        signalingUrl: `http://127.0.0.1:${server.port}`,
+        code: 'WXYZ-2345',
+        sessionId: 's1',
+        questionId: 'q1',
+        answer: 'Yes',
+        authRequired: true,
+      });
+      expect(result).toEqual({ kind: 'delivered' });
+      expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
+      expect(typeof body?.auth?.signature).toBe('string');
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('bad signaling url => unreachable', async () => {
+    const result = await relayAnswerViaSignaling({
+      signalingUrl: 'ftp://bad',
+      code: 'WXYZ-2345',
+      sessionId: 's1',
+      questionId: 'q1',
+      answer: 'Yes',
+      authRequired: false,
+    });
+    expect(result.kind).toBe('unreachable');
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 (backend) of the native lock-screen answer relay (#591, part of #575). The 0.6.12 live test showed the Model B held-escalation round-trip works **in-app** (WebSocket answer resolves the held hook) but a **lock-screen answer never reaches the hook**: the answer-send logic is JS-only (not running when iOS background-launches the app) and the existing `/answer` relay posts **directly to the daemon** (LAN-only). The fix follows the **Cisco-Duo pattern** — a native handler that relays the verdict through an always-reachable **service** (our signaling Worker). This PR builds that reverse path.

## What's in P1 (this PR)

- **Signaling Worker** (`index.ts`, `connection-room.ts`): new `POST /answer/{code}` -> `ConnectionRoom.handleAnswerRelay` forwards the answer into the host (daemon) room WebSocket as a `relay` envelope wrapping an `answer` message. Code-gated like joining the room; rate-limited.
- **Daemon** (`relay-adapter.ts`, `connection-adapter.ts`): a relayed `answer` carrying an Ed25519 `auth` block is treated as **self-authenticating and connection-independent** — the adapter verifies the signature (canonical `sessionId|questionId|answer`, matching the HTTP `/answer` endpoint) and dispatches via `onAnswerRelay`, **bypassing the peer/handshake gates** (a lock-screen answer has no connected WS peer). Without an authenticator (rotating no-auth mode) the room code is the only gate, consistent with the relay's WS path.
- **Web** (`push-answer-relay.ts`): `relayAnswerViaSignaling` + `signalingAnswerUrl` — deliver an answer via the Worker reverse relay when the daemon isn't directly reachable (the remote/WebRTC-relay case). Same signed body + `RelayResult` shape.

## Security note

The relay-adapter `onAnswer` (WS-peer) path trusts the authenticated peer. An HTTP-injected answer has **no** WS peer, so the relayed-answer path verifies the Ed25519 signature itself before acting — closing the gap rather than trusting an unauthenticated injection.

## Deferred to P2/P3 (tracked on #591)

- **P2 (native iOS):** `UNTextInputNotificationAction` category + native `userNotificationCenter(_:didReceive:)` (actions without `.foreground`) + Ed25519 signing (Keychain) + `beginBackgroundTask` + Capacitor delegate coordination; wire `relayAnswerViaSignaling` into `App.tsx` `handlePushAnswer` as the fallback (needs the per-connection code + signaling URL threaded in, validated with the native flow).
- **P3:** on-device validation (lock screen, app killed, cellular).

## Test plan (NO MOCKS)

- [x] `bun run typecheck` clean (root + web strict)
- [x] `bunx biome check` clean on changed files
- [x] signaling: real `ConnectionRoom` + `worker.fetch` — forward-to-host envelope, no-peer (503), missing-fields (400), invalid-json (400), 426 non-POST, route code-validation (8 tests)
- [x] daemon: real Ed25519 + real `Authenticator` — valid signature resolves, wrong-answer signature rejected, missing/empty auth rejected, no-auth code-gated (5 tests)
- [x] web: real Bun HTTP server + real Ed25519 — url mapping, no-auth delivery, 503->unreachable, signed auth block, bad-url (new tests in the existing relay suite)

Design doc: `.context/native-lockscreen-answer-relay.md`. Part of #575.