### PR TITLE
feat(signaling): dual-env APNS fallback for mixed sandbox+prod tokens (#618)

### DIFF
--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -141,9 +141,13 @@ export function planApnsAttempts(primarySandbox: boolean): boolean[] {
  * environment (or malformed)"; everything else is env-independent or transient
  * (429 throttle, 410 `Unregistered`, 403 `InvalidProviderToken`) and must NOT
  * trigger a redundant cross-environment retry. Pure + total.
+ *
+ * Matched against the structured APNS `reason` field rather than the raw string
+ * so a stray `BadDeviceToken` substring (e.g. inside a CDN/proxy error page that
+ * is not a clean APNS rejection) cannot provoke a spurious second round-trip.
  */
 export function isEnvMismatchError(error: string | undefined): boolean {
-  return /BadDeviceToken/i.test(error ?? '');
+  return /"reason"\s*:\s*"BadDeviceToken"/i.test(error ?? '');
 }
 
 /**
@@ -165,7 +169,7 @@ export async function sendApnsPush(
   const jwt = await createApnsJwt(config);
   const attempts = planApnsAttempts(payload.sandbox === true);
 
-  let lastError = '';
+  let lastError: string | undefined;
   for (const sandbox of attempts) {
     const { url, headers, body } = buildApnsRequest({ ...payload, sandbox }, jwt);
     const response = await fetch(url, { method: 'POST', headers, body });
@@ -184,7 +188,11 @@ export async function sendApnsPush(
     }
   }
 
-  return { success: false, error: lastError };
+  // `attempts` is always non-empty, so `lastError` is set on any failure; the
+  // fallback only guards a future change to `planApnsAttempts`. A non-empty
+  // message keeps the downstream tokenInvalid classifier from mistaking an empty
+  // error for a (non-permanent) blank and is surfaced rather than swallowed.
+  return { success: false, error: lastError ?? 'APNS: no delivery attempt was made' };
 }
 
 /** Cache APNS JWTs per keyId: Apple rate-limits token updates to once per 20 min. */

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -119,24 +119,72 @@ export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest
 }
 
 /**
+ * Plan the APNS host attempts for a push (#618, dual-env fallback).
+ *
+ * A device token is only valid for the APNS environment it was issued in
+ * (sandbox for development builds, production otherwise). The daemons in
+ * practice hold MIXED-environment tokens, so a single global host choice
+ * `BadDeviceToken`-rejects every token from the other environment. We try the
+ * preferred environment first (chosen by the `APNS_SANDBOX` flag), then fall
+ * back to the opposite one. Returns the `sandbox` flag per attempt, preferred
+ * first.
+ *
+ * Pure so the fallback policy is asserted without touching the network.
+ */
+export function planApnsAttempts(primarySandbox: boolean): boolean[] {
+  return [primarySandbox, !primarySandbox];
+}
+
+/**
+ * Whether an APNS error is an environment mismatch that warrants retrying the
+ * other host (#618). Only `BadDeviceToken` means "valid token, wrong
+ * environment (or malformed)"; everything else is env-independent or transient
+ * (429 throttle, 410 `Unregistered`, 403 `InvalidProviderToken`) and must NOT
+ * trigger a redundant cross-environment retry. Pure + total.
+ */
+export function isEnvMismatchError(error: string | undefined): boolean {
+  return /BadDeviceToken/i.test(error ?? '');
+}
+
+/**
  * Send a push notification via APNS HTTP/2 API.
  * Uses JWT bearer token authentication.
+ *
+ * Dual-env (#618): the push is attempted against the preferred environment
+ * first and, only on a `BadDeviceToken` environment mismatch, retried against
+ * the other one with the SAME JWT. A correctly-matched token costs exactly one
+ * round-trip; a mismatched token costs one extra. The returned `error` is the
+ * LAST attempt's error, so the daemon's permanent-vs-transient classifier (and
+ * Phase 6 token pruning) sees `BadDeviceToken` only when the token is dead in
+ * BOTH environments.
  */
 export async function sendApnsPush(
   payload: ApnsPayload,
   config: ApnsConfig,
 ): Promise<{ success: boolean; error?: string }> {
   const jwt = await createApnsJwt(config);
-  const { url, headers, body } = buildApnsRequest(payload, jwt);
+  const attempts = planApnsAttempts(payload.sandbox === true);
 
-  const response = await fetch(url, { method: 'POST', headers, body });
+  let lastError = '';
+  for (const sandbox of attempts) {
+    const { url, headers, body } = buildApnsRequest({ ...payload, sandbox }, jwt);
+    const response = await fetch(url, { method: 'POST', headers, body });
 
-  if (response.ok) {
-    return { success: true };
+    if (response.ok) {
+      return { success: true };
+    }
+
+    const errorBody = await response.text().catch(() => '');
+    lastError = `APNS ${response.status}: ${errorBody}`;
+
+    // Only an environment mismatch is worth retrying the other host; any other
+    // failure (throttle, unregistered, bad provider token) repeats identically.
+    if (!isEnvMismatchError(lastError)) {
+      break;
+    }
   }
 
-  const errorBody = await response.text().catch(() => '');
-  return { success: false, error: `APNS ${response.status}: ${errorBody}` };
+  return { success: false, error: lastError };
 }
 
 /** Cache APNS JWTs per keyId: Apple rate-limits token updates to once per 20 min. */

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -259,8 +259,11 @@ export default {
 
       // bundleId is always server-controlled (never from client)
       const bundleId = env.APNS_BUNDLE_ID || 'live.yooz.remi';
-      // sandbox: env var is the global gate. body.sandbox is reserved for future per-request
-      // override — the daemon does not send it today (payload is Record<string, string>).
+      // sandbox: the PREFERRED APNS environment to try first (#618 dual-env makes
+      // `sendApnsPush` fall back to the other environment on a BadDeviceToken, so
+      // this flag only saves a round-trip for the common case — it is no longer a
+      // hard gate). body.sandbox is reserved for future per-request override — the
+      // daemon does not send it today (payload is Record<string, string>).
       // `.trim()`: a secret set via `echo "true" | wrangler secret put` carries a
       // trailing newline, so an exact `=== 'true'` silently fails — match leniently.
       const sandbox = env.APNS_SANDBOX?.trim() === 'true' || body.sandbox === true;

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -109,12 +109,21 @@ describe('dual-env fallback policy (#618)', () => {
     expect(planApnsAttempts(true)).toEqual([true, false]);
   });
 
-  test('the two planned attempts target opposite APNS hosts', () => {
+  test('production-preferred plan hits prod first, then sandbox', () => {
     const [first, second] = planApnsAttempts(false).map(
       (sandbox) => buildApnsRequest({ ...BASE, sandbox }, 'jwt').url,
     );
     expect(first).toContain('api.push.apple.com');
     expect(second).toContain('api.sandbox.push.apple.com');
+    expect(first).not.toBe(second);
+  });
+
+  test('sandbox-preferred plan hits sandbox first, then prod (the historically misconfigured path)', () => {
+    const [first, second] = planApnsAttempts(true).map(
+      (sandbox) => buildApnsRequest({ ...BASE, sandbox }, 'jwt').url,
+    );
+    expect(first).toContain('api.sandbox.push.apple.com');
+    expect(second).toContain('api.push.apple.com');
     expect(first).not.toBe(second);
   });
 
@@ -132,6 +141,9 @@ describe('dual-env fallback policy (#618)', () => {
     expect(isEnvMismatchError('APNS 403: {"reason":"InvalidProviderToken"}')).toBe(false);
     // Topic mismatch is a bundle problem, not an environment one.
     expect(isEnvMismatchError('APNS 400: {"reason":"DeviceTokenNotForTopic"}')).toBe(false);
+    // A stray BadDeviceToken substring outside the reason field (e.g. a proxy
+    // error page) must not provoke a spurious cross-environment retry.
+    expect(isEnvMismatchError('502 Bad Gateway: BadDeviceToken handler unavailable')).toBe(false);
   });
 
   test('isEnvMismatchError is total (no error / empty string -> false)', () => {

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { buildApnsRequest } from '../src/apns.ts';
+import { buildApnsRequest, isEnvMismatchError, planApnsAttempts } from '../src/apns.ts';
 
 const BASE = {
   token: 'device-token-abc',
@@ -98,6 +98,45 @@ describe('buildApnsRequest (#575 P4a)', () => {
     expect(req.headers['apns-topic']).toBe('live.yooz.remi');
     expect(req.headers['apns-push-type']).toBe('alert');
     expect(req.headers['apns-priority']).toBe('10');
+  });
+});
+
+describe('dual-env fallback policy (#618)', () => {
+  test('planApnsAttempts tries the preferred environment first, then the other', () => {
+    // Production preferred (APNS_SANDBOX unset) -> prod then sandbox.
+    expect(planApnsAttempts(false)).toEqual([false, true]);
+    // Sandbox preferred (APNS_SANDBOX=true) -> sandbox then prod.
+    expect(planApnsAttempts(true)).toEqual([true, false]);
+  });
+
+  test('the two planned attempts target opposite APNS hosts', () => {
+    const [first, second] = planApnsAttempts(false).map(
+      (sandbox) => buildApnsRequest({ ...BASE, sandbox }, 'jwt').url,
+    );
+    expect(first).toContain('api.push.apple.com');
+    expect(second).toContain('api.sandbox.push.apple.com');
+    expect(first).not.toBe(second);
+  });
+
+  test('isEnvMismatchError matches only BadDeviceToken (the wrong-environment signal)', () => {
+    expect(isEnvMismatchError('APNS 400: {"reason":"BadDeviceToken"}')).toBe(true);
+    expect(isEnvMismatchError('APNS 400: {"reason":"baddevicetoken"}')).toBe(true);
+  });
+
+  test('isEnvMismatchError does NOT retry on env-independent or transient errors', () => {
+    // Token genuinely gone for its environment — retrying the other host is pointless.
+    expect(isEnvMismatchError('APNS 410: {"reason":"Unregistered"}')).toBe(false);
+    // Throttle — same host would re-throttle; not an environment problem.
+    expect(isEnvMismatchError('APNS 429: {"reason":"TooManyRequests"}')).toBe(false);
+    // Auth/provider error — affects both hosts equally.
+    expect(isEnvMismatchError('APNS 403: {"reason":"InvalidProviderToken"}')).toBe(false);
+    // Topic mismatch is a bundle problem, not an environment one.
+    expect(isEnvMismatchError('APNS 400: {"reason":"DeviceTokenNotForTopic"}')).toBe(false);
+  });
+
+  test('isEnvMismatchError is total (no error / empty string -> false)', () => {
+    expect(isEnvMismatchError(undefined)).toBe(false);
+    expect(isEnvMismatchError('')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #618. Part of epic #603 (Milestone 2).

## Problem

The signaling Worker picked ONE APNS environment from a single global flag (`APNS_SANDBOX`). A device token is only valid for the environment it was issued in, but the daemons hold **mixed-environment tokens** (live diagnosis 2026-06-22: 3 distinct tokens across 8 daemons; one succeeded in *sandbox* mode and another in *production* mode in the same window). A single host choice therefore `BadDeviceToken`-rejects every token from the other environment — the headline failure behind epic #603, and the blocker hit during 0.6.14 on-device validation.

## Fix

`sendApnsPush` now attempts the **preferred** environment first (still chosen by `APNS_SANDBOX` / `body.sandbox`, so the common case is one round-trip) and, **only** on a `BadDeviceToken` mismatch, retries the **other** host with the same JWT. Any other error (`429` throttle, `410 Unregistered`, `403 InvalidProviderToken`, `DeviceTokenNotForTopic`) does NOT retry — those are env-independent or transient.

- Pure, no-mocks decision helpers `planApnsAttempts(primarySandbox)` and `isEnvMismatchError(error)`, asserted directly (mirrors the existing `buildApnsRequest` test approach).
- `tokenInvalid` classification (Phase 6 pruning) still works off the FINAL error: a token that is `BadDeviceToken` in BOTH environments is correctly flagged dead; a token that succeeds on the fallback is not.
- Cost: one extra APNS round-trip ONLY when the preferred environment mismatches; correctly-matched tokens are unaffected.

## Tests

- `planApnsAttempts` orders preferred-first for both flags; the two attempts hit opposite hosts.
- `isEnvMismatchError` matches only `BadDeviceToken` (incl. case-insensitive); does not retry on `Unregistered` / `429` / `InvalidProviderToken` / `DeviceTokenNotForTopic`; total on `undefined`/empty.
- Full signaling suite: 89 pass. `tsc --noEmit` + `biome check` clean.

## Deploy

Already deployed to `remi-signaling` (version `a8cf4b9f`) to unblock live validation; this PR formalizes it. No secret change required — the flag is now just the preferred-first hint.