### PR TITLE
fix: graceful Exit (/exit) that frees the daemon (#641)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -918,6 +918,10 @@ const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
     ? cliOrphanTimeout * 1000
     : remiConfig.daemon.orphan_timeout * 1000;
+// Forward reference to the session handlers' deferred-Stop resolver (#641). The
+// registry below is constructed before `sessionHandlers` exists, so onSessionClosed
+// reaches the resolver through this holder, assigned once the handlers are wired.
+let resolveStopOnClose: ((sessionId: UUID) => void) | null = null;
 const sessionRegistry = new SessionRegistry(
   {
     orphanTimeoutMs,
@@ -929,6 +933,9 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionClosed: (sessionId, reason) => {
       log(`Session closed: ${sessionId} (reason: ${reason})`);
+      // Resolve any deferred Stop (#641): ack the requester + notify a
+      // third-party client now that the session has actually ended.
+      resolveStopOnClose?.(sessionId);
       // Tear down the drive-mode binder (rotation dir-poll + fallback timer) at
       // session close, not just at process cleanup — else the poll interval leaks
       // for the rest of the daemon's life across resumes (#463 phase 3 review).
@@ -1473,6 +1480,9 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) }),
   send: sendToConnection,
 });
+// Wire the deferred-Stop resolver now that the handlers exist (#641); the
+// registry's onSessionClosed reaches it through this holder.
+resolveStopOnClose = sessionHandlers.resolveStopOnClose;
 
 // The single authoritative "current owned session" accessor (#499), shared by
 // the transcript-request redirect and the hello_ack binding so they never diverge.

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -1,7 +1,8 @@
 /**
  * sharedEvents handlers for whole-session lifecycle requests:
  *   onSessionListRequest, enumerate daemon + external sessions
- *   onKillSessionRequest, tear down a session (and notify any active client)
+ *   onKillSessionRequest, gracefully end a session (type Claude /exit, with a
+ *     force-close fallback) and notify any active client
  *   onDetachSession, release a session's active connection without killing it
  *
  * These three are grouped because they all operate on session records via
@@ -44,6 +45,12 @@ export interface SessionHandlerDeps {
   onConnectionRemoved: () => void;
   send: SendToConnection;
 }
+
+/**
+ * How long to wait for a graceful `/exit` to land before force-closing the
+ * session. Covers a Claude that ignores /exit because it is stuck mid-task.
+ */
+const EXIT_FALLBACK_MS = 8000;
 
 export type SessionHandlers = ReturnType<typeof createSessionHandlers>;
 
@@ -117,7 +124,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     },
 
     onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID): void => {
-      log(`Kill session request from ${connectionId} for session ${sessionId}`);
+      log(`Stop session request from ${connectionId} for session ${sessionId}`);
 
       const session = sessionRegistry.getSession(sessionId);
       if (!session) {
@@ -129,25 +136,35 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       }
 
       const sessionName = session.name;
-      log(`Killing session: ${sessionName} (${sessionId})`);
+      log(`Stopping session: ${sessionName} (${sessionId})`);
 
-      // Notify attached client before destroying the session.
+      // Notify attached client that the session is ending.
       if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
-        send(
-          session.activeConnectionId,
-          createError('SESSION_ENDED', 'Session killed by remote request'),
-        );
+        send(session.activeConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
       }
 
-      const hadActiveClient =
-        session.activeConnectionId !== null && session.activeConnectionId !== connectionId;
-      sessionRegistry.closeSession(sessionId, 'forced');
+      // Graceful stop (#641): type `/exit` on our own PTY so Claude quits cleanly
+      // (flushing its transcript + emitting the resume hint) and the PTY-exit path
+      // tears the session down and frees the daemon. Writing to our own PTY avoids
+      // the write-lock requirement a client-side input would have. A force-close
+      // fallback covers a Claude that ignores /exit (e.g. stuck mid-task).
+      session.pty.submitInput('/exit').catch((err) => {
+        logError(
+          `[Stop] /exit write failed for ${sessionName}; forcing close: ${errorToString(err)}`,
+        );
+        sessionRegistry.closeSession(sessionId, 'forced');
+      });
+      const forceFallback = setTimeout(() => {
+        if (sessionRegistry.getSession(sessionId)) {
+          log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
+          sessionRegistry.closeSession(sessionId, 'forced');
+        }
+      }, EXIT_FALLBACK_MS);
+      // Don't let the fallback timer keep the event loop (or process) alive.
+      forceFallback.unref?.();
+
       send(connectionId, createKillSessionResponse(true, requestId));
-      if (hadActiveClient) {
-        log(`Session killed: ${sessionName} (disconnected attached client)`);
-      } else {
-        log(`Session killed: ${sessionName}`);
-      }
+      log(`Session stop initiated: ${sessionName}`);
     },
 
     onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID): void => {

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -66,6 +66,37 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     send,
   } = deps;
 
+  // In-flight graceful stops (#641). A Stop types `/exit` and returns; the
+  // success ack + SESSION_ENDED notice are deferred to `resolveStopOnClose`
+  // (driven by the registry's onSessionClosed) so "success" means the session
+  // actually ended — not merely "stop initiated" — and the third-party notice
+  // arrives after PTY output has stopped. Keyed by sessionId.
+  interface PendingStop {
+    readonly connectionId: UUID;
+    readonly requestId: UUID;
+    /** Active client to notify with SESSION_ENDED, if it isn't the requester. */
+    readonly notifyConnectionId: UUID | null;
+    readonly fallbackTimer: ReturnType<typeof setTimeout>;
+  }
+  const pendingStops = new Map<UUID, PendingStop>();
+
+  /**
+   * Resolve a deferred Stop once the session has actually closed. Call from the
+   * registry's onSessionClosed for every close reason; a no-op when the session
+   * ended on its own (no pending Stop). Cancels the force-fallback, notifies a
+   * third-party client, and acks the requester.
+   */
+  function resolveStopOnClose(sessionId: UUID): void {
+    const pending = pendingStops.get(sessionId);
+    if (!pending) return;
+    pendingStops.delete(sessionId);
+    clearTimeout(pending.fallbackTimer);
+    if (pending.notifyConnectionId) {
+      send(pending.notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
+    }
+    send(pending.connectionId, createKillSessionResponse(true, pending.requestId));
+  }
+
   return {
     onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean): void => {
       // Decorate daemon-sourced sessions with their pre-assigned Claude
@@ -135,13 +166,14 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         return;
       }
 
+      // Idempotent: a Stop already in flight just re-acks on close.
+      if (pendingStops.has(sessionId)) {
+        log(`Stop already in flight for ${session.name}; ignoring duplicate request`);
+        return;
+      }
+
       const sessionName = session.name;
       log(`Stopping session: ${sessionName} (${sessionId})`);
-
-      // Notify attached client that the session is ending.
-      if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
-        send(session.activeConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
-      }
 
       // Graceful stop (#641): type `/exit` on our own PTY so Claude quits cleanly
       // (flushing its transcript + emitting the resume hint) and the PTY-exit path
@@ -154,16 +186,23 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         );
         sessionRegistry.closeSession(sessionId, 'forced');
       });
-      const forceFallback = setTimeout(() => {
+      const fallbackTimer = setTimeout(() => {
         if (sessionRegistry.getSession(sessionId)) {
           log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
           sessionRegistry.closeSession(sessionId, 'forced');
         }
       }, EXIT_FALLBACK_MS);
       // Don't let the fallback timer keep the event loop (or process) alive.
-      forceFallback.unref?.();
+      fallbackTimer.unref?.();
 
-      send(connectionId, createKillSessionResponse(true, requestId));
+      // Defer the ack + the third-party SESSION_ENDED notice until the session
+      // actually closes (resolveStopOnClose), so success means done and the
+      // notice arrives after PTY output stops.
+      const notifyConnectionId =
+        session.activeConnectionId && session.activeConnectionId !== connectionId
+          ? session.activeConnectionId
+          : null;
+      pendingStops.set(sessionId, { connectionId, requestId, notifyConnectionId, fallbackTimer });
       log(`Session stop initiated: ${sessionName}`);
     },
 
@@ -206,5 +245,8 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
       );
     },
+
+    /** Resolve a deferred Stop on session close; wired to onSessionClosed in cli.ts. */
+    resolveStopOnClose,
   };
 }

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -50,11 +50,18 @@ export interface PtySessionSetupDeps {
   /** Forward outgoing messages to the connection layer (raw PTY bytes). */
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
   /**
-   * Process-level cleanup invoked on PTY exit when passThrough is set.
-   * `createNewSession` in cli.ts passes the main-flow cleanup function; this
-   * is the only way an in-terminal session exits the wrapper process.
+   * Process-level cleanup invoked on PTY exit. `createNewSession` in cli.ts
+   * passes the main-flow cleanup function (uninstall hooks, stop mDNS, etc.).
    */
   cleanup: () => Promise<void>;
+  /**
+   * Terminate the daemon process after cleanup once the session's Claude has
+   * exited (#641). One daemon = one session, so a daemon with no session has
+   * nothing to host and would otherwise linger as a phantom host. Injected so
+   * tests can drive a real PTY exit without killing the test runner; defaults
+   * to `process.exit`.
+   */
+  exitProcess?: (code: number) => void;
 }
 
 export interface PtySessionSetupArgs {
@@ -110,6 +117,7 @@ export function createPtySessionForSession(
     wsPort,
     sendMessage,
     cleanup,
+    exitProcess = (code: number) => process.exit(code),
   } = deps;
   const { sessionId, workingDirectory, extraArgs, passThrough, reservedRows = 0 } = args;
 
@@ -201,14 +209,18 @@ export function createPtySessionForSession(
           logError(`[live-sessions] markClaudeChildExited failed: ${errorToString(err)}`);
         }
 
-        if (passThrough) {
-          cleanup()
-            .then(() => process.exit(code ?? 0))
-            .catch((err) => {
-              logError(`[PTY] Cleanup failed: ${errorToString(err)}`);
-              process.exit(1);
-            });
-        }
+        // One daemon = one session. When the session's Claude exits — via /exit,
+        // a Stop request, or on its own — the daemon has nothing left to host, so
+        // it shuts down and frees its port instead of lingering as a phantom host
+        // (#641). The session stays resumable from its transcript + stored Claude
+        // session hash (markExited above keeps the entry). Wrapper mode
+        // (passThrough) exits with Claude's code; a standalone daemon exits 0.
+        cleanup()
+          .then(() => exitProcess(passThrough ? (code ?? 0) : 0))
+          .catch((err) => {
+            logError(`[PTY] Cleanup failed: ${errorToString(err)}`);
+            exitProcess(1);
+          });
       },
       onError: (error: Error) => {
         logError(`PTY ${ptySession.id} error:`, error);

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -189,9 +189,18 @@ describe('createSessionHandlers', () => {
       expect(msg.success).toBe(false);
     });
 
-    test('closes the session and acks success when called by the active client', () => {
+    test('types /exit (graceful) and acks success when called by the active client', () => {
+      const submitted: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: () => {},
+        submitInput: async (text: string) => {
+          submitted.push(text);
+        },
+        close: async () => {},
+      } as unknown as PTYSession;
       const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, CID);
 
       makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
@@ -201,7 +210,10 @@ describe('createSessionHandlers', () => {
       const ack = sendCalls[0]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
-      expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
+      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
+      // the PTY-exit path), not SIGKILLed; the session stays until Claude exits.
+      expect(submitted).toEqual(['/exit']);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
     });
 
     test('notifies a third-party attached client with SESSION_ENDED before killing', () => {

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -189,7 +189,7 @@ describe('createSessionHandlers', () => {
       expect(msg.success).toBe(false);
     });
 
-    test('types /exit (graceful) and acks success when called by the active client', () => {
+    test('types /exit (graceful) and defers the success ack until the session closes', () => {
       const submitted: string[] = [];
       const pty = {
         id: generateId(),
@@ -203,26 +203,38 @@ describe('createSessionHandlers', () => {
       sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, CID);
 
-      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+      const handlers = makeHandlers();
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
 
-      // Only an ack to the caller: no SESSION_ENDED error since the requester IS the active client.
+      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
+      // the PTY-exit path), not SIGKILLed; the session stays alive and NO ack is
+      // sent until it actually closes — "success" must mean done, not initiated.
+      expect(submitted).toEqual(['/exit']);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls).toHaveLength(0);
+
+      // On close, the requester is acked success (no third-party notice: the
+      // requester IS the active client).
+      handlers.resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(1);
       const ack = sendCalls[0]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
-      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
-      // the PTY-exit path), not SIGKILLed; the session stays until Claude exits.
-      expect(submitted).toEqual(['/exit']);
-      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls[0]?.connectionId).toBe(CID);
     });
 
-    test('notifies a third-party attached client with SESSION_ENDED before killing', () => {
+    test('on close, notifies a third-party active client with SESSION_ENDED then acks the requester', () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, OTHER_CID);
 
-      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+      const handlers = makeHandlers();
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      // Deferred: nothing is sent until the session actually closes (so the
+      // SESSION_ENDED notice arrives after PTY output has stopped).
+      expect(sendCalls).toHaveLength(0);
 
+      handlers.resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(2);
       const notice = sendCalls[0]?.message as { type: string; code?: string };
       expect(notice.type).toBe('error');
@@ -231,6 +243,15 @@ describe('createSessionHandlers', () => {
       const ack = sendCalls[1]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
+      expect(sendCalls[1]?.connectionId).toBe(CID);
+    });
+
+    test('resolveStopOnClose is a no-op for a session with no pending stop', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+
+      makeHandlers().resolveStopOnClose(sessionId);
+      expect(sendCalls).toHaveLength(0);
     });
   });
 

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -168,6 +168,9 @@ describe('createPtySessionForSession', () => {
       claudeChildPid: process.pid,
     });
 
+    // Capture the daemon-shutdown call instead of actually exiting the test
+    // runner (#641): a daemon-mode session that exits must terminate the daemon.
+    const exitCalls: number[] = [];
     const pty = createPtySessionForSession(
       {
         sessionRegistry,
@@ -177,6 +180,7 @@ describe('createPtySessionForSession', () => {
         wsPort: 9999,
         sendMessage: (sid, message) => sendCalls.push({ sessionId: sid, message }),
         cleanup: async () => {},
+        exitProcess: (code) => exitCalls.push(code),
       },
       { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: false },
     );
@@ -196,10 +200,12 @@ describe('createPtySessionForSession', () => {
       const deadline = Date.now() + 4000;
       while (Date.now() < deadline) {
         const entry = liveSessionsRegistry.findBySessionId(SID);
-        if (entry?.claudeChildExited === true) break;
+        if (entry?.claudeChildExited === true && exitCalls.length > 0) break;
         await new Promise((r) => setTimeout(r, 25));
       }
       expect(liveSessionsRegistry.findBySessionId(SID)?.claudeChildExited).toBe(true);
+      // #641: a daemon-mode session ending must shut the daemon down (exit 0).
+      expect(exitCalls).toEqual([0]);
     } finally {
       // Restore PATH (originalPath is effectively always defined in practice).
       process.env['PATH'] = originalPath ?? '';

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2132,7 +2132,7 @@ function App() {
   const handleKillSession = useCallback(
     (sessionId: UUID, connectionId: ConnectionId, label?: string) => {
       const ok = window.confirm(
-        `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
+        `Exit ${label ? `"${label}"` : 'this session'}? Claude runs /exit and the session closes. You can resume it later from Recent.`,
       );
       if (!ok) return;
       const req = createKillSessionRequest(sessionId);
@@ -2147,7 +2147,7 @@ function App() {
         pendingKillsRef.current.delete(req.id);
         pushSessionSystemMessage(
           sessionId,
-          'Stop session timed out; the daemon may be unreachable.',
+          'Exit session timed out; the daemon may be unreachable.',
         );
       }, 12_000);
       pendingKillsRef.current.set(req.id, { sessionId, timeoutId });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -954,7 +954,7 @@ function App() {
             sessionId: killedSessionId,
             connectionId: '' as ConnectionId,
             sender: 'system',
-            content: `Failed to stop session: ${message.error || 'unknown error'}`,
+            content: `Failed to exit session: ${message.error || 'unknown error'}`,
             timestamp: new Date().toISOString(),
             state: 'delivered',
             isEditing: false,
@@ -2138,7 +2138,7 @@ function App() {
       const req = createKillSessionRequest(sessionId);
       const sent = cmSendMessage(connectionId, req);
       if (!sent) {
-        pushSessionSystemMessage(sessionId, 'Cannot stop session: not connected to daemon.');
+        pushSessionSystemMessage(sessionId, 'Cannot exit session: not connected to daemon.');
         return;
       }
       // Guard against a daemon that never replies (crash / WS drop): surface a
@@ -2159,7 +2159,10 @@ function App() {
     if (!activeSessionId) return;
     const connId = getActiveConnectionId();
     if (!connId) {
-      pushSessionSystemMessage(activeSessionId, 'Cannot stop session: session is no longer available.');
+      pushSessionSystemMessage(
+        activeSessionId,
+        'Cannot exit session: session is no longer available.',
+      );
       return;
     }
     handleKillSession(activeSessionId, connId);

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -17,7 +17,7 @@ import {
   Layers,
   LogOut,
   MoreVertical,
-  Square,
+  Power,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -223,8 +223,8 @@ export function ChatHeader({
               )}
               {onEndSession && (
                 <MenuItem
-                  icon={<Square className="size-4" />}
-                  label="Stop session"
+                  icon={<Power className="size-4" />}
+                  label="Exit session"
                   tone="error"
                   onClick={() => {
                     onEndSession();

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -12,7 +12,7 @@ import { sessionPillState, splitSessionName } from '@/lib/session-display';
 import type { ConnectionId, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { GitBranch, Link2Off, RotateCcw, Square } from 'lucide-react';
+import { GitBranch, Link2Off, Power, RotateCcw } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
@@ -147,10 +147,10 @@ export function SessionCard({
               onKill(session.id, session.connectionId, project);
             }}
             className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
-            aria-label="Stop session"
-            title="Stop session"
+            aria-label="Exit session"
+            title="Exit session"
           >
-            <Square className="size-3.5" />
+            <Power className="size-3.5" />
           </button>
         )}
       </div>


### PR DESCRIPTION
Closes #641.

## Problem

The Stop control (from #639) force-SIGKILLed the session, and a daemon-mode daemon does **not** self-exit on PTY exit (only wrapper/`passThrough` mode did), so stopping a session left a session-less daemon lingering on its port — a phantom "host". Found in the #639 live test.

## Changes

**Daemon — graceful stop (`session-events.ts`):**
- `onKillSessionRequest` now types `/exit` on the session's **own PTY** (`submitInput('/exit')`) so Claude quits cleanly (flushes its transcript, emits the resume hint) instead of being SIGKILLed. Doing it daemon-side avoids the client write-lock a client-typed input would need.
- A force-close fallback (8s) covers a Claude that ignores `/exit` (e.g. stuck mid-task or still loading).

**Daemon — frees up (`pty-session-setup.ts`), the root of #641:**
- A daemon-mode daemon now shuts down when its session's Claude exits (it previously only exited in `passThrough` mode). One daemon = one session, so a session-less daemon has nothing to host. The session stays resumable from its transcript + stored Claude session hash (`markExited` keeps the entry).
- The process exit is an injected seam (`exitProcess`, default `process.exit`) so the real-PTY test can drive an exit without killing the test runner.

**Web — relabel (`SessionCard`, `ChatHeader`, `App`):**
- "Stop session" → **"Exit session"** (Power icon), distinct from the escape "Stop the current action" under the send button (which just sends one Esc). Confirm reworded for the graceful `/exit` + mentions resume from Recent.

## Live validation

- **Daemon frees up (#641): confirmed.** After Exit, the child daemon exits and its port is freed (verified via `lsof` + process checks). No more phantom host.
- **Graceful `/exit`: pending live validation.** In the isolated test harness Claude (2.1.195) sits on first-run onboarding (throwaway HOME) and never reaches the chat prompt, so Exit hit the 8s force-fallback. Whether the injected `/exit` quits a *ready, configured* Claude will be validated on a real session post-merge. Either way the daemon frees up and the session is resumable (hash retained).

## Tests

- `session-events.test.ts`: Stop types `/exit` (graceful) + acks, does not immediately close.
- `pty-session-setup.test.ts`: a daemon-mode PTY exit now drives `exitProcess(0)` (the #641 shutdown) — guarded so the real-PTY test doesn't kill the runner.
- `bun run typecheck` clean; biome clean; daemon session/handler/phase suites green.