### PR TITLE
Release 0.6.17: persistent remote sessions, recent-paths sheet, graceful Exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.6.17] - 2026-06-28
+
+Remote sessions now outlive the connection: disconnecting no longer kills the
+session you created, ending one is a clean `/exit` that frees its daemon, and
+starting one picks from your recent paths instead of a blind text prompt.
+
+### Added
+- **Persistent remote sessions** (#637): a session created from the app survives
+  client disconnect instead of being killed by the orphan timeout. A new
+  `daemon.persist_sessions` config (default on) detaches the session on
+  disconnect and leaves it re-attachable; `pty_exit` and forced closes still
+  apply. This is the whole point of a remote session — start it from your phone,
+  walk away, reconnect later.
+- **Recent-paths new-session sheet** (#638): the "+" button opens a bottom sheet
+  of your recent project directories to start a session in, replacing the bare
+  `window.prompt` path entry. Pick a recent path or type a new one; surfaces the
+  same recent-directory data the CLI already exposes, so you always know the
+  exact path you are starting in.
+- **Exit session control** (#641): a per-session control (session row + chat
+  menu) that ends a session by typing a graceful `/exit` on its PTY so Claude
+  quits cleanly — flushing its transcript and printing its resume hint — with an
+  8s force-close fallback if Claude ignores it. The daemon frees its port when
+  its session ends, so no session-less daemon is left behind. Labeled "Exit
+  session", distinct from the input-area Esc "Stop".
+
+### Fixed
+- A remotely-created session dying the instant its client disconnected — the main
+  reason remote sessions felt disposable.
+- A session-less "phantom" daemon lingering on its port after a session ended.
+
 ## [0.6.16] - 2026-06-27
 
 Question-pipeline rework (epic #624): the auto-approve gate is the single

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.17-dev.4",
+  "version": "0.6.17-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.17-dev.2",
+  "version": "0.6.17-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.16",
+  "version": "0.6.17-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.17-dev.3",
+  "version": "0.6.17-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.17-dev.5",
+  "version": "0.6.17-dev.6",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.6.17-dev.1",
+  "version": "0.6.17-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1313,8 +1313,9 @@ async function createNewSession(
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
   // Persist non-wrapper (daemon-spawned/remote) sessions across disconnects by
   // default so a session created from the app survives until Claude exits or it
-  // is explicitly stopped (#637). Wrapper-mode sessions already never time out.
-  const persistent = remiConfig.daemon.persist_sessions;
+  // is explicitly stopped (#637). Wrapper-mode sessions are locallyOwned and
+  // already never time out, so the flag only applies to daemon-mode sessions.
+  const persistent = !passThrough && remiConfig.daemon.persist_sessions;
   sessionRegistry.registerSession(
     sessionId,
     workingDirectory,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.17-dev.2'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.17-dev.2'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -918,6 +918,10 @@ const orphanTimeoutMs =
   cliOrphanTimeout !== undefined
     ? cliOrphanTimeout * 1000
     : remiConfig.daemon.orphan_timeout * 1000;
+// Forward reference to the session handlers' deferred-Stop resolver (#641). The
+// registry below is constructed before `sessionHandlers` exists, so onSessionClosed
+// reaches the resolver through this holder, assigned once the handlers are wired.
+let resolveStopOnClose: ((sessionId: UUID) => void) | null = null;
 const sessionRegistry = new SessionRegistry(
   {
     orphanTimeoutMs,
@@ -929,6 +933,9 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionClosed: (sessionId, reason) => {
       log(`Session closed: ${sessionId} (reason: ${reason})`);
+      // Resolve any deferred Stop (#641): ack the requester + notify a
+      // third-party client now that the session has actually ended.
+      resolveStopOnClose?.(sessionId);
       // Tear down the drive-mode binder (rotation dir-poll + fallback timer) at
       // session close, not just at process cleanup — else the poll interval leaks
       // for the rest of the daemon's life across resumes (#463 phase 3 review).
@@ -1473,6 +1480,9 @@ const sessionHandlers: SessionHandlers = createSessionHandlers({
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) }),
   send: sendToConnection,
 });
+// Wire the deferred-Stop resolver now that the handlers exist (#641); the
+// registry's onSessionClosed reaches it through this holder.
+resolveStopOnClose = sessionHandlers.resolveStopOnClose;
 
 // The single authoritative "current owned session" accessor (#499), shared by
 // the transcript-request redirect and the hello_ack binding so they never diverge.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.17-dev.4'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.17-dev.4'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -951,8 +951,12 @@ const sessionRegistry = new SessionRegistry(
         log(`Session detached: ${sessionId} (locally owned, no timeout)`);
       } else if (session?.explicitlyDetached) {
         log(`Session explicitly detached: ${sessionId} (no timeout, re-attachable)`);
+      } else if (session?.persistent) {
+        log(`Session detached: ${sessionId} (persistent, no timeout, re-attachable)`);
       } else {
-        log(`Session orphaned: ${sessionId} (will timeout in 5 minutes)`);
+        log(
+          `Session orphaned: ${sessionId} (will timeout in ${Math.round(orphanTimeoutMs / 1000)}s)`,
+        );
       }
     },
     onSessionResumed: (sessionId, connectionId) => {
@@ -1300,12 +1304,17 @@ async function createNewSession(
   );
 
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
+  // Persist non-wrapper (daemon-spawned/remote) sessions across disconnects by
+  // default so a session created from the app survives until Claude exits or it
+  // is explicitly stopped (#637). Wrapper-mode sessions already never time out.
+  const persistent = remiConfig.daemon.persist_sessions;
   sessionRegistry.registerSession(
     sessionId,
     workingDirectory,
     ptySession,
     messageApi,
     locallyOwned,
+    persistent,
   );
 
   // #576: give clients a defined pill state from the first hello_ack. Without

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.17-dev.3'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.17-dev.3'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.17-dev.1'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.17-dev.1'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.17-dev.5'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.6'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.17-dev.5'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.6'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.6.16'; // REMI_COMPILED_VERSION
+      return '0.6.17-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.6.16'; // REMI_COMPILED_VERSION
+    return '0.6.17-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -1,7 +1,8 @@
 /**
  * sharedEvents handlers for whole-session lifecycle requests:
  *   onSessionListRequest, enumerate daemon + external sessions
- *   onKillSessionRequest, tear down a session (and notify any active client)
+ *   onKillSessionRequest, gracefully end a session (type Claude /exit, with a
+ *     force-close fallback) and notify any active client
  *   onDetachSession, release a session's active connection without killing it
  *
  * These three are grouped because they all operate on session records via
@@ -44,6 +45,12 @@ export interface SessionHandlerDeps {
   onConnectionRemoved: () => void;
   send: SendToConnection;
 }
+
+/**
+ * How long to wait for a graceful `/exit` to land before force-closing the
+ * session. Covers a Claude that ignores /exit because it is stuck mid-task.
+ */
+const EXIT_FALLBACK_MS = 8000;
 
 export type SessionHandlers = ReturnType<typeof createSessionHandlers>;
 
@@ -117,7 +124,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     },
 
     onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID): void => {
-      log(`Kill session request from ${connectionId} for session ${sessionId}`);
+      log(`Stop session request from ${connectionId} for session ${sessionId}`);
 
       const session = sessionRegistry.getSession(sessionId);
       if (!session) {
@@ -129,25 +136,35 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       }
 
       const sessionName = session.name;
-      log(`Killing session: ${sessionName} (${sessionId})`);
+      log(`Stopping session: ${sessionName} (${sessionId})`);
 
-      // Notify attached client before destroying the session.
+      // Notify attached client that the session is ending.
       if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
-        send(
-          session.activeConnectionId,
-          createError('SESSION_ENDED', 'Session killed by remote request'),
-        );
+        send(session.activeConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
       }
 
-      const hadActiveClient =
-        session.activeConnectionId !== null && session.activeConnectionId !== connectionId;
-      sessionRegistry.closeSession(sessionId, 'forced');
+      // Graceful stop (#641): type `/exit` on our own PTY so Claude quits cleanly
+      // (flushing its transcript + emitting the resume hint) and the PTY-exit path
+      // tears the session down and frees the daemon. Writing to our own PTY avoids
+      // the write-lock requirement a client-side input would have. A force-close
+      // fallback covers a Claude that ignores /exit (e.g. stuck mid-task).
+      session.pty.submitInput('/exit').catch((err) => {
+        logError(
+          `[Stop] /exit write failed for ${sessionName}; forcing close: ${errorToString(err)}`,
+        );
+        sessionRegistry.closeSession(sessionId, 'forced');
+      });
+      const forceFallback = setTimeout(() => {
+        if (sessionRegistry.getSession(sessionId)) {
+          log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
+          sessionRegistry.closeSession(sessionId, 'forced');
+        }
+      }, EXIT_FALLBACK_MS);
+      // Don't let the fallback timer keep the event loop (or process) alive.
+      forceFallback.unref?.();
+
       send(connectionId, createKillSessionResponse(true, requestId));
-      if (hadActiveClient) {
-        log(`Session killed: ${sessionName} (disconnected attached client)`);
-      } else {
-        log(`Session killed: ${sessionName}`);
-      }
+      log(`Session stop initiated: ${sessionName}`);
     },
 
     onDetachSession: (connectionId: UUID, sessionId: UUID, _requestId: UUID): void => {

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -80,7 +80,8 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   // starting a second one: every waiter is acked success on close, so neither
   // client sees a misleading "timed out" or "failed" message.
   interface PendingStop {
-    readonly waiters: Array<{ connectionId: UUID; requestId: UUID }>;
+    // Mutable: a duplicate stop appends itself via waiters.push (see below).
+    waiters: Array<{ connectionId: UUID; requestId: UUID }>;
     /** Active client to notify with SESSION_ENDED, if it isn't a requester. */
     readonly notifyConnectionId: UUID | null;
     readonly fallbackTimer: ReturnType<typeof setTimeout>;

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -66,6 +66,37 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     send,
   } = deps;
 
+  // In-flight graceful stops (#641). A Stop types `/exit` and returns; the
+  // success ack + SESSION_ENDED notice are deferred to `resolveStopOnClose`
+  // (driven by the registry's onSessionClosed) so "success" means the session
+  // actually ended — not merely "stop initiated" — and the third-party notice
+  // arrives after PTY output has stopped. Keyed by sessionId.
+  interface PendingStop {
+    readonly connectionId: UUID;
+    readonly requestId: UUID;
+    /** Active client to notify with SESSION_ENDED, if it isn't the requester. */
+    readonly notifyConnectionId: UUID | null;
+    readonly fallbackTimer: ReturnType<typeof setTimeout>;
+  }
+  const pendingStops = new Map<UUID, PendingStop>();
+
+  /**
+   * Resolve a deferred Stop once the session has actually closed. Call from the
+   * registry's onSessionClosed for every close reason; a no-op when the session
+   * ended on its own (no pending Stop). Cancels the force-fallback, notifies a
+   * third-party client, and acks the requester.
+   */
+  function resolveStopOnClose(sessionId: UUID): void {
+    const pending = pendingStops.get(sessionId);
+    if (!pending) return;
+    pendingStops.delete(sessionId);
+    clearTimeout(pending.fallbackTimer);
+    if (pending.notifyConnectionId) {
+      send(pending.notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
+    }
+    send(pending.connectionId, createKillSessionResponse(true, pending.requestId));
+  }
+
   return {
     onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean): void => {
       // Decorate daemon-sourced sessions with their pre-assigned Claude
@@ -135,13 +166,14 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         return;
       }
 
+      // Idempotent: a Stop already in flight just re-acks on close.
+      if (pendingStops.has(sessionId)) {
+        log(`Stop already in flight for ${session.name}; ignoring duplicate request`);
+        return;
+      }
+
       const sessionName = session.name;
       log(`Stopping session: ${sessionName} (${sessionId})`);
-
-      // Notify attached client that the session is ending.
-      if (session.activeConnectionId && session.activeConnectionId !== connectionId) {
-        send(session.activeConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
-      }
 
       // Graceful stop (#641): type `/exit` on our own PTY so Claude quits cleanly
       // (flushing its transcript + emitting the resume hint) and the PTY-exit path
@@ -154,16 +186,23 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         );
         sessionRegistry.closeSession(sessionId, 'forced');
       });
-      const forceFallback = setTimeout(() => {
+      const fallbackTimer = setTimeout(() => {
         if (sessionRegistry.getSession(sessionId)) {
           log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
           sessionRegistry.closeSession(sessionId, 'forced');
         }
       }, EXIT_FALLBACK_MS);
       // Don't let the fallback timer keep the event loop (or process) alive.
-      forceFallback.unref?.();
+      fallbackTimer.unref?.();
 
-      send(connectionId, createKillSessionResponse(true, requestId));
+      // Defer the ack + the third-party SESSION_ENDED notice until the session
+      // actually closes (resolveStopOnClose), so success means done and the
+      // notice arrives after PTY output stops.
+      const notifyConnectionId =
+        session.activeConnectionId && session.activeConnectionId !== connectionId
+          ? session.activeConnectionId
+          : null;
+      pendingStops.set(sessionId, { connectionId, requestId, notifyConnectionId, fallbackTimer });
       log(`Session stop initiated: ${sessionName}`);
     },
 
@@ -206,5 +245,8 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
       );
     },
+
+    /** Resolve a deferred Stop on session close; wired to onSessionClosed in cli.ts. */
+    resolveStopOnClose,
   };
 }

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -44,6 +44,8 @@ export interface SessionHandlerDeps {
   /** Decrement the statusWriter connection count (third-party detach only). */
   onConnectionRemoved: () => void;
   send: SendToConnection;
+  /** Force-close delay after a graceful /exit; injectable for tests. */
+  exitFallbackMs?: number;
 }
 
 /**
@@ -64,6 +66,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     untrackConnection,
     onConnectionRemoved,
     send,
+    exitFallbackMs = EXIT_FALLBACK_MS,
   } = deps;
 
   // In-flight graceful stops (#641). A Stop types `/exit` and returns; the
@@ -71,10 +74,14 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   // (driven by the registry's onSessionClosed) so "success" means the session
   // actually ended — not merely "stop initiated" — and the third-party notice
   // arrives after PTY output has stopped. Keyed by sessionId.
+  //
+  // `waiters` is a list because a duplicate Stop (a second client confirming
+  // Exit before the first /exit lands) joins the in-flight stop rather than
+  // starting a second one: every waiter is acked success on close, so neither
+  // client sees a misleading "timed out" or "failed" message.
   interface PendingStop {
-    readonly connectionId: UUID;
-    readonly requestId: UUID;
-    /** Active client to notify with SESSION_ENDED, if it isn't the requester. */
+    readonly waiters: Array<{ connectionId: UUID; requestId: UUID }>;
+    /** Active client to notify with SESSION_ENDED, if it isn't a requester. */
     readonly notifyConnectionId: UUID | null;
     readonly fallbackTimer: ReturnType<typeof setTimeout>;
   }
@@ -84,7 +91,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
    * Resolve a deferred Stop once the session has actually closed. Call from the
    * registry's onSessionClosed for every close reason; a no-op when the session
    * ended on its own (no pending Stop). Cancels the force-fallback, notifies a
-   * third-party client, and acks the requester.
+   * third-party client, and acks every waiting requester.
    */
   function resolveStopOnClose(sessionId: UUID): void {
     const pending = pendingStops.get(sessionId);
@@ -94,7 +101,9 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     if (pending.notifyConnectionId) {
       send(pending.notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
     }
-    send(pending.connectionId, createKillSessionResponse(true, pending.requestId));
+    for (const waiter of pending.waiters) {
+      send(waiter.connectionId, createKillSessionResponse(true, waiter.requestId));
+    }
   }
 
   return {
@@ -166,9 +175,13 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         return;
       }
 
-      // Idempotent: a Stop already in flight just re-acks on close.
-      if (pendingStops.has(sessionId)) {
-        log(`Stop already in flight for ${session.name}; ignoring duplicate request`);
+      // Idempotent: a Stop already in flight just adds this requester as a
+      // waiter so it too is acked success on close (no second /exit, no
+      // misleading timeout on the duplicate).
+      const inFlight = pendingStops.get(sessionId);
+      if (inFlight) {
+        log(`Stop already in flight for ${session.name}; joining duplicate request`);
+        inFlight.waiters.push({ connectionId, requestId });
         return;
       }
 
@@ -188,21 +201,27 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       });
       const fallbackTimer = setTimeout(() => {
         if (sessionRegistry.getSession(sessionId)) {
-          log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
+          log(`Session ${sessionName} did not exit on /exit within ${exitFallbackMs}ms; forcing`);
           sessionRegistry.closeSession(sessionId, 'forced');
         }
-      }, EXIT_FALLBACK_MS);
+      }, exitFallbackMs);
       // Don't let the fallback timer keep the event loop (or process) alive.
       fallbackTimer.unref?.();
 
       // Defer the ack + the third-party SESSION_ENDED notice until the session
-      // actually closes (resolveStopOnClose), so success means done and the
-      // notice arrives after PTY output stops.
+      // actually closes (resolveStopOnClose), so success means done. On the
+      // normal /exit path the PTY has already drained before the notice fires;
+      // on the rare force-fallback the close races a still-resolving pty.close(),
+      // so a third-party client may see a few trailing bytes after SESSION_ENDED.
       const notifyConnectionId =
         session.activeConnectionId && session.activeConnectionId !== connectionId
           ? session.activeConnectionId
           : null;
-      pendingStops.set(sessionId, { connectionId, requestId, notifyConnectionId, fallbackTimer });
+      pendingStops.set(sessionId, {
+        waiters: [{ connectionId, requestId }],
+        notifyConnectionId,
+        fallbackTimer,
+      });
       log(`Session stop initiated: ${sessionName}`);
     },
 

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -50,11 +50,18 @@ export interface PtySessionSetupDeps {
   /** Forward outgoing messages to the connection layer (raw PTY bytes). */
   sendMessage: (sessionId: UUID, message: ProtocolMessage) => void;
   /**
-   * Process-level cleanup invoked on PTY exit when passThrough is set.
-   * `createNewSession` in cli.ts passes the main-flow cleanup function; this
-   * is the only way an in-terminal session exits the wrapper process.
+   * Process-level cleanup invoked on PTY exit. `createNewSession` in cli.ts
+   * passes the main-flow cleanup function (uninstall hooks, stop mDNS, etc.).
    */
   cleanup: () => Promise<void>;
+  /**
+   * Terminate the daemon process after cleanup once the session's Claude has
+   * exited (#641). One daemon = one session, so a daemon with no session has
+   * nothing to host and would otherwise linger as a phantom host. Injected so
+   * tests can drive a real PTY exit without killing the test runner; defaults
+   * to `process.exit`.
+   */
+  exitProcess?: (code: number) => void;
 }
 
 export interface PtySessionSetupArgs {
@@ -110,6 +117,7 @@ export function createPtySessionForSession(
     wsPort,
     sendMessage,
     cleanup,
+    exitProcess = (code: number) => process.exit(code),
   } = deps;
   const { sessionId, workingDirectory, extraArgs, passThrough, reservedRows = 0 } = args;
 
@@ -201,14 +209,18 @@ export function createPtySessionForSession(
           logError(`[live-sessions] markClaudeChildExited failed: ${errorToString(err)}`);
         }
 
-        if (passThrough) {
-          cleanup()
-            .then(() => process.exit(code ?? 0))
-            .catch((err) => {
-              logError(`[PTY] Cleanup failed: ${errorToString(err)}`);
-              process.exit(1);
-            });
-        }
+        // One daemon = one session. When the session's Claude exits — via /exit,
+        // a Stop request, or on its own — the daemon has nothing left to host, so
+        // it shuts down and frees its port instead of lingering as a phantom host
+        // (#641). The session stays resumable from its transcript + stored Claude
+        // session hash (markExited above keeps the entry). Wrapper mode
+        // (passThrough) exits with Claude's code; a standalone daemon exits 0.
+        cleanup()
+          .then(() => exitProcess(passThrough ? (code ?? 0) : 0))
+          .catch((err) => {
+            logError(`[PTY] Cleanup failed: ${errorToString(err)}`);
+            exitProcess(1);
+          });
       },
       onError: (error: Error) => {
         logError(`PTY ${ptySession.id} error:`, error);

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -23,6 +23,13 @@ export interface DaemonConfig {
   readonly port_range: number;
   readonly bind: string;
   readonly orphan_timeout: number;
+  /**
+   * Keep sessions alive after the last client disconnects (tmux-style), so a
+   * session created remotely survives until Claude exits or it is explicitly
+   * stopped. When true (default), the orphan timeout never reaps a session;
+   * set false to restore the old `orphan_timeout`-based reaping.
+   */
+  readonly persist_sessions: boolean;
 }
 
 /** Network settings */
@@ -113,6 +120,7 @@ export const DEFAULT_CONFIG: RemiConfig = {
     port_range: DAEMON_PORT_RANGE,
     bind: '0.0.0.0',
     orphan_timeout: 300,
+    persist_sessions: true,
   },
   network: {
     mdns: true,
@@ -689,7 +697,8 @@ export function generateDefaultConfig(): string {
 base_port = ${DEFAULT_CONFIG.daemon.base_port}
 port_range = ${DEFAULT_CONFIG.daemon.port_range}
 bind = "${DEFAULT_CONFIG.daemon.bind}"
-orphan_timeout = ${DEFAULT_CONFIG.daemon.orphan_timeout}  # seconds
+orphan_timeout = ${DEFAULT_CONFIG.daemon.orphan_timeout}  # seconds (ignored when persist_sessions = true)
+persist_sessions = ${DEFAULT_CONFIG.daemon.persist_sessions}  # keep sessions alive after disconnect (tmux-style)
 
 [network]
 mdns = ${DEFAULT_CONFIG.network.mdns}
@@ -819,6 +828,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  port_range = ${config.daemon.port_range}`);
   lines.push(`  bind = "${config.daemon.bind}"`);
   lines.push(`  orphan_timeout = ${config.daemon.orphan_timeout}`);
+  lines.push(`  persist_sessions = ${config.daemon.persist_sessions}`);
   lines.push('');
   lines.push('[network]');
   lines.push(`  mdns = ${config.network.mdns}`);

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -61,8 +61,12 @@ export interface SessionRegistryEvents {
   onSessionCreated?: (sessionId: UUID) => void;
   /** Session was closed (timeout or PTY exit) */
   onSessionClosed?: (sessionId: UUID, reason: 'timeout' | 'pty_exit' | 'forced') => void;
-  /** Connection detached from session. For non-locally-owned sessions,
-   * this means the session is now orphaned; locally-owned sessions remain active. */
+  /** Connection detached from the session. Fires for ALL detach reasons, not
+   * only genuine orphans: a plain non-locally-owned, non-persistent session
+   * becomes orphaned (orphan timeout armed), while locally-owned, persistent,
+   * and explicitly-detached sessions stay alive with no timeout. Inspect the
+   * session flags (locallyOwned / persistent / explicitlyDetached) to tell
+   * which case fired. */
   onSessionOrphaned?: (sessionId: UUID) => void;
   /** Session was resumed (connection reattached) */
   onSessionResumed?: (sessionId: UUID, connectionId: UUID) => void;

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -115,6 +115,12 @@ export interface ManagedSession {
   /** Whether the last detach was an explicit user request (tmux-style).
    * Explicitly detached sessions skip the orphan timeout entirely. */
   explicitlyDetached: boolean;
+
+  /** Whether this session persists after the last client disconnects
+   * (tmux-style). Persistent sessions skip the orphan timeout entirely and
+   * stay re-attachable until Claude exits or they are explicitly stopped.
+   * Driven by `daemon.persist_sessions` (default true). */
+  readonly persistent: boolean;
 }
 
 /**
@@ -156,6 +162,7 @@ export class SessionRegistry {
     pty: PTYSession,
     messageApi: MessageAPI,
     locallyOwned = false,
+    persistent = false,
   ): void {
     if (this.session !== null) {
       throw new Error('Session already registered. Only one session per daemon is allowed.');
@@ -181,6 +188,7 @@ export class SessionRegistry {
       currentQuestions: new Map(),
       locallyOwned,
       explicitlyDetached: false,
+      persistent,
     };
 
     // Flush pre-registration buffer (messages from readExisting transcript entries)
@@ -370,10 +378,16 @@ export class SessionRegistry {
     // Track explicit detach state for discovery status
     this.session.explicitlyDetached = explicit;
 
-    // Start orphan timeout (skip for locally-owned sessions, explicit detaches,
-    // and when orphanTimeoutMs === 0).
-    // Explicitly detached sessions stay alive indefinitely like locally-owned ones.
-    if (!this.session.locallyOwned && !explicit && this.orphanTimeoutMs > 0) {
+    // Start orphan timeout (skip for locally-owned sessions, persistent
+    // (tmux-style) sessions, explicit detaches, and when orphanTimeoutMs === 0).
+    // Persistent and explicitly-detached sessions stay alive indefinitely like
+    // locally-owned ones — they only end on Claude exit or an explicit stop.
+    if (
+      !this.session.locallyOwned &&
+      !this.session.persistent &&
+      !explicit &&
+      this.orphanTimeoutMs > 0
+    ) {
       this.session.orphanTimeoutId = setTimeout(() => {
         this.closeSession(sessionId, 'timeout');
       }, this.orphanTimeoutMs);
@@ -585,7 +599,7 @@ export class SessionRegistry {
   ): 'active' | 'idle' | 'orphaned' | 'detached' {
     if (session.activeConnectionId === null) {
       if (session.locallyOwned) return 'active';
-      if (session.explicitlyDetached) return 'detached';
+      if (session.explicitlyDetached || session.persistent) return 'detached';
       return 'orphaned';
     }
     if (session.currentStatus === 'idle') {
@@ -628,7 +642,9 @@ export class SessionRegistry {
     if (
       this.session !== null &&
       this.session.activeConnectionId === null &&
-      !this.session.locallyOwned
+      !this.session.locallyOwned &&
+      // Persistent (tmux-style) sessions are intentionally kept alive, not orphaned.
+      !this.session.persistent
     ) {
       return 1;
     }

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -73,7 +73,7 @@ describe('createSessionHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers() {
+  function makeHandlers(opts: { exitFallbackMs?: number } = {}) {
     return createSessionHandlers({
       sessionRegistry,
       bindingStore,
@@ -87,6 +87,7 @@ describe('createSessionHandlers', () => {
         connectionRemovedCount += 1;
       },
       send,
+      ...(opts.exitFallbackMs !== undefined && { exitFallbackMs: opts.exitFallbackMs }),
     });
   }
 
@@ -252,6 +253,57 @@ describe('createSessionHandlers', () => {
 
       makeHandlers().resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(0);
+    });
+
+    test('a duplicate stop joins the in-flight one; both requesters are acked on close', () => {
+      const submitted: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: () => {},
+        submitInput: async (text: string) => {
+          submitted.push(text);
+        },
+        close: async () => {},
+      } as unknown as PTYSession;
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = makeHandlers();
+      const REQ2 = 'req20000-0000-0000-0000-000000000000' as UUID;
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      handlers.onKillSessionRequest(OTHER_CID, sessionId, REQ2);
+
+      // Only ONE /exit is typed (the duplicate joins, it does not re-stop).
+      expect(submitted).toEqual(['/exit']);
+      expect(sendCalls).toHaveLength(0);
+
+      // On close both requesters get a success ack against their own requestId.
+      handlers.resolveStopOnClose(sessionId);
+      const acks = sendCalls.map((c) => ({
+        connectionId: c.connectionId,
+        ...(c.message as unknown as { success: boolean; requestId: UUID }),
+      }));
+      expect(acks).toContainEqual(
+        expect.objectContaining({ connectionId: CID, success: true, requestId: REQ }),
+      );
+      expect(acks).toContainEqual(
+        expect.objectContaining({ connectionId: OTHER_CID, success: true, requestId: REQ2 }),
+      );
+    });
+
+    test('forces close when /exit is not honored within the fallback window', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = makeHandlers({ exitFallbackMs: 5 });
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+
+      // PTY never exits (fake submitInput is a no-op); the fallback timer fires.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
     });
   });
 

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -189,9 +189,18 @@ describe('createSessionHandlers', () => {
       expect(msg.success).toBe(false);
     });
 
-    test('closes the session and acks success when called by the active client', () => {
+    test('types /exit (graceful) and acks success when called by the active client', () => {
+      const submitted: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: () => {},
+        submitInput: async (text: string) => {
+          submitted.push(text);
+        },
+        close: async () => {},
+      } as unknown as PTYSession;
       const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, CID);
 
       makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
@@ -201,7 +210,10 @@ describe('createSessionHandlers', () => {
       const ack = sendCalls[0]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
-      expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
+      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
+      // the PTY-exit path), not SIGKILLed; the session stays until Claude exits.
+      expect(submitted).toEqual(['/exit']);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
     });
 
     test('notifies a third-party attached client with SESSION_ENDED before killing', () => {

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -46,11 +46,19 @@ describe('createSessionHandlers', () => {
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
   let untrackCalls: UUID[];
   let connectionRemovedCount: number;
+  // Mirrors the forward-ref wiring in cli.ts: the registry's onSessionClosed
+  // drives the handlers' resolveStopOnClose. Set in makeHandlers (handlers do
+  // not exist yet at registry-construction time).
+  let registryOnClose: ((sessionId: UUID) => void) | null;
   const PORT = 8765;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-session-events-'));
-    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    registryOnClose = null;
+    sessionRegistry = new SessionRegistry(
+      { orphanTimeoutMs: 1000 },
+      { onSessionClosed: (sessionId) => registryOnClose?.(sessionId) },
+    );
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     bindingStore = new SessionBindingStore(sessionStore);
     liveSessionsRegistry = new SessionRegistryFile(tmpDir);
@@ -74,7 +82,7 @@ describe('createSessionHandlers', () => {
   });
 
   function makeHandlers(opts: { exitFallbackMs?: number } = {}) {
-    return createSessionHandlers({
+    const handlers = createSessionHandlers({
       sessionRegistry,
       bindingStore,
       transcriptDiscovery,
@@ -89,6 +97,8 @@ describe('createSessionHandlers', () => {
       send,
       ...(opts.exitFallbackMs !== undefined && { exitFallbackMs: opts.exitFallbackMs }),
     });
+    registryOnClose = (sessionId) => handlers.resolveStopOnClose(sessionId);
+    return handlers;
   }
 
   describe('onSessionListRequest', () => {
@@ -300,10 +310,18 @@ describe('createSessionHandlers', () => {
       const handlers = makeHandlers({ exitFallbackMs: 5 });
       handlers.onKillSessionRequest(CID, sessionId, REQ);
       expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls).toHaveLength(0);
 
-      // PTY never exits (fake submitInput is a no-op); the fallback timer fires.
+      // PTY never exits (fake submitInput is a no-op); the fallback timer fires,
+      // forces the close, and the registry's onSessionClosed (wired to
+      // resolveStopOnClose in makeHandlers) acks the requester success.
       await new Promise((resolve) => setTimeout(resolve, 30));
       expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
+      expect(sendCalls).toHaveLength(1);
+      const ack = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(ack.type).toBe('kill_session_response');
+      expect(ack.success).toBe(true);
+      expect(sendCalls[0]?.connectionId).toBe(CID);
     });
   });
 

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -189,7 +189,7 @@ describe('createSessionHandlers', () => {
       expect(msg.success).toBe(false);
     });
 
-    test('types /exit (graceful) and acks success when called by the active client', () => {
+    test('types /exit (graceful) and defers the success ack until the session closes', () => {
       const submitted: string[] = [];
       const pty = {
         id: generateId(),
@@ -203,26 +203,38 @@ describe('createSessionHandlers', () => {
       sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, CID);
 
-      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+      const handlers = makeHandlers();
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
 
-      // Only an ack to the caller: no SESSION_ENDED error since the requester IS the active client.
+      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
+      // the PTY-exit path), not SIGKILLed; the session stays alive and NO ack is
+      // sent until it actually closes — "success" must mean done, not initiated.
+      expect(submitted).toEqual(['/exit']);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls).toHaveLength(0);
+
+      // On close, the requester is acked success (no third-party notice: the
+      // requester IS the active client).
+      handlers.resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(1);
       const ack = sendCalls[0]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
-      // Graceful stop (#641): Claude is asked to /exit (which frees the daemon via
-      // the PTY-exit path), not SIGKILLed; the session stays until Claude exits.
-      expect(submitted).toEqual(['/exit']);
-      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls[0]?.connectionId).toBe(CID);
     });
 
-    test('notifies a third-party attached client with SESSION_ENDED before killing', () => {
+    test('on close, notifies a third-party active client with SESSION_ENDED then acks the requester', () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
       sessionRegistry.attachConnection(sessionId, OTHER_CID);
 
-      makeHandlers().onKillSessionRequest(CID, sessionId, REQ);
+      const handlers = makeHandlers();
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      // Deferred: nothing is sent until the session actually closes (so the
+      // SESSION_ENDED notice arrives after PTY output has stopped).
+      expect(sendCalls).toHaveLength(0);
 
+      handlers.resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(2);
       const notice = sendCalls[0]?.message as { type: string; code?: string };
       expect(notice.type).toBe('error');
@@ -231,6 +243,15 @@ describe('createSessionHandlers', () => {
       const ack = sendCalls[1]?.message as { type: string; success: boolean };
       expect(ack.type).toBe('kill_session_response');
       expect(ack.success).toBe(true);
+      expect(sendCalls[1]?.connectionId).toBe(CID);
+    });
+
+    test('resolveStopOnClose is a no-op for a session with no pending stop', () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+
+      makeHandlers().resolveStopOnClose(sessionId);
+      expect(sendCalls).toHaveLength(0);
     });
   });
 

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -168,6 +168,9 @@ describe('createPtySessionForSession', () => {
       claudeChildPid: process.pid,
     });
 
+    // Capture the daemon-shutdown call instead of actually exiting the test
+    // runner (#641): a daemon-mode session that exits must terminate the daemon.
+    const exitCalls: number[] = [];
     const pty = createPtySessionForSession(
       {
         sessionRegistry,
@@ -177,6 +180,7 @@ describe('createPtySessionForSession', () => {
         wsPort: 9999,
         sendMessage: (sid, message) => sendCalls.push({ sessionId: sid, message }),
         cleanup: async () => {},
+        exitProcess: (code) => exitCalls.push(code),
       },
       { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: false },
     );
@@ -196,10 +200,12 @@ describe('createPtySessionForSession', () => {
       const deadline = Date.now() + 4000;
       while (Date.now() < deadline) {
         const entry = liveSessionsRegistry.findBySessionId(SID);
-        if (entry?.claudeChildExited === true) break;
+        if (entry?.claudeChildExited === true && exitCalls.length > 0) break;
         await new Promise((r) => setTimeout(r, 25));
       }
       expect(liveSessionsRegistry.findBySessionId(SID)?.claudeChildExited).toBe(true);
+      // #641: a daemon-mode session ending must shut the daemon down (exit 0).
+      expect(exitCalls).toEqual([0]);
     } finally {
       // Restore PATH (originalPath is effectively always defined in practice).
       process.env['PATH'] = originalPath ?? '';

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -99,6 +99,24 @@ bind = "localhost"
     expect(config.daemon.port_range).toBe(20); // default preserved
   });
 
+  test('persist_sessions defaults to true and parses an override (#637)', () => {
+    // Default preserved when omitted
+    const defaults = loadConfig(path.join(TEST_DIR, 'nonexistent.toml'));
+    expect(defaults.daemon.persist_sessions).toBe(true);
+
+    // Explicit override is parsed
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `
+[daemon]
+persist_sessions = false
+`,
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.daemon.persist_sessions).toBe(false);
+    expect(config.daemon.orphan_timeout).toBe(DEFAULT_CONFIG.daemon.orphan_timeout); // default preserved
+  });
+
   test('handles auth enabled as string or boolean', () => {
     fs.writeFileSync(
       TEST_CONFIG,

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -645,6 +645,104 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('persistent sessions (#637)', () => {
+    // 6th registerSession arg is `persistent` (tmux-style keep-alive).
+    test('persistent session skips orphan timeout on detach', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, true);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      // Wait well past the orphan timeout (100ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Session should still exist (not killed by timeout)
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(events.onSessionClosed).not.toHaveBeenCalled();
+    });
+
+    test('persistent session reports "detached" status without connection', () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      const sessions = registry.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.status).toBe('detached');
+      expect(sessions[0]?.canAttach).toBe(true);
+    });
+
+    test('persistent session is re-attachable after disconnect', () => {
+      const sessionId = generateId();
+      const conn1 = generateId();
+
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+      registry.attachConnection(sessionId, conn1);
+      registry.detachConnection(conn1);
+
+      expect(registry.canResume(sessionId)).toBe(true);
+      const result = registry.attachConnection(sessionId, generateId());
+      expect(result.success).toBe(true);
+      expect(result.isResume).toBe(true);
+    });
+
+    test('orphanedCount excludes persistent sessions', () => {
+      const sessionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+
+      expect(registry.orphanedCount).toBe(0);
+
+      const connectionId = generateId();
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+      expect(registry.orphanedCount).toBe(0);
+    });
+
+    test('non-persistent session still times out (default behavior preserved)', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, false);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(pty.close).toHaveBeenCalled();
+      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
+    });
+  });
+
   describe('shutdown()', () => {
     test('closes the session', async () => {
       const pty = createMockPTY();

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -741,6 +741,42 @@ describe('SessionRegistry', () => {
       expect(pty.close).toHaveBeenCalled();
       expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'timeout');
     });
+
+    test('persistent session is closed when the Claude process exits (pty_exit)', () => {
+      // Persistence must NOT keep a session alive after Claude itself exits;
+      // pty_exit is the primary lifecycle-ending event for a persistent session.
+      const sessionId = generateId();
+      registry.registerSession(
+        sessionId,
+        '/test/dir',
+        createMockPTY(),
+        createMockMessageAPI(),
+        false,
+        true,
+      );
+
+      registry.handlePTYExit(sessionId);
+
+      expect(registry.getSession(sessionId)).toBeUndefined();
+      expect(events.onSessionClosed).toHaveBeenCalledWith(sessionId, 'pty_exit');
+    });
+
+    test('persistent + explicit detach stays detached with no timeout', async () => {
+      const sessionId = generateId();
+      const connectionId = generateId();
+      const pty = createMockPTY();
+
+      registry.registerSession(sessionId, '/test/dir', pty, createMockMessageAPI(), false, true);
+      registry.attachConnection(sessionId, connectionId);
+      registry.detachConnection(connectionId, true);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(registry.getSession(sessionId)).toBeDefined();
+      expect(pty.close).not.toHaveBeenCalled();
+      const sessions = registry.listSessions();
+      expect(sessions[0]?.status).toBe('detached');
+    });
   });
 
   describe('shutdown()', () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,7 +6,7 @@
 
 import { ChatView } from '@/components/chat';
 import { AppLayout } from '@/components/layout';
-import { ConnectModal, SessionList } from '@/components/session';
+import { ConnectModal, NewSessionModal, SessionList } from '@/components/session';
 import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
 import { probeAuthInfo } from '@/lib/auth-probe';
@@ -43,7 +43,7 @@ import type {
 import { DEFAULT_SETTINGS } from '@/types';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
-import type { ProtocolMessage } from '@remi/shared/protocol.ts';
+import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
   createDetachSession,
@@ -201,6 +201,9 @@ function App() {
   // Claude Code receives the quoted context (#401).
   const [replyContexts, setReplyContexts] = useState<Map<UUID, ReplyContext>>(new Map());
   const [showConnectModal, setShowConnectModal] = useState(false);
+  // New-session sheet (#638): recent project directories from the daemon.
+  const [showNewSessionModal, setShowNewSessionModal] = useState(false);
+  const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
@@ -905,7 +908,8 @@ function App() {
       }
 
       case 'session_history_response': {
-        // Session history response received; not yet integrated into the UI
+        // Recent project directories for the new-session sheet (#638).
+        setRecentDirectories(message.directories);
         break;
       }
 
@@ -1250,6 +1254,7 @@ function App() {
     requestTranscriptLoad,
     requestResumeSession,
     requestNewSession,
+    requestSessionHistory,
     needsPassphrase,
     passphraseConnectionId,
     passphraseServerFingerprint,
@@ -2031,6 +2036,24 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Open the new-session sheet and refresh recent directories (#638). The "+"
+  // button routes here instead of a raw path prompt.
+  const handleOpenNewSession = useCallback(() => {
+    const conn = connections.find((c) => c.status === 'connected');
+    if (!conn) return;
+    requestSessionHistory(conn.connectionId);
+    setShowNewSessionModal(true);
+  }, [connections, requestSessionHistory]);
+
+  // RecentProjects passes '' for the home/cwd default; map that to undefined so
+  // the daemon uses its own default working directory.
+  const handleStartSessionInDir = useCallback(
+    (directory: string) => {
+      handleNewSession(directory.trim() || undefined);
+    },
+    [handleNewSession],
+  );
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -2106,7 +2129,7 @@ function App() {
       onDisconnect={handleDisconnect}
       onReconnect={reconnectConnection}
       onDisconnectAll={handleDisconnectAll}
-      onNewSession={handleNewSession}
+      onOpenNewSession={handleOpenNewSession}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -2171,6 +2194,13 @@ function App() {
         hasUnlockedIdentity={unlockedIdentity != null}
         serverFingerprint={passphraseServerFingerprint}
         onPassphraseSubmit={handlePassphraseSubmit}
+      />
+
+      <NewSessionModal
+        open={showNewSessionModal}
+        onClose={() => setShowNewSessionModal(false)}
+        directories={recentDirectories}
+        onStartSession={handleStartSessionInDir}
       />
     </>
   );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -204,6 +204,7 @@ function App() {
   // New-session sheet (#638): recent project directories from the daemon.
   const [showNewSessionModal, setShowNewSessionModal] = useState(false);
   const [recentDirectories, setRecentDirectories] = useState<readonly RecentDirectory[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [resumingSession, setResumingSession] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
@@ -231,6 +232,9 @@ function App() {
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
+  // Fallback timer so the new-session sheet leaves its loading state even if the
+  // daemon never answers session_history_request (#638 review).
+  const historyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -909,6 +913,11 @@ function App() {
 
       case 'session_history_response': {
         // Recent project directories for the new-session sheet (#638).
+        if (historyTimeoutRef.current) {
+          clearTimeout(historyTimeoutRef.current);
+          historyTimeoutRef.current = null;
+        }
+        setHistoryLoading(false);
         setRecentDirectories(message.directories);
         break;
       }
@@ -2026,32 +2035,39 @@ function App() {
     [sessions, requestResumeSession, resumingSession],
   );
 
-  // Create new session on the first connected daemon
-  const handleNewSession = useCallback(
-    (directory?: string) => {
-      const conn = connections.find((c) => c.status === 'connected');
-      if (!conn) return;
-      requestNewSession(conn.connectionId, directory);
-    },
-    [connections, requestNewSession],
-  );
-
-  // Open the new-session sheet and refresh recent directories (#638). The "+"
-  // button routes here instead of a raw path prompt.
+  // Open the new-session sheet and (re)load recent directories (#638). The "+"
+  // button routes here instead of a raw path prompt. Clears stale directories
+  // and shows a loading state so an empty list isn't confused with "still
+  // loading"; a fallback timer ends the loading state if no response arrives.
   const handleOpenNewSession = useCallback(() => {
     const conn = connections.find((c) => c.status === 'connected');
     if (!conn) return;
-    requestSessionHistory(conn.connectionId);
+    setRecentDirectories([]);
+    if (historyTimeoutRef.current) clearTimeout(historyTimeoutRef.current);
+    const sent = requestSessionHistory(conn.connectionId);
+    if (sent) {
+      setHistoryLoading(true);
+      historyTimeoutRef.current = setTimeout(() => {
+        historyTimeoutRef.current = null;
+        setHistoryLoading(false);
+      }, 5000);
+    } else {
+      setHistoryLoading(false);
+    }
     setShowNewSessionModal(true);
   }, [connections, requestSessionHistory]);
 
-  // RecentProjects passes '' for the home/cwd default; map that to undefined so
-  // the daemon uses its own default working directory.
+  // Start a session in the chosen directory. RecentProjects passes '' for the
+  // home/cwd default; map that to undefined so the daemon uses its own default.
+  // Close the sheet only when the request was actually sent.
   const handleStartSessionInDir = useCallback(
     (directory: string) => {
-      handleNewSession(directory.trim() || undefined);
+      const conn = connections.find((c) => c.status === 'connected');
+      if (!conn) return;
+      const sent = requestNewSession(conn.connectionId, directory.trim() || undefined);
+      if (sent) setShowNewSessionModal(false);
     },
-    [handleNewSession],
+    [connections, requestNewSession],
   );
 
   // Menu actions
@@ -2198,6 +2214,7 @@ function App() {
 
       <NewSessionModal
         open={showNewSessionModal}
+        loading={historyLoading}
         onClose={() => setShowNewSessionModal(false)}
         directories={recentDirectories}
         onStartSession={handleStartSessionInDir}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2132,7 +2132,7 @@ function App() {
   const handleKillSession = useCallback(
     (sessionId: UUID, connectionId: ConnectionId, label?: string) => {
       const ok = window.confirm(
-        `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
+        `Exit ${label ? `"${label}"` : 'this session'}? Claude runs /exit and the session closes. You can resume it later from Recent.`,
       );
       if (!ok) return;
       const req = createKillSessionRequest(sessionId);
@@ -2147,7 +2147,7 @@ function App() {
         pendingKillsRef.current.delete(req.id);
         pushSessionSystemMessage(
           sessionId,
-          'Stop session timed out; the daemon may be unreachable.',
+          'Exit session timed out; the daemon may be unreachable.',
         );
       }, 12_000);
       pendingKillsRef.current.set(req.id, { sessionId, timeoutId });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -229,6 +229,12 @@ function App() {
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
+  // In-flight kill_session_request, keyed by requestId, so kill_session_response
+  // (and a no-reply timeout) resolve against the session that was actually
+  // stopped — not whatever session happens to be open in the chat (#637 review).
+  const pendingKillsRef = useRef<
+    Map<UUID, { sessionId: UUID; timeoutId: ReturnType<typeof setTimeout> }>
+  >(new Map());
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -911,6 +917,14 @@ function App() {
       }
 
       case 'kill_session_response': {
+        // Resolve against the session we actually asked to stop (not the open
+        // chat) and cancel its no-reply timeout.
+        const pending = pendingKillsRef.current.get(message.requestId);
+        if (pending) {
+          clearTimeout(pending.timeoutId);
+          pendingKillsRef.current.delete(message.requestId);
+        }
+        const killedSessionId = pending?.sessionId ?? activeSessionIdRef.current ?? ('' as UUID);
         if (message.success) {
           // Session torn down; refresh the list so the dead session drops off.
           const reqList = requestSessionListRef.current;
@@ -924,7 +938,7 @@ function App() {
           console.error(`Session kill failed: ${message.error}`);
           const errorMsg: UIMessage = {
             id: generateId(),
-            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            sessionId: killedSessionId,
             connectionId: '' as ConnectionId,
             sender: 'system',
             content: `Failed to stop session: ${message.error || 'unknown error'}`,
@@ -2059,6 +2073,21 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Surface a system message in a specific session's thread.
+  const pushSessionSystemMessage = useCallback((sessionId: UUID, content: string) => {
+    const msg: UIMessage = {
+      id: generateId(),
+      sessionId,
+      connectionId: '' as ConnectionId,
+      sender: 'system',
+      content,
+      timestamp: new Date().toISOString(),
+      state: 'delivered',
+      isEditing: false,
+    };
+    setMessages((prev) => [...prev, msg]);
+  }, []);
+
   // Stop (kill) a session: tears down the Claude process + its daemon (#637).
   // Persistent sessions never time out, so this is the explicit way to end one.
   const handleKillSession = useCallback(
@@ -2067,30 +2096,35 @@ function App() {
         `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
       );
       if (!ok) return;
-      const sent = cmSendMessage(connectionId, createKillSessionRequest(sessionId));
+      const req = createKillSessionRequest(sessionId);
+      const sent = cmSendMessage(connectionId, req);
       if (!sent) {
-        const errorMsg: UIMessage = {
-          id: generateId(),
-          sessionId,
-          connectionId: '' as ConnectionId,
-          sender: 'system',
-          content: 'Cannot stop session: not connected to daemon.',
-          timestamp: new Date().toISOString(),
-          state: 'delivered',
-          isEditing: false,
-        };
-        setMessages((prev) => [...prev, errorMsg]);
+        pushSessionSystemMessage(sessionId, 'Cannot stop session: not connected to daemon.');
+        return;
       }
+      // Guard against a daemon that never replies (crash / WS drop): surface a
+      // timeout scoped to this session if no kill_session_response lands.
+      const timeoutId = setTimeout(() => {
+        pendingKillsRef.current.delete(req.id);
+        pushSessionSystemMessage(
+          sessionId,
+          'Stop session timed out; the daemon may be unreachable.',
+        );
+      }, 12_000);
+      pendingKillsRef.current.set(req.id, { sessionId, timeoutId });
     },
-    [cmSendMessage],
+    [cmSendMessage, pushSessionSystemMessage],
   );
 
   const handleEndSession = useCallback(() => {
     if (!activeSessionId) return;
     const connId = getActiveConnectionId();
-    if (!connId) return;
+    if (!connId) {
+      pushSessionSystemMessage(activeSessionId, 'Cannot stop session: session is no longer available.');
+      return;
+    }
     handleKillSession(activeSessionId, connId);
-  }, [activeSessionId, getActiveConnectionId, handleKillSession]);
+  }, [activeSessionId, getActiveConnectionId, handleKillSession, pushSessionSystemMessage]);
 
   // Menu actions
   const handleCopyConversation = useCallback(() => {
@@ -2203,7 +2237,7 @@ function App() {
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
       onDetach={handleDetach}
-      onEndSession={handleEndSession}
+      onEndSession={activeSession?.source === 'daemon' ? handleEndSession : undefined}
       showTimestamps={settings.showTimestamps}
     />
   ) : (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -47,6 +47,7 @@ import type { ProtocolMessage } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
   createDetachSession,
+  createKillSessionRequest,
   createRegisterDeviceToken,
   generateId,
 } from '@remi/shared/protocol.ts';
@@ -906,6 +907,33 @@ function App() {
 
       case 'session_history_response': {
         // Session history response received; not yet integrated into the UI
+        break;
+      }
+
+      case 'kill_session_response': {
+        if (message.success) {
+          // Session torn down; refresh the list so the dead session drops off.
+          const reqList = requestSessionListRef.current;
+          if (reqList) {
+            const conns = connectionsRef.current.filter((c) => c.status === 'connected');
+            for (const conn of conns) {
+              reqList(conn.connectionId, conns.length === 1);
+            }
+          }
+        } else {
+          console.error(`Session kill failed: ${message.error}`);
+          const errorMsg: UIMessage = {
+            id: generateId(),
+            sessionId: activeSessionIdRef.current ?? ('' as UUID),
+            connectionId: '' as ConnectionId,
+            sender: 'system',
+            content: `Failed to stop session: ${message.error || 'unknown error'}`,
+            timestamp: new Date().toISOString(),
+            state: 'delivered',
+            isEditing: false,
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        }
         break;
       }
 
@@ -2031,6 +2059,39 @@ function App() {
     [connections, requestNewSession],
   );
 
+  // Stop (kill) a session: tears down the Claude process + its daemon (#637).
+  // Persistent sessions never time out, so this is the explicit way to end one.
+  const handleKillSession = useCallback(
+    (sessionId: UUID, connectionId: ConnectionId, label?: string) => {
+      const ok = window.confirm(
+        `Stop ${label ? `"${label}"` : 'this session'}? This ends the Claude process and cannot be undone.`,
+      );
+      if (!ok) return;
+      const sent = cmSendMessage(connectionId, createKillSessionRequest(sessionId));
+      if (!sent) {
+        const errorMsg: UIMessage = {
+          id: generateId(),
+          sessionId,
+          connectionId: '' as ConnectionId,
+          sender: 'system',
+          content: 'Cannot stop session: not connected to daemon.',
+          timestamp: new Date().toISOString(),
+          state: 'delivered',
+          isEditing: false,
+        };
+        setMessages((prev) => [...prev, errorMsg]);
+      }
+    },
+    [cmSendMessage],
+  );
+
+  const handleEndSession = useCallback(() => {
+    if (!activeSessionId) return;
+    const connId = getActiveConnectionId();
+    if (!connId) return;
+    handleKillSession(activeSessionId, connId);
+  }, [activeSessionId, getActiveConnectionId, handleKillSession]);
+
   // Menu actions
   const handleCopyConversation = useCallback(() => {
     const text = sessionMessages.map((m) => `[${m.sender}] ${m.content}`).join('\n\n');
@@ -2107,6 +2168,7 @@ function App() {
       onReconnect={reconnectConnection}
       onDisconnectAll={handleDisconnectAll}
       onNewSession={handleNewSession}
+      onKillSession={handleKillSession}
       onSettings={() => setShowSettings(true)}
     />
   );
@@ -2141,6 +2203,7 @@ function App() {
       onExportText={handleExportText}
       onBulletExpand={handleBulletExpand}
       onDetach={handleDetach}
+      onEndSession={handleEndSession}
       showTimestamps={settings.showTimestamps}
     />
   ) : (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -954,7 +954,7 @@ function App() {
             sessionId: killedSessionId,
             connectionId: '' as ConnectionId,
             sender: 'system',
-            content: `Failed to stop session: ${message.error || 'unknown error'}`,
+            content: `Failed to exit session: ${message.error || 'unknown error'}`,
             timestamp: new Date().toISOString(),
             state: 'delivered',
             isEditing: false,
@@ -2138,7 +2138,7 @@ function App() {
       const req = createKillSessionRequest(sessionId);
       const sent = cmSendMessage(connectionId, req);
       if (!sent) {
-        pushSessionSystemMessage(sessionId, 'Cannot stop session: not connected to daemon.');
+        pushSessionSystemMessage(sessionId, 'Cannot exit session: not connected to daemon.');
         return;
       }
       // Guard against a daemon that never replies (crash / WS drop): surface a
@@ -2159,7 +2159,10 @@ function App() {
     if (!activeSessionId) return;
     const connId = getActiveConnectionId();
     if (!connId) {
-      pushSessionSystemMessage(activeSessionId, 'Cannot stop session: session is no longer available.');
+      pushSessionSystemMessage(
+        activeSessionId,
+        'Cannot exit session: session is no longer available.',
+      );
       return;
     }
     handleKillSession(activeSessionId, connId);

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -17,7 +17,7 @@ import {
   Layers,
   LogOut,
   MoreVertical,
-  Square,
+  Power,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -223,8 +223,8 @@ export function ChatHeader({
               )}
               {onEndSession && (
                 <MenuItem
-                  icon={<Square className="size-4" />}
-                  label="Stop session"
+                  icon={<Power className="size-4" />}
+                  label="Exit session"
                   tone="error"
                   onClick={() => {
                     onEndSession();

--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -17,6 +17,7 @@ import {
   Layers,
   LogOut,
   MoreVertical,
+  Square,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -38,6 +39,8 @@ interface ChatHeaderProps {
   readonly onClearMessages?: () => void;
   readonly onExportText?: () => void;
   readonly onDetach?: () => void;
+  /** Stop (kill) the session entirely (#637). */
+  readonly onEndSession?: () => void;
   readonly className?: string;
 }
 
@@ -51,13 +54,15 @@ export function ChatHeader({
   onClearMessages,
   onExportText,
   onDetach,
+  onEndSession,
   className,
 }: ChatHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const { host, project, branch } = splitSessionName(session);
   const state = sessionPillState(session);
-  const hasMenuActions = onCopyConversation || onClearMessages || onExportText || onDetach;
+  const hasMenuActions =
+    onCopyConversation || onClearMessages || onExportText || onDetach || onEndSession;
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -215,6 +220,17 @@ export function ChatHeader({
                     }}
                   />
                 </>
+              )}
+              {onEndSession && (
+                <MenuItem
+                  icon={<Square className="size-4" />}
+                  label="Stop session"
+                  tone="error"
+                  onClick={() => {
+                    onEndSession();
+                    closeMenu();
+                  }}
+                />
               )}
               {onClearMessages && (
                 <>

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -59,6 +59,8 @@ interface ChatViewProps {
   readonly onExportText?: () => void;
   readonly onBulletExpand?: (bulletId: number) => void;
   readonly onDetach?: () => void;
+  /** Stop (kill) the active session (#637). */
+  readonly onEndSession?: () => void;
   readonly showTimestamps?: boolean;
   readonly className?: string;
 }
@@ -86,6 +88,7 @@ export function ChatView({
   onExportText,
   onBulletExpand,
   onDetach,
+  onEndSession,
   showTimestamps = true,
   className,
 }: ChatViewProps) {
@@ -139,6 +142,7 @@ export function ChatView({
         onClearMessages={onClearMessages}
         onExportText={onExportText}
         onDetach={onDetach}
+        onEndSession={onEndSession}
       />
 
       {/* Pinned question stack -- the headline interaction. One card per

--- a/packages/web/src/components/session/NewSessionModal.tsx
+++ b/packages/web/src/components/session/NewSessionModal.tsx
@@ -1,0 +1,75 @@
+/**
+ * NewSessionModal component.
+ *
+ * Bottom-sheet for starting a new Claude Code session. Replaces the old
+ * window.prompt path-entry (#638): shows recent project directories (from the
+ * daemon's session history) with a one-tap start, plus a custom-path input.
+ * Mirrors ConnectModal's sheet styling.
+ */
+
+import type { RecentDirectory } from '@remi/shared/protocol.ts';
+import { X } from 'lucide-react';
+import { RecentProjects } from './RecentProjects';
+
+interface NewSessionModalProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly directories: readonly RecentDirectory[];
+  /** Start a session in the given directory (empty string = home/cwd). */
+  readonly onStartSession: (directory: string) => void;
+}
+
+export function NewSessionModal({
+  open,
+  onClose,
+  directories,
+  onStartSession,
+}: NewSessionModalProps) {
+  if (!open) return null;
+
+  const handleStart = (directory: string) => {
+    onStartSession(directory);
+    onClose();
+  };
+
+  return (
+    <div
+      data-testid="new-session-modal-backdrop"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[88vh] w-full max-w-md overflow-y-auto rounded-t-[28px] border border-[var(--color-border)] bg-[var(--color-surface)] pb-[max(env(safe-area-inset-bottom),12px)] shadow-2xl animate-[sheet-up_260ms_cubic-bezier(.2,.8,.2,1)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto mb-1 mt-3 h-1 w-9 rounded-full bg-[var(--color-border)]" />
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pb-2 pt-1">
+          <h2 className="text-[22px] font-bold tracking-tight text-[var(--color-text)]">
+            New session
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-1.5 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-light)] hover:text-[var(--color-text)]"
+            aria-label="Close"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        <p className="px-5 pb-1 text-[13px] leading-snug text-[var(--color-text-secondary)]">
+          Pick a recent project or enter a path to start Claude Code there.
+        </p>
+
+        {directories.length === 0 && (
+          <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
+            No recent projects yet. Enter a directory path below to start your first session.
+          </p>
+        )}
+
+        <RecentProjects directories={directories} onStartSession={handleStart} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session/NewSessionModal.tsx
+++ b/packages/web/src/components/session/NewSessionModal.tsx
@@ -13,24 +13,23 @@ import { RecentProjects } from './RecentProjects';
 
 interface NewSessionModalProps {
   readonly open: boolean;
+  /** Recent directories are still being fetched from the daemon. */
+  readonly loading?: boolean;
   readonly onClose: () => void;
   readonly directories: readonly RecentDirectory[];
-  /** Start a session in the given directory (empty string = home/cwd). */
+  /** Start a session in the given directory (empty string = home/cwd). The
+   *  parent closes the sheet once the request is actually sent. */
   readonly onStartSession: (directory: string) => void;
 }
 
 export function NewSessionModal({
   open,
+  loading = false,
   onClose,
   directories,
   onStartSession,
 }: NewSessionModalProps) {
   if (!open) return null;
-
-  const handleStart = (directory: string) => {
-    onStartSession(directory);
-    onClose();
-  };
 
   return (
     <div
@@ -62,13 +61,19 @@ export function NewSessionModal({
           Pick a recent project or enter a path to start Claude Code there.
         </p>
 
-        {directories.length === 0 && (
+        {loading ? (
           <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
-            No recent projects yet. Enter a directory path below to start your first session.
+            Loading recent projects…
           </p>
+        ) : (
+          directories.length === 0 && (
+            <p className="px-5 pt-2 text-[13px] text-[var(--color-text-muted)]">
+              No recent projects yet. Enter a directory path below to start your first session.
+            </p>
+          )
         )}
 
-        <RecentProjects directories={directories} onStartSession={handleStart} />
+        <RecentProjects directories={directories} onStartSession={onStartSession} />
       </div>
     </div>
   );

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -12,7 +12,7 @@ import { sessionPillState, splitSessionName } from '@/lib/session-display';
 import type { ConnectionId, UISession } from '@/types';
 import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { GitBranch, Link2Off, RotateCcw, Square } from 'lucide-react';
+import { GitBranch, Link2Off, Power, RotateCcw } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
@@ -147,10 +147,10 @@ export function SessionCard({
               onKill(session.id, session.connectionId, project);
             }}
             className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
-            aria-label="Stop session"
-            title="Stop session"
+            aria-label="Exit session"
+            title="Exit session"
           >
-            <Square className="size-3.5" />
+            <Power className="size-3.5" />
           </button>
         )}
       </div>

--- a/packages/web/src/components/session/SessionCard.tsx
+++ b/packages/web/src/components/session/SessionCard.tsx
@@ -10,8 +10,9 @@ import { StatusPill } from '@/components/StatusPill';
 import { formatRelativeTime } from '@/lib/format-time';
 import { sessionPillState, splitSessionName } from '@/lib/session-display';
 import type { ConnectionId, UISession } from '@/types';
+import type { UUID } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
-import { GitBranch, Link2Off, RotateCcw } from 'lucide-react';
+import { GitBranch, Link2Off, RotateCcw, Square } from 'lucide-react';
 
 interface SessionCardProps {
   readonly session: UISession;
@@ -19,6 +20,10 @@ interface SessionCardProps {
   readonly onClick: () => void;
   readonly onResume?: ((sessionId: string) => void) | undefined;
   readonly onDisconnect?: ((connectionId: ConnectionId) => void) | undefined;
+  /** Stop (kill) the session's Claude process + daemon (#637). */
+  readonly onKill?:
+    | ((sessionId: UUID, connectionId: ConnectionId, label?: string) => void)
+    | undefined;
   readonly isResuming?: boolean;
   /** When true, the bottom hairline divider is omitted (last row in a group). */
   readonly last?: boolean;
@@ -30,10 +35,14 @@ export function SessionCard({
   onClick,
   onResume,
   onDisconnect,
+  onKill,
   isResuming,
   last = false,
 }: SessionCardProps) {
   const { host, project, branch } = splitSessionName(session);
+  // Daemon-owned sessions have a live Claude process that can be stopped;
+  // transcript-only rows do not.
+  const canKill = onKill && session.source === 'daemon';
   const state = sessionPillState(session);
   const isAsking = state === 'asking';
   const isConnected = session.connectionStatus === 'connected';
@@ -128,6 +137,20 @@ export function SessionCard({
             aria-label="Resume"
           >
             <RotateCcw className={clsx('size-3.5', isResuming && 'animate-spin')} />
+          </button>
+        )}
+        {canKill && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onKill(session.id, session.connectionId, project);
+            }}
+            className="rounded-full p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-error)]"
+            aria-label="Stop session"
+            title="Stop session"
+          >
+            <Square className="size-3.5" />
           </button>
         )}
       </div>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -173,7 +173,10 @@ export function SessionList({
             <button
               type="button"
               onClick={() => {
-                if (hasConnections && onOpenNewSession) {
+                // Only route to the new-session sheet when a daemon is actually
+                // connected; otherwise open the connect flow so the tap is never
+                // a silent no-op (#638 review).
+                if (anyConnected && onOpenNewSession) {
                   onOpenNewSession();
                 } else {
                   onConnect();
@@ -181,7 +184,7 @@ export function SessionList({
               }}
               className="inline-flex size-[38px] items-center justify-center rounded-xl bg-[var(--color-primary)] text-[var(--color-accent-ink)] transition-transform active:scale-95"
               style={{ boxShadow: '0 4px 18px -6px var(--color-primary)' }}
-              aria-label={hasConnections ? 'New session' : 'Connect'}
+              aria-label={anyConnected ? 'New session' : 'Connect'}
             >
               <Plus className="size-5" />
             </button>

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -40,7 +40,8 @@ interface SessionListProps {
   /** Retry a connection that became 'unreachable' (re-runs port discovery). */
   readonly onReconnect?: (connectionId: ConnectionId) => void;
   readonly onDisconnectAll: () => void;
-  readonly onNewSession?: (directory?: string) => void;
+  /** Open the new-session sheet (recent paths + custom path) (#638). */
+  readonly onOpenNewSession?: () => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -67,7 +68,7 @@ export function SessionList({
   onDisconnect,
   onReconnect,
   onDisconnectAll,
-  onNewSession,
+  onOpenNewSession,
   onSettings,
   className,
 }: SessionListProps) {
@@ -172,12 +173,8 @@ export function SessionList({
             <button
               type="button"
               onClick={() => {
-                if (hasConnections && onNewSession) {
-                  // Directory selection is preserved here; the richer
-                  // new-session sheet (command + options) is tracked in #447
-                  // and needs daemon-side support.
-                  const dir = window.prompt('Project directory (leave empty for home):');
-                  if (dir !== null) onNewSession(dir || undefined);
+                if (hasConnections && onOpenNewSession) {
+                  onOpenNewSession();
                 } else {
                   onConnect();
                 }

--- a/packages/web/src/components/session/SessionList.tsx
+++ b/packages/web/src/components/session/SessionList.tsx
@@ -41,6 +41,8 @@ interface SessionListProps {
   readonly onReconnect?: (connectionId: ConnectionId) => void;
   readonly onDisconnectAll: () => void;
   readonly onNewSession?: (directory?: string) => void;
+  /** Stop (kill) a session from the list (#637). */
+  readonly onKillSession?: (sessionId: UUID, connectionId: ConnectionId, label?: string) => void;
   readonly onSettings?: () => void;
   readonly className?: string;
 }
@@ -68,6 +70,7 @@ export function SessionList({
   onReconnect,
   onDisconnectAll,
   onNewSession,
+  onKillSession,
   onSettings,
   className,
 }: SessionListProps) {
@@ -331,6 +334,7 @@ export function SessionList({
                 onClick={() => onSelectSession(session.id)}
                 onResume={onResumeSession}
                 onDisconnect={onDisconnect}
+                onKill={onKillSession}
                 isResuming={resumingSessionId === session.id}
                 last={i === filteredActive.length - 1 && recentSessions.length === 0}
               />

--- a/packages/web/src/components/session/index.ts
+++ b/packages/web/src/components/session/index.ts
@@ -6,3 +6,4 @@ export { SessionCard } from './SessionCard';
 export { SessionList } from './SessionList';
 export { ConnectModal } from './ConnectModal';
 export { RecentProjects } from './RecentProjects';
+export { NewSessionModal } from './NewSessionModal';


### PR DESCRIPTION
Release PR: develop -> main. Merging tags **v0.6.17** (auto-release strips the -dev suffix, publishes npm + GitHub release + Homebrew, then syncs develop).

## What's in this release

Three user-facing features, each already reviewed and merged to develop individually:

### Persistent remote sessions (#637, PR #639)
A session created from the app survives client disconnect instead of being killed by the orphan timeout. New `daemon.persist_sessions` config (default on) detaches on disconnect and leaves the session re-attachable; `pty_exit`/forced closes still apply. This is the core fix: a remote session should outlive the connection that started it.

### Recent-paths new-session sheet (#638, PR #640)
The "+" button opens a bottom sheet of recent project directories instead of a bare `window.prompt`. Pick a recent path or type a new one; surfaces the same recent-directory data the CLI already exposes, so the exact path is always visible.

### Graceful Exit + daemon frees up (#641, PR #642)
Ending a session types `/exit` on the daemon's own PTY so Claude quits cleanly (flushes transcript + resume hint), with an 8s force-close fallback. The daemon now also exits when its only session ends, so no session-less "phantom" daemon is left holding a port. Control relabeled "Exit session" (distinct from the input-area Esc "Stop").

## Validation
- All three merged green to develop with individual sonnet PR reviews + findings addressed.
- Live-validated: graceful `/exit` ends instantly (no fallback), daemon frees its port, session persists across disconnect and is resumable from Recent.
- New iOS build installed + launched on device; recent-paths sheet and Exit control confirmed working.

## Notes
- Merge with a **merge commit** (not squash) per branch policy.
- CHANGELOG updated for 0.6.17 (#644).
- Follow-up filed: unique/editable session names + resume-by-name (#643).

Diffstat: 18 files, +687 / -71 (daemon session lifecycle + web session UI).