### PR TITLE
Epic #603 Milestone 1: notification-delivery robustness (Phases 1+2+3)

### DIFF
--- a/packages/daemon/src/api/message-api.ts
+++ b/packages/daemon/src/api/message-api.ts
@@ -26,8 +26,9 @@ export interface MessageAPIEvents {
   /** Message finalized (no more edits expected) */
   onMessageFinalized: (messageId: UUID) => void;
 
-  /** Question detected (pass-through from OutputProcessor) */
-  onQuestion: (question: Question) => void;
+  /** Question detected (pass-through from OutputProcessor). `opts.held` marks a
+   *  load-bearing held-hook card that bypassed dedup (#603 Phase 3). */
+  onQuestion: (question: Question, opts?: { held?: boolean }) => void;
 
   /** Status changed (pass-through from OutputProcessor) */
   onStatusChange: (status: AgentStatus, context?: string) => void;
@@ -213,7 +214,15 @@ export class MessageAPI {
    * Emit a question, deduping against recent emissions. See QuestionDedup
    * for upgrade rules.
    */
-  handleQuestion(question: Question): void {
+  handleQuestion(question: Question, opts?: { held?: boolean }): void {
+    // A HELD escalation (Model B, #573) bypasses the content-dedup: its card is
+    // load-bearing — it registers the question that makes the held hook
+    // answerable — not a PTY/hook echo. Deduping it away would leave the hook
+    // held with no answerable question until it fails open (#603 Phase 3, R7).
+    if (opts?.held) {
+      this.events.onQuestion?.(question, opts);
+      return;
+    }
     if (!this.questionDedup.shouldEmit(question)) return;
     this.events.onQuestion?.(question);
   }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -37,13 +37,23 @@
 import { MAIN_AGENT_ID } from '@remi/shared';
 import type { AgentStatus, Question } from '@remi/shared';
 
+export interface PushOptions {
+  /**
+   * This is a HELD escalation (Model B, #573). Its card is LOAD-BEARING — it
+   * registers the question that makes the held hook answerable — not a cosmetic
+   * PTY/hook echo. So it must BYPASS the content-dedup and deliver to the lock
+   * screen even when a client is attached (it may be backgrounded). #603 Phase 3.
+   */
+  held?: boolean;
+}
+
 /**
  * Callable sink: the tracker's only output. Called when a push to iOS
  * should fire. Implementations forward to `MessageAPI.handleQuestion`,
  * which applies the content-identity QuestionDedup before the network
- * layer.
+ * layer — unless `opts.held` marks the load-bearing held-hook card.
  */
-export type PushQuestion = (question: Question) => void;
+export type PushQuestion = (question: Question, opts?: PushOptions) => void;
 
 /** Pending-hook map key: the prompt's agent, or MAIN_AGENT_ID for the primary. */
 function agentKey(question: Question): string {
@@ -180,7 +190,9 @@ export class QuestionPresenceTracker {
     this.pending.delete(recordKey);
     this.pushedHeldIds.add(questionId);
     try {
-      this.push(question);
+      // held: bypass the cosmetic dedup + deliver regardless of an attached
+      // client — the held card is load-bearing for answerability (#603 Phase 3).
+      this.push(question, { held: true });
     } catch (err) {
       console.error(
         `[QuestionPresenceTracker] pushHeldHook push sink threw: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -342,8 +342,18 @@ export class AutoApproveGate {
    */
   private armDeliveryGate(qid: UUID): void {
     const confirmMs = this.deps.deliveryConfirmMs ?? 0;
+    if (confirmMs <= 0) return; // delivery gating disabled (legacy hold to holdMs)
     const probe = this.deps.awaitDelivery?.(qid);
-    if (confirmMs <= 0 || !probe) return;
+    if (!probe) {
+      // Gating is ON but no delivery signal was recorded for this question —
+      // either awaitDelivery is unwired, or onHeldEscalate threw before maybePush
+      // ran (its throw is swallowed as a cosmetic cue). Fall back to the legacy
+      // hold, but log it: a silently-skipped gate could still stall to holdMs.
+      log(
+        `[AutoApprove ${this.sessionTag}] No delivery signal for ${qid.slice(0, 8)}; delivery gate skipped (holding to hold_timeout)`,
+      );
+      return;
+    }
     const timeout = new Promise<'timeout'>((resolve) => {
       const t = setTimeout(() => resolve('timeout'), confirmMs);
       t.unref?.();

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -30,6 +30,7 @@ import type { UUID } from '@remi/shared';
 import type { QuestionPresenceTracker } from '../api/question-presence-tracker.ts';
 import { log, logError } from '../cli/logger.ts';
 import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
+import { type DeliveryOutcome, isDelivered } from '../notifications/notification-dispatcher.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
@@ -126,6 +127,23 @@ export interface AutoApproveGateDeps {
    *  late verdict then resolves the held hook. <=0 (or absent) disables Part B
    *  entirely — the eval/timer race never arms, so behavior reverts to A+C. */
   pushHoldMs?: number;
+  /**
+   * Probe a held escalation's notification delivery outcome (epic #603 Phase 1,
+   * R1/R2). Returns the promise `NotificationDispatcher.maybePush` recorded for
+   * `questionId`, or undefined when no push was attempted. The gate races it
+   * against `deliveryConfirmMs`: a hold whose notification is never confirmed
+   * delivered no longer blocks Claude for the full `holdMs` — it fails open fast
+   * (or holds a short secondary window, `holdUnconfirmedMs`). Absent => delivery
+   * gating disabled (legacy: hold to holdMs regardless of delivery). */
+  awaitDelivery?: (questionId: UUID) => Promise<DeliveryOutcome> | undefined;
+  /** Milliseconds to wait for a held escalation's delivery to be confirmed
+   *  before treating it as undeliverable (epic #603 Phase 1). <=0 (or absent)
+   *  disables delivery gating. From `auto_approve.delivery_confirm_timeout`. */
+  deliveryConfirmMs?: number;
+  /** Milliseconds to keep holding an UNDELIVERED escalation instead of failing
+   *  open immediately (epic #603 Phase 1, D2 — hold-always-no-phone). <=0 (or
+   *  absent) => fail open fast. From `auto_approve.hold_unconfirmed_timeout`. */
+  holdUnconfirmedMs?: number;
 }
 
 /** A held PermissionRequest hook awaiting a user answer (#573). The `resolve`
@@ -282,25 +300,104 @@ export class AutoApproveGate {
     this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
     const decision = new Promise<PermissionDecision>((resolve) => {
       const timer = setTimeout(() => {
-        // Fail open: the user did not answer within the hold window, so let
-        // Claude render its native prompt (the local terminal can take over).
-        this.pendingHolds.delete(qid);
-        log(
-          `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} timed out -> passthrough`,
-        );
-        // The pushed card is now stale (Claude will render its own prompt); tell
-        // every client to dismiss it BEFORE failing open (#585, P7), and drop the
-        // registry entry so no ghost card replays. Throw-safe.
-        this.notifyResolved(qid, 'cancelled');
-        this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
-        resolve('passthrough');
+        this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} timed out -> passthrough`);
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;
       // unref so a held hook never blocks daemon shutdown.
       timer.unref?.();
       this.pendingHolds.set(qid, { resolve, timer });
     });
+    // Phase 1 (#603, R1/R2): gate the hold on CONFIRMED delivery. A held hook is
+    // only worth blocking Claude for if the user can actually be notified; if
+    // the notification is not confirmed delivered within delivery_confirm_timeout
+    // (e.g. a dead device token), fail open fast instead of stalling for holdMs.
+    this.armDeliveryGate(qid);
     return { decision, questionId: qid };
+  }
+
+  /**
+   * Fail a held hook OPEN to passthrough (#573 hold-timeout / #603 undeliverable):
+   * dismiss the now-stale pushed card on every client, drop the registry entry,
+   * and resolve the hook so Claude renders its native prompt and the local
+   * terminal can take over. No-op when the hold is already gone (answered, Part-B
+   * verdict, cancelled) so it never double-resolves.
+   */
+  private failOpenHeld(qid: UUID, logMessage: string): void {
+    if (!this.pendingHolds.has(qid)) return;
+    log(`[AutoApprove ${this.sessionTag}] ${logMessage}`);
+    // Dismiss the stale card everywhere BEFORE resolving (#585, P7); releaseHeld
+    // then clears the timer, drops the registry entry, and resolves passthrough.
+    this.notifyResolved(qid, 'cancelled');
+    this.releaseHeld(qid, 'passthrough');
+  }
+
+  /**
+   * Race a held escalation's notification delivery against `deliveryConfirmMs`
+   * (epic #603 Phase 1). If delivery is confirmed (in_app / pushed / deduped) in
+   * time, the hold keeps blocking to `holdMs` as before. If it is NOT confirmed
+   * — a dead token, no registered token, or the probe times out — the hold no
+   * longer stalls Claude for the full window: `onDeliveryUnconfirmed` fails it
+   * open fast (or re-arms a short secondary hold). Disabled (legacy hold) when
+   * `deliveryConfirmMs <= 0` or no delivery signal was recorded for `qid`.
+   */
+  private armDeliveryGate(qid: UUID): void {
+    const confirmMs = this.deps.deliveryConfirmMs ?? 0;
+    const probe = this.deps.awaitDelivery?.(qid);
+    if (confirmMs <= 0 || !probe) return;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      const t = setTimeout(() => resolve('timeout'), confirmMs);
+      t.unref?.();
+    });
+    Promise.race([probe, timeout])
+      .then((result) => {
+        // The hold may already be resolved (user answered, Part-B verdict, or a
+        // cancel) — then there is nothing to gate.
+        if (!this.pendingHolds.has(qid)) return;
+        if (result !== 'timeout' && isDelivered(result)) return; // confirmed: keep holding
+        this.onDeliveryUnconfirmed(qid, result);
+      })
+      .catch((err) => {
+        logError(
+          `[AutoApprove ${this.sessionTag}] delivery probe threw (treating as unconfirmed):`,
+          err,
+        );
+        if (this.pendingHolds.has(qid)) this.onDeliveryUnconfirmed(qid, 'failed');
+      });
+  }
+
+  /**
+   * A held escalation's notification was NOT confirmed delivered (epic #603
+   * Phase 1). Default (hybrid): fail open NOW so the local terminal can answer,
+   * instead of blocking Claude for the full `holdMs` on a notification nobody
+   * received. When `holdUnconfirmedMs > 0` (D2 hold-always-no-phone): re-arm the
+   * hold to a SHORT secondary window so a transient failure can recover before
+   * fail-open. Either path is LOUD (logError) so an undelivered notification is
+   * never a silent stall.
+   */
+  private onDeliveryUnconfirmed(qid: UUID, reason: DeliveryOutcome | 'timeout'): void {
+    if (!this.pendingHolds.has(qid)) return;
+    const holdUnconfirmedMs = this.deps.holdUnconfirmedMs ?? 0;
+    if (holdUnconfirmedMs > 0) {
+      const hold = this.pendingHolds.get(qid);
+      if (!hold) return;
+      clearTimeout(hold.timer);
+      const timer = setTimeout(() => {
+        this.failOpenHeld(
+          qid,
+          `Held hook ${qid.slice(0, 8)} still undelivered (${reason}); short hold expired -> passthrough`,
+        );
+      }, holdUnconfirmedMs);
+      timer.unref?.();
+      this.pendingHolds.set(qid, { resolve: hold.resolve, timer });
+      logError(
+        `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNCONFIRMED (${reason}); holding ${Math.round(holdUnconfirmedMs / 1000)}s (hold_unconfirmed_timeout) with retry before fail-open`,
+      );
+      return;
+    }
+    logError(
+      `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNDELIVERED (${reason}); failing open to passthrough so the terminal can answer (no notification reached your devices)`,
+    );
+    this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} undelivered -> passthrough`);
   }
 
   /**

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -333,8 +333,9 @@ export class AutoApproveGate {
 
   /**
    * Race a held escalation's notification delivery against `deliveryConfirmMs`
-   * (epic #603 Phase 1). If delivery is confirmed (in_app / pushed / deduped) in
-   * time, the hold keeps blocking to `holdMs` as before. If it is NOT confirmed
+   * (epic #603 Phase 1). If delivery is confirmed (`isDelivered`: in_app / pushed
+   * — `deduped` does NOT count, and never occurs for held pushes after Phase 3)
+   * in time, the hold keeps blocking to `holdMs` as before. If it is NOT confirmed
    * — a dead token, no registered token, or the probe times out — the hold no
    * longer stalls Claude for the full window: `onDeliveryUnconfirmed` fails it
    * open fast (or re-arms a short secondary hold). Disabled (legacy hold) when

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -212,4 +212,30 @@ export interface AutoApproveConfig {
    * `hold_timeout` so the early-push window opens before the hold itself expires.
    */
   readonly push_hold_timeout: number;
+  /**
+   * Seconds to wait for a held escalation's notification to be CONFIRMED
+   * delivered before deciding the hold is undeliverable (epic #603 Phase 1,
+   * R1/R2). A binary escalation holds the PermissionRequest hook (Model B) only
+   * makes sense if the user can actually be notified; delivery is "confirmed"
+   * when a client is attached (in-app), an APNS push returns 2xx, or an
+   * identical push was already sent (deduped). If NONE confirm within this
+   * window — e.g. a dead device token (BadDeviceToken) or no registered token on
+   * this daemon — the hold no longer blocks Claude for the full `hold_timeout`;
+   * it fails open fast to passthrough (native prompt) unless
+   * `hold_unconfirmed_timeout` is set. 0 disables delivery gating (legacy: hold
+   * to `hold_timeout` regardless of delivery). Default 6.
+   */
+  readonly delivery_confirm_timeout: number;
+  /**
+   * Seconds to keep holding a binary escalation whose notification delivery was
+   * NOT confirmed within `delivery_confirm_timeout` (epic #603 Phase 1, D2 —
+   * the "hold-always-no-phone" two-tier escape). 0 (default) = fail open
+   * immediately when delivery is unconfirmed (the hybrid default: let the local
+   * terminal answer). > 0 = instead hold to this SHORT secondary timeout (e.g.
+   * 180) so a transient delivery failure can recover via retries before the hook
+   * fails open — for users who run headless and want the hook to wait for their
+   * phone even when no client is currently reachable. Always far below
+   * `hold_timeout` so an undeliverable hold can never stall for the full window.
+   */
+  readonly hold_unconfirmed_timeout: number;
 }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1130,7 +1130,7 @@ async function createNewSession(
   // screen presence: hooks record (no push), PTY confirms (push). Status
   // transitions out of 'waiting' drop pending records so auto-approve
   // silent paths never push.
-  const tracker = new QuestionPresenceTracker((q) => messageApi.handleQuestion(q));
+  const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts));
 
   const outputProcessor = new OutputProcessor(
     { sessionId, streamStatusOnly: true },

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1199,6 +1199,16 @@ async function createNewSession(
         // native prompt immediately (the pre-0.6.12 behavior). 0 => no hold.
         holdTimeoutSec: autoApproveService ? remiConfig.auto_approve.hold_timeout : 0,
         pushHoldTimeoutSec: autoApproveService ? remiConfig.auto_approve.push_hold_timeout : 0,
+        // #603 Phase 1: gate a held hook on confirmed notification delivery. Same
+        // AA-enabled guard as holdTimeoutSec — gating is only meaningful when the
+        // gate can hold. The dispatcher records the per-question delivery outcome.
+        awaitDelivery: (questionId) => notifications.awaitDelivery(questionId),
+        deliveryConfirmSec: autoApproveService
+          ? remiConfig.auto_approve.delivery_confirm_timeout
+          : 0,
+        holdUnconfirmedSec: autoApproveService
+          ? remiConfig.auto_approve.hold_unconfirmed_timeout
+          : 0,
         // #585: a held question the gate resolves without a user answer dismisses
         // its pushed card on every client.
         broadcastQuestionResolved: onQuestionResolved,

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -248,8 +248,16 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     const active = sessionRegistry.getQuestion(session.sessionId, questionId);
     if (active === null) {
       const pendingIds = [...session.currentQuestions.keys()];
+      // #603 Phase 3: the question is gone from the registry (evicted under the
+      // pending-question cap, or already removed), but its PermissionRequest hook
+      // may STILL be held (Model B). Pop that hold to passthrough so Claude
+      // renders its native prompt and unblocks NOW, rather than stalling to
+      // hold_timeout. The answer itself is stale (we no longer hold the options
+      // to map it), so it is still refused — but the terminal can take over.
+      const freedHeld = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
+      if (freedHeld) cancelAutoApprove?.(session.sessionId, 'user-answered-stale');
       log(
-        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]`,
+        `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]${freedHeld ? ' (freed an orphaned held hook -> passthrough)' : ''}`,
       );
       if (!viaRelay) {
         send(

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -55,6 +55,7 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type { HookServer } from '../../hooks/index.ts';
 import { classifySessionEvent } from '../../hooks/session-lock-classifier.ts';
+import type { DeliveryOutcome } from '../../notifications/notification-dispatcher.ts';
 import { claudeChildLooksAlive } from '../../session/index.ts';
 import type {
   SessionBindingStore,
@@ -140,6 +141,25 @@ export interface HookBridgeDeps {
    * Part B disabled (the eval/timer race never arms).
    */
   pushHoldTimeoutSec?: number;
+  /**
+   * Probe a held escalation's notification delivery outcome (epic #603 Phase 1).
+   * Wired from this session's `NotificationDispatcher.awaitDelivery`. Lets the
+   * gate fail a hold open fast when no notification reached the user instead of
+   * blocking for the full hold_timeout. Absent => delivery gating disabled.
+   */
+  awaitDelivery?: (questionId: UUID) => Promise<DeliveryOutcome> | undefined;
+  /**
+   * Seconds to wait for a held escalation's delivery to be confirmed before
+   * treating it as undeliverable (epic #603 Phase 1). From
+   * `config.auto_approve.delivery_confirm_timeout`. 0 / absent => no gating.
+   */
+  deliveryConfirmSec?: number;
+  /**
+   * Seconds to keep holding an UNDELIVERED escalation instead of failing open
+   * immediately (epic #603 Phase 1, D2 hold-always-no-phone). From
+   * `config.auto_approve.hold_unconfirmed_timeout`. 0 / absent => fail open fast.
+   */
+  holdUnconfirmedSec?: number;
   /**
    * Cross-client question dismissal (#585, P7). Called by the gate when a HELD
    * question resolves WITHOUT a user answer (Part-B late verdict, hold timeout,
@@ -838,6 +858,11 @@ export function setupHookBridge(
       alwaysEscalateTools: deps.alwaysEscalateTools ?? new Set<string>(),
       holdMs: (deps.holdTimeoutSec ?? 0) * 1000,
       pushHoldMs: (deps.pushHoldTimeoutSec ?? 0) * 1000,
+      // #603 Phase 1: gate a held hook on confirmed notification delivery, so a
+      // dead push channel fails open fast instead of stalling for holdMs.
+      ...(deps.awaitDelivery ? { awaitDelivery: deps.awaitDelivery } : {}),
+      deliveryConfirmMs: (deps.deliveryConfirmSec ?? 0) * 1000,
+      holdUnconfirmedMs: (deps.holdUnconfirmedSec ?? 0) * 1000,
     },
     sessionId,
   );

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -118,7 +118,7 @@ export function createMessageApiForSession(
     onMessageFinalized: (msgId) => {
       log(`Message ${msgId} finalized`);
     },
-    onQuestion: (question: Question) => {
+    onQuestion: (question: Question, opts?: { held?: boolean }) => {
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
       const claudeSessionId = getClaudeSessionId?.() ?? undefined;
@@ -133,10 +133,12 @@ export function createMessageApiForSession(
       sendAndRecord(msg);
       sessionRegistry.addQuestion(questionSessionId, question);
 
-      // Push only when no client is attached; attached clients see it in-app.
-      // maybePush records the delivery outcome (epic #603 Phase 1) for the gate
-      // to probe; the regular question path does not await it.
-      void notifications.maybePush(questionSessionId, question);
+      // Push: a non-held question only pushes when no client is attached (the
+      // client sees it in-app). A HELD escalation (#603 Phase 3) always also
+      // pushes to the lock screen — the attached client may be backgrounded.
+      // maybePush records the delivery outcome (#603 Phase 1) for the gate to
+      // probe; the regular question path does not await it.
+      void notifications.maybePush(questionSessionId, question, { held: opts?.held === true });
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -134,7 +134,9 @@ export function createMessageApiForSession(
       sessionRegistry.addQuestion(questionSessionId, question);
 
       // Push only when no client is attached; attached clients see it in-app.
-      notifications.maybePush(questionSessionId, question);
+      // maybePush records the delivery outcome (epic #603 Phase 1) for the gate
+      // to probe; the regular question path does not await it.
+      void notifications.maybePush(questionSessionId, question);
     },
     onStatusChange: (status: AgentStatus, context?: string) => {
       log(`Status: ${status}${context ? ` (${context})` : ''}`);

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -194,6 +194,15 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Push + hold early if a binary main-context eval is still running after
     // this many seconds (Part B, #573). 0 disables Part B (A+C only).
     push_hold_timeout: 60,
+    // Wait this long for a held escalation's notification to be confirmed
+    // delivered before treating the hold as undeliverable (epic #603 Phase 1).
+    // On no confirmation, fail open fast instead of blocking for hold_timeout.
+    // 0 disables delivery gating (legacy: always hold to hold_timeout).
+    delivery_confirm_timeout: 6,
+    // Keep holding an undeliverable escalation for this short secondary window
+    // instead of failing open immediately (epic #603 Phase 1, D2). 0 = fail
+    // open fast (the hybrid default); > 0 = hold-always-no-phone mode.
+    hold_unconfirmed_timeout: 0,
   },
   features: {
     transcript_binder_shadow: false,
@@ -363,6 +372,26 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   ) {
     throw new Error(
       `Invalid auto_approve.push_hold_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable slow-eval push), got ${typeof cfg.push_hold_timeout === 'string' ? `string "${cfg.push_hold_timeout}"` : typeof cfg.push_hold_timeout}. Example: push_hold_timeout = 60`,
+    );
+  }
+
+  if (
+    typeof cfg.delivery_confirm_timeout !== 'number' ||
+    !Number.isFinite(cfg.delivery_confirm_timeout) ||
+    cfg.delivery_confirm_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.delivery_confirm_timeout in ${configPath}: must be a non-negative number (seconds; 0 = disable delivery gating), got ${typeof cfg.delivery_confirm_timeout === 'string' ? `string "${cfg.delivery_confirm_timeout}"` : typeof cfg.delivery_confirm_timeout}. Example: delivery_confirm_timeout = 6`,
+    );
+  }
+
+  if (
+    typeof cfg.hold_unconfirmed_timeout !== 'number' ||
+    !Number.isFinite(cfg.hold_unconfirmed_timeout) ||
+    cfg.hold_unconfirmed_timeout < 0
+  ) {
+    throw new Error(
+      `Invalid auto_approve.hold_unconfirmed_timeout in ${configPath}: must be a non-negative number (seconds; 0 = fail open fast when delivery unconfirmed), got ${typeof cfg.hold_unconfirmed_timeout === 'string' ? `string "${cfg.hold_unconfirmed_timeout}"` : typeof cfg.hold_unconfirmed_timeout}. Example: hold_unconfirmed_timeout = 180`,
     );
   }
 
@@ -839,6 +868,8 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  queue_timeout = ${config.auto_approve.queue_timeout}`);
   lines.push(`  hold_timeout = ${config.auto_approve.hold_timeout}`);
   lines.push(`  push_hold_timeout = ${config.auto_approve.push_hold_timeout}`);
+  lines.push(`  delivery_confirm_timeout = ${config.auto_approve.delivery_confirm_timeout}`);
+  lines.push(`  hold_unconfirmed_timeout = ${config.auto_approve.hold_unconfirmed_timeout}`);
   lines.push(`  disable_thinking = ${config.auto_approve.disable_thinking}`);
   lines.push(
     `  always_escalate_tools = [${config.auto_approve.always_escalate_tools.map((s) => `"${s}"`).join(', ')}]`,

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -225,30 +225,44 @@ export class NotificationDispatcher {
    * delivery (the regular PTY-prompt path) can ignore the returned promise; the
    * recording still happens.
    */
-  maybePush(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
-    const outcome = this.computeDelivery(questionSessionId, question);
+  maybePush(
+    questionSessionId: UUID,
+    question: Question,
+    opts: { held?: boolean } = {},
+  ): Promise<DeliveryOutcome> {
+    const outcome = this.computeDelivery(questionSessionId, question, opts.held ?? false);
     this.recordDelivery(question.id, outcome);
     return outcome;
   }
 
   /** Resolve the delivery outcome for one question (fanning out the per-token
-   *  pushes when a push is actually warranted). See `DeliveryOutcome`. */
-  private computeDelivery(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
+   *  pushes when a push is actually warranted). See `DeliveryOutcome`. A HELD
+   *  escalation (#603 Phase 3) skips the attached-client short-circuit and the
+   *  dedup gate — its lock-screen card is load-bearing. */
+  private computeDelivery(
+    questionSessionId: UUID,
+    question: Question,
+    held: boolean,
+  ): Promise<DeliveryOutcome> {
     const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
 
     const sessionForPush = sessionRegistry.getSession(questionSessionId);
     const hasActiveClient =
       sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-    // A client is attached: it sees the question in-app over the WebSocket. No
-    // push (as before), but the user IS reachable -> in_app.
-    if (hasActiveClient) return Promise.resolve('in_app');
-    // No client AND no device tokens: there is no channel to notify anyone.
+    // A non-held question with a client attached: it is seen in-app over the
+    // WebSocket; no push (as before), and the user IS reachable -> in_app. A HELD
+    // escalation does NOT short-circuit here — it also pushes to the lock screen
+    // because the attached client may be backgrounded (#603 Phase 3), like
+    // dismiss(). Its outcome still reports in_app (reachable) below.
+    if (!held && hasActiveClient) return Promise.resolve('in_app');
+    // No device tokens: nobody can be pushed. If a client is attached the user
+    // is still reachable in-app (held case); otherwise there is no channel.
     if (deviceTokens.size === 0) {
-      log(`Push skipped: no device tokens for session ${questionSessionId}`);
-      return Promise.resolve('no_channel');
+      if (!hasActiveClient) log(`Push skipped: no device tokens for session ${questionSessionId}`);
+      return Promise.resolve(hasActiveClient ? 'in_app' : 'no_channel');
     }
 
-    if (!this.pushDedup.shouldPush(question)) {
+    if (!held && !this.pushDedup.shouldPush(question)) {
       log(`Push suppressed by dedup for session ${questionSessionId}`);
       // An identical push already went out; the earlier one is the delivery.
       return Promise.resolve('deduped');
@@ -279,8 +293,12 @@ export class NotificationDispatcher {
     const perToken = [...deviceTokens.values()].map((dt) =>
       this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
     );
-    // Delivered if ANY registered device accepted the push.
-    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+    const pushed = Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+    // A HELD escalation with an attached client is reachable in-app regardless
+    // of the APNS result, so report `in_app` (delivered) — but the push still
+    // fired above to cover a backgrounded client (#603 Phase 3). Otherwise the
+    // outcome IS the push result: delivered if ANY device accepted it.
+    return held && hasActiveClient ? pushed.then((): DeliveryOutcome => 'in_app') : pushed;
   }
 
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -114,10 +114,14 @@ export type PushFn = typeof sendPushTrigger;
 export type DeliveryOutcome = 'in_app' | 'pushed' | 'deduped' | 'no_channel' | 'failed';
 
 /** Whether a delivery outcome means the user can actually be notified (epic
- *  #603 Phase 1). `in_app` / `pushed` / `deduped` reach the user; `no_channel` /
- *  `failed` do not, so a hold gated on delivery fails open. */
+ *  #603 Phase 1). `in_app` / `pushed` reach the user. `deduped` is deliberately
+ *  NOT treated as confirmed: PushDedup suppresses a second identical push
+ *  WITHOUT tracking whether the push it deduped against actually succeeded, so a
+ *  held hook must not keep blocking on it — fail open (always safe) instead.
+ *  (Phase 3 makes held escalations bypass dedup, so a held push is never deduped
+ *  in the first place.) `no_channel` / `failed` obviously do not reach anyone. */
 export function isDelivered(outcome: DeliveryOutcome): boolean {
-  return outcome === 'in_app' || outcome === 'pushed' || outcome === 'deduped';
+  return outcome === 'in_app' || outcome === 'pushed';
 }
 
 /** Transient push failures retried with backoff (epic #603 Phase 1). */
@@ -146,7 +150,18 @@ const sleep = (ms: number): Promise<void> =>
  */
 export function isRetriablePushError(err: unknown): boolean {
   const msg = String(err instanceof Error ? err.message : err);
-  if (/BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(msg)) return false;
+  // Permanent APNS token rejections (the Worker wraps these as HTTP 502): never
+  // retry. `Unregistered` is word-boundaried so a generic 5xx body that happens
+  // to contain the word is not misclassified as a permanent token failure.
+  if (/BadDeviceToken|DeviceTokenNotForTopic|\bUnregistered\b/i.test(msg)) return false;
+  // Network-level failures (no HTTP response received at all) are transient —
+  // a Worker cold-start, a brief flap, DNS hiccup — so retry them.
+  if (
+    err instanceof TypeError ||
+    /ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|Failed to fetch/i.test(msg)
+  ) {
+    return true;
+  }
   const m = msg.match(/failed: (\d{3})/);
   if (!m) return false;
   const status = Number(m[1]);
@@ -294,7 +309,10 @@ export class NotificationDispatcher {
           await sleep(delay);
           continue;
         }
-        log(`Push notification failed: ${err}`);
+        // Loud: a real push attempt failed (permanent token rejection, network
+        // error, or exhausted retries). This is the root cause behind a held
+        // hook's fail-open, so it must be visible at error level, not buried.
+        logError(`Push notification failed for session ${pushSessionId}: ${err}`);
         return false;
       }
     }
@@ -304,10 +322,12 @@ export class NotificationDispatcher {
    *  can `awaitDelivery` it (epic #603 Phase 1). */
   private recordDelivery(questionId: UUID, outcome: Promise<DeliveryOutcome>): void {
     this.deliveryOutcomes.set(questionId, outcome);
-    outcome.finally(() => {
-      const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
-      t.unref?.();
-    });
+    // Evict after a fixed TTL regardless of whether `outcome` ever settles: a
+    // push whose fetch hangs (unreachable Worker, no AbortSignal yet) must not
+    // leak a map entry until the OS TCP timeout. The gate probes within ms of
+    // recording, so a 60s TTL is a generous upper bound.
+    const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
+    t.unref?.();
   }
 
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -98,6 +98,61 @@ export function buildPushText(
  *  observable in tests without mocking a network module. */
 export type PushFn = typeof sendPushTrigger;
 
+/**
+ * The outcome of attempting to deliver a question's notification (epic #603
+ * Phase 1). The gate consumes this via `awaitDelivery` to decide whether a held
+ * hook should keep blocking Claude or fail open fast:
+ *   - `in_app`     a client is attached, so the question shows in-app (the only
+ *                  case where `maybePush` deliberately does NOT push — but the
+ *                  user IS reachable).
+ *   - `pushed`     at least one APNS push returned 2xx.
+ *   - `deduped`    the push was suppressed because an identical one already went
+ *                  out (the earlier push is the delivery).
+ *   - `no_channel` no client attached AND no device tokens — nobody can be told.
+ *   - `failed`     tokens exist but every push failed (e.g. BadDeviceToken).
+ */
+export type DeliveryOutcome = 'in_app' | 'pushed' | 'deduped' | 'no_channel' | 'failed';
+
+/** Whether a delivery outcome means the user can actually be notified (epic
+ *  #603 Phase 1). `in_app` / `pushed` / `deduped` reach the user; `no_channel` /
+ *  `failed` do not, so a hold gated on delivery fails open. */
+export function isDelivered(outcome: DeliveryOutcome): boolean {
+  return outcome === 'in_app' || outcome === 'pushed' || outcome === 'deduped';
+}
+
+/** Transient push failures retried with backoff (epic #603 Phase 1). */
+const MAX_PUSH_RETRIES = 2;
+/** Backoff base; attempt N waits BASE * 2^N (400ms, 800ms). Kept short so the
+ *  per-token result settles well within the gate's delivery_confirm_timeout. */
+const PUSH_RETRY_BASE_MS = 400;
+/** How long a recorded delivery outcome stays probeable before cleanup. The
+ *  gate probes within ~ms of the push; this is a generous upper bound so the
+ *  map never grows unbounded across a long-lived session. */
+const DELIVERY_OUTCOME_TTL_MS = 60_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+
+/**
+ * Whether a failed push is worth retrying (epic #603 Phase 1). The signaling
+ * Worker wraps a permanent APNS token rejection (BadDeviceToken / Unregistered /
+ * DeviceTokenNotForTopic) as an HTTP 502, so a naive "retry all 5xx" would spin
+ * on a dead token. Treat those reasons as permanent (no retry -> fail open
+ * fast); retry only a genuine rate-limit (429) or a transient 5xx with no
+ * permanent reason.
+ */
+export function isRetriablePushError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err);
+  if (/BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(msg)) return false;
+  const m = msg.match(/failed: (\d{3})/);
+  if (!m) return false;
+  const status = Number(m[1]);
+  return status === 429 || (status >= 500 && status < 600);
+}
+
 export interface NotificationDispatcherDeps {
   sessionRegistry: SessionRegistry;
   deviceTokens: Map<string, DeviceTokenEntry>;
@@ -122,6 +177,13 @@ export class NotificationDispatcher {
    *  injected an override. Fixed for the instance lifetime. */
   private readonly pushFn: PushFn;
 
+  /**
+   * Delivery outcome per question id (epic #603 Phase 1), recorded by every
+   * `maybePush` so the gate can `awaitDelivery` to decide a held hook's fate.
+   * Entries self-evict after `DELIVERY_OUTCOME_TTL_MS` so the map stays bounded.
+   */
+  private readonly deliveryOutcomes = new Map<UUID, Promise<DeliveryOutcome>>();
+
   constructor(
     private readonly deps: NotificationDispatcherDeps,
     private readonly sessionId: UUID,
@@ -141,18 +203,40 @@ export class NotificationDispatcher {
    * Push `question` to all registered devices, unless a client is actively
    * attached (they see it in-app) or the dedup gate suppresses it.
    * `questionSessionId` is the primary id the client knows (from hello_ack).
+   *
+   * Returns the resolved DELIVERY OUTCOME (epic #603 Phase 1) and records it
+   * keyed by `question.id` so a held hook can `awaitDelivery` to decide whether
+   * to keep blocking Claude or fail open fast. Callers that do not care about
+   * delivery (the regular PTY-prompt path) can ignore the returned promise; the
+   * recording still happens.
    */
-  maybePush(questionSessionId: UUID, question: Question): void {
+  maybePush(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
+    const outcome = this.computeDelivery(questionSessionId, question);
+    this.recordDelivery(question.id, outcome);
+    return outcome;
+  }
+
+  /** Resolve the delivery outcome for one question (fanning out the per-token
+   *  pushes when a push is actually warranted). See `DeliveryOutcome`. */
+  private computeDelivery(questionSessionId: UUID, question: Question): Promise<DeliveryOutcome> {
     const { sessionRegistry, deviceTokens, pushConfig } = this.deps;
 
     const sessionForPush = sessionRegistry.getSession(questionSessionId);
     const hasActiveClient =
       sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
-    if (deviceTokens.size === 0 || hasActiveClient) return;
+    // A client is attached: it sees the question in-app over the WebSocket. No
+    // push (as before), but the user IS reachable -> in_app.
+    if (hasActiveClient) return Promise.resolve('in_app');
+    // No client AND no device tokens: there is no channel to notify anyone.
+    if (deviceTokens.size === 0) {
+      log(`Push skipped: no device tokens for session ${questionSessionId}`);
+      return Promise.resolve('no_channel');
+    }
 
     if (!this.pushDedup.shouldPush(question)) {
       log(`Push suppressed by dedup for session ${questionSessionId}`);
-      return;
+      // An identical push already went out; the earlier one is the delivery.
+      return Promise.resolve('deduped');
     }
 
     const session = sessionRegistry.getSession(this.sessionId);
@@ -167,20 +251,74 @@ export class NotificationDispatcher {
     // label is empty so the button still carries something answerable.
     const pushOptions = question.options.map((o) => o.label || o.value);
     const { title, body } = buildPushText(sessionName, question);
+    const opts = {
+      title,
+      body,
+      ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+      sessionId: pushSessionId,
+      questionId: question.id,
+      ...(pushCategory !== undefined ? { category: pushCategory } : {}),
+      ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+    };
 
-    for (const dt of deviceTokens.values()) {
-      this.pushFn(cfg.signalingUrl, dt.token, {
-        title,
-        body,
-        ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
-        sessionId: pushSessionId,
-        questionId: question.id,
-        ...(pushCategory !== undefined ? { category: pushCategory } : {}),
-        ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
-      })
-        .then(() => log(`Push notification sent for session ${pushSessionId}`))
-        .catch((err) => log(`Push notification failed: ${err}`));
+    const perToken = [...deviceTokens.values()].map((dt) =>
+      this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
+    );
+    // Delivered if ANY registered device accepted the push.
+    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
+  }
+
+  /**
+   * Push to one device token, retrying a TRANSIENT failure (429 / transient
+   * 5xx) with short backoff (epic #603 Phase 1). A permanent token rejection
+   * (BadDeviceToken etc., which the Worker wraps as 502) is NOT retried — it
+   * fails fast so the gate can fail the hold open. Resolves true on a 2xx.
+   */
+  private async pushOnceWithRetry(
+    signalingUrl: string,
+    token: string,
+    opts: Parameters<PushFn>[2],
+    pushSessionId: UUID,
+  ): Promise<boolean> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.pushFn(signalingUrl, token, opts);
+        log(`Push notification sent for session ${pushSessionId}`);
+        return true;
+      } catch (err) {
+        if (isRetriablePushError(err) && attempt < MAX_PUSH_RETRIES) {
+          const delay = PUSH_RETRY_BASE_MS * 2 ** attempt;
+          log(
+            `Push transient failure (retry ${attempt + 1}/${MAX_PUSH_RETRIES} in ${delay}ms): ${err}`,
+          );
+          await sleep(delay);
+          continue;
+        }
+        log(`Push notification failed: ${err}`);
+        return false;
+      }
     }
+  }
+
+  /** Record (and schedule cleanup of) a question's delivery outcome so the gate
+   *  can `awaitDelivery` it (epic #603 Phase 1). */
+  private recordDelivery(questionId: UUID, outcome: Promise<DeliveryOutcome>): void {
+    this.deliveryOutcomes.set(questionId, outcome);
+    outcome.finally(() => {
+      const t = setTimeout(() => this.deliveryOutcomes.delete(questionId), DELIVERY_OUTCOME_TTL_MS);
+      t.unref?.();
+    });
+  }
+
+  /**
+   * The delivery outcome recorded for `questionId` by `maybePush` (epic #603
+   * Phase 1). The gate races this against `delivery_confirm_timeout` to decide a
+   * held hook's fate. `undefined` when no push was attempted for the id (e.g. the
+   * held push found no pending hook record) — the gate then keeps its legacy
+   * behavior (hold to hold_timeout) rather than failing open on a missing signal.
+   */
+  awaitDelivery(questionId: UUID): Promise<DeliveryOutcome> | undefined {
+    return this.deliveryOutcomes.get(questionId);
   }
 
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -293,12 +293,15 @@ export class NotificationDispatcher {
     const perToken = [...deviceTokens.values()].map((dt) =>
       this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, pushSessionId),
     );
-    const pushed = Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
-    // A HELD escalation with an attached client is reachable in-app regardless
-    // of the APNS result, so report `in_app` (delivered) — but the push still
-    // fired above to cover a backgrounded client (#603 Phase 3). Otherwise the
-    // outcome IS the push result: delivered if ANY device accepted it.
-    return held && hasActiveClient ? pushed.then((): DeliveryOutcome => 'in_app') : pushed;
+    // Delivered if ANY registered device accepted the push. For a HELD
+    // escalation we gate on THIS push result — not on socket-attachment —
+    // because the attached client may be backgrounded (that is WHY we push). A
+    // failed push therefore fails the hold open fast rather than stalling on an
+    // unreliable `in_app`; the in-app answer path still works, routing via the
+    // PTY to the native prompt after fail-open. (The no-token branch above falls
+    // back to the socket signal since there is no push channel at all; Phase 7's
+    // presence signal hardens that remaining `in_app` trust.)
+    return Promise.all(perToken).then((rs) => (rs.some(Boolean) ? 'pushed' : 'failed'));
   }
 
   /**

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1142,21 +1142,28 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
 
   /** A holding gate whose held escalation's delivery outcome and gating timeouts
    *  the test controls. `delivery` is what `awaitDelivery` resolves to (or
-   *  undefined for "no delivery signal recorded"). */
+   *  undefined for "no delivery signal recorded"). `evalNeverSettles` + a
+   *  `pushHoldMs` exercise the Part-B early-push path combined with the gate. */
   function deliveryGate(opts: {
     delivery: Promise<DeliveryOutcome> | undefined;
     deliveryConfirmMs?: number;
     holdUnconfirmedMs?: number;
     holdMs?: number;
+    pushHoldMs?: number;
+    evalNeverSettles?: boolean;
+    onResolved?: (questionId: UUID, reason: 'auto_approved' | 'auto_denied' | 'cancelled') => void;
   }): AutoApproveGate {
     registry.registerSession(SID, '/d', fakePTY([]), {
       handleMessage: () => {},
       handleQuestion: () => {},
       handleStatusChange: () => {},
     } as never);
+    const service: AutoApproveEvaluator = opts.evalNeverSettles
+      ? { evaluate: () => new Promise<AutoApproveResult>(() => {}), cancel: () => true }
+      : evaluator(escalate);
     return new AutoApproveGate(
       {
-        service: evaluator(escalate),
+        service,
         sessionRegistry: registry,
         tracker: new QuestionPresenceTracker(() => {}),
         isInSubagentContext: () => false,
@@ -1166,9 +1173,11 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
           return lastQuestionId;
         },
         holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
         awaitDelivery: () => opts.delivery,
         deliveryConfirmMs: opts.deliveryConfirmMs ?? 0,
         holdUnconfirmedMs: opts.holdUnconfirmedMs ?? 0,
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
         alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
       },
       SID,
@@ -1309,5 +1318,41 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     await new Promise((r) => setTimeout(r, 50)); // inside the short secondary window
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
     expect(await pending).toBe('allow');
+  });
+
+  test('a delivery outcome that resolves AFTER the hold already failed open does not double-resolve', async () => {
+    const resolved: Array<'auto_approved' | 'auto_denied' | 'cancelled'> = [];
+    const gate = deliveryGate({
+      // Resolves 'failed' well after the (short) holdMs timer has already fired.
+      delivery: new Promise<DeliveryOutcome>((r) => {
+        const t = setTimeout(() => r('failed'), 80);
+        t.unref?.();
+      }),
+      deliveryConfirmMs: 500, // longer than holdMs -> the holdMs timeout wins the fail-open
+      holdMs: 30,
+      onResolved: (_q, reason) => resolved.push(reason),
+    });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough'); // failed open via holdMs timeout
+    // Let the slow delivery probe resolve, now that the hold is already gone.
+    await new Promise((r) => setTimeout(r, 120));
+    // Exactly ONE resolution broadcast (the timeout fail-open); the late probe
+    // sees pendingHolds no longer has the id and no-ops (no spurious 2nd dismiss).
+    expect(resolved).toEqual(['cancelled']);
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('Part B early push + delivery gating: a slow eval whose push is undelivered fails open fast', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      pushHoldMs: 15, // Part B pushes + holds early at ~15ms
+      evalNeverSettles: true, // the eval never returns a verdict
+      holdMs: 60_000,
+    });
+    // Part B holds early; delivery is 'failed', so the gate fails the hold open
+    // fast (~deliveryConfirmMs) instead of waiting the 60s holdMs for a verdict
+    // that never comes.
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -9,6 +9,7 @@ import {
 import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
 import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { DeliveryOutcome } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../src/session/session-registry.ts';
 
@@ -1107,5 +1108,206 @@ describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
     g.cancelStale('SessionEnd');
     expect(await pending).toBe('passthrough');
     expect(registry.getQuestion(SID, qid)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delivery gating (#603 Phase 1, R1/R2): a held hook is only worth blocking
+// Claude for if the user can actually be notified. The gate races the held
+// escalation's notification delivery against delivery_confirm_timeout; an
+// undeliverable hold fails open FAST instead of stalling for hold_timeout.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  /** A holding gate whose held escalation's delivery outcome and gating timeouts
+   *  the test controls. `delivery` is what `awaitDelivery` resolves to (or
+   *  undefined for "no delivery signal recorded"). */
+  function deliveryGate(opts: {
+    delivery: Promise<DeliveryOutcome> | undefined;
+    deliveryConfirmMs?: number;
+    holdUnconfirmedMs?: number;
+    holdMs?: number;
+  }): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId() as UUID;
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        awaitDelivery: () => opts.delivery,
+        deliveryConfirmMs: opts.deliveryConfirmMs ?? 0,
+        holdUnconfirmedMs: opts.holdUnconfirmedMs ?? 0,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('undelivered (failed push) fails the hold open fast, not after hold_timeout', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 200,
+      holdMs: 60_000,
+    });
+    // If the hold blocked for holdMs (60s) this await would hang the test; it
+    // resolves promptly to passthrough because delivery was never confirmed.
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+    // The hold is gone (failed open): a late answer reports "no hold".
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
+  });
+
+  test('no_channel (no client, no token) fails the hold open fast', async () => {
+    const gate = deliveryGate({ delivery: Promise.resolve('no_channel'), deliveryConfirmMs: 200 });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+  });
+
+  test('a delivery probe that never resolves fails open after delivery_confirm_timeout', async () => {
+    const gate = deliveryGate({
+      delivery: new Promise<DeliveryOutcome>(() => {}),
+      deliveryConfirmMs: 40,
+      holdMs: 60_000,
+    });
+    expect(await gate.resolvePermission(pr())).toBe('passthrough');
+  });
+
+  test('confirmed delivery (pushed) keeps holding; the user answer resolves it', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('pushed'),
+      deliveryConfirmMs: 30,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 60)); // past delivery_confirm_timeout
+    expect(settled).toBe(false); // still held — delivery was confirmed
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('confirmed delivery (in_app) keeps holding', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('in_app'),
+      deliveryConfirmMs: 30,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 60));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('gating disabled (delivery_confirm_timeout = 0) keeps the legacy hold even if delivery failed', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 0,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 40));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    expect(await pending).toBe('allow');
+  });
+
+  test('no recorded delivery signal (awaitDelivery undefined) keeps the legacy hold', async () => {
+    const gate = deliveryGate({ delivery: undefined, deliveryConfirmMs: 50, holdMs: 60_000 });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 70));
+    expect(settled).toBe(false);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('hold_unconfirmed mode: an undelivered hold waits the short window, then fails open', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      holdUnconfirmedMs: 150,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    // It does NOT fail open immediately on the unconfirmed signal — it re-arms a
+    // short 150ms hold.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(settled).toBe(false);
+    // ...which then fails open (well before the 60s holdMs).
+    expect(await pending).toBe('passthrough');
+  });
+
+  test('hold_unconfirmed mode: the user can still answer during the short window', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      holdUnconfirmedMs: 500,
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 50)); // inside the short secondary window
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -56,6 +56,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -121,6 +121,8 @@ function makeConfig(timeoutSeconds: number, baseUrl?: string): AutoApproveConfig
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/llm-judgment.test.ts
+++ b/packages/daemon/tests/auto-approve/llm-judgment.test.ts
@@ -71,6 +71,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/auto-approve/run-model-sweep.ts
+++ b/packages/daemon/tests/auto-approve/run-model-sweep.ts
@@ -336,6 +336,8 @@ function makeConfig(model: string): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
   };
 }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -108,6 +108,8 @@ function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
     always_escalate_tools: [],
     hold_timeout: 0,
     push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
     ...overrides,
   };
 }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -293,6 +293,11 @@ describe('formatConfig', () => {
     expect(output).toContain('escalate_model = ""');
     // always_escalate_tools visible (#572).
     expect(output).toContain('always_escalate_tools = ["AskUserQuestion", "ExitPlanMode"]');
+    // delivery_confirm_timeout / hold_unconfirmed_timeout visible (#603 Phase 1)
+    // — guards against the #517-class regression of omitting a field from `config
+    // show`.
+    expect(output).toContain('delivery_confirm_timeout = 6');
+    expect(output).toContain('hold_unconfirmed_timeout = 0');
   });
 
   test('default model is a fast 4b; escalate_model empty (#522)', () => {
@@ -547,6 +552,31 @@ Escalate anything touching secrets.
   test('rejects a negative push_hold_timeout (#573)', () => {
     fs.writeFileSync(TEST_CONFIG, '[auto_approve]\npush_hold_timeout = -5\n');
     expect(() => loadConfig(TEST_CONFIG)).toThrow(/push_hold_timeout/);
+  });
+
+  test('rejects a negative delivery_confirm_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ndelivery_confirm_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/delivery_confirm_timeout/);
+  });
+
+  test('rejects a non-numeric delivery_confirm_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\ndelivery_confirm_timeout = "fast"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/delivery_confirm_timeout/);
+  });
+
+  test('rejects a negative hold_unconfirmed_timeout (#603)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[auto_approve]\nhold_unconfirmed_timeout = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/hold_unconfirmed_timeout/);
+  });
+
+  test('loads delivery_confirm_timeout / hold_unconfirmed_timeout from TOML (#603)', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      '[auto_approve]\ndelivery_confirm_timeout = 8\nhold_unconfirmed_timeout = 180\n',
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.delivery_confirm_timeout).toBe(8);
+    expect(config.auto_approve.hold_unconfirmed_timeout).toBe(180);
   });
 
   test('REMI_AUTO_APPROVE_HOLD_TIMEOUT / PUSH_HOLD_TIMEOUT env overrides (#573)', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -348,6 +348,8 @@ describe('auto_approve config', () => {
       always_escalate_tools: ['AskUserQuestion', 'ExitPlanMode'],
       hold_timeout: 1800,
       push_hold_timeout: 60,
+      delivery_confirm_timeout: 6,
+      hold_unconfirmed_timeout: 0,
     });
   });
 

--- a/packages/daemon/tests/message-api.test.ts
+++ b/packages/daemon/tests/message-api.test.ts
@@ -281,6 +281,28 @@ describe('MessageAPI', () => {
       expect(survivor.id).toBe('q-1');
     });
 
+    test('a held question bypasses dedup and forwards the held flag (#603 Phase 3)', () => {
+      const q1 = {
+        id: 'q-1',
+        text: 'Allow Bash: ls',
+        options: [
+          { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+          { label: 'Yes, always', value: '2', isRecommended: false, isYes: true, isNo: false },
+          { label: 'No', value: '3', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      } as const;
+      const q2 = { ...q1, id: 'q-2' };
+
+      api.handleQuestion(q1); // emits
+      // Identical content -> would normally be deduped, but held is load-bearing.
+      api.handleQuestion(q2, { held: true });
+
+      expect(events.onQuestion).toHaveBeenCalledTimes(2);
+      expect(events.onQuestion.mock.calls[1]?.[1]).toEqual({ held: true });
+    });
+
     test('emits upgrade when later question has more options', () => {
       const hookQ = {
         id: 'q-hook',

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -449,6 +449,87 @@ describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
   });
 });
 
+describe('NotificationDispatcher held escalation (#603 Phase 3)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: string[];
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  const capturePush: PushFn = async (_url, token) => {
+    pushed.push(token);
+  };
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn: capturePush,
+      },
+      SID,
+    );
+  }
+  const addToken = (t: string): void => {
+    deviceTokens.set(t, { token: t, platform: 'ios', registeredAt: 1, connectionId: SID });
+  };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a held escalation pushes to the lock screen EVEN when a client is attached', async () => {
+    register(true); // client attached
+    addToken('a');
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    // Pushed despite the attached client (it may be backgrounded), and still
+    // reported reachable in-app.
+    expect(pushed).toEqual(['a']);
+    expect(outcome).toBe('in_app');
+  });
+
+  test('a non-held push with a client attached still does NOT push (unchanged)', async () => {
+    register(true);
+    addToken('a');
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pushed).toEqual([]);
+    expect(outcome).toBe('in_app');
+  });
+
+  test('a held escalation bypasses dedup: a second identical held push still fires', async () => {
+    register(false);
+    addToken('a');
+    const d = make();
+    await d.maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    await d.maybePush(SID, question('q2', [yesOpt, noOpt]), { held: true }); // same shape
+    expect(pushed).toEqual(['a', 'a']); // both fired — not deduped
+  });
+
+  test('a held escalation with no client and no token is no_channel (no false confirm)', async () => {
+    register(false);
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+    expect(pushed).toEqual([]);
+    expect(outcome).toBe('no_channel');
+  });
+});
+
 describe('isRetriablePushError / isDelivered (#603 Phase 1)', () => {
   test('permanent APNS token rejections are NOT retriable (even wrapped as 502)', () => {
     expect(

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -499,10 +499,31 @@ describe('NotificationDispatcher held escalation (#603 Phase 3)', () => {
     register(true); // client attached
     addToken('a');
     const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
-    // Pushed despite the attached client (it may be backgrounded), and still
-    // reported reachable in-app.
+    // Pushed despite the attached client (it may be backgrounded), and the
+    // outcome gates on the PUSH result, not the socket -> 'pushed'.
     expect(pushed).toEqual(['a']);
-    expect(outcome).toBe('in_app');
+    expect(outcome).toBe('pushed');
+  });
+
+  test('a held escalation with an attached client whose push FAILS reports failed (no false in_app)', async () => {
+    register(true); // client attached, but...
+    addToken('a');
+    const failPush: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    const d = new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn: failPush,
+      },
+      SID,
+    );
+    // The attached client may be backgrounded, so a dead token must NOT mask as
+    // in_app — it reports failed so the held hook fails open fast (#603 Phase 3).
+    expect(await d.maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true })).toBe('failed');
   });
 
   test('a non-held push with a client attached still does NOT push (unchanged)', async () => {

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -6,6 +6,8 @@ import {
   NotificationDispatcher,
   type PushFn,
   buildPushText,
+  isDelivered,
+  isRetriablePushError,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -406,9 +408,91 @@ describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
     expect(calls).toBe(2);
   });
 
+  test('a retriable error exhausts MAX_PUSH_RETRIES (3 attempts) then -> failed', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const always429: PushFn = async () => {
+      calls++;
+      throw new Error('Push trigger failed: 429 rate limited');
+    };
+    expect(await make(always429).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+    expect(calls).toBe(3); // 1 initial + MAX_PUSH_RETRIES (2)
+  });
+
+  test('multi-token: one dead token + one live token still resolves pushed (the 2-token case)', async () => {
+    register(false);
+    addToken('dead');
+    addToken('live');
+    const mixedPush: PushFn = async (_url, token) => {
+      if (token === 'dead') {
+        throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+      }
+    };
+    expect(await make(mixedPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+  });
+
+  test('multi-token: every token failing resolves failed', async () => {
+    register(false);
+    addToken('a');
+    addToken('b');
+    const allFail: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(allFail).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+  });
+
   test('awaitDelivery is undefined for an unknown question id', () => {
     expect(
       make(okPush).awaitDelivery('zzzzzzzz-0000-0000-0000-000000000000' as UUID),
     ).toBeUndefined();
+  });
+});
+
+describe('isRetriablePushError / isDelivered (#603 Phase 1)', () => {
+  test('permanent APNS token rejections are NOT retriable (even wrapped as 502)', () => {
+    expect(
+      isRetriablePushError(
+        new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}'),
+      ),
+    ).toBe(false);
+    expect(
+      isRetriablePushError(new Error('Push trigger failed: 410 {"reason":"Unregistered"}')),
+    ).toBe(false);
+    expect(isRetriablePushError(new Error('Push trigger failed: 400 DeviceTokenNotForTopic'))).toBe(
+      false,
+    );
+  });
+
+  test('a transient 429 / 5xx is retriable', () => {
+    expect(isRetriablePushError(new Error('Push trigger failed: 429 rate limited'))).toBe(true);
+    expect(isRetriablePushError(new Error('Push trigger failed: 503 unavailable'))).toBe(true);
+    expect(isRetriablePushError(new Error('Push trigger failed: 500 internal'))).toBe(true);
+  });
+
+  test('network-level errors (no HTTP response) are retriable', () => {
+    expect(isRetriablePushError(new TypeError('Failed to fetch'))).toBe(true);
+    expect(isRetriablePushError(new Error('connect ECONNREFUSED 127.0.0.1:8787'))).toBe(true);
+    expect(isRetriablePushError(new Error('getaddrinfo ENOTFOUND remi-signaling'))).toBe(true);
+  });
+
+  test('a permanent reason wins even if the message also carries a 5xx status', () => {
+    // The Worker wraps a BadDeviceToken as 502; the permanent reason must take
+    // precedence over the retriable 5xx status.
+    expect(isRetriablePushError(new Error('Push trigger failed: 502 BadDeviceToken'))).toBe(false);
+  });
+
+  test('a 4xx (non-token) is not retriable', () => {
+    expect(isRetriablePushError(new Error('Push trigger failed: 401 unauthorized'))).toBe(false);
+    expect(isRetriablePushError(new Error('Push trigger failed: 400 bad request'))).toBe(false);
+  });
+
+  test('isDelivered: in_app/pushed reach the user; deduped/no_channel/failed do not', () => {
+    expect(isDelivered('in_app')).toBe(true);
+    expect(isDelivered('pushed')).toBe(true);
+    // deduped is NOT treated as confirmed (the deduped-against push may have failed).
+    expect(isDelivered('deduped')).toBe(false);
+    expect(isDelivered('no_channel')).toBe(false);
+    expect(isDelivered('failed')).toBe(false);
   });
 });

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -301,3 +301,114 @@ describe('NotificationDispatcher.dismiss (#585 P7)', () => {
     expect(pushed).toHaveLength(0);
   });
 });
+
+describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  function register(active: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (active) registry.attachConnection(SID, 'c0000000-0000-0000-0000-000000000000' as UUID);
+  }
+
+  function make(pushFn: PushFn): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  const okPush: PushFn = async () => {};
+  const addToken = (t: string): void => {
+    deviceTokens.set(t, { token: t, platform: 'ios', registeredAt: 1, connectionId: SID });
+  };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('in_app when a client is attached (no push, but the user is reachable)', async () => {
+    register(true);
+    addToken('a');
+    expect(await make(okPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('in_app');
+  });
+
+  test('no_channel when there is no client and no device token', async () => {
+    register(false);
+    expect(await make(okPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('no_channel');
+  });
+
+  test('pushed when a device accepts; awaitDelivery returns the same outcome', async () => {
+    register(false);
+    addToken('a');
+    const d = make(okPush);
+    const q = question('q1', [yesOpt, noOpt]);
+    expect(await d.maybePush(SID, q)).toBe('pushed');
+    expect(await d.awaitDelivery(q.id)).toBe('pushed');
+  });
+
+  test('deduped when a second identical prompt is suppressed', async () => {
+    register(false);
+    addToken('a');
+    const d = make(okPush);
+    expect(await d.maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+    expect(await d.maybePush(SID, question('q2', [yesOpt, noOpt]))).toBe('deduped');
+  });
+
+  test('failed when the only device push fails', async () => {
+    register(false);
+    addToken('a');
+    const failPush: PushFn = async () => {
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(failPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+  });
+
+  test('a permanent BadDeviceToken (502) is NOT retried', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const failPush: PushFn = async () => {
+      calls++;
+      throw new Error('Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken"}');
+    };
+    expect(await make(failPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('failed');
+    expect(calls).toBe(1);
+  });
+
+  test('a transient 429 is retried with backoff, then succeeds -> pushed', async () => {
+    register(false);
+    addToken('a');
+    let calls = 0;
+    const flakyPush: PushFn = async () => {
+      calls++;
+      if (calls === 1) throw new Error('Push trigger failed: 429 rate limited');
+    };
+    expect(await make(flakyPush).maybePush(SID, question('q1', [yesOpt, noOpt]))).toBe('pushed');
+    expect(calls).toBe(2);
+  });
+
+  test('awaitDelivery is undefined for an unknown question id', () => {
+    expect(
+      make(okPush).awaitDelivery('zzzzzzzz-0000-0000-0000-000000000000' as UUID),
+    ).toBeUndefined();
+  });
+});

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -232,14 +232,24 @@ export default {
       // them); dismiss pushes draw from a separate budget so they cannot starve
       // alerts. Malformed/auth-failed requests above never reach here, so they
       // do not consume budget.
-      const authed = Boolean(env.PUSH_SECRET);
+      // `authed` must mean "this request proved possession of the secret", not
+      // merely "a secret is configured" — re-check the bearer so a future
+      // refactor of the auth block above cannot silently grant the trusted
+      // budget to an unauthenticated caller.
+      const authed =
+        Boolean(env.PUSH_SECRET) &&
+        request.headers.get('Authorization') === `Bearer ${env.PUSH_SECRET}`;
       const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
       const rlKey = authed ? authBucketKey(env.PUSH_SECRET as string) : `ip:${pushClientIp}`;
-      const limiter = isDismiss
-        ? dismissRateLimiter
-        : authed
-          ? pushAuthRateLimiter
-          : pushIpRateLimiter;
+      // Unauthenticated callers (only when no PUSH_SECRET is configured) always
+      // use the tight per-IP fallback — INCLUDING dismisses, which must not get
+      // the raised budget. Authenticated alert vs dismiss draw from separate
+      // raised budgets so a dismiss flood cannot starve alerts.
+      const limiter = !authed
+        ? pushIpRateLimiter
+        : isDismiss
+          ? dismissRateLimiter
+          : pushAuthRateLimiter;
       if (!limiter.check(rlKey)) {
         return new Response(
           JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -58,10 +58,38 @@ interface PushRequestBody {
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
 const rateLimiter = new RateLimiter(10, 60_000);
-/** Per-IP rate limiter for push: 5 pushes per 60 seconds */
-const pushRateLimiter = new RateLimiter(5, 60_000);
+/**
+ * Push budget (epic #603 Phase 2, R3). The old single per-IP limiter (5/60s)
+ * was shared across every daemon behind one NAT and across alert + dismiss
+ * pushes, each fanned out per device token — so a power user running several
+ * worktree daemons hit 429 and silently dropped notifications. Now:
+ *   - AUTHENTICATED callers (they hold PUSH_SECRET, so they are trusted) are
+ *     keyed by identity, not IP, with a ceiling well above
+ *     (device tokens x concurrent sessions). Sharing a NAT no longer throttles.
+ *   - UNAUTHENTICATED callers (only possible when no PUSH_SECRET is configured)
+ *     keep the original tight per-IP fallback to limit abuse.
+ *   - DISMISS pushes get their own budget so quiet resolutions never starve
+ *     alert pushes.
+ */
+const PUSH_AUTH_LIMIT = 60;
+const pushAuthRateLimiter = new RateLimiter(PUSH_AUTH_LIMIT, 60_000);
+const pushIpRateLimiter = new RateLimiter(5, 60_000);
+const dismissRateLimiter = new RateLimiter(PUSH_AUTH_LIMIT, 60_000);
 /** Per-IP rate limiter for the answer relay: 10 answers per 60 seconds */
 const answerRateLimiter = new RateLimiter(10, 60_000);
+
+/**
+ * A stable, non-secret rate-limit bucket key for an authenticated push identity
+ * (epic #603 Phase 2). Hashes the shared secret (djb2) so the key never stores
+ * the secret itself, and distinct secrets (multi-tenant) get distinct buckets.
+ */
+function authBucketKey(secret: string): string {
+  let h = 5381;
+  for (let i = 0; i < secret.length; i++) {
+    h = ((h << 5) + h + secret.charCodeAt(i)) | 0;
+  }
+  return `auth:${(h >>> 0).toString(36)}`;
+}
 
 /** Main worker */
 export default {
@@ -166,15 +194,6 @@ export default {
         }
       }
 
-      // Rate limit per IP
-      const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
-      if (!pushRateLimiter.check(pushClientIp)) {
-        return new Response(
-          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),
-          { status: 429, headers: corsHeaders },
-        );
-      }
-
       if (!env.APNS_KEY_ID || !env.APNS_TEAM_ID || !env.APNS_PRIVATE_KEY) {
         return new Response(
           JSON.stringify({ error: 'APNS_NOT_CONFIGURED', message: 'APNS credentials not set' }),
@@ -205,6 +224,26 @@ export default {
             message: isDismiss ? 'token is required' : 'token, title, and body are required',
           }),
           { status: 400, headers: corsHeaders },
+        );
+      }
+
+      // Rate limit (epic #603 Phase 2, R3). Authenticated callers are keyed by
+      // identity with a generous ceiling (a shared NAT IP no longer throttles
+      // them); dismiss pushes draw from a separate budget so they cannot starve
+      // alerts. Malformed/auth-failed requests above never reach here, so they
+      // do not consume budget.
+      const authed = Boolean(env.PUSH_SECRET);
+      const pushClientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      const rlKey = authed ? authBucketKey(env.PUSH_SECRET as string) : `ip:${pushClientIp}`;
+      const limiter = isDismiss
+        ? dismissRateLimiter
+        : authed
+          ? pushAuthRateLimiter
+          : pushIpRateLimiter;
+      if (!limiter.check(rlKey)) {
+        return new Response(
+          JSON.stringify({ error: 'RATE_LIMITED', message: 'Too many push requests' }),
+          { status: 429, headers: corsHeaders },
         );
       }
 
@@ -264,7 +303,16 @@ export default {
         });
       }
 
-      return new Response(JSON.stringify({ success: false, error: result.error }), {
+      // Surface a PERMANENT token rejection as a structured flag (epic #603
+      // Phase 2 -> consumed by Phase 6 token pruning). APNS reports these as a
+      // 4xx that the Worker wraps in `result.error`; the daemon prunes the dead
+      // token instead of retrying it forever. The reason text is kept in `error`
+      // so the daemon's transient-vs-permanent classifier (#603 Phase 1) still
+      // works off the message.
+      const tokenInvalid = /BadDeviceToken|Unregistered|DeviceTokenNotForTopic/i.test(
+        result.error ?? '',
+      );
+      return new Response(JSON.stringify({ success: false, error: result.error, tokenInvalid }), {
         status: 502,
         headers: corsHeaders,
       });

--- a/packages/signaling/tests/push-budget.test.ts
+++ b/packages/signaling/tests/push-budget.test.ts
@@ -148,6 +148,25 @@ describe('/push budget (#603 Phase 2)', () => {
     expect(dRes.status).toBe(200);
   });
 
+  test('unauthenticated dismiss uses the tight per-IP fallback, not the raised budget', async () => {
+    const env = { ...baseEnv } as TestEnv; // no PUSH_SECRET
+    ipCounter += 1;
+    const ip = `198.51.100.${200 + ipCounter}`;
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const req = new Request('https://signaling.example/push', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': ip },
+        body: JSON.stringify({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+      });
+      const res = await worker.fetch(req, env as never);
+      statuses.push(res.status);
+    }
+    // The tight 5/60s fallback applies to unauthenticated dismisses too.
+    expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(statuses[5]).toBe(429);
+  });
+
   test('a permanent token rejection is surfaced as tokenInvalid:true (502)', async () => {
     const secret = freshSecret();
     const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;

--- a/packages/signaling/tests/push-budget.test.ts
+++ b/packages/signaling/tests/push-budget.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Worker-level tests for the /push rate-limit budget (epic #603 Phase 2, R3).
+ *
+ * Drives the worker's `fetch` directly (no miniflare; bun provides crypto.subtle
+ * and fetch, which we stub for the Apple call). Confirms:
+ *   - authenticated callers are NOT throttled at the old 5/60s per-IP limit
+ *     (a power user's many daemons behind one NAT no longer 429);
+ *   - unauthenticated callers keep the tight per-IP fallback;
+ *   - dismiss pushes draw from a SEPARATE budget so they can't starve alerts;
+ *   - a permanent token rejection is surfaced as a structured `tokenInvalid`.
+ *
+ * Each test uses a UNIQUE secret (authed) or a unique IP (unauthed) so its
+ * rate-limit bucket is fresh despite the module-level limiters persisting across
+ * tests in the run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+  PUSH_SECRET?: string;
+}
+
+describe('/push budget (#603 Phase 2)', () => {
+  let baseEnv: Omit<TestEnv, 'PUSH_SECRET'>;
+  let realFetch: typeof globalThis.fetch;
+  // Configurable Apple response so a token-rejection case can be simulated.
+  let appleStatus = 200;
+  let appleBody = '';
+  let secretCounter = 0;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    baseEnv = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleStatus = 200;
+    appleBody = '';
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        return new Response(appleBody, { status: appleStatus });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  /** A unique PUSH_SECRET per call so each test gets a fresh auth rate bucket. */
+  function freshSecret(): string {
+    secretCounter += 1;
+    return `test-secret-${secretCounter}`;
+  }
+
+  function alertReq(opts: { ip: string; secret?: string }): Request {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'CF-Connecting-IP': opts.ip,
+    };
+    if (opts.secret) headers['Authorization'] = `Bearer ${opts.secret}`;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ token: 'device-abc', title: 'T', body: 'B', questionId: 'q-1' }),
+    });
+  }
+
+  function dismissReq(opts: { ip: string; secret: string }): Request {
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': opts.ip,
+        Authorization: `Bearer ${opts.secret}`,
+      },
+      body: JSON.stringify({ token: 'device-abc', questionId: 'q-1', dismiss: true }),
+    });
+  }
+
+  test('authenticated alert pushes are NOT throttled at the old 5/60s (shared-NAT power user)', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    const ip = '198.51.100.7'; // same IP for all 6 (simulates many daemons, one NAT)
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await worker.fetch(alertReq({ ip, secret }), env as never);
+      statuses.push(res.status);
+    }
+    // The old per-IP 5-limit would 429 the 6th; the raised per-identity budget
+    // lets all six through.
+    expect(statuses).toEqual([200, 200, 200, 200, 200, 200]);
+  });
+
+  test('unauthenticated push keeps the tight per-IP fallback (6th is 429)', async () => {
+    const env = { ...baseEnv } as TestEnv; // no PUSH_SECRET
+    ipCounter += 1;
+    const ip = `198.51.100.${100 + ipCounter}`;
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await worker.fetch(alertReq({ ip }), env as never);
+      statuses.push(res.status);
+    }
+    expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(statuses[5]).toBe(429);
+  });
+
+  test('dismiss pushes draw from a separate budget and are not starved by alerts', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    const ip = '198.51.100.50';
+    // Exhaust the authenticated ALERT budget (PUSH_AUTH_LIMIT = 60).
+    let lastAlert = 200;
+    for (let i = 0; i < 61; i++) {
+      const res = await worker.fetch(alertReq({ ip, secret }), env as never);
+      lastAlert = res.status;
+    }
+    expect(lastAlert).toBe(429); // alert budget is now exhausted
+    // A dismiss for the same identity still succeeds — separate budget.
+    const dRes = await worker.fetch(dismissReq({ ip, secret }), env as never);
+    expect(dRes.status).toBe(200);
+  });
+
+  test('a permanent token rejection is surfaced as tokenInvalid:true (502)', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    appleStatus = 400;
+    appleBody = '{"reason":"BadDeviceToken"}';
+    const res = await worker.fetch(alertReq({ ip: '198.51.100.60', secret }), env as never);
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { success: boolean; error?: string; tokenInvalid?: boolean };
+    expect(json.success).toBe(false);
+    expect(json.tokenInvalid).toBe(true);
+    expect(json.error).toContain('BadDeviceToken'); // reason kept for the Phase 1 classifier
+  });
+
+  test('a transient APNS failure is NOT flagged tokenInvalid', async () => {
+    const secret = freshSecret();
+    const env = { ...baseEnv, PUSH_SECRET: secret } as TestEnv;
+    appleStatus = 503;
+    appleBody = 'service unavailable';
+    const res = await worker.fetch(alertReq({ ip: '198.51.100.61', secret }), env as never);
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { tokenInvalid?: boolean };
+    expect(json.tokenInvalid).toBe(false);
+  });
+});


### PR DESCRIPTION
Epic #603 — Milestone 1 ("stop the bleeding"): Phases 1+2+3. Closes #604, #605, #606. Advances epic #603.

## Why

Running multiple concurrent sessions, notifications were dropped and **work paused**. Root cause, confirmed from live logs (`~/.remi/remi.log`): **134 `BadDeviceToken` push failures**, each followed by `Held hook <id> timed out -> passthrough`. Model B holds the `PermissionRequest` hook open *regardless of whether any notification was delivered*, so a dead push channel turned every escalation into a ~30-minute frozen hold. Full root-cause + the 9 architectural issues + 35 verified failure modes are in `.context/epic-notification-robustness-refactor.md`.

## What this milestone delivers

**Phase 1 (#604) — hold contingent on confirmed delivery (R1/R2).** A held hook now arms optimistically but is gated on delivery: `NotificationDispatcher.maybePush` records a per-question `DeliveryOutcome`; the gate probes it and, if delivery isn't confirmed within `delivery_confirm_timeout` (default 6s), **fails the hold open fast** instead of blocking for `hold_timeout`. Transient push errors (429 / network) retry with backoff; permanent ones (`BadDeviceToken`) never do. Every undelivered fail-open is logged loudly. New config: `delivery_confirm_timeout`, `hold_unconfirmed_timeout` (the D2 hold-always-no-phone escape).

**Phase 2 (#605) — per-identity push budget + dismiss isolation (R3).** The signaling Worker's push rate limiter was a single 5/60s per-IP bucket shared across all daemons behind one NAT + alert/dismiss + per-token fan-out (a second silent-drop cause). Rekeyed to per-authenticated-identity with a 60/60s ceiling; dismiss gets its own budget; a permanent token rejection is surfaced as a structured `tokenInvalid` flag (for Phase 6 pruning). Unauthenticated callers keep the tight per-IP fallback.

**Phase 3 (#606) — held escalations bypass dedup + always deliver (R7).** A held escalation's card is load-bearing but flowed through the same content-dedup + attached-client short-circuit as a cosmetic echo (logs show `[QuestionDedup] Suppressed`). Held now bypasses both dedups, always pushes to the lock screen (covering a backgrounded client), and gates delivery on the push result (a failed push fails the hold open fast).

## The shape of the fix

This is **wire-it-correctly + invert one contract**, not a rewrite. The master defect was that a hold existed without confirmed delivery; Phase 1 inverts that, Phase 2 makes delivery actually succeed under concurrency, Phase 3 stops the held card being suppressed.

## Deploy / release notes

- The signaling Worker must be **redeployed** for Phase 2 to take effect (`cd packages/signaling && npx cfman wrangler --account yooz-labs deploy`).
- An immediate live mitigation (`APNS_SANDBOX=true` for the current dev-build token) was already applied to the Worker separately; the durable per-token environment fix is Phase 2/6.

## Testing (NO MOCKS)

Real local push sinks, real `AutoApproveGate` + `SessionRegistry`, real `worker.fetch` + stubbed Apple host, real `MessageAPI`. Each phase reviewed by sonnet agents; all findings addressed. Integrated epic branch: typecheck + biome clean, 334 pass across the changed suites (full `bun test --coverage` runs in CI here).

## Remaining (Milestone 2, epic #603 stays open)

Phases 4-8: wire the (already-built, zero-caller) connection-independent answer relay (R8); GPU/eval-cancellation scoping (R5/R6); user-level device-token registry + APNS-410/400 pruning (R4, consumes Phase 2's `tokenInvalid`); socket-liveness presence + teardown hold release (R9); Yes-always/pick correctness. Plus the deferred APNS provider-JWT KV cache (TooManyProviderTokenUpdates).
