### PR TITLE
Phase 2: structured AskUserQuestion display (#626)

### DIFF
--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -256,6 +256,16 @@ export class HookEventBridge {
       // Rich source: carries tool + command + agent context. The tracker
       // keeps this over a trailing generic notification for the same agent (#574).
       source: 'permission_request',
+      // #626: surface the full AskUserQuestion structure (all sub-questions with
+      // headers, descriptions, multiSelect) so the client can render it properly.
+      // text/options above still mirror questions[0] for back-compat.
+      ...(toolQuestion?.kind === 'multi_question' && toolQuestion.questions
+        ? {
+            kind: 'multi_question' as const,
+            questions: toolQuestion.questions,
+            ...(toolQuestion.submitLabel ? { submitLabel: toolQuestion.submitLabel } : {}),
+          }
+        : {}),
     });
     this.events.onStatusChange('waiting');
     return questionId;

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -13,11 +13,19 @@
  * Claude renders in its native numbered prompt once the held hook is released.
  */
 
-import type { QuestionOption } from '@remi/shared';
+import type { QuestionOption, QuestionStep } from '@remi/shared';
 
 export interface ToolQuestion {
   readonly text: string;
   readonly options: QuestionOption[];
+  /** #626: 'multi_question' for an AskUserQuestion-shaped tool (structured
+   *  sub-questions in `questions`). Absent for a plain single prompt. */
+  readonly kind?: 'multi_question';
+  /** #626: the full sub-question set (header / text / multiSelect / options with
+   *  descriptions). `text`/`options` above mirror `questions[0]` for back-compat. */
+  readonly questions?: QuestionStep[];
+  /** #626: submit-button label for the multi-question form. */
+  readonly submitLabel?: string;
 }
 
 /**
@@ -36,13 +44,15 @@ function cleanText(s: string): string {
  * Index 0 is marked recommended only to match the existing option convention
  * (display-only; it does not change which digit is submitted).
  */
-function pickOption(label: string, index: number): QuestionOption {
+function pickOption(label: string, index: number, description?: string): QuestionOption {
+  const desc = description ? cleanText(description) : '';
   return {
     label: cleanText(label),
     value: String(index + 1),
     isRecommended: index === 0,
     isYes: false,
     isNo: false,
+    ...(desc.length > 0 ? { description: desc } : {}),
   };
 }
 
@@ -65,13 +75,39 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
-/** One option label from an AskUserQuestion option entry (a string, or `{label}`). */
-function optionLabel(entry: unknown): string | null {
-  if (typeof entry === 'string' && entry.trim().length > 0) return entry;
+/** One option from an AskUserQuestion option entry: a plain string label, or
+ *  `{ label, description? }`. Returns null for an unusable entry (#626). */
+function optionEntry(entry: unknown): { label: string; description?: string } | null {
+  if (typeof entry === 'string' && entry.trim().length > 0) return { label: entry };
   if (isRecord(entry) && typeof entry['label'] === 'string' && entry['label'].trim().length > 0) {
-    return entry['label'];
+    const rawDesc = entry['description'];
+    const description =
+      typeof rawDesc === 'string' && rawDesc.trim().length > 0 ? rawDesc : undefined;
+    return description ? { label: entry['label'], description } : { label: entry['label'] };
   }
   return null;
+}
+
+/** Build one {@link QuestionStep} from a raw AskUserQuestion entry (#626), or
+ *  null when it lacks a usable question text + options. Pure + total. */
+function buildStep(raw: unknown): QuestionStep | null {
+  if (!isRecord(raw)) return null;
+  const text = typeof raw['question'] === 'string' ? cleanText(raw['question']) : '';
+  const rawOptions = raw['options'];
+  if (text.length === 0 || !Array.isArray(rawOptions)) return null;
+  const entries = rawOptions
+    .map(optionEntry)
+    .filter((e): e is { label: string; description?: string } => e !== null);
+  if (entries.length === 0) return null;
+  const rawHeader = raw['header'];
+  const header =
+    typeof rawHeader === 'string' && rawHeader.trim().length > 0 ? cleanText(rawHeader) : undefined;
+  return {
+    ...(header ? { header } : {}),
+    text,
+    multiSelect: raw['multiSelect'] === true,
+    options: entries.map((e, i) => pickOption(e.label, i, e.description)),
+  };
 }
 
 /**
@@ -95,25 +131,25 @@ export function extractToolQuestion(
   // mirrors the auto-approve `isDesignQuestion` detector (multichoice.ts), which
   // routes the SAME shape to always-escalate — so an MCP/custom tool that mimics
   // AskUserQuestion gets its real options surfaced here too, consistently. The
-  // shape guards below are tight (record with a `question` string + a non-empty
-  // `options` array), so a tool with an unrelated `questions` field returns null
-  // and falls through to permission_suggestions. Remi answers one prompt at a
-  // time, so surface the FIRST question; a multi-question call still shows the
-  // first and the rest fall to Claude's native prompt on release. A `header`
-  // (short topic) prefixes the question when present.
+  // shape guards (record with a `question` string + a non-empty `options` array)
+  // are tight, so a tool with an unrelated `questions` field returns null and
+  // falls through to permission_suggestions.
+  //
+  // #626: surface the FULL set of sub-questions (header / text / multiSelect /
+  // options with descriptions) as `questions`, not just the first. `text`/
+  // `options` mirror questions[0] for back-compat: the lock-screen summary and
+  // the first-question answer path (digit submit) still read the flat fields.
   if (!isRecord(toolInput)) return null;
-  const questions = toolInput['questions'];
-  if (!Array.isArray(questions) || questions.length === 0) return null;
-  const first = questions[0];
-  if (!isRecord(first)) return null;
-  const qText = typeof first['question'] === 'string' ? cleanText(first['question']) : '';
-  const rawOptions = first['options'];
-  if (qText.length === 0 || !Array.isArray(rawOptions)) return null;
-  const labels = rawOptions.map(optionLabel).filter((l): l is string => l !== null);
-  if (labels.length === 0) return null;
-  const header = typeof first['header'] === 'string' ? cleanText(first['header']) : '';
+  const rawQuestions = toolInput['questions'];
+  if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) return null;
+  const steps = rawQuestions.map(buildStep).filter((s): s is QuestionStep => s !== null);
+  const first = steps[0];
+  if (!first) return null;
   return {
-    text: header ? `${header}: ${qText}` : qText,
-    options: labels.map((label, i) => pickOption(label, i)),
+    text: first.header ? `${first.header}: ${first.text}` : first.text,
+    options: [...first.options],
+    kind: 'multi_question',
+    questions: steps,
+    submitLabel: 'Submit',
   };
 }

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -87,6 +87,19 @@ export function buildPushText(
   sessionName: string,
   question: Question,
 ): { title: string; body: string } {
+  // #626: a multi-question AskUserQuestion can't fit a per-question option list on
+  // the lock screen, so summarize the SCOPE — "<N> questions" + a numbered list of
+  // each sub-question's topic (header, or its text) — and route the user to the
+  // in-app form. A single-question AUQ falls through to the normal option-list body.
+  if (question.kind === 'multi_question' && question.questions && question.questions.length > 1) {
+    const steps = question.questions;
+    const title = `${sessionName}: ${steps.length} questions`.slice(0, TITLE_MAX);
+    const body = steps
+      .map((s, i) => `${i + 1}. ${normalizeNotificationText(s.header || s.text)}`)
+      .join('\n')
+      .slice(0, BODY_MAX);
+    return { title, body };
+  }
   const ask = normalizeNotificationText(question.text) || 'Allow this action?';
   const title = `${sessionName}: ${ask}`.slice(0, TITLE_MAX);
   const optionList = formatOptionList(question.options);
@@ -294,7 +307,14 @@ export class NotificationDispatcher {
     const sessionName = session?.name || 'Agent';
     const cfg = pushConfig();
     const pushSessionId = this.deps.getPrimarySessionId() ?? this.sessionId;
-    const pushCategory = selectPushCategory(question.options);
+    // #626: an AskUserQuestion (kind === 'multi_question') never uses the
+    // count-based permission categories — REMI_YN/YNA carry hardcoded
+    // "Yes / Yes, always / No" button titles that would MISLABEL arbitrary picks
+    // (e.g. "PostgreSQL / MySQL / MongoDB"). With no category the lock screen
+    // shows the summary and opens the app, where the structured card renders the
+    // real options + descriptions. (One-tap AUQ answering arrives in #627.)
+    const pushCategory =
+      question.kind === 'multi_question' ? undefined : selectPushCategory(question.options);
     // Send the human-readable LABELS for DISPLAY (#574, issue 4); answer
     // routing in input-events resolves an incoming label OR value back to the
     // option, then submits the option's index when a PTY submit is required, so

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -187,6 +187,62 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.options[2]?.isNo).toBe(true);
   });
 
+  // #626: the bridge must THREAD the structured AskUserQuestion fields onto the
+  // emitted Question (extractToolQuestion proves the shape; this proves wiring).
+  it('threads the structured AskUserQuestion fields onto the emitted Question', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          {
+            question: 'Who is the PI?',
+            header: 'Collab PI',
+            multiSelect: false,
+            options: [{ label: 'Scott', description: 'EEGLAB founder' }],
+          },
+          {
+            question: 'Which tools?',
+            header: 'Software focus',
+            multiSelect: true,
+            options: [{ label: 'EEGLAB', description: 'plugins' }],
+          },
+        ],
+      },
+    } as PermissionRequestHookInput);
+
+    expect(questions.length).toBe(1);
+    const q = questions[0];
+    expect(q?.kind).toBe('multi_question');
+    expect(q?.submitLabel).toBe('Submit');
+    expect(q?.questions).toHaveLength(2);
+    expect(q?.questions?.[0]?.header).toBe('Collab PI');
+    expect(q?.questions?.[0]?.options[0]?.description).toBe('EEGLAB founder');
+    expect(q?.questions?.[1]?.multiSelect).toBe(true);
+    // Back-compat flat fields still mirror questions[0].
+    expect(q?.text).toBe('Collab PI: Who is the PI?');
+    expect(q?.options[0]?.label).toBe('Scott');
+  });
+
+  it('does NOT set kind/questions on a plain (non-AskUserQuestion) permission', () => {
+    const { bridge, questions } = createBridge();
+
+    bridge.handlePermissionRequest({
+      ...makeCommon(),
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+    } as PermissionRequestHookInput);
+
+    expect(questions.length).toBe(1);
+    expect(questions[0]?.kind).toBeUndefined();
+    expect(questions[0]?.questions).toBeUndefined();
+    expect(questions[0]?.submitLabel).toBeUndefined();
+  });
+
   // Inputs that yield fewer than 2 usable string labels: must fall back to
   // the default 3-option set so the iOS card always renders something the
   // user can act on. Object entries (e.g. {type:"addDirectories",...}) are

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -94,6 +94,70 @@ describe('extractToolQuestion', () => {
     expect(q?.options.map((o) => o.label)).toEqual(['Confirm']);
     expect(q?.options[0]?.value).toBe('1');
   });
+
+  // #626: the full structured multi-question is surfaced, not just questions[0].
+  it('surfaces ALL sub-questions with headers, descriptions, and multiSelect', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        {
+          question: 'Who is the collaborating PI?',
+          header: 'Collab PI',
+          multiSelect: false,
+          options: [
+            { label: 'Scott', description: 'EEGLAB founder' },
+            { label: 'Arnaud', description: 'EEGLAB lead' },
+          ],
+        },
+        {
+          question: 'Which tools to center on?',
+          header: 'Software focus',
+          multiSelect: true,
+          options: [
+            { label: 'EEGLAB', description: 'plugins + BIDS' },
+            { label: 'NEMAR', description: 'pipelines' },
+          ],
+        },
+      ],
+    });
+    expect(q).not.toBeNull();
+    if (!q) return;
+    expect(q.kind).toBe('multi_question');
+    expect(q.submitLabel).toBe('Submit');
+    expect(q.questions).toHaveLength(2);
+    // Back-compat flat fields mirror questions[0] (header-prefixed text + its options).
+    expect(q.text).toBe('Collab PI: Who is the collaborating PI?');
+    expect(q.options.map((o) => o.label)).toEqual(['Scott', 'Arnaud']);
+    // Step 0: header (NOT prefixed into step text), descriptions, single-select.
+    const s0 = q.questions?.[0];
+    expect(s0?.header).toBe('Collab PI');
+    expect(s0?.text).toBe('Who is the collaborating PI?');
+    expect(s0?.multiSelect).toBe(false);
+    expect(s0?.options.map((o) => o.description)).toEqual(['EEGLAB founder', 'EEGLAB lead']);
+    // Step 1: multiSelect carried; per-step 1-based values.
+    const s1 = q.questions?.[1];
+    expect(s1?.header).toBe('Software focus');
+    expect(s1?.multiSelect).toBe(true);
+    expect(s1?.options.map((o) => o.value)).toEqual(['1', '2']);
+  });
+
+  it('omits description when the AskUserQuestion option has none', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [{ question: 'Pick', options: ['A', { label: 'B' }] }],
+    });
+    expect(q?.options.every((o) => o.description === undefined)).toBe(true);
+  });
+
+  it('drops malformed sub-questions but keeps the well-formed ones', () => {
+    const q = extractToolQuestion('AskUserQuestion', {
+      questions: [
+        { question: 'Good one', options: ['A', 'B'] },
+        { question: 'No options', options: [] },
+        { options: ['orphan'] },
+      ],
+    });
+    expect(q?.questions).toHaveLength(1);
+    expect(q?.questions?.[0]?.text).toBe('Good one');
+  });
 });
 
 describe('optionsFromSuggestions', () => {

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -263,6 +263,42 @@ describe('NotificationDispatcher.maybePush', () => {
     expect(pushed[0]?.opts['category']).toBe('REMI_YNA');
   });
 
+  // #626: an AskUserQuestion must NOT get a count-based category (REMI_YN/YNA
+  // would mislabel arbitrary picks as Yes/No); the lock screen opens the app.
+  test('multi-question (AskUserQuestion) pushes with NO category', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    const mq: Question = {
+      id: 'q1' as UUID,
+      text: 'Collab PI: Who is the PI?',
+      // Three options would normally select REMI_YNA — proving the kind guard wins.
+      options: [
+        { value: '1', label: 'Scott', isRecommended: true, isYes: false, isNo: false },
+        { value: '2', label: 'Arnaud', isRecommended: false, isYes: false, isNo: false },
+        { value: '3', label: 'Other', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        {
+          header: 'Collab PI',
+          text: 'Who is the PI?',
+          multiSelect: false,
+          options: [],
+        },
+        { header: 'Software focus', text: 'Which tools?', multiSelect: true, options: [] },
+      ],
+    };
+    make().maybePush(SID, mq);
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.opts['category']).toBeUndefined();
+    expect(pushed[0]?.opts['title']).toContain('2 questions');
+    expect(pushed[0]?.opts['body']).toBe('1. Collab PI\n2. Software focus');
+  });
+
   test('body shows the ask + real labels and is never the collapsed PTY garble (#574 issue 3)', () => {
     register(false);
     deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -112,6 +112,54 @@ describe('buildPushText (#574 issues 3+4)', () => {
     const { body } = buildPushText('agent', question('q', ynOpts, 'Retry?'));
     expect(body).toBe('Retry?\ny. Yes  n. No');
   });
+
+  // #626: a multi-question AskUserQuestion summarizes its SCOPE on the lock screen.
+  test('multi-question summarizes the topics instead of one option list', () => {
+    const q: Question = {
+      id: 'q' as UUID,
+      text: 'Collab PI: Who is the PI?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        { header: 'Collab PI', text: 'Who is the PI?', multiSelect: false, options: [] },
+        { header: 'Software focus', text: 'Which tools?', multiSelect: true, options: [] },
+        { header: 'Scaffold', text: 'Scaffold now?', multiSelect: false, options: [] },
+      ],
+    };
+    const { title, body } = buildPushText('proj', q);
+    expect(title).toBe('proj: 3 questions');
+    expect(body).toBe('1. Collab PI\n2. Software focus\n3. Scaffold');
+  });
+
+  test('single-question AskUserQuestion still uses the normal option-list body', () => {
+    const q: Question = {
+      id: 'q' as UUID,
+      text: 'DB: Which database?',
+      options: [
+        { value: '1', label: 'Postgres', isRecommended: true, isYes: false, isNo: false },
+        { value: '2', label: 'SQLite', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        {
+          header: 'DB',
+          text: 'Which database?',
+          multiSelect: false,
+          options: [
+            { value: '1', label: 'Postgres', isRecommended: true, isYes: false, isNo: false },
+            { value: '2', label: 'SQLite', isRecommended: false, isYes: false, isNo: false },
+          ],
+        },
+      ],
+    };
+    const { title, body } = buildPushText('proj', q);
+    expect(title).toBe('proj: DB: Which database?');
+    expect(body).toBe('DB: Which database?\n1. Postgres  2. SQLite');
+  });
 });
 
 describe('NotificationDispatcher.maybePush', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,7 @@ export type {
   Question,
   QuestionOption,
   QuestionSource,
+  QuestionStep,
   Session,
   ConnectionInfo,
   Result,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -186,6 +186,43 @@ export interface Question {
    * ignored on the wire; consumed only by the daemon's notification path.
    */
   readonly source?: QuestionSource | undefined;
+
+  /**
+   * Shape discriminator (#626). `'permission'` (the default when omitted) is a
+   * single prompt described by `text` + `options`. `'multi_question'` is a
+   * structured `AskUserQuestion` tool call: the full set of sub-questions is in
+   * `questions`, while `text`/`options` mirror `questions[0]` for back-compat
+   * (lock-screen summary + the first-question answer path).
+   */
+  readonly kind?: 'permission' | 'multi_question' | undefined;
+
+  /**
+   * The sub-questions for `kind === 'multi_question'` (#626): each carries its
+   * own `header`, `text`, `multiSelect`, and `options` (with authored
+   * `description`s). Authored by Claude in `AskUserQuestion.tool_input`; the
+   * daemon surfaces them verbatim instead of collapsing to the first question.
+   */
+  readonly questions?: readonly QuestionStep[] | undefined;
+
+  /** Submit-button label for a multi-question form (#626); defaults to "Submit". */
+  readonly submitLabel?: string | undefined;
+}
+
+/**
+ * One sub-question of a `kind === 'multi_question'` {@link Question} (#626),
+ * mirroring an `AskUserQuestion` entry: a short topic `header`, the `text`, a
+ * `multiSelect` flag (pick one vs many), and `options` each with an authored
+ * `description`.
+ */
+export interface QuestionStep {
+  /** Short topic chip shown above the question (AskUserQuestion `header`). */
+  readonly header?: string | undefined;
+  /** The sub-question text. */
+  readonly text: string;
+  /** True when the user may select MORE THAN ONE option. */
+  readonly multiSelect: boolean;
+  /** Options for this sub-question. */
+  readonly options: readonly QuestionOption[];
 }
 
 /**
@@ -217,6 +254,14 @@ export interface QuestionOption {
 
   /** Is this a "no" type answer */
   readonly isNo: boolean;
+
+  /**
+   * Authored per-option explanation (#626). Present for `AskUserQuestion`
+   * options, whose `tool_input` carries a `description` for each choice; this is
+   * the text that lets the user understand a choice without seeing the terminal.
+   * Absent for plain permission options (Yes / Yes, always / No).
+   */
+  readonly description?: string | undefined;
 }
 
 /**

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -626,6 +626,23 @@ function App() {
           isYes: o.isYes || undefined,
           isNo: o.isNo || undefined,
           isRecommended: o.isRecommended || undefined,
+          description: o.description || undefined,
+        }));
+
+        // #626: carry the full AskUserQuestion structure (headers, per-option
+        // descriptions, multiSelect) so the card can render it properly.
+        const uiQuestions: UIQuestion['questions'] = q.questions?.map((step) => ({
+          ...(step.header ? { header: step.header } : {}),
+          text: step.text,
+          multiSelect: step.multiSelect,
+          options: step.options.map((o) => ({
+            label: o.label,
+            value: o.value,
+            isYes: o.isYes || undefined,
+            isNo: o.isNo || undefined,
+            isRecommended: o.isRecommended || undefined,
+            description: o.description || undefined,
+          })),
         }));
 
         // sessionId is mandatory on the wire now (#437); never fall back to
@@ -646,6 +663,9 @@ function App() {
           structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
           timestamp: new Date().toISOString(),
           agentId: questionAgentId,
+          ...(q.kind ? { kind: q.kind } : {}),
+          ...(uiQuestions && uiQuestions.length > 0 ? { questions: uiQuestions } : {}),
+          ...(q.submitLabel ? { submitLabel: q.submitLabel } : {}),
         };
         const key = questionKey(questionSessionId, questionAgentId);
         setQuestions((prev) => {

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -42,6 +42,8 @@ interface RenderOption {
   readonly label: string;
   readonly hint?: string;
   readonly kind: OptionKind;
+  /** Authored per-option explanation (AskUserQuestion `description`, #626). */
+  readonly description?: string;
 }
 
 /** Hint text shown to the right of permission-style options. */
@@ -67,6 +69,7 @@ function buildOptions(question: UIQuestion): RenderOption[] {
       label: o.label,
       hint: optionHint(o),
       kind: optionKind(o),
+      ...(o.description ? { description: o.description } : {}),
     }));
   }
   if (question.type === 'yes_no') {
@@ -86,14 +89,18 @@ function buildOptions(question: UIQuestion): RenderOption[] {
   return [];
 }
 
-/** A single option row. */
+/** A single option row. With an authored description (#626) the label sits on
+ *  top and the explanation wraps below it; otherwise it stays a single line. */
 function OptionRow({ option, onAnswer }: { readonly option: RenderOption; readonly onAnswer: (v: string) => void }) {
-  const { kind } = option;
+  const { kind, description } = option;
   return (
     <button
       type="button"
       onClick={() => onAnswer(option.key)}
-      className="flex min-h-[44px] items-center gap-2.5 rounded-[10px] px-3 py-2.5 text-left transition-transform active:scale-[0.99]"
+      className={clsx(
+        'flex min-h-[44px] gap-2.5 rounded-[10px] px-3 py-2.5 text-left transition-transform active:scale-[0.99]',
+        description ? 'items-start' : 'items-center',
+      )}
       style={{
         background:
           kind === 'primary'
@@ -106,7 +113,10 @@ function OptionRow({ option, onAnswer }: { readonly option: RenderOption; readon
       }}
     >
       <span
-        className="inline-flex size-[22px] shrink-0 items-center justify-center rounded-md font-mono text-[11px] font-bold"
+        className={clsx(
+          'inline-flex size-[22px] shrink-0 items-center justify-center rounded-md font-mono text-[11px] font-bold',
+          description && 'mt-0.5',
+        )}
         style={{
           background:
             kind === 'primary'
@@ -119,10 +129,17 @@ function OptionRow({ option, onAnswer }: { readonly option: RenderOption; readon
       >
         {option.badge}
       </span>
-      <span className="text-sm font-semibold">{option.label}</span>
-      {option.hint && (
-        <span className="ml-auto text-[11px] opacity-70">{option.hint}</span>
-      )}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="flex items-center gap-2">
+          <span className="text-sm font-semibold">{option.label}</span>
+          {option.hint && <span className="ml-auto text-[11px] opacity-70">{option.hint}</span>}
+        </span>
+        {description && (
+          <span className="break-anywhere mt-0.5 text-[12px] leading-snug opacity-75">
+            {description}
+          </span>
+        )}
+      </span>
     </button>
   );
 }
@@ -173,7 +190,15 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
   const isAnswered = question.answeredWith != null;
   const options = buildOptions(question);
   const isPermission = options.some((o) => o.kind === 'primary' || o.kind === 'danger');
-  const headerLabel = isPermission ? 'Permission request' : 'Question';
+  // #626: structured AskUserQuestion. The first sub-question is rendered as the
+  // interactive prompt; the rest are previewed until batched submit lands (#627).
+  const steps = question.kind === 'multi_question' ? question.questions : undefined;
+  const firstStep = steps?.[0];
+  const topic = firstStep?.header;
+  const promptText = firstStep?.text ?? question.prompt;
+  const isMultiSelect = firstStep?.multiSelect ?? false;
+  const extraSteps = steps && steps.length > 1 ? steps.slice(1) : [];
+  const headerLabel = topic ?? (steps ? 'Question' : isPermission ? 'Permission request' : 'Question');
 
   if (isAnswered) {
     return (
@@ -233,8 +258,11 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
       {/* Prompt */}
       <div className="px-4 pb-1.5 pt-3.5">
         <p className="break-anywhere text-[15px] font-medium leading-snug text-[var(--color-text)]">
-          {question.prompt}
+          {promptText}
         </p>
+        {isMultiSelect && (
+          <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">Select all that apply</p>
+        )}
       </div>
 
       {/* Options / free text */}
@@ -245,6 +273,30 @@ export function QuestionCard({ question, onAnswer, className }: QuestionCardProp
           <FreeTextRow onAnswer={onAnswer} />
         )}
       </div>
+
+      {/* #626: preview the remaining sub-questions so the user sees the full scope.
+          They become individually answerable with batched submit in #627. */}
+      {extraSteps.length > 0 && (
+        <div
+          className="mx-3 mb-3 rounded-[10px] px-3 py-2.5"
+          style={{ background: 'var(--color-surface-elevated)' }}
+        >
+          <p className="text-[11px] font-bold uppercase tracking-[0.06em] text-[var(--color-text-secondary)]">
+            {extraSteps.length} more question{extraSteps.length > 1 ? 's' : ''} follow
+          </p>
+          <ul className="mt-1.5 flex flex-col gap-1">
+            {extraSteps.map((s, i) => (
+              <li
+                key={`${s.header ?? ''}-${s.text.slice(0, 24)}-${i}`}
+                className="break-anywhere text-[13px] leading-snug text-[var(--color-text)]"
+              >
+                <span className="font-semibold">{s.header ? `${s.header}: ` : ''}</span>
+                {s.text}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -159,6 +159,16 @@ export interface UIQuestionOption {
   readonly isYes?: boolean;
   readonly isNo?: boolean;
   readonly isRecommended?: boolean;
+  /** Authored per-option explanation (AskUserQuestion `description`, #626). */
+  readonly description?: string;
+}
+
+/** One sub-question of a multi-question (AskUserQuestion) prompt (#626). */
+export interface UIQuestionStep {
+  readonly header?: string;
+  readonly text: string;
+  readonly multiSelect: boolean;
+  readonly options: readonly UIQuestionOption[];
 }
 
 /** Question from the agent requiring user response */
@@ -175,6 +185,13 @@ export interface UIQuestion {
   /** The Claude agent this prompt belongs to ('main' default). Keys the
    *  collection so a main + subagent prompt coexist rather than overwrite. */
   readonly agentId?: string;
+  /** #626: 'multi_question' for an AskUserQuestion with structured sub-questions. */
+  readonly kind?: 'permission' | 'multi_question';
+  /** #626: the full sub-question set (AskUserQuestion). The first is interactive;
+   *  the rest are previewed until batched submit lands (#627). */
+  readonly questions?: readonly UIQuestionStep[];
+  /** #626: submit-button label for the multi-question form. */
+  readonly submitLabel?: string;
 }
 
 /** App settings */


### PR DESCRIPTION
Phase 2 of the question-pipeline rework (epic #624). Closes #626.

**Stacked on #629 (Phase 1)** — base is `feature/issue-625-phase1-single-gate`; will retarget to the epic branch once Phase 1 merges.

## Problem

The new `AskUserQuestion` format bundles up to 4 sub-questions, each with a `header`, a `multiSelect` flag, and **per-option `description`s** (authored by Claude). Remi collapsed it to `questions[0]` with plain string options — so on a phone the title/context and the meaning of each option were lost. This is the "options are not shown properly" pain for remote sessions.

## Fix: surface the full structure from the hook

The structured data is already in the `PermissionRequest` hook `tool_input`; we stop discarding it. No model needed — the descriptions are authored.

**shared:** `QuestionOption.description`; new `QuestionStep` (`header`/`text`/`multiSelect`/`options`); `Question.kind` (`'permission' | 'multi_question'`), `questions[]`, `submitLabel`. `text`/`options` still mirror `questions[0]` for back-compat (lock-screen + first-question answer path).

**daemon:** `extractToolQuestion` surfaces ALL sub-questions (headers, descriptions, multiSelect), dropping malformed ones; `handlePermissionRequest` threads them onto the escalation; the notification summarizes a multi-question's **scope** ("N questions" + topic list) and uses no count-based category (`REMI_YN`/`YNA` would mislabel arbitrary picks as Yes/No). Single-question AUQ keeps the normal option-list body.

**web:** `QuestionCard` renders the topic header chip, **per-option descriptions**, a "select all that apply" hint for multiSelect, and a preview of the remaining sub-questions.

## Scope boundary

Display is complete. The first sub-question stays interactive via the existing path; full **batched multi-question answering + submit** (incl. multiSelect and the keystroke-driver for the new interactive TUI) is **#627 (Phase 3)**.

## Tests

- tool-question: full structure, descriptions, multiSelect, malformed-sub-question drop, back-compat flat fields.
- notification: multi-question scope summary vs single-question option-list body.
- typecheck + web build + Biome clean; 1,219 daemon/shared tests pass.

Visual QA of the card is pending live testing (the in-app view is the web `QuestionCard` wrapped by Capacitor).
