### PR TITLE
fix(#597): surface real AskUserQuestion/ExitPlanMode question + options

### DIFF
--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -35,6 +35,7 @@ import type {
   SubagentStopHookInput,
 } from './hook-types.ts';
 import { SubagentContextTracker } from './subagent-context-tracker.ts';
+import { extractToolQuestion } from './tool-question.ts';
 
 export interface HookBridgeEvents {
   onStatusChange: (status: AgentStatus, context?: string) => void;
@@ -69,6 +70,26 @@ const DEFAULT_PERMISSION_OPTIONS: readonly QuestionOption[] = [
     isNo: true,
   },
 ];
+
+/**
+ * Build options from a PermissionRequest's `permission_suggestions`. The union
+ * carries string labels (pickable) and structured objects (rule-suggestion
+ * metadata the iOS card cannot render); only >= 2 string labels yield real
+ * options, otherwise the default Yes / Yes, always / No 3-set substitutes.
+ * Exported so the mapping is unit-testable independent of the bridge.
+ */
+export function optionsFromSuggestions(suggestions: unknown): QuestionOption[] {
+  const stringSuggestions = Array.isArray(suggestions)
+    ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : [];
+  if (stringSuggestions.length < 2) return [...DEFAULT_PERMISSION_OPTIONS];
+  return stringSuggestions.map((suggestion, idx) => {
+    const lower = suggestion.toLowerCase();
+    const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
+    const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
+    return { label: suggestion, value: String(idx + 1), isRecommended: idx === 0, isYes, isNo };
+  });
+}
 
 export class HookEventBridge {
   private readonly sessionId: UUID;
@@ -197,40 +218,31 @@ export class HookEventBridge {
     // one that does is genuinely answerable. The tracker handles both
     // cases; this method now only builds the question payload.
     const toolName = input.tool_name || 'unknown tool';
-    const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
-    // The action carries the command/path/pattern context (#497).
-    const action = inputSummary ? `${toolName}: ${inputSummary}` : toolName;
-    // A subagent prompt names the agent so the user knows WHO is asking, e.g.
-    // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
-    const promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
 
+    // Question-bearing tools (AskUserQuestion, ExitPlanMode) carry the real
+    // question + option labels in tool_input; surface those instead of the
+    // generic "Allow <tool>" + Yes / Yes, always / No (#597). The options are
+    // picks (1-based value, never isYes/isNo) so a user answer releases the held
+    // hook and submits the matching digit to Claude's native numbered prompt.
+    const toolQuestion = extractToolQuestion(toolName, input.tool_input);
+
+    let promptText: string;
     let options: QuestionOption[];
-
-    // permission_suggestions is a union of string labels and structured
-    // object entries (e.g. {type:"addDirectories",...}, {type:"setMode",...}).
-    // The iOS question card renders text labels only, so filter to strings.
-    const suggestions = input.permission_suggestions;
-    const stringSuggestions = Array.isArray(suggestions)
-      ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
-      : [];
-
-    if (stringSuggestions.length >= 2) {
-      options = stringSuggestions.map((suggestion, idx) => {
-        const lower = suggestion.toLowerCase();
-        const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
-        const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
-        return {
-          label: suggestion,
-          value: String(idx + 1),
-          isRecommended: idx === 0,
-          isYes,
-          isNo,
-        };
-      });
+    if (toolQuestion) {
+      // Already phrased as a question, so no "Allow" prefix. A subagent prompt
+      // still names the agent so the user knows WHO is asking.
+      promptText = input.agent_type
+        ? `${input.agent_type} · ${toolQuestion.text}`
+        : toolQuestion.text;
+      options = toolQuestion.options;
     } else {
-      // Either no suggestions (Bash) or only structured object entries
-      // that the iOS card cannot render. Fall back to the default 3-set.
-      options = [...DEFAULT_PERMISSION_OPTIONS];
+      const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
+      // The action carries the command/path/pattern context (#497).
+      const action = inputSummary ? `${toolName}: ${inputSummary}` : toolName;
+      // A subagent prompt names the agent, e.g.
+      // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
+      promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
+      options = optionsFromSuggestions(input.permission_suggestions);
     }
 
     const questionId = generateId();

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -49,9 +49,11 @@ function pickOption(label: string, index: number): QuestionOption {
 /**
  * ExitPlanMode's choices are NOT in tool_input (only the `plan` markdown is) —
  * they are Claude Code's built-in plan-approval options. Kept in the SAME order
- * Claude renders so a pick's submitted digit lands on the intended choice. If
- * Claude changes this set, the labels (display) drift but the positional digit
- * still maps; update here when that happens.
+ * Claude renders, because a pick's submitted digit lands on whatever Claude has
+ * at that position once the held hook releases — a wrong order is a silent
+ * wrong-pick. This order matches the maintainer's live observation 2026-06-19
+ * ("1 = auto mode, 2 = manual mode"). Reverify on each Claude Code release and
+ * update if it drifts — tracked in #598.
  */
 const EXIT_PLAN_MODE_OPTIONS: readonly string[] = [
   'Yes, and auto-accept edits',
@@ -88,11 +90,17 @@ export function extractToolQuestion(
     };
   }
 
-  // AskUserQuestion (and shape-compatible tools): `tool_input.questions[]`, each
-  // with a `question` string + `options` (strings or `{label}`). Remi answers one
-  // prompt at a time, so surface the FIRST question; a multi-question call still
-  // shows the first correctly and the rest fall to Claude's native prompt on
-  // release. A `header` (short topic) prefixes the question when present.
+  // AskUserQuestion AND shape-compatible tools (intentional, not name-gated): any
+  // tool whose tool_input carries `questions: [{ question, options }]`. This
+  // mirrors the auto-approve `isDesignQuestion` detector (multichoice.ts), which
+  // routes the SAME shape to always-escalate — so an MCP/custom tool that mimics
+  // AskUserQuestion gets its real options surfaced here too, consistently. The
+  // shape guards below are tight (record with a `question` string + a non-empty
+  // `options` array), so a tool with an unrelated `questions` field returns null
+  // and falls through to permission_suggestions. Remi answers one prompt at a
+  // time, so surface the FIRST question; a multi-question call still shows the
+  // first and the rest fall to Claude's native prompt on release. A `header`
+  // (short topic) prefixes the question when present.
   if (!isRecord(toolInput)) return null;
   const questions = toolInput['questions'];
   if (!Array.isArray(questions) || questions.length === 0) return null;

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -1,0 +1,111 @@
+/**
+ * Extract the real user-facing question + options a tool poses in its
+ * PermissionRequest, for tools whose escalation is genuinely the user's decision
+ * (AskUserQuestion, ExitPlanMode). Without this the `HookEventBridge` falls back
+ * to "Allow <tool>" + the default Yes / Yes, always / No, which is wrong for a
+ * multi-option plan/design question (#597) — the user sees a generic prompt and
+ * the wrong choices on both the in-app card and the lock-screen notification.
+ *
+ * The options are PICKS: `value` is the 1-based index and `isYes`/`isNo` are
+ * always false. That routes a user's answer through the daemon's release-hook +
+ * submit-digit path (a binary allow/deny response cannot express "pick option 2"),
+ * so the ORDER here MUST match the order the tool passes — which is the order
+ * Claude renders in its native numbered prompt once the held hook is released.
+ */
+
+import type { QuestionOption } from '@remi/shared';
+
+export interface ToolQuestion {
+  readonly text: string;
+  readonly options: QuestionOption[];
+}
+
+/**
+ * Collapse runs of whitespace (newlines, the column padding a PTY leaves behind)
+ * to single spaces and trim — WITHOUT removing the single spaces between words.
+ * tool_input text is already clean, but normalising here keeps a multi-line
+ * `question` from rendering as separate lines in the notification body.
+ */
+function cleanText(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * A pick option: 1-based value, never yes/no-shaped so the answer path releases
+ * the held hook and submits the digit rather than resolving a binary allow/deny.
+ * Index 0 is marked recommended only to match the existing option convention
+ * (display-only; it does not change which digit is submitted).
+ */
+function pickOption(label: string, index: number): QuestionOption {
+  return {
+    label: cleanText(label),
+    value: String(index + 1),
+    isRecommended: index === 0,
+    isYes: false,
+    isNo: false,
+  };
+}
+
+/**
+ * ExitPlanMode's choices are NOT in tool_input (only the `plan` markdown is) —
+ * they are Claude Code's built-in plan-approval options. Kept in the SAME order
+ * Claude renders so a pick's submitted digit lands on the intended choice. If
+ * Claude changes this set, the labels (display) drift but the positional digit
+ * still maps; update here when that happens.
+ */
+const EXIT_PLAN_MODE_OPTIONS: readonly string[] = [
+  'Yes, and auto-accept edits',
+  'Yes, and manually approve edits',
+  'No, keep planning',
+];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** One option label from an AskUserQuestion option entry (a string, or `{label}`). */
+function optionLabel(entry: unknown): string | null {
+  if (typeof entry === 'string' && entry.trim().length > 0) return entry;
+  if (isRecord(entry) && typeof entry['label'] === 'string' && entry['label'].trim().length > 0) {
+    return entry['label'];
+  }
+  return null;
+}
+
+/**
+ * Extract the real question + options for a question-bearing tool, or null when
+ * the tool does not carry one (the caller keeps its `permission_suggestions` /
+ * default fallback). Pure + total: never throws on a malformed tool_input.
+ */
+export function extractToolQuestion(
+  toolName: string,
+  toolInput: Record<string, unknown> | null | undefined,
+): ToolQuestion | null {
+  if (toolName === 'ExitPlanMode') {
+    return {
+      text: 'Plan ready for review. How do you want to proceed?',
+      options: EXIT_PLAN_MODE_OPTIONS.map((label, i) => pickOption(label, i)),
+    };
+  }
+
+  // AskUserQuestion (and shape-compatible tools): `tool_input.questions[]`, each
+  // with a `question` string + `options` (strings or `{label}`). Remi answers one
+  // prompt at a time, so surface the FIRST question; a multi-question call still
+  // shows the first correctly and the rest fall to Claude's native prompt on
+  // release. A `header` (short topic) prefixes the question when present.
+  if (!isRecord(toolInput)) return null;
+  const questions = toolInput['questions'];
+  if (!Array.isArray(questions) || questions.length === 0) return null;
+  const first = questions[0];
+  if (!isRecord(first)) return null;
+  const qText = typeof first['question'] === 'string' ? cleanText(first['question']) : '';
+  const rawOptions = first['options'];
+  if (qText.length === 0 || !Array.isArray(rawOptions)) return null;
+  const labels = rawOptions.map(optionLabel).filter((l): l is string => l !== null);
+  if (labels.length === 0) return null;
+  const header = typeof first['header'] === 'string' ? cleanText(first['header']) : '';
+  return {
+    text: header ? `${header}: ${qText}` : qText,
+    options: labels.map((label, i) => pickOption(label, i)),
+  };
+}

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -291,6 +291,54 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.text).toBe('code-reviewer · Bash: git push origin main');
   });
 
+  it('surfaces the real AskUserQuestion question + options, not "Allow AskUserQuestion" (#597)', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          {
+            question: 'Which approach do you prefer?',
+            header: 'Approach',
+            options: [
+              { label: 'Refactor first', description: 'a' },
+              { label: 'Ship then refactor', description: 'b' },
+            ],
+          },
+        ],
+      },
+    } as PermissionRequestHookInput);
+
+    expect(questions[0]?.text).toBe('Approach: Which approach do you prefer?');
+    expect(questions[0]?.options.map((o) => o.label)).toEqual([
+      'Refactor first',
+      'Ship then refactor',
+    ]);
+    // Picks, so the answer path releases the hook + submits the digit.
+    expect(questions[0]?.options.every((o) => !o.isYes && !o.isNo)).toBe(true);
+  });
+
+  it('surfaces ExitPlanMode plan-approval choices (#597)', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'ExitPlanMode',
+      tool_input: { plan: '# Plan\n- do the thing' },
+    } as PermissionRequestHookInput);
+
+    expect(questions[0]?.options.map((o) => o.label)).toEqual([
+      'Yes, and auto-accept edits',
+      'Yes, and manually approve edits',
+      'No, keep planning',
+    ]);
+    expect(questions[0]?.text).toContain('Plan ready');
+  });
+
   it('maps PostToolUseFailure to executing status with error context', () => {
     const { bridge, statuses } = createBridge();
 

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -73,6 +73,27 @@ describe('extractToolQuestion', () => {
       extractToolQuestion('AskUserQuestion', { questions: [{ options: ['a', 'b'] }] }),
     ).toBeNull();
   });
+
+  it('surfaces a shape-compatible tool (mirrors isDesignQuestion), not an unrelated questions field', () => {
+    // Intentional + name-agnostic: an MCP/custom tool mimicking the
+    // AskUserQuestion shape gets its real options surfaced.
+    const q = extractToolQuestion('mcp__custom__ask', {
+      questions: [{ question: 'Proceed?', options: ['A', 'B'] }],
+    });
+    expect(q?.options.map((o) => o.label)).toEqual(['A', 'B']);
+    // A `questions` field that is not the question shape -> null (falls through).
+    expect(extractToolQuestion('SomeTool', { questions: [1, 2, 3] })).toBeNull();
+    expect(extractToolQuestion('SomeTool', { questions: ['just', 'strings'] })).toBeNull();
+  });
+
+  it('surfaces a single-option AskUserQuestion as one pick (does not mask it with Yes/No)', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [{ question: 'Confirm the one thing?', options: ['Confirm'] }],
+    });
+    // Showing the real single choice beats a fabricated Yes/No fallback.
+    expect(q?.options.map((o) => o.label)).toEqual(['Confirm']);
+    expect(q?.options[0]?.value).toBe('1');
+  });
 });
 
 describe('optionsFromSuggestions', () => {

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+import { optionsFromSuggestions } from '../../src/hooks/hook-event-bridge.ts';
+import { extractToolQuestion } from '../../src/hooks/tool-question.ts';
+
+describe('extractToolQuestion', () => {
+  it('extracts the real AskUserQuestion question + option labels as picks', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        {
+          question: 'Which database should we use?',
+          header: 'Database',
+          options: [
+            { label: 'Postgres', description: 'relational' },
+            { label: 'SQLite', description: 'embedded' },
+            { label: 'Redis', description: 'kv' },
+          ],
+        },
+      ],
+    });
+    expect(q).not.toBeNull();
+    if (!q) return;
+    // Header prefixes the question.
+    expect(q.text).toBe('Database: Which database should we use?');
+    expect(q.options.map((o) => o.label)).toEqual(['Postgres', 'SQLite', 'Redis']);
+    // Picks: 1-based value, never yes/no-shaped (forces the digit-submit path).
+    expect(q.options.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(q.options.every((o) => o.isYes === false && o.isNo === false)).toBe(true);
+  });
+
+  it('accepts string options (not just {label} objects)', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [{ question: 'Pick a color', options: ['Red', 'Green'] }],
+    });
+    expect(q?.options.map((o) => o.label)).toEqual(['Red', 'Green']);
+    expect(q?.text).toBe('Pick a color');
+  });
+
+  it('does NOT eat the spaces in the question text', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        { question: 'Do you want to   proceed\nwith the migration?', options: ['Yes', 'No'] },
+      ],
+    });
+    // Runs of whitespace collapse to a single space; words stay separated.
+    expect(q?.text).toBe('Do you want to proceed with the migration?');
+  });
+
+  it('returns the standard ExitPlanMode choices in render order', () => {
+    const q = extractToolQuestion('ExitPlanMode', { plan: '# Plan\n- step 1\n- step 2' });
+    expect(q).not.toBeNull();
+    if (!q) return;
+    expect(q.options.map((o) => o.label)).toEqual([
+      'Yes, and auto-accept edits',
+      'Yes, and manually approve edits',
+      'No, keep planning',
+    ]);
+    expect(q.options.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(q.options.every((o) => o.isYes === false && o.isNo === false)).toBe(true);
+  });
+
+  it('returns null for tools that carry no question (so the caller falls back)', () => {
+    expect(extractToolQuestion('Bash', { command: 'git push' })).toBeNull();
+    expect(extractToolQuestion('Edit', { file_path: '/tmp/x.ts' })).toBeNull();
+  });
+
+  it('returns null on a malformed AskUserQuestion (no questions / no options)', () => {
+    expect(extractToolQuestion('AskUserQuestion', {})).toBeNull();
+    expect(extractToolQuestion('AskUserQuestion', { questions: [] })).toBeNull();
+    expect(
+      extractToolQuestion('AskUserQuestion', { questions: [{ question: 'Q', options: [] }] }),
+    ).toBeNull();
+    expect(
+      extractToolQuestion('AskUserQuestion', { questions: [{ options: ['a', 'b'] }] }),
+    ).toBeNull();
+  });
+});
+
+describe('optionsFromSuggestions', () => {
+  it('maps >= 2 string suggestions, flagging yes/no shape', () => {
+    const opts = optionsFromSuggestions(['Yes', 'Always', 'No']);
+    expect(opts.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
+    expect(opts.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(opts[0]?.isYes).toBe(true);
+    expect(opts[1]?.isYes).toBe(true); // "Always"
+    expect(opts[2]?.isNo).toBe(true);
+  });
+
+  it('falls back to the default 3-set when there are < 2 string suggestions', () => {
+    const def = optionsFromSuggestions(undefined);
+    expect(def).toHaveLength(3);
+    expect(def[0]?.isYes).toBe(true);
+    expect(def[2]?.isNo).toBe(true);
+    // Structured-only suggestions (no pickable strings) also fall back.
+    expect(optionsFromSuggestions([{ type: 'addDirectories' }])).toHaveLength(3);
+    expect(optionsFromSuggestions(['OnlyOne'])).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

AskUserQuestion / ExitPlanMode escalations showed the generic **"Allow AskUserQuestion"** + default **Yes / Yes, always / No** instead of the real question text and option labels — wrong on the in-app card AND the lock-screen notification. Root cause: `HookEventBridge.handlePermissionRequest` built the question from `permission_suggestions` only, which these tools don't populate with pickable strings.

## Changes

- **`tool-question.ts`** (new): `extractToolQuestion(toolName, toolInput)` reads the real question + option labels from `tool_input` — AskUserQuestion `questions[0].question` + `options[].label` (name-agnostic, mirrors auto-approve's `isDesignQuestion`); ExitPlanMode's standard plan-approval set (not in the hook payload). Options are **picks** (1-based `value`, never `isYes`/`isNo`) so a user answer releases the held hook and submits the matching digit to Claude's native numbered prompt. Whitespace collapsed so a multi-line question doesn't garble.
- **Refactor:** `optionsFromSuggestions()` extracted from the bridge, exported + unit-tested. Fallback (non-question tools) behavior unchanged.
- `handlePermissionRequest` tries the extractor first, else the prior summary + suggestions path.

## Test plan

- `tool-question.test.ts`: extractor + mapping, NO MOCKS (AskUserQuestion shape, string/object options, header, whitespace, ExitPlanMode, fallback, shape-compatible tool, single-option, malformed).
- `hook-event-bridge.test.ts`: +2 integration tests (real bridge) for AskUserQuestion + ExitPlanMode.
- Full hooks suite 128/128; typecheck + biome clean.

Closes #597. Follow-up #598 (reverify ExitPlanMode order per Claude Code release).