### PR TITLE
feat: persist remote sessions across disconnect + Stop control (#637)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -951,8 +951,12 @@ const sessionRegistry = new SessionRegistry(
         log(`Session detached: ${sessionId} (locally owned, no timeout)`);
       } else if (session?.explicitlyDetached) {
         log(`Session explicitly detached: ${sessionId} (no timeout, re-attachable)`);
+      } else if (session?.persistent) {
+        log(`Session detached: ${sessionId} (persistent, no timeout, re-attachable)`);
       } else {
-        log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
+        log(
+          `Session orphaned: ${sessionId} (will timeout in ${Math.round(orphanTimeoutMs / 1000)}s)`,
+        );
       }
     },
     onSessionResumed: (sessionId, connectionId) => {
@@ -1300,12 +1304,17 @@ async function createNewSession(
   );
 
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
+  // Persist non-wrapper (daemon-spawned/remote) sessions across disconnects by
+  // default so a session created from the app survives until Claude exits or it
+  // is explicitly stopped (#637). Wrapper-mode sessions already never time out.
+  const persistent = remiConfig.daemon.persist_sessions;
   sessionRegistry.registerSession(
     sessionId,
     workingDirectory,
     ptySession,
     messageApi,
     locallyOwned,
+    persistent,
   );
 
   // #576: give clients a defined pill state from the first hello_ack. Without

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -23,6 +23,13 @@ export interface DaemonConfig {
   readonly port_range: number;
   readonly bind: string;
   readonly orphan_timeout: number;
+  /**
+   * Keep sessions alive after the last client disconnects (tmux-style), so a
+   * session created remotely survives until Claude exits or it is explicitly
+   * stopped. When true (default), the orphan timeout never reaps a session;
+   * set false to restore the old `orphan_timeout`-based reaping.
+   */
+  readonly persist_sessions: boolean;
 }
 
 /** Network settings */
@@ -113,6 +120,7 @@ export const DEFAULT_CONFIG: RemiConfig = {
     port_range: DAEMON_PORT_RANGE,
     bind: '0.0.0.0',
     orphan_timeout: 300,
+    persist_sessions: true,
   },
   network: {
     mdns: true,
@@ -689,7 +697,8 @@ export function generateDefaultConfig(): string {
 base_port = ${DEFAULT_CONFIG.daemon.base_port}
 port_range = ${DEFAULT_CONFIG.daemon.port_range}
 bind = "${DEFAULT_CONFIG.daemon.bind}"
-orphan_timeout = ${DEFAULT_CONFIG.daemon.orphan_timeout}  # seconds
+orphan_timeout = ${DEFAULT_CONFIG.daemon.orphan_timeout}  # seconds (ignored when persist_sessions = true)
+persist_sessions = ${DEFAULT_CONFIG.daemon.persist_sessions}  # keep sessions alive after disconnect (tmux-style)
 
 [network]
 mdns = ${DEFAULT_CONFIG.network.mdns}
@@ -819,6 +828,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  port_range = ${config.daemon.port_range}`);
   lines.push(`  bind = "${config.daemon.bind}"`);
   lines.push(`  orphan_timeout = ${config.daemon.orphan_timeout}`);
+  lines.push(`  persist_sessions = ${config.daemon.persist_sessions}`);
   lines.push('');
   lines.push('[network]');
   lines.push(`  mdns = ${config.network.mdns}`);

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -61,8 +61,12 @@ export interface SessionRegistryEvents {
   onSessionCreated?: (sessionId: UUID) => void;
   /** Session was closed (timeout or PTY exit) */
   onSessionClosed?: (sessionId: UUID, reason: 'timeout' | 'pty_exit' | 'forced') => void;
-  /** Connection detached from session. For non-locally-owned sessions,
-   * this means the session is now orphaned; locally-owned sessions remain active. */
+  /** Connection detached from the session. Fires for ALL detach reasons, not
+   * only genuine orphans: a plain non-locally-owned, non-persistent session
+   * becomes orphaned (orphan timeout armed), while locally-owned, persistent,
+   * and explicitly-detached sessions stay alive with no timeout. Inspect the
+   * session flags (locallyOwned / persistent / explicitlyDetached) to tell
+   * which case fired. */
   onSessionOrphaned?: (sessionId: UUID) => void;
   /** Session was resumed (connection reattached) */
   onSessionResumed?: (sessionId: UUID, connectionId: UUID) => void;

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -115,6 +115,12 @@ export interface ManagedSession {
   /** Whether the last detach was an explicit user request (tmux-style).
    * Explicitly detached sessions skip the orphan timeout entirely. */
   explicitlyDetached: boolean;
+
+  /** Whether this session persists after the last client disconnects
+   * (tmux-style). Persistent sessions skip the orphan timeout entirely and
+   * stay re-attachable until Claude exits or they are explicitly stopped.
+   * Driven by `daemon.persist_sessions` (default true). */
+  readonly persistent: boolean;
 }
 
 /**
@@ -156,6 +162,7 @@ export class SessionRegistry {
     pty: PTYSession,
     messageApi: MessageAPI,
     locallyOwned = false,
+    persistent = false,
   ): void {
     if (this.session !== null) {
       throw new Error('Session already registered. Only one session per daemon is allowed.');
@@ -181,6 +188,7 @@ export class SessionRegistry {
       currentQuestions: new Map(),
       locallyOwned,
       explicitlyDetached: false,
+      persistent,
     };
 
     // Flush pre-registration buffer (messages from readExisting transcript entries)
@@ -370,10 +378,16 @@ export class SessionRegistry {
     // Track explicit detach state for discovery status
     this.session.explicitlyDetached = explicit;
 
-    // Start orphan timeout (skip for locally-owned sessions, explicit detaches,
-    // and when orphanTimeoutMs === 0).
-    // Explicitly detached sessions stay alive indefinitely like locally-owned ones.
-    if (!this.session.locallyOwned && !explicit && this.orphanTimeoutMs > 0) {
+    // Start orphan timeout (skip for locally-owned sessions, persistent
+    // (tmux-style) sessions, explicit detaches, and when orphanTimeoutMs === 0).
+    // Persistent and explicitly-detached sessions stay alive indefinitely like
+    // locally-owned ones — they only end on Claude exit or an explicit stop.
+    if (
+      !this.session.locallyOwned &&
+      !this.session.persistent &&
+      !explicit &&
+      this.orphanTimeoutMs > 0
+    ) {
       this.session.orphanTimeoutId = setTimeout(() => {
         this.closeSession(sessionId, 'timeout');
       }, this.orphanTimeoutMs);
@@ -585,7 +599,7 @@ export class SessionRegistry {
   ): 'active' | 'idle' | 'orphaned' | 'detached' {
     if (session.activeConnectionId === null) {
       if (session.locallyOwned) return 'active';
-      if (session.explicitlyDetached) return 'detached';
+      if (session.explicitlyDetached || session.persistent) return 'detached';
       return 'orphaned';
     }
     if (session.currentStatus === 'idle') {
@@ -628,7 +642,9 @@ export class SessionRegistry {
     if (
       this.session !== null &&
       this.session.activeConnectionId === null &&
-      !this.session.locallyOwned
+      !this.session.locallyOwned &&
+      // Persistent (tmux-style) sessions are intentionally kept alive, not orphaned.
+      !this.session.persistent
     ) {
       return 1;
     }

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -99,6 +99,24 @@ bind = "localhost"
     expect(config.daemon.port_range).toBe(20); // default preserved
   });
 
+  test('persist_sessions defaults to true and parses an override (#637)', () => {
+    // Default preserved when omitted
+    const defaults = loadConfig(path.join(TEST_DIR, 'nonexistent.toml'));
+    expect(defaults.daemon.persist_sessions).toBe(true);
+
+    // Explicit override is parsed
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `
+[daemon]
+persist_sessions = false
+`,
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.daemon.persist_sessions).toBe(false);
+    expect(config.daemon.orphan_timeout).toBe(DEFAULT_CONFIG.daemon.orphan_timeout); // default preserved
+  });
+
   test('handles auth enabled as string or boolean', () => {
     fs.writeFileSync(
       TEST_CONFIG,

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -645,6 +645,104 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('persistent sessions (#637)', () => {
+    // 6th registerSession arg is `persistent` (tmux-style keep-alive).
+    test('persistent session skips orphan timeout on detach', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, true);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      // Wait well past the orphan timeout (100ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Session should still exist (not killed by timeout)
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(events.onSessionClosed).not.toHaveBeenCalled();
+    });
+
+    test('persistent session reports "detached" status without connection', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('detached');
+      expect(sessions[0]?.canAttach).toBe(true);
+    });
+
+    test('persistent session is re-attachable after disconnect', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1);
+
+      expect(registry.canResume(sessionId)).toBe(true);
+      const result = registry.attachConnection(sessionId, generateId());
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
+    });
+
+    test('orphanedCount excludes persistent sessions', () => {
+      const sessionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+
+      expect(registry.orphanedCount).toBe(0);
+
+      const connectionId = generateId();
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+      expect(registry.orphanedCount).toBe(0);
+    });
+
+    test('non-persistent session still times out (default behavior preserved)', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, false);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(pty.close).toHaveBeenCalled();
+      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
+    });
+  });
+
   describe('shutdown()', () => {
     test('closes the session', async () => {
       const pty = createMockPTY();

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -741,6 +741,42 @@ describe('SessionRegistry', () => {
       expect(pty.close).toHaveBeenCalled();
       expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
     });
+
+    test('persistent session is closed when the Claude process exits (pty_exit)', () => {
+      // Persistence must NOT keep a session alive after Claude itself exits;
+      // pty_exit is the primary lifecycle-ending event for a persistent session.
+      const sessionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+
+      registry.handlePTYExit(sessionId);
+
+      expect(registry.getSession(sessionId)).toBeUndefined();
+      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'pty_exit');
+    });
+
+    test('persistent + explicit detach stays detached with no timeout', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, true);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      const sessions = registry.listSessions();
+      expect(sessions[0]?.status).toBe('detached');
+    });
   });
 
   describe('shutdown()', () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -229,6 +229,12 @@ function App() {
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
+  // In-flight kill_session_request, keyed by requestId, so kill_session_response
+  // (and a no-reply timeout) resolve against the session that was actually
+  // stopped — not whatever session happens to be open in the chat (#637 review).
+  const pendingKillsRef = useRef<
+    Map<UUID, { sessionId: UUID; timeoutId: ReturnType<typeof setTimeout> }>
+  >(new Map());
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -911,6 +917,14 @@ function App() {
       }
 
       case 'kill_session_response': {
+        // Resolve against the session we actually asked to stop (not the open
+        // chat) and cancel its no-reply timeout.
+        const pending = pendingKillsRef.current.get(message.requestId);
+        if (pending) {
+          clearTimeout(pending.timeoutId);
+          pendingKillsRef.current.delete(message.requestId);
+        }
+        const killedSessionId = pending?.sessionId ?? activeSessionIdRef.current ?? ('' as UUID);
         if (message.success) {
           // Session torn down; refresh the list so the dead session drops off.
           const reqList = requestSessionListRef.current;
@@ -924,7 +938,7 @@ function App() {
           console.error(`Session kill failed: ${message.error}`);
           const errorMsg: UIMessage = {
             id: generateId(),
-            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            sessionId: killedSessionId,
             connectionId: '' as ConnectionId,
             sender: 'system',
             content: `Failed to stop session: ${message.error || 'unknown error'}`,
@@ -2059,6 +2073,21 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Surface a system message in a specific session's thread.
+  const pushSessionSystemMessage = useCallback((sessionId: UUID, content: string) => {
+    const msg: UIMessage = {
+      id: generateId(),
+      sessionId,
+      connectionId: '' as ConnectionId,
+      sender: 'system',
+      content,
+      timestamp: new Date().toISOString(),
+      state: 'delivered',
+      isEditing: false,
+    };
+    setMessages((prev) => [...prev, msg]);
+  }, []);
+
   // Stop (kill) a session: tears down the Claude process + its daemon (#637).
   // Persistent sessions never time out, so this is the explicit way to end one.
   const handleKillSession = useCallback(
@@ -2067,30 +2096,35 @@ function App() {
         `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
       );
       if (!ok) return;
-      const sent = cmSendMessage(connectionId, createKillSessionRequest(sessionId));
+      const req = createKillSessionRequest(sessionId);
+      const sent = cmSendMessage(connectionId, req);
       if (!sent) {
-        const errorMsg: UIMessage = {
-          id: generateId(),
-          sessionId,
-          connectionId: '' as ConnectionId,
-          sender: 'system',
-          content: 'Cannot stop session: not connected to daemon.',
-          timestamp: new Date().toISOString(),
-          state: 'delivered',
-          isEditing: false,
-        };
-        setMessages((prev) => [...prev, errorMsg]);
+        pushSessionSystemMessage(sessionId, 'Cannot stop session: not connected to daemon.');
+        return;
       }
+      // Guard against a daemon that never replies (crash / WS drop): surface a
+      // timeout scoped to this session if no kill_session_response lands.
+      const timeoutId = setTimeout(() => {
+        pendingKillsRef.current.delete(req.id);
+        pushSessionSystemMessage(
+          sessionId,
+          'Stop session timed out; the daemon may be unreachable.',
+        );
+      }, 12_000);
+      pendingKillsRef.current.set(req.id, { sessionId, timeoutId });
     },
-    [cmSendMessage],
+    [cmSendMessage, pushSessionSystemMessage],
   );
 
   const handleEndSession = useCallback(() => {
     if (!activeSessionId) return;
     const connId = getActiveConnectionId();
-    if (!connId) return;
+    if (!connId) {
+      pushSessionSystemMessage(activeSessionId, 'Cannot stop session: session is no longer available.');
+      return;
+    }
     handleKillSession(activeSessionId, connId);
-  }, [activeSessionId, getActiveConnectionId, handleKillSession]);
+  }, [activeSessionId, getActiveConnectionId, handleKillSession, pushSessionSystemMessage]);
 
   // Menu actions
   const handleCopyConversation = useCallback(() => {
@@ -2203,7 +2237,7 @@ function App() {
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
       onDetach={handleDetach}
-      onEndSession={handleEndSession}
+      onEndSession={activeSession?.source === 'daemon' ? handleEndSession : undefined}
       showTimestamps={settings.showTimestamps}
     />
   ) : (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -47,6 +47,7 @@ import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
   createDetachSession,
+  createKillSessionRequest,
   createRegisterDeviceToken,
   generateId,
 } from '@remi/shared/protocol.ts';
@@ -906,6 +907,33 @@ function App() {
 
       case 'session_history_response': {
         // Session history response received; not yet integrated into the UI
+        break;
+      }
+
+      case 'kill_session_response': {
+        if (message.success) {
+          // Session torn down; refresh the list so the dead session drops off.
+          const reqList = requestSessionListRef.current;
+          if (reqList) {
+            const conns = connectionsRef.current.filter((c) => c.status === 'connected');
+            for (const conn of conns) {
+              reqList(conn.connectionId, conns.length === 1);
+            }
+          }
+        } else {
+          console.error(`Session kill failed: ${message.error}`);
+          const errorMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            connectionId: '' as ConnectionId,
+            sender: 'system',
+            content: `Failed to stop session: ${message.error || 'unknown error'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        }
         break;
       }
 
@@ -2031,6 +2059,39 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Stop (kill) a session: tears down the Claude process + its daemon (#637).
+  // Persistent sessions never time out, so this is the explicit way to end one.
+  const handleKillSession = useCallback(
+    (sessionId: UUID, connectionId: ConnectionId, label?: string) => {
+      const ok = window.confirm(
+        `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
+      );
+      if (!ok) return;
+      const sent = cmSendMessage(connectionId, createKillSessionRequest(sessionId));
+      if (!sent) {
+        const errorMsg: UIMessage = {
+          id: generateId(),
+          sessionId,
+          connectionId: '' as ConnectionId,
+          sender: 'system',
+          content: 'Cannot stop session: not connected to daemon.',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, errorMsg]);
+      }
+    },
+    [cmSendMessage],
+  );
+
+  const handleEndSession = useCallback(() => {
+    if (!activeSessionId) return;
+    const connId = getActiveConnectionId();
+    if (!connId) return;
+    handleKillSession(activeSessionId, connId);
+  }, [activeSessionId, getActiveConnectionId, handleKillSession]);
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -2107,6 +2168,7 @@ function App() {
       onReconnect={reconnectConnection}
       onDisconnectAll={handleDisconnectAll}
       onNewSession={handleNewSession}
+      onKillSession={handleKillSession}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -2141,6 +2203,7 @@ function App() {
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
       onDetach={handleDetach}
+      onEndSession={handleEndSession}
       showTimestamps={settings.showTimestamps}
     />
   ) : (

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -17,6 +17,7 @@ import {
   Layers,
   LogOut,
   MoreVertical,
+  Square,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -38,6 +39,8 @@ interface ChatHeaderProps {
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
   readonly onDetach?: () => void;
+  /** Stop (kill) the session entirely (#637). */
+  readonly onEndSession?: () => void;
   readonly className?: string;
 }
 
@@ -51,13 +54,15 @@ export function ChatHeader({
   onClearMessages,
   onExportText,
   onDetach,
+  onEndSession,
   className,
 }: ChatHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const { host, project, branch } = splitSessionName(session);
   const state = sessionPillState(session);
-  const hasMenuActions = onCopyConversation || onClearMessages || onExportText || onDetach;
+  const hasMenuActions =
+    onCopyConversation || onClearMessages || onExportText || onDetach || onEndSession;
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -215,6 +220,17 @@ export function ChatHeader({
                     }}
                   />
                 </>
+              )}
+              {onEndSession && (
+                <MenuItem
+                  icon={<Square className="size-4" />}
+                  label="Stop session"
+                  tone="error"
+                  onClick={() => {
+                    onEndSession();
+                    closeMenu();
+                  }}
+                />
               )}
               {onClearMessages && (
                 <>

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -59,6 +59,8 @@ interface ChatViewProps {
   readonly onExportText?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
   readonly onDetach?: () => void;
+  /** Stop (kill) the active session (#637). */
+  readonly onEndSession?: () => void;
   readonly showTimestamps?: boolean;
   readonly className?: string;
 }
@@ -86,6 +88,7 @@ export function ChatView({
   onExportText,
   onBulletExpand,
   onDetach,
+  onEndSession,
   showTimestamps = true,
   className,
 }: ChatViewProps) {
@@ -139,6 +142,7 @@ export function ChatView({
         onClearMessages={onClearMessages}
         onExportText={onExportText}
         onDetach={onDetach}
+        onEndSession={onEndSession}
       />
 
       {/* Pinned question stack -- the headline interaction. One card per

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -10,8 +10,9 @@ import { StatusPill } from '@/components/StatusPill';
 import { formatRelativeTime } from '@/lib/format-time';
 import { sessionPillState, splitSessionName } from '@/lib/session-display';
 import type { ConnectionId, UISession } from '@/types';
+import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { GitBranch, Link2Off, RotateCcw } from 'lucide-react';
+import { GitBranch, Link2Off, RotateCcw, Square } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
@@ -19,6 +20,10 @@ interface SessionCardProps {
   readonly onClick: () => void;
   readonly onResume?: ((sessionId: string) => void) | undefined;
   readonly onDisconnect?: ((connectionId: ConnectionId) => void) | undefined;
+  /** Stop (kill) the session's Claude process + daemon (#637). */
+  readonly onKill?:
+    | ((sessionId: UUID, connectionId: ConnectionId, label?: string) => void)
+    | undefined;
   readonly isResuming?: boolean;
   /** When true, the bottom hairline divider is omitted (last row in a group). */
   readonly last?: boolean;
@@ -30,10 +35,14 @@ export function SessionCard({
   onClick,
   onResume,
   onDisconnect,
+  onKill,
   isResuming,
   last = false,
 }: SessionCardProps) {
   const { host, project, branch } = splitSessionName(session);
+  // Daemon-owned sessions have a live Claude process that can be stopped;
+  // transcript-only rows do not.
+  const canKill = onKill && session.source === 'daemon';
   const state = sessionPillState(session);
   const isAsking = state === 'asking';
   const isConnected = session.connectionStatus === 'connected';
@@ -128,6 +137,20 @@ export function SessionCard({
             aria-label="Resume"
           >
             <RotateCcw className={clsx('size-3.5', isResuming && 'animate-spin')} />
+          </button>
+        )}
+        {canKill && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onKill(session.id, session.connectionId, project);
+            }}
+            className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
+            aria-label="Stop session"
+            title="Stop session"
+          >
+            <Square className="size-3.5" />
           </button>
         )}
       </div>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -41,6 +41,8 @@ interface SessionListProps {
   readonly onReconnect?: (connectionId: ConnectionId) => void;
   readonly onDisconnectAll: () => void;
   readonly onNewSession?: (directory?: string) => void;
+  /** Stop (kill) a session from the list (#637). */
+  readonly onKillSession?: (sessionId: UUID, connectionId: ConnectionId, label?: string) => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -68,6 +70,7 @@ export function SessionList({
   onReconnect,
   onDisconnectAll,
   onNewSession,
+  onKillSession,
   onSettings,
   className,
 }: SessionListProps) {
@@ -331,6 +334,7 @@ export function SessionList({
                 onClick={() => onSelectSession(session.id)}
                 onResume={onResumeSession}
                 onDisconnect={onDisconnect}
+                onKill={onKillSession}
                 isResuming={resumingSessionId === session.id}
                 last={i === filteredActive.length - 1 && recentSessions.length === 0}
               />


### PR DESCRIPTION
Closes #637.

## Problem

A session created remotely (from the app or a remote terminal) was killed ~5 minutes after the client disconnected, defeating remote monitoring. Users expect a remotely-created session to keep running until Claude exits or they explicitly stop it.

## Root cause

No tmux needed: the daemon already owns the PTY and spawns child daemons `detached: true` + `unref()`, so the process tree survives client disconnect and parent-daemon death. The only thing killing the session was the **orphan timeout**: remotely-created sessions register `locallyOwned = false`, and on disconnect non-locally-owned sessions start a 5-minute `orphan_timeout` countdown that SIGTERM/SIGKILLs Claude.

## Changes

**Daemon (persistence):**
- New per-session `persistent` flag on `ManagedSession`, driven by a new `daemon.persist_sessions` config (default `true`).
- `detachConnection` skips the orphan-timeout kill for persistent sessions, exactly like the existing wrapper-mode (`locallyOwned`) and explicit-detach paths.
- Persistent sessions report `detached` status (re-attachable) and are excluded from `orphanedCount`.
- `orphan_timeout` is still honored when `persist_sessions = false` (escape hatch).

**Web (Stop control):**
- Wires the already-existing `kill_session_request` to the UI so persistent sessions never become invisible zombies:
  - a Stop (square) button on each daemon session row in the list, and
  - a "Stop session" item in the chat header menu.
- Both are confirm-gated. `kill_session_response` refreshes the session list (or surfaces an error).

## Reconnect story

Unchanged and already works: `session_list_response` ships the other live daemon ports, so reopening the app auto-reconnects and the persisted session shows as `detached` and re-attachable.

## Tests

- New `persistent sessions (#637)` suite in `session-registry.test.ts`: skips timeout on detach, reports `detached`, re-attachable, excluded from `orphanedCount`, and a negative control proving non-persistent sessions still time out.
- New config test: `persist_sessions` defaults true and parses an override.
- `bun run typecheck` clean; biome clean (daemon); ESLint clean for the changed web files; daemon session/config/handler suites green (234 tests).

## Notes

- Behavior change: sessions now persist by default. Set `persist_sessions = false` in `[daemon]` to restore the old orphan-timeout reaping.