### PR TITLE
Phase 1: gate-only question emission (#625)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -489,8 +489,29 @@ export class AutoApproveGate {
     if (this.isBinaryEscalation(input)) {
       return this.escalateAndHold(input);
     }
-    this.escalateToUser(input);
-    return Promise.resolve('passthrough');
+    return Promise.resolve(this.escalatePassthrough(input));
+  }
+
+  /**
+   * Escalate a NON-holdable (passthrough) permission to the user AND push it from
+   * the gate (#625). A binary escalation pushes via `createHold` -> `onHeldEscalate`;
+   * a passthrough one (multi-choice / design / AskUserQuestion) historically relied
+   * on the PTY render to trigger its push (`onPTYPromptVisible`). That coupling is the
+   * phantom-notification source: the PTY echoes EVERY on-screen prompt, including ones
+   * the gate already auto-approved. The gate is now the single push trigger, so a
+   * passthrough escalation must push here too — otherwise, with PTY question-emission
+   * gated off for hooked sessions (#625), the escalation would never reach the phone.
+   *
+   * Reuses the held-push primitive (`onHeldEscalate` -> `tracker.pushHeldHook`): it
+   * registers the stashed question in `sessionRegistry` (answerable) and delivers it to
+   * the lock screen idempotently. No hold is registered — Claude renders its native
+   * prompt and waits there — so there is no delivery gate / hold timeout; the user
+   * answers the pushed card (digit injected via the PTY) or the terminal directly.
+   */
+  private escalatePassthrough(input: PermissionRequestHookInput): PermissionDecision {
+    const qid = this.escalateToUser(input);
+    if (qid) this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
+    return 'passthrough';
   }
 
   /**
@@ -609,17 +630,15 @@ export class AutoApproveGate {
       // must escalate, not silently fall through to the subagent-deny below.
       if (result.pickIndex === undefined) {
         logError(`[AutoApprove ${this.sessionTag}] pick result missing pickIndex; escalating`);
-        this.escalateToUser(input);
-        return 'passthrough';
+        return this.escalatePassthrough(input);
       }
       if (
         await this.inject(input, String(result.pickIndex), `multichoice-pick-${result.pickIndex}`)
       ) {
         this.markHandled();
-      } else {
-        this.escalateToUser(input);
+        return 'passthrough';
       }
-      return 'passthrough';
+      return this.escalatePassthrough(input);
     }
     // escalate: a subagent prompt the user cannot answer is default-denied via
     // the response (no hang, no PTY).

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -87,14 +87,19 @@ export interface AutoApproveGateDeps {
   /** Called when the verdict is escalate (the user must answer), so the tracker
    *  releases the buffered PTY prompt. #484. */
   onEscalate?: () => void;
-  /** Called when a BINARY escalation HOLDS its hook open (Model B, #573):
-   *  Claude blocks on the hook response, so it never renders the native prompt
-   *  and the tracker's PTY-render push trigger never fires. The gate calls this
-   *  with the held `Question.id` so the tracker pushes that question IMMEDIATELY
-   *  (-> sessionRegistry.addQuestion + APNS), making it answerable. Called ONLY
-   *  in the held branch — passthrough / multi-choice escalations still render the
-   *  PTY and push via `onPTYPromptVisible`, so calling it for them would
-   *  double-push. Absent => no immediate held push (tests / no-AA callers). #573 */
+  /** The gate's push trigger: called with a `Question.id` so the tracker pushes
+   *  that question IMMEDIATELY (-> sessionRegistry.addQuestion + APNS), making it
+   *  answerable. Called for BOTH escalation shapes (#625):
+   *    - a BINARY escalation that HOLDS its hook (Model B, #573) — Claude blocks on
+   *      the response and never renders the native prompt (via `createHold`);
+   *    - a PASSTHROUGH escalation (multi-choice / design / AskUserQuestion) via
+   *      `escalatePassthrough`.
+   *  Since #625, PTY question-emission is suppressed for hooked sessions, so this
+   *  callback is the SOLE push trigger in both cases — do NOT remove it from the
+   *  passthrough path believing `onPTYPromptVisible` covers it (it does not; that
+   *  would silently drop every passthrough notification). Idempotent per id
+   *  (`pushedHeldIds`), so it can never double-push. Absent => no immediate push
+   *  (tests / no-AA callers). #573 / #625 */
   onHeldEscalate?: (questionId: UUID) => void;
   /** Called when the permission was auto-approved/denied silently (inject
    *  succeeded; the user never sees it). Drives the terminal "done" cue. #513. */
@@ -510,7 +515,17 @@ export class AutoApproveGate {
    */
   private escalatePassthrough(input: PermissionRequestHookInput): PermissionDecision {
     const qid = this.escalateToUser(input);
-    if (qid) this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
+    if (qid) {
+      this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
+    } else {
+      // escalateToUser returned no id (escalate() threw — already logged there).
+      // Unlike a binary hold there is no timer fallback here, so make the lost
+      // push explicit: Claude still renders + waits at its native terminal prompt
+      // (the user can answer locally), but no phone notification was sent.
+      logError(
+        `[AutoApprove ${this.sessionTag}] passthrough escalation produced no question id; no push sent (terminal prompt still answerable locally)`,
+      );
+    }
     return 'passthrough';
   }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1183,6 +1183,15 @@ async function createNewSession(
         messageApi.handleMessage(message);
       },
       onQuestion: (question) => {
+        // #625 single gate: when a hook server is active the auto-approve gate is
+        // the SOLE authority for permission questions and pushes escalations itself
+        // (binary via onHeldEscalate, passthrough via escalatePassthrough). The PTY
+        // parser echoes EVERY on-screen prompt — including ones the gate already
+        // auto-approved — so routing it here is the phantom-notification source
+        // (>1,100 confirmed pushes fired right after a 0 ms approve). Suppress it for
+        // hooked sessions; keep it as the only signal when no hook server is
+        // configured (the genuine fallback for un-hooked / Agent-Teams prompts).
+        if (hookServer) return;
         tracker.onPTYPromptVisible(question);
       },
       onStatusChange: (status, context) => {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -681,7 +681,18 @@ export function setupHookBridge(
       tracker.onStatusChange(status);
     },
     onQuestion: (question) => {
-      tracker.recordPendingHook(question);
+      // #625 single gate: a PERMISSION question is coordinated by the auto-approve
+      // gate — it is stashed here and the gate drives its push on escalate (binary
+      // via onHeldEscalate, passthrough via escalatePassthrough). A STANDALONE hook
+      // question that no gate pushes (e.g. a Stop-failure "Retry?", which carries no
+      // permission source) must be emitted directly to the client + lock screen,
+      // because the PTY-render push that used to deliver it is suppressed for hooked
+      // sessions. recordPendingHook only stashes; it never emits on its own.
+      if (question.source === 'permission_request' || question.source === 'notification') {
+        tracker.recordPendingHook(question);
+      } else {
+        messageApi.handleQuestion(question);
+      }
     },
     onSessionInfo: (hookClaudeSessionId: string, transcriptPath: string) => {
       // DRIVE: the binder's onHookEvent (fired from the SessionStart listener)

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -683,11 +683,19 @@ export function setupHookBridge(
     onQuestion: (question) => {
       // #625 single gate: a PERMISSION question is coordinated by the auto-approve
       // gate — it is stashed here and the gate drives its push on escalate (binary
-      // via onHeldEscalate, passthrough via escalatePassthrough). A STANDALONE hook
-      // question that no gate pushes (e.g. a Stop-failure "Retry?", which carries no
-      // permission source) must be emitted directly to the client + lock screen,
-      // because the PTY-render push that used to deliver it is suppressed for hooked
-      // sessions. recordPendingHook only stashes; it never emits on its own.
+      // via onHeldEscalate, passthrough via escalatePassthrough). recordPendingHook
+      // only stashes; it never emits on its own.
+      //   - 'permission_request' (rich: tool + command + options) is the one the gate
+      //     escalates and pushes by id.
+      //   - 'notification' is Claude's redundant generic "needs your permission"
+      //     prompt; it is INTENTIONALLY stashed-and-suppressed (NOT routed to the
+      //     direct-emit path), because direct-emitting it would push for EVERY
+      //     permission — including auto-approved ones — which is exactly the phantom
+      //     #625 removes. It is bounded (one per agent) and cleared on status-leaves-
+      //     waiting. (Assumes Claude pairs it with a PermissionRequest, true today.)
+      // A STANDALONE hook question that no gate pushes (e.g. a Stop-failure "Retry?",
+      // source-less) is emitted directly to the client + lock screen, since the
+      // PTY-render push that used to deliver it is suppressed for hooked sessions.
       if (question.source === 'permission_request' || question.source === 'notification') {
         tracker.recordPendingHook(question);
       } else {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -534,9 +534,18 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
    *  `lastQuestionId` so tests can resolve the hold. */
   function holdGate(
     service: AutoApproveEvaluator | null,
-    opts: { holdMs?: number; subagent?: boolean; alwaysEscalateTools?: ReadonlySet<string> } = {},
+    opts: {
+      holdMs?: number;
+      subagent?: boolean;
+      alwaysEscalateTools?: ReadonlySet<string>;
+      /** PTY.submitInput throws — exercises inject() failure -> escalatePassthrough. */
+      ptyThrows?: boolean;
+      /** escalate() returns undefined (push creation failed) — exercises the
+       *  escalatePassthrough `qid === undefined` skip-push branch (#625). */
+      escalateUndefined?: boolean;
+    } = {},
   ): AutoApproveGate {
-    registry.registerSession(SID, '/d', fakePTY(submits), {
+    registry.registerSession(SID, '/d', fakePTY(submits, { throws: opts.ptyThrows ?? false }), {
       handleMessage: () => {},
       handleQuestion: () => {},
       handleStatusChange: () => {},
@@ -550,6 +559,10 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
         isInSubagentContext: () => opts.subagent ?? false,
         escalate: (i) => {
           escalations.push(i);
+          if (opts.escalateUndefined) {
+            lastQuestionId = undefined;
+            return undefined;
+          }
           lastQuestionId = generateId();
           return lastQuestionId;
         },
@@ -690,6 +703,42 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
     expect(d).toBe('deny');
     expect(heldPushes).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+  });
+
+  test('#625 malformed pick (no pickIndex) escalates AND pushes from the gate', async () => {
+    const malformedPick = {
+      decision: 'pick',
+      reasoning: 't',
+      durationMs: 0,
+      model: 'm',
+    } as unknown as AutoApproveResult;
+    const gate = holdGate(evaluator(malformedPick));
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+    expect(heldPushes).toEqual([lastQuestionId as UUID]);
+  });
+
+  test('#625 pick inject failure (PTY throws) escalates AND pushes from the gate', async () => {
+    const gate = holdGate(evaluator(pick(2)), { ptyThrows: true });
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(submits).toEqual(['2']); // inject was attempted before it threw
+    expect(escalations).toHaveLength(1);
+    expect(heldPushes).toEqual([lastQuestionId as UUID]);
+  });
+
+  test('#625 passthrough escalate with no question id skips the push (no throw)', async () => {
+    // escalate() returns undefined (push creation failed): escalatePassthrough must
+    // not call onHeldEscalate(undefined), and must not throw — Claude still
+    // passes through to its native terminal prompt.
+    const gate = holdGate(evaluator(escalate), { escalateUndefined: true });
+    const d = await gate.resolvePermission(
+      pr({ tool_name: 'AskUserQuestion', tool_input: { question: 'Which approach?' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+    expect(heldPushes).toHaveLength(0);
   });
 
   test('hold timeout -> passthrough and the pending map is cleaned', async () => {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -520,6 +520,10 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
   let submits: string[];
   let escalations: PermissionRequestHookInput[];
   let lastQuestionId: UUID | undefined;
+  // #625: every gate-driven push (binary createHold AND passthrough escalate) is
+  // recorded here so a test can assert push <=> escalate and that approve/deny push
+  // nothing. The held-push primitive is onHeldEscalate -> tracker.pushHeldHook.
+  let heldPushes: UUID[];
 
   function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
     return { evaluate: async () => result, cancel: () => true };
@@ -549,6 +553,9 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
           lastQuestionId = generateId();
           return lastQuestionId;
         },
+        onHeldEscalate: (qid) => {
+          heldPushes.push(qid);
+        },
         holdMs: opts.holdMs ?? 60_000,
         alwaysEscalateTools:
           opts.alwaysEscalateTools ?? new Set(['AskUserQuestion', 'ExitPlanMode']),
@@ -575,6 +582,7 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
     submits = [];
     escalations = [];
     lastQuestionId = undefined;
+    heldPushes = [];
     configureLogger({ writeLog: () => {} });
   });
 
@@ -637,6 +645,51 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
     );
     expect(d).toBe('passthrough');
     expect(escalations).toHaveLength(1);
+  });
+
+  // #625 single gate: the gate is the SOLE push trigger. A passthrough escalation
+  // (design / AskUserQuestion / multi-choice) must push from the gate too — it can no
+  // longer rely on the PTY render, which is suppressed for hooked sessions.
+  test('#625 design (AskUserQuestion) escalate pushes from the gate (onHeldEscalate)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    await gate.resolvePermission(
+      pr({ tool_name: 'AskUserQuestion', tool_input: { question: 'Which approach?' } }),
+    );
+    expect(escalations).toHaveLength(1);
+    expect(heldPushes).toEqual([lastQuestionId as UUID]);
+  });
+
+  test('#625 multi-choice escalate pushes from the gate (onHeldEscalate)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    await gate.resolvePermission(
+      pr({ permission_suggestions: ['Alpha', 'Beta', 'Gamma', 'Delta'] }),
+    );
+    expect(heldPushes).toEqual([lastQuestionId as UUID]);
+  });
+
+  test('#625 binary escalate also pushes from the gate (createHold path)', async () => {
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(heldPushes).toEqual([lastQuestionId as UUID]);
+    gate.resolveHeld(lastQuestionId as UUID, 'allow');
+    await pending;
+  });
+
+  test('#625 approve pushes NOTHING (no phantom)', async () => {
+    const gate = holdGate(evaluator(approve));
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(heldPushes).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+  });
+
+  test('#625 deny pushes NOTHING (no phantom)', async () => {
+    const gate = holdGate(evaluator(deny));
+    const d = await gate.resolvePermission(pr());
+    expect(d).toBe('deny');
+    expect(heldPushes).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
   });
 
   test('hold timeout -> passthrough and the pending map is cleaned', async () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -346,6 +346,17 @@ describe('setupHookBridge', () => {
       expect(messageApiLog.questionCalls).toBe(0);
     });
 
+    test('#625 StopFailure emits DIRECTLY even with a real (non-passthrough) tracker', () => {
+      // With a real QuestionPresenceTracker, recordPendingHook only STASHES (it does
+      // not push without a PTY-visible signal). A source-less Stop-failure question has
+      // no gate to push it, so the bridge must emit it directly to messageApi — proven
+      // here by questionCalls incrementing despite the real tracker never pushing.
+      build({ realTracker: true });
+      lock('claude-A');
+      hookServer.fire('StopFailure', { session_id: 'claude-A', error_type: 'timeout' });
+      expect(messageApiLog.questionCalls).toBeGreaterThanOrEqual(1);
+    });
+
     test('PostToolUseFailure sets executing status (main); a subagent failure is dropped', () => {
       build();
       lock('claude-A');


### PR DESCRIPTION
Phase 1 of the question-pipeline rework (epic #624). Closes #625.

## Problem

The phone got permission notifications for actions the system had **already auto-approved**. Live `~/.remi/remi.log`: 10,155 `approve` verdicts but 10,483 "Question detected" events and ~2,000 pushes — **1,184+ pushes fired immediately after an `approve`**, plus the question registry overflowing 2,458 times. The "Question detected" text was dominated by ANSI-garbled PTY screen-scrapes (`Doyouwanttoproceed?`, `7Gproceed?`).

## Root cause

Three independent emitters pushed questions without truly gating each other: `HookEventBridge`, the PTY `OutputProcessor` (screen-scraper), and the `AutoApproveGate` (the real decider). A fragile timing layer tried to reconcile them and leaked under multi-session load.

## Fix: one gate

A question reaches the phone **iff** the auto-approve verdict is `escalate`.

- **gate** (`auto-approve-gate.ts`): passthrough escalations (multi-choice / design / AskUserQuestion) now push from the gate via `escalatePassthrough` -> `onHeldEscalate` — the same primitive binary holds use. They no longer depend on the PTY render to trigger a push.
- **cli** (`cli.ts`): PTY-detected questions are suppressed when a hook server is active (the gate owns the decision). PTY stays the only signal when no hook server is configured (the genuine fallback for un-hooked / Agent-Teams prompts).
- **hook bridge** (`hook-bridge-setup.ts`): standalone hook questions with no gate to push them (a Stop-failure "Retry?", which carries no permission source) emit directly to the client + lock screen.

Net: `push <=> escalate`. `approve`/`deny` reach nobody. The presence-tracker buffer machinery is now dormant for hooked sessions (left in place; it still drives the no-hook fallback + the terminal-cue lifecycle, so removing it is a separate decoupling).

## Tests

- gate: `push <=> escalate` for binary + passthrough + multi-choice escalations; `approve`/`deny` push nothing (no phantom).
- bridge: Stop-failure emits directly under a real (non-passthrough) tracker.
- typecheck + biome clean; 1,147 daemon tests pass.

## Not covered here (later phases)

- #626 structured AskUserQuestion display (header / per-option descriptions / multiSelect)
- #627 multi-question answer + submit
- #628 LLM/engine summaries for generic escalations
