### PR TITLE
0.6.16 release prep: changelog + persistent escape control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ properly on a remote session.
   LLM also returns a one-line, plain-language question ("Force-push to main?")
   shown on the push instead of the raw "Allow Bash: <command>" — folded into the
   existing decision call, no added latency.
-- **Persistent escape in the chat** (#627 review): a Stop/Esc control in the input
-  row, a long-press on the send button, and the busy "Stop" all send a bare `Esc`
-  to the session — interrupting Claude's running work or escaping an on-screen
-  prompt at any time, not only from a question card.
+- **Escape from the chat input** (#627 review): long-pressing the send button opens
+  a Stop dialog that sends a bare `Esc` to the session — interrupting Claude's
+  running work or dismissing an on-screen prompt at any time, not only from a
+  question card. One control (the send button), confirmation-gated so it can never
+  fire accidentally, and reachable even while the input is empty.
 
 ### Changed
 - **One gate, escalate-only** (#625): a question reaches your phone if and only if
@@ -41,8 +42,8 @@ properly on a remote session.
 
 ### Fixed
 - Phantom permission notifications for actions the LLM/rules had already approved.
-- AskUserQuestion prompts whose options/context were lost or mis-answered on the
-  phone (the old single-digit answer path could not express the new tabbed form).
+- AskUserQuestion prompts whose options/context were lost or answered incorrectly
+  on the phone (the old single-digit path could not express the new tabbed form).
 
 Notification-delivery robustness (epic #603): escalations reliably reach the
 lock screen, a manual answer frees the GPU, dead device tokens self-heal, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ properly on a remote session.
   LLM also returns a one-line, plain-language question ("Force-push to main?")
   shown on the push instead of the raw "Allow Bash: <command>" — folded into the
   existing decision call, no added latency.
+- **Persistent escape in the chat** (#627 review): a Stop/Esc control in the input
+  row, a long-press on the send button, and the busy "Stop" all send a bare `Esc`
+  to the session — interrupting Claude's running work or escaping an on-screen
+  prompt at any time, not only from a question card.
 
 ### Changed
 - **One gate, escalate-only** (#625): a question reaches your phone if and only if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
-## [0.6.16] - 2026-06-28
+## [0.6.16] - 2026-06-27
 
 Question-pipeline rework (epic #624): the auto-approve gate is the single
 authority for what reaches your phone — killing phantom permission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,41 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
-## [0.6.15] - 2026-06-22
+## [0.6.16] - 2026-06-28
+
+Question-pipeline rework (epic #624): the auto-approve gate is the single
+authority for what reaches your phone — killing phantom permission
+notifications — and the new `AskUserQuestion` format is shown and answered
+properly on a remote session.
+
+### Added
+- **Structured AskUserQuestion display** (#626): the full set of sub-questions —
+  topic headers, per-option descriptions, and multi-select — flows from the hook
+  to the client and renders as a real form, instead of collapsing to the first
+  question with bare labels. The lock-screen push summarizes the question scope.
+- **Multi-question answer + submit** (#627): a remote answer drives Claude's
+  interactive AskUserQuestion terminal UI (built from live captures), verifying
+  the review screen before submitting so it never submits the wrong answer. A
+  **Cancel / Esc control on every question card** is the universal unstick — it
+  escapes any prompt the app can't drive, so you are never stuck on a blocked
+  Claude. Built-in env-gated PTY capture (`REMI_PTY_CAPTURE`) to re-verify the
+  keystroke model when Claude Code's renderer changes.
+- **Natural lock-screen summaries** (#628): on a generic escalation the deciding
+  LLM also returns a one-line, plain-language question ("Force-push to main?")
+  shown on the push instead of the raw "Allow Bash: <command>" — folded into the
+  existing decision call, no added latency.
+
+### Changed
+- **One gate, escalate-only** (#625): a question reaches your phone if and only if
+  the auto-approve verdict is `escalate`. Approvals and denials are silent. The
+  PTY screen-scraper no longer emits questions for hooked sessions — it was
+  echoing prompts the gate had already auto-approved, the source of the phantom
+  notifications (live logs showed 1,100+ pushes fired right after a 0 ms approve).
+
+### Fixed
+- Phantom permission notifications for actions the LLM/rules had already approved.
+- AskUserQuestion prompts whose options/context were lost or mis-answered on the
+  phone (the old single-digit answer path could not express the new tabbed form).
 
 Notification-delivery robustness (epic #603): escalations reliably reach the
 lock screen, a manual answer frees the GPU, dead device tokens self-heal, and

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1240,6 +1240,7 @@ function App() {
     reconnect: reconnectConnection,
     disconnectAll,
     sendInput,
+    sendEscape,
     sendAnswer,
     sendAuqAnswer,
     sendCancelQuestion,
@@ -1778,6 +1779,19 @@ function App() {
     [getActiveConnectionId, sendCancelQuestion],
   );
 
+  // Persistent escape: send a bare Esc to the ACTIVE session at any time — it
+  // interrupts Claude's running work and escapes/cancels an on-screen prompt,
+  // even before a question card exists. Surfaced as a button in the input row and
+  // a long-press on the send button.
+  const handleEscape = useCallback(() => {
+    if (!activeSessionId) return;
+    const connId =
+      sessions.find((s) => s.id === activeSessionId)?.connectionId ?? getActiveConnectionId();
+    if (!connId) return;
+    const binding = sessions.find((s) => s.id === activeSessionId)?.claudeSessionId;
+    sendEscape(connId, activeSessionId, binding as UUID | undefined);
+  }, [activeSessionId, getActiveConnectionId, sendEscape, sessions]);
+
   // Send a regular user input message, optionally with a reply context.
   // Always routes through sendInput regardless of pending question state
   // (#401 bug fix). The QuestionCard owns the answer flow via handleAnswer.
@@ -2116,6 +2130,7 @@ function App() {
       onAnswer={handleAnswer}
       onAuqAnswer={handleAuqAnswer}
       onCancelQuestion={handleCancelQuestion}
+      onCancel={handleEscape}
       onReply={handleReply}
       replyContext={sessionReplyContext}
       onClearReply={handleClearReply}

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -102,10 +102,12 @@ export function InputArea({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
-  // Long-press on the send button fires the escape (#624 review): hold to send Esc
-  // to the session. `longPressedRef` suppresses the click that follows the release.
+  // Long-press on the send button opens the Stop dialog (#624 review): hold to
+  // confirm sending Esc to the session. `longPressedRef` suppresses the click
+  // that follows the release so the long-press doesn't also send the message.
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressedRef = useRef(false);
+  const [stopDialogOpen, setStopDialogOpen] = useState(false);
 
   // Re-hydrate when the active session (and therefore draftKey) changes.
   useEffect(() => {
@@ -217,24 +219,28 @@ export function InputArea({
     }
   };
 
-  // #624 review: the persistent escape — send Esc to the session (interrupt the
-  // running work / cancel an on-screen prompt) any time.
-  const fireEscape = useCallback(() => {
+  // #624 review: the escape — send Esc to the session (interrupt running work /
+  // cancel an on-screen prompt). Confirmed via the Stop dialog so it can never
+  // fire accidentally.
+  const confirmStop = useCallback(() => {
+    setStopDialogOpen(false);
     if (!onCancel) return;
     hapticImpact('medium');
     onCancel();
   }, [onCancel]);
 
-  // Long-press the send button to fire the escape (works while the button is
-  // enabled, i.e. there is text); the persistent Esc button covers the empty case.
+  // Long-press the send button (the one button) opens the Stop dialog. Works
+  // whether or not there is text, so it's available exactly when Claude is busy
+  // and the input is empty.
   const startLongPress = useCallback(() => {
     longPressedRef.current = false;
-    if (!onCancel) return;
+    if (!onCancel || disabled) return;
     longPressTimer.current = setTimeout(() => {
       longPressedRef.current = true;
-      fireEscape();
+      hapticImpact('medium');
+      setStopDialogOpen(true);
     }, 450);
-  }, [onCancel, fireEscape]);
+  }, [onCancel, disabled]);
 
   const cancelLongPress = useCallback(() => {
     if (longPressTimer.current) {
@@ -300,20 +306,6 @@ export function InputArea({
         </div>
       )}
 
-      {/* Cancel button when agent is busy */}
-      {isAgentBusy && onCancel && (
-        <div className="flex justify-center border-b border-[var(--color-border)] py-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="flex items-center gap-2 rounded-full bg-[var(--color-error)]/10 px-4 py-1.5 text-sm text-[var(--color-error)] transition-colors hover:bg-[var(--color-error)]/20"
-          >
-            <StopCircle className="size-4" />
-            Stop
-          </button>
-        </div>
-      )}
-
       {/* Reply banner: shown when long-press set a reply context (#401). */}
       {replyContext && (
         <div className="flex items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface-light)] px-4 py-2">
@@ -362,40 +354,73 @@ export function InputArea({
           />
         </div>
 
-        {/* Persistent escape (#624 review): always available, sends Esc to the
-            session to interrupt the running work or cancel an on-screen prompt. */}
-        {onCancel && (
-          <button
-            type="button"
-            onClick={fireEscape}
-            title="Stop / Esc"
-            aria-label="Stop or escape (Esc)"
-            className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-error)] active:scale-95"
-          >
-            <StopCircle className="size-5" />
-          </button>
-        )}
-
-        {/* Send button — long-press to fire the escape too. */}
+        {/* The one button: tap sends, long-press opens the Stop dialog (#624
+            review). Not HTML-`disabled` when the text is empty — only when the
+            whole input is disabled — so the long-press escape stays reachable
+            while Claude is busy and the field is empty. The empty-state tap is a
+            no-op (handled in handleSend); the greyed style signals it. */}
         <button
           onClick={handleSend}
           onPointerDown={startLongPress}
           onPointerUp={cancelLongPress}
           onPointerLeave={cancelLongPress}
           onPointerCancel={cancelLongPress}
-          disabled={disabled || !value.trim()}
+          disabled={disabled}
           className={clsx(
-            'flex size-10 shrink-0 items-center justify-center rounded-full transition-all',
+            'flex size-10 shrink-0 select-none items-center justify-center rounded-full transition-all',
             value.trim()
               ? 'bg-[var(--color-primary)] text-[var(--color-accent-ink)] hover:bg-[var(--color-primary-dark)] active:scale-95'
               : 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)]',
             disabled && 'cursor-not-allowed opacity-50',
           )}
-          aria-label="Send message (long-press to escape)"
+          aria-label={onCancel ? 'Send message (long-press to stop)' : 'Send message'}
         >
           <Send className="size-5" />
         </button>
       </div>
+
+      {/* Stop dialog (#624 review): the single confirmation surface for the
+          escape, reached by long-pressing the send button. Confirming sends a
+          bare Esc to interrupt Claude's running work or dismiss a prompt. */}
+      {stopDialogOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 pb-28"
+          onClick={() => setStopDialogOpen(false)}
+          role="presentation"
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl bg-[var(--color-surface-elevated)] p-4 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Stop the current action"
+          >
+            <p className="mb-1 text-base font-semibold text-[var(--color-text)]">
+              Stop the current action?
+            </p>
+            <p className="mb-4 text-sm text-[var(--color-text-secondary)]">
+              Sends Esc to interrupt Claude's running work or dismiss an on-screen prompt.
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setStopDialogOpen(false)}
+                className="flex-1 rounded-full bg-[var(--color-surface-light)] py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface)] active:scale-95"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmStop}
+                className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[var(--color-error)] py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95"
+              >
+                <StopCircle className="size-4" />
+                Stop
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -269,7 +269,7 @@ export function InputArea({
     <div
       ref={containerRef}
       className={clsx(
-        'border-t border-[var(--color-border)] bg-[var(--color-surface)]',
+        'relative border-t border-[var(--color-border)] bg-[var(--color-surface)]',
         'safe-area-bottom',
         className,
       )}
@@ -381,45 +381,50 @@ export function InputArea({
 
       {/* Stop dialog (#624 review): the single confirmation surface for the
           escape, reached by long-pressing the send button. Confirming sends a
-          bare Esc to interrupt Claude's running work or dismiss a prompt. */}
+          bare Esc to interrupt Claude's running work or dismiss a prompt. The
+          card is anchored to the input area (absolute, bottom-full) so it rides
+          up with the send button when the keyboard pushes the input up; only the
+          dim backdrop is fixed to the viewport. */}
       {stopDialogOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 pb-28"
-          onClick={() => setStopDialogOpen(false)}
-          role="presentation"
-        >
+        <>
           <div
-            className="w-full max-w-sm rounded-2xl bg-[var(--color-surface-elevated)] p-4 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Stop the current action"
-          >
-            <p className="mb-1 text-base font-semibold text-[var(--color-text)]">
-              Stop the current action?
-            </p>
-            <p className="mb-4 text-sm text-[var(--color-text-secondary)]">
-              Sends Esc to interrupt Claude's running work or dismiss an on-screen prompt.
-            </p>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setStopDialogOpen(false)}
-                className="flex-1 rounded-full bg-[var(--color-surface-light)] py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface)] active:scale-95"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={confirmStop}
-                className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[var(--color-error)] py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95"
-              >
-                <StopCircle className="size-4" />
-                Stop
-              </button>
+            className="fixed inset-0 z-40 bg-black/40"
+            onClick={() => setStopDialogOpen(false)}
+            role="presentation"
+          />
+          <div className="absolute inset-x-0 bottom-full z-50 flex justify-center px-4 pb-2">
+            <div
+              className="w-full max-w-sm rounded-2xl bg-[var(--color-surface-elevated)] p-4 shadow-xl"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Stop the current action"
+            >
+              <p className="mb-1 text-base font-semibold text-[var(--color-text)]">
+                Stop the current action?
+              </p>
+              <p className="mb-4 text-sm text-[var(--color-text-secondary)]">
+                Sends Esc to interrupt Claude's running work or dismiss an on-screen prompt.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setStopDialogOpen(false)}
+                  className="flex-1 rounded-full bg-[var(--color-surface-light)] py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface)] active:scale-95"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmStop}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[var(--color-error)] py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95"
+                >
+                  <StopCircle className="size-4" />
+                  Stop
+                </button>
+              </div>
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/packages/web/src/components/chat/InputArea.tsx
+++ b/packages/web/src/components/chat/InputArea.tsx
@@ -102,6 +102,10 @@ export function InputArea({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
+  // Long-press on the send button fires the escape (#624 review): hold to send Esc
+  // to the session. `longPressedRef` suppresses the click that follows the release.
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressedRef = useRef(false);
 
   // Re-hydrate when the active session (and therefore draftKey) changes.
   useEffect(() => {
@@ -193,6 +197,11 @@ export function InputArea({
 
   // Handle send (for button click)
   const handleSend = () => {
+    // Suppress the click that follows a long-press (which fired the escape).
+    if (longPressedRef.current) {
+      longPressedRef.current = false;
+      return;
+    }
     const trimmed = value.trim();
     if (!trimmed || disabled) {
       return;
@@ -207,6 +216,35 @@ export function InputArea({
       textareaRef.current.style.height = 'auto';
     }
   };
+
+  // #624 review: the persistent escape — send Esc to the session (interrupt the
+  // running work / cancel an on-screen prompt) any time.
+  const fireEscape = useCallback(() => {
+    if (!onCancel) return;
+    hapticImpact('medium');
+    onCancel();
+  }, [onCancel]);
+
+  // Long-press the send button to fire the escape (works while the button is
+  // enabled, i.e. there is text); the persistent Esc button covers the empty case.
+  const startLongPress = useCallback(() => {
+    longPressedRef.current = false;
+    if (!onCancel) return;
+    longPressTimer.current = setTimeout(() => {
+      longPressedRef.current = true;
+      fireEscape();
+    }, 450);
+  }, [onCancel, fireEscape]);
+
+  const cancelLongPress = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  // Clear any pending long-press timer on unmount.
+  useEffect(() => () => cancelLongPress(), [cancelLongPress]);
 
   // Quick-response chips for an active question. Route through onAnswer so
   // a tap on Yes/No/option-N is a real `sendAnswer`, not the literal value
@@ -324,9 +362,27 @@ export function InputArea({
           />
         </div>
 
-        {/* Send button */}
+        {/* Persistent escape (#624 review): always available, sends Esc to the
+            session to interrupt the running work or cancel an on-screen prompt. */}
+        {onCancel && (
+          <button
+            type="button"
+            onClick={fireEscape}
+            title="Stop / Esc"
+            aria-label="Stop or escape (Esc)"
+            className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface-light)] text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-error)] active:scale-95"
+          >
+            <StopCircle className="size-5" />
+          </button>
+        )}
+
+        {/* Send button — long-press to fire the escape too. */}
         <button
           onClick={handleSend}
+          onPointerDown={startLongPress}
+          onPointerUp={cancelLongPress}
+          onPointerLeave={cancelLongPress}
+          onPointerCancel={cancelLongPress}
           disabled={disabled || !value.trim()}
           className={clsx(
             'flex size-10 shrink-0 items-center justify-center rounded-full transition-all',
@@ -335,7 +391,7 @@ export function InputArea({
               : 'bg-[var(--color-surface-light)] text-[var(--color-text-muted)]',
             disabled && 'cursor-not-allowed opacity-50',
           )}
-          aria-label="Send message"
+          aria-label="Send message (long-press to escape)"
         >
           <Send className="size-5" />
         </button>

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -101,6 +101,8 @@ export interface UseConnectionManagerReturn {
     content: string,
     claudeSessionId?: UUID,
   ) => boolean;
+  /** Send a bare Esc keystroke to the session (interrupt / escape any prompt). */
+  sendEscape: (connectionId: ConnectionId, sessionId: UUID, claudeSessionId?: UUID) => boolean;
   /** Send answer to a question via the correct connection */
   sendAnswer: (
     connectionId: ConnectionId,
@@ -659,6 +661,19 @@ export function useConnectionManager(
     [sendToConnection],
   );
 
+  // Send a bare Esc keystroke (raw, no Enter) to the session's PTY — the
+  // persistent escape: interrupts Claude's running work AND cancels/escapes an
+  // on-screen prompt, available any time (not tied to a question card).
+  const sendEscape = useCallback(
+    (connectionId: ConnectionId, sessionId: UUID, claudeSessionId?: UUID): boolean => {
+      return sendToConnection(
+        connectionId,
+        createUserInput(sessionId, '\x1b', true, claudeSessionId),
+      );
+    },
+    [sendToConnection],
+  );
+
   const sendAnswer = useCallback(
     (
       connectionId: ConnectionId,
@@ -850,6 +865,7 @@ export function useConnectionManager(
     reconnect,
     disconnectAll,
     sendInput,
+    sendEscape,
     sendAnswer,
     sendAuqAnswer,
     sendCancelQuestion,


### PR DESCRIPTION
CHANGELOG entry for the question-pipeline epic (#624) ahead of the 0.6.16 release. Docs only.