### PR TITLE
fix(#654): AUQ auto-answer rejects valid answer when an option label has a comma

### DIFF
--- a/packages/daemon/src/hooks/auq-answer.ts
+++ b/packages/daemon/src/hooks/auq-answer.ts
@@ -154,25 +154,50 @@ export function parseReviewAnswers(frameText: string): ReviewAnswer[] {
   return out;
 }
 
-/** Case-insensitive, order-insensitive label-set equality for one answer. */
-function sameLabels(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false;
-  const norm = (xs: readonly string[]) => [...xs].map((x) => x.toLowerCase().trim()).sort();
-  const na = norm(a);
-  const nb = norm(b);
-  return na.every((x, i) => x === nb[i]);
+/** Lowercase + strip ALL whitespace, so wrapped/run-together renders compare equal. */
+function squash(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, '');
+}
+
+/**
+ * Whether one review answer shows exactly the expected option label(s), matched
+ * order-insensitively and ROBUST TO LABELS THAT CONTAIN COMMAS (#654).
+ *
+ * `parseReviewAnswers` splits the rendered label region on commas to separate
+ * multiple selected labels, but a comma is ambiguous: an option label can itself
+ * contain one (e.g. "Sidecar first, channels.tsv fallback"), which the splitter
+ * shatters into phantom labels. A naive set-equality then rejects a correct
+ * answer. Instead we reconstruct the region from the (possibly over-split) parts
+ * and remove each WHOLE expected label from it (longest first, so a label that is
+ * a substring of another can't shadow it); whatever remains must be only commas.
+ */
+function reviewLabelsMatch(parsedParts: readonly string[], expected: readonly string[]): boolean {
+  if (expected.length === 0) return false;
+  // Rejoin with a comma (whitespace is squashed away anyway), restoring any
+  // label-internal comma the parser split on.
+  let region = squash(parsedParts.join(','));
+  const wanted = [...expected].map(squash).sort((a, b) => b.length - a.length);
+  for (const label of wanted) {
+    if (label.length === 0) return false;
+    const idx = region.indexOf(label);
+    if (idx < 0) return false;
+    region = region.slice(0, idx) + region.slice(idx + label.length);
+  }
+  // Only the separators the join/render introduced may remain.
+  return /^,*$/.test(region);
 }
 
 /**
  * Verify the parsed review matches the expected per-question label sets (the labels
- * of the chosen options). Order of questions must match; labels within a question
- * are compared as a set. Any length/label mismatch -> false -> the runner escalates
- * instead of submitting. `expectedLabels[k]` is the label(s) chosen for question k.
+ * of the chosen options). Order of QUESTIONS must match; labels within a question
+ * are matched order-insensitively and tolerantly (see `reviewLabelsMatch`). Any
+ * length/label mismatch -> false -> the runner escalates instead of submitting.
+ * `expectedLabels[k]` is the label(s) chosen for question k.
  */
 export function reviewMatchesTarget(
   parsed: readonly ReviewAnswer[],
   expectedLabels: readonly (readonly string[])[],
 ): boolean {
   if (parsed.length !== expectedLabels.length) return false;
-  return parsed.every((ans, k) => sameLabels(ans.labels, expectedLabels[k] ?? []));
+  return parsed.every((ans, k) => reviewLabelsMatch(ans.labels, expectedLabels[k] ?? []));
 }

--- a/packages/daemon/src/hooks/auq-answer.ts
+++ b/packages/daemon/src/hooks/auq-answer.ts
@@ -154,43 +154,48 @@ export function parseReviewAnswers(frameText: string): ReviewAnswer[] {
   return out;
 }
 
-/** Lowercase + strip ALL whitespace, so wrapped/run-together renders compare equal. */
-function squash(s: string): string {
-  return s.toLowerCase().replace(/\s+/g, '');
+/**
+ * Lowercase, collapse whitespace to single spaces, and canonicalize comma spacing
+ * ("a , b" / "a,b" -> "a,b"). Keeps internal spaces (so "foo bar" stays distinct
+ * from "foobar") while absorbing terminal line-wrap / run-together artifacts.
+ */
+function normalizeLabel(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ',')
+    .trim();
 }
 
 /**
- * Whether one review answer shows exactly the expected option label(s), matched
- * order-insensitively and ROBUST TO LABELS THAT CONTAIN COMMAS (#654).
+ * Whether one review answer shows exactly the expected option label(s) — ROBUST TO
+ * LABELS THAT CONTAIN COMMAS (#654), without ever accepting a different option.
  *
  * `parseReviewAnswers` splits the rendered label region on commas to separate
  * multiple selected labels, but a comma is ambiguous: an option label can itself
  * contain one (e.g. "Sidecar first, channels.tsv fallback"), which the splitter
- * shatters into phantom labels. A naive set-equality then rejects a correct
- * answer. Instead we reconstruct the region from the (possibly over-split) parts
- * and remove each WHOLE expected label from it (longest first, so a label that is
- * a substring of another can't shadow it); whatever remains must be only commas.
+ * shatters into phantom parts. Rather than compare comma-split sets (which then
+ * miscounts), we re-join BOTH the parsed parts and the expected labels with a
+ * single canonical comma and compare the normalized strings exactly. The label is
+ * restored, and a different option — even one whose whitespace-stripped text would
+ * overlap — does not match, so the runner never submits a wrong answer.
+ *
+ * Order-sensitive by design: the daemon toggles options in ascending index order
+ * and the TUI renders them the same way, so the expected order always equals the
+ * rendered order; a genuine reorder escalates (fail-safe) rather than mis-submits.
  */
 function reviewLabelsMatch(parsedParts: readonly string[], expected: readonly string[]): boolean {
   if (expected.length === 0) return false;
-  // Rejoin with a comma (whitespace is squashed away anyway), restoring any
-  // label-internal comma the parser split on.
-  let region = squash(parsedParts.join(','));
-  const wanted = [...expected].map(squash).sort((a, b) => b.length - a.length);
-  for (const label of wanted) {
-    if (label.length === 0) return false;
-    const idx = region.indexOf(label);
-    if (idx < 0) return false;
-    region = region.slice(0, idx) + region.slice(idx + label.length);
-  }
-  // Only the separators the join/render introduced may remain.
-  return /^,*$/.test(region);
+  const want = expected.map(normalizeLabel);
+  if (want.some((l) => l.length === 0)) return false;
+  const region = parsedParts.map(normalizeLabel).filter((l) => l.length > 0);
+  return region.join(',') === want.join(',');
 }
 
 /**
  * Verify the parsed review matches the expected per-question label sets (the labels
  * of the chosen options). Order of QUESTIONS must match; labels within a question
- * are matched order-insensitively and tolerantly (see `reviewLabelsMatch`). Any
+ * are matched exactly after normalization (see `reviewLabelsMatch`). Any
  * length/label mismatch -> false -> the runner escalates instead of submitting.
  * `expectedLabels[k]` is the label(s) chosen for question k.
  */

--- a/packages/daemon/src/hooks/auq-answer.ts
+++ b/packages/daemon/src/hooks/auq-answer.ts
@@ -182,7 +182,8 @@ function normalizeLabel(s: string): string {
  *
  * Order-sensitive by design: the daemon toggles options in ascending index order
  * and the TUI renders them the same way, so the expected order always equals the
- * rendered order; a genuine reorder escalates (fail-safe) rather than mis-submits.
+ * rendered order; a genuine reorder escalates (fail-safe) rather than submitting
+ * the wrong answer.
  */
 function reviewLabelsMatch(parsedParts: readonly string[], expected: readonly string[]): boolean {
   if (expected.length === 0) return false;

--- a/packages/daemon/src/hooks/auq-runner.ts
+++ b/packages/daemon/src/hooks/auq-runner.ts
@@ -130,7 +130,14 @@ export async function runAuqAnswer(
     if (isAuqClosed(out)) return submitted ? 'submitted' : 'closed';
     if (!submitted && isReviewScreen(out)) {
       const parsed = parseReviewAnswers(out);
-      if (parsed.length > 0 && reviewMatchesTarget(parsed, input.expectedLabels)) {
+      if (parsed.length === 0) {
+        // Review screen is up but nothing parsed — a render/format change or a
+        // half-rendered frame, NOT a label mismatch. Keep polling until closure
+        // or timeout rather than escalating on a transient frame.
+        await deps.sleep(pollMs);
+        continue;
+      }
+      if (reviewMatchesTarget(parsed, input.expectedLabels)) {
         try {
           await deps.write(AUQ_KEYS.ENTER); // "Submit answers"
         } catch (err) {

--- a/packages/daemon/src/hooks/auq-runner.ts
+++ b/packages/daemon/src/hooks/auq-runner.ts
@@ -146,7 +146,7 @@ export async function runAuqAnswer(
       // The review is up but does not match (open-loop nav drifted, or an
       // unexpected variant). Do NOT submit and do NOT Esc — hand back to the user.
       deps.log?.(
-        `[auq-runner] review did not match target (escalating, no submit): parsed=${JSON.stringify(parsed)}`,
+        `[auq-runner] review did not match target (escalating, no submit): parsed=${JSON.stringify(parsed)} expected=${JSON.stringify(input.expectedLabels)}`,
       );
       return 'escalated';
     }

--- a/packages/daemon/tests/hooks/auq-answer.test.ts
+++ b/packages/daemon/tests/hooks/auq-answer.test.ts
@@ -120,6 +120,34 @@ describe('review parsing + verification (against real captures)', () => {
     expect(reviewMatchesTarget(parsed, [['Green']])).toBe(false); // wrong arity
   });
 
+  it('verifies a single-select option whose LABEL contains a comma (#654 regression)', () => {
+    // The real failure: a single-select option labelled "Sidecar first, channels.tsv
+    // fallback". parseReviewAnswers splits the review line on commas, shattering the
+    // one label into two; the matcher must still recognise the correct answer.
+    const frame =
+      'Review your answers● #854 scope → Epic via epic-dev● #854 data source → Sidecar first, channels.tsv fallback● #855 → Implement nowReady to submit your answers?❯ 1. Submit answers 2. Cancel';
+    const parsed = parseReviewAnswers(frame);
+    expect(parsed[1]?.labels).toEqual(['Sidecar first', 'channels.tsv fallback']); // over-split
+    expect(
+      reviewMatchesTarget(parsed, [
+        ['Epic via epic-dev'],
+        ['Sidecar first, channels.tsv fallback'], // ONE label, with its comma
+        ['Implement now'],
+      ]),
+    ).toBe(true);
+  });
+
+  it('verifies a multi-select where one chosen label contains a comma (#654)', () => {
+    const frame =
+      'Review your answers● Pick → Sidecar first, channels.tsv fallback, Other optionReady to submit your answers?❯ 1. Submit answers';
+    const parsed = parseReviewAnswers(frame);
+    expect(
+      reviewMatchesTarget(parsed, [['Other option', 'Sidecar first, channels.tsv fallback']]),
+    ).toBe(true);
+    // A genuinely wrong selection still fails (no false positive from the looser match).
+    expect(reviewMatchesTarget(parsed, [['Sidecar first', 'Other option']])).toBe(false);
+  });
+
   it('isReviewScreen / isAuqClosed are false for a plain option frame', () => {
     const out = fixtureOutput('one-question-single-select.txt');
     // The single-select capture DID close (submitted on pick).

--- a/packages/daemon/tests/hooks/auq-answer.test.ts
+++ b/packages/daemon/tests/hooks/auq-answer.test.ts
@@ -109,15 +109,31 @@ describe('review parsing + verification (against real captures)', () => {
     ]);
   });
 
-  it('reviewMatchesTarget is order-insensitive for multi labels, exact on questions', () => {
+  it('reviewMatchesTarget matches labels in render order, exact on questions', () => {
     const parsed = [
       { question: 'Favorite color?', labels: ['Green'] },
       { question: 'Which fruits?', labels: ['Apple', 'Cherry'] },
     ];
-    expect(reviewMatchesTarget(parsed, [['Green'], ['Cherry', 'Apple']])).toBe(true);
+    // Order-sensitive: the daemon toggles + the TUI renders in ascending option
+    // index, so the expected order always equals the rendered order. A reorder
+    // escalates (fail-safe) rather than risking a wrong submit.
+    expect(reviewMatchesTarget(parsed, [['Green'], ['Apple', 'Cherry']])).toBe(true);
+    expect(reviewMatchesTarget(parsed, [['Green'], ['Cherry', 'Apple']])).toBe(false); // reordered
     expect(reviewMatchesTarget(parsed, [['Green'], ['Apple']])).toBe(false); // wrong count
     expect(reviewMatchesTarget(parsed, [['Blue'], ['Apple', 'Cherry']])).toBe(false); // wrong label
     expect(reviewMatchesTarget(parsed, [['Green']])).toBe(false); // wrong arity
+  });
+
+  it('returns false when an expected label set is empty (cannot verify)', () => {
+    const parsed = [{ question: 'Pick one', labels: ['Green'] }];
+    expect(reviewMatchesTarget(parsed, [[]])).toBe(false);
+  });
+
+  it('does not conflate options that differ only by internal spaces (no wrong-submit)', () => {
+    // "foo bar" must NOT verify as "foobar": internal spaces stay significant.
+    const parsed = [{ question: 'Pick', labels: ['foobar'] }];
+    expect(reviewMatchesTarget(parsed, [['foo bar']])).toBe(false);
+    expect(reviewMatchesTarget(parsed, [['foobar']])).toBe(true);
   });
 
   it('verifies a single-select option whose LABEL contains a comma (#654 regression)', () => {
@@ -135,17 +151,40 @@ describe('review parsing + verification (against real captures)', () => {
         ['Implement now'],
       ]),
     ).toBe(true);
+    // A fragment of the comma-label alone must NOT verify (no false positive).
+    expect(
+      reviewMatchesTarget(parsed, [['Epic via epic-dev'], ['Sidecar first'], ['Implement now']]),
+    ).toBe(false);
   });
 
-  it('verifies a multi-select where one chosen label contains a comma (#654)', () => {
+  it('verifies multi-select labels containing commas, in render order (#654)', () => {
+    // Render order = ascending option index, so expected uses that order.
     const frame =
       'Review your answers● Pick → Sidecar first, channels.tsv fallback, Other optionReady to submit your answers?❯ 1. Submit answers';
     const parsed = parseReviewAnswers(frame);
     expect(
-      reviewMatchesTarget(parsed, [['Other option', 'Sidecar first, channels.tsv fallback']]),
+      reviewMatchesTarget(parsed, [['Sidecar first, channels.tsv fallback', 'Other option']]),
     ).toBe(true);
-    // A genuinely wrong selection still fails (no false positive from the looser match).
+    // A wrong selection (fragments, not the whole comma-label) still fails.
     expect(reviewMatchesTarget(parsed, [['Sidecar first', 'Other option']])).toBe(false);
+  });
+
+  it('verifies two comma-containing labels selected in one question (#654)', () => {
+    const frame =
+      'Review your answers● Choose → A first, then B, C also, or DReady to submit your answers?❯ 1. Submit answers';
+    const parsed = parseReviewAnswers(frame);
+    expect(parsed[0]?.labels.length).toBe(4); // both labels over-split
+    expect(reviewMatchesTarget(parsed, [['A first, then B', 'C also, or D']])).toBe(true);
+    expect(reviewMatchesTarget(parsed, [['A first, then B']])).toBe(false); // only one of two
+  });
+
+  it('matches a label that is a suffix of another, in render order (#654)', () => {
+    const frame =
+      'Review your answers● Pick → sidecar, carReady to submit your answers?❯ 1. Submit answers';
+    const parsed = parseReviewAnswers(frame);
+    expect(parsed[0]?.labels).toEqual(['sidecar', 'car']);
+    expect(reviewMatchesTarget(parsed, [['sidecar', 'car']])).toBe(true);
+    expect(reviewMatchesTarget(parsed, [['car']])).toBe(false); // only one of two
   });
 
   it('isReviewScreen / isAuqClosed are false for a plain option frame', () => {

--- a/packages/web/src/components/chat/QuestionCard.tsx
+++ b/packages/web/src/components/chat/QuestionCard.tsx
@@ -323,7 +323,7 @@ function MultiQuestionForm({
               step={step}
               index={oi}
               selected={selected.get(qi)?.has(oi) ?? false}
-              disabled={submitting}
+              disabled={submitting || failed}
               onToggle={() => toggle(qi, oi, step.multiSelect)}
             />
           ))}
@@ -339,22 +339,35 @@ function MultiQuestionForm({
         </p>
       )}
 
+      {/* #654: once auto-answer has failed, re-submitting the structured form
+          re-drives an already-navigated TUI and only corrupts it further, so the
+          Submit button is withdrawn — Cancel (Esc) or the terminal are the safe
+          ways forward. Before failure, Submit + Cancel render as usual. */}
       <div className="flex items-center gap-2 pt-0.5">
-        <button
-          type="button"
-          onClick={submit}
-          disabled={!allAnswered || submitting}
-          className="flex min-h-[44px] flex-1 items-center justify-center rounded-[10px] text-sm font-semibold transition-transform active:scale-[0.99] disabled:opacity-50"
-          style={{ background: 'var(--color-primary)', color: 'var(--color-accent-ink)' }}
-        >
-          {submitting ? 'Answering…' : (question.submitLabel ?? 'Submit')}
-        </button>
+        {!failed && (
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!allAnswered || submitting}
+            className="flex min-h-[44px] flex-1 items-center justify-center rounded-[10px] text-sm font-semibold transition-transform active:scale-[0.99] disabled:opacity-50"
+            style={{ background: 'var(--color-primary)', color: 'var(--color-accent-ink)' }}
+          >
+            {submitting ? 'Answering…' : (question.submitLabel ?? 'Submit')}
+          </button>
+        )}
         {onCancel && (
           <button
             type="button"
             onClick={onCancel}
-            className="flex min-h-[44px] items-center justify-center rounded-[10px] px-4 text-sm font-semibold transition-transform active:scale-[0.99]"
-            style={{ background: 'transparent', color: 'var(--color-text)', border: '1px solid var(--color-border)' }}
+            className={clsx(
+              'flex min-h-[44px] items-center justify-center rounded-[10px] px-4 text-sm font-semibold transition-transform active:scale-[0.99]',
+              failed && 'flex-1',
+            )}
+            style={
+              failed
+                ? { background: 'var(--color-primary)', color: 'var(--color-accent-ink)' }
+                : { background: 'transparent', color: 'var(--color-text)', border: '1px solid var(--color-border)' }
+            }
           >
             Cancel
           </button>


### PR DESCRIPTION
Closes #654.

## What the user hit
A three-question AskUserQuestion form rendered beautifully but **submit failed** ("could not auto-answer; cancel or respond as plain text"), and the **same question reappeared several times** until they cancelled.

## Root cause (confirmed from `~/.remi/remi.log` + the Claude transcript)
Session `0a09a341`, question `1cebbb13`. The auto-answer driver verifies the review screen before submitting. `parseReviewAnswers` splits each review line's label region on `,` to separate multiple selected labels. One **single-select** option's label was literally:

> `Sidecar first, channels.tsv fallback`

The comma made the splitter produce two phantom labels `["Sidecar first", "channels.tsv fallback"]`; `reviewMatchesTarget` then compared 2 labels against the 1 expected and returned false → escalate, even though the rendered answer was correct (log: attempt 1 "review did not match target" with the right text parsed).

Each retry made it worse: the web card left **Submit enabled in the failed state**, so re-submitting re-drove the TUI from a non-initial cursor (the runner assumes the cursor starts on the first option). Log degraded `parsed=[correct]` → `parsed=[]` → `timed out` → `timed out`; the user cancelled.

## Fixes
1. **Verifier (root cause)** — `reviewMatchesTarget` now removes each WHOLE expected label from the reconstructed, whitespace-squashed region (longest-first so a substring label can't shadow another). Order-insensitive as before; an option label containing a comma now verifies; genuinely wrong selections still fail. (`auq-answer.ts`)
2. **Diagnosability** — log `expectedLabels` next to `parsed` on a mismatch. (`auq-runner.ts`)
3. **UX guard** — once `autoAnswerFailed`, withdraw the structured Submit button and lock the option toggles; Cancel becomes the clear, full-width action. Re-driving an already-navigated TUI can't help, so we stop offering it. (`QuestionCard.tsx`)

## Tests / validation
- New regression tests: single- and multi-select option labels containing commas verify correctly; a wrong selection with comma labels still fails.
- `bun test packages/daemon/tests/hooks` AUQ suites pass (13 + 8); root + web `tsc` clean; `eslint` + `biome` clean; `vite build` green.

Note: independent of #653 (that PR fixes web question-card lifecycle races; this fixes the daemon AUQ verifier + the AUQ form's failed-state). Needs a quick on-device re-test of an AUQ whose option label contains a comma.