### PR TITLE
Release 0.6.14

### DIFF
--- a/.context/native-lockscreen-p2.md
+++ b/.context/native-lockscreen-p2.md
@@ -47,6 +47,31 @@ foreground and we never clobber the global delegate.
      fires when the app is alive.
    - Actions WITHOUT `.foreground` (background handling).
 
+### Verified Capacitor seam + native foot-guns (read before coding)
+
+`Capacitor/NotificationRouter.swift` is the `UNUserNotificationCenterDelegate`.
+The push plugin sets `bridge.notificationRouter.pushNotificationHandler` (a
+`NotificationHandlerProtocol` with `willPresent` + `didReceive(response:)`) in its
+`load()`. Wrap THAT property: capture the existing handler, install a wrapper that
+does the native relay then forwards to the captured handler. Three gotchas the
+router source makes explicit:
+
+1. **`pushNotificationHandler` is `weak`.** A wrapper must be retained by us (a
+   static/singleton) or it deallocates to nil and notifications stop routing. Also
+   keep a strong ref to Capacitor's original handler inside the wrapper to forward.
+2. **`didReceive(response:)` is synchronous** and the router calls
+   `completionHandler()` immediately after it returns. So an async URLSession POST
+   started in `didReceive` is NOT covered by the router's completion — it must run
+   under its own `application.beginBackgroundTask` (~30s) and `endBackgroundTask`
+   on completion, independent of the router.
+3. **Install timing**: the wrap must run AFTER the push plugin's `load()` (which
+   sets the original handler). Plugin load order isn't guaranteed, so do the wrap
+   from a deferred hook (e.g. AppDelegate `applicationDidBecomeActive`, guarded to
+   run once) rather than a custom plugin's `load()`.
+4. Only a PUSH-trigger response routes to `pushNotificationHandler` (the router
+   checks `UNPushNotificationTrigger`), which matches our APNS escalation pushes.
+5. Actions stay WITHOUT `.foreground` (background handling, no app open).
+
 ### On-device validation (one cycle, after the build)
 
 - Lock screen, app killed, cellular: tap Yes/No -> Claude proceeds; card clears.

--- a/.context/native-lockscreen-p2.md
+++ b/.context/native-lockscreen-p2.md
@@ -1,0 +1,62 @@
+# #591 P2 — native silent lock-screen answer (Duo-style)
+
+Goal: answer a held permission from the iOS lock screen **without opening the
+app** — iOS background-launches a native handler that signs + relays the answer
+to the signaling Worker `/answer/{code}` (the #591 P1 backend). No app foreground.
+
+## De-risked off-device (done)
+
+- **Crypto compat PROVEN** (`packages/shared/tests/ed25519-native-seed-compat.test.ts`):
+  the JS identity's PKCS8 private key yields a 32-byte Ed25519 seed (`pkcs8.slice(16)`);
+  a signature from that seed alone verifies with the daemon's `verify()` and is
+  byte-identical to the full-key signature. CryptoKit's
+  `Curve25519.Signing.PrivateKey(rawRepresentation: seed)` is exactly this, so a
+  native signature WILL verify on the daemon. No device needed to trust the crypto.
+- **No daemon change needed**: the native handler reads the room `code` +
+  `signalingUrl` from app-stored connection info (written by JS), and `sessionId`/
+  `questionId` from the push payload. The `/answer/{code}` route already ships (P1).
+
+## Architecture
+
+Capacitor 8 owns `UNUserNotificationCenter.delegate` and routes to
+`bridge.notificationRouter.pushNotificationHandler` (the push plugin's handler,
+which forwards to JS). We **wrap** that handler — native relay first, then
+delegate to the captured Capacitor handler — so JS forwarding still works in the
+foreground and we never clobber the global delegate.
+
+### Pieces (remaining)
+
+1. **JS -> native bridge** (`@capacitor/preferences`, UserDefaults-backed):
+   - On identity load: write `{ seed (32B b64), publicKeyRaw (b64), fingerprint }`.
+     (Seed = `pkcs8.slice(16)`; only for an UNENCRYPTED identity — an encrypted one
+     can't be bridged without a passphrase, so the lock-screen path is unavailable
+     then, same limit as the JS relay.)
+   - On connect: write a per-session route `{ sessionId -> { code, signalingUrl, claudeSessionId } }`.
+   - Preferences stores under `UserDefaults.standard` key `CapacitorStorage.<key>`,
+     which AppDelegate reads natively. (Seed in UserDefaults is no worse than the
+     existing localStorage identity; Keychain hardening is a follow-up.)
+2. **Native categories**: add a `UNTextInputNotificationAction` category
+   (`REMI_TEXT`) for free-text / numbered questions (`userText`).
+3. **Native `didReceive` handler** (wrap the router handler):
+   - Map `actionIdentifier` (`OPT_0/1/2/3`) to the option value carried in the push
+     `data` (`opt_0`, `opt_1`, ...), or `userText` for the text action.
+   - Look up the session route + seed from UserDefaults.
+   - `beginBackgroundTask`; CryptoKit sign `sessionId|questionId|answer`; URLSession
+     POST `signalingUrl/answer/{code}` with `{sessionId, questionId, answer, claudeSessionId?, auth:{signature, clientPublicKey, clientFingerprint}}`; `completionHandler` when done.
+   - Then call the captured Capacitor handler's `didReceive` so the JS path still
+     fires when the app is alive.
+   - Actions WITHOUT `.foreground` (background handling).
+
+### On-device validation (one cycle, after the build)
+
+- Lock screen, app killed, cellular: tap Yes/No -> Claude proceeds; card clears.
+- Xcode console: native handler logs the signed POST + the Worker 200.
+- Confirm `completionHandler` always called (no background-budget warnings).
+- Text-input action returns `userText` and resolves.
+
+### Notes / risks (all on-device-only)
+
+- The notificationRouter handler-wrapping (Capacitor internals) — validate the
+  wrap fires for a backgrounded action and Capacitor's JS path still works alive.
+- Background execution budget (~30s) — the single URLSession POST is well within it.
+- The seed-in-UserDefaults security posture (Keychain hardening follow-up).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.14] - 2026-06-19
+
+The iOS client side of native lock-screen permission answering, and correct
+question text + options for plan/design escalations.
+
+### Added
+- **Native lock-screen answer** (#591 P2): the iOS app answers a held permission
+  from the lock screen WITHOUT opening — a notification action is signed
+  (Ed25519) and POSTed straight to the daemon's `/answer` endpoint, then
+  forwarded to the in-app handler so the foreground path still works. Builds on
+  the #591 P1 relay backend (0.6.13). The signer + per-session daemon URL are
+  bridged to native storage via `@capacitor/preferences`; only an unencrypted
+  identity is bridgeable, and a stale route is dropped on session eviction.
+
+### Fixed
+- **AskUserQuestion / ExitPlanMode escalations show the real question + options**
+  (#597): these were surfaced as the generic "Allow <tool>" + Yes / Yes, always /
+  No on both the in-app card and the lock-screen notification, because the
+  question builder read only `permission_suggestions`. The daemon now extracts
+  the real question text + option labels from the tool's `tool_input`
+  (AskUserQuestion `questions[0]`; ExitPlanMode's standard plan-approval set) and
+  emits them as picks, so answering selects the intended choice. Whitespace is
+  collapsed so a multi-line question no longer renders as a run-together string.
+  ExitPlanMode option order is reverified per Claude Code release (#598).
+
 ## [0.6.13] - 2026-06-19
 
 Backend for native lock-screen permission answering, and a fix for subagent

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@capacitor/keyboard": "^8.0.1",
         "@capacitor/local-notifications": "^8.0.2",
         "@capacitor/network": "^8.0.1",
+        "@capacitor/preferences": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/status-bar": "^8.0.1",
         "@fontsource-variable/inter-tight": "^5.2.7",
@@ -165,6 +166,8 @@
     "@capacitor/local-notifications": ["@capacitor/local-notifications@8.0.2", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw=="],
 
     "@capacitor/network": ["@capacitor/network@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w=="],
+
+    "@capacitor/preferences": ["@capacitor/preferences@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ=="],
 
     "@capacitor/push-notifications": ["@capacitor/push-notifications@8.0.3", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-jmBBoJvOzmzem8YoO9dQJBPFiM1bksTNAoV7yksCBN10BybAOtmBF19vFPt/jr2KGAirnPZz0ne2X0OH/rRGtg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.14-dev.1",
+  "version": "0.6.14-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.14-dev.3",
+  "version": "0.6.14-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.13",
+  "version": "0.6.14-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.14-dev.2",
+  "version": "0.6.14-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.14-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.14-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.14-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.14-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.14-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.14-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.14-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.14-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.13'; // REMI_COMPILED_VERSION
+      return '0.6.14-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.13'; // REMI_COMPILED_VERSION
+    return '0.6.14-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.14-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.14-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.14-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.14-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -35,6 +35,7 @@ import type {
   SubagentStopHookInput,
 } from './hook-types.ts';
 import { SubagentContextTracker } from './subagent-context-tracker.ts';
+import { extractToolQuestion } from './tool-question.ts';
 
 export interface HookBridgeEvents {
   onStatusChange: (status: AgentStatus, context?: string) => void;
@@ -69,6 +70,26 @@ const DEFAULT_PERMISSION_OPTIONS: readonly QuestionOption[] = [
     isNo: true,
   },
 ];
+
+/**
+ * Build options from a PermissionRequest's `permission_suggestions`. The union
+ * carries string labels (pickable) and structured objects (rule-suggestion
+ * metadata the iOS card cannot render); only >= 2 string labels yield real
+ * options, otherwise the default Yes / Yes, always / No 3-set substitutes.
+ * Exported so the mapping is unit-testable independent of the bridge.
+ */
+export function optionsFromSuggestions(suggestions: unknown): QuestionOption[] {
+  const stringSuggestions = Array.isArray(suggestions)
+    ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : [];
+  if (stringSuggestions.length < 2) return [...DEFAULT_PERMISSION_OPTIONS];
+  return stringSuggestions.map((suggestion, idx) => {
+    const lower = suggestion.toLowerCase();
+    const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
+    const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
+    return { label: suggestion, value: String(idx + 1), isRecommended: idx === 0, isYes, isNo };
+  });
+}
 
 export class HookEventBridge {
   private readonly sessionId: UUID;
@@ -197,40 +218,31 @@ export class HookEventBridge {
     // one that does is genuinely answerable. The tracker handles both
     // cases; this method now only builds the question payload.
     const toolName = input.tool_name || 'unknown tool';
-    const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
-    // The action carries the command/path/pattern context (#497).
-    const action = inputSummary ? `${toolName}: ${inputSummary}` : toolName;
-    // A subagent prompt names the agent so the user knows WHO is asking, e.g.
-    // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
-    const promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
 
+    // Question-bearing tools (AskUserQuestion, ExitPlanMode) carry the real
+    // question + option labels in tool_input; surface those instead of the
+    // generic "Allow <tool>" + Yes / Yes, always / No (#597). The options are
+    // picks (1-based value, never isYes/isNo) so a user answer releases the held
+    // hook and submits the matching digit to Claude's native numbered prompt.
+    const toolQuestion = extractToolQuestion(toolName, input.tool_input);
+
+    let promptText: string;
     let options: QuestionOption[];
-
-    // permission_suggestions is a union of string labels and structured
-    // object entries (e.g. {type:"addDirectories",...}, {type:"setMode",...}).
-    // The iOS question card renders text labels only, so filter to strings.
-    const suggestions = input.permission_suggestions;
-    const stringSuggestions = Array.isArray(suggestions)
-      ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
-      : [];
-
-    if (stringSuggestions.length >= 2) {
-      options = stringSuggestions.map((suggestion, idx) => {
-        const lower = suggestion.toLowerCase();
-        const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
-        const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
-        return {
-          label: suggestion,
-          value: String(idx + 1),
-          isRecommended: idx === 0,
-          isYes,
-          isNo,
-        };
-      });
+    if (toolQuestion) {
+      // Already phrased as a question, so no "Allow" prefix. A subagent prompt
+      // still names the agent so the user knows WHO is asking.
+      promptText = input.agent_type
+        ? `${input.agent_type} · ${toolQuestion.text}`
+        : toolQuestion.text;
+      options = toolQuestion.options;
     } else {
-      // Either no suggestions (Bash) or only structured object entries
-      // that the iOS card cannot render. Fall back to the default 3-set.
-      options = [...DEFAULT_PERMISSION_OPTIONS];
+      const inputSummary = this.summarizeToolInput(toolName, input.tool_input);
+      // The action carries the command/path/pattern context (#497).
+      const action = inputSummary ? `${toolName}: ${inputSummary}` : toolName;
+      // A subagent prompt names the agent, e.g.
+      // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
+      promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
+      options = optionsFromSuggestions(input.permission_suggestions);
     }
 
     const questionId = generateId();

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -49,9 +49,11 @@ function pickOption(label: string, index: number): QuestionOption {
 /**
  * ExitPlanMode's choices are NOT in tool_input (only the `plan` markdown is) —
  * they are Claude Code's built-in plan-approval options. Kept in the SAME order
- * Claude renders so a pick's submitted digit lands on the intended choice. If
- * Claude changes this set, the labels (display) drift but the positional digit
- * still maps; update here when that happens.
+ * Claude renders, because a pick's submitted digit lands on whatever Claude has
+ * at that position once the held hook releases — a wrong order is a silent
+ * wrong-pick. This order matches the maintainer's live observation 2026-06-19
+ * ("1 = auto mode, 2 = manual mode"). Reverify on each Claude Code release and
+ * update if it drifts — tracked in #598.
  */
 const EXIT_PLAN_MODE_OPTIONS: readonly string[] = [
   'Yes, and auto-accept edits',
@@ -88,11 +90,17 @@ export function extractToolQuestion(
     };
   }
 
-  // AskUserQuestion (and shape-compatible tools): `tool_input.questions[]`, each
-  // with a `question` string + `options` (strings or `{label}`). Remi answers one
-  // prompt at a time, so surface the FIRST question; a multi-question call still
-  // shows the first correctly and the rest fall to Claude's native prompt on
-  // release. A `header` (short topic) prefixes the question when present.
+  // AskUserQuestion AND shape-compatible tools (intentional, not name-gated): any
+  // tool whose tool_input carries `questions: [{ question, options }]`. This
+  // mirrors the auto-approve `isDesignQuestion` detector (multichoice.ts), which
+  // routes the SAME shape to always-escalate — so an MCP/custom tool that mimics
+  // AskUserQuestion gets its real options surfaced here too, consistently. The
+  // shape guards below are tight (record with a `question` string + a non-empty
+  // `options` array), so a tool with an unrelated `questions` field returns null
+  // and falls through to permission_suggestions. Remi answers one prompt at a
+  // time, so surface the FIRST question; a multi-question call still shows the
+  // first and the rest fall to Claude's native prompt on release. A `header`
+  // (short topic) prefixes the question when present.
   if (!isRecord(toolInput)) return null;
   const questions = toolInput['questions'];
   if (!Array.isArray(questions) || questions.length === 0) return null;

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -1,0 +1,111 @@
+/**
+ * Extract the real user-facing question + options a tool poses in its
+ * PermissionRequest, for tools whose escalation is genuinely the user's decision
+ * (AskUserQuestion, ExitPlanMode). Without this the `HookEventBridge` falls back
+ * to "Allow <tool>" + the default Yes / Yes, always / No, which is wrong for a
+ * multi-option plan/design question (#597) — the user sees a generic prompt and
+ * the wrong choices on both the in-app card and the lock-screen notification.
+ *
+ * The options are PICKS: `value` is the 1-based index and `isYes`/`isNo` are
+ * always false. That routes a user's answer through the daemon's release-hook +
+ * submit-digit path (a binary allow/deny response cannot express "pick option 2"),
+ * so the ORDER here MUST match the order the tool passes — which is the order
+ * Claude renders in its native numbered prompt once the held hook is released.
+ */
+
+import type { QuestionOption } from '@remi/shared';
+
+export interface ToolQuestion {
+  readonly text: string;
+  readonly options: QuestionOption[];
+}
+
+/**
+ * Collapse runs of whitespace (newlines, the column padding a PTY leaves behind)
+ * to single spaces and trim — WITHOUT removing the single spaces between words.
+ * tool_input text is already clean, but normalising here keeps a multi-line
+ * `question` from rendering as separate lines in the notification body.
+ */
+function cleanText(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * A pick option: 1-based value, never yes/no-shaped so the answer path releases
+ * the held hook and submits the digit rather than resolving a binary allow/deny.
+ * Index 0 is marked recommended only to match the existing option convention
+ * (display-only; it does not change which digit is submitted).
+ */
+function pickOption(label: string, index: number): QuestionOption {
+  return {
+    label: cleanText(label),
+    value: String(index + 1),
+    isRecommended: index === 0,
+    isYes: false,
+    isNo: false,
+  };
+}
+
+/**
+ * ExitPlanMode's choices are NOT in tool_input (only the `plan` markdown is) —
+ * they are Claude Code's built-in plan-approval options. Kept in the SAME order
+ * Claude renders so a pick's submitted digit lands on the intended choice. If
+ * Claude changes this set, the labels (display) drift but the positional digit
+ * still maps; update here when that happens.
+ */
+const EXIT_PLAN_MODE_OPTIONS: readonly string[] = [
+  'Yes, and auto-accept edits',
+  'Yes, and manually approve edits',
+  'No, keep planning',
+];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** One option label from an AskUserQuestion option entry (a string, or `{label}`). */
+function optionLabel(entry: unknown): string | null {
+  if (typeof entry === 'string' && entry.trim().length > 0) return entry;
+  if (isRecord(entry) && typeof entry['label'] === 'string' && entry['label'].trim().length > 0) {
+    return entry['label'];
+  }
+  return null;
+}
+
+/**
+ * Extract the real question + options for a question-bearing tool, or null when
+ * the tool does not carry one (the caller keeps its `permission_suggestions` /
+ * default fallback). Pure + total: never throws on a malformed tool_input.
+ */
+export function extractToolQuestion(
+  toolName: string,
+  toolInput: Record<string, unknown> | null | undefined,
+): ToolQuestion | null {
+  if (toolName === 'ExitPlanMode') {
+    return {
+      text: 'Plan ready for review. How do you want to proceed?',
+      options: EXIT_PLAN_MODE_OPTIONS.map((label, i) => pickOption(label, i)),
+    };
+  }
+
+  // AskUserQuestion (and shape-compatible tools): `tool_input.questions[]`, each
+  // with a `question` string + `options` (strings or `{label}`). Remi answers one
+  // prompt at a time, so surface the FIRST question; a multi-question call still
+  // shows the first correctly and the rest fall to Claude's native prompt on
+  // release. A `header` (short topic) prefixes the question when present.
+  if (!isRecord(toolInput)) return null;
+  const questions = toolInput['questions'];
+  if (!Array.isArray(questions) || questions.length === 0) return null;
+  const first = questions[0];
+  if (!isRecord(first)) return null;
+  const qText = typeof first['question'] === 'string' ? cleanText(first['question']) : '';
+  const rawOptions = first['options'];
+  if (qText.length === 0 || !Array.isArray(rawOptions)) return null;
+  const labels = rawOptions.map(optionLabel).filter((l): l is string => l !== null);
+  if (labels.length === 0) return null;
+  const header = typeof first['header'] === 'string' ? cleanText(first['header']) : '';
+  return {
+    text: header ? `${header}: ${qText}` : qText,
+    options: labels.map((label, i) => pickOption(label, i)),
+  };
+}

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -291,6 +291,54 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.text).toBe('code-reviewer · Bash: git push origin main');
   });
 
+  it('surfaces the real AskUserQuestion question + options, not "Allow AskUserQuestion" (#597)', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          {
+            question: 'Which approach do you prefer?',
+            header: 'Approach',
+            options: [
+              { label: 'Refactor first', description: 'a' },
+              { label: 'Ship then refactor', description: 'b' },
+            ],
+          },
+        ],
+      },
+    } as PermissionRequestHookInput);
+
+    expect(questions[0]?.text).toBe('Approach: Which approach do you prefer?');
+    expect(questions[0]?.options.map((o) => o.label)).toEqual([
+      'Refactor first',
+      'Ship then refactor',
+    ]);
+    // Picks, so the answer path releases the hook + submits the digit.
+    expect(questions[0]?.options.every((o) => !o.isYes && !o.isNo)).toBe(true);
+  });
+
+  it('surfaces ExitPlanMode plan-approval choices (#597)', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'ExitPlanMode',
+      tool_input: { plan: '# Plan\n- do the thing' },
+    } as PermissionRequestHookInput);
+
+    expect(questions[0]?.options.map((o) => o.label)).toEqual([
+      'Yes, and auto-accept edits',
+      'Yes, and manually approve edits',
+      'No, keep planning',
+    ]);
+    expect(questions[0]?.text).toContain('Plan ready');
+  });
+
   it('maps PostToolUseFailure to executing status with error context', () => {
     const { bridge, statuses } = createBridge();
 

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -73,6 +73,27 @@ describe('extractToolQuestion', () => {
       extractToolQuestion('AskUserQuestion', { questions: [{ options: ['a', 'b'] }] }),
     ).toBeNull();
   });
+
+  it('surfaces a shape-compatible tool (mirrors isDesignQuestion), not an unrelated questions field', () => {
+    // Intentional + name-agnostic: an MCP/custom tool mimicking the
+    // AskUserQuestion shape gets its real options surfaced.
+    const q = extractToolQuestion('mcp__custom__ask', {
+      questions: [{ question: 'Proceed?', options: ['A', 'B'] }],
+    });
+    expect(q?.options.map((o) => o.label)).toEqual(['A', 'B']);
+    // A `questions` field that is not the question shape -> null (falls through).
+    expect(extractToolQuestion('SomeTool', { questions: [1, 2, 3] })).toBeNull();
+    expect(extractToolQuestion('SomeTool', { questions: ['just', 'strings'] })).toBeNull();
+  });
+
+  it('surfaces a single-option AskUserQuestion as one pick (does not mask it with Yes/No)', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [{ question: 'Confirm the one thing?', options: ['Confirm'] }],
+    });
+    // Showing the real single choice beats a fabricated Yes/No fallback.
+    expect(q?.options.map((o) => o.label)).toEqual(['Confirm']);
+    expect(q?.options[0]?.value).toBe('1');
+  });
 });
 
 describe('optionsFromSuggestions', () => {

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+import { optionsFromSuggestions } from '../../src/hooks/hook-event-bridge.ts';
+import { extractToolQuestion } from '../../src/hooks/tool-question.ts';
+
+describe('extractToolQuestion', () => {
+  it('extracts the real AskUserQuestion question + option labels as picks', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        {
+          question: 'Which database should we use?',
+          header: 'Database',
+          options: [
+            { label: 'Postgres', description: 'relational' },
+            { label: 'SQLite', description: 'embedded' },
+            { label: 'Redis', description: 'kv' },
+          ],
+        },
+      ],
+    });
+    expect(q).not.toBeNull();
+    if (!q) return;
+    // Header prefixes the question.
+    expect(q.text).toBe('Database: Which database should we use?');
+    expect(q.options.map((o) => o.label)).toEqual(['Postgres', 'SQLite', 'Redis']);
+    // Picks: 1-based value, never yes/no-shaped (forces the digit-submit path).
+    expect(q.options.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(q.options.every((o) => o.isYes === false && o.isNo === false)).toBe(true);
+  });
+
+  it('accepts string options (not just {label} objects)', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [{ question: 'Pick a color', options: ['Red', 'Green'] }],
+    });
+    expect(q?.options.map((o) => o.label)).toEqual(['Red', 'Green']);
+    expect(q?.text).toBe('Pick a color');
+  });
+
+  it('does NOT eat the spaces in the question text', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        { question: 'Do you want to   proceed\nwith the migration?', options: ['Yes', 'No'] },
+      ],
+    });
+    // Runs of whitespace collapse to a single space; words stay separated.
+    expect(q?.text).toBe('Do you want to proceed with the migration?');
+  });
+
+  it('returns the standard ExitPlanMode choices in render order', () => {
+    const q = extractToolQuestion('ExitPlanMode', { plan: '# Plan\n- step 1\n- step 2' });
+    expect(q).not.toBeNull();
+    if (!q) return;
+    expect(q.options.map((o) => o.label)).toEqual([
+      'Yes, and auto-accept edits',
+      'Yes, and manually approve edits',
+      'No, keep planning',
+    ]);
+    expect(q.options.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(q.options.every((o) => o.isYes === false && o.isNo === false)).toBe(true);
+  });
+
+  it('returns null for tools that carry no question (so the caller falls back)', () => {
+    expect(extractToolQuestion('Bash', { command: 'git push' })).toBeNull();
+    expect(extractToolQuestion('Edit', { file_path: '/tmp/x.ts' })).toBeNull();
+  });
+
+  it('returns null on a malformed AskUserQuestion (no questions / no options)', () => {
+    expect(extractToolQuestion('AskUserQuestion', {})).toBeNull();
+    expect(extractToolQuestion('AskUserQuestion', { questions: [] })).toBeNull();
+    expect(
+      extractToolQuestion('AskUserQuestion', { questions: [{ question: 'Q', options: [] }] }),
+    ).toBeNull();
+    expect(
+      extractToolQuestion('AskUserQuestion', { questions: [{ options: ['a', 'b'] }] }),
+    ).toBeNull();
+  });
+});
+
+describe('optionsFromSuggestions', () => {
+  it('maps >= 2 string suggestions, flagging yes/no shape', () => {
+    const opts = optionsFromSuggestions(['Yes', 'Always', 'No']);
+    expect(opts.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
+    expect(opts.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(opts[0]?.isYes).toBe(true);
+    expect(opts[1]?.isYes).toBe(true); // "Always"
+    expect(opts[2]?.isNo).toBe(true);
+  });
+
+  it('falls back to the default 3-set when there are < 2 string suggestions', () => {
+    const def = optionsFromSuggestions(undefined);
+    expect(def).toHaveLength(3);
+    expect(def[0]?.isYes).toBe(true);
+    expect(def[2]?.isNo).toBe(true);
+    // Structured-only suggestions (no pickable strings) also fall back.
+    expect(optionsFromSuggestions([{ type: 'addDirectories' }])).toHaveLength(3);
+    expect(optionsFromSuggestions(['OnlyOne'])).toHaveLength(3);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -186,6 +186,10 @@ export {
   createAuthorizedKeysFile,
 } from './identity.ts';
 
+// Native lock-screen relay bridge (#591 P2)
+export type { NativeIdentityRecord } from './native-bridge.ts';
+export { deriveNativeIdentity } from './native-bridge.ts';
+
 // Error helpers
 export { errorToString } from './error-utils.ts';
 

--- a/packages/shared/src/native-bridge.ts
+++ b/packages/shared/src/native-bridge.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure identity transform for the native lock-screen answer relay (#591 P2).
+ *
+ * The iOS native handler (`RemiAnswerRelay.swift`) signs a lock-screen answer
+ * WITHOUT opening the app, using CryptoKit's
+ * `Curve25519.Signing.PrivateKey(rawRepresentation:)` — which takes the raw
+ * 32-byte Ed25519 seed. It cannot reach the WebView's localStorage, so the web
+ * layer mirrors the minimum it needs (seed + raw public key + fingerprint) into
+ * native-readable storage.
+ *
+ * This module owns the pure derivation so it can be unit-tested (NO MOCKS)
+ * against the daemon's own `verify()` — see `tests/native-bridge.test.ts`. The
+ * Capacitor Preferences I/O that ships it to UserDefaults lives in the web
+ * package (`lib/native-bridge.ts`), which is thin glue around this function.
+ */
+
+import { fromBase64, toBase64 } from './crypto.ts';
+import { type RemiIdentity, isEncrypted } from './identity.ts';
+
+/**
+ * The minimum identity the native handler needs to sign an answer. All fields
+ * are base64. `seed` is the raw 32-byte Ed25519 private seed; `publicKey` is the
+ * raw 32-byte public key (the daemon's authenticator verifies with it); the
+ * fingerprint identifies the key in the daemon's authorized-keys store.
+ */
+export interface NativeIdentityRecord {
+  readonly seed: string;
+  readonly publicKey: string;
+  readonly fingerprint: string;
+}
+
+/**
+ * PKCS8 (RFC 8410) wrapping of an Ed25519 private key: a 16-byte prefix followed
+ * by the 32-byte seed. An unencrypted `RemiIdentity` stores this PKCS8 blob
+ * (base64) directly in `encryptedPrivateKey`; CryptoKit needs only the seed.
+ */
+const PKCS8_PREFIX_LEN = 16;
+const ED25519_SEED_LEN = 32;
+
+/**
+ * Derive the native identity record from a stored identity.
+ *
+ * Returns null when the identity is encrypted (the seed can't be bridged without
+ * a passphrase prompt the lock screen cannot show — the same limitation the JS
+ * relay's `buildAuth` has) or when the stored PKCS8 is malformed. A null result
+ * means the lock-screen relay is simply unavailable for that identity, never an
+ * error to swallow.
+ */
+export function deriveNativeIdentity(identity: RemiIdentity): NativeIdentityRecord | null {
+  if (isEncrypted(identity)) return null;
+  // Unencrypted: `encryptedPrivateKey` is the raw PKCS8 base64. `fromBase64`
+  // returns an ArrayBuffer, so slice past the 16-byte prefix and check byteLength.
+  const pkcs8 = fromBase64(identity.encryptedPrivateKey);
+  const seed = pkcs8.slice(PKCS8_PREFIX_LEN);
+  if (seed.byteLength !== ED25519_SEED_LEN) return null;
+  return {
+    seed: toBase64(seed),
+    publicKey: identity.publicKey,
+    fingerprint: identity.fingerprint,
+  };
+}

--- a/packages/shared/src/native-bridge.ts
+++ b/packages/shared/src/native-bridge.ts
@@ -49,8 +49,16 @@ const ED25519_SEED_LEN = 32;
 export function deriveNativeIdentity(identity: RemiIdentity): NativeIdentityRecord | null {
   if (isEncrypted(identity)) return null;
   // Unencrypted: `encryptedPrivateKey` is the raw PKCS8 base64. `fromBase64`
-  // returns an ArrayBuffer, so slice past the 16-byte prefix and check byteLength.
-  const pkcs8 = fromBase64(identity.encryptedPrivateKey);
+  // throws on a malformed (non-base64) value; treat that as not-bridgeable too,
+  // so the function honors its documented "null on malformed PKCS8" contract
+  // instead of leaking a throw to a fire-and-forget caller.
+  let pkcs8: ArrayBuffer;
+  try {
+    pkcs8 = fromBase64(identity.encryptedPrivateKey);
+  } catch {
+    return null;
+  }
+  // Slice past the 16-byte prefix; `fromBase64` returns an ArrayBuffer, so check byteLength.
   const seed = pkcs8.slice(PKCS8_PREFIX_LEN);
   if (seed.byteLength !== ED25519_SEED_LEN) return null;
   return {

--- a/packages/shared/tests/ed25519-native-seed-compat.test.ts
+++ b/packages/shared/tests/ed25519-native-seed-compat.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #591 P2 de-risk: prove the native (iOS CryptoKit) signing path is byte-compatible
+ * with the daemon's web-crypto Ed25519 verifier — OFF-DEVICE, so we don't burn a
+ * costly on-device cycle discovering a crypto mismatch.
+ *
+ * The native handler will hold only the raw 32-byte Ed25519 seed (CryptoKit's
+ * `Curve25519.Signing.PrivateKey(rawRepresentation:)`), bridged from the JS
+ * identity's PKCS8 private key. This test extracts that seed exactly as the JS
+ * bridge will (`pkcs8.slice(16)`), reconstructs a signer from ONLY the seed
+ * (equivalent to what CryptoKit does), signs the canonical answer message, and
+ * verifies it with the SAME `verify()` the daemon's authenticator uses. If this
+ * passes, a CryptoKit signature from the same seed will verify on the daemon.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  createIdentity,
+  fromBase64,
+  importPublicKey,
+  sign,
+  toBase64,
+  unlockIdentity,
+  verify,
+} from '@remi/shared';
+
+// PKCS8 prefix for an Ed25519 private key (RFC 8410): 16 bytes, then the 32-byte
+// seed. CryptoKit's rawRepresentation is exactly those trailing 32 bytes.
+const ED25519_PKCS8_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+function seedToPkcs8(seed: Uint8Array): ArrayBuffer {
+  const out = new Uint8Array(ED25519_PKCS8_PREFIX.length + seed.length);
+  out.set(ED25519_PKCS8_PREFIX, 0);
+  out.set(seed, ED25519_PKCS8_PREFIX.length);
+  return out.buffer;
+}
+
+describe('#591 P2 — native seed Ed25519 compatibility', () => {
+  test('a signature from the bridged 32-byte seed verifies with the daemon verifier', async () => {
+    const idFile = await createIdentity(); // unencrypted -> signable without a passphrase
+    const unlocked = await unlockIdentity(idFile);
+
+    // Export the PKCS8 the JS bridge has, and slice the 32-byte seed it ships to
+    // native (the only thing CryptoKit needs).
+    const pkcs8 = await crypto.subtle.exportKey('pkcs8', unlocked.privateKey);
+    const seed = new Uint8Array(pkcs8).slice(ED25519_PKCS8_PREFIX.length);
+    expect(seed.length).toBe(32);
+
+    // Reconstruct a signer from ONLY the seed (what CryptoKit does natively).
+    const seedKey = await crypto.subtle.importKey('pkcs8', seedToPkcs8(seed), 'Ed25519', false, [
+      'sign',
+    ]);
+
+    const message = 'aaaaaaaa-0000-0000-0000-000000000000|bbbbbbbb-0000-0000-0000-000000000000|yes';
+    const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+    const sigFromSeed = await sign(seedKey, data);
+
+    // Verify with the public key, exactly as the daemon authenticator does
+    // (verify signature is (publicKey, data, signatureBase64)).
+    const pub = await importPublicKey(fromBase64(unlocked.publicKeyRaw));
+    expect(await verify(pub, data, sigFromSeed)).toBe(true);
+
+    // Ed25519 is deterministic, so the seed-only signer must produce the SAME
+    // signature as the original full key — extra proof the seed is the whole key.
+    const sigFromFull = await sign(unlocked.privateKey, data);
+    expect(sigFromSeed).toBe(sigFromFull);
+
+    // And the public key the native bridge ships (raw, base64) matches.
+    expect(toBase64(await crypto.subtle.exportKey('raw', unlocked.publicKey))).toBe(
+      unlocked.publicKeyRaw,
+    );
+  });
+});

--- a/packages/shared/tests/native-bridge.test.ts
+++ b/packages/shared/tests/native-bridge.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #591 P2: prove the PRODUCTION `deriveNativeIdentity` transform produces a seed
+ * that signs answers the daemon will accept — OFF-DEVICE, NO MOCKS, against the
+ * same `verify()` the daemon's authenticator uses.
+ *
+ * `ed25519-native-seed-compat.test.ts` proves the raw seed-extraction technique
+ * in isolation; this test pins the actual function the web bridge ships through
+ * Capacitor Preferences, so a regression in `deriveNativeIdentity` (wrong slice,
+ * wrong public key, encrypted-identity leak) fails here rather than on a device.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  createIdentity,
+  deriveNativeIdentity,
+  fromBase64,
+  importPublicKey,
+  sign,
+  toBase64,
+  verify,
+} from '@remi/shared';
+
+// PKCS8 (RFC 8410) Ed25519 prefix: 16 bytes, then the 32-byte seed. CryptoKit's
+// rawRepresentation IS those trailing 32 bytes; we rebuild a signer from them.
+const ED25519_PKCS8_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+function seedToPkcs8(seedB64: string): ArrayBuffer {
+  const seed = new Uint8Array(fromBase64(seedB64));
+  const out = new Uint8Array(ED25519_PKCS8_PREFIX.length + seed.length);
+  out.set(ED25519_PKCS8_PREFIX, 0);
+  out.set(seed, ED25519_PKCS8_PREFIX.length);
+  return out.buffer;
+}
+
+describe('#591 P2 — deriveNativeIdentity', () => {
+  test('the derived seed signs an answer the daemon verifier accepts', async () => {
+    const identity = await createIdentity(); // unencrypted -> bridgeable
+    const record = deriveNativeIdentity(identity);
+    expect(record).not.toBeNull();
+    if (!record) return;
+
+    // The native handler holds exactly these three base64 fields.
+    expect(new Uint8Array(fromBase64(record.seed)).length).toBe(32);
+    expect(record.publicKey).toBe(identity.publicKey);
+    expect(record.fingerprint).toBe(identity.fingerprint);
+
+    // Reconstruct CryptoKit's seed-only signer and sign the canonical message.
+    const seedKey = await crypto.subtle.importKey(
+      'pkcs8',
+      seedToPkcs8(record.seed),
+      'Ed25519',
+      false,
+      ['sign'],
+    );
+    const message = 'aaaaaaaa-0000-0000-0000-000000000000|bbbbbbbb-0000-0000-0000-000000000000|yes';
+    const data = new TextEncoder().encode(message).buffer as ArrayBuffer;
+    const signature = await sign(seedKey, data);
+
+    // Verify with the bridged public key, exactly as the daemon authenticator does.
+    const pub = await importPublicKey(fromBase64(record.publicKey));
+    expect(await verify(pub, data, signature)).toBe(true);
+  });
+
+  test('an encrypted identity is NOT bridgeable (returns null, no leak)', async () => {
+    const encrypted = await createIdentity('a-real-passphrase');
+    expect(deriveNativeIdentity(encrypted)).toBeNull();
+  });
+
+  test('the public key round-trips to the same raw bytes the daemon expects', async () => {
+    const identity = await createIdentity();
+    const record = deriveNativeIdentity(identity);
+    if (!record) throw new Error('expected a bridgeable identity');
+    // Re-exporting the imported public key yields the identical base64 the
+    // record carries — confirms publicKey is raw (not SPKI) as the daemon needs.
+    const pub = await importPublicKey(fromBase64(record.publicKey));
+    expect(toBase64(await crypto.subtle.exportKey('raw', pub))).toBe(record.publicKey);
+  });
+});

--- a/packages/shared/tests/native-bridge.test.ts
+++ b/packages/shared/tests/native-bridge.test.ts
@@ -68,6 +68,13 @@ describe('#591 P2 — deriveNativeIdentity', () => {
     expect(deriveNativeIdentity(encrypted)).toBeNull();
   });
 
+  test('a malformed (non-base64) unencrypted key returns null, never throws', async () => {
+    const identity = await createIdentity();
+    // iterations === 0 keeps it "unencrypted", but the PKCS8 blob is garbage.
+    const malformed = { ...identity, encryptedPrivateKey: '%%% not base64 %%%' };
+    expect(deriveNativeIdentity(malformed)).toBeNull();
+  });
+
   test('the public key round-trips to the same raw bytes the daemon expects', async () => {
     const identity = await createIdentity();
     const record = deriveNativeIdentity(identity);

--- a/packages/web/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/web/ios/App/App.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
+		416D7EE8D263A59980B72F80 /* RemiAnswerRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7624428F4554B48AC7C71AC4 /* RemiAnswerRelay.swift */; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
@@ -23,6 +24,7 @@
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		7624428F4554B48AC7C71AC4 /* RemiAnswerRelay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemiAnswerRelay.swift; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -64,6 +66,7 @@
 				504EC3131FED79650016851F /* Info.plist */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
+				7624428F4554B48AC7C71AC4 /* RemiAnswerRelay.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -147,13 +150,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				416D7EE8D263A59980B72F80 /* RemiAnswerRelay.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXVariantGroup section */
-/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		504EC3141FED79650016851F /* Debug */ = {

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -156,4 +156,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             backgroundTask = .invalid
         }
     }
+
+    // #591 P2: wrap Capacitor's push notification handler so a lock-screen answer
+    // relays natively (silent, no app open). Deferred to here so it runs AFTER the
+    // push plugin's load() installed the original handler; install() is idempotent.
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        if let bridgeVC = window?.rootViewController as? CAPBridgeViewController {
+            RemiAnswerRelay.shared.install(bridge: bridgeVC.bridge)
+        }
+    }
 }

--- a/packages/web/ios/App/App/RemiAnswerRelay.swift
+++ b/packages/web/ios/App/App/RemiAnswerRelay.swift
@@ -7,10 +7,10 @@ import Capacitor
 /// #591 P2 — native silent lock-screen answer relay (Duo-style).
 ///
 /// Wraps Capacitor's push `NotificationHandlerProtocol` (the handler the router
-/// invokes on a notification action) so a lock-screen Yes/No/Always tap is
-/// relayed to the daemon via the signaling Worker `/answer/{code}` WITHOUT opening
-/// the app. The captured Capacitor handler is still invoked, so the JS path keeps
-/// working when the app is alive (foreground).
+/// invokes on a notification action) so a lock-screen Yes/No/Always tap is signed
+/// and POSTed to the daemon's direct `/answer` endpoint WITHOUT opening the app.
+/// The captured Capacitor handler is still invoked, so the JS path keeps working
+/// when the app is alive (foreground).
 ///
 /// Gotchas handled (from Capacitor/NotificationRouter.swift):
 ///  - `pushNotificationHandler` is WEAK -> `shared` retains this instance.
@@ -125,14 +125,16 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         }
 
         // didReceive is synchronous + the router completes immediately, so extend
-        // execution ourselves for the async POST (~30s budget).
+        // execution ourselves for the async POST (~30s budget). The expiry handler
+        // and the URLSession completion can fire on different queues, so serialize
+        // the end-task with a lock to avoid a double endBackgroundTask race.
+        let lock = NSLock()
         var bgTask: UIBackgroundTaskIdentifier = .invalid
-        bgTask = UIApplication.shared.beginBackgroundTask(withName: "RemiAnswerRelay") {
-            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
-        }
         let endTask = {
+            lock.lock(); defer { lock.unlock() }
             if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
         }
+        bgTask = UIApplication.shared.beginBackgroundTask(withName: "RemiAnswerRelay") { endTask() }
 
         var body: [String: Any] = [
             "sessionId": sessionId,
@@ -196,9 +198,17 @@ enum RemiNativeStore {
     }
 
     /// Look up the daemon ws URL pinned for a session (written by the web app).
+    /// Distinguishes "never set up" (silent nil) from a corrupt blob (logged) so
+    /// the two failure modes aren't indistinguishable in the device log.
     static func route(forSession sessionId: String) -> Route? {
-        guard let map = jsonObject(routesKey) as? [String: [String: String]],
-              let r = map[sessionId], let wsUrl = r["wsUrl"] else { return nil }
+        guard let raw = UserDefaults.standard.string(forKey: routesKey) else { return nil }
+        guard let data = raw.data(using: .utf8),
+              let map = (try? JSONSerialization.jsonObject(with: data)) as? [String: [String: String]]
+        else {
+            NSLog("[remi] RemiNativeStore: routes blob is corrupt or unreadable")
+            return nil
+        }
+        guard let r = map[sessionId], let wsUrl = r["wsUrl"] else { return nil }
         return Route(wsUrl: wsUrl, claudeSessionId: r["claudeSessionId"])
     }
 }

--- a/packages/web/ios/App/App/RemiAnswerRelay.swift
+++ b/packages/web/ios/App/App/RemiAnswerRelay.swift
@@ -19,9 +19,12 @@ import Capacitor
 ///  - install runs AFTER the push plugin's load() (called from a deferred hook).
 ///
 /// Inputs are bridged from JS via Capacitor Preferences (UserDefaults
-/// `CapacitorStorage.*`): the Ed25519 seed/pubkey/fingerprint and the per-session
-/// route {code, signalingUrl}. Crypto compat is proven in
-/// packages/shared/tests/ed25519-native-seed-compat.test.ts.
+/// `CapacitorStorage.*`): the Ed25519 seed/pubkey/fingerprint and a per-session
+/// route {wsUrl} — the daemon URL the session is connected on, which the web app
+/// pins on hello_ack (the same URL its cold-start push-answer routing uses). The
+/// answer POSTs to that daemon's direct `/answer` endpoint (the same one
+/// `relayAnswerDirect` uses in-app), signed with the bridged seed. Crypto compat
+/// is proven in packages/shared/tests/native-bridge.test.ts.
 final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
     static let shared = RemiAnswerRelay()
 
@@ -80,17 +83,17 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
             return
         }
 
-        // Route to the daemon's room: primary from the push payload (the daemon
-        // stamps its relay `code` + `signalingUrl`), with a JS-bridged per-session
-        // route as a fallback.
-        let fallback = RemiNativeStore.route(forSession: sessionId)
-        let code = (userInfo["code"] as? String) ?? fallback?.code
-        let signalingUrl = (userInfo["signalingUrl"] as? String) ?? fallback?.signalingUrl
-        guard let code = code, !code.isEmpty, let signalingUrl = signalingUrl, !signalingUrl.isEmpty else {
-            NSLog("[remi] relay: no room code/signalingUrl in push or stored route; cannot relay")
+        // Route to the daemon: the web app pins the per-session daemon ws URL
+        // (CapacitorStorage.remi-native-routes) on hello_ack. POST the answer to
+        // that daemon's direct `/answer` endpoint, signed — the same path
+        // `relayAnswerDirect` uses in-app. Reachable from the lock screen when the
+        // daemon URL is a Tailscale/public host; a LAN-only daemon is not, the
+        // same limit the in-app reconnect has.
+        guard let route = RemiNativeStore.route(forSession: sessionId), !route.wsUrl.isEmpty else {
+            NSLog("[remi] relay: no stored daemon URL for session \(sessionId); cannot relay")
             return
         }
-        let claudeSessionId = (userInfo["claudeSessionId"] as? String) ?? fallback?.claudeSessionId
+        let claudeSessionId = (userInfo["claudeSessionId"] as? String) ?? route.claudeSessionId
 
         let message = "\(sessionId)|\(questionId)|\(answerValue)"
         guard let auth = RemiNativeStore.sign(message: message) else {
@@ -98,18 +101,26 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
             return
         }
 
-        post(signalingUrl: signalingUrl, code: code, sessionId: sessionId, questionId: questionId,
+        post(wsUrl: route.wsUrl, sessionId: sessionId, questionId: questionId,
              answer: answerValue, claudeSessionId: claudeSessionId, auth: auth)
     }
 
-    private func post(signalingUrl: String, code: String, sessionId: String, questionId: String,
+    private func post(wsUrl: String, sessionId: String, questionId: String,
                       answer: String, claudeSessionId: String?, auth: RemiNativeStore.Auth) {
-        // Normalize a ws(s):// base to http(s):// for the POST.
-        let base = signalingUrl
+        // Normalize the daemon ws(s):// URL to http(s):// and target the root
+        // `/answer` endpoint (mirrors push-answer-relay.ts `answerUrl`).
+        let base = wsUrl
             .replacingOccurrences(of: "wss://", with: "https://")
             .replacingOccurrences(of: "ws://", with: "http://")
-        guard let url = URL(string: "\(base)/answer/\(code)") else {
-            NSLog("[remi] relay: bad URL \(base)/answer/\(code)")
+        guard var comps = URLComponents(string: base) else {
+            NSLog("[remi] relay: bad daemon URL \(base)")
+            return
+        }
+        comps.path = "/answer"
+        comps.query = nil
+        comps.fragment = nil
+        guard let url = comps.url else {
+            NSLog("[remi] relay: cannot build /answer URL from \(base)")
             return
         }
 
@@ -162,7 +173,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
 /// (UserDefaults `CapacitorStorage.<key>`) and signs with CryptoKit.
 enum RemiNativeStore {
     struct Auth { let signature: String; let publicKey: String; let fingerprint: String }
-    struct Route { let code: String; let signalingUrl: String; let claudeSessionId: String? }
+    struct Route { let wsUrl: String; let claudeSessionId: String? }
 
     private static let identityKey = "CapacitorStorage.remi-native-identity"
     private static let routesKey = "CapacitorStorage.remi-native-routes"
@@ -184,10 +195,10 @@ enum RemiNativeStore {
         return Auth(signature: sig.base64EncodedString(), publicKey: pub, fingerprint: fp)
     }
 
-    /// Look up the relay route (room code + signaling base URL) for a session.
+    /// Look up the daemon ws URL pinned for a session (written by the web app).
     static func route(forSession sessionId: String) -> Route? {
         guard let map = jsonObject(routesKey) as? [String: [String: String]],
-              let r = map[sessionId], let code = r["code"], let url = r["signalingUrl"] else { return nil }
-        return Route(code: code, signalingUrl: url, claudeSessionId: r["claudeSessionId"])
+              let r = map[sessionId], let wsUrl = r["wsUrl"] else { return nil }
+        return Route(wsUrl: wsUrl, claudeSessionId: r["claudeSessionId"])
     }
 }

--- a/packages/web/ios/App/App/RemiAnswerRelay.swift
+++ b/packages/web/ios/App/App/RemiAnswerRelay.swift
@@ -1,0 +1,193 @@
+import Foundation
+import UserNotifications
+import CryptoKit
+import UIKit
+import Capacitor
+
+/// #591 P2 — native silent lock-screen answer relay (Duo-style).
+///
+/// Wraps Capacitor's push `NotificationHandlerProtocol` (the handler the router
+/// invokes on a notification action) so a lock-screen Yes/No/Always tap is
+/// relayed to the daemon via the signaling Worker `/answer/{code}` WITHOUT opening
+/// the app. The captured Capacitor handler is still invoked, so the JS path keeps
+/// working when the app is alive (foreground).
+///
+/// Gotchas handled (from Capacitor/NotificationRouter.swift):
+///  - `pushNotificationHandler` is WEAK -> `shared` retains this instance.
+///  - `didReceive` is synchronous and the router calls its completionHandler right
+///    after, so the async POST runs under its own `beginBackgroundTask`.
+///  - install runs AFTER the push plugin's load() (called from a deferred hook).
+///
+/// Inputs are bridged from JS via Capacitor Preferences (UserDefaults
+/// `CapacitorStorage.*`): the Ed25519 seed/pubkey/fingerprint and the per-session
+/// route {code, signalingUrl}. Crypto compat is proven in
+/// packages/shared/tests/ed25519-native-seed-compat.test.ts.
+final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
+    static let shared = RemiAnswerRelay()
+
+    private weak var wrapped: NotificationHandlerProtocol?
+    private var installed = false
+
+    /// Idempotently wrap the bridge's push notification handler. Safe to call
+    /// repeatedly (e.g. on every applicationDidBecomeActive).
+    func install(bridge: CAPBridgeProtocol?) {
+        guard !installed, let router = bridge?.notificationRouter else { return }
+        let existing = router.pushNotificationHandler
+        // Don't wrap ourselves if somehow already installed.
+        if existing === self { installed = true; return }
+        wrapped = existing
+        router.pushNotificationHandler = self
+        installed = true
+        NSLog("[remi] RemiAnswerRelay installed (wrapped=\(existing.map { String(describing: type(of: $0)) } ?? "nil"))")
+    }
+
+    // MARK: NotificationHandlerProtocol
+
+    func willPresent(notification: UNNotification) -> UNNotificationPresentationOptions {
+        return wrapped?.willPresent(notification: notification) ?? []
+    }
+
+    func didReceive(response: UNNotificationResponse) {
+        relay(response: response)
+        // Keep Capacitor's JS path alive for the foreground/app-open case.
+        wrapped?.didReceive(response: response)
+    }
+
+    // MARK: Relay
+
+    private func relay(response: UNNotificationResponse) {
+        let userInfo = response.notification.request.content.userInfo
+        guard let sessionId = userInfo["sessionId"] as? String,
+              let questionId = userInfo["questionId"] as? String else {
+            NSLog("[remi] relay: push missing sessionId/questionId; ignoring")
+            return
+        }
+
+        // Resolve the answer value. Buttons map OPT_<n> -> the option's `value`,
+        // carried in the push data as `opt_<n>` (set by the signaling worker).
+        // A text/number action returns userText. Default/dismiss are ignored.
+        let answer: String?
+        if let text = response as? UNTextInputNotificationResponse {
+            answer = text.userText
+        } else if response.actionIdentifier.hasPrefix("OPT_") {
+            let idx = response.actionIdentifier.dropFirst("OPT_".count)
+            answer = userInfo["opt_\(idx)"] as? String
+        } else {
+            answer = nil  // tap / dismiss -> let Capacitor's JS handler open the app
+        }
+        guard let answerValue = answer, !answerValue.isEmpty else {
+            NSLog("[remi] relay: no actionable answer (action=\(response.actionIdentifier)); deferring to app")
+            return
+        }
+
+        // Route to the daemon's room: primary from the push payload (the daemon
+        // stamps its relay `code` + `signalingUrl`), with a JS-bridged per-session
+        // route as a fallback.
+        let fallback = RemiNativeStore.route(forSession: sessionId)
+        let code = (userInfo["code"] as? String) ?? fallback?.code
+        let signalingUrl = (userInfo["signalingUrl"] as? String) ?? fallback?.signalingUrl
+        guard let code = code, !code.isEmpty, let signalingUrl = signalingUrl, !signalingUrl.isEmpty else {
+            NSLog("[remi] relay: no room code/signalingUrl in push or stored route; cannot relay")
+            return
+        }
+        let claudeSessionId = (userInfo["claudeSessionId"] as? String) ?? fallback?.claudeSessionId
+
+        let message = "\(sessionId)|\(questionId)|\(answerValue)"
+        guard let auth = RemiNativeStore.sign(message: message) else {
+            NSLog("[remi] relay: no signing identity stored; cannot relay")
+            return
+        }
+
+        post(signalingUrl: signalingUrl, code: code, sessionId: sessionId, questionId: questionId,
+             answer: answerValue, claudeSessionId: claudeSessionId, auth: auth)
+    }
+
+    private func post(signalingUrl: String, code: String, sessionId: String, questionId: String,
+                      answer: String, claudeSessionId: String?, auth: RemiNativeStore.Auth) {
+        // Normalize a ws(s):// base to http(s):// for the POST.
+        let base = signalingUrl
+            .replacingOccurrences(of: "wss://", with: "https://")
+            .replacingOccurrences(of: "ws://", with: "http://")
+        guard let url = URL(string: "\(base)/answer/\(code)") else {
+            NSLog("[remi] relay: bad URL \(base)/answer/\(code)")
+            return
+        }
+
+        // didReceive is synchronous + the router completes immediately, so extend
+        // execution ourselves for the async POST (~30s budget).
+        var bgTask: UIBackgroundTaskIdentifier = .invalid
+        bgTask = UIApplication.shared.beginBackgroundTask(withName: "RemiAnswerRelay") {
+            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
+        }
+        let endTask = {
+            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
+        }
+
+        var body: [String: Any] = [
+            "sessionId": sessionId,
+            "questionId": questionId,
+            "answer": answer,
+            "auth": [
+                "signature": auth.signature,
+                "clientPublicKey": auth.publicKey,
+                "clientFingerprint": auth.fingerprint,
+            ],
+        ]
+        if let cid = claudeSessionId { body["claudeSessionId"] = cid }
+
+        guard let payload = try? JSONSerialization.data(withJSONObject: body) else {
+            NSLog("[remi] relay: failed to encode body"); endTask(); return
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = payload
+        req.timeoutInterval = 20
+
+        NSLog("[remi] relay: POST \(url.absoluteString) answer=\(answer)")
+        URLSession.shared.dataTask(with: req) { data, resp, err in
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            let result = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            if let err = err {
+                NSLog("[remi] relay: POST failed: \(err.localizedDescription)")
+            } else {
+                NSLog("[remi] relay: POST status=\(status) result=\(result)")
+            }
+            endTask()
+        }.resume()
+    }
+}
+
+/// Reads the JS-bridged identity + routes from Capacitor Preferences
+/// (UserDefaults `CapacitorStorage.<key>`) and signs with CryptoKit.
+enum RemiNativeStore {
+    struct Auth { let signature: String; let publicKey: String; let fingerprint: String }
+    struct Route { let code: String; let signalingUrl: String; let claudeSessionId: String? }
+
+    private static let identityKey = "CapacitorStorage.remi-native-identity"
+    private static let routesKey = "CapacitorStorage.remi-native-routes"
+
+    private static func jsonObject(_ key: String) -> Any? {
+        guard let s = UserDefaults.standard.string(forKey: key),
+              let data = s.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+
+    /// Sign `message` with the bridged Ed25519 seed. Returns the base64 signature
+    /// + the public key (raw, base64) + fingerprint for the daemon's auth block.
+    static func sign(message: String) -> Auth? {
+        guard let obj = jsonObject(identityKey) as? [String: String],
+              let seedB64 = obj["seed"], let pub = obj["publicKey"], let fp = obj["fingerprint"],
+              let seed = Data(base64Encoded: seedB64) else { return nil }
+        guard let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: seed),
+              let sig = try? key.signature(for: Data(message.utf8)) else { return nil }
+        return Auth(signature: sig.base64EncodedString(), publicKey: pub, fingerprint: fp)
+    }
+
+    /// Look up the relay route (room code + signaling base URL) for a session.
+    static func route(forSession sessionId: String) -> Route? {
+        guard let map = jsonObject(routesKey) as? [String: [String: String]],
+              let r = map[sessionId], let code = r["code"], let url = r["signalingUrl"] else { return nil }
+        return Route(code: code, signalingUrl: url, claudeSessionId: r["claudeSessionId"])
+    }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,6 +27,7 @@
     "@capacitor/keyboard": "^8.0.1",
     "@capacitor/local-notifications": "^8.0.2",
     "@capacitor/network": "^8.0.1",
+    "@capacitor/preferences": "^8.0.1",
     "@capacitor/push-notifications": "^8.0.3",
     "@capacitor/status-bar": "^8.0.1",
     "@fontsource-variable/inter-tight": "^5.2.7",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,7 +13,7 @@ import { probeAuthInfo } from '@/lib/auth-probe';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
-import { setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
+import { clearNativeRoute, setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
 import { setSoundEnabled } from '@/lib/notifications';
 import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
@@ -91,6 +91,10 @@ function rememberSessionDaemon(sessionId: string, url: string): void {
  */
 function forgetEvictedSessions(evictedIds: readonly string[]): void {
   if (evictedIds.length === 0) return;
+  // Mirror eviction into native storage (#591 P2) so a stale daemon URL can't
+  // misdirect a lock-screen answer for a session that no longer exists.
+  // Fire-and-forget; no-op off-native, never throws.
+  for (const id of evictedIds) void clearNativeRoute(id);
   const evicted = new Set(evictedIds);
   try {
     const stored = localStorage.getItem(LOCALSTORAGE_SESSION_DAEMONS_KEY);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,6 +13,7 @@ import { probeAuthInfo } from '@/lib/auth-probe';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
+import { setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
 import { setSoundEnabled } from '@/lib/notifications';
 import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
@@ -348,7 +349,17 @@ function App() {
         // right daemon when multiple are paired. Look up the connection's URL
         // synchronously from the latest snapshot.
         const conn = connectionsRef.current.find((c) => c.connectionId === connectionId);
-        if (conn?.url) rememberSessionDaemon(message.sessionId, conn.url);
+        if (conn?.url) {
+          rememberSessionDaemon(message.sessionId, conn.url);
+          // Mirror the daemon URL + signer to native storage (#591 P2) so a
+          // lock-screen answer can sign + POST to the daemon's /answer endpoint
+          // without opening the app. No-ops off-native; never throws.
+          void setNativeRoute(message.sessionId, {
+            wsUrl: conn.url,
+            ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
+          });
+          void syncNativeIdentity();
+        }
 
         // Reconnect-mid-rotation only: if the chat the user is CURRENTLY
         // viewing belongs to this connection and the daemon came back with a
@@ -1154,6 +1165,14 @@ function App() {
   useEffect(() => {
     resumingSessionRef.current = resumingSession;
   }, [resumingSession]);
+
+  // Bridge the current signer to native storage once on launch (#591 P2) so the
+  // lock-screen answer handler can sign even before a fresh connection — covers
+  // a cold start from a push and identity changes made in Settings. No-op
+  // off-native; re-pinned per-connection at hello_ack.
+  useEffect(() => {
+    void syncNativeIdentity();
+  }, []);
 
   useEffect(() => {
     messagesRef.current = messages;

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   isIdentityEncrypted,
   removeIdentity,
 } from '@/lib/identity-client';
+import { syncNativeIdentity } from '@/lib/native-bridge';
 import { checkNotificationPermission, openNotificationSettings } from '@/lib/notifications';
 import { isNative } from '@/lib/platform';
 import type { AppSettings } from '@/types';
@@ -129,6 +130,9 @@ function IdentitySection() {
     try {
       await generateIdentity(usePassphrase ? passphrase : undefined);
       refresh();
+      // Re-bridge the new signer to native storage (#591 P2) so a lock-screen
+      // answer signs with the current key, not the rotated-out one.
+      void syncNativeIdentity();
       setShowGenerate(false);
       setPassphrase('');
       setConfirmPassphrase('');
@@ -146,6 +150,7 @@ function IdentitySection() {
     try {
       importIdentity(importJson);
       refresh();
+      void syncNativeIdentity();
       setShowImport(false);
       setImportJson('');
       setFeedback('Identity imported successfully.');
@@ -184,6 +189,8 @@ function IdentitySection() {
     }
     removeIdentity();
     refresh();
+    // Clears the native seed too (deriveNativeIdentity -> null -> Preferences.remove).
+    void syncNativeIdentity();
     setConfirmRemove(false);
     setFeedback('Identity removed.');
   };

--- a/packages/web/src/lib/native-bridge.ts
+++ b/packages/web/src/lib/native-bridge.ts
@@ -1,0 +1,105 @@
+/**
+ * JS → native bridge for the lock-screen answer relay (#591 P2).
+ *
+ * The iOS native handler (`RemiAnswerRelay.swift`) answers a held permission from
+ * the lock screen WITHOUT opening the app: it signs the answer with the Ed25519
+ * seed and POSTs it to the signaling Worker's `/answer/{code}` reverse relay. The
+ * native code runs in a background launch and cannot read the WebView's
+ * localStorage, so this module mirrors the minimum it needs into UserDefaults via
+ * `@capacitor/preferences` (which stores under `CapacitorStorage.<key>` — exactly
+ * the keys `RemiNativeStore` reads natively):
+ *
+ *   - `remi-native-identity` : { seed, publicKey, fingerprint }  (the signer)
+ *   - `remi-native-routes`   : { [sessionId]: { wsUrl, claudeSessionId? } }
+ *
+ * `wsUrl` is the daemon URL the session is connected on (the web app pins it on
+ * hello_ack, the same value its cold-start push-answer routing uses). The native
+ * handler POSTs the signed answer to that daemon's direct `/answer` endpoint.
+ *
+ * All writes are no-ops off-native (web/browser). The pure seed derivation +
+ * crypto compatibility are proven in `@remi/shared` `tests/native-bridge.test.ts`
+ * and `tests/ed25519-native-seed-compat.test.ts`.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import { deriveNativeIdentity } from '@remi/shared';
+import { loadIdentity } from './identity-client';
+import { isNative } from './platform';
+
+const IDENTITY_KEY = 'remi-native-identity';
+const ROUTES_KEY = 'remi-native-routes';
+
+/** Per-session routing the native handler uses to reach the daemon. */
+export interface NativeRoute {
+  /** The daemon ws(s):// URL this session is connected on. */
+  readonly wsUrl: string;
+  readonly claudeSessionId?: string;
+}
+
+/**
+ * Mirror the stored identity's signer to native storage so the lock-screen
+ * handler can sign. Writes only an UNENCRYPTED identity's seed; if the identity
+ * is encrypted or missing, any previously-bridged seed is CLEARED (so a stale
+ * key can never sign after the user switches to an encrypted identity). No-op
+ * off-native. Never throws — a bridge failure only means the lock-screen relay is
+ * unavailable, which the handler already degrades to "open the app".
+ */
+export async function syncNativeIdentity(): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const identity = loadIdentity();
+    const record = identity ? deriveNativeIdentity(identity) : null;
+    if (!record) {
+      await Preferences.remove({ key: IDENTITY_KEY });
+      return;
+    }
+    await Preferences.set({ key: IDENTITY_KEY, value: JSON.stringify(record) });
+  } catch (err) {
+    console.warn('[remi] syncNativeIdentity failed (lock-screen relay unavailable):', err);
+  }
+}
+
+/**
+ * Record (or update) the relay route for a session so a lock-screen answer can
+ * reach the daemon's signaling room. Call when a signaling-backed connection is
+ * established for `sessionId`. No-op off-native; never throws.
+ */
+export async function setNativeRoute(sessionId: string, route: NativeRoute): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const routes = await readRoutes();
+    routes[sessionId] = {
+      wsUrl: route.wsUrl,
+      ...(route.claudeSessionId ? { claudeSessionId: route.claudeSessionId } : {}),
+    };
+    await Preferences.set({ key: ROUTES_KEY, value: JSON.stringify(routes) });
+  } catch (err) {
+    console.warn('[remi] setNativeRoute failed:', err);
+  }
+}
+
+/** Drop a session's relay route (e.g. on disconnect). No-op off-native; never throws. */
+export async function clearNativeRoute(sessionId: string): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const routes = await readRoutes();
+    if (!(sessionId in routes)) return;
+    delete routes[sessionId];
+    await Preferences.set({ key: ROUTES_KEY, value: JSON.stringify(routes) });
+  } catch (err) {
+    console.warn('[remi] clearNativeRoute failed:', err);
+  }
+}
+
+/** Read + parse the routes map, tolerating a missing or corrupt value. */
+async function readRoutes(): Promise<Record<string, NativeRoute>> {
+  const { value } = await Preferences.get({ key: ROUTES_KEY });
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, NativeRoute>) : {};
+  } catch {
+    // Corrupt blob: start fresh rather than wedging every future write.
+    return {};
+  }
+}

--- a/packages/web/src/lib/native-bridge.ts
+++ b/packages/web/src/lib/native-bridge.ts
@@ -3,9 +3,10 @@
  *
  * The iOS native handler (`RemiAnswerRelay.swift`) answers a held permission from
  * the lock screen WITHOUT opening the app: it signs the answer with the Ed25519
- * seed and POSTs it to the signaling Worker's `/answer/{code}` reverse relay. The
- * native code runs in a background launch and cannot read the WebView's
- * localStorage, so this module mirrors the minimum it needs into UserDefaults via
+ * seed and POSTs it to the daemon's direct `/answer` endpoint (the same path
+ * `relayAnswerDirect` uses in-app). The native code runs in a background launch
+ * and cannot read the WebView's localStorage, so this module mirrors the minimum
+ * it needs into UserDefaults via
  * `@capacitor/preferences` (which stores under `CapacitorStorage.<key>` — exactly
  * the keys `RemiNativeStore` reads natively):
  *
@@ -28,6 +29,9 @@ import { isNative } from './platform';
 
 const IDENTITY_KEY = 'remi-native-identity';
 const ROUTES_KEY = 'remi-native-routes';
+/** Backstop cap on stored routes so a long-lived install can't grow unbounded
+ *  if a teardown clear is ever missed. Routes are also dropped on eviction. */
+const MAX_ROUTES = 32;
 
 /** Per-session routing the native handler uses to reach the daemon. */
 export interface NativeRoute {
@@ -60,9 +64,9 @@ export async function syncNativeIdentity(): Promise<void> {
 }
 
 /**
- * Record (or update) the relay route for a session so a lock-screen answer can
- * reach the daemon's signaling room. Call when a signaling-backed connection is
- * established for `sessionId`. No-op off-native; never throws.
+ * Record (or update) the daemon URL for a session so a lock-screen answer can
+ * reach the daemon's `/answer` endpoint directly. Call at `hello_ack` for any
+ * connection (direct or relay). No-op off-native; never throws.
  */
 export async function setNativeRoute(sessionId: string, route: NativeRoute): Promise<void> {
   if (!isNative()) return;
@@ -72,6 +76,14 @@ export async function setNativeRoute(sessionId: string, route: NativeRoute): Pro
       wsUrl: route.wsUrl,
       ...(route.claudeSessionId ? { claudeSessionId: route.claudeSessionId } : {}),
     };
+    // Backstop eviction (oldest first, never the entry we just wrote) so a
+    // missed teardown can't grow the map without bound.
+    const keys = Object.keys(routes);
+    if (keys.length > MAX_ROUTES) {
+      for (const k of keys.slice(0, keys.length - MAX_ROUTES)) {
+        if (k !== sessionId) delete routes[k];
+      }
+    }
     await Preferences.set({ key: ROUTES_KEY, value: JSON.stringify(routes) });
   } catch (err) {
     console.warn('[remi] setNativeRoute failed:', err);
@@ -99,7 +111,9 @@ async function readRoutes(): Promise<Record<string, NativeRoute>> {
     const parsed = JSON.parse(value) as unknown;
     return parsed && typeof parsed === 'object' ? (parsed as Record<string, NativeRoute>) : {};
   } catch {
-    // Corrupt blob: start fresh rather than wedging every future write.
+    // Corrupt blob: start fresh rather than wedging every future write. Log it,
+    // else "lock-screen answer stopped working after a crash" debugs blind.
+    console.warn('[remi] native routes blob is corrupt; resetting');
     return {};
   }
 }


### PR DESCRIPTION
## Release 0.6.14

Merging `develop` to `main` to cut the 0.6.14 release. Auto-release strips the `-dev` suffix, tags `v0.6.14`, and publishes npm + Homebrew + GitHub; sync-develop then bumps the next dev line.

### Shipping
- **#597** — AskUserQuestion / ExitPlanMode escalations now show the real question text + option labels (card + lock screen) instead of "Allow <tool>" + Yes/Yes-always/No. Daemon-side. Follow-up #598 (reverify ExitPlanMode order).
- **#591 P2** — native iOS lock-screen answer relay (the client side of the 0.6.13 #591 P1 backend). Ships to phones via a separate TestFlight/production build.

### Test plan
- Per-PR CI green (#599, #600, #601); hooks suite 128/128; shared crypto/native-bridge tests pass.
- On-device: lock-screen answer relay validated; question/options fix to be verified post-release via `brew upgrade remi`.