### PR TITLE
fix(#641): join duplicate stops + fallback test

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1313,8 +1313,9 @@ async function createNewSession(
   const locallyOwned = passThrough; // wrapper-mode sessions are locally owned
   // Persist non-wrapper (daemon-spawned/remote) sessions across disconnects by
   // default so a session created from the app survives until Claude exits or it
-  // is explicitly stopped (#637). Wrapper-mode sessions already never time out.
-  const persistent = remiConfig.daemon.persist_sessions;
+  // is explicitly stopped (#637). Wrapper-mode sessions are locallyOwned and
+  // already never time out, so the flag only applies to daemon-mode sessions.
+  const persistent = !passThrough && remiConfig.daemon.persist_sessions;
   sessionRegistry.registerSession(
     sessionId,
     workingDirectory,

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -80,7 +80,8 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   // starting a second one: every waiter is acked success on close, so neither
   // client sees a misleading "timed out" or "failed" message.
   interface PendingStop {
-    readonly waiters: Array<{ connectionId: UUID; requestId: UUID }>;
+    // Mutable: a duplicate stop appends itself via waiters.push (see below).
+    waiters: Array<{ connectionId: UUID; requestId: UUID }>;
     /** Active client to notify with SESSION_ENDED, if it isn't a requester. */
     readonly notifyConnectionId: UUID | null;
     readonly fallbackTimer: ReturnType<typeof setTimeout>;

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -44,6 +44,8 @@ export interface SessionHandlerDeps {
   /** Decrement the statusWriter connection count (third-party detach only). */
   onConnectionRemoved: () => void;
   send: SendToConnection;
+  /** Force-close delay after a graceful /exit; injectable for tests. */
+  exitFallbackMs?: number;
 }
 
 /**
@@ -64,6 +66,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     untrackConnection,
     onConnectionRemoved,
     send,
+    exitFallbackMs = EXIT_FALLBACK_MS,
   } = deps;
 
   // In-flight graceful stops (#641). A Stop types `/exit` and returns; the
@@ -71,10 +74,14 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   // (driven by the registry's onSessionClosed) so "success" means the session
   // actually ended — not merely "stop initiated" — and the third-party notice
   // arrives after PTY output has stopped. Keyed by sessionId.
+  //
+  // `waiters` is a list because a duplicate Stop (a second client confirming
+  // Exit before the first /exit lands) joins the in-flight stop rather than
+  // starting a second one: every waiter is acked success on close, so neither
+  // client sees a misleading "timed out" or "failed" message.
   interface PendingStop {
-    readonly connectionId: UUID;
-    readonly requestId: UUID;
-    /** Active client to notify with SESSION_ENDED, if it isn't the requester. */
+    readonly waiters: Array<{ connectionId: UUID; requestId: UUID }>;
+    /** Active client to notify with SESSION_ENDED, if it isn't a requester. */
     readonly notifyConnectionId: UUID | null;
     readonly fallbackTimer: ReturnType<typeof setTimeout>;
   }
@@ -84,7 +91,7 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
    * Resolve a deferred Stop once the session has actually closed. Call from the
    * registry's onSessionClosed for every close reason; a no-op when the session
    * ended on its own (no pending Stop). Cancels the force-fallback, notifies a
-   * third-party client, and acks the requester.
+   * third-party client, and acks every waiting requester.
    */
   function resolveStopOnClose(sessionId: UUID): void {
     const pending = pendingStops.get(sessionId);
@@ -94,7 +101,9 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
     if (pending.notifyConnectionId) {
       send(pending.notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
     }
-    send(pending.connectionId, createKillSessionResponse(true, pending.requestId));
+    for (const waiter of pending.waiters) {
+      send(waiter.connectionId, createKillSessionResponse(true, waiter.requestId));
+    }
   }
 
   return {
@@ -166,9 +175,13 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         return;
       }
 
-      // Idempotent: a Stop already in flight just re-acks on close.
-      if (pendingStops.has(sessionId)) {
-        log(`Stop already in flight for ${session.name}; ignoring duplicate request`);
+      // Idempotent: a Stop already in flight just adds this requester as a
+      // waiter so it too is acked success on close (no second /exit, no
+      // misleading timeout on the duplicate).
+      const inFlight = pendingStops.get(sessionId);
+      if (inFlight) {
+        log(`Stop already in flight for ${session.name}; joining duplicate request`);
+        inFlight.waiters.push({ connectionId, requestId });
         return;
       }
 
@@ -188,21 +201,27 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       });
       const fallbackTimer = setTimeout(() => {
         if (sessionRegistry.getSession(sessionId)) {
-          log(`Session ${sessionName} did not exit on /exit within ${EXIT_FALLBACK_MS}ms; forcing`);
+          log(`Session ${sessionName} did not exit on /exit within ${exitFallbackMs}ms; forcing`);
           sessionRegistry.closeSession(sessionId, 'forced');
         }
-      }, EXIT_FALLBACK_MS);
+      }, exitFallbackMs);
       // Don't let the fallback timer keep the event loop (or process) alive.
       fallbackTimer.unref?.();
 
       // Defer the ack + the third-party SESSION_ENDED notice until the session
-      // actually closes (resolveStopOnClose), so success means done and the
-      // notice arrives after PTY output stops.
+      // actually closes (resolveStopOnClose), so success means done. On the
+      // normal /exit path the PTY has already drained before the notice fires;
+      // on the rare force-fallback the close races a still-resolving pty.close(),
+      // so a third-party client may see a few trailing bytes after SESSION_ENDED.
       const notifyConnectionId =
         session.activeConnectionId && session.activeConnectionId !== connectionId
           ? session.activeConnectionId
           : null;
-      pendingStops.set(sessionId, { connectionId, requestId, notifyConnectionId, fallbackTimer });
+      pendingStops.set(sessionId, {
+        waiters: [{ connectionId, requestId }],
+        notifyConnectionId,
+        fallbackTimer,
+      });
       log(`Session stop initiated: ${sessionName}`);
     },
 

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -73,7 +73,7 @@ describe('createSessionHandlers', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function makeHandlers() {
+  function makeHandlers(opts: { exitFallbackMs?: number } = {}) {
     return createSessionHandlers({
       sessionRegistry,
       bindingStore,
@@ -87,6 +87,7 @@ describe('createSessionHandlers', () => {
         connectionRemovedCount += 1;
       },
       send,
+      ...(opts.exitFallbackMs !== undefined && { exitFallbackMs: opts.exitFallbackMs }),
     });
   }
 
@@ -252,6 +253,57 @@ describe('createSessionHandlers', () => {
 
       makeHandlers().resolveStopOnClose(sessionId);
       expect(sendCalls).toHaveLength(0);
+    });
+
+    test('a duplicate stop joins the in-flight one; both requesters are acked on close', () => {
+      const submitted: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: () => {},
+        submitInput: async (text: string) => {
+          submitted.push(text);
+        },
+        close: async () => {},
+      } as unknown as PTYSession;
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = makeHandlers();
+      const REQ2 = 'req20000-0000-0000-0000-000000000000' as UUID;
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      handlers.onKillSessionRequest(OTHER_CID, sessionId, REQ2);
+
+      // Only ONE /exit is typed (the duplicate joins, it does not re-stop).
+      expect(submitted).toEqual(['/exit']);
+      expect(sendCalls).toHaveLength(0);
+
+      // On close both requesters get a success ack against their own requestId.
+      handlers.resolveStopOnClose(sessionId);
+      const acks = sendCalls.map((c) => ({
+        connectionId: c.connectionId,
+        ...(c.message as unknown as { success: boolean; requestId: UUID }),
+      }));
+      expect(acks).toContainEqual(
+        expect.objectContaining({ connectionId: CID, success: true, requestId: REQ }),
+      );
+      expect(acks).toContainEqual(
+        expect.objectContaining({ connectionId: OTHER_CID, success: true, requestId: REQ2 }),
+      );
+    });
+
+    test('forces close when /exit is not honored within the fallback window', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = makeHandlers({ exitFallbackMs: 5 });
+      handlers.onKillSessionRequest(CID, sessionId, REQ);
+      expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+
+      // PTY never exits (fake submitInput is a no-op); the fallback timer fires.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
     });
   });
 

--- a/packages/daemon/tests/cli/handlers/session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/session-events.test.ts
@@ -46,11 +46,19 @@ describe('createSessionHandlers', () => {
   let send: (connectionId: UUID, message: ProtocolMessage) => boolean;
   let untrackCalls: UUID[];
   let connectionRemovedCount: number;
+  // Mirrors the forward-ref wiring in cli.ts: the registry's onSessionClosed
+  // drives the handlers' resolveStopOnClose. Set in makeHandlers (handlers do
+  // not exist yet at registry-construction time).
+  let registryOnClose: ((sessionId: UUID) => void) | null;
   const PORT = 8765;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-session-events-'));
-    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    registryOnClose = null;
+    sessionRegistry = new SessionRegistry(
+      { orphanTimeoutMs: 1000 },
+      { onSessionClosed: (sessionId) => registryOnClose?.(sessionId) },
+    );
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
     bindingStore = new SessionBindingStore(sessionStore);
     liveSessionsRegistry = new SessionRegistryFile(tmpDir);
@@ -74,7 +82,7 @@ describe('createSessionHandlers', () => {
   });
 
   function makeHandlers(opts: { exitFallbackMs?: number } = {}) {
-    return createSessionHandlers({
+    const handlers = createSessionHandlers({
       sessionRegistry,
       bindingStore,
       transcriptDiscovery,
@@ -89,6 +97,8 @@ describe('createSessionHandlers', () => {
       send,
       ...(opts.exitFallbackMs !== undefined && { exitFallbackMs: opts.exitFallbackMs }),
     });
+    registryOnClose = (sessionId) => handlers.resolveStopOnClose(sessionId);
+    return handlers;
   }
 
   describe('onSessionListRequest', () => {
@@ -300,10 +310,18 @@ describe('createSessionHandlers', () => {
       const handlers = makeHandlers({ exitFallbackMs: 5 });
       handlers.onKillSessionRequest(CID, sessionId, REQ);
       expect(sessionRegistry.getSession(sessionId)).toBeDefined();
+      expect(sendCalls).toHaveLength(0);
 
-      // PTY never exits (fake submitInput is a no-op); the fallback timer fires.
+      // PTY never exits (fake submitInput is a no-op); the fallback timer fires,
+      // forces the close, and the registry's onSessionClosed (wired to
+      // resolveStopOnClose in makeHandlers) acks the requester success.
       await new Promise((resolve) => setTimeout(resolve, 30));
       expect(sessionRegistry.getSession(sessionId)).toBeUndefined();
+      expect(sendCalls).toHaveLength(1);
+      const ack = sendCalls[0]?.message as { type: string; success: boolean };
+      expect(ack.type).toBe('kill_session_response');
+      expect(ack.success).toBe(true);
+      expect(sendCalls[0]?.connectionId).toBe(CID);
     });
   });
 


### PR DESCRIPTION
Addresses the release-review findings on PR #645 (develop -> main) so the 0.6.17 release ships clean.

### Important
A second `kill_session_request` for a session whose graceful `/exit` is already in flight (two clients confirming Exit within the 8s window) previously got **no reply** — the duplicate's web-side 12s timeout then pushed a misleading "Exit session timed out" even though the session exited fine. Now the duplicate **joins** the in-flight stop as a waiter: no second `/exit` is typed, and every waiter is acked `success` against its own `requestId` when the session actually closes. `PendingStop.waiters` replaces the single requester tuple.

### Minor
- `daemon.persist_sessions` now applies only to daemon-mode sessions (`!passThrough && …`), matching its "non-wrapper" comment; wrapper sessions are `locallyOwned` and never time out anyway, so behavior is unchanged.
- The forced-fallback close comment no longer claims PTY output has fully drained — true on the normal `/exit` path, but the rare 8s force path races a still-resolving `pty.close()`.

### Tests
- Duplicate stop joins the in-flight one and both requesters are acked on close.
- Force-fallback closes the session when `/exit` is not honored within the window (new injectable `exitFallbackMs` seam, consistent with the existing test seams in this handler).

All local gates green: biome, `tsc --noEmit`, and the handler suite (14 pass).