### PR TITLE
fix(binder): subagent permissions reach auto-approve + diagnose drops (#593)

### DIFF
--- a/.context/subagent-aa-routing.md
+++ b/.context/subagent-aa-routing.md
@@ -38,28 +38,44 @@ and return `passthrough`** — they never reach the gate. That drop was **silent
 The main-agent Skill worked because it arrived after binding settled and carries
 the main session_id; the subagent perms did not (different id and/or window).
 
-## This PR (safe, certain): fail-loud diagnostic
+## The fix (implemented)
 
-`hook-bridge-setup.ts:1203` now LOGS every PermissionRequest it rejects to
-`passthrough`, tagging `agent=subagent|main` and the incoming session_id. The
-next occurrence will show exactly why a subagent permission was dropped
-(`incoming=<subagent-id>` != bound id, or during the unbound window), turning an
-invisible silent drop into a diagnosable line. No behavior change.
+The drop is in the DRIVE-mode binder's `admits` (`transcript-binder.ts`), the
+default path. A parallel/team subagent (or one with an empty `00000000` id)
+fails the `session_id === currentBoundId` check and falls to the marker
+head-read (`incomingReclaimsViaMarker`), which FAILED in give because the
+transcript content/marker was not yet readable (binding still settling).
 
-## Deferred (needs a confirmed repro; binder is high blast-radius)
+`admits` now adds a file-free ownership check BEFORE the marker read: a SUBAGENT
+event (`agent_id` present) whose `transcript_path` equals the transcript we are
+bound to (`lastTranscriptPath`) is admitted. The path comes from the hook event,
+so no file content is read — robust to the marker-read delay that broke give. A
+sibling daemon's subagent carries the SIBLING's transcript path, so it stays
+foreign and cross-session isolation (#451) is preserved. Gated on `agent_id`, so
+a real foreign MAIN event still requires the marker (no over-admit).
 
-The targeted fix depends on which hypothesis the diagnostic confirms:
-- If session-id mismatch: admit a SUBAGENT PermissionRequest (agent_id present)
-  when it owns the bound transcript (`input.transcript_path` is the MAIN
-  transcript per #499 phase 3), even if `session_id` differs — rather than the
-  strict `session_id === claudeSessionId` equality.
-- If startup window: ensure the binding is adopted before the resolver admits,
-  and/or buffer PermissionRequests briefly until `currentBoundId` is set.
+Also: `hook-bridge-setup.ts:1203` now LOGS every PermissionRequest it drops to
+`passthrough` (tagged `agent=subagent|main`), so any future drop is diagnosable
+instead of silent.
 
-Do NOT reintroduce a PTY-inject -> AA fallback for subagents: #496 removed it
-because the daemon cannot tell whose prompt is on the PTY for parallel subagents
-(the leak). Any PTY fallback would have to be eval-and-deny-only (no inject),
-which does not help auto-APPROVE. The fix belongs in the routing, not the PTY.
+### Tests (real binder, NO MOCKS, no interactive repro)
+
+`transcript-binder.test.ts` -> `#593 subagent admits`:
+- subagent with a DIFFERENT session_id sharing our bound transcript -> admitted
+- subagent with an empty/zero session_id sharing our bound transcript -> admitted
+- sibling subagent (foreign transcript, different port marker) -> NOT admitted
+- foreign NON-subagent event with our (unmarked) path -> NOT admitted (the gate)
+- main agent (matching id) -> admitted (unchanged)
+
+## Notes / not done
+
+- Legacy NON-drive `filterBySession` (binder disabled, not the default) has the
+  same latent strict-id gap; left as-is — drive mode is the default and the
+  legacy path is being removed (#470).
+- Did NOT reintroduce a PTY-inject -> AA fallback for subagents: #496 removed it
+  (the daemon cannot tell whose prompt is on the PTY for parallel subagents); a
+  PTY fallback could only eval-and-deny, which does not help auto-APPROVE. The
+  fix belongs in the routing, which is where it landed.
 
 ## Repro
 

--- a/.context/subagent-aa-routing.md
+++ b/.context/subagent-aa-routing.md
@@ -1,0 +1,68 @@
+# Subagent permissions bypass auto-approve (#593)
+
+## Symptom
+
+In a session with parallel research subagents (project "give"), subagent
+permission prompts (mostly WebFetch) appear but auto-approve never evaluates
+them — no "evaluating" status, no auto-approve/escalate. The MAIN agent's
+permissions evaluate normally. Another session forwarded 99 subagent
+PermissionRequests fine, so it is intermittent / session-specific.
+
+## Where it breaks (traced)
+
+AA is hook-driven (Model B / #571). The path is:
+
+`hook-server` (`PermissionRequest` -> `permissionResolver`) ->
+`hook-bridge-setup.ts` `setPermissionResolver` callback (~1198) ->
+`driveBinder.admits(input)` / `filterBySession(input)` (~1203) ->
+`autoApproveGate.resolvePermission` (logs `Subagent PermissionRequest forwarded`).
+
+The give session had **0** forwarded logs + **0** subagent AA evals for the
+WebFetch burst, while the main-agent Skill permission evaluated. So subagent
+PermissionRequests are **rejected at the `admits`/`filterBySession` gate (1203)
+and return `passthrough`** — they never reach the gate. That drop was **silent**
+(no log at 1203), which is why the cause was invisible.
+
+## Root-cause hypotheses (to confirm with the new diagnostic)
+
+1. **Session-id mismatch for parallel/async subagents.** `filterBySession`
+   admits only when `input.session_id === claudeSessionId`. Sync subagents share
+   the main session_id (admitted); a parallel/background subagent may carry its
+   OWN session_id (or empty `00000000`, which we saw dropped) -> rejected as
+   foreign. The give subagents were many parallel research agents.
+2. **Startup / binding window.** During a hook-server port change + a
+   transcript-binding timeout + self-heal, `driveBinder.currentBoundId` can be
+   null or stale, or a lingering sibling registry entry makes `hasSiblingInDir()`
+   true -> the fail-safe rejects events until the binding settles.
+
+The main-agent Skill worked because it arrived after binding settled and carries
+the main session_id; the subagent perms did not (different id and/or window).
+
+## This PR (safe, certain): fail-loud diagnostic
+
+`hook-bridge-setup.ts:1203` now LOGS every PermissionRequest it rejects to
+`passthrough`, tagging `agent=subagent|main` and the incoming session_id. The
+next occurrence will show exactly why a subagent permission was dropped
+(`incoming=<subagent-id>` != bound id, or during the unbound window), turning an
+invisible silent drop into a diagnosable line. No behavior change.
+
+## Deferred (needs a confirmed repro; binder is high blast-radius)
+
+The targeted fix depends on which hypothesis the diagnostic confirms:
+- If session-id mismatch: admit a SUBAGENT PermissionRequest (agent_id present)
+  when it owns the bound transcript (`input.transcript_path` is the MAIN
+  transcript per #499 phase 3), even if `session_id` differs — rather than the
+  strict `session_id === claudeSessionId` equality.
+- If startup window: ensure the binding is adopted before the resolver admits,
+  and/or buffer PermissionRequests briefly until `currentBoundId` is set.
+
+Do NOT reintroduce a PTY-inject -> AA fallback for subagents: #496 removed it
+because the daemon cannot tell whose prompt is on the PTY for parallel subagents
+(the leak). Any PTY fallback would have to be eval-and-deny-only (no inject),
+which does not help auto-APPROVE. The fix belongs in the routing, not the PTY.
+
+## Repro
+
+Spawn several parallel research subagents doing WebFetch to non-allowlisted
+domains, especially right after session start / a daemon restart. Watch for the
+new `PermissionRequest NOT admitted` lines with `agent=subagent`.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -1200,7 +1200,21 @@ export function setupHookBridge(
     if (driveBinder) driveBinder.onHookEvent(input);
     else initFromHookEvent(input);
     shadowDecide('PermissionRequest', input);
-    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) return 'passthrough';
+    if (!(driveBinder ? driveBinder.admits(input) : filterBySession(input))) {
+      // #593: a PermissionRequest we don't own returns passthrough so the owning
+      // daemon decides. Until now that drop was SILENT — which hid the bug where a
+      // SUBAGENT permission is rejected here (e.g. it carries a different/empty
+      // session_id, or arrives during a startup/binding window) and so never
+      // reaches the auto-approve gate: the user sees the native prompt with no AA
+      // and no "evaluating" status. Log it so the drop is diagnosable; a `subagent`
+      // tag on these lines is the smell for #593.
+      log(
+        `[Hooks] PermissionRequest NOT admitted -> passthrough (no AA eval): tool=${input.tool_name} ` +
+          `incoming=${input.session_id?.slice(0, 8) ?? '-'} ` +
+          `agent=${isSubagentEvent(input) ? (input.agent_id?.slice(0, 8) ?? 'subagent') : 'main'}`,
+      );
+      return 'passthrough';
+    }
     return autoApproveGate.resolvePermission(input);
   });
   hookServer.on('Stop', (input) => {

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -517,6 +517,19 @@ export class TranscriptBinder {
     this.adoptLockFromStore();
     if (!this.currentBoundId) return !this.hasSiblingInDir();
     if (event.session_id === this.currentBoundId) return true;
+    // #593: a SUBAGENT of our session (agent_id present) can carry a session_id
+    // that differs from our lock — parallel/team subagents, or an empty
+    // 00000000 id — while still sharing OUR main transcript. Admit it when its
+    // transcript_path is the one we are bound to: a file-free check, so it is
+    // robust to a transcript whose head marker is not yet readable (a binding
+    // still settling), which the marker read below is NOT. Without this, such a
+    // subagent's PermissionRequest is dropped to passthrough and never reaches
+    // the auto-approve gate (no eval, no "evaluating" status). A sibling daemon's
+    // subagent carries the SIBLING's transcript path, so it stays foreign here
+    // and cross-session isolation (#451) is preserved.
+    if (this.isSubagentEvent(event) && this.boundTranscriptMatches(event.transcript_path)) {
+      return true;
+    }
     // Stale-lock recovery (#518): the lock disagrees, but the incoming event's
     // transcript carries OUR port marker, so it is provably ours. Admit it; the
     // next binding event's onHookEvent re-adopts the lock. No state mutation —
@@ -525,6 +538,22 @@ export class TranscriptBinder {
     // stays genuinely foreign (a real sibling), where the 8KB head read is
     // bounded and acceptable.
     return this.incomingReclaimsViaMarker(event);
+  }
+
+  /**
+   * #593: file-free ownership — true when `transcriptPath` is the transcript this
+   * binder is bound to (our main transcript, tracked as `lastTranscriptPath`).
+   * Unlike the marker head-read it needs no file content, so it survives the
+   * window where a transcript exists in the hook event but its content/marker is
+   * not yet readable (the give-session failure mode).
+   */
+  private boundTranscriptMatches(transcriptPath: string | undefined): boolean {
+    if (!transcriptPath || !this.lastTranscriptPath) return false;
+    try {
+      return path.resolve(transcriptPath) === path.resolve(this.lastTranscriptPath);
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -541,16 +541,30 @@ export class TranscriptBinder {
   }
 
   /**
-   * #593: file-free ownership — true when `transcriptPath` is the transcript this
-   * binder is bound to (our main transcript, tracked as `lastTranscriptPath`).
-   * Unlike the marker head-read it needs no file content, so it survives the
-   * window where a transcript exists in the hook event but its content/marker is
-   * not yet readable (the give-session failure mode).
+   * #593: file-free ownership of `transcriptPath` (our main transcript), used to
+   * admit a subagent that shares it. Two signals, neither reads file content, so
+   * both survive the window where a transcript exists in the hook event but its
+   * head marker is not yet readable (the give failure mode):
+   *   (a) exact equality with the transcript we are actively watching
+   *       (`lastTranscriptPath`); and
+   *   (b) the file is named `<claudeSessionId>.jsonl`, so its basename equals our
+   *       bound id (`currentBoundId`). (b) is REQUIRED for the case the lock was
+   *       adopted from the binding store WITHOUT a SessionStart (mid-session
+   *       attach / daemon restart), where `lastTranscriptPath` is still null.
+   * A sibling daemon's subagent is named after the SIBLING's id / lives at the
+   * sibling's path, so neither signal matches and isolation (#451) holds.
    */
   private boundTranscriptMatches(transcriptPath: string | undefined): boolean {
-    if (!transcriptPath || !this.lastTranscriptPath) return false;
+    if (!transcriptPath) return false;
     try {
-      return path.resolve(transcriptPath) === path.resolve(this.lastTranscriptPath);
+      const resolved = path.resolve(transcriptPath);
+      if (this.lastTranscriptPath && resolved === path.resolve(this.lastTranscriptPath)) {
+        return true;
+      }
+      if (this.currentBoundId && path.basename(resolved, '.jsonl') === this.currentBoundId) {
+        return true;
+      }
+      return false;
     } catch {
       return false;
     }

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1052,4 +1052,83 @@ describe('TranscriptBinder', () => {
       expect(transcriptFallbackTimers.has(SID)).toBe(false);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // #593: a subagent PermissionRequest that shares our bound transcript must be
+  // admitted even when its session_id differs from our lock (parallel/team
+  // subagents, empty 00000000 id) and even when the transcript marker is not yet
+  // readable — otherwise it is dropped to passthrough and never auto-approved.
+  // Covered here without a costly interactive repro: drive `admits` directly.
+  // -------------------------------------------------------------------------
+  describe('#593 subagent admits — connection-independent ownership', () => {
+    function bindMain(mainPath: string): TranscriptBinder {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'main-claude',
+        transcript_path: mainPath,
+        hook_event_name: 'SessionStart',
+      });
+      return binder;
+    }
+
+    test('admits a subagent with a DIFFERENT session_id that shares our bound transcript', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: 'subagent-parallel-1',
+        agent_id: 'agent-aaaa',
+        transcript_path: mainPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test('admits a subagent with an empty/zero session_id sharing our bound transcript', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: '00000000-0000-0000-0000-000000000000',
+        agent_id: 'agent-bbbb',
+        transcript_path: mainPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test("does NOT admit a sibling daemon's subagent (foreign transcript, different port marker)", () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const siblingPath = writeMarkedTranscript('sibling.jsonl', 9999);
+      const admitted = binder.admits({
+        session_id: 'sibling-subagent',
+        agent_id: 'agent-cccc',
+        transcript_path: siblingPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('the path shortcut is GATED on agent_id: a foreign NON-subagent event with our (unmarked) path is not admitted', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: 'foreign-main',
+        transcript_path: mainPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('still admits the main agent (matching session_id), unchanged', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: 'main-claude',
+        transcript_path: mainPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+  });
 });

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1130,5 +1130,36 @@ describe('TranscriptBinder', () => {
       });
       expect(admitted).toBe(true);
     });
+
+    test('admits a subagent in the store-adopt window: lock set, lastTranscriptPath still null', () => {
+      // The reviewer's gap: adoptLockFromStore can promote currentBoundId WITHOUT
+      // a SessionStart (mid-session attach / daemon restart), so lastTranscriptPath
+      // stays null and the exact-path check cannot fire. The basename signal must
+      // still admit a subagent sharing the main transcript named <boundId>.jsonl.
+      registerSession();
+      const binder = makeBinder();
+      (binder as unknown as { currentBoundId: string | null }).currentBoundId = 'main-claude';
+      const admitted = binder.admits({
+        session_id: 'subagent-store-adopt',
+        agent_id: 'agent-dddd',
+        transcript_path: path.join(tmpDir, 'main-claude.jsonl'),
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test('store-adopt window stays isolated: a sibling subagent (foreign-named transcript) is not admitted', () => {
+      registerSession();
+      const binder = makeBinder();
+      (binder as unknown as { currentBoundId: string | null }).currentBoundId = 'main-claude';
+      const admitted = binder.admits({
+        session_id: 'sibling-sub',
+        agent_id: 'agent-eeee',
+        // named after the SIBLING's id, not ours; the file has no marker either
+        transcript_path: path.join(tmpDir, 'sibling-claude.jsonl'),
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

First step on #593 (subagent permissions bypass auto-approve). Traced the path: a subagent PermissionRequest is rejected at the resolver's `admits`/`filterBySession` gate (`hook-bridge-setup.ts:1203`) and returned as `passthrough`, so it never reaches `autoApproveGate.resolvePermission` -- no AA eval, no "evaluating" status. The user sees the native prompt instead. **That drop was silent** (no log at 1203), which is why the cause was invisible in the give session (0 forwarded logs, 0 subagent evals, yet many PTY "Question detected").

This PR makes the drop **fail loud**: every PermissionRequest rejected to passthrough is now logged with `agent=subagent|main` + the incoming session_id. No behavior change.

## Root cause (hypotheses, to confirm via the new log)

1. **Session-id mismatch** for parallel/async subagents: `filterBySession` admits only `input.session_id === claudeSessionId`; a parallel/background subagent may carry its own (or empty `00000000`) session_id -> rejected as foreign. (The give run was many parallel research subagents; we already saw `Dropped foreign PermissionRequest incoming=00000000`.)
2. **Startup/binding window**: during a hook-server port change + transcript-binding timeout + self-heal, the binder is unbound/stale and the fail-safe rejects events.

## Deferred (needs a confirmed repro; the binder is high blast-radius)

Targeted fix depends on which hypothesis the new log confirms — most likely: admit a subagent PermissionRequest (agent_id present) when it owns the bound MAIN transcript even if `session_id` differs, rather than strict equality. **Not** a PTY->AA fallback (#496 removed PTY-inject for subagents due to the parallel-prompt leak; eval-and-deny-only wouldn't help auto-approve).

Analysis + plan: `.context/subagent-aa-routing.md`. Part of #593.