### PR TITLE
Phase 1: gate held hooks on confirmed notification delivery (#604)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -342,8 +342,18 @@ export class AutoApproveGate {
    */
   private armDeliveryGate(qid: UUID): void {
     const confirmMs = this.deps.deliveryConfirmMs ?? 0;
+    if (confirmMs <= 0) return; // delivery gating disabled (legacy hold to holdMs)
     const probe = this.deps.awaitDelivery?.(qid);
-    if (confirmMs <= 0 || !probe) return;
+    if (!probe) {
+      // Gating is ON but no delivery signal was recorded for this question —
+      // either awaitDelivery is unwired, or onHeldEscalate threw before maybePush
+      // ran (its throw is swallowed as a cosmetic cue). Fall back to the legacy
+      // hold, but log it: a silently-skipped gate could still stall to holdMs.
+      log(
+        `[AutoApprove ${this.sessionTag}] No delivery signal for ${qid.slice(0, 8)}; delivery gate skipped (holding to hold_timeout)`,
+      );
+      return;
+    }
     const timeout = new Promise<'timeout'>((resolve) => {
       const t = setTimeout(() => resolve('timeout'), confirmMs);
       t.unref?.();

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -30,6 +30,7 @@ import type { UUID } from '@remi/shared';
 import type { QuestionPresenceTracker } from '../api/question-presence-tracker.ts';
 import { log, logError } from '../cli/logger.ts';
 import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
+import { type DeliveryOutcome, isDelivered } from '../notifications/notification-dispatcher.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
@@ -126,6 +127,23 @@ export interface AutoApproveGateDeps {
    *  late verdict then resolves the held hook. <=0 (or absent) disables Part B
    *  entirely — the eval/timer race never arms, so behavior reverts to A+C. */
   pushHoldMs?: number;
+  /**
+   * Probe a held escalation's notification delivery outcome (epic #603 Phase 1,
+   * R1/R2). Returns the promise `NotificationDispatcher.maybePush` recorded for
+   * `questionId`, or undefined when no push was attempted. The gate races it
+   * against `deliveryConfirmMs`: a hold whose notification is never confirmed
+   * delivered no longer blocks Claude for the full `holdMs` — it fails open fast
+   * (or holds a short secondary window, `holdUnconfirmedMs`). Absent => delivery
+   * gating disabled (legacy: hold to holdMs regardless of delivery). */
+  awaitDelivery?: (questionId: UUID) => Promise<DeliveryOutcome> | undefined;
+  /** Milliseconds to wait for a held escalation's delivery to be confirmed
+   *  before treating it as undeliverable (epic #603 Phase 1). <=0 (or absent)
+   *  disables delivery gating. From `auto_approve.delivery_confirm_timeout`. */
+  deliveryConfirmMs?: number;
+  /** Milliseconds to keep holding an UNDELIVERED escalation instead of failing
+   *  open immediately (epic #603 Phase 1, D2 — hold-always-no-phone). <=0 (or
+   *  absent) => fail open fast. From `auto_approve.hold_unconfirmed_timeout`. */
+  holdUnconfirmedMs?: number;
 }
 
 /** A held PermissionRequest hook awaiting a user answer (#573). The `resolve`
@@ -282,25 +300,104 @@ export class AutoApproveGate {
     this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
     const decision = new Promise<PermissionDecision>((resolve) => {
       const timer = setTimeout(() => {
-        // Fail open: the user did not answer within the hold window, so let
-        // Claude render its native prompt (the local terminal can take over).
-        this.pendingHolds.delete(qid);
-        log(
-          `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
-        );
-        // The pushed card is now stale (Claude will render its own prompt); tell
-        // every client to dismiss it BEFORE failing open (#585, P7), and drop the
-        // registry entry so no ghost card replays. Throw-safe.
-        this.notifyResolved(qid, 'cancelled');
-        this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
-        resolve('passthrough');
+        this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} timed out -> passthrough`);
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;
       // unref so a held hook never blocks daemon shutdown.
       timer.unref?.();
       this.pendingHolds.set(qid, { resolve, timer });
     });
+    // Phase 1 (#603, R1/R2): gate the hold on CONFIRMED delivery. A held hook is
+    // only worth blocking Claude for if the user can actually be notified; if
+    // the notification is not confirmed delivered within delivery_confirm_timeout
+    // (e.g. a dead device token), fail open fast instead of stalling for holdMs.
+    this.armDeliveryGate(qid);
     return { decision, questionId: qid };
+  }
+
+  /**
+   * Fail a held hook OPEN to passthrough (#573 hold-timeout / #603 undeliverable):
+   * dismiss the now-stale pushed card on every client, drop the registry entry,
+   * and resolve the hook so Claude renders its native prompt and the local
+   * terminal can take over. No-op when the hold is already gone (answered, Part-B
+   * verdict, cancelled) so it never double-resolves.
+   */
+  private failOpenHeld(qid: UUID, logMessage: string): void {
+    if (!this.pendingHolds.has(qid)) return;
+    log(`[AutoApprove ${this.sessionTag}] ${logMessage}`);
+    // Dismiss the stale card everywhere BEFORE resolving (#585, P7); releaseHeld
+    // then clears the timer, drops the registry entry, and resolves passthrough.
+    this.notifyResolved(qid, 'cancelled');
+    this.releaseHeld(qid, 'passthrough');
+  }
+
+  /**
+   * Race a held escalation's notification delivery against `deliveryConfirmMs`
+   * (epic #603 Phase 1). If delivery is confirmed (in_app / pushed / deduped) in
+   * time, the hold keeps blocking to `holdMs` as before. If it is NOT confirmed
+   * — a dead token, no registered token, or the probe times out — the hold no
+   * longer stalls Claude for the full window: `onDeliveryUnconfirmed` fails it
+   * open fast (or re-arms a short secondary hold). Disabled (legacy hold) when
+   * `deliveryConfirmMs <= 0` or no delivery signal was recorded for `qid`.
+   */
+  private armDeliveryGate(qid: UUID): void {
+    const confirmMs = this.deps.deliveryConfirmMs ?? 0;
+    const probe = this.deps.awaitDelivery?.(qid);
+    if (confirmMs <= 0 || !probe) return;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      const t = setTimeout(() => resolve('timeout'), confirmMs);
+      t.unref?.();
+    });
+    Promise.race([probe, timeout])
+      .then((result) => {
+        // The hold may already be resolved (user answered, Part-B verdict, or a
+        // cancel) — then there is nothing to gate.
+        if (!this.pendingHolds.has(qid)) return;
+        if (result !== 'timeout' && isDelivered(result)) return; // confirmed: keep holding
+        this.onDeliveryUnconfirmed(qid, result);
+      })
+      .catch((err) => {
+        logError(
+          `[AutoApprove ${this.sessionTag}] delivery probe threw (treating as unconfirmed):`,
+          err,
+        );
+        if (this.pendingHolds.has(qid)) this.onDeliveryUnconfirmed(qid, 'failed');
+      });
+  }
+
+  /**
+   * A held escalation's notification was NOT confirmed delivered (epic #603
+   * Phase 1). Default (hybrid): fail open NOW so the local terminal can answer,
+   * instead of blocking Claude for the full `holdMs` on a notification nobody
+   * received. When `holdUnconfirmedMs > 0` (D2 hold-always-no-phone): re-arm the
+   * hold to a SHORT secondary window so a transient failure can recover before
+   * fail-open. Either path is LOUD (logError) so an undelivered notification is
+   * never a silent stall.
+   */
+  private onDeliveryUnconfirmed(qid: UUID, reason: DeliveryOutcome | 'timeout'): void {
+    if (!this.pendingHolds.has(qid)) return;
+    const holdUnconfirmedMs = this.deps.holdUnconfirmedMs ?? 0;
+    if (holdUnconfirmedMs > 0) {
+      const hold = this.pendingHolds.get(qid);
+      if (!hold) return;
+      clearTimeout(hold.timer);
+      const timer = setTimeout(() => {
+        this.failOpenHeld(
+          qid,
+          `Held hook ${qid.slice(0, 8)} still undelivered (${reason}); short hold expired -> passthrough`,
+        );
+      }, holdUnconfirmedMs);
+      timer.unref?.();
+      this.pendingHolds.set(qid, { resolve: hold.resolve, timer });
+      logError(
+        `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNCONFIRMED (${reason}); holding ${Math.round(holdUnconfirmedMs / 1000)}s (hold_unconfirmed_timeout) with retry before fail-open`,
+      );
+      return;
+    }
+    logError(
+      `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNDELIVERED (${reason}); failing open to passthrough so the terminal can answer (no notification reached your devices)`,
+    );
+    this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} undelivered -> passthrough`);
   }
 
   /**

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -212,4 +212,30 @@ export interface AutoApproveConfig {
    * `hold_timeout` so the early-push window opens before the hold itself expires.
    */
   readonly push_hold_timeout: number;
+  /**
+   * Seconds to wait for a held escalation's notification to be CONFIRMED
+   * delivered before deciding the hold is undeliverable (epic #603 Phase 1,
+   * R1/R2). A binary escalation holds the PermissionRequest hook (Model B) only
+   * makes sense if the user can actually be notified; delivery is "confirmed"
+   * when a client is attached (in-app), an APNS push returns 2xx, or an
+   * identical push was already sent (deduped). If NONE confirm within this
+   * window — e.g. a dead device token (BadDeviceToken) or no registered token on
+   * this daemon — the hold no longer blocks Claude for the full `hold_timeout`;
+   * it fails open fast to passthrough (native prompt) unless
+   * `hold_unconfirmed_timeout` is set. 0 disables delivery gating (legacy: hold
+   * to `hold_timeout` regardless of delivery). Default 6.
+   */
+  readonly delivery_confirm_timeout: number;
+  /**
+   * Seconds to keep holding a binary escalation whose notification delivery was
+   * NOT confirmed within `delivery_confirm_timeout` (epic #603 Phase 1, D2 —
+   * the "hold-always-no-phone" two-tier escape). 0 (default) = fail open
+   * immediately when delivery is unconfirmed (the hybrid default: let the local
+   * terminal answer). > 0 = instead hold to this SHORT secondary timeout (e.g.
+   * 180) so a transient delivery failure can recover via retries before the hook
+   * fails open — for users who run headless and want the hook to wait for their
+   * phone even when no client is currently reachable. Always far below
+   * `hold_timeout` so an undeliverable hold can never stall for the full window.
+   */
+  readonly hold_unconfirmed_timeout: number;
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1199,6 +1199,16 @@ async function createNewSession(
         // native prompt immediately (the pre-0.6.12 behavior). 0 => no hold.
         holdTimeoutSec: autoApproveService ? remiConfig.auto_approve.hold_timeout : 0,
         pushHoldTimeoutSec: autoApproveService ? remiConfig.auto_approve.push_hold_timeout : 0,
+        // #603 Phase 1: gate a held hook on confirmed notification delivery. Same
+        // AA-enabled guard as holdTimeoutSec — gating is only meaningful when the
+        // gate can hold. The dispatcher records the per-question delivery outcome.
+        awaitDelivery: (questionId) => notifications.awaitDelivery(questionId),
+        deliveryConfirmSec: autoApproveService
+          ? remiConfig.auto_approve.delivery_confirm_timeout
+          : 0,
+        holdUnconfirmedSec: autoApproveService
+          ? remiConfig.auto_approve.hold_unconfirmed_timeout
+          : 0,
         // #585: a held question the gate resolves without a user answer dismisses
         // its pushed card on every client.
         broadcastQuestionResolved: onQuestionResolved,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -55,6 +55,7 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
 import { classifySessionEvent } from '../../hooks/session-lock-classifier.ts';
+import type { DeliveryOutcome } from '../../notifications/notification-dispatcher.ts';
 import { claudeChildLooksAlive } from '../../session/index.ts';
 import type {
   SessionBindingStore,
@@ -140,6 +141,25 @@ export interface HookBridgeDeps {
    * Part B disabled (the eval/timer race never arms).
    */
   pushHoldTimeoutSec?: number;
+  /**
+   * Probe a held escalation's notification delivery outcome (epic #603 Phase 1).
+   * Wired from this session's `NotificationDispatcher.awaitDelivery`. Lets the
+   * gate fail a hold open fast when no notification reached the user instead of
+   * blocking for the full hold_timeout. Absent => delivery gating disabled.
+   */
+  awaitDelivery?: (questionId: UUID) => Promise<DeliveryOutcome> | undefined;
+  /**
+   * Seconds to wait for a held escalation's delivery to be confirmed before
+   * treating it as undeliverable (epic #603 Phase 1). From
+   * `config.auto_approve.delivery_confirm_timeout`. 0 / absent => no gating.
+   */
+  deliveryConfirmSec?: number;
+  /**
+   * Seconds to keep holding an UNDELIVERED escalation instead of failing open
+   * immediately (epic #603 Phase 1, D2 hold-always-no-phone). From
+   * `config.auto_approve.hold_unconfirmed_timeout`. 0 / absent => fail open fast.
+   */
+  holdUnconfirmedSec?: number;
   /**
    * Cross-client question dismissal (#585, P7). Called by the gate when a HELD
    * question resolves WITHOUT a user answer (Part-B late verdict, hold timeout,
@@ -838,6 +858,11 @@ export function setupHookBridge(
       alwaysEscalateTools: deps.alwaysEscalateTools ?? new Set<string>(),
       holdMs: (deps.holdTimeoutSec ?? 0) * 1000,
       pushHoldMs: (deps.pushHoldTimeoutSec ?? 0) * 1000,
+      // #603 Phase 1: gate a held hook on confirmed notification delivery, so a
+      // dead push channel fails open fast instead of stalling for holdMs.
+      ...(deps.awaitDelivery ? { awaitDelivery: deps.awaitDelivery } : {}),
+      deliveryConfirmMs: (deps.deliveryConfirmSec ?? 0) * 1000,
+      holdUnconfirmedMs: (deps.holdUnconfirmedSec ?? 0) * 1000,
     },
     sessionId,
   );

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -134,7 +134,9 @@ export function createMessageApiForSession(
       sessionRegistry.addQuestion(questionSessionId, question);
 
       // Push only when no client is attached; attached clients see it in-app.
-      notifications.maybePush(questionSessionId, question);
+      // maybePush records the delivery outcome (epic #603 Phase 1) for the gate
+      // to probe; the regular question path does not await it.
+      void notifications.maybePush(questionSessionId, question);
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -194,6 +194,15 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Push + hold early if a binary main-context eval is still running after
     // this many seconds (Part B, #573). 0 disables Part B (A+C only).
     push_hold_timeout: 60,
+    // Wait this long for a held escalation's notification to be confirmed
+    // delivered before treating the hold as undeliverable (epic #603 Phase 1).
+    // On no confirmation, fail open fast instead of blocking for hold_timeout.
+    // 0 disables delivery gating (legacy: always hold to hold_timeout).
+    delivery_confirm_timeout: 6,
+    // Keep holding an undeliverable escalation for this short secondary window
+    // instead of failing open immediately (epic #603 Phase 1, D2). 0 = fail
+    // open fast (the hybrid default); > 0 = hold-always-no-phone mode.
+    hold_unconfirmed_timeout: 0,
   },
   features: {
     transcript_binder_shadow: false,
@@ -363,6 +372,26 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   ) {
     throw new Error(
       `Invalid auto_approve.push_hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable slow-eval push), got ${typeof cfg.push_hold_timeout === 'string' ? `string "${cfg.push_hold_timeout}"` : typeof cfg.push_hold_timeout}. Example: push_hold_timeout = 60`,
+    );
+  }
+
+  if (
+    typeof cfg.delivery_confirm_timeout !== 'number' ||
+    !Number.isFinite(cfg.delivery_confirm_timeout) ||
+    cfg.delivery_confirm_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.delivery_confirm_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable delivery gating), got ${typeof cfg.delivery_confirm_timeout === 'string' ? `string "${cfg.delivery_confirm_timeout}"` : typeof cfg.delivery_confirm_timeout}. Example: delivery_confirm_timeout = 6`,
+    );
+  }
+
+  if (
+    typeof cfg.hold_unconfirmed_timeout !== 'number' ||
+    !Number.isFinite(cfg.hold_unconfirmed_timeout) ||
+    cfg.hold_unconfirmed_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.hold_unconfirmed_timeout in ${configPath}: must be a non-negative number (seconds; 0 = fail open fast when delivery unconfirmed), got ${typeof cfg.hold_unconfirmed_timeout === 'string' ? `string "${cfg.hold_unconfirmed_timeout}"` : typeof cfg.hold_unconfirmed_timeout}. Example: hold_unconfirmed_timeout = 180`,
     );
   }
 
@@ -839,6 +868,8 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
   lines.push(`  hold_timeout = ${config.auto_approve.hold_timeout}`);
   lines.push(`  push_hold_timeout = ${config.auto_approve.push_hold_timeout}`);
+  lines.push(`  delivery_confirm_timeout = ${config.auto_approve.delivery_confirm_timeout}`);
+  lines.push(`  hold_unconfirmed_timeout = ${config.auto_approve.hold_unconfirmed_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push(
     `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -114,10 +114,14 @@ export type PushFn = typeof sendPushTrigger;
 export type DeliveryOutcome = 'in_app' | 'pushed' | 'deduped' | 'no_channel' | 'failed';
 
 /** Whether a delivery outcome means the user can actually be notified (epic
- *  #603 Phase 1). `in_app` / `pushed` / `deduped` reach the user; `no_channel` /
- *  `failed` do not, so a hold gated on delivery fails open. */
+ *  #603 Phase 1). `in_app` / `pushed` reach the user. `deduped` is deliberately
+ *  NOT treated as confirmed: PushDedup suppresses a second identical push
+ *  WITHOUT tracking whether the push it deduped against actually succeeded, so a
+ *  held hook must not keep blocking on it — fail open (always safe) instead.
+ *  (Phase 3 makes held escalations bypass dedup, so a held push is never deduped
+ *  in the first place.) `no_channel` / `failed` obviously do not reach anyone. */
 export function isDelivered(outcome: DeliveryOutcome): boolean {
-  return outcome === 'in_app' || outcome === 'pushed' || outcome === 'deduped';
+  return outcome === 'in_app' || outcome === 'pushed';
 }
 
 /** Transient push failures retried with backoff (epic #603 Phase 1). */
@@ -146,7 +150,18 @@ const sleep = (ms: number): Promise<void> =>
  */
 export function isRetriablePushError(err: unknown): boolean {
   const msg = String(err instanceof Error ? err.message : err);
-  if (/BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(msg)) return false;
+  // Permanent APNS token rejections (the Worker wraps these as HTTP 502): never
+  // retry. `Unregistered` is word-boundaried so a generic 5xx body that happens
+  // to contain the word is not misclassified as a permanent token failure.
+  if (/BadDeviceToken|DeviceTokenNotForTopic|\bUnregistered\b/i.test(msg)) return false;
+  // Network-level failures (no HTTP response received at all) are transient —
+  // a Worker cold-start, a brief flap, DNS hiccup — so retry them.
+  if (
+    err instanceof TypeError ||
+    /ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|Failed to fetch/i.test(msg)
+  ) {
+    return true;
+  }
   const m = msg.match(/failed: (\d{3})/);
   if (!m) return false;
   const status = Number(m[1]);
@@ -294,7 +309,10 @@ export class NotificationDispatcher {
           await sleep(delay);
           continue;
         }
-        log(`Push notification failed: ${err}`);
+        // Loud: a real push attempt failed (permanent token rejection, network
+        // error, or exhausted retries). This is the root cause behind a held
+        // hook's fail-open, so it must be visible at error level, not buried.
+        logError(`Push notification failed for session ${pushSessionId}: ${err}`);
         return false;
       }
     }
@@ -304,10 +322,12 @@ export class NotificationDispatcher {
    *  can `awaitDelivery` it (epic #603 Phase 1). */
   private recordDelivery(questionId: UUID, outcome: Promise<DeliveryOutcome>): void {
     this.deliveryOutcomes.set(questionId, outcome);
-    outcome.finally(() => {
-      const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
-      t.unref?.();
-    });
+    // Evict after a fixed TTL regardless of whether `outcome` ever settles: a
+    // push whose fetch hangs (unreachable Worker, no AbortSignal yet) must not
+    // leak a map entry until the OS TCP timeout. The gate probes within ms of
+    // recording, so a 60s TTL is a generous upper bound.
+    const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
+    t.unref?.();
   }
 
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -98,6 +98,61 @@ export function buildPushText(
  *  observable in tests without mocking a network module. */
 export type PushFn = typeof sendPushTrigger;
 
+/**
+ * The outcome of attempting to deliver a question's notification (epic #603
+ * Phase 1). The gate consumes this via `awaitDelivery` to decide whether a held
+ * hook should keep blocking Claude or fail open fast:
+ *   - `in_app`     a client is attached, so the question shows in-app (the only
+ *                  case where `maybePush` deliberately does NOT push — but the
+ *                  user IS reachable).
+ *   - `pushed`     at least one APNS push returned 2xx.
+ *   - `deduped`    the push was suppressed because an identical one already went
+ *                  out (the earlier push is the delivery).
+ *   - `no_channel` no client attached AND no device tokens — nobody can be told.
+ *   - `failed`     tokens exist but every push failed (e.g. BadDeviceToken).
+ */
+export type DeliveryOutcome = 'in_app' | 'pushed' | 'deduped' | 'no_channel' | 'failed';
+
+/** Whether a delivery outcome means the user can actually be notified (epic
+ *  #603 Phase 1). `in_app` / `pushed` / `deduped` reach the user; `no_channel` /
+ *  `failed` do not, so a hold gated on delivery fails open. */
+export function isDelivered(outcome: DeliveryOutcome): boolean {
+  return outcome === 'in_app' || outcome === 'pushed' || outcome === 'deduped';
+}
+
+/** Transient push failures retried with backoff (epic #603 Phase 1). */
+const MAX_PUSH_RETRIES = 2;
+/** Backoff base; attempt N waits BASE * 2^N (400ms, 800ms). Kept short so the
+ *  per-token result settles well within the gate's delivery_confirm_timeout. */
+const PUSH_RETRY_BASE_MS = 400;
+/** How long a recorded delivery outcome stays probeable before cleanup. The
+ *  gate probes within ~ms of the push; this is a generous upper bound so the
+ *  map never grows unbounded across a long-lived session. */
+const DELIVERY_OUTCOME_TTL_MS = 60_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+
+/**
+ * Whether a failed push is worth retrying (epic #603 Phase 1). The signaling
+ * Worker wraps a permanent APNS token rejection (BadDeviceToken / Unregistered /
+ * DeviceTokenNotForTopic) as an HTTP 502, so a naive "retry all 5xx" would spin
+ * on a dead token. Treat those reasons as permanent (no retry -> fail open
+ * fast); retry only a genuine rate-limit (429) or a transient 5xx with no
+ * permanent reason.
+ */
+export function isRetriablePushError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err);
+  if (/BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(msg)) return false;
+  const m = msg.match(/failed: (\d{3})/);
+  if (!m) return false;
+  const status = Number(m[1]);
+  return status === 429 || (status >= 500 && status < 600);
+}
+
 export interface NotificationDispatcherDeps {
   sessionRegistry: SessionRegistry;
   deviceTokens: Map<string, DeviceTokenEntry>;
@@ -122,6 +177,13 @@ export class NotificationDispatcher {
    *  injected an override. Fixed for the instance lifetime. */
   private readonly pushFn: PushFn;
 
+  /**
+   * Delivery outcome per question id (epic #603 Phase 1), recorded by every
+   * `maybePush` so the gate can `awaitDelivery` to decide a held hook's fate.
+   * Entries self-evict after `DELIVERY_OUTCOME_TTL_MS` so the map stays bounded.
+   */
+  private readonly deliveryOutcomes = new Map<UUID, Promise<DeliveryOutcome>>();
+
   constructor(
     private readonly deps: NotificationDispatcherDeps,
     private readonly sessionId: UUID,
@@ -141,18 +203,40 @@ export class NotificationDispatcher {
    * Push `question` to all registered devices, unless a client is actively
    * attached (they see it in-app) or the dedup gate suppresses it.
    * `questionSessionId` is the primary id the client knows (from hello_ack).
+   *
+   * Returns the resolved DELIVERY OUTCOME (epic #603 Phase 1) and records it
+   * keyed by `question.id` so a held hook can `awaitDelivery` to decide whether
+   * to keep blocking Claude or fail open fast. Callers that do not care about
+   * delivery (the regular PTY-prompt path) can ignore the returned promise; the
+   * recording still happens.
    */
-  maybePush(questionSessionId: UUID, question: Question): void {
+  maybePush(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
+    const outcome = this.computeDelivery(questionSessionId, question);
+    this.recordDelivery(question.id, outcome);
+    return outcome;
+  }
+
+  /** Resolve the delivery outcome for one question (fanning out the per-token
+   *  pushes when a push is actually warranted). See `DeliveryOutcome`. */
+  private computeDelivery(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
     const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
 
     const sessionForPush = sessionRegistry.getSession(questionSessionId);
     const hasActiveClient =
       sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-    if (deviceTokens.size === 0 || hasActiveClient) return;
+    // A client is attached: it sees the question in-app over the WebSocket. No
+    // push (as before), but the user IS reachable -> in_app.
+    if (hasActiveClient) return Promise.resolve('in_app');
+    // No client AND no device tokens: there is no channel to notify anyone.
+    if (deviceTokens.size === 0) {
+      log(`Push skipped: no device tokens for session ${questionSessionId}`);
+      return Promise.resolve('no_channel');
+    }
 
     if (!this.pushDedup.shouldPush(question)) {
       log(`Push suppressed by dedup for session ${questionSessionId}`);
-      return;
+      // An identical push already went out; the earlier one is the delivery.
+      return Promise.resolve('deduped');
     }
 
     const session = sessionRegistry.getSession(this.sessionId);
@@ -167,20 +251,74 @@ export class NotificationDispatcher {
     // label is empty so the button still carries something answerable.
     const pushOptions = question.options.map((o) => o.label || o.value);
     const { title, body } = buildPushText(sessionName, question);
+    const opts = {
+      title,
+      body,
+      ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+      sessionId: pushSessionId,
+      questionId: question.id,
+      ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+      ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+    };
 
-    for (const dt of deviceTokens.values()) {
-      this.pushFn(cfg.signalingUrl, dt.token, {
-        title,
-        body,
-        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
-        sessionId: pushSessionId,
-        questionId: question.id,
-        ...(pushCategory !== undefined ? { category: pushCategory } : {}),
-        ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
-      })
-        .then(() => log(`Push notification sent for session ${pushSessionId}`))
-        .catch((err) => log(`Push notification failed: ${err}`));
+    const perToken = [...deviceTokens.values()].map((dt) =>
+      this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
+    );
+    // Delivered if ANY registered device accepted the push.
+    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+  }
+
+  /**
+   * Push to one device token, retrying a TRANSIENT failure (429 / transient
+   * 5xx) with short backoff (epic #603 Phase 1). A permanent token rejection
+   * (BadDeviceToken etc., which the Worker wraps as 502) is NOT retried — it
+   * fails fast so the gate can fail the hold open. Resolves true on a 2xx.
+   */
+  private async pushOnceWithRetry(
+    signalingUrl: string,
+    token: string,
+    opts: Parameters<PushFn>[2],
+    pushSessionId: UUID,
+  ): Promise<boolean> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.pushFn(signalingUrl, token, opts);
+        log(`Push notification sent for session ${pushSessionId}`);
+        return true;
+      } catch (err) {
+        if (isRetriablePushError(err) && attempt < MAX_PUSH_RETRIES) {
+          const delay = PUSH_RETRY_BASE_MS * 2 ** attempt;
+          log(
+            `Push transient failure (retry ${attempt + 1}/${MAX_PUSH_RETRIES} in ${delay}ms): ${err}`,
+          );
+          await sleep(delay);
+          continue;
+        }
+        log(`Push notification failed: ${err}`);
+        return false;
+      }
     }
+  }
+
+  /** Record (and schedule cleanup of) a question's delivery outcome so the gate
+   *  can `awaitDelivery` it (epic #603 Phase 1). */
+  private recordDelivery(questionId: UUID, outcome: Promise<DeliveryOutcome>): void {
+    this.deliveryOutcomes.set(questionId, outcome);
+    outcome.finally(() => {
+      const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
+      t.unref?.();
+    });
+  }
+
+  /**
+   * The delivery outcome recorded for `questionId` by `maybePush` (epic #603
+   * Phase 1). The gate races this against `delivery_confirm_timeout` to decide a
+   * held hook's fate. `undefined` when no push was attempted for the id (e.g. the
+   * held push found no pending hook record) — the gate then keeps its legacy
+   * behavior (hold to hold_timeout) rather than failing open on a missing signal.
+   */
+  awaitDelivery(questionId: UUID): Promise<DeliveryOutcome> | undefined {
+    return this.deliveryOutcomes.get(questionId);
   }
 
   /**

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1142,21 +1142,28 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
 
   /** A holding gate whose held escalation's delivery outcome and gating timeouts
    *  the test controls. `delivery` is what `awaitDelivery` resolves to (or
-   *  undefined for "no delivery signal recorded"). */
+   *  undefined for "no delivery signal recorded"). `evalNeverSettles` + a
+   *  `pushHoldMs` exercise the Part-B early-push path combined with the gate. */
   function deliveryGate(opts: {
     delivery: Promise<DeliveryOutcome> | undefined;
     deliveryConfirmMs?: number;
     holdUnconfirmedMs?: number;
     holdMs?: number;
+    pushHoldMs?: number;
+    evalNeverSettles?: boolean;
+    onResolved?: (questionId: UUID, reason: 'auto_approved' | 'auto_denied' | 'cancelled') => void;
   }): AutoApproveGate {
     registry.registerSession(SID, '/d', fakePTY([]), {
       handleMessage: () => {},
       handleQuestion: () => {},
       handleStatusChange: () => {},
     } as never);
+    const service: AutoApproveEvaluator = opts.evalNeverSettles
+      ? { evaluate: () => new Promise<AutoApproveResult>(() => {}), cancel: () => true }
+      : evaluator(escalate);
     return new AutoApproveGate(
       {
-        service: evaluator(escalate),
+        service,
         sessionRegistry: registry,
         tracker: new QuestionPresenceTracker(() => {}),
         isInSubagentContext: () => false,
@@ -1166,9 +1173,11 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
           return lastQuestionId;
         },
         holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
         awaitDelivery: () => opts.delivery,
         deliveryConfirmMs: opts.deliveryConfirmMs ?? 0,
         holdUnconfirmedMs: opts.holdUnconfirmedMs ?? 0,
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
         alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
       },
       SID,
@@ -1309,5 +1318,41 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     await new Promise((r) => setTimeout(r, 50)); // inside the short secondary window
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
     expect(await pending).toBe('allow');
+  });
+
+  test('a delivery outcome that resolves AFTER the hold already failed open does not double-resolve', async () => {
+    const resolved: Array<'auto_approved' | 'auto_denied' | 'cancelled'> = [];
+    const gate = deliveryGate({
+      // Resolves 'failed' well after the (short) holdMs timer has already fired.
+      delivery: new Promise<DeliveryOutcome>((r) => {
+        const t = setTimeout(() => r('failed'), 80);
+        t.unref?.();
+      }),
+      deliveryConfirmMs: 500, // longer than holdMs -> the holdMs timeout wins the fail-open
+      holdMs: 30,
+      onResolved: (_q, reason) => resolved.push(reason),
+    });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough'); // failed open via holdMs timeout
+    // Let the slow delivery probe resolve, now that the hold is already gone.
+    await new Promise((r) => setTimeout(r, 120));
+    // Exactly ONE resolution broadcast (the timeout fail-open); the late probe
+    // sees pendingHolds no longer has the id and no-ops (no spurious 2nd dismiss).
+    expect(resolved).toEqual(['cancelled']);
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('Part B early push + delivery gating: a slow eval whose push is undelivered fails open fast', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      pushHoldMs: 15, // Part B pushes + holds early at ~15ms
+      evalNeverSettles: true, // the eval never returns a verdict
+      holdMs: 60_000,
+    });
+    // Part B holds early; delivery is 'failed', so the gate fails the hold open
+    // fast (~deliveryConfirmMs) instead of waiting the 60s holdMs for a verdict
+    // that never comes.
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -9,6 +9,7 @@ import {
 import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
 import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { DeliveryOutcome } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../src/session/session-registry.ts';
 
@@ -1107,5 +1108,206 @@ describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
     g.cancelStale('SessionEnd');
     expect(await pending).toBe('passthrough');
     expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delivery gating (#603 Phase 1, R1/R2): a held hook is only worth blocking
+// Claude for if the user can actually be notified. The gate races the held
+// escalation's notification delivery against delivery_confirm_timeout; an
+// undeliverable hold fails open FAST instead of stalling for hold_timeout.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  /** A holding gate whose held escalation's delivery outcome and gating timeouts
+   *  the test controls. `delivery` is what `awaitDelivery` resolves to (or
+   *  undefined for "no delivery signal recorded"). */
+  function deliveryGate(opts: {
+    delivery: Promise<DeliveryOutcome> | undefined;
+    deliveryConfirmMs?: number;
+    holdUnconfirmedMs?: number;
+    holdMs?: number;
+  }): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId() as UUID;
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        awaitDelivery: () => opts.delivery,
+        deliveryConfirmMs: opts.deliveryConfirmMs ?? 0,
+        holdUnconfirmedMs: opts.holdUnconfirmedMs ?? 0,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('undelivered (failed push) fails the hold open fast, not after hold_timeout', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 200,
+      holdMs: 60_000,
+    });
+    // If the hold blocked for holdMs (60s) this await would hang the test; it
+    // resolves promptly to passthrough because delivery was never confirmed.
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+    // The hold is gone (failed open): a late answer reports "no hold".
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('no_channel (no client, no token) fails the hold open fast', async () => {
+    const gate = deliveryGate({ delivery: Promise.resolve('no_channel'), deliveryConfirmMs: 200 });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+  });
+
+  test('a delivery probe that never resolves fails open after delivery_confirm_timeout', async () => {
+    const gate = deliveryGate({
+      delivery: new Promise<DeliveryOutcome>(() => {}),
+      deliveryConfirmMs: 40,
+      holdMs: 60_000,
+    });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+  });
+
+  test('confirmed delivery (pushed) keeps holding; the user answer resolves it', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('pushed'),
+      deliveryConfirmMs: 30,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 60)); // past delivery_confirm_timeout
+    expect(settled).toBe(false); // still held — delivery was confirmed
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('confirmed delivery (in_app) keeps holding', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('in_app'),
+      deliveryConfirmMs: 30,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 60));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('gating disabled (delivery_confirm_timeout = 0) keeps the legacy hold even if delivery failed', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 0,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 40));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    expect(await pending).toBe('allow');
+  });
+
+  test('no recorded delivery signal (awaitDelivery undefined) keeps the legacy hold', async () => {
+    const gate = deliveryGate({ delivery: undefined, deliveryConfirmMs: 50, holdMs: 60_000 });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 70));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('hold_unconfirmed mode: an undelivered hold waits the short window, then fails open', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      holdUnconfirmedMs: 150,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    // It does NOT fail open immediately on the unconfirmed signal — it re-arms a
+    // short 150ms hold.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(settled).toBe(false);
+    // ...which then fails open (well before the 60s holdMs).
+    expect(await pending).toBe('passthrough');
+  });
+
+  test('hold_unconfirmed mode: the user can still answer during the short window', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      holdUnconfirmedMs: 500,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 50)); // inside the short secondary window
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -56,6 +56,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -121,6 +121,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -71,6 +71,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -336,6 +336,8 @@ function makeConfig(model: string): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -108,6 +108,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -293,6 +293,11 @@ describe('formatConfig', () => {
     expect(output).toContain('escalate_model = ""');
     // always_escalate_tools visible (#572).
     expect(output).toContain('always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]');
+    // delivery_confirm_timeout / hold_unconfirmed_timeout visible (#603 Phase 1)
+    // — guards against the #517-class regression of omitting a field from `config
+    // show`.
+    expect(output).toContain('delivery_confirm_timeout = 6');
+    expect(output).toContain('hold_unconfirmed_timeout = 0');
   });
 
   test('default model is a fast 4b; escalate_model empty (#522)', () => {
@@ -547,6 +552,31 @@ Escalate anything touching secrets.
   test('rejects a negative push_hold_timeout (#573)', () => {
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\npush_hold_timeout = -5\n');
     expect(() => loadConfig(TEST_CONFIG)).toThrow(/push_hold_timeout/);
+  });
+
+  test('rejects a negative delivery_confirm_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ndelivery_confirm_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/delivery_confirm_timeout/);
+  });
+
+  test('rejects a non-numeric delivery_confirm_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ndelivery_confirm_timeout = "fast"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/delivery_confirm_timeout/);
+  });
+
+  test('rejects a negative hold_unconfirmed_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_unconfirmed_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/hold_unconfirmed_timeout/);
+  });
+
+  test('loads delivery_confirm_timeout / hold_unconfirmed_timeout from TOML (#603)', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      '[auto_approve]\ndelivery_confirm_timeout = 8\nhold_unconfirmed_timeout = 180\n',
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.delivery_confirm_timeout).toBe(8);
+    expect(config.auto_approve.hold_unconfirmed_timeout).toBe(180);
   });
 
   test('REMI_AUTO_APPROVE_HOLD_TIMEOUT / PUSH_HOLD_TIMEOUT env overrides (#573)', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -348,6 +348,8 @@ describe('auto_approve config', () => {
       always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
       hold_timeout: 1800,
       push_hold_timeout: 60,
+      delivery_confirm_timeout: 6,
+      hold_unconfirmed_timeout: 0,
     });
   });
 

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -6,6 +6,8 @@ import {
   NotificationDispatcher,
   type PushFn,
   buildPushText,
+  isDelivered,
+  isRetriablePushError,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -406,9 +408,91 @@ describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
     expect(calls).toBe(2);
   });
 
+  test('a retriable error exhausts MAX_PUSH_RETRIES (3 attempts) then -> failed', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const always429: PushFn = async () => {
+      calls++;
+      throw new Error('Push trigger failed: 429 rate limited');
+    };
+    expect(await make(always429).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+    expect(calls).toBe(3); // 1 initial + MAX_PUSH_RETRIES (2)
+  });
+
+  test('multi-token: one dead token + one live token still resolves pushed (the 2-token case)', async () => {
+    register(false);
+    addToken('dead');
+    addToken('live');
+    const mixedPush: PushFn = async (_url, token) => {
+      if (token === 'dead') {
+        throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+      }
+    };
+    expect(await make(mixedPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+  });
+
+  test('multi-token: every token failing resolves failed', async () => {
+    register(false);
+    addToken('a');
+    addToken('b');
+    const allFail: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(allFail).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+  });
+
   test('awaitDelivery is undefined for an unknown question id', () => {
     expect(
       make(okPush).awaitDelivery('zzzzzzzz-0000-0000-0000-000000000000' as UUID),
     ).toBeUndefined();
+  });
+});
+
+describe('isRetriablePushError / isDelivered (#603 Phase 1)', () => {
+  test('permanent APNS token rejections are NOT retriable (even wrapped as 502)', () => {
+    expect(
+      isRetriablePushError(
+        new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}'),
+      ),
+    ).toBe(false);
+    expect(
+      isRetriablePushError(new Error('Push trigger failed: 410 {"reason":"Unregistered"}')),
+    ).toBe(false);
+    expect(isRetriablePushError(new Error('Push trigger failed: 400 DeviceTokenNotForTopic'))).toBe(
+      false,
+    );
+  });
+
+  test('a transient 429 / 5xx is retriable', () => {
+    expect(isRetriablePushError(new Error('Push trigger failed: 429 rate limited'))).toBe(true);
+    expect(isRetriablePushError(new Error('Push trigger failed: 503 unavailable'))).toBe(true);
+    expect(isRetriablePushError(new Error('Push trigger failed: 500 internal'))).toBe(true);
+  });
+
+  test('network-level errors (no HTTP response) are retriable', () => {
+    expect(isRetriablePushError(new TypeError('Failed to fetch'))).toBe(true);
+    expect(isRetriablePushError(new Error('connect ECONNREFUSED 127.0.0.1:8787'))).toBe(true);
+    expect(isRetriablePushError(new Error('getaddrinfo ENOTFOUND remi-signaling'))).toBe(true);
+  });
+
+  test('a permanent reason wins even if the message also carries a 5xx status', () => {
+    // The Worker wraps a BadDeviceToken as 502; the permanent reason must take
+    // precedence over the retriable 5xx status.
+    expect(isRetriablePushError(new Error('Push trigger failed: 502 BadDeviceToken'))).toBe(false);
+  });
+
+  test('a 4xx (non-token) is not retriable', () => {
+    expect(isRetriablePushError(new Error('Push trigger failed: 401 unauthorized'))).toBe(false);
+    expect(isRetriablePushError(new Error('Push trigger failed: 400 bad request'))).toBe(false);
+  });
+
+  test('isDelivered: in_app/pushed reach the user; deduped/no_channel/failed do not', () => {
+    expect(isDelivered('in_app')).toBe(true);
+    expect(isDelivered('pushed')).toBe(true);
+    // deduped is NOT treated as confirmed (the deduped-against push may have failed).
+    expect(isDelivered('deduped')).toBe(false);
+    expect(isDelivered('no_channel')).toBe(false);
+    expect(isDelivered('failed')).toBe(false);
   });
 });

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -301,3 +301,114 @@ describe('NotificationDispatcher.dismiss (#585 P7)', () => {
     expect(pushed).toHaveLength(0);
   });
 });
+
+describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  function make(pushFn: PushFn): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  const okPush: PushFn = async () => {};
+  const addToken = (t: string): void => {
+    deviceTokens.set(t, { token: t, platform: 'ios', registeredAt: 1, connectionId: SID });
+  };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('in_app when a client is attached (no push, but the user is reachable)', async () => {
+    register(true);
+    addToken('a');
+    expect(await make(okPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('in_app');
+  });
+
+  test('no_channel when there is no client and no device token', async () => {
+    register(false);
+    expect(await make(okPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('no_channel');
+  });
+
+  test('pushed when a device accepts; awaitDelivery returns the same outcome', async () => {
+    register(false);
+    addToken('a');
+    const d = make(okPush);
+    const q = question('q1', [yesOpt, noOpt]);
+    expect(await d.maybePush(SID, q)).toBe('pushed');
+    expect(await d.awaitDelivery(q.id)).toBe('pushed');
+  });
+
+  test('deduped when a second identical prompt is suppressed', async () => {
+    register(false);
+    addToken('a');
+    const d = make(okPush);
+    expect(await d.maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+    expect(await d.maybePush(SID, question('q2', [yesOpt, noOpt]))).toBe('deduped');
+  });
+
+  test('failed when the only device push fails', async () => {
+    register(false);
+    addToken('a');
+    const failPush: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(failPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+  });
+
+  test('a permanent BadDeviceToken (502) is NOT retried', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const failPush: PushFn = async () => {
+      calls++;
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(failPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+    expect(calls).toBe(1);
+  });
+
+  test('a transient 429 is retried with backoff, then succeeds -> pushed', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const flakyPush: PushFn = async () => {
+      calls++;
+      if (calls === 1) throw new Error('Push trigger failed: 429 rate limited');
+    };
+    expect(await make(flakyPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+    expect(calls).toBe(2);
+  });
+
+  test('awaitDelivery is undefined for an unknown question id', () => {
+    expect(
+      make(okPush).awaitDelivery('zzzzzzzz-0000-0000-0000-000000000000' as UUID),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #604. Phase 1 of epic #603 (notification-delivery robustness).

## The bug

Model B holds a Claude Code `PermissionRequest` hook open until the user answers — but it held **regardless of whether any notification was actually delivered**. So a dead push channel (your live `BadDeviceToken` logs, a 429 rate-limit, or no registered token on that daemon) turned every escalation into a ~30-minute frozen hold == "work paused."

## The fix: hold contingent on confirmed delivery (hybrid arm-then-fast-fail-open)

- `NotificationDispatcher.maybePush` now records a per-question `DeliveryOutcome` (`in_app` / `pushed` / `deduped` / `no_channel` / `failed`), exposed via `awaitDelivery(questionId)`.
- `AutoApproveGate` arms the hold optimistically, then races delivery against `delivery_confirm_timeout` (default **6s**). If delivery is not confirmed in time, the hold **fails open fast to passthrough** (native prompt → the terminal can answer) instead of blocking for `hold_timeout`.
- `hold_unconfirmed_timeout` (default **0** = fail open fast) opts into a short secondary hold-with-retry for headless "hold-always-no-phone" users (decision D2).
- Push retry: a **transient** failure (429 / transient 5xx / network error) is retried with short backoff; a **permanent** token rejection (`BadDeviceToken`, which the Worker wraps as HTTP 502) is never retried — it fails fast so the gate fails open.
- Every undelivered fail-open is logged **loudly** (`logError`), never a silent stall.

## Config (validated; shown in `config show`)

`auto_approve.delivery_confirm_timeout` (default 6) · `auto_approve.hold_unconfirmed_timeout` (default 0). `0` for the former disables gating (legacy hold to `hold_timeout`).

## Tests (NO MOCKS)

Real `NotificationDispatcher` with a real injected push sink (outcome aggregation, retry classification, multi-token one-dead-one-live → pushed, exhausted retries → failed); real `AutoApproveGate` + `SessionRegistry` (fast-fail-open vs keep-holding vs short-secondary-hold, probe-resolves-after-fail-open no-double-resolve, Part B + gating combined); direct `isRetriablePushError` / `isDelivered` unit tests; config rejection + `formatConfig` coverage. **174 pass / 0 fail** in the touched suites; typecheck + biome clean.

## Review

Reviewed by 3 sonnet agents (code-reviewer, silent-failure-hunter, pr-test-analyzer). All real findings addressed in the second commit (word-boundary `Unregistered`, retry network errors, `deduped`≠confirmed, push-failure `logError`, leak-proof TTL eviction, missing-delivery-signal diagnostic log, + the test gaps above). One finding declined as intended: the dispatcher logs `no_channel` at `log` (not `logError`) because it is a normal condition for users who never set up push; the gate already surfaces the held-hook fail-open reason loudly.

## Tested

Tests pass locally; not yet validated on-device (immediate live mitigation `APNS_SANDBOX=true` already applied to the signaling Worker separately).
