### PR TITLE
Phase 2: per-identity push budget + dismiss isolation (#605)

### DIFF
--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -232,14 +232,24 @@ export default {
       // them); dismiss pushes draw from a separate budget so they cannot starve
       // alerts. Malformed/auth-failed requests above never reach here, so they
       // do not consume budget.
-      const authed = Boolean(env.PUSH_SECRET);
+      // `authed` must mean "this request proved possession of the secret", not
+      // merely "a secret is configured" — re-check the bearer so a future
+      // refactor of the auth block above cannot silently grant the trusted
+      // budget to an unauthenticated caller.
+      const authed =
+        Boolean(env.PUSH_SECRET) &&
+        request.headers.get('Authorization') === `Bearer ${env.PUSH_SECRET}`;
       const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
       const rlKey = authed ? authBucketKey(env.PUSH_SECRET as string) : `ip:${pushClientIp}`;
-      const limiter = isDismiss
-        ? dismissRateLimiter
-        : authed
-          ? pushAuthRateLimiter
-          : pushIpRateLimiter;
+      // Unauthenticated callers (only when no PUSH_SECRET is configured) always
+      // use the tight per-IP fallback — INCLUDING dismisses, which must not get
+      // the raised budget. Authenticated alert vs dismiss draw from separate
+      // raised budgets so a dismiss flood cannot starve alerts.
+      const limiter = !authed
+        ? pushIpRateLimiter
+        : isDismiss
+          ? dismissRateLimiter
+          : pushAuthRateLimiter;
       if (!limiter.check(rlKey)) {
         return new Response(
           JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -58,10 +58,38 @@ interface PushRequestBody {
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
 const rateLimiter = new RateLimiter(10, 60_000);
-/** Per-IP rate limiter for push: 5 pushes per 60 seconds */
-const pushRateLimiter = new RateLimiter(5, 60_000);
+/**
+ * Push budget (epic #603 Phase 2, R3). The old single per-IP limiter (5/60s)
+ * was shared across every daemon behind one NAT and across alert + dismiss
+ * pushes, each fanned out per device token — so a power user running several
+ * worktree daemons hit 429 and silently dropped notifications. Now:
+ *   - AUTHENTICATED callers (they hold PUSH_SECRET, so they are trusted) are
+ *     keyed by identity, not IP, with a ceiling well above
+ *     (device tokens x concurrent sessions). Sharing a NAT no longer throttles.
+ *   - UNAUTHENTICATED callers (only possible when no PUSH_SECRET is configured)
+ *     keep the original tight per-IP fallback to limit abuse.
+ *   - DISMISS pushes get their own budget so quiet resolutions never starve
+ *     alert pushes.
+ */
+const PUSH_AUTH_LIMIT = 60;
+const pushAuthRateLimiter = new RateLimiter(PUSH_AUTH_LIMIT, 60_000);
+const pushIpRateLimiter = new RateLimiter(5, 60_000);
+const dismissRateLimiter = new RateLimiter(PUSH_AUTH_LIMIT, 60_000);
 /** Per-IP rate limiter for the answer relay: 10 answers per 60 seconds */
 const answerRateLimiter = new RateLimiter(10, 60_000);
+
+/**
+ * A stable, non-secret rate-limit bucket key for an authenticated push identity
+ * (epic #603 Phase 2). Hashes the shared secret (djb2) so the key never stores
+ * the secret itself, and distinct secrets (multi-tenant) get distinct buckets.
+ */
+function authBucketKey(secret: string): string {
+  let h = 5381;
+  for (let i = 0; i < secret.length; i++) {
+    h = ((h << 5) + h + secret.charCodeAt(i)) | 0;
+  }
+  return `auth:${(h >>> 0).toString(36)}`;
+}
 
 /** Main worker */
 export default {
@@ -166,15 +194,6 @@ export default {
         }
       }
 
-      // Rate limit per IP
-      const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
-      if (!pushRateLimiter.check(pushClientIp)) {
-        return new Response(
-          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),
-          { status: 429, headers: corsHeaders },
-        );
-      }
-
       if (!env.APNS_KEY_ID || !env.APNS_TEAM_ID || !env.APNS_PRIVATE_KEY) {
         return new Response(
           JSON.stringify({ error: 'APNS_NOT_CONFIGURED', message: 'APNS credentials not set' }),
@@ -205,6 +224,26 @@ export default {
             message: isDismiss ? 'token is required' : 'token, title, and body are required',
           }),
           { status: 400, headers: corsHeaders },
+        );
+      }
+
+      // Rate limit (epic #603 Phase 2, R3). Authenticated callers are keyed by
+      // identity with a generous ceiling (a shared NAT IP no longer throttles
+      // them); dismiss pushes draw from a separate budget so they cannot starve
+      // alerts. Malformed/auth-failed requests above never reach here, so they
+      // do not consume budget.
+      const authed = Boolean(env.PUSH_SECRET);
+      const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      const rlKey = authed ? authBucketKey(env.PUSH_SECRET as string) : `ip:${pushClientIp}`;
+      const limiter = isDismiss
+        ? dismissRateLimiter
+        : authed
+          ? pushAuthRateLimiter
+          : pushIpRateLimiter;
+      if (!limiter.check(rlKey)) {
+        return new Response(
+          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),
+          { status: 429, headers: corsHeaders },
         );
       }
 
@@ -264,7 +303,16 @@ export default {
         });
       }
 
-      return new Response(JSON.stringify({ success: false, error: result.error }), {
+      // Surface a PERMANENT token rejection as a structured flag (epic #603
+      // Phase 2 -> consumed by Phase 6 token pruning). APNS reports these as a
+      // 4xx that the Worker wraps in `result.error`; the daemon prunes the dead
+      // token instead of retrying it forever. The reason text is kept in `error`
+      // so the daemon's transient-vs-permanent classifier (#603 Phase 1) still
+      // works off the message.
+      const tokenInvalid = /BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(
+        result.error ?? '',
+      );
+      return new Response(JSON.stringify({ success: false, error: result.error, tokenInvalid }), {
         status: 502,
         headers: corsHeaders,
       });

--- a/packages/signaling/tests/push-budget.test.ts
+++ b/packages/signaling/tests/push-budget.test.ts
@@ -148,6 +148,25 @@ describe('/push budget (#603 Phase 2)', () => {
     expect(dRes.status).toBe(200);
   });
 
+  test('unauthenticated dismiss uses the tight per-IP fallback, not the raised budget', async () => {
+    const env = { ...baseEnv } as TestEnv; // no PUSH_SECRET
+    ipCounter += 1;
+    const ip = `198.51.100.${200 + ipCounter}`;
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const req = new Request('https://signaling.example/push', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': ip },
+        body: JSON.stringify({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+      });
+      const res = await worker.fetch(req, env as never);
+      statuses.push(res.status);
+    }
+    // The tight 5/60s fallback applies to unauthenticated dismisses too.
+    expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(statuses[5]).toBe(429);
+  });
+
   test('a permanent token rejection is surfaced as tokenInvalid:true (502)', async () => {
     const secret = freshSecret();
     const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;

--- a/packages/signaling/tests/push-budget.test.ts
+++ b/packages/signaling/tests/push-budget.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Worker-level tests for the /push rate-limit budget (epic #603 Phase 2, R3).
+ *
+ * Drives the worker's `fetch` directly (no miniflare; bun provides crypto.subtle
+ * and fetch, which we stub for the Apple call). Confirms:
+ *   - authenticated callers are NOT throttled at the old 5/60s per-IP limit
+ *     (a power user's many daemons behind one NAT no longer 429);
+ *   - unauthenticated callers keep the tight per-IP fallback;
+ *   - dismiss pushes draw from a SEPARATE budget so they can't starve alerts;
+ *   - a permanent token rejection is surfaced as a structured `tokenInvalid`.
+ *
+ * Each test uses a UNIQUE secret (authed) or a unique IP (unauthed) so its
+ * rate-limit bucket is fresh despite the module-level limiters persisting across
+ * tests in the run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+  PUSH_SECRET?: string;
+}
+
+describe('/push budget (#603 Phase 2)', () => {
+  let baseEnv: Omit<TestEnv, 'PUSH_SECRET'>;
+  let realFetch: typeof globalThis.fetch;
+  // Configurable Apple response so a token-rejection case can be simulated.
+  let appleStatus = 200;
+  let appleBody = '';
+  let secretCounter = 0;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    baseEnv = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleStatus = 200;
+    appleBody = '';
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        return new Response(appleBody, { status: appleStatus });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  /** A unique PUSH_SECRET per call so each test gets a fresh auth rate bucket. */
+  function freshSecret(): string {
+    secretCounter += 1;
+    return `test-secret-${secretCounter}`;
+  }
+
+  function alertReq(opts: { ip: string; secret?: string }): Request {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'CF-Connecting-IP': opts.ip,
+    };
+    if (opts.secret) headers['Authorization'] = `Bearer ${opts.secret}`;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ token: 'device-abc', title: 'T', body: 'B', questionId: 'q-1' }),
+    });
+  }
+
+  function dismissReq(opts: { ip: string; secret: string }): Request {
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': opts.ip,
+        Authorization: `Bearer ${opts.secret}`,
+      },
+      body: JSON.stringify({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+    });
+  }
+
+  test('authenticated alert pushes are NOT throttled at the old 5/60s (shared-NAT power user)', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    const ip = '198.51.100.7'; // same IP for all 6 (simulates many daemons, one NAT)
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await worker.fetch(alertReq({ ip, secret }), env as never);
+      statuses.push(res.status);
+    }
+    // The old per-IP 5-limit would 429 the 6th; the raised per-identity budget
+    // lets all six through.
+    expect(statuses).toEqual([200, 200, 200, 200, 200, 200]);
+  });
+
+  test('unauthenticated push keeps the tight per-IP fallback (6th is 429)', async () => {
+    const env = { ...baseEnv } as TestEnv; // no PUSH_SECRET
+    ipCounter += 1;
+    const ip = `198.51.100.${100 + ipCounter}`;
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await worker.fetch(alertReq({ ip }), env as never);
+      statuses.push(res.status);
+    }
+    expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(statuses[5]).toBe(429);
+  });
+
+  test('dismiss pushes draw from a separate budget and are not starved by alerts', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    const ip = '198.51.100.50';
+    // Exhaust the authenticated ALERT budget (PUSH_AUTH_LIMIT = 60).
+    let lastAlert = 200;
+    for (let i = 0; i < 61; i++) {
+      const res = await worker.fetch(alertReq({ ip, secret }), env as never);
+      lastAlert = res.status;
+    }
+    expect(lastAlert).toBe(429); // alert budget is now exhausted
+    // A dismiss for the same identity still succeeds — separate budget.
+    const dRes = await worker.fetch(dismissReq({ ip, secret }), env as never);
+    expect(dRes.status).toBe(200);
+  });
+
+  test('a permanent token rejection is surfaced as tokenInvalid:true (502)', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    appleStatus = 400;
+    appleBody = '{"reason":"BadDeviceToken"}';
+    const res = await worker.fetch(alertReq({ ip: '198.51.100.60', secret }), env as never);
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { success: boolean; error?: string; tokenInvalid?: boolean };
+    expect(json.success).toBe(false);
+    expect(json.tokenInvalid).toBe(true);
+    expect(json.error).toContain('BadDeviceToken'); // reason kept for the Phase 1 classifier
+  });
+
+  test('a transient APNS failure is NOT flagged tokenInvalid', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    appleStatus = 503;
+    appleBody = 'service unavailable';
+    const res = await worker.fetch(alertReq({ ip: '198.51.100.61', secret }), env as never);
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { tokenInvalid?: boolean };
+    expect(json.tokenInvalid).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #605. Phase 2 of epic #603 (R3). Rekeys the signaling Worker push rate limiter from per-IP (5/60s, shared across all daemons behind one NAT + alert/dismiss + per-token fan-out) to per-authenticated-identity with a raised 60/60s ceiling; gives dismiss pushes a separate budget; surfaces a permanent token rejection as a structured `tokenInvalid` flag (for Phase 6 pruning). Unauthenticated callers keep the tight per-IP fallback (incl. dismisses). Reviewed (sonnet); 2 findings fixed (unauthenticated-dismiss budget, bearer re-check). Tests: real worker.fetch + stubbed Apple host, 80 pass. Note: APNS provider-JWT over-mint (TooManyProviderTokenUpdates) needs a KV/DO-backed cache (new infra binding) — deferred as an epic follow-up. Worker redeploy happens at the epic→develop release.