### PR TITLE
feat: recent-paths sheet for the new-session (+) flow (#638)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,7 +6,7 @@
 
 import { ChatView } from '@/components/chat';
 import { AppLayout } from '@/components/layout';
-import { ConnectModal, SessionList } from '@/components/session';
+import { ConnectModal, NewSessionModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
 import { probeAuthInfo } from '@/lib/auth-probe';
@@ -43,7 +43,7 @@ import type {
 import { DEFAULT_SETTINGS } from '@/types';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
-import type { ProtocolMessage } from '@remi/shared/protocol.ts';
+import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
   createDetachSession,
@@ -201,6 +201,9 @@ function App() {
   // Claude Code receives the quoted context (#401).
   const [replyContexts, setReplyContexts] = useState<Map<UUID, ReplyContext>>(new Map());
   const [showConnectModal, setShowConnectModal] = useState(false);
+  // New-session sheet (#638): recent project directories from the daemon.
+  const [showNewSessionModal, setShowNewSessionModal] = useState(false);
+  const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
@@ -905,7 +908,8 @@ function App() {
       }
 
       case 'session_history_response': {
-        // Session history response received; not yet integrated into the UI
+        // Recent project directories for the new-session sheet (#638).
+        setRecentDirectories(message.directories);
         break;
       }
 
@@ -1250,6 +1254,7 @@ function App() {
     requestTranscriptLoad,
     requestResumeSession,
     requestNewSession,
+    requestSessionHistory,
     needsPassphrase,
     passphraseConnectionId,
     passphraseServerFingerprint,
@@ -2031,6 +2036,24 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Open the new-session sheet and refresh recent directories (#638). The "+"
+  // button routes here instead of a raw path prompt.
+  const handleOpenNewSession = useCallback(() => {
+    const conn = connections.find((c) => c.status === 'connected');
+    if (!conn) return;
+    requestSessionHistory(conn.connectionId);
+    setShowNewSessionModal(true);
+  }, [connections, requestSessionHistory]);
+
+  // RecentProjects passes '' for the home/cwd default; map that to undefined so
+  // the daemon uses its own default working directory.
+  const handleStartSessionInDir = useCallback(
+    (directory: string) => {
+      handleNewSession(directory.trim() || undefined);
+    },
+    [handleNewSession],
+  );
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -2106,7 +2129,7 @@ function App() {
       onDisconnect={handleDisconnect}
       onReconnect={reconnectConnection}
       onDisconnectAll={handleDisconnectAll}
-      onNewSession={handleNewSession}
+      onOpenNewSession={handleOpenNewSession}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -2171,6 +2194,13 @@ function App() {
         hasUnlockedIdentity={unlockedIdentity != null}
         serverFingerprint={passphraseServerFingerprint}
         onPassphraseSubmit={handlePassphraseSubmit}
+      />
+
+      <NewSessionModal
+        open={showNewSessionModal}
+        onClose={() => setShowNewSessionModal(false)}
+        directories={recentDirectories}
+        onStartSession={handleStartSessionInDir}
       />
     </>
   );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -204,6 +204,7 @@ function App() {
   // New-session sheet (#638): recent project directories from the daemon.
   const [showNewSessionModal, setShowNewSessionModal] = useState(false);
   const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
@@ -231,6 +232,9 @@ function App() {
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
+  // Fallback timer so the new-session sheet leaves its loading state even if the
+  // daemon never answers session_history_request (#638 review).
+  const historyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -909,6 +913,11 @@ function App() {
 
       case 'session_history_response': {
         // Recent project directories for the new-session sheet (#638).
+        if (historyTimeoutRef.current) {
+          clearTimeout(historyTimeoutRef.current);
+          historyTimeoutRef.current = null;
+        }
+        setHistoryLoading(false);
         setRecentDirectories(message.directories);
         break;
       }
@@ -2026,32 +2035,39 @@ function App() {
     [sessions, requestResumeSession, resumingSession],
   );
 
-  // Create new session on the first connected daemon
-  const handleNewSession = useCallback(
-    (directory?: string) => {
-      const conn = connections.find((c) => c.status === 'connected');
-      if (!conn) return;
-      requestNewSession(conn.connectionId, directory);
-    },
-    [connections, requestNewSession],
-  );
-
-  // Open the new-session sheet and refresh recent directories (#638). The "+"
-  // button routes here instead of a raw path prompt.
+  // Open the new-session sheet and (re)load recent directories (#638). The "+"
+  // button routes here instead of a raw path prompt. Clears stale directories
+  // and shows a loading state so an empty list isn't confused with "still
+  // loading"; a fallback timer ends the loading state if no response arrives.
   const handleOpenNewSession = useCallback(() => {
     const conn = connections.find((c) => c.status === 'connected');
     if (!conn) return;
-    requestSessionHistory(conn.connectionId);
+    setRecentDirectories([]);
+    if (historyTimeoutRef.current) clearTimeout(historyTimeoutRef.current);
+    const sent = requestSessionHistory(conn.connectionId);
+    if (sent) {
+      setHistoryLoading(true);
+      historyTimeoutRef.current = setTimeout(() => {
+        historyTimeoutRef.current = null;
+        setHistoryLoading(false);
+      }, 5000);
+    } else {
+      setHistoryLoading(false);
+    }
     setShowNewSessionModal(true);
   }, [connections, requestSessionHistory]);
 
-  // RecentProjects passes '' for the home/cwd default; map that to undefined so
-  // the daemon uses its own default working directory.
+  // Start a session in the chosen directory. RecentProjects passes '' for the
+  // home/cwd default; map that to undefined so the daemon uses its own default.
+  // Close the sheet only when the request was actually sent.
   const handleStartSessionInDir = useCallback(
     (directory: string) => {
-      handleNewSession(directory.trim() || undefined);
+      const conn = connections.find((c) => c.status === 'connected');
+      if (!conn) return;
+      const sent = requestNewSession(conn.connectionId, directory.trim() || undefined);
+      if (sent) setShowNewSessionModal(false);
     },
-    [handleNewSession],
+    [connections, requestNewSession],
   );
 
   // Menu actions
@@ -2198,6 +2214,7 @@ function App() {
 
       <NewSessionModal
         open={showNewSessionModal}
+        loading={historyLoading}
         onClose={() => setShowNewSessionModal(false)}
         directories={recentDirectories}
         onStartSession={handleStartSessionInDir}

--- a/packages/web/src/components/session/NewSessionModal.tsx
+++ b/packages/web/src/components/session/NewSessionModal.tsx
@@ -1,0 +1,75 @@
+/**
+ * NewSessionModal component.
+ *
+ * Bottom-sheet for starting a new Claude Code session. Replaces the old
+ * window.prompt path-entry (#638): shows recent project directories (from the
+ * daemon's session history) with a one-tap start, plus a custom-path input.
+ * Mirrors ConnectModal's sheet styling.
+ */
+
+import type { RecentDirectory } from '@remi/shared/protocol.ts';
+import { X } from 'lucide-react';
+import { RecentProjects } from './RecentProjects';
+
+interface NewSessionModalProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly directories: readonly RecentDirectory[];
+  /** Start a session in the given directory (empty string = home/cwd). */
+  readonly onStartSession: (directory: string) => void;
+}
+
+export function NewSessionModal({
+  open,
+  onClose,
+  directories,
+  onStartSession,
+}: NewSessionModalProps) {
+  if (!open) return null;
+
+  const handleStart = (directory: string) => {
+    onStartSession(directory);
+    onClose();
+  };
+
+  return (
+    <div
+      data-testid="new-session-modal-backdrop"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[88vh] w-full max-w-md overflow-y-auto rounded-t-[28px] border border-[var(--color-border)] bg-[var(--color-surface)] pb-[max(env(safe-area-inset-bottom),12px)] shadow-2xl animate-[sheet-up_260ms_cubic-bezier(.2,.8,.2,1)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto mb-1 mt-3 h-1 w-9 rounded-full bg-[var(--color-border)]" />
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pb-2 pt-1">
+          <h2 className="text-[22px] font-bold tracking-tight text-[var(--color-text)]">
+            New session
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+            aria-label="Close"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        <p className="px-5 pb-1 text-[13px] leading-snug text-[var(--color-text-secondary)]">
+          Pick a recent project or enter a path to start Claude Code there.
+        </p>
+
+        {directories.length === 0 && (
+          <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
+            No recent projects yet. Enter a directory path below to start your first session.
+          </p>
+        )}
+
+        <RecentProjects directories={directories} onStartSession={handleStart} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session/NewSessionModal.tsx
+++ b/packages/web/src/components/session/NewSessionModal.tsx
@@ -13,24 +13,23 @@ import { RecentProjects } from './RecentProjects';
 
 interface NewSessionModalProps {
   readonly open: boolean;
+  /** Recent directories are still being fetched from the daemon. */
+  readonly loading?: boolean;
   readonly onClose: () => void;
   readonly directories: readonly RecentDirectory[];
-  /** Start a session in the given directory (empty string = home/cwd). */
+  /** Start a session in the given directory (empty string = home/cwd). The
+   *  parent closes the sheet once the request is actually sent. */
   readonly onStartSession: (directory: string) => void;
 }
 
 export function NewSessionModal({
   open,
+  loading = false,
   onClose,
   directories,
   onStartSession,
 }: NewSessionModalProps) {
   if (!open) return null;
-
-  const handleStart = (directory: string) => {
-    onStartSession(directory);
-    onClose();
-  };
 
   return (
     <div
@@ -62,13 +61,19 @@ export function NewSessionModal({
           Pick a recent project or enter a path to start Claude Code there.
         </p>
 
-        {directories.length === 0 && (
+        {loading ? (
           <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
-            No recent projects yet. Enter a directory path below to start your first session.
+            Loading recent projects…
           </p>
+        ) : (
+          directories.length === 0 && (
+            <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
+              No recent projects yet. Enter a directory path below to start your first session.
+            </p>
+          )
         )}
 
-        <RecentProjects directories={directories} onStartSession={handleStart} />
+        <RecentProjects directories={directories} onStartSession={onStartSession} />
       </div>
     </div>
   );

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -173,7 +173,10 @@ export function SessionList({
             <button
               type="button"
               onClick={() => {
-                if (hasConnections && onOpenNewSession) {
+                // Only route to the new-session sheet when a daemon is actually
+                // connected; otherwise open the connect flow so the tap is never
+                // a silent no-op (#638 review).
+                if (anyConnected && onOpenNewSession) {
                   onOpenNewSession();
                 } else {
                   onConnect();
@@ -181,7 +184,7 @@ export function SessionList({
               }}
               className="inline-flex size-[38px] items-center justify-center rounded-xl bg-[var(--color-primary)] text-[var(--color-accent-ink)] transition-transform active:scale-95"
               style={{ boxShadow: '0 4px 18px -6px var(--color-primary)' }}
-              aria-label={hasConnections ? 'New session' : 'Connect'}
+              aria-label={anyConnected ? 'New session' : 'Connect'}
             >
               <Plus className="size-5" />
             </button>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -40,7 +40,8 @@ interface SessionListProps {
   /** Retry a connection that became 'unreachable' (re-runs port discovery). */
   readonly onReconnect?: (connectionId: ConnectionId) => void;
   readonly onDisconnectAll: () => void;
-  readonly onNewSession?: (directory?: string) => void;
+  /** Open the new-session sheet (recent paths + custom path) (#638). */
+  readonly onOpenNewSession?: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -67,7 +68,7 @@ export function SessionList({
   onDisconnect,
   onReconnect,
   onDisconnectAll,
-  onNewSession,
+  onOpenNewSession,
   onSettings,
   className,
 }: SessionListProps) {
@@ -172,12 +173,8 @@ export function SessionList({
             <button
               type="button"
               onClick={() => {
-                if (hasConnections && onNewSession) {
-                  // Directory selection is preserved here; the richer
-                  // new-session sheet (command + options) is tracked in #447
-                  // and needs daemon-side support.
-                  const dir = window.prompt('Project directory (leave empty for home):');
-                  if (dir !== null) onNewSession(dir || undefined);
+                if (hasConnections && onOpenNewSession) {
+                  onOpenNewSession();
                 } else {
                   onConnect();
                 }

--- a/packages/web/src/components/session/index.ts
+++ b/packages/web/src/components/session/index.ts
@@ -6,3 +6,4 @@ export { SessionCard } from './SessionCard';
 export { SessionList } from './SessionList';
 export { ConnectModal } from './ConnectModal';
 export { RecentProjects } from './RecentProjects';
+export { NewSessionModal } from './NewSessionModal';


### PR DESCRIPTION
Closes #638.

## Problem

The app's "+" new-session button used `window.prompt('Project directory...')`, forcing the user to know and type an exact absolute path on a phone.

## What already existed (just unwired)

- Daemon enumerates recent dirs from `~/.remi/sessions.json` (`recent-client.ts` `getRecentDirectories`).
- Protocol `session_history_request` / `session_history_response` with `RecentDirectory[]`.
- `RecentProjects.tsx` component (recent list + custom-path input) — built but never rendered.
- `useConnectionManager.requestSessionHistory` — existed; App's `session_history_response` case was a TODO no-op.

## Changes (web only, no daemon changes)

- New `NewSessionModal` bottom-sheet (mirrors `ConnectModal`) that renders `RecentProjects`.
- The "+" button now calls `onOpenNewSession` → requests session history and opens the sheet, instead of `window.prompt`.
- `session_history_response` now stores the directories into App state and feeds the sheet.
- Selecting a recent dir or entering a custom path calls the existing `handleNewSession` (→ `create_session_request`); empty maps to the daemon default cwd. The sheet closes on start.

## Tests

- `bun run typecheck` clean; web `tsc -b` + `vite build` succeed; ESLint clean for the changed files. (Web has no component-test harness; this layer is manual/Chrome-tested per project norm.)

## Note

This pairs naturally with #639 (persistent sessions): create a session from a recent path, disconnect, and it keeps running.