### PR TITLE
fix(#656): make recent projects tappable on touch (was hover-only)

### DIFF
--- a/packages/web/src/components/session/RecentProjects.tsx
+++ b/packages/web/src/components/session/RecentProjects.tsx
@@ -40,9 +40,16 @@ export function RecentProjects({ directories, onStartSession }: RecentProjectsPr
 
       <div className="space-y-1">
         {visibleDirs.map((dir) => (
-          <div
+          // The WHOLE row is the tap target (#656): the start affordance used to
+          // be a Play button hidden behind `group-hover:visible`, which never
+          // reveals on touch — so the recents were dead on the phone. The Play
+          // icon is now an always-visible cue, brighter on hover for mouse users.
+          <button
             key={dir.directory}
-            className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-light)]"
+            type="button"
+            onClick={() => onStartSession(dir.directory)}
+            className="group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--color-surface-light)] active:bg-[var(--color-surface-light)]"
+            aria-label={`Start session in ${dir.displayName}`}
           >
             <FolderOpen className="size-4 shrink-0 text-[var(--color-text-muted)]" />
             <div className="min-w-0 flex-1">
@@ -54,14 +61,8 @@ export function RecentProjects({ directories, onStartSession }: RecentProjectsPr
                 {dir.sessionCount !== 1 ? 's' : ''}
               </div>
             </div>
-            <button
-              onClick={() => onStartSession(dir.directory)}
-              className="invisible rounded p-1 text-[var(--color-primary)] transition-colors hover:bg-[var(--color-primary)]/10 group-hover:visible"
-              aria-label={`Start session in ${dir.displayName}`}
-            >
-              <Play className="size-4" />
-            </button>
-          </div>
+            <Play className="size-4 shrink-0 text-[var(--color-primary)] opacity-60 transition-opacity group-hover:opacity-100" />
+          </button>
         ))}
       </div>
 


### PR DESCRIPTION
Closes #656.

## Symptom
Tapping **+** opens the New session sheet; recent projects render correctly but **the rows aren't clickable at all on the phone**. 🤣

## Root cause
In `RecentProjects.tsx` each row was a non-interactive `<div>`; the only handler was on a trailing Play `<button>` styled `invisible … group-hover:visible`. `group-hover` never fires on a touch device, so the start affordance was permanently hidden and the row had no tap target. (It "worked" on desktop because a mouse can hover.)

## Fix
The entire row is now a `<button>` calling `onStartSession(dir.directory)`, and the Play icon is an always-visible cue (brighter on hover for mouse users). Touch, mouse, and keyboard/focus all work. No nested-button issue (the inner Play button is gone).

## Validation
`tsc -b`, `eslint`, and `vite build` clean. `packages/web` has no DOM component-test harness (pure-function tests only), so this needs a device tap-test: open +, tap a recent row, confirm a session starts.