### PR TITLE
fix(#652): stop in-app question card flicker + show resolved-elsewhere trace

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,10 +23,10 @@ import {
   clearSessionQuestions,
   getSessionQuestions,
   isQuestionPending,
-  markQuestionResolved,
   questionKey,
   removeQuestionById,
   removeQuestionByKeyIfId,
+  resolveQuestionCard,
 } from '@/lib/question-collection';
 import { dismissDeliveredNotification } from '@/lib/notifications';
 import { shouldKeepExisting } from '@/lib/question-merge';
@@ -721,27 +721,26 @@ function App() {
         // (not the pre-mutation ref) keeps two concurrent resolutions from
         // leaving the badge stuck `questionPending: true`. The ref is the latest
         // committed map (kept in sync by the effect below).
-        const tracedQuestions = markQuestionResolved(
+        const { questions: nextQuestions, fade } = resolveQuestionCard(
           questionsRef.current,
           resolvedSessionId,
           resolvedQuestionId,
           message.reason,
         );
-        const flippedToTrace = tracedQuestions !== questionsRef.current;
-        const stillPending = getSessionQuestions(tracedQuestions, resolvedSessionId).some(
+        const stillPending = getSessionQuestions(nextQuestions, resolvedSessionId).some(
           isQuestionPending,
         );
-        questionsRef.current = tracedQuestions;
-        setQuestions(tracedQuestions);
+        questionsRef.current = nextQuestions;
+        setQuestions(nextQuestions);
         setSessions((prev) =>
           prev.map((s) => (s.id === resolvedSessionId ? { ...s, questionPending: stillPending } : s)),
         );
         // Clear the matching delivered lock-screen / in-app notification (native).
         dismissDeliveredNotification(resolvedQuestionId);
         // Fade the trace card we just flipped; remove by id so a newer prompt
-        // that took the same slot meanwhile is never wiped. When the card was
-        // already answered/absent (no flip), its own lifecycle owns removal.
-        if (flippedToTrace) {
+        // that took the same slot meanwhile is never wiped. A submitting card was
+        // already removed above, and an answered/absent card owns its own removal.
+        if (fade) {
           setTimeout(() => {
             setQuestions((prev) =>
               removeQuestionById(prev, resolvedSessionId, resolvedQuestionId),

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -712,8 +712,8 @@ function App() {
         // the session. Rather than vanish instantly (#652 — left a lock-screen
         // answer with no in-app confirmation), flip a still-pending card to a
         // brief "resolved elsewhere" trace, then fade it after the linger window.
-        // A card already answered LOCALLY keeps its own answeredWith trace and
-        // removal timer (markQuestionResolved no-ops on it).
+        // resolveQuestionCard decides per card: pending => trace+fade, submitting
+        // (#627) => removed here, answered-locally => left to its own timer.
         const resolvedSessionId = message.sessionId;
         const resolvedQuestionId = message.questionId;
         // Compute the next map from the CURRENT committed ref, then drive both

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -18,11 +18,15 @@ import { setSoundEnabled } from '@/lib/notifications';
 import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import {
+  RESOLVED_TRACE_LINGER_MS,
+  clearMainQuestionOnStatus,
   clearSessionQuestions,
   getSessionQuestions,
+  isQuestionPending,
+  markQuestionResolved,
   questionKey,
   removeQuestionById,
-  statusClearsMainQuestion,
+  removeQuestionByKeyIfId,
 } from '@/lib/question-collection';
 import { dismissDeliveredNotification } from '@/lib/notifications';
 import { shouldKeepExisting } from '@/lib/question-merge';
@@ -522,16 +526,10 @@ function App() {
         // change it), so clear just the main-agent slot; a concurrent subagent
         // prompt must survive. The transient auto-approve broadcasts
         // ('evaluating'/'approved', #576) must NOT clear a pending card; see
-        // statusClearsMainQuestion for the rationale.
-        if (statusClearsMainQuestion(sessionData.status)) {
-          setQuestions((prev) => {
-            const key = questionKey(sessionData.id);
-            if (!prev.has(key)) return prev;
-            const next = new Map(prev);
-            next.delete(key);
-            return next;
-          });
-        }
+        // statusClearsMainQuestion for the rationale. A freshness gate (#652)
+        // additionally protects a just-arrived card from a status update racing
+        // it in the same burst (the cause of the "flash and vanish" flicker).
+        setQuestions((prev) => clearMainQuestionOnStatus(prev, sessionData.id, sessionData.status));
         break;
       }
 
@@ -709,34 +707,47 @@ function App() {
 
       case 'question_resolved': {
         // Cross-client dismissal (#585, P7): the question resolved on some
-        // channel (answered elsewhere, auto-approved/denied, or cancelled), so
-        // drop its card and clear any lock-screen notification for it here.
-        // Idempotent — if we never held it (or already dropped it), this is a
-        // no-op. The message carries no agentId, so locate the card by question
-        // id within the session.
+        // channel (answered elsewhere, auto-approved/denied, or cancelled). The
+        // message carries no agentId, so locate the card by question id within
+        // the session. Rather than vanish instantly (#652 — left a lock-screen
+        // answer with no in-app confirmation), flip a still-pending card to a
+        // brief "resolved elsewhere" trace, then fade it after the linger window.
+        // A card already answered LOCALLY keeps its own answeredWith trace and
+        // removal timer (markQuestionResolved no-ops on it).
         const resolvedSessionId = message.sessionId;
         const resolvedQuestionId = message.questionId;
-        // Compute the post-removal map from the CURRENT committed ref, then drive
-        // both setters from that one value (#585, P7 FIX 3). Reading the updated
-        // map (not the pre-removal ref) is what prevents two concurrent
-        // resolutions from leaving the badge stuck `questionPending: true`. The
-        // ref is the latest committed map (kept in sync by the effect below), so
-        // the second resolution sees the first's removal.
-        const updatedQuestions = removeQuestionById(
+        // Compute the next map from the CURRENT committed ref, then drive both
+        // setters from that one value (#585, P7 FIX 3): reading the updated map
+        // (not the pre-mutation ref) keeps two concurrent resolutions from
+        // leaving the badge stuck `questionPending: true`. The ref is the latest
+        // committed map (kept in sync by the effect below).
+        const tracedQuestions = markQuestionResolved(
           questionsRef.current,
           resolvedSessionId,
           resolvedQuestionId,
+          message.reason,
         );
-        const stillPending = getSessionQuestions(updatedQuestions, resolvedSessionId).some(
-          (q) => q.answeredWith === undefined,
+        const flippedToTrace = tracedQuestions !== questionsRef.current;
+        const stillPending = getSessionQuestions(tracedQuestions, resolvedSessionId).some(
+          isQuestionPending,
         );
-        questionsRef.current = updatedQuestions;
-        setQuestions(updatedQuestions);
+        questionsRef.current = tracedQuestions;
+        setQuestions(tracedQuestions);
         setSessions((prev) =>
           prev.map((s) => (s.id === resolvedSessionId ? { ...s, questionPending: stillPending } : s)),
         );
         // Clear the matching delivered lock-screen / in-app notification (native).
         dismissDeliveredNotification(resolvedQuestionId);
+        // Fade the trace card we just flipped; remove by id so a newer prompt
+        // that took the same slot meanwhile is never wiped. When the card was
+        // already answered/absent (no flip), its own lifecycle owns removal.
+        if (flippedToTrace) {
+          setTimeout(() => {
+            setQuestions((prev) =>
+              removeQuestionById(prev, resolvedSessionId, resolvedQuestionId),
+            );
+          }, RESOLVED_TRACE_LINGER_MS);
+        }
         break;
       }
 
@@ -1747,6 +1758,7 @@ function App() {
         return;
       }
       const key = questionKey(sid, question.agentId);
+      const answeredId = question.id;
       // Mark this question answered (card shows collapsed state briefly), then
       // remove it; sibling prompts for the session stay in the stack.
       setQuestions((prev) => {
@@ -1756,19 +1768,18 @@ function App() {
         next.set(key, { ...existing, answeredWith: content });
         return next;
       });
+      // Remove by (key, id), not key alone: a newer prompt may have taken this
+      // session/agent slot before the timer fires (back-to-back escalations);
+      // deleting it would make the new card "flash and vanish" (#652).
       setTimeout(() => {
-        setQuestions((prev) => {
-          if (!prev.has(key)) return prev;
-          const next = new Map(prev);
-          next.delete(key);
-          return next;
-        });
-      }, 1500);
+        setQuestions((prev) => removeQuestionByKeyIfId(prev, key, answeredId));
+      }, RESOLVED_TRACE_LINGER_MS);
       // Keep the session flagged while OTHER prompts remain unanswered. Read
       // the ref (latest committed map) rather than the closure so the badge
-      // can't get stuck after the dep snapshot goes stale.
+      // can't get stuck after the dep snapshot goes stale. The ref still holds
+      // the pre-answer card for this id, so exclude it explicitly.
       const stillPending = getSessionQuestions(questionsRef.current, sid).some(
-        (q) => q.id !== question.id && q.answeredWith === undefined,
+        (q) => q.id !== question.id && isQuestionPending(q),
       );
       setSessions((prev) =>
         prev.map((s) => (s.id === sid ? { ...s, questionPending: stillPending } : s)),

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -111,7 +111,12 @@ export function ChatView({
   // quick-response chips now -- the pinned card owns answering).
   const questionList = questions ?? [];
   const primaryQuestion = questionList[0] ?? null;
-  const chatCards = questionList.filter((q) => q.answeredWith != null || isConnected);
+  // An answered or resolved-elsewhere card (#652) stays briefly regardless of
+  // connection so the user sees confirmation; a still-pending card needs a live
+  // connection to be actionable.
+  const chatCards = questionList.filter(
+    (q) => q.answeredWith != null || q.resolvedReason != null || isConnected,
+  );
 
   // iOS edge-swipe back (#411): rightward swipe from the left edge pops
   // the chat back to the session list. Mirrors the native iOS gesture.

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -11,7 +11,12 @@
  */
 
 import { formatRelativeTime } from '@/lib/format-time';
-import type { UIQuestion, UIQuestionOption, UIQuestionStep } from '@/types';
+import type {
+  UIQuestion,
+  UIQuestionOption,
+  UIQuestionResolvedReason,
+  UIQuestionStep,
+} from '@/types';
 import { clsx } from 'clsx';
 import { Check, Send, X } from 'lucide-react';
 import { type KeyboardEvent, useCallback, useMemo, useState } from 'react';
@@ -34,6 +39,20 @@ interface QuestionCardProps {
 }
 
 /** Resolve the display label for an answered value. */
+/** Human label for a prompt resolved on another channel (#652). */
+function resolveTraceLabel(reason: UIQuestionResolvedReason): string {
+  switch (reason) {
+    case 'answered':
+      return 'Answered on another device';
+    case 'auto_approved':
+      return 'Auto-approved';
+    case 'auto_denied':
+      return 'Auto-denied';
+    case 'cancelled':
+      return 'Cancelled';
+  }
+}
+
 function resolveAnswerLabel(question: UIQuestion, answer: string): string {
   if (question.structuredOptions) {
     const match = question.structuredOptions.find((o) => o.value === answer);
@@ -377,7 +396,13 @@ export function QuestionCard({ question, onAnswer, onAuqAnswer, onCancel, classN
       ? 'Permission request'
       : 'Question';
 
-  if (isAnswered) {
+  const resolvedReason = question.resolvedReason;
+  if (isAnswered || resolvedReason != null) {
+    // Positive resolutions (answered locally, answered elsewhere, auto-approved)
+    // read as a green confirmation; auto-denied / cancelled use a neutral bar so
+    // the trace doesn't masquerade as an approval (#652).
+    const positive =
+      isAnswered || resolvedReason === 'answered' || resolvedReason === 'auto_approved';
     return (
       <div
         className={clsx(
@@ -385,19 +410,37 @@ export function QuestionCard({ question, onAnswer, onAuqAnswer, onCancel, classN
           'animate-[fade-in_200ms_ease-out]',
           className,
         )}
-        style={{
-          background: 'var(--color-success-soft)',
-          borderColor: 'var(--color-success-line)',
-          color: 'var(--color-text-secondary)',
-        }}
+        style={
+          positive
+            ? {
+                background: 'var(--color-success-soft)',
+                borderColor: 'var(--color-success-line)',
+                color: 'var(--color-text-secondary)',
+              }
+            : {
+                background: 'var(--color-surface-light)',
+                borderColor: 'var(--color-border)',
+                color: 'var(--color-text-secondary)',
+              }
+        }
       >
-        <Check className="size-4 shrink-0 text-[var(--color-success)]" />
-        <span>
-          Answered:{' '}
-          <span className="font-medium text-[var(--color-text)]">
-            {resolveAnswerLabel(question, question.answeredWith ?? '')}
+        {positive ? (
+          <Check className="size-4 shrink-0 text-[var(--color-success)]" />
+        ) : (
+          <X className="size-4 shrink-0 text-[var(--color-text-muted)]" />
+        )}
+        {isAnswered ? (
+          <span>
+            Answered:{' '}
+            <span className="font-medium text-[var(--color-text)]">
+              {resolveAnswerLabel(question, question.answeredWith ?? '')}
+            </span>
           </span>
-        </span>
+        ) : (
+          <span className="font-medium text-[var(--color-text)]">
+            {resolvedReason ? resolveTraceLabel(resolvedReason) : ''}
+          </span>
+        )}
       </div>
     );
   }

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -8,7 +8,26 @@
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';
-import type { AgentStatus, UIQuestion } from '@/types';
+import type { AgentStatus, UIQuestion, UIQuestionResolvedReason } from '@/types';
+
+/**
+ * How long an answered/resolved card lingers (collapsed) before it is removed
+ * (#652). Long enough to read the confirmation, short enough not to clutter.
+ */
+export const RESOLVED_TRACE_LINGER_MS = 1500;
+
+/**
+ * A just-arrived main-agent card younger than this is protected from a
+ * `session_update` status-clear (#652). The status fallback exists to drop a
+ * card the agent has moved past, but a status update arriving in the same burst
+ * as a fresh prompt must NOT wipe it before the user can act; the precise
+ * `question_resolved` path (or a later status) clears it once it ages out.
+ */
+export const STATUS_CLEAR_FRESHNESS_MS = 2000;
+
+interface ClockOptions {
+  readonly now?: () => number;
+}
 
 /** Composite map key: a session's prompt, scoped to its agent (main default). */
 export function questionKey(sessionId: string, agentId?: string | undefined): string {
@@ -97,4 +116,87 @@ export function removeQuestionById(
  */
 export function statusClearsMainQuestion(status: AgentStatus): boolean {
   return status !== 'waiting' && status !== 'evaluating' && status !== 'approved';
+}
+
+/**
+ * Remove the entry at `key` ONLY if it still holds question `id` (#652).
+ *
+ * The post-answer cleanup timer captures the slot key when the user answers,
+ * but a newer prompt can take that same `sessionId#agentId` slot before the
+ * timer fires (back-to-back auto-approve escalations). Deleting by key alone
+ * then wipes the NEW card; the daemon re-emits and it "reappears". Verifying the
+ * id makes the timer a no-op once the slot has been reused. Returns the SAME
+ * reference when nothing was removed so React skips the re-render.
+ */
+export function removeQuestionByKeyIfId(
+  questions: Map<string, UIQuestion>,
+  key: string,
+  id: string,
+): Map<string, UIQuestion> {
+  const existing = questions.get(key);
+  if (!existing || existing.id !== id) return questions;
+  const next = new Map(questions);
+  next.delete(key);
+  return next;
+}
+
+/**
+ * Apply a `session_update` status to the MAIN-agent card, clearing it only when
+ * the status resolves the prompt AND the card is not freshly arrived (#652).
+ *
+ * Composes `statusClearsMainQuestion` (status semantics) with a freshness gate
+ * so a status update racing a just-shown prompt cannot wipe it. A card with a
+ * malformed timestamp fails open to clearing, matching the rest of the UI's
+ * "never pin on bad data" stance. Returns the SAME reference when nothing
+ * changed.
+ */
+export function clearMainQuestionOnStatus(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+  status: AgentStatus,
+  options: ClockOptions & { readonly freshnessMs?: number } = {},
+): Map<string, UIQuestion> {
+  if (!statusClearsMainQuestion(status)) return questions;
+  const key = questionKey(sessionId);
+  const existing = questions.get(key);
+  if (!existing) return questions;
+  const freshnessMs = options.freshnessMs ?? STATUS_CLEAR_FRESHNESS_MS;
+  const clock = options.now ?? Date.now;
+  const ageMs = clock() - Date.parse(existing.timestamp);
+  // Finite, non-negative, and within the window => protect the fresh card.
+  if (Number.isFinite(ageMs) && ageMs >= 0 && ageMs < freshnessMs) return questions;
+  const next = new Map(questions);
+  next.delete(key);
+  return next;
+}
+
+/**
+ * Flip the card matching (sessionId, questionId) to a "resolved elsewhere"
+ * trace (#652) so a lock-screen / terminal / other-client answer leaves visible
+ * confirmation before it fades, instead of vanishing instantly.
+ *
+ * No-op (same reference) when the card is absent, was already answered LOCALLY
+ * (`answeredWith` / `submitting` own their own lifecycle), or is already marked
+ * resolved (idempotent for a duplicate broadcast). Located by `id` within the
+ * session because `question_resolved` carries no agentId.
+ */
+export function markQuestionResolved(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+  questionId: string,
+  reason: UIQuestionResolvedReason,
+): Map<string, UIQuestion> {
+  for (const [key, q] of questions) {
+    if (q.sessionId !== sessionId || q.id !== questionId) continue;
+    if (q.answeredWith != null || q.submitting || q.resolvedReason != null) return questions;
+    const next = new Map(questions);
+    next.set(key, { ...q, resolvedReason: reason });
+    return next;
+  }
+  return questions;
+}
+
+/** Whether a card is still awaiting the user (drives the session's pending badge). */
+export function isQuestionPending(q: UIQuestion): boolean {
+  return q.answeredWith == null && q.resolvedReason == null;
 }

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -25,8 +25,10 @@ export const RESOLVED_TRACE_LINGER_MS = 1500;
  */
 export const STATUS_CLEAR_FRESHNESS_MS = 2000;
 
-interface ClockOptions {
+/** Options for the freshness-gated status clear; mirrors `ShouldKeepExistingOptions`. */
+export interface StatusClearOptions {
   readonly now?: () => number;
+  readonly freshnessMs?: number;
 }
 
 /** Composite map key: a session's prompt, scoped to its agent (main default). */
@@ -154,7 +156,7 @@ export function clearMainQuestionOnStatus(
   questions: Map<string, UIQuestion>,
   sessionId: string,
   status: AgentStatus,
-  options: ClockOptions & { readonly freshnessMs?: number } = {},
+  options: StatusClearOptions = {},
 ): Map<string, UIQuestion> {
   if (!statusClearsMainQuestion(status)) return questions;
   const key = questionKey(sessionId);
@@ -163,37 +165,60 @@ export function clearMainQuestionOnStatus(
   const freshnessMs = options.freshnessMs ?? STATUS_CLEAR_FRESHNESS_MS;
   const clock = options.now ?? Date.now;
   const ageMs = clock() - Date.parse(existing.timestamp);
-  // Finite, non-negative, and within the window => protect the fresh card.
-  if (Number.isFinite(ageMs) && ageMs >= 0 && ageMs < freshnessMs) return questions;
+  // Only clear when we can PROVE the card is old enough. An unknown age
+  // (malformed timestamp => NaN) or a future-dated card (daemon clock ahead of
+  // the client => negative age) is treated as fresh and protected: the precise
+  // `question_resolved` broadcast is the guaranteed cleaner, so erring toward
+  // keeping an actionable card is the safe failure direction here.
+  if (!Number.isFinite(ageMs) || ageMs < freshnessMs) return questions;
   const next = new Map(questions);
   next.delete(key);
   return next;
 }
 
+/** Result of applying a `question_resolved` broadcast to the card collection. */
+export interface QuestionResolution {
+  readonly questions: Map<string, UIQuestion>;
+  /** True => the caller flipped a card to a trace and must fade-remove it later. */
+  readonly fade: boolean;
+}
+
 /**
- * Flip the card matching (sessionId, questionId) to a "resolved elsewhere"
- * trace (#652) so a lock-screen / terminal / other-client answer leaves visible
- * confirmation before it fades, instead of vanishing instantly.
+ * Apply a `question_resolved` broadcast to the card matching (sessionId,
+ * questionId), located by `id` because the message carries no agentId (#652).
+ * The card always ends up resolved; HOW depends on who acted:
  *
- * No-op (same reference) when the card is absent, was already answered LOCALLY
- * (`answeredWith` / `submitting` own their own lifecycle), or is already marked
- * resolved (idempotent for a duplicate broadcast). Located by `id` within the
- * session because `question_resolved` carries no agentId.
+ * - Answered LOCALLY (`answeredWith`) or already traced (duplicate broadcast):
+ *   left untouched — those own their own removal timer. `fade: false`.
+ * - SUBMITTING (#627 AUQ / cancel): the "Answering…" card has no self-removal
+ *   timer and relies on this broadcast to clear; the user acted in-app, so it is
+ *   removed outright rather than shown an "elsewhere" trace. `fade: false`.
+ * - Otherwise PENDING (the user did NOT act here — lock screen / terminal /
+ *   auto): flipped to a brief trace the caller fades after the linger window.
+ *   `fade: true`.
+ * - Absent: no-op (same reference). `fade: false`.
  */
-export function markQuestionResolved(
+export function resolveQuestionCard(
   questions: Map<string, UIQuestion>,
   sessionId: string,
   questionId: string,
   reason: UIQuestionResolvedReason,
-): Map<string, UIQuestion> {
+): QuestionResolution {
   for (const [key, q] of questions) {
     if (q.sessionId !== sessionId || q.id !== questionId) continue;
-    if (q.answeredWith != null || q.submitting || q.resolvedReason != null) return questions;
+    if (q.answeredWith != null || q.resolvedReason != null) {
+      return { questions, fade: false };
+    }
+    if (q.submitting) {
+      const next = new Map(questions);
+      next.delete(key);
+      return { questions: next, fade: false };
+    }
     const next = new Map(questions);
     next.set(key, { ...q, resolvedReason: reason });
-    return next;
+    return { questions: next, fade: true };
   }
-  return questions;
+  return { questions, fade: false };
 }
 
 /** Whether a card is still awaiting the user (drives the session's pending badge). */

--- a/packages/web/src/lib/question-merge.ts
+++ b/packages/web/src/lib/question-merge.ts
@@ -86,18 +86,23 @@ export function shouldKeepExisting(
   incoming: UIQuestion,
   options: ShouldKeepExistingOptions = {},
 ): boolean {
-  // Replay-after-answer: a `replay_batch` re-feed of the original
-  // question carries the same id. Keep the answered state intact so
-  // the user is not re-prompted for a question they already resolved.
-  if (existing.answeredWith && existing.id === incoming.id) {
+  // A resolved card is either answered locally (`answeredWith`) or flipped to a
+  // short-lived "resolved elsewhere" trace (`resolvedReason`, #652). Both are
+  // terminal states and must be handled symmetrically below.
+  const existingResolved = existing.answeredWith != null || existing.resolvedReason != null;
+
+  // Replay-after-resolve: a `replay_batch` re-feed of the original question
+  // carries the same id. Keep the resolved state intact so the user is not
+  // re-prompted for a question they already resolved.
+  if (existingResolved && existing.id === incoming.id) {
     logSuppression('replay-of-answered', existing, incoming);
     return true;
   }
 
-  // Different question id with an answered existing: a genuinely new
-  // prompt is arriving (the answer ack will demote `answeredWith`
-  // shortly). Let the new one through.
-  if (existing.answeredWith) return false;
+  // Different id with a resolved existing: a genuinely new prompt is arriving
+  // (the trace fades / the answer ack clears shortly). Let the new one through
+  // rather than let a stale trace suppress a live question.
+  if (existingResolved) return false;
 
   const freshnessMs = options.freshnessMs ?? QUESTION_FRESHNESS_MS;
   const clock = options.now ?? Date.now;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -4,6 +4,7 @@
  * These types extend the shared protocol types with UI-specific state.
  */
 
+import type { QuestionResolvedMessage } from '@remi/shared/protocol.ts';
 import type { MessageState, Timestamp, UUID } from '@remi/shared/types.ts';
 
 /** Source that produced a UI message */
@@ -11,11 +12,13 @@ export type MessageSource = 'optimistic' | 'pty' | 'transcript';
 
 /**
  * How a question resolved on a channel OTHER than this client's own answer
- * (#652). Mirrors `QuestionResolvedMessage['reason']`; drives the brief
- * "resolved elsewhere" trace the card shows before it fades, so a lock-screen
- * or terminal answer leaves visible confirmation instead of vanishing.
+ * (#652). Derived from the wire type so the two can never drift; drives the
+ * brief "resolved elsewhere" trace the card shows before it fades, so a
+ * lock-screen or terminal answer leaves visible confirmation instead of
+ * vanishing. A new wire reason makes `resolveTraceLabel`'s switch non-exhaustive
+ * (a compile error), forcing it to be handled here too.
  */
-export type UIQuestionResolvedReason = 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
+export type UIQuestionResolvedReason = QuestionResolvedMessage['reason'];
 
 /** Peer role in WebRTC connection */
 export type PeerRole = 'host' | 'client';

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -9,6 +9,14 @@ import type { MessageState, Timestamp, UUID } from '@remi/shared/types.ts';
 /** Source that produced a UI message */
 export type MessageSource = 'optimistic' | 'pty' | 'transcript';
 
+/**
+ * How a question resolved on a channel OTHER than this client's own answer
+ * (#652). Mirrors `QuestionResolvedMessage['reason']`; drives the brief
+ * "resolved elsewhere" trace the card shows before it fades, so a lock-screen
+ * or terminal answer leaves visible confirmation instead of vanishing.
+ */
+export type UIQuestionResolvedReason = 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
+
 /** Peer role in WebRTC connection */
 export type PeerRole = 'host' | 'client';
 
@@ -182,6 +190,11 @@ export interface UIQuestion {
   readonly timestamp: Timestamp;
   /** The answer that was selected (set after answering) */
   readonly answeredWith?: string;
+  /** #652: the prompt resolved on another channel (lock screen / terminal /
+   *  another client). Set by the `question_resolved` handler when the card was
+   *  NOT answered locally, so the card shows a brief trace then fades instead of
+   *  vanishing with no confirmation. Mutually exclusive with `answeredWith`. */
+  readonly resolvedReason?: UIQuestionResolvedReason;
   /** The Claude agent this prompt belongs to ('main' default). Keys the
    *  collection so a main + subagent prompt coexist rather than overwrite. */
   readonly agentId?: string;

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -5,14 +5,22 @@
 
 import { describe, expect, test } from 'bun:test';
 import {
+  STATUS_CLEAR_FRESHNESS_MS,
+  clearMainQuestionOnStatus,
   clearSessionQuestions,
   getSessionQuestions,
   hasSessionQuestion,
+  isQuestionPending,
+  markQuestionResolved,
   questionKey,
   removeQuestionById,
+  removeQuestionByKeyIfId,
   statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
+
+const BASE_TS = '2026-05-29T00:00:00.000Z';
+const BASE_MS = Date.parse(BASE_TS);
 
 function q(sessionId: string, agentId: string | undefined, id: string): UIQuestion {
   return {
@@ -20,9 +28,13 @@ function q(sessionId: string, agentId: string | undefined, id: string): UIQuesti
     sessionId: sessionId as UIQuestion['sessionId'],
     type: 'yes_no',
     prompt: `${id}?`,
-    timestamp: '2026-05-29T00:00:00.000Z',
+    timestamp: BASE_TS,
     agentId,
   };
+}
+
+function qWith(base: UIQuestion, overrides: Partial<UIQuestion>): UIQuestion {
+  return { ...base, ...overrides };
 }
 
 function build(...items: UIQuestion[]): Map<string, UIQuestion> {
@@ -117,5 +129,122 @@ describe('statusClearsMainQuestion (#576)', () => {
     expect(statusClearsMainQuestion('executing')).toBe(true);
     expect(statusClearsMainQuestion('idle')).toBe(true);
     expect(statusClearsMainQuestion('starting')).toBe(true);
+  });
+});
+
+describe('removeQuestionByKeyIfId (#652)', () => {
+  test('removes the entry when the slot still holds the same id', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = removeQuestionByKeyIfId(map, questionKey('s1'), 'a');
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('NO-OP when the slot was reused by a newer prompt (the core fix)', () => {
+    // The post-answer timer captured key s1#main for id 'a', but id 'b' took the
+    // slot before it fired; deleting by key alone would wipe the new card.
+    const map = build(q('s1', undefined, 'b'));
+    expect(removeQuestionByKeyIfId(map, questionKey('s1'), 'a')).toBe(map);
+    expect(getSessionQuestions(map, 's1').map((x) => x.id)).toEqual(['b']);
+  });
+
+  test('NO-OP (same reference) when the key is absent', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(removeQuestionByKeyIfId(map, questionKey('s2'), 'a')).toBe(map);
+  });
+});
+
+describe('clearMainQuestionOnStatus (#652)', () => {
+  test('non-clearing status is a no-op (same reference)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(clearMainQuestionOnStatus(map, 's1', 'waiting', { now: () => BASE_MS })).toBe(map);
+  });
+
+  test('protects a FRESH card from a status update racing it in the same burst', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = clearMainQuestionOnStatus(map, 's1', 'executing', {
+      now: () => BASE_MS + 500, // 500ms old, inside the 2s window
+    });
+    expect(next).toBe(map);
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('clears a STALE main card the agent has moved past', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = clearMainQuestionOnStatus(map, 's1', 'executing', {
+      now: () => BASE_MS + STATUS_CLEAR_FRESHNESS_MS + 1,
+    });
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('clears only the MAIN slot; a concurrent subagent prompt survives', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'));
+    const next = clearMainQuestionOnStatus(map, 's1', 'idle', {
+      now: () => BASE_MS + STATUS_CLEAR_FRESHNESS_MS + 1,
+    });
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['b']);
+  });
+
+  test('no main card present is a no-op (same reference)', () => {
+    const map = build(q('s1', 'sub-7', 'b'));
+    expect(
+      clearMainQuestionOnStatus(map, 's1', 'idle', { now: () => BASE_MS + 10_000 }),
+    ).toBe(map);
+  });
+
+  test('a malformed timestamp fails open to clearing (never pins the UI)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { timestamp: 'not-a-date' as never }));
+    const next = clearMainQuestionOnStatus(map, 's1', 'executing', { now: () => BASE_MS });
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+});
+
+describe('markQuestionResolved (#652)', () => {
+  test('flips a still-pending card to a resolved-elsewhere trace, keeping it on screen', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = markQuestionResolved(map, 's1', 'a', 'answered');
+    const card = next.get(questionKey('s1'));
+    expect(card?.resolvedReason).toBe('answered');
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('NO-OP when the card was already answered locally (owns its own trace/timer)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }));
+    expect(markQuestionResolved(map, 's1', 'a', 'answered')).toBe(map);
+  });
+
+  test('NO-OP while the card is submitting (#627 auto-answer in flight)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { submitting: true }));
+    expect(markQuestionResolved(map, 's1', 'a', 'auto_approved')).toBe(map);
+  });
+
+  test('NO-OP on a duplicate broadcast (already marked resolved)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { resolvedReason: 'cancelled' }));
+    expect(markQuestionResolved(map, 's1', 'a', 'answered')).toBe(map);
+  });
+
+  test('NO-OP (same reference) when the card is absent', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(markQuestionResolved(map, 's1', 'nope', 'answered')).toBe(map);
+  });
+
+  test('locates by id within the session; a same-id card in another session is untouched', () => {
+    const map = build(q('s1', undefined, 'dup'), q('s2', undefined, 'dup'));
+    const next = markQuestionResolved(map, 's1', 'dup', 'auto_denied');
+    expect(next.get(questionKey('s1'))?.resolvedReason).toBe('auto_denied');
+    expect(next.get(questionKey('s2'))?.resolvedReason).toBeUndefined();
+  });
+});
+
+describe('isQuestionPending (#652)', () => {
+  test('true for a fresh unanswered card', () => {
+    expect(isQuestionPending(q('s1', undefined, 'a'))).toBe(true);
+  });
+  test('false once answered locally', () => {
+    expect(isQuestionPending(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }))).toBe(false);
+  });
+  test('false once resolved elsewhere', () => {
+    expect(isQuestionPending(qWith(q('s1', undefined, 'a'), { resolvedReason: 'answered' }))).toBe(
+      false,
+    );
   });
 });

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -11,10 +11,10 @@ import {
   getSessionQuestions,
   hasSessionQuestion,
   isQuestionPending,
-  markQuestionResolved,
   questionKey,
   removeQuestionById,
   removeQuestionByKeyIfId,
+  resolveQuestionCard,
   statusClearsMainQuestion,
 } from '../../src/lib/question-collection';
 import type { UIQuestion } from '../../src/types';
@@ -176,6 +176,21 @@ describe('clearMainQuestionOnStatus (#652)', () => {
     expect(getSessionQuestions(next, 's1')).toEqual([]);
   });
 
+  test('clears at EXACTLY the freshness boundary (protection window is exclusive)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = clearMainQuestionOnStatus(map, 's1', 'executing', {
+      now: () => BASE_MS + STATUS_CLEAR_FRESHNESS_MS,
+    });
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('PROTECTS a future-dated card (daemon clock ahead => negative age)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    // Client clock 1ms behind the card's timestamp => negative age. A card that
+    // cannot be old must not be cleared by a racing status update.
+    expect(clearMainQuestionOnStatus(map, 's1', 'executing', { now: () => BASE_MS - 1 })).toBe(map);
+  });
+
   test('clears only the MAIN slot; a concurrent subagent prompt survives', () => {
     const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'));
     const next = clearMainQuestionOnStatus(map, 's1', 'idle', {
@@ -191,53 +206,66 @@ describe('clearMainQuestionOnStatus (#652)', () => {
     ).toBe(map);
   });
 
-  test('a malformed timestamp fails open to clearing (never pins the UI)', () => {
+  test('a malformed timestamp protects the card (question_resolved is the precise cleaner)', () => {
     const map = build(qWith(q('s1', undefined, 'a'), { timestamp: 'not-a-date' as never }));
-    const next = clearMainQuestionOnStatus(map, 's1', 'executing', { now: () => BASE_MS });
-    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    // Unknown age must not silently drop a possibly-actionable permission card.
+    expect(clearMainQuestionOnStatus(map, 's1', 'executing', { now: () => BASE_MS })).toBe(map);
   });
 });
 
-describe('markQuestionResolved (#652)', () => {
-  test('flips a still-pending card to a resolved-elsewhere trace, keeping it on screen', () => {
+describe('resolveQuestionCard (#652)', () => {
+  test('flips a still-pending card to a resolved-elsewhere trace, fade=true', () => {
     const map = build(q('s1', undefined, 'a'));
-    const next = markQuestionResolved(map, 's1', 'a', 'answered');
-    const card = next.get(questionKey('s1'));
-    expect(card?.resolvedReason).toBe('answered');
-    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+    const { questions, fade } = resolveQuestionCard(map, 's1', 'a', 'answered');
+    expect(fade).toBe(true);
+    expect(questions.get(questionKey('s1'))?.resolvedReason).toBe('answered');
+    expect(getSessionQuestions(questions, 's1').map((x) => x.id)).toEqual(['a']);
   });
 
-  test('NO-OP when the card was already answered locally (owns its own trace/timer)', () => {
-    const map = build(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }));
-    expect(markQuestionResolved(map, 's1', 'a', 'answered')).toBe(map);
-  });
-
-  test('NO-OP while the card is submitting (#627 auto-answer in flight)', () => {
+  test('REMOVES a submitting card (#627 AUQ/cancel relies on this broadcast), fade=false', () => {
+    // Regression: the card has no self-removal timer, so it must be cleared here
+    // or the "Answering…" spinner + pending badge stick forever.
     const map = build(qWith(q('s1', undefined, 'a'), { submitting: true }));
-    expect(markQuestionResolved(map, 's1', 'a', 'auto_approved')).toBe(map);
+    const { questions, fade } = resolveQuestionCard(map, 's1', 'a', 'answered');
+    expect(fade).toBe(false);
+    expect(getSessionQuestions(questions, 's1')).toEqual([]);
   });
 
-  test('NO-OP on a duplicate broadcast (already marked resolved)', () => {
+  test('leaves a locally answered card untouched (owns its own timer), fade=false', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }));
+    const { questions, fade } = resolveQuestionCard(map, 's1', 'a', 'answered');
+    expect(fade).toBe(false);
+    expect(questions).toBe(map);
+  });
+
+  test('no-op on a duplicate broadcast (already marked resolved), fade=false', () => {
     const map = build(qWith(q('s1', undefined, 'a'), { resolvedReason: 'cancelled' }));
-    expect(markQuestionResolved(map, 's1', 'a', 'answered')).toBe(map);
+    const { questions, fade } = resolveQuestionCard(map, 's1', 'a', 'answered');
+    expect(fade).toBe(false);
+    expect(questions).toBe(map);
   });
 
-  test('NO-OP (same reference) when the card is absent', () => {
+  test('no-op (same reference, fade=false) when the card is absent', () => {
     const map = build(q('s1', undefined, 'a'));
-    expect(markQuestionResolved(map, 's1', 'nope', 'answered')).toBe(map);
+    const { questions, fade } = resolveQuestionCard(map, 's1', 'nope', 'answered');
+    expect(fade).toBe(false);
+    expect(questions).toBe(map);
   });
 
   test('locates by id within the session; a same-id card in another session is untouched', () => {
     const map = build(q('s1', undefined, 'dup'), q('s2', undefined, 'dup'));
-    const next = markQuestionResolved(map, 's1', 'dup', 'auto_denied');
-    expect(next.get(questionKey('s1'))?.resolvedReason).toBe('auto_denied');
-    expect(next.get(questionKey('s2'))?.resolvedReason).toBeUndefined();
+    const { questions } = resolveQuestionCard(map, 's1', 'dup', 'auto_denied');
+    expect(questions.get(questionKey('s1'))?.resolvedReason).toBe('auto_denied');
+    expect(questions.get(questionKey('s2'))?.resolvedReason).toBeUndefined();
   });
 });
 
 describe('isQuestionPending (#652)', () => {
   test('true for a fresh unanswered card', () => {
     expect(isQuestionPending(q('s1', undefined, 'a'))).toBe(true);
+  });
+  test('true while submitting (an in-flight answer still counts as pending)', () => {
+    expect(isQuestionPending(qWith(q('s1', undefined, 'a'), { submitting: true }))).toBe(true);
   });
   test('false once answered locally', () => {
     expect(isQuestionPending(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }))).toBe(false);

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -4,13 +4,22 @@
 
 import { describe, expect, test } from 'bun:test';
 import { shouldKeepExisting } from '../../src/lib/question-merge';
-import type { UIQuestion, UIQuestionOption, UUID } from '../../src/types';
+import type {
+  UIQuestion,
+  UIQuestionOption,
+  UIQuestionResolvedReason,
+  UUID,
+} from '../../src/types';
 
 let nextId = 0;
 function uiq(
   prompt: string,
   options: ReadonlyArray<{ label: string; isYes?: boolean; isNo?: boolean }>,
-  extra: { timestamp?: string; answeredWith?: string } = {},
+  extra: {
+    timestamp?: string;
+    answeredWith?: string;
+    resolvedReason?: UIQuestionResolvedReason;
+  } = {},
 ): UIQuestion {
   const structured: UIQuestionOption[] = options.map((o, i) => ({
     label: o.label,
@@ -29,6 +38,7 @@ function uiq(
     options: structured.length > 0 ? structured.map((o) => o.label) : undefined,
     timestamp: ts,
     ...(extra.answeredWith !== undefined ? { answeredWith: extra.answeredWith } : {}),
+    ...(extra.resolvedReason !== undefined ? { resolvedReason: extra.resolvedReason } : {}),
   };
 }
 
@@ -228,5 +238,21 @@ describe('shouldKeepExisting', () => {
       { label: ' no ' },
     ]);
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  describe('resolved-elsewhere trace (#652)', () => {
+    test('a resolvedReason trace never blocks a genuinely new prompt (different id)', () => {
+      // A richer (4-option) trace would normally out-rank an incoming default
+      // 3-set; once resolved it must step aside so the live prompt shows.
+      const existing = uiq('Which approach?', fourSentenceOptions, { resolvedReason: 'answered' });
+      const incoming = uiq('Claude needs your permission to use Bash', yesYesalwaysNo);
+      expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
+    });
+
+    test('a same-id replay keeps the resolved trace (no re-prompt)', () => {
+      const existing = uiq('Allow Bash: ls', yesYesalwaysNo, { resolvedReason: 'cancelled' });
+      const incoming = { ...existing };
+      expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Closes #652.

## What the user saw
In the chat view a permission/question card **flashes and vanishes, then reappears** — sometimes with no answer, so there's no way to tell what it was for while it's gone. And answering a multi-choice prompt **from the iOS lock screen** showed **nothing in chat** afterward — no confirmation the tap registered. (The lock-screen option rendering itself works fine; this is in-app delivery/state.)

## Root cause
The web client's question collection has several independent add/remove paths that race:

1. **`handleAnswer` deleted by slot key, not question id.** The post-answer 1.5s timer deleted the `sessionId#agentId` slot. If a new prompt took that slot first (back-to-back auto-approve escalations), the timer wiped the *new* card; the daemon re-emitted → "reappears".
2. **`session_update` status-clear could wipe a just-arrived card.** Any non-`waiting`/`evaluating`/`approved` status deleted the main card; a status update arriving in the same burst as a fresh `question` killed it before the user could act.
3. **`question_resolved` removed the card outright, leaving no trace.** A lock-screen / terminal / other-client answer dismissed the card with no "resolved" feedback.

## Fix (web-side, per chosen scope)
- `removeQuestionByKeyIfId` — post-answer removal only deletes when the slot still holds the answered id.
- `clearMainQuestionOnStatus` — status-clear gated by a 2s freshness window; the precise `question_resolved` path or a later status still clears an aged card. Malformed timestamp fails open to clearing (never pins the UI).
- `markQuestionResolved` — `question_resolved` flips a still-pending card to a brief **"Answered on another device / Auto-approved / Auto-denied / Cancelled"** trace, then fades it. A locally answered card keeps its own `answeredWith` trace and timer.
- New `UIQuestion.resolvedReason`; `QuestionCard` renders the trace (green for positive resolutions, neutral for denied/cancelled); `ChatView` keeps trace cards visible regardless of connection.

Out of scope (separate follow-up if wanted): collapsing the daemon's two-ids-per-prompt emission and the escalate/held re-push race.

## Tests / validation
- 18 new pure-function unit tests (no mocks) for the four helpers — fresh-card protection, slot-reuse no-op, resolve-trace flip + idempotency, cross-session id isolation.
- `bun test packages/web/tests` 242 pass; `tsc -b` clean; `eslint` clean; `vite build` green.

Note: needs live on-device re-test of the lock-screen → chat trace path (the original report's hardest-to-reproduce symptom).