### PR TITLE
Phase 6: persistent device-token registry + prune dead tokens (#615)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -144,6 +144,7 @@ import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { HookConfigManager, HookServer } from './hooks/index.ts';
+import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, type PTYSession } from './pty/index.ts';
@@ -981,10 +982,14 @@ const spawningPorts = new Set<number>();
 // WebSocket disconnect — push notifications are the suspended-app path, so
 // dropping on disconnect breaks the only case they exist for. Cleanup happens
 // at process exit only. Issue #286.
-const deviceTokens = new Map<
-  string,
-  { token: string; platform: string; registeredAt: number; connectionId: UUID }
->();
+// Persistent, shared device-token registry (epic #603 Phase 6, R4): every local
+// daemon loads the same `~/.remi/device-tokens.json` so a fresh worktree daemon
+// can push immediately, and a dead token pruned on APNS rejection stays pruned.
+// `deviceTokens` is the store's live in-memory map (stable reference), so all the
+// existing Map consumers are unchanged.
+const deviceTokenStore = new DeviceTokenStore(path.join(REMI_DIR, 'device-tokens.json'));
+deviceTokenStore.load();
+const deviceTokens = deviceTokenStore.map;
 
 // Hook infrastructure (initialized in wrapper mode when hooks are enabled)
 let HOOK_PORT = 0; // OS-assigned; actual port read from hookServer.port after start
@@ -1095,6 +1100,9 @@ async function createNewSession(
       sessionRegistry,
       transcriptWatchers,
       deviceTokens,
+      // #603 Phase 6: prune a permanently-invalid token (BadDeviceToken) so the
+      // daemon stops retrying it; the store removes + persists it.
+      pruneToken: (token) => deviceTokenStore.prune(token, 'apns-invalid'),
       pushConfig: () => ({
         signalingUrl: cliSignalingUrl ?? remiConfig.network.signaling_url,
         ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
@@ -1361,7 +1369,9 @@ const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean
 };
 
 const trivialHandlers: TrivialHandlers = createTrivialHandlers({
-  deviceTokens,
+  // #603 Phase 6: registration goes through the store (rotation prune + persist).
+  registerDeviceToken: (token, platform, connectionId) =>
+    deviceTokenStore.register(token, platform, connectionId),
   sessionStore,
   sessionRegistry,
   send: sendToConnection,

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -21,7 +21,12 @@ export interface DeviceTokenEntry {
 export type SendToConnection = (connectionId: UUID, message: ProtocolMessage) => boolean;
 
 export interface TrivialHandlerDeps {
-  deviceTokens: Map<string, DeviceTokenEntry>;
+  /**
+   * Register a device token (epic #603 Phase 6). The `DeviceTokenStore` owns the
+   * map: it does the #585 rotation prune (a re-registration from the same
+   * connection drops that connection's OTHER, now-rotated token) and persists.
+   */
+  registerDeviceToken: (token: string, platform: string, connectionId: UUID) => void;
   sessionStore: SessionStore;
   sessionRegistry: SessionRegistry;
   send: SendToConnection;
@@ -30,29 +35,12 @@ export interface TrivialHandlerDeps {
 export type TrivialHandlers = ReturnType<typeof createTrivialHandlers>;
 
 export function createTrivialHandlers(deps: TrivialHandlerDeps) {
-  const { deviceTokens, sessionStore, sessionRegistry, send } = deps;
+  const { registerDeviceToken, sessionStore, sessionRegistry, send } = deps;
 
   return {
     onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string): void => {
       log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
-      // Dedup (#585, P7): the map is already keyed by token, so re-registering an
-      // identical token collapses to one entry (no duplicate push). The remaining
-      // duplicate-push case is APNS token ROTATION — the same physical device
-      // hands the daemon a NEW token while the old one is still registered, so a
-      // push fans out to BOTH (the user's reported 2x). The connection that
-      // re-registers is the same client session, so prune any OTHER token
-      // previously registered from THIS connectionId before recording the new one.
-      // This is conservative: it only drops a stale token tied to the same client,
-      // never a genuinely distinct device on another connection.
-      for (const [existingToken, entry] of deviceTokens) {
-        if (existingToken !== token && entry.connectionId === connectionId) {
-          deviceTokens.delete(existingToken);
-          log(
-            `Pruned stale device token from ${connectionId} (rotated): ${existingToken.slice(0, 20)}...`,
-          );
-        }
-      }
-      deviceTokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
+      registerDeviceToken(token, platform, connectionId);
     },
 
     onSessionHistoryRequest: (

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -37,6 +37,9 @@ export interface MessageApiSetupDeps {
   sessionRegistry: SessionRegistry;
   transcriptWatchers: Map<UUID, TranscriptWatcher>;
   deviceTokens: Map<string, DeviceTokenEntry>;
+  /** Prune a permanently-invalid device token (epic #603 Phase 6). Forwarded to
+   *  the dispatcher so a BadDeviceToken push removes the dead token. */
+  pruneToken?: (token: string) => void;
   /**
    * Called on every question emission so the caller can swap config sources
    * without re-wiring the factory. MUST be synchronous and non-throwing: it
@@ -76,6 +79,7 @@ export function createMessageApiForSession(
     sessionRegistry,
     transcriptWatchers,
     deviceTokens,
+    pruneToken,
     pushConfig,
     updateRemiStatus,
     maxBulletLength,
@@ -96,7 +100,13 @@ export function createMessageApiForSession(
   // active-client gate, the per-prompt PushDedup baseline (#409), and the
   // device-token fan-out; the MessageAPI callback just hands it the question.
   const notifications = new NotificationDispatcher(
-    { sessionRegistry, deviceTokens, pushConfig, getPrimarySessionId },
+    {
+      sessionRegistry,
+      deviceTokens,
+      pushConfig,
+      getPrimarySessionId,
+      ...(pruneToken ? { pruneToken } : {}),
+    },
     sessionId,
   );
 

--- a/packages/daemon/src/notifications/device-token-store.ts
+++ b/packages/daemon/src/notifications/device-token-store.ts
@@ -1,0 +1,137 @@
+/**
+ * DeviceTokenStore — the APNS device-token registry (epic #603 Phase 6, R4).
+ *
+ * Replaces the per-daemon in-memory `Map` that was never persisted and never
+ * shared, which caused two failures:
+ *   - a fresh worktree daemon the phone never connected to had ZERO tokens, so
+ *     its escalations could never push (a black-hole);
+ *   - a dead/rotated token (BadDeviceToken / Unregistered) was never pruned, so
+ *     the daemon retried it on every escalation forever.
+ *
+ * This store:
+ *   - persists to a shared `~/.remi/device-tokens.json` every local daemon loads
+ *     on start, so a token registered by one daemon is visible to the next;
+ *   - prunes a token on a permanent APNS rejection (self-healing) and remembers
+ *     it so a concurrent daemon's stale copy is not re-adopted;
+ *   - writes atomically via a per-pid `.tmp` + rename (#461 pattern), and
+ *     read-merges before each write so a concurrent daemon's registrations are
+ *     not clobbered (last-writer-wins on the SAME token; union across tokens).
+ *
+ * The in-memory `map` is mutated in place (never replaced) so existing consumers
+ * (the dispatcher's iteration) keep a stable reference.
+ */
+
+import * as fs from 'node:fs';
+
+import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
+import { log, logError } from '../cli/logger.ts';
+
+function isValidEntry(e: unknown): e is DeviceTokenEntry {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    typeof (e as DeviceTokenEntry).token === 'string' &&
+    (e as DeviceTokenEntry).token.length > 0 &&
+    typeof (e as DeviceTokenEntry).platform === 'string' &&
+    typeof (e as DeviceTokenEntry).connectionId === 'string'
+  );
+}
+
+export class DeviceTokenStore {
+  private readonly tokens = new Map<string, DeviceTokenEntry>();
+  /** Tokens this store intentionally REMOVED this session — pruned (dead) OR
+   *  rotated out. Kept so the read-merge on persist does NOT re-adopt one from
+   *  the stale on-disk copy (this store wrote it before removing it). Cleared for
+   *  a token if it is later re-registered. */
+  private readonly removed = new Set<string>();
+
+  constructor(private readonly filePath: string) {}
+
+  /** The live in-memory map. Stable reference — mutated in place, never replaced. */
+  get map(): Map<string, DeviceTokenEntry> {
+    return this.tokens;
+  }
+
+  get size(): number {
+    return this.tokens.size;
+  }
+
+  /** Load the persisted registry into memory. Tolerant of a missing/corrupt file
+   *  (starts empty). Call once at daemon start. */
+  load(): void {
+    for (const e of this.readFile()) {
+      this.tokens.set(e.token, e);
+    }
+    if (this.tokens.size > 0) {
+      log(`[DeviceTokens] Loaded ${this.tokens.size} persisted device token(s)`);
+    }
+  }
+
+  /**
+   * Register (or refresh) a device token. Mirrors the prior #585 rotation prune:
+   * a re-registration from the SAME connection drops any OTHER token that
+   * connection previously registered (APNS token rotation). Persists.
+   */
+  register(token: string, platform: string, connectionId: string): void {
+    for (const [existingToken, entry] of this.tokens) {
+      if (existingToken !== token && entry.connectionId === connectionId) {
+        this.tokens.delete(existingToken);
+        this.removed.add(existingToken); // do not re-adopt the rotated-out token on merge
+        log(
+          `[DeviceTokens] Pruned stale token from ${connectionId} (rotated): ${existingToken.slice(0, 20)}...`,
+        );
+      }
+    }
+    this.tokens.set(token, { token, platform, registeredAt: Date.now(), connectionId });
+    // A token registered again is no longer considered removed.
+    this.removed.delete(token);
+    this.persist();
+  }
+
+  /**
+   * Prune a dead token (permanent APNS rejection). Self-healing: the daemon stops
+   * retrying it, and it is remembered so a concurrent daemon's stale copy is not
+   * re-adopted on the next read-merge. Returns true iff the token was present.
+   */
+  prune(token: string, reason: string): boolean {
+    const had = this.tokens.delete(token);
+    this.removed.add(token);
+    if (had) {
+      log(`[DeviceTokens] Pruned dead token (${reason}): ${token.slice(0, 20)}...`);
+      this.persist();
+    }
+    return had;
+  }
+
+  private readFile(): DeviceTokenEntry[] {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      const list = (parsed as { tokens?: unknown })?.tokens;
+      if (Array.isArray(list)) return list.filter(isValidEntry);
+    } catch {
+      // Missing or corrupt -> treat as empty; the file is rebuilt on the next write.
+    }
+    return [];
+  }
+
+  /** Read-merge then atomic write, so a concurrent daemon's registrations survive
+   *  (union across tokens) while this daemon's prunes/refreshes win on the same token. */
+  private persist(): void {
+    try {
+      for (const e of this.readFile()) {
+        // Adopt another daemon's token we do not have and have not removed.
+        if (!this.tokens.has(e.token) && !this.removed.has(e.token)) {
+          this.tokens.set(e.token, e);
+        }
+      }
+      const tmp = `${this.filePath}.${process.pid}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify({ tokens: [...this.tokens.values()] }));
+      fs.renameSync(tmp, this.filePath);
+    } catch (err) {
+      // Persistence is best-effort: the in-memory map is still authoritative for
+      // this process, so a write failure must not break push delivery.
+      logError(`[DeviceTokens] Failed to persist registry: ${err}`);
+    }
+  }
+}

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -168,9 +168,31 @@ export function isRetriablePushError(err: unknown): boolean {
   return status === 429 || (status >= 500 && status < 600);
 }
 
+/**
+ * Whether a push error means the DEVICE TOKEN itself is permanently invalid
+ * (epic #603 Phase 6) — so the daemon should PRUNE it, not just stop retrying.
+ * Matches the Worker's structured `tokenInvalid` flag (#603 Phase 2) and the raw
+ * APNS reasons. Distinct from `isRetriablePushError`: a 401/auth error or an
+ * exhausted transient failure is non-retriable but does NOT invalidate the token.
+ */
+export function isTokenInvalidError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err);
+  return (
+    /"tokenInvalid"\s*:\s*true/.test(msg) ||
+    /BadDeviceToken|DeviceTokenNotForTopic|\bUnregistered\b/i.test(msg)
+  );
+}
+
 export interface NotificationDispatcherDeps {
   sessionRegistry: SessionRegistry;
   deviceTokens: Map<string, DeviceTokenEntry>;
+  /**
+   * Prune a permanently-invalid device token (epic #603 Phase 6). Called when a
+   * push fails with `isTokenInvalidError` (BadDeviceToken / Unregistered), so the
+   * daemon stops retrying a dead token on every future escalation. Wired to
+   * `DeviceTokenStore.prune` (removes + persists). Absent => no pruning (the
+   * token stays in the map; tests / old callers). */
+  pruneToken?: (token: string) => void;
   /**
    * Current push config; read on every dispatch so the caller can swap the
    * source without re-wiring. Must be synchronous and non-throwing.
@@ -334,6 +356,13 @@ export class NotificationDispatcher {
         // error, or exhausted retries). This is the root cause behind a held
         // hook's fail-open, so it must be visible at error level, not buried.
         logError(`Push notification failed for session ${pushSessionId}: ${err}`);
+        // Self-heal (epic #603 Phase 6): a PERMANENTLY invalid token (dead /
+        // unregistered / wrong-app) is pruned so it is never retried again. A
+        // network error or exhausted-transient failure is NOT a token problem,
+        // so the token survives.
+        if (isTokenInvalidError(err)) {
+          this.deps.pruneToken?.(token);
+        }
         return false;
       }
     }

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -3,10 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
-import {
-  type DeviceTokenEntry,
-  createTrivialHandlers,
-} from '../../../src/cli/handlers/trivial-events.ts';
+import { createTrivialHandlers } from '../../../src/cli/handlers/trivial-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
@@ -49,11 +46,14 @@ describe('createTrivialHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('onRegisterDeviceToken stores the token in the shared map', () => {
-    const deviceTokens = new Map<string, DeviceTokenEntry>();
+  test('onRegisterDeviceToken forwards token/platform/connection to the store (#603 P6)', () => {
+    // The map + rotation prune + persistence now live in DeviceTokenStore (see
+    // device-token-store.test.ts); the handler just forwards.
+    const calls: Array<{ token: string; platform: string; connectionId: UUID }> = [];
     const { send } = makeSend();
     const handlers = createTrivialHandlers({
-      deviceTokens,
+      registerDeviceToken: (token, platform, connectionId) =>
+        calls.push({ token, platform, connectionId }),
       sessionStore,
       sessionRegistry,
       send,
@@ -62,66 +62,14 @@ describe('createTrivialHandlers', () => {
 
     handlers.onRegisterDeviceToken(CID, 'ios-device-token-abc', 'ios');
 
-    expect(deviceTokens.size).toBe(1);
-    const entry = deviceTokens.get('ios-device-token-abc');
-    expect(entry).toBeDefined();
-    expect(entry?.platform).toBe('ios');
-    expect(entry?.connectionId).toBe(CID);
-    expect(typeof entry?.registeredAt).toBe('number');
-  });
-
-  test('onRegisterDeviceToken: registering the same token twice yields ONE entry (#585 P7)', () => {
-    const deviceTokens = new Map<string, DeviceTokenEntry>();
-    const { send } = makeSend();
-    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
-    configureLogger({ writeLog: () => {} });
-
-    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
-    handlers.onRegisterDeviceToken(CID, 'same-token', 'ios');
-
-    expect(deviceTokens.size).toBe(1);
-    expect(deviceTokens.has('same-token')).toBe(true);
-  });
-
-  test('onRegisterDeviceToken: a rotated token from the same connection prunes the old one (#585 P7)', () => {
-    // APNS token rotation: the same physical device (same client connection)
-    // re-registers a NEW token while the old one is still live -> a push would
-    // otherwise fan out to BOTH (the 2x duplicate). The old token from this
-    // connection is pruned, leaving only the new one.
-    const deviceTokens = new Map<string, DeviceTokenEntry>();
-    const { send } = makeSend();
-    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
-    configureLogger({ writeLog: () => {} });
-
-    handlers.onRegisterDeviceToken(CID, 'old-token', 'ios');
-    handlers.onRegisterDeviceToken(CID, 'new-token', 'ios');
-
-    expect(deviceTokens.size).toBe(1);
-    expect(deviceTokens.has('new-token')).toBe(true);
-    expect(deviceTokens.has('old-token')).toBe(false);
-  });
-
-  test('onRegisterDeviceToken: a different connection keeps its own token (no cross-device prune)', () => {
-    const OTHER = 'conn1111-1111-1111-1111-111111111111' as UUID;
-    const deviceTokens = new Map<string, DeviceTokenEntry>();
-    const { send } = makeSend();
-    const handlers = createTrivialHandlers({ deviceTokens, sessionStore, sessionRegistry, send });
-    configureLogger({ writeLog: () => {} });
-
-    handlers.onRegisterDeviceToken(CID, 'token-a', 'ios');
-    handlers.onRegisterDeviceToken(OTHER, 'token-b', 'ios');
-
-    // Two genuinely distinct devices on different connections must both survive.
-    expect(deviceTokens.size).toBe(2);
-    expect(deviceTokens.has('token-a')).toBe(true);
-    expect(deviceTokens.has('token-b')).toBe(true);
+    expect(calls).toEqual([{ token: 'ios-device-token-abc', platform: 'ios', connectionId: CID }]);
   });
 
   test('onTerminalResize logs and returns when no session is attached', () => {
     const logs: string[] = [];
     const { send } = makeSend();
     const handlers = createTrivialHandlers({
-      deviceTokens: new Map(),
+      registerDeviceToken: () => {},
       sessionStore,
       sessionRegistry,
       send,
@@ -138,7 +86,7 @@ describe('createTrivialHandlers', () => {
     const logs: string[] = [];
     const { send } = makeSend();
     const handlers = createTrivialHandlers({
-      deviceTokens: new Map(),
+      registerDeviceToken: () => {},
       sessionStore,
       sessionRegistry,
       send,
@@ -153,7 +101,7 @@ describe('createTrivialHandlers', () => {
   test('onSessionHistoryRequest sends session_history_response with real SessionStore', () => {
     const { send, captured } = makeSend();
     const handlers = createTrivialHandlers({
-      deviceTokens: new Map(),
+      registerDeviceToken: () => {},
       sessionStore,
       sessionRegistry,
       send,
@@ -170,7 +118,7 @@ describe('createTrivialHandlers', () => {
   test('onSessionHistoryRequest clamps limit to a minimum of 1', () => {
     const { send, captured } = makeSend();
     const handlers = createTrivialHandlers({
-      deviceTokens: new Map(),
+      registerDeviceToken: () => {},
       sessionStore,
       sessionRegistry,
       send,

--- a/packages/daemon/tests/notifications/device-token-store.test.ts
+++ b/packages/daemon/tests/notifications/device-token-store.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import { DeviceTokenStore } from '../../src/notifications/device-token-store.ts';
+
+const CID = 'conn0000-0000-0000-0000-000000000000';
+
+function tokensOnDisk(file: string): string[] {
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+    tokens: Array<{ token: string }>;
+  };
+  return parsed.tokens.map((e) => e.token);
+}
+
+describe('DeviceTokenStore (#603 Phase 6)', () => {
+  let tmpDir: string;
+  let file: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tokens-'));
+    file = path.join(tmpDir, 'device-tokens.json');
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('register stores a token in the map and persists it to disk', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('tok-a', 'ios', CID);
+    expect(s.map.get('tok-a')?.platform).toBe('ios');
+    expect(tokensOnDisk(file)).toEqual(['tok-a']);
+  });
+
+  test('register: a rotated token from the same connection prunes the old one (#585)', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('old', 'ios', CID);
+    s.register('new', 'ios', CID);
+    expect([...s.map.keys()]).toEqual(['new']);
+    expect(tokensOnDisk(file)).toEqual(['new']);
+  });
+
+  test('register: a different connection keeps its own token (no cross-device prune)', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('tok-a', 'ios', CID);
+    s.register('tok-b', 'ios', 'conn2');
+    expect(s.size).toBe(2);
+  });
+
+  test('prune removes a dead token and persists the removal', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('dead', 'ios', CID);
+    expect(s.prune('dead', 'apns-invalid')).toBe(true);
+    expect(s.map.has('dead')).toBe(false);
+    expect(tokensOnDisk(file)).toEqual([]);
+  });
+
+  test('prune of an unknown token returns false', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('live', 'ios', CID);
+    expect(s.prune('nope', 'apns-invalid')).toBe(false);
+  });
+
+  test('load lets a fresh daemon see a token a prior daemon registered (no black-hole)', () => {
+    const a = new DeviceTokenStore(file);
+    a.register('tok-a', 'ios', CID);
+    const b = new DeviceTokenStore(file); // a brand-new daemon (e.g. a fresh worktree)
+    b.load();
+    expect(b.map.has('tok-a')).toBe(true);
+  });
+
+  test('load tolerates a missing file (starts empty)', () => {
+    const s = new DeviceTokenStore(path.join(tmpDir, 'absent.json'));
+    s.load();
+    expect(s.size).toBe(0);
+  });
+
+  test('load tolerates a corrupt file (starts empty, no throw)', () => {
+    fs.writeFileSync(file, 'not json{');
+    const s = new DeviceTokenStore(file);
+    s.load();
+    expect(s.size).toBe(0);
+  });
+
+  test('persist read-merges a concurrent daemon token instead of clobbering it', () => {
+    const a = new DeviceTokenStore(file);
+    a.register('tok-a', 'ios', CID);
+    // Another daemon appended tok-b to the SAME file out-of-band.
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        tokens: [
+          { token: 'tok-a', platform: 'ios', registeredAt: 1, connectionId: CID },
+          { token: 'tok-b', platform: 'ios', registeredAt: 1, connectionId: 'conn2' },
+        ],
+      }),
+    );
+    // a's next write must MERGE tok-b in (adopt it), not overwrite it away.
+    a.register('tok-d', 'ios', 'conn3');
+    expect(a.map.has('tok-b')).toBe(true);
+    expect(new Set(tokensOnDisk(file))).toEqual(new Set(['tok-a', 'tok-b', 'tok-d']));
+  });
+
+  test('a pruned token is NOT re-adopted from a concurrent daemon stale copy', () => {
+    const a = new DeviceTokenStore(file);
+    a.register('dead', 'ios', CID);
+    a.prune('dead', 'apns-invalid');
+    // Another daemon still lists the (now-dead) token because it has not pushed yet.
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        tokens: [{ token: 'dead', platform: 'ios', registeredAt: 1, connectionId: 'conn2' }],
+      }),
+    );
+    // a's next persist read-merge must NOT re-adopt the token it just pruned.
+    a.register('fresh', 'ios', 'conn3');
+    expect(a.map.has('dead')).toBe(false);
+    expect(new Set(tokensOnDisk(file))).toEqual(new Set(['fresh']));
+  });
+});

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -653,16 +653,9 @@ describe('NotificationDispatcher token pruning (#603 Phase 6)', () => {
     expect(pruned).toEqual(['dead']);
   });
 
-  test('a transient (429) failure does NOT prune the token', async () => {
-    register();
-    addToken('flaky');
-    const fail: PushFn = async () => {
-      throw new Error('Push trigger failed: 429 rate limited');
-    };
-    await make(fail).maybePush(SID, question('q1', [yesOpt, noOpt]));
-    expect(pruned).toEqual([]);
-  });
-
+  // (A transient 429/5xx classifies as not-token-invalid -> no prune; covered
+  // instantly by the 401 case below + the isTokenInvalidError unit tests, so the
+  // slow real-backoff 429 path is not re-tested here.)
   test('a 401 (non-token) failure does NOT prune the token', async () => {
     register();
     addToken('t');

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -8,6 +8,7 @@ import {
   buildPushText,
   isDelivered,
   isRetriablePushError,
+  isTokenInvalidError,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -596,5 +597,95 @@ describe('isRetriablePushError / isDelivered (#603 Phase 1)', () => {
     expect(isDelivered('deduped')).toBe(false);
     expect(isDelivered('no_channel')).toBe(false);
     expect(isDelivered('failed')).toBe(false);
+  });
+});
+
+describe('NotificationDispatcher token pruning (#603 Phase 6)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pruned: string[];
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+
+  function register(): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+  }
+  function make(pushFn: PushFn): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+        pruneToken: (t) => pruned.push(t),
+      },
+      SID,
+    );
+  }
+  const addToken = (t: string): void => {
+    deviceTokens.set(t, { token: t, platform: 'ios', registeredAt: 1, connectionId: SID });
+  };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pruned = [];
+    configureLogger({ writeLog: () => {} });
+  });
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a BadDeviceToken push prunes the dead token', async () => {
+    register();
+    addToken('dead');
+    const fail: PushFn = async () => {
+      throw new Error(
+        'Push trigger failed: 502 {"error":"APNS 400: BadDeviceToken","tokenInvalid":true}',
+      );
+    };
+    await make(fail).maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pruned).toEqual(['dead']);
+  });
+
+  test('a transient (429) failure does NOT prune the token', async () => {
+    register();
+    addToken('flaky');
+    const fail: PushFn = async () => {
+      throw new Error('Push trigger failed: 429 rate limited');
+    };
+    await make(fail).maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pruned).toEqual([]);
+  });
+
+  test('a 401 (non-token) failure does NOT prune the token', async () => {
+    register();
+    addToken('t');
+    const fail: PushFn = async () => {
+      throw new Error('Push trigger failed: 401 unauthorized');
+    };
+    await make(fail).maybePush(SID, question('q1', [yesOpt, noOpt]));
+    expect(pruned).toEqual([]);
+  });
+});
+
+describe('isTokenInvalidError (#603 Phase 6)', () => {
+  test('matches the structured tokenInvalid flag and the APNS token reasons', () => {
+    expect(isTokenInvalidError(new Error('502 {"error":"x","tokenInvalid":true}'))).toBe(true);
+    expect(isTokenInvalidError(new Error('APNS 400: BadDeviceToken'))).toBe(true);
+    expect(isTokenInvalidError(new Error('410 {"reason":"Unregistered"}'))).toBe(true);
+    expect(isTokenInvalidError(new Error('DeviceTokenNotForTopic'))).toBe(true);
+  });
+
+  test('does NOT match transient / auth / network errors', () => {
+    expect(isTokenInvalidError(new Error('Push trigger failed: 429 rate limited'))).toBe(false);
+    expect(isTokenInvalidError(new Error('Push trigger failed: 401 unauthorized'))).toBe(false);
+    expect(isTokenInvalidError(new Error('Push trigger failed: 503 unavailable'))).toBe(false);
+    expect(isTokenInvalidError(new TypeError('Failed to fetch'))).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #615. Epic #603 Phase 6 (R4) — makes the push channel self-repairing.

**Problem:** device tokens were a per-daemon in-memory Map, never persisted/shared, never pruned. A fresh worktree daemon had zero tokens (push black-hole); a dead `BadDeviceToken` was retried on every escalation forever (exactly the failure this epic chased — the manual token fix I had to do).

**Fix:**
- New `DeviceTokenStore`: persists to a shared `~/.remi/device-tokens.json` every local daemon loads on start (fresh daemon can push immediately); atomic per-pid `.tmp`+rename write; read-merges before each write so a concurrent daemon's tokens aren't clobbered while removed (pruned/rotated) tokens aren't re-adopted; owns the #585 rotation prune.
- **Self-healing prune:** a push failing with a permanent token rejection (Phase 2's structured `tokenInvalid` flag, or BadDeviceToken/Unregistered/DeviceTokenNotForTopic — new `isTokenInvalidError`) removes the token. Transient (429/5xx/network) and 401 do NOT prune.

**Tests (NO MOCKS):** real on-disk store round-trip (register/rotate/prune/load/corrupt/read-merge/no-re-adopt); dispatcher prunes on permanent failure, not transient/auth; classifier unit tests. 808 daemon tests pass.

Reviewed (sonnet): no critical findings; concurrency/persistence model + classifier + prune-during-fan-out + stable-map-reference all verified correct. One test-perf finding (slow redundant 429 test) fixed.

Note: cross-daemon LIVE sync (a token registered on running daemon A appearing on running daemon B without restart) needs file-watching — load-on-start covers the main case; documented as a possible refinement.