### PR TITLE
feat(daemon): per-eval cancel so a manual answer frees Ollama + remi unstick (#617)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -54,10 +54,16 @@ export interface AutoApproveEvaluator {
     tag?: string,
     permissionSuggestions?: readonly unknown[],
     modelOverride?: string,
+    evalId?: number,
   ): Promise<AutoApproveResult>;
-  /** Abort any in-flight `evaluate`. Returns true if an abort was issued, false
-   *  if nothing was in flight (idempotent). */
-  cancel(reason: string): boolean;
+  /** Abort an in-flight `evaluate`. With `evalId`, aborts ONLY when that id is the
+   *  eval currently running (#617 per-eval scoping); without it, aborts whatever
+   *  is in flight. Returns true if an abort was issued, false otherwise (idempotent). */
+  cancel(reason: string, evalId?: number): boolean;
+  /** Drain queued evals so they escalate gracefully instead of seizing the freed
+   *  GPU (#617 force-release). Returns the number drained. Optional: a minimal
+   *  evaluator under test may omit it. */
+  drainQueue?(): number;
 }
 
 export interface AutoApproveGateDeps {
@@ -167,6 +173,22 @@ export class AutoApproveGate {
    */
   private readonly pendingHolds = new Map<UUID, PendingHold>();
 
+  /** Monotonic id stamped on each primary eval (#617), so a held question can be
+   *  tied to the exact eval running for it and a manual answer cancels only that
+   *  one. */
+  private evalSeq = 0;
+
+  /**
+   * Maps a held question's id to the id of the eval still running for it (#617),
+   * populated only by Part B (the early push + hold fires WHILE the eval keeps
+   * running — the one case where the user can answer mid-eval). A manual answer
+   * looks the question up here to cancel exactly its eval and free the GPU.
+   * Entries are removed when the eval settles (reconcileLateVerdict) or on
+   * force-release; a stale entry is harmless (cancel no-ops if that eval is no
+   * longer the running one).
+   */
+  private readonly evalIdByQuestion = new Map<UUID, number>();
+
   constructor(
     private readonly deps: AutoApproveGateDeps,
     private readonly sessionId: UUID,
@@ -195,6 +217,49 @@ export class AutoApproveGate {
     if (this.deps.service.cancel(reason)) {
       log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
     }
+  }
+
+  /**
+   * Cancel the in-flight eval (if any) for a question the user just answered, so
+   * the GPU is freed immediately (#617, the user's critical "answer == GPU freed"
+   * contract). Scoped by the per-question eval id, so it aborts ONLY that
+   * question's eval and never another permission's that happens to be running.
+   * Unlike `cancelStale` it does NOT release other holds — answering one question
+   * must never fail the others open. No-op when no eval is tracked (it already
+   * settled, or the question was not held mid-eval), so it is safe to call on
+   * every answer unconditionally.
+   */
+  cancelEvalForQuestion(questionId: UUID, reason: string): void {
+    const evalId = this.evalIdByQuestion.get(questionId);
+    if (evalId === undefined) return;
+    this.evalIdByQuestion.delete(questionId);
+    if (this.deps.service?.cancel(reason, evalId)) {
+      log(
+        `[AutoApprove ${this.sessionTag}] Answer freed the eval for ${questionId.slice(0, 8)} (${reason})`,
+      );
+    }
+  }
+
+  /**
+   * Force-release escape (#617, `remi unstick`): the "just get me out" lever when
+   * Ollama and a question are stuck and the phone has no device visibility.
+   * Releases EVERY held hook to passthrough (the native terminal prompt), aborts
+   * the in-flight eval, and drains queued evals so they escalate gracefully
+   * instead of seizing the freed GPU. Safe with no service configured (only
+   * releases holds). Returns a summary for the caller to log.
+   */
+  forceRelease(reason: string): { holds: number; cancelled: boolean; drained: number } {
+    const holds = this.pendingHolds.size;
+    this.releaseAllHolds('passthrough', reason);
+    this.evalIdByQuestion.clear();
+    const service = this.deps.service;
+    if (service === null) return { holds, cancelled: false, drained: 0 };
+    const cancelled = service.cancel(reason);
+    const drained = service.drainQueue?.() ?? 0;
+    log(
+      `[AutoApprove ${this.sessionTag}] Force-release (${reason}): released ${holds} hold(s), ${cancelled ? 'cancelled the eval' : 'no eval in flight'}, drained ${drained} queued`,
+    );
+    return { holds, cancelled, drained };
   }
 
   /**
@@ -486,11 +551,16 @@ export class AutoApproveGate {
     // Raw suggestions: the service does its own strict-string filtering; we
     // forward the raw shape so the multi-choice classifier can route a
     // non-string entry through escalate instead of crashing.
+    // Stamp a unique id so a held question (Part B) can be tied to THIS eval and
+    // a manual answer cancels exactly it (#617).
+    const evalId = ++this.evalSeq;
     const evalPromise = service.evaluate(
       input.tool_name,
       input.tool_input,
       this.sessionTag,
       input.permission_suggestions as readonly unknown[] | undefined,
+      undefined,
+      evalId,
     );
 
     // Part B (#573, ISOLATED behind push_hold_timeout): if the eval is still
@@ -500,7 +570,7 @@ export class AutoApproveGate {
     // When push_hold_timeout <= 0 this never arms and the eval is awaited as
     // usual (Parts A + C only). A non-null result means the early hold fired and
     // the returned decision is what the hook server is blocked on.
-    const earlyHold = await this.maybePushOnSlowEval(input, evalPromise);
+    const earlyHold = await this.maybePushOnSlowEval(input, evalPromise, evalId);
     if (earlyHold !== null) return earlyHold;
 
     let result: AutoApproveResult;
@@ -641,6 +711,7 @@ export class AutoApproveGate {
   private async maybePushOnSlowEval(
     input: PermissionRequestHookInput,
     evalPromise: Promise<AutoApproveResult>,
+    evalId: number,
   ): Promise<PermissionDecision | null> {
     const pushHoldMs = this.deps.pushHoldMs ?? 0;
     // Disabled, or this escalation could not be answered via the hook response
@@ -682,6 +753,10 @@ export class AutoApproveGate {
     // createHold escalates AND (when a hold is registered) pushes the held
     // question via onHeldEscalate (#573), so the user can step in immediately.
     const { decision: heldDecision, questionId } = this.createHold(input);
+    // Tie the held question to THIS still-running eval so a manual answer cancels
+    // exactly it and frees the GPU (#617). This is the only place an eval is live
+    // while its question is answerable.
+    if (questionId) this.evalIdByQuestion.set(questionId, evalId);
     // The reconciliation NEVER pushes again — a late escalate just leaves the
     // existing hold in place (guarded by the pendingHolds membership check
     // inside reconcileLateVerdict), and pushHeldHook is itself idempotent.
@@ -703,6 +778,8 @@ export class AutoApproveGate {
     qid: UUID | undefined,
   ): Promise<void> {
     const outcome = await safeEval;
+    // The eval has settled; its question can no longer be cancelled (#617).
+    if (qid) this.evalIdByQuestion.delete(qid);
     if (!qid || !this.pendingHolds.has(qid)) return; // already resolved/timed out
     if (!outcome.ok) {
       // Eval threw: the user is already looking at the pushed question; leave the

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -107,7 +107,16 @@ export class AutoApproveService {
    *  deny/allow/group checks run BEFORE acquiring a slot, so they are never
    *  queued. */
   private evalActive = false;
-  private readonly evalQueue: Array<{ grant: () => void; deny: () => void }> = [];
+  private readonly evalQueue: Array<{
+    /** Id of the queued eval (#617), so cancel(reason, evalId) can drop a waiter
+     *  whose question was answered before it ever reached the GPU. */
+    evalId: number | undefined;
+    /** Take the slot (becomes the running eval). */
+    grant: () => void;
+    /** Resolve as NOT acquired -> the eval escalates gracefully (force-release /
+     *  answered-while-queued) instead of seizing the slot. */
+    deny: () => void;
+  }> = [];
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
    *  aborts via this. Held alongside the active slot so they share the same
    *  lifecycle window. */
@@ -152,39 +161,40 @@ export class AutoApproveService {
 
   /**
    * Acquire the single eval slot, serializing concurrent LLM evaluations (one
-   * GPU). Resolves true when the slot is held; resolves false if the wait
+   * GPU). Resolves `'acquired'` when the slot is held; `'timeout'` if the wait
    * exceeded `deadlineMs` (the caller then escalates gracefully rather than
-   * risking the ~600s hook budget). When the slot is free it is taken
-   * immediately; otherwise the caller is queued FIFO and granted by
-   * `releaseSlot`.
+   * risking the ~600s hook budget); `'drained'` if force-release (#617) dropped
+   * the waiter. When the slot is free it is taken immediately; otherwise the
+   * caller is queued FIFO and granted by `releaseSlot`. `evalId` tags the waiter
+   * so a per-question cancel can drop it while still queued.
    */
-  private acquireSlot(deadlineMs: number): Promise<boolean> {
+  private acquireSlot(deadlineMs: number, evalId?: number): Promise<SlotOutcome> {
     if (!this.evalActive) {
       this.evalActive = true;
-      return Promise.resolve(true);
+      return Promise.resolve('acquired');
     }
-    return new Promise<boolean>((resolve) => {
+    return new Promise<SlotOutcome>((resolve) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
+      // One-shot settle: grant / deny / timeout can race (e.g. drainQueue vs the
+      // deadline timer); the first wins and the rest are inert.
+      let settled = false;
+      const settle = (outcome: SlotOutcome): void => {
+        if (settled) return;
+        settled = true;
+        if (timer !== null) clearTimeout(timer);
+        resolve(outcome);
+      };
       const waiter = {
-        grant: () => {
-          if (timer !== null) clearTimeout(timer);
-          resolve(true);
-        },
-        // Force-release (#617): resolve the waiter as NOT acquired so the eval
-        // takes the graceful escalate path instead of grabbing the freed GPU.
-        deny: () => {
-          if (timer !== null) clearTimeout(timer);
-          resolve(false);
-        },
+        evalId,
+        grant: () => settle('acquired'),
+        deny: () => settle('drained'),
       };
       this.evalQueue.push(waiter);
       if (deadlineMs > 0) {
         timer = setTimeout(() => {
           const i = this.evalQueue.indexOf(waiter);
-          if (i !== -1) {
-            this.evalQueue.splice(i, 1);
-            resolve(false);
-          }
+          if (i !== -1) this.evalQueue.splice(i, 1);
+          settle('timeout');
         }, deadlineMs);
       }
     });
@@ -207,7 +217,9 @@ export class AutoApproveService {
    * Drain every queued waiter, resolving each as NOT acquired so its eval takes
    * the graceful escalate path instead of running on the GPU (#617 force-release).
    * Does NOT touch the eval currently holding the slot — `cancel()` aborts that.
-   * Returns the number of waiters drained.
+   * Returns the number of waiters drained. Called synchronously right after
+   * `cancel()` in `forceRelease`, so the aborted eval's `releaseSlot` (a later
+   * microtask) cannot hand the slot to a waiter before they are all drained.
    */
   drainQueue(): number {
     let drained = 0;
@@ -358,10 +370,13 @@ export class AutoApproveService {
       // A second request QUEUES instead of escalating-on-busy; only a request
       // that waits past queue_timeout escalates gracefully so a deep burst
       // (parallel subagents) never risks the ~600s hook budget.
-      const acquired = await this.acquireSlot(this.queueTimeoutMs);
-      if (!acquired) {
+      const slot = await this.acquireSlot(this.queueTimeoutMs, evalId);
+      if (slot !== 'acquired') {
         const durationMs = Date.now() - start;
-        const reasoning = `eval queue wait exceeded ${this.queueTimeoutMs}ms; escalating to user`;
+        const reasoning =
+          slot === 'drained'
+            ? 'force-released (remi unstick) before slot acquisition; escalating to user'
+            : `eval queue wait exceeded ${this.queueTimeoutMs}ms; escalating to user`;
         this.logFn(`${prefix} ${toolName}: escalate (${durationMs}ms) - ${reasoning}`);
         return { decision: 'escalate', reasoning, durationMs, model };
       }
@@ -514,18 +529,39 @@ export class AutoApproveService {
    *
    * When `evalId` is given, the abort fires ONLY if that id matches the eval
    * currently holding the slot — so a manual answer for question X cancels X's
-   * eval and never a different permission's that happens to be running now. With
-   * no `evalId` it aborts whatever is in flight (session teardown / force-release).
+   * eval and never a different permission's that happens to be running now. If
+   * that eval is still QUEUED (answered under contention before it reached the
+   * GPU), the queued waiter is dropped instead (it escalates gracefully) so the
+   * answer never triggers a now-pointless LLM call. With no `evalId` it aborts
+   * whatever is in flight (session teardown / force-release).
    *
-   * Returns true if a call was actually cancelled, false if there was no
-   * in-flight eval or the running eval did not match `evalId` (idempotent, safe
-   * to call always).
+   * Returns true if a call was actually cancelled (running aborted or queued
+   * dropped), false otherwise (idempotent, safe to call always).
    */
   cancel(reason: string, evalId?: number): boolean {
-    if (this.currentAbortController === null) return false;
-    if (evalId !== undefined && this.currentEvalId !== evalId) return false;
-    this.cancelReason = reason;
-    this.currentAbortController.abort();
-    return true;
+    // The running eval: abort when untargeted, or when the target matches.
+    if (
+      this.currentAbortController !== null &&
+      (evalId === undefined || this.currentEvalId === evalId)
+    ) {
+      this.cancelReason = reason;
+      this.currentAbortController.abort();
+      return true;
+    }
+    // A targeted eval still waiting for the slot: drop it so it escalates
+    // instead of running after its question was already answered (#617).
+    if (evalId !== undefined) {
+      const i = this.evalQueue.findIndex((w) => w.evalId === evalId);
+      if (i !== -1) {
+        const waiter = this.evalQueue.splice(i, 1)[0];
+        waiter?.deny();
+        return true;
+      }
+    }
+    return false;
   }
 }
+
+/** Outcome of an `acquireSlot` request (#617): the eval ran, timed out waiting,
+ *  or was dropped by force-release / a per-question cancel. */
+type SlotOutcome = 'acquired' | 'timeout' | 'drained';

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -107,11 +107,17 @@ export class AutoApproveService {
    *  deny/allow/group checks run BEFORE acquiring a slot, so they are never
    *  queued. */
   private evalActive = false;
-  private readonly evalQueue: Array<{ grant: () => void }> = [];
+  private readonly evalQueue: Array<{ grant: () => void; deny: () => void }> = [];
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
    *  aborts via this. Held alongside the active slot so they share the same
    *  lifecycle window. */
   private currentAbortController: AbortController | null = null;
+  /** Caller-supplied id of the eval currently holding the slot (#617). Lets
+   *  `cancel(reason, evalId)` abort ONLY the targeted eval instead of whatever
+   *  happens to be running — so a manual answer for question X frees X's eval and
+   *  never a different permission's (the wrong-victim risk that forced the old
+   *  answer-cancel to be gated). null when the running eval supplied no id. */
+  private currentEvalId: number | null = null;
   /** Set by cancel() so the catch block can distinguish a user-driven abort
    *  (Claude advanced past the prompt) from a timeout abort. */
   private cancelReason: string | null = null;
@@ -164,6 +170,12 @@ export class AutoApproveService {
           if (timer !== null) clearTimeout(timer);
           resolve(true);
         },
+        // Force-release (#617): resolve the waiter as NOT acquired so the eval
+        // takes the graceful escalate path instead of grabbing the freed GPU.
+        deny: () => {
+          if (timer !== null) clearTimeout(timer);
+          resolve(false);
+        },
       };
       this.evalQueue.push(waiter);
       if (deadlineMs > 0) {
@@ -189,6 +201,21 @@ export class AutoApproveService {
     } else {
       this.evalActive = false;
     }
+  }
+
+  /**
+   * Drain every queued waiter, resolving each as NOT acquired so its eval takes
+   * the graceful escalate path instead of running on the GPU (#617 force-release).
+   * Does NOT touch the eval currently holding the slot — `cancel()` aborts that.
+   * Returns the number of waiters drained.
+   */
+  drainQueue(): number {
+    let drained = 0;
+    for (let next = this.evalQueue.shift(); next; next = this.evalQueue.shift()) {
+      next.deny();
+      drained++;
+    }
+    return drained;
   }
 
   /**
@@ -229,6 +256,7 @@ export class AutoApproveService {
     tag?: string,
     permissionSuggestions?: readonly unknown[],
     modelOverride?: string,
+    evalId?: number,
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     // modelOverride (#522: the escalate_model second opinion) replaces the base
@@ -339,6 +367,7 @@ export class AutoApproveService {
       }
 
       this.currentAbortController = new AbortController();
+      this.currentEvalId = evalId ?? null;
       const externalSignal = this.currentAbortController.signal;
       // The heavy escalate_model gets its dedicated (longer) budget when set, so
       // a cold model-load does not abort the fast model's shorter timeout.
@@ -438,6 +467,7 @@ export class AutoApproveService {
       } finally {
         if (raceTimer !== null) clearTimeout(raceTimer);
         this.currentAbortController = null;
+        this.currentEvalId = null;
         this.releaseSlot();
       }
     } catch (err) {
@@ -477,16 +507,23 @@ export class AutoApproveService {
   }
 
   /**
-   * Abort any in-flight LLM evaluation. Called by the hook bridge when
-   * Claude advances past the prompt (PreToolUse / PostToolUse / Stop /
-   * SessionEnd) so a slow LLM call cannot return a stale decision after
-   * the user already answered in the local terminal.
+   * Abort an in-flight LLM evaluation. Called by the hook bridge when Claude
+   * advances past the prompt (PreToolUse / PostToolUse / Stop / SessionEnd) so a
+   * slow LLM call cannot return a stale decision after the user already answered
+   * in the local terminal, and by a manual answer to free the GPU (#617).
+   *
+   * When `evalId` is given, the abort fires ONLY if that id matches the eval
+   * currently holding the slot — so a manual answer for question X cancels X's
+   * eval and never a different permission's that happens to be running now. With
+   * no `evalId` it aborts whatever is in flight (session teardown / force-release).
    *
    * Returns true if a call was actually cancelled, false if there was no
-   * in-flight eval (idempotent, safe to call always).
+   * in-flight eval or the running eval did not match `evalId` (idempotent, safe
+   * to call always).
    */
-  cancel(reason: string): boolean {
+  cancel(reason: string, evalId?: number): boolean {
     if (this.currentAbortController === null) return false;
+    if (evalId !== undefined && this.currentEvalId !== evalId) return false;
     this.cancelReason = reason;
     this.currentAbortController.abort();
     return true;

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -111,6 +111,7 @@ import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts'
 import { resolveClaudeBinding } from './cli/claude-binding.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
+import { runUnstickCommand } from './cli/cmd-unstick.ts';
 import { DetachScanner } from './cli/detach-scanner.ts';
 import {
   type ConnectionHandlers,
@@ -234,6 +235,13 @@ if (parsedArgs.subcommand === 'config') {
 // Handle 'reload' subcommand
 if (parsedArgs.subcommand === 'reload') {
   process.exit(runReloadCommand());
+}
+
+// Handle 'unstick' subcommand (#617): SIGUSR2 -> force-release stuck daemon(s).
+if (parsedArgs.subcommand === 'unstick') {
+  const parsedPort = parsedArgs.subcommandArg ? Number(parsedArgs.subcommandArg) : Number.NaN;
+  const targetPort = Number.isInteger(parsedPort) ? parsedPort : undefined;
+  process.exit(runUnstickCommand(targetPort));
 }
 
 // Destructure into existing variable names for zero downstream changes
@@ -859,6 +867,27 @@ const binderClosers: Map<UUID, () => void> = new Map();
 // (multi-session daemons). Populated in createNewSession after setupHookBridge;
 // removed on session close. Empty when no hookServer is configured.
 const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
+/**
+ * Force-release every session's gate (#617, `remi unstick` -> SIGUSR2): the "just
+ * get me out" lever when Ollama + a question are stuck and the phone has no device
+ * visibility. Each gate releases its held hooks to passthrough (native prompt),
+ * aborts the in-flight eval, and drains its eval queue. Idempotent and safe with
+ * zero sessions.
+ */
+function forceReleaseAllSessions(): void {
+  let holds = 0;
+  let cancelled = 0;
+  let drained = 0;
+  for (const handle of sessionGateHandles.values()) {
+    const r = handle.forceRelease('force-release (remi unstick)');
+    holds += r.holds;
+    cancelled += r.cancelled ? 1 : 0;
+    drained += r.drained;
+  }
+  log(
+    `[unstick] Force-released ${sessionGateHandles.size} session(s): ${holds} hold(s) -> passthrough, ${cancelled} eval(s) cancelled, ${drained} queued drained`,
+  );
+}
 // Per-session APNS dispatchers (#585, P7), keyed by sessionId, so the
 // question-resolved path can fire a quiet lock-screen dismissal through the same
 // device-token fan-out that pushed the card. Populated in createNewSession;
@@ -1388,7 +1417,11 @@ const inputHandlers: InputHandlers = createInputHandlers({
     sessionGateHandles.get(sessionId)?.resolveHeld(questionId, decision) ?? false,
   releaseHeldAsPassthrough: (sessionId, questionId) =>
     sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
-  cancelAutoApprove: (sessionId, reason) => sessionGateHandles.get(sessionId)?.cancelStale(reason),
+  // #617: a manual answer frees the GPU by cancelling ONLY that question's eval,
+  // without failing the session's other holds open (which cancelStale would do).
+  // (cancelStale itself is wired for Stop/SessionEnd teardown in hook-bridge-setup.)
+  cancelAutoApproveForQuestion: (sessionId, questionId, reason) =>
+    sessionGateHandles.get(sessionId)?.cancelEvalForQuestion(questionId, reason),
   // #585: a locally answered question dismisses its card + lock-screen push on
   // every other client.
   onQuestionResolved: (sessionId, questionId) =>
@@ -1899,6 +1932,7 @@ if (cliDaemonMode) {
       console.error(`[reload] Failed to load config: ${errorToString(err)}`);
     }
   });
+  process.on('SIGUSR2', forceReleaseAllSessions);
 } else {
   // Wrapper mode: spawn Claude immediately, pass through terminal I/O
   // Block ALL output paths to the terminal. In Bun compiled binaries,
@@ -2298,6 +2332,8 @@ if (cliDaemonMode) {
       logError(`[reload] Failed to load config: ${errorToString(err)}`);
     }
   });
+  // SIGUSR2: force-release signal (triggered by `remi unstick`)
+  process.on('SIGUSR2', forceReleaseAllSessions);
 
   // Forward SIGINT/SIGTERM to PTY instead of exiting
   process.on('SIGINT', () => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -878,11 +878,17 @@ function forceReleaseAllSessions(): void {
   let holds = 0;
   let cancelled = 0;
   let drained = 0;
-  for (const handle of sessionGateHandles.values()) {
-    const r = handle.forceRelease('force-release (remi unstick)');
-    holds += r.holds;
-    cancelled += r.cancelled ? 1 : 0;
-    drained += r.drained;
+  // Per-session try/catch: a throw in one gate's release must not abort the loop
+  // and leave the remaining sessions stuck (the whole point is "get me out").
+  for (const [sessionId, handle] of sessionGateHandles.entries()) {
+    try {
+      const r = handle.forceRelease('force-release (remi unstick)');
+      holds += r.holds;
+      cancelled += r.cancelled ? 1 : 0;
+      drained += r.drained;
+    } catch (err) {
+      logError(`[unstick] Failed to force-release session ${sessionId.slice(0, 8)}:`, err);
+    }
   }
   log(
     `[unstick] Force-released ${sessionGateHandles.size} session(s): ${holds} hold(s) -> passthrough, ${cancelled} eval(s) cancelled, ${drained} queued drained`,

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -22,6 +22,7 @@ const SUBCOMMAND_LIST = [
   'detach',
   'recent',
   'reload',
+  'unstick',
   'start',
   'stop',
   'status',
@@ -39,6 +40,7 @@ const SUBCOMMANDS_WITH_POSITIONAL_ARG: ReadonlySet<Subcommand> = new Set<Subcomm
   'authorize',
   'kill',
   'detach',
+  'unstick',
 ]);
 
 export function isSubcommand(s: string): s is Subcommand {

--- a/packages/daemon/src/cli/cmd-unstick.ts
+++ b/packages/daemon/src/cli/cmd-unstick.ts
@@ -1,0 +1,89 @@
+/**
+ * Handler for `remi unstick [port]` — sends SIGUSR2 to live daemon(s), the "just
+ * get me out" lever (#617). On receipt each daemon releases every held
+ * PermissionRequest hook to passthrough (Claude renders its native prompt),
+ * aborts the in-flight auto-approve eval, and drains its eval queue so a stuck
+ * Ollama + question unblocks immediately. The phone has no device visibility, so
+ * this is the operator's manual escape hatch when an eval is wedged.
+ *
+ * With no port, every live daemon is unstuck; with a port, only the daemon bound
+ * to that WebSocket port. Exits 0 if at least one daemon was signaled, 1 otherwise
+ * (no live/matching daemons, or all signal attempts failed). Stale entries (ESRCH)
+ * are reported but do not count as success.
+ */
+
+import { errorToString } from '@remi/shared';
+import { SessionRegistryFile } from '../session/session-registry-file.ts';
+
+export interface UnstickCommandIO {
+  readonly out: (msg: string) => void;
+  readonly err: (msg: string) => void;
+}
+
+const defaultIO: UnstickCommandIO = {
+  out: (msg) => console.log(msg),
+  err: (msg) => console.error(msg),
+};
+
+/** Dependencies the handler needs. Exposed for tests. */
+export interface UnstickCommandDeps {
+  /** Lists currently-live daemons. Defaults to the production SessionRegistryFile. */
+  readonly listLive?: () => ReadonlyArray<{
+    name: string;
+    pid: number;
+    wsPort: number;
+  }>;
+  /** Sends a signal to a pid. Defaults to `process.kill`. Must throw with
+   *  `code: 'ESRCH'` on NodeJS.ErrnoException when the pid is gone. */
+  readonly kill?: (pid: number, signal: NodeJS.Signals) => void;
+}
+
+/**
+ * @param targetPort When set, only the daemon bound to this WebSocket port is
+ *   signaled; otherwise every live daemon is.
+ */
+export function runUnstickCommand(
+  targetPort: number | undefined = undefined,
+  io: UnstickCommandIO = defaultIO,
+  deps: UnstickCommandDeps = {},
+): number {
+  const listLive = deps.listLive ?? (() => new SessionRegistryFile().listLive());
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+
+  const live = listLive();
+  const targets = targetPort !== undefined ? live.filter((e) => e.wsPort === targetPort) : live;
+
+  if (targets.length === 0) {
+    io.err(
+      targetPort !== undefined
+        ? `No running daemon found on port ${targetPort}.`
+        : 'No running daemons found.',
+    );
+    return 1;
+  }
+
+  let unstuck = 0;
+  for (const entry of targets) {
+    try {
+      kill(entry.pid, 'SIGUSR2');
+      io.out(`Sent unstick signal to ${entry.name} (PID ${entry.pid}, port ${entry.wsPort})`);
+      unstuck++;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ESRCH') {
+        io.err(`Process ${entry.pid} not found (stale session entry)`);
+      } else {
+        io.err(`Failed to signal PID ${entry.pid}: ${errorToString(err)}`);
+      }
+    }
+  }
+
+  if (unstuck > 0) {
+    io.out(
+      `Unstuck ${unstuck} daemon(s): released holds, cancelled in-flight evals, drained queues.`,
+    );
+    return 0;
+  }
+  io.err('Failed to unstick any daemons (all matching session entries appear stale).');
+  return 1;
+}

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -43,14 +43,12 @@ export interface InputHandlerDeps {
    */
   releaseHeldAsPassthrough?: (sessionId: UUID, questionId: UUID) => boolean;
   /**
-   * Cancel the in-flight auto-approve eval (and release holds) for `sessionId`
-   * when the user answers a HELD permission from any channel (#573, issue 2): a
-   * stale eval would otherwise keep running and could inject a phantom decision.
-   * Fired ONLY when a hold was actually resolved/released, so answering an
-   * unrelated passthrough question does not abort a different binary permission's
-   * in-flight eval. Session-keyed.
+   * Cancel ONLY the eval for the question the user just answered (#617), freeing
+   * the GPU without touching the session's other holds. Per-eval scoping makes it
+   * safe to fire on every answer (a no-op when no eval is in flight for the
+   * question, and it never aborts a different permission's eval). Session-keyed.
    */
-  cancelAutoApprove?: (sessionId: UUID, reason: string) => void;
+  cancelAutoApproveForQuestion?: (sessionId: UUID, questionId: UUID, reason: string) => void;
   /**
    * Cross-client question dismissal (#585, P7). Called after a question is
    * answered here so the daemon broadcasts `question_resolved` to every client and
@@ -186,7 +184,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     send,
     resolveHeldPermission,
     releaseHeldAsPassthrough,
-    cancelAutoApprove,
+    cancelAutoApproveForQuestion,
     onQuestionResolved,
   } = deps;
 
@@ -255,7 +253,11 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // hold_timeout. The answer itself is stale (we no longer hold the options
       // to map it), so it is still refused — but the terminal can take over.
       const freedHeld = releaseHeldAsPassthrough?.(session.sessionId, questionId) ?? false;
-      if (freedHeld) cancelAutoApprove?.(session.sessionId, 'user-answered-stale');
+      // Free the GPU for this specific orphaned question (#617), scoped so a stale
+      // tap never fails the session's OTHER holds open (cancelStale's releaseAllHolds
+      // belongs to teardown/force-release only).
+      if (freedHeld)
+        cancelAutoApproveForQuestion?.(session.sessionId, questionId, 'user-answered-stale');
       log(
         `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]${freedHeld ? ' (freed an orphaned held hook -> passthrough)' : ''}`,
       );
@@ -319,12 +321,14 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         );
       }
 
-      // Cancel the in-flight eval ONLY when a held permission was actually
-      // resolved/released (#573, issue 2): a stale verdict for THIS permission
-      // must not inject a phantom decision. Answering an unrelated passthrough
-      // question must NOT abort a different binary permission's eval, so this is
-      // gated on hadHold rather than firing on every answer.
-      if (hadHold) cancelAutoApprove?.(session.sessionId, 'user-answered');
+      // Free the GPU on EVERY answer (#617): cancel the eval for THIS question
+      // unconditionally. Per-eval scoping (the eval id captured when the question
+      // was held) makes this safe where the old `hadHold`-gated cancelStale was
+      // not — it aborts only this question's eval, never another permission's,
+      // and is a no-op when no eval is in flight for it. It deliberately does NOT
+      // release the session's other holds (cancelStale's releaseAllHolds), which
+      // belongs to teardown/force-release, not a single answer.
+      cancelAutoApproveForQuestion?.(session.sessionId, questionId, 'user-answered');
     } finally {
       // Remove only the answered question; sibling prompts remain answerable.
       // In `finally` so a throwing submit cannot leave a zombie question.

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -139,6 +139,17 @@ const commandHelp: Record<Subcommand, string[]> = {
     dim('  Currently all settings require a daemon restart to take effect.'),
     dim('  Future versions will support hot-reloading select settings.'),
   ],
+  unstick: [
+    'Force-release stuck auto-approve evals / held permissions.',
+    '',
+    bold('Usage:'),
+    entry('remi unstick', 'Unstick every running daemon'),
+    entry('remi unstick <port>', 'Unstick only the daemon on <port>'),
+    '',
+    dim('  The "just get me out" lever when Ollama and a question are wedged.'),
+    dim('  Releases held permissions to the native terminal prompt, cancels the'),
+    dim('  in-flight eval (freeing the GPU), and drains the eval queue.'),
+  ],
   start: [
     'Start the Remi daemon in the background.',
     '',

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -213,6 +213,12 @@ export interface SessionGateHandle {
   /** Cancel any in-flight eval AND release pending holds for this session (the
    *  user answered / advanced). Forwards to the gate's `cancelStale`. */
   cancelStale: (reason: string) => void;
+  /** Cancel ONLY the eval for the question the user just answered, freeing the
+   *  GPU without touching other holds (#617). Forwards to `cancelEvalForQuestion`. */
+  cancelEvalForQuestion: (questionId: UUID, reason: string) => void;
+  /** Force-release escape (#617 `remi unstick`): release all holds to passthrough,
+   *  abort the in-flight eval, drain the queue. Forwards to `forceRelease`. */
+  forceRelease: (reason: string) => { holds: number; cancelled: boolean; drained: number };
 }
 
 export interface HookBridgeHandle {
@@ -1367,6 +1373,9 @@ export function setupHookBridge(
       releaseHeldAsPassthrough: (questionId) =>
         autoApproveGate.releaseHeldAsPassthrough(questionId),
       cancelStale: (reason) => autoApproveGate.cancelStale(reason),
+      cancelEvalForQuestion: (questionId, reason) =>
+        autoApproveGate.cancelEvalForQuestion(questionId, reason),
+      forceRelease: (reason) => autoApproveGate.forceRelease(reason),
     },
   };
 }

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -225,6 +225,34 @@ describe('AutoApproveService.cancel()', () => {
   // (a second request queues instead of escalating). That behavior, including
   // the cancel-drains-the-queue interaction, is covered in serialize.test.ts.
 
+  test('per-eval scoping: cancel(reason, evalId) aborts ONLY the matching running eval (#617)', async () => {
+    const svc = new AutoApproveService(makeConfig(60), noLog);
+    // Eval stamped with id 7 is the one running on the single GPU slot.
+    const evalPromise = svc.evaluate('Bash', { command: 'ls' }, undefined, undefined, undefined, 7);
+    await hanging.awaitNextRequest();
+
+    // A cancel targeting a DIFFERENT eval id must not abort the running one
+    // (the wrong-victim case the old hadHold gate guarded against).
+    expect(svc.cancel('answer-for-other', 99)).toBe(false);
+
+    // Targeting the running eval's id aborts it and frees the GPU.
+    expect(svc.cancel('user-answered', 7)).toBe(true);
+    const result = await evalPromise;
+    expect(result.decision).toBe('cancelled');
+    expect(result.reasoning).toContain('user-answered');
+  });
+
+  test('per-eval scoping: a no-id cancel still aborts whatever runs (teardown/force-release) (#617)', async () => {
+    const svc = new AutoApproveService(makeConfig(60), noLog);
+    const evalPromise = svc.evaluate('Bash', { command: 'ls' }, undefined, undefined, undefined, 3);
+    await hanging.awaitNextRequest();
+    // cancelStale / forceRelease pass no evalId: abort the current eval regardless.
+    expect(svc.cancel('SessionEnd')).toBe(true);
+    const result = await evalPromise;
+    expect(result.decision).toBe('cancelled');
+    expect(result.reasoning).toContain('SessionEnd');
+  });
+
   test('hard-kill timer does not abort a subsequent successful eval', async () => {
     // Regression: prior implementation never cleared the race timer when
     // chatCompletion won, so a successful eval at t<<timeoutMs left a

--- a/packages/daemon/tests/auto-approve/force-release.test.ts
+++ b/packages/daemon/tests/auto-approve/force-release.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for per-eval cancellation + force-release at the AutoApproveGate level
+ * (#617). A REAL gate is driven with a controllable evaluator object (no mocks,
+ * per the gate's seam contract): its `evaluate` hangs so Part B's early push +
+ * hold fires WHILE the eval is still running — the one window where the user can
+ * answer mid-eval — and its `cancel`/`drainQueue` record the calls the gate makes.
+ *
+ * Covers the user's critical "answer == GPU freed" contract: a manual answer for
+ * question X cancels exactly X's eval and never another permission's, and the
+ * force-release escape (`remi unstick`) releases holds + cancels + drains.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import {
+  type AutoApproveEvaluator,
+  AutoApproveGate,
+} from '../../src/auto-approve/auto-approve-gate.ts';
+import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    isRunning: true,
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+/** A controllable evaluator whose eval hangs until cancelled, recording the
+ *  eval ids it was handed and every cancel / drainQueue call. */
+function controllableEvaluator() {
+  const cancelCalls: Array<{ reason: string; evalId: number | undefined }> = [];
+  const evalIds: Array<number | undefined> = [];
+  let drainCount = 0;
+  let resolveEval: ((r: AutoApproveResult) => void) | null = null;
+  const evaluator: AutoApproveEvaluator = {
+    evaluate: (_t, _i, _tag, _sugg, _model, evalId) => {
+      evalIds.push(evalId);
+      return new Promise<AutoApproveResult>((resolve) => {
+        resolveEval = resolve;
+      });
+    },
+    cancel: (reason, evalId) => {
+      cancelCalls.push({ reason, evalId });
+      // Mimic the abort surfacing as a cancelled verdict so the eval settles.
+      resolveEval?.({ decision: 'cancelled', reasoning: reason, durationMs: 0 });
+      return true;
+    },
+    drainQueue: () => {
+      drainCount++;
+      return 0;
+    },
+  };
+  return { evaluator, cancelCalls, evalIds, drainCount: () => drainCount };
+}
+
+function permission(over: Record<string, unknown> = {}): never {
+  return {
+    session_id: 'claude-test',
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/d',
+    permission_mode: 'default',
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    ...over,
+  } as never;
+}
+
+async function waitFor(pred: () => boolean, ms = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > ms) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('per-eval cancellation + force-release (#617)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+  let harness: ReturnType<typeof controllableEvaluator>;
+  let gate: AutoApproveGate;
+
+  beforeEach(() => {
+    configureLogger({ writeLog: () => {} });
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    lastQuestionId = undefined;
+    harness = controllableEvaluator();
+    gate = new AutoApproveGate(
+      {
+        service: harness.evaluator,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        onHeldEscalate: () => {},
+        holdMs: 60_000,
+        // Tiny window so the early push + hold fires while the eval still hangs.
+        pushHoldMs: 10,
+        alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
+      },
+      SID,
+    );
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a manual answer cancels EXACTLY the held question’s eval (the eval id Part B captured)', async () => {
+    const decision = gate.resolvePermission(permission());
+    await waitFor(() => lastQuestionId !== undefined);
+    const qid = lastQuestionId as UUID;
+    // Part B handed the eval an id; that exact id must be the cancel target.
+    const evalId = harness.evalIds[0];
+    expect(typeof evalId).toBe('number');
+
+    gate.cancelEvalForQuestion(qid, 'user-answered');
+
+    expect(harness.cancelCalls).toEqual([{ reason: 'user-answered', evalId }]);
+    // The hold reconciles to passthrough once the eval settles cancelled.
+    expect(await decision).toBe('passthrough');
+  });
+
+  test('cancelEvalForQuestion is a no-op for a question with no tracked eval (never wrong-victim)', async () => {
+    gate.resolvePermission(permission());
+    await waitFor(() => lastQuestionId !== undefined);
+    // A different/unknown question id must not cancel the running eval.
+    gate.cancelEvalForQuestion(generateId() as UUID, 'user-answered');
+    expect(harness.cancelCalls).toEqual([]);
+  });
+
+  test('forceRelease releases the hold to passthrough, cancels the eval, and drains the queue', async () => {
+    const decision = gate.resolvePermission(permission());
+    await waitFor(() => lastQuestionId !== undefined);
+
+    const summary = gate.forceRelease('force-release (remi unstick)');
+
+    expect(summary.holds).toBe(1);
+    expect(summary.cancelled).toBe(true);
+    // The held hook fails open to the native terminal prompt.
+    expect(await decision).toBe('passthrough');
+    // cancel was called WITHOUT an eval id (abort whatever runs), and the queue drained.
+    expect(harness.cancelCalls).toEqual([
+      { reason: 'force-release (remi unstick)', evalId: undefined },
+    ]);
+    expect(harness.drainCount()).toBe(1);
+  });
+
+  test('forceRelease with no holds / no service is a safe no-op summary', () => {
+    const idle = new AutoApproveGate(
+      {
+        service: null,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => generateId(),
+      },
+      SID,
+    );
+    expect(idle.forceRelease('unstick')).toEqual({ holds: 0, cancelled: false, drained: 0 });
+  });
+});

--- a/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
+++ b/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
@@ -200,7 +200,7 @@ describe('Held escalation round-trip — register + push + shared answer (#573)'
       }) as never,
       resolveHeldPermission: (_s, q, d) => gate.resolveHeld(q, d),
       releaseHeldAsPassthrough: (_s, q) => gate.releaseHeldAsPassthrough(q),
-      cancelAutoApprove: (_s, reason) => gate.cancelStale(reason),
+      cancelAutoApproveForQuestion: (_s, q, reason) => gate.cancelEvalForQuestion(q, reason),
     });
   }
 

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -205,6 +205,9 @@ describe('AutoApproveService - eval serialization (#551)', () => {
     const d3 = await p3;
     expect(d2.decision).toBe('escalate');
     expect(d3.decision).toBe('escalate');
+    // The reasoning names force-release, not a phantom "queue wait exceeded".
+    expect(d2.reasoning).toContain('force-released');
+    expect(d2.reasoning).not.toContain('queue wait exceeded');
     expect(gate.requestCount()).toBe(1); // drained evals never reached the LLM
 
     // c1 is still in flight; cancel it (as force-release also does) to finish.
@@ -216,6 +219,28 @@ describe('AutoApproveService - eval serialization (#551)', () => {
   test('drainQueue() returns 0 when nothing is queued', () => {
     const svc = new AutoApproveService(makeConfig(), noLog);
     expect(svc.drainQueue()).toBe(0);
+  });
+
+  test('cancel(reason, evalId) drops a QUEUED eval (answered before it reached the GPU) (#617)', async () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    const r1 = gate.awaitNextRequest();
+    // eval id 1 acquires the slot and runs; id 2 queues behind it.
+    const p1 = svc.evaluate('Bash', { command: 'c1' }, undefined, undefined, undefined, 1);
+    const p2 = svc.evaluate('Bash', { command: 'c2' }, undefined, undefined, undefined, 2);
+
+    await r1;
+    expect(gate.requestCount()).toBe(1); // only c1 reached the LLM
+
+    // The user answers the question whose eval (id 2) is still QUEUED. cancel
+    // targets the running eval first (id 1 != 2, untouched), then drops the
+    // queued waiter — so c2 escalates and never burns a pointless GPU call.
+    expect(svc.cancel('user-answered', 2)).toBe(true);
+    const d2 = await p2;
+    expect(d2.decision).toBe('escalate');
+    expect(gate.requestCount()).toBe(1); // c2 never reached the LLM
+
+    gate.releaseNext(); // c1 finishes cleanly, untouched by the cancel
+    expect((await p1).decision).toBe('approve');
   });
 
   test('cancel() during a queued burst aborts the in-flight eval and drains the rest', async () => {

--- a/packages/daemon/tests/auto-approve/serialize.test.ts
+++ b/packages/daemon/tests/auto-approve/serialize.test.ts
@@ -188,6 +188,36 @@ describe('AutoApproveService - eval serialization (#551)', () => {
     expect((await p3).decision).toBe('approve');
   });
 
+  test('drainQueue() escalates queued waiters without hitting the GPU (#617 force-release)', async () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    const r1 = gate.awaitNextRequest();
+    const p1 = svc.evaluate('Bash', { command: 'c1' }); // holds the slot
+    const p2 = svc.evaluate('Bash', { command: 'c2' }); // queued
+    const p3 = svc.evaluate('Bash', { command: 'c3' }); // queued
+
+    await r1;
+    expect(gate.requestCount()).toBe(1); // only c1 reached the LLM
+
+    // Force-release drains the two queued waiters: each takes the not-acquired
+    // path and escalates to the user instead of seizing the freed GPU.
+    expect(svc.drainQueue()).toBe(2);
+    const d2 = await p2;
+    const d3 = await p3;
+    expect(d2.decision).toBe('escalate');
+    expect(d3.decision).toBe('escalate');
+    expect(gate.requestCount()).toBe(1); // drained evals never reached the LLM
+
+    // c1 is still in flight; cancel it (as force-release also does) to finish.
+    expect(svc.cancel('force-release')).toBe(true);
+    expect((await p1).decision).toBe('cancelled');
+    gate.releaseAll(); // clean up c1's orphaned server holder
+  });
+
+  test('drainQueue() returns 0 when nothing is queued', () => {
+    const svc = new AutoApproveService(makeConfig(), noLog);
+    expect(svc.drainQueue()).toBe(0);
+  });
+
   test('cancel() during a queued burst aborts the in-flight eval and drains the rest', async () => {
     const svc = new AutoApproveService(makeConfig(), noLog);
     const r1 = gate.awaitNextRequest();

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -125,6 +125,18 @@ describe('parseArgs', () => {
       expect(r.subcommandArg).toBe('abc');
       expect(r.host).toBe('myhost');
     });
+
+    test('remi unstick (no port) parses with no positional arg', () => {
+      const r = parseArgs(['unstick']);
+      expect(r.subcommand).toBe('unstick');
+      expect(r.subcommandArg).toBeUndefined();
+    });
+
+    test('remi unstick <port> captures the port as the positional arg', () => {
+      const r = parseArgs(['unstick', '18767']);
+      expect(r.subcommand).toBe('unstick');
+      expect(r.subcommandArg).toBe('18767');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/cli/cmd-unstick.test.ts
+++ b/packages/daemon/tests/cli/cmd-unstick.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { runUnstickCommand } from '../../src/cli/cmd-unstick.ts';
+
+function makeIO() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    io: { out: (msg: string) => out.push(msg), err: (msg: string) => err.push(msg) },
+    out,
+    err,
+  };
+}
+
+function mkSession(name: string, pid: number, wsPort: number) {
+  return { name, pid, wsPort };
+}
+
+describe('runUnstickCommand (#617)', () => {
+  test('exits 1 and logs an error when no daemons are running', () => {
+    const { io, out, err } = makeIO();
+    const code = runUnstickCommand(undefined, io, { listLive: () => [], kill: () => {} });
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(err).toEqual(['No running daemons found.']);
+  });
+
+  test('SIGUSR2s every live daemon when no port is given', () => {
+    const killCalls: Array<[number, NodeJS.Signals]> = [];
+    const { io, out, err } = makeIO();
+    const code = runUnstickCommand(undefined, io, {
+      listLive: () => [mkSession('alpha', 100, 18765), mkSession('beta', 101, 18766)],
+      kill: (pid, sig) => {
+        killCalls.push([pid, sig]);
+      },
+    });
+    expect(code).toBe(0);
+    expect(killCalls).toEqual([
+      [100, 'SIGUSR2'],
+      [101, 'SIGUSR2'],
+    ]);
+    expect(
+      out.some((m) => m.includes('Unstuck 1 daemon(s)') || m.includes('Unstuck 2 daemon(s)')),
+    ).toBe(true);
+    expect(err).toHaveLength(0);
+  });
+
+  test('targets only the daemon on the given port', () => {
+    const killCalls: number[] = [];
+    const { io, out } = makeIO();
+    const code = runUnstickCommand(18766, io, {
+      listLive: () => [mkSession('alpha', 100, 18765), mkSession('beta', 101, 18766)],
+      kill: (pid) => {
+        killCalls.push(pid);
+      },
+    });
+    expect(code).toBe(0);
+    expect(killCalls).toEqual([101]); // only the 18766 daemon
+    expect(out.some((m) => m.includes('port 18766'))).toBe(true);
+  });
+
+  test('exits 1 with a port-specific message when no daemon matches the port', () => {
+    const { io, err } = makeIO();
+    const code = runUnstickCommand(19999, io, {
+      listLive: () => [mkSession('alpha', 100, 18765)],
+      kill: () => {},
+    });
+    expect(code).toBe(1);
+    expect(err).toEqual(['No running daemon found on port 19999.']);
+  });
+
+  test('handles ESRCH (stale pid) separately from other errors', () => {
+    const { io, err } = makeIO();
+    const kill = (pid: number) => {
+      if (pid === 100) {
+        const e = new Error('no such process') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        throw e;
+      }
+    };
+    const code = runUnstickCommand(undefined, io, {
+      listLive: () => [mkSession('stale', 100, 18765), mkSession('live', 101, 18766)],
+      kill,
+    });
+    expect(code).toBe(0); // at least one succeeded
+    expect(err).toEqual(['Process 100 not found (stale session entry)']);
+  });
+
+  test('exits 1 when every matching daemon is stale', () => {
+    const { io, err } = makeIO();
+    const kill = () => {
+      const e = new Error('no such process') as NodeJS.ErrnoException;
+      e.code = 'ESRCH';
+      throw e;
+    };
+    const code = runUnstickCommand(undefined, io, {
+      listLive: () => [mkSession('stale', 100, 18765)],
+      kill,
+    });
+    expect(code).toBe(1);
+    expect(err.some((m) => m.includes('Failed to unstick any daemons'))).toBe(true);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -394,7 +394,7 @@ describe('createInputHandlers', () => {
       addYesNoQuestion(sessionId);
 
       const held: Array<{ sessionId: UUID; questionId: UUID; decision: 'allow' | 'deny' }> = [];
-      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
         sessionRegistry,
         bindingStore,
@@ -403,14 +403,16 @@ describe('createInputHandlers', () => {
           held.push({ sessionId: s, questionId: q, decision: d });
           return true; // a hold existed and was resolved
         },
-        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+        cancelAutoApproveForQuestion: (s, q, reason) =>
+          cancels.push({ sessionId: s, questionId: q, reason }),
       });
 
       await handlers.onAnswer(CID, sessionId, QID, '1'); // option 1 = Yes
 
       expect(held).toEqual([{ sessionId, questionId: QID, decision: 'allow' }]);
       expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
-      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]);
+      // #617: the answer cancels exactly this question's eval (frees the GPU).
+      expect(cancels).toEqual([{ sessionId, questionId: QID, reason: 'user-answered' }]);
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
@@ -458,7 +460,7 @@ describe('createInputHandlers', () => {
 
       const resolveDecisions: Array<'allow' | 'deny'> = [];
       const released: UUID[] = [];
-      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
         sessionRegistry,
         bindingStore,
@@ -473,7 +475,8 @@ describe('createInputHandlers', () => {
           released.push(q);
           return true; // a hold existed and was popped to passthrough
         },
-        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+        cancelAutoApproveForQuestion: (s, q, reason) =>
+          cancels.push({ sessionId: s, questionId: q, reason }),
       });
 
       await handlers.onAnswer(CID, sessionId, QID, '2'); // option 2 = Yes, always
@@ -481,11 +484,12 @@ describe('createInputHandlers', () => {
       expect(resolveDecisions).toEqual([]); // never resolved as a one-time allow
       expect(released).toEqual([QID]); // hook released to passthrough
       expect(ptyCapture.submits).toEqual(['2']); // digit submitted into the native prompt
-      expect(cancels).toEqual([{ sessionId, reason: 'user-answered' }]); // hold was released
+      // #617: still cancels this question's eval (frees the GPU).
+      expect(cancels).toEqual([{ sessionId, questionId: QID, reason: 'user-answered' }]);
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
-    test('a non-held answer does NOT cancel the eval and still submits to the PTY (FIX 3)', async () => {
+    test('a non-held answer still scoped-cancels its own question and submits to the PTY (#617)', async () => {
       const ptyCapture = { writes: [] as string[], submits: [] as string[] };
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(
@@ -496,22 +500,25 @@ describe('createInputHandlers', () => {
       );
       addYesNoQuestion(sessionId);
 
-      const cancels: Array<{ sessionId: UUID; reason: string }> = [];
+      const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
         sessionRegistry,
         bindingStore,
         send,
         resolveHeldPermission: () => false, // no hold for this question
         releaseHeldAsPassthrough: () => false, // no hold to release either
-        cancelAutoApprove: (s, reason) => cancels.push({ sessionId: s, reason }),
+        cancelAutoApproveForQuestion: (s, q, reason) =>
+          cancels.push({ sessionId: s, questionId: q, reason }),
       });
 
       await handlers.onAnswer(CID, sessionId, QID, '1');
 
       expect(ptyCapture.submits).toEqual(['1']); // falls back to the PTY path
-      // FIX 3: no hold was resolved/released, so an unrelated eval must NOT be
-      // cancelled by this answer.
-      expect(cancels).toEqual([]);
+      // #617: every answer fires the per-question cancel. It is now SAFE because
+      // the gate scopes it by eval id (cancelEvalForQuestion is a no-op when no
+      // eval is tracked for this question) — the wrong-victim protection moved
+      // from this gate-on-hadHold into the gate's per-eval scoping (tested there).
+      expect(cancels).toEqual([{ sessionId, questionId: QID, reason: 'user-answered' }]);
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
@@ -1068,7 +1075,7 @@ describe('createInputHandlers', () => {
       });
 
       const held: Array<{ decision: 'allow' | 'deny' }> = [];
-      const cancels: string[] = [];
+      const cancels: Array<{ questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
         sessionRegistry,
         bindingStore,
@@ -1077,7 +1084,7 @@ describe('createInputHandlers', () => {
           held.push({ decision: d });
           return true;
         },
-        cancelAutoApprove: (_s, reason) => cancels.push(reason),
+        cancelAutoApproveForQuestion: (_s, q, reason) => cancels.push({ questionId: q, reason }),
       });
 
       const outcome = await handlers.relayAnswer(sessionId, QID, '1');
@@ -1085,7 +1092,8 @@ describe('createInputHandlers', () => {
       expect(outcome).toBe('delivered');
       expect(held).toEqual([{ decision: 'allow' }]); // resolved via the held hook
       expect(ptyCapture.submits).toEqual([]); // held => no PTY submit
-      expect(cancels).toEqual(['user-answered']);
+      // #617: the relay answer also frees the GPU, scoped to this question.
+      expect(cancels).toEqual([{ questionId: QID, reason: 'user-answered' }]);
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 


### PR DESCRIPTION
Closes #617. Part of epic #603 (Milestone 2). R5 (cross-daemon GPU semaphore) split to #620.

## The user's pain

"Ollama and questions get stuck and there is nothing to get out of it." The phone has zero device visibility, so a **manual answer must free the GPU** — that's the user's only lever.

## What was wrong

1. One shared `currentAbortController` for the single GPU slot, so `cancel()` could abort the WRONG permission's eval. That forced the answer-path cancel to be **gated on `hadHold`**, so many answers never freed the GPU.
2. The held-answer cancel routed through `cancelStale` -> `releaseAllHolds`, failing open **all** of a session's holds for a single answer.
3. No escape hatch when an eval is genuinely wedged.

## Change

- **Per-eval cancellation scoping** (`auto-approve-service.ts`): each `evaluate()` is stamped with a monotonic `evalId`; `cancel(reason, evalId?)` aborts ONLY the matching running eval (or, if it is still queued under contention, drops the queued waiter). With no `evalId` it aborts whatever runs (teardown / force-release).
- **Every answer frees the GPU** (`auto-approve-gate.ts` + `input-events.ts`): a new scoped `cancelEvalForQuestion(questionId, reason)` fires on EVERY answer (held / passthrough / relay / stale), cancelling exactly that question's eval and never another's. `releaseAllHolds` is now teardown/force-release only (acceptance #4).
- **Force-release escape**: `remi unstick [port]` -> SIGUSR2 -> each gate releases its held hooks to passthrough, aborts the in-flight eval, and drains the eval queue (`forceRelease` + `drainQueue`). Queued evals escalate gracefully instead of seizing the freed GPU.

## Acceptance criteria

- [x] A manual answer for question X cancels exactly X's eval (if running OR queued) and never another permission's.
- [x] A passthrough / multi-choice answer also cancels its eval (not gated to held only).
- [x] `releaseAllHolds` only fires on Stop/SessionEnd teardown or force-release, not a single answer.
- [x] Force-release cancels the eval + releases holds to passthrough + drains the queue.
- [ ] **LIVE: a manual answer actually frees Ollama** — to confirm on-device with GPU monitoring (the headline; not unit-observable).

## Tests (NO MOCKS)

Real `AutoApproveService` + a controllable local-server/evaluator + a real `AutoApproveGate`:
- per-eval scoping aborts only the targeted running eval; a no-id cancel still aborts (teardown); a queued eval is dropped by id.
- `drainQueue` escalates queued waiters without hitting the LLM and reports `force-released` (not a phantom timeout); returns 0 when empty.
- gate `cancelEvalForQuestion` cancels exactly the held question's eval and is a no-op (never wrong-victim) for an unknown question; `forceRelease` releases holds + cancels + drains; safe no-op with no service.
- `remi unstick` CLI: all daemons, port filter, no-match, ESRCH, all-stale; arg-parser parses the optional port.

Full affected suites: 371 pass (the 1 skip-when-no-Ollama LLM-judgment test is non-deterministic and unrelated). `tsc` + `biome` clean.

## Review

pr-review-toolkit (sonnet): code-reviewer + silent-failure-hunter. Real findings fixed in the second commit (drain-vs-timeout reasoning, queued-eval cancel, idempotent settle guard, per-gate try/catch in the SIGUSR2 handler). False positives (non-Part-B "GPU pegged" — the eval completes before the question exists; drain/release ordering — cancel+drain run synchronously) documented inline.