### PR TITLE
Phase 3: held escalations bypass dedup + always deliver (#606)

### DIFF
--- a/packages/daemon/src/api/message-api.ts
+++ b/packages/daemon/src/api/message-api.ts
@@ -26,8 +26,9 @@ export interface MessageAPIEvents {
   /** Message finalized (no more edits expected) */
   onMessageFinalized: (messageId: UUID) => void;
 
-  /** Question detected (pass-through from OutputProcessor) */
-  onQuestion: (question: Question) => void;
+  /** Question detected (pass-through from OutputProcessor). `opts.held` marks a
+   *  load-bearing held-hook card that bypassed dedup (#603 Phase 3). */
+  onQuestion: (question: Question, opts?: { held?: boolean }) => void;
 
   /** Status changed (pass-through from OutputProcessor) */
   onStatusChange: (status: AgentStatus, context?: string) => void;
@@ -213,7 +214,15 @@ export class MessageAPI {
    * Emit a question, deduping against recent emissions. See QuestionDedup
    * for upgrade rules.
    */
-  handleQuestion(question: Question): void {
+  handleQuestion(question: Question, opts?: { held?: boolean }): void {
+    // A HELD escalation (Model B, #573) bypasses the content-dedup: its card is
+    // load-bearing — it registers the question that makes the held hook
+    // answerable — not a PTY/hook echo. Deduping it away would leave the hook
+    // held with no answerable question until it fails open (#603 Phase 3, R7).
+    if (opts?.held) {
+      this.events.onQuestion?.(question, opts);
+      return;
+    }
     if (!this.questionDedup.shouldEmit(question)) return;
     this.events.onQuestion?.(question);
   }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -37,13 +37,23 @@
 import { MAIN_AGENT_ID } from '@remi/shared';
 import type { AgentStatus, Question } from '@remi/shared';
 
+export interface PushOptions {
+  /**
+   * This is a HELD escalation (Model B, #573). Its card is LOAD-BEARING — it
+   * registers the question that makes the held hook answerable — not a cosmetic
+   * PTY/hook echo. So it must BYPASS the content-dedup and deliver to the lock
+   * screen even when a client is attached (it may be backgrounded). #603 Phase 3.
+   */
+  held?: boolean;
+}
+
 /**
  * Callable sink: the tracker's only output. Called when a push to iOS
  * should fire. Implementations forward to `MessageAPI.handleQuestion`,
  * which applies the content-identity QuestionDedup before the network
- * layer.
+ * layer — unless `opts.held` marks the load-bearing held-hook card.
  */
-export type PushQuestion = (question: Question) => void;
+export type PushQuestion = (question: Question, opts?: PushOptions) => void;
 
 /** Pending-hook map key: the prompt's agent, or MAIN_AGENT_ID for the primary. */
 function agentKey(question: Question): string {
@@ -180,7 +190,9 @@ export class QuestionPresenceTracker {
     this.pending.delete(recordKey);
     this.pushedHeldIds.add(questionId);
     try {
-      this.push(question);
+      // held: bypass the cosmetic dedup + deliver regardless of an attached
+      // client — the held card is load-bearing for answerability (#603 Phase 3).
+      this.push(question, { held: true });
     } catch (err) {
       console.error(
         `[QuestionPresenceTracker] pushHeldHook push sink threw: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1130,7 +1130,7 @@ async function createNewSession(
   // screen presence: hooks record (no push), PTY confirms (push). Status
   // transitions out of 'waiting' drop pending records so auto-approve
   // silent paths never push.
-  const tracker = new QuestionPresenceTracker((q) => messageApi.handleQuestion(q));
+  const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts));
 
   const outputProcessor = new OutputProcessor(
     { sessionId, streamStatusOnly: true },

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -248,8 +248,16 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     const active = sessionRegistry.getQuestion(session.sessionId, questionId);
     if (active === null) {
       const pendingIds = [...session.currentQuestions.keys()];
+      // #603 Phase 3: the question is gone from the registry (evicted under the
+      // pending-question cap, or already removed), but its PermissionRequest hook
+      // may STILL be held (Model B). Pop that hold to passthrough so Claude
+      // renders its native prompt and unblocks NOW, rather than stalling to
+      // hold_timeout. The answer itself is stale (we no longer hold the options
+      // to map it), so it is still refused — but the terminal can take over.
+      const freedHeld = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
+      if (freedHeld) cancelAutoApprove?.(session.sessionId, 'user-answered-stale');
       log(
-        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
+        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]${freedHeld ? ' (freed an orphaned held hook -> passthrough)' : ''}`,
       );
       if (!viaRelay) {
         send(

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -118,7 +118,7 @@ export function createMessageApiForSession(
     onMessageFinalized: (msgId) => {
       log(`Message ${msgId} finalized`);
     },
-    onQuestion: (question: Question) => {
+    onQuestion: (question: Question, opts?: { held?: boolean }) => {
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
       const claudeSessionId = getClaudeSessionId?.() ?? undefined;
@@ -133,10 +133,12 @@ export function createMessageApiForSession(
       sendAndRecord(msg);
       sessionRegistry.addQuestion(questionSessionId, question);
 
-      // Push only when no client is attached; attached clients see it in-app.
-      // maybePush records the delivery outcome (epic #603 Phase 1) for the gate
-      // to probe; the regular question path does not await it.
-      void notifications.maybePush(questionSessionId, question);
+      // Push: a non-held question only pushes when no client is attached (the
+      // client sees it in-app). A HELD escalation (#603 Phase 3) always also
+      // pushes to the lock screen — the attached client may be backgrounded.
+      // maybePush records the delivery outcome (#603 Phase 1) for the gate to
+      // probe; the regular question path does not await it.
+      void notifications.maybePush(questionSessionId, question, { held: opts?.held === true });
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -225,30 +225,44 @@ export class NotificationDispatcher {
    * delivery (the regular PTY-prompt path) can ignore the returned promise; the
    * recording still happens.
    */
-  maybePush(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
-    const outcome = this.computeDelivery(questionSessionId, question);
+  maybePush(
+    questionSessionId: UUID,
+    question: Question,
+    opts: { held?: boolean } = {},
+  ): Promise<DeliveryOutcome> {
+    const outcome = this.computeDelivery(questionSessionId, question, opts.held ?? false);
     this.recordDelivery(question.id, outcome);
     return outcome;
   }
 
   /** Resolve the delivery outcome for one question (fanning out the per-token
-   *  pushes when a push is actually warranted). See `DeliveryOutcome`. */
-  private computeDelivery(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
+   *  pushes when a push is actually warranted). See `DeliveryOutcome`. A HELD
+   *  escalation (#603 Phase 3) skips the attached-client short-circuit and the
+   *  dedup gate — its lock-screen card is load-bearing. */
+  private computeDelivery(
+    questionSessionId: UUID,
+    question: Question,
+    held: boolean,
+  ): Promise<DeliveryOutcome> {
     const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
 
     const sessionForPush = sessionRegistry.getSession(questionSessionId);
     const hasActiveClient =
       sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-    // A client is attached: it sees the question in-app over the WebSocket. No
-    // push (as before), but the user IS reachable -> in_app.
-    if (hasActiveClient) return Promise.resolve('in_app');
-    // No client AND no device tokens: there is no channel to notify anyone.
+    // A non-held question with a client attached: it is seen in-app over the
+    // WebSocket; no push (as before), and the user IS reachable -> in_app. A HELD
+    // escalation does NOT short-circuit here — it also pushes to the lock screen
+    // because the attached client may be backgrounded (#603 Phase 3), like
+    // dismiss(). Its outcome still reports in_app (reachable) below.
+    if (!held && hasActiveClient) return Promise.resolve('in_app');
+    // No device tokens: nobody can be pushed. If a client is attached the user
+    // is still reachable in-app (held case); otherwise there is no channel.
     if (deviceTokens.size === 0) {
-      log(`Push skipped: no device tokens for session ${questionSessionId}`);
-      return Promise.resolve('no_channel');
+      if (!hasActiveClient) log(`Push skipped: no device tokens for session ${questionSessionId}`);
+      return Promise.resolve(hasActiveClient ? 'in_app' : 'no_channel');
     }
 
-    if (!this.pushDedup.shouldPush(question)) {
+    if (!held && !this.pushDedup.shouldPush(question)) {
       log(`Push suppressed by dedup for session ${questionSessionId}`);
       // An identical push already went out; the earlier one is the delivery.
       return Promise.resolve('deduped');
@@ -279,8 +293,12 @@ export class NotificationDispatcher {
     const perToken = [...deviceTokens.values()].map((dt) =>
       this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
     );
-    // Delivered if ANY registered device accepted the push.
-    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+    const pushed = Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+    // A HELD escalation with an attached client is reachable in-app regardless
+    // of the APNS result, so report `in_app` (delivered) — but the push still
+    // fired above to cover a backgrounded client (#603 Phase 3). Otherwise the
+    // outcome IS the push result: delivered if ANY device accepted it.
+    return held && hasActiveClient ? pushed.then((): DeliveryOutcome => 'in_app') : pushed;
   }
 
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -293,12 +293,15 @@ export class NotificationDispatcher {
     const perToken = [...deviceTokens.values()].map((dt) =>
       this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
     );
-    const pushed = Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
-    // A HELD escalation with an attached client is reachable in-app regardless
-    // of the APNS result, so report `in_app` (delivered) — but the push still
-    // fired above to cover a backgrounded client (#603 Phase 3). Otherwise the
-    // outcome IS the push result: delivered if ANY device accepted it.
-    return held && hasActiveClient ? pushed.then((): DeliveryOutcome => 'in_app') : pushed;
+    // Delivered if ANY registered device accepted the push. For a HELD
+    // escalation we gate on THIS push result — not on socket-attachment —
+    // because the attached client may be backgrounded (that is WHY we push). A
+    // failed push therefore fails the hold open fast rather than stalling on an
+    // unreliable `in_app`; the in-app answer path still works, routing via the
+    // PTY to the native prompt after fail-open. (The no-token branch above falls
+    // back to the socket signal since there is no push channel at all; Phase 7's
+    // presence signal hardens that remaining `in_app` trust.)
+    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
   }
 
   /**

--- a/packages/daemon/tests/message-api.test.ts
+++ b/packages/daemon/tests/message-api.test.ts
@@ -281,6 +281,28 @@ describe('MessageAPI', () => {
       expect(survivor.id).toBe('q-1');
     });
 
+    test('a held question bypasses dedup and forwards the held flag (#603 Phase 3)', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Allow Bash: ls',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+      const q2 = { ...q1, id: 'q-2' };
+
+      api.handleQuestion(q1); // emits
+      // Identical content -> would normally be deduped, but held is load-bearing.
+      api.handleQuestion(q2, { held: true });
+
+      expect(events.onQuestion).toHaveBeenCalledTimes(2);
+      expect(events.onQuestion.mock.calls[1]?.[1]).toEqual({ held: true });
+    });
+
     test('emits upgrade when later question has more options', () => {
       const hookQ = {
         id: 'q-hook',

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -449,6 +449,87 @@ describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
   });
 });
 
+describe('NotificationDispatcher held escalation (#603 Phase 3)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: string[];
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  const capturePush: PushFn = async (_url, token) => {
+    pushed.push(token);
+  };
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn: capturePush,
+      },
+      SID,
+    );
+  }
+  const addToken = (t: string): void => {
+    deviceTokens.set(t, { token: t, platform: 'ios', registeredAt: 1, connectionId: SID });
+  };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a held escalation pushes to the lock screen EVEN when a client is attached', async () => {
+    register(true); // client attached
+    addToken('a');
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    // Pushed despite the attached client (it may be backgrounded), and still
+    // reported reachable in-app.
+    expect(pushed).toEqual(['a']);
+    expect(outcome).toBe('in_app');
+  });
+
+  test('a non-held push with a client attached still does NOT push (unchanged)', async () => {
+    register(true);
+    addToken('a');
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pushed).toEqual([]);
+    expect(outcome).toBe('in_app');
+  });
+
+  test('a held escalation bypasses dedup: a second identical held push still fires', async () => {
+    register(false);
+    addToken('a');
+    const d = make();
+    await d.maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    await d.maybePush(SID, question('q2', [yesOpt, noOpt]), { held: true }); // same shape
+    expect(pushed).toEqual(['a', 'a']); // both fired — not deduped
+  });
+
+  test('a held escalation with no client and no token is no_channel (no false confirm)', async () => {
+    register(false);
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    expect(pushed).toEqual([]);
+    expect(outcome).toBe('no_channel');
+  });
+});
+
 describe('isRetriablePushError / isDelivered (#603 Phase 1)', () => {
   test('permanent APNS token rejections are NOT retriable (even wrapped as 502)', () => {
     expect(

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -499,10 +499,31 @@ describe('NotificationDispatcher held escalation (#603 Phase 3)', () => {
     register(true); // client attached
     addToken('a');
     const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
-    // Pushed despite the attached client (it may be backgrounded), and still
-    // reported reachable in-app.
+    // Pushed despite the attached client (it may be backgrounded), and the
+    // outcome gates on the PUSH result, not the socket -> 'pushed'.
     expect(pushed).toEqual(['a']);
-    expect(outcome).toBe('in_app');
+    expect(outcome).toBe('pushed');
+  });
+
+  test('a held escalation with an attached client whose push FAILS reports failed (no false in_app)', async () => {
+    register(true); // client attached, but...
+    addToken('a');
+    const failPush: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    const d = new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn: failPush,
+      },
+      SID,
+    );
+    // The attached client may be backgrounded, so a dead token must NOT mask as
+    // in_app — it reports failed so the held hook fails open fast (#603 Phase 3).
+    expect(await d.maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true })).toBe('failed');
   });
 
   test('a non-held push with a client attached still does NOT push (unchanged)', async () => {


### PR DESCRIPTION
Closes #606. Phase 3 of epic #603 (R7). A held escalation's card is load-bearing (it registers the question that makes the held hook answerable), but it flowed through the same content-dedup + attached-client short-circuit as a cosmetic echo — so it could be deduped away (your logs show `[QuestionDedup] Suppressed` + `Push suppressed by dedup`) or suppressed for a backgrounded-but-attached client. Fix: thread a `held` flag through pushHeldHook -> handleQuestion -> onQuestion -> maybePush; held bypasses both dedups, always pushes to the lock screen, and gates delivery on the push result (a failed push fails the hold open fast, not a false in_app). Plus a cheap answer-path safety: an answer for an evicted-but-still-held question pops the hold to passthrough instead of STALE_ANSWER. Reviewed (sonnet, no >=80 findings); addressed the in_app-masks-failed-push concern. Tests NO MOCKS, 145+ pass. Registry-eviction->gate-notify (#606) targets an effectively-unreachable 8-concurrent-main-holds state (subagents default-deny, main blocks sequentially) — covered defensively by the answer-path fail-open + Phase 1's fast fail-open; documented.