### PR TITLE
Phase 4 (part 1): never misroute a cold-start answer to the wrong daemon (#612)

### DIFF
--- a/packages/web/src/lib/push-answer-resolver.ts
+++ b/packages/web/src/lib/push-answer-resolver.ts
@@ -97,9 +97,16 @@ export function resolvePushAnswerTarget(input: {
     }
   }
 
-  // 3. Cold start: prefer the URL we last saw this sessionId on. Falling back
-  // to storedUrls[0] for multi-daemon users would route to the wrong daemon.
-  const cold = sessionUrlMap?.[sessionId] ?? storedUrls[0];
+  // 3. Cold start: prefer the URL we last saw this sessionId on. With NO
+  // per-session URL, only fall back to a stored URL when it is UNAMBIGUOUS
+  // (exactly one daemon paired). For a multi-daemon user, guessing storedUrls[0]
+  // silently delivers the answer to the WRONG daemon (#603 Phase 4, R8) — report
+  // unreachable instead so the caller surfaces "open the app" / uses the
+  // connection-independent reverse-relay (which carries the daemon's room code).
+  let cold = sessionUrlMap?.[sessionId];
+  if (cold === undefined && storedUrls.length === 1) {
+    cold = storedUrls[0];
+  }
   if (!cold) return { kind: 'unreachable' };
 
   const inflight = connections.find(

--- a/packages/web/tests/lib/push-answer-resolver.test.ts
+++ b/packages/web/tests/lib/push-answer-resolver.test.ts
@@ -82,6 +82,19 @@ describe('resolvePushAnswerTarget (#278)', () => {
     ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
   });
 
+  test('cold start: single stored URL is an empty string — unreachable, not a bogus reconnect', () => {
+    // storedUrls is JSON.parse'd from localStorage without sanitization, so a
+    // corrupted/empty entry is real; the `!cold` guard must catch it.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's-unknown',
+        sessions: [],
+        connections: [],
+        storedUrls: [''],
+      }),
+    ).toEqual({ kind: 'unreachable' });
+  });
+
   test('cold start: MULTIPLE daemons, no per-session URL — unreachable, NOT a wrong-daemon guess (#603 P4 R8)', () => {
     // We do not know which paired daemon owns this session, so guessing
     // storedUrls[0] would silently answer the WRONG daemon. Report unreachable

--- a/packages/web/tests/lib/push-answer-resolver.test.ts
+++ b/packages/web/tests/lib/push-answer-resolver.test.ts
@@ -69,9 +69,23 @@ describe('resolvePushAnswerTarget (#278)', () => {
     ).toEqual({ kind: 'pending', connectionId: 'c2', url: 'ws://daemon-a/ws' });
   });
 
-  test('cold start: no session in memory — fall back to first localStorage URL', () => {
+  test('cold start: a single paired daemon — fall back to it (unambiguous)', () => {
     // App was suspended; lock-screen tap brought it back; sessions list is
-    // empty until reconnect. localStorage holds the URLs we were attached to.
+    // empty until reconnect. With exactly one stored URL there is no ambiguity.
+    expect(
+      resolvePushAnswerTarget({
+        sessionId: 's-unknown',
+        sessions: [],
+        connections: [],
+        storedUrls: ['ws://daemon-a/ws'],
+      }),
+    ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+  });
+
+  test('cold start: MULTIPLE daemons, no per-session URL — unreachable, NOT a wrong-daemon guess (#603 P4 R8)', () => {
+    // We do not know which paired daemon owns this session, so guessing
+    // storedUrls[0] would silently answer the WRONG daemon. Report unreachable
+    // instead; the caller surfaces "open the app" / uses the reverse-relay.
     expect(
       resolvePushAnswerTarget({
         sessionId: 's-unknown',
@@ -79,7 +93,7 @@ describe('resolvePushAnswerTarget (#278)', () => {
         connections: [],
         storedUrls: ['ws://daemon-a/ws', 'ws://daemon-b/ws'],
       }),
-    ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+    ).toEqual({ kind: 'unreachable' });
   });
 
   test('cold start: localStorage url already mid-connect — reuse the in-flight attempt', () => {
@@ -156,9 +170,9 @@ describe('resolvePushAnswerTarget (#278)', () => {
       ).toEqual({ kind: 'pending', connectionId: 'c-boot', url: 'ws://daemon-b/ws' });
     });
 
-    test('sessionUrlMap missing the requested sessionId — falls back to storedUrls[0]', () => {
-      // s-other was never paired; the map has nothing useful so the legacy
-      // cold-start fallback applies.
+    test('sessionUrlMap missing the requested sessionId, single daemon — falls back to it', () => {
+      // s-other was never mapped; with exactly one stored URL the fallback is
+      // unambiguous so the legacy cold-start fallback still applies.
       expect(
         resolvePushAnswerTarget({
           sessionId: 's-other',
@@ -168,6 +182,20 @@ describe('resolvePushAnswerTarget (#278)', () => {
           sessionUrlMap: { s2: 'ws://daemon-b/ws' },
         }),
       ).toEqual({ kind: 'reconnect', url: 'ws://daemon-a/ws' });
+    });
+
+    test('sessionUrlMap missing the requested sessionId, MULTIPLE daemons — unreachable (#603 P4 R8)', () => {
+      // The map has no entry for s-other and several daemons are paired, so any
+      // pick would be a guess. Report unreachable rather than misroute.
+      expect(
+        resolvePushAnswerTarget({
+          sessionId: 's-other',
+          sessions: [],
+          connections: [],
+          storedUrls: ['ws://daemon-a/ws', 'ws://daemon-b/ws'],
+          sessionUrlMap: { s2: 'ws://daemon-b/ws' },
+        }),
+      ).toEqual({ kind: 'unreachable' });
     });
 
     test('sessionUrlMap entry not in storedUrls — still reconnects (daemon de-paired but session known)', () => {


### PR DESCRIPTION
Part 1 of epic #603 Phase 4 (R8). Pure-function fix: `resolvePushAnswerTarget` blind-fell-back to `storedUrls[0]` on a cold-start answer with no per-session URL, silently delivering to the WRONG daemon for multi-daemon users. Now the stored-URL fallback applies only when unambiguous (one paired daemon); multiple paired daemons + no per-session URL -> `unreachable` (caller surfaces 'open the app' / uses the reverse-relay). Tests updated + added (single vs multi daemon, partial map). typecheck + web tsc + eslint + 16 resolver tests pass.

Remaining P4 (part 2, the dedicated on-device test session): carry the daemon's room code in the push payload (daemon push-client -> Worker PushRequestBody -> APNS data); wire the already-built `relayAnswerViaSignaling` into App.tsx's unreachable branch; native iOS `RemiAnswerRelay` reverse-relay + failure notification. These need device validation, so they're intentionally separate.