### PR TITLE
fix(#665): watch-answerable actions + cold-launch relay install

### DIFF
--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -15,52 +15,89 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         self.window = window
         registerNotificationCategories()
+        // #665: also attempt the relay install here (not just on
+        // applicationDidBecomeActive) so a background launch that exists
+        // solely to deliver a notification action still gets it installed.
+        installAnswerRelayWithRetry()
         return true
     }
 
     /// Register UNNotificationCategory objects for lock-screen / Apple Watch action buttons.
     /// Capacitor owns UNUserNotificationCenter.delegate; do NOT override it here.
+    ///
+    /// #665: `.authenticationRequired` blocks watchOS mirrored-notification
+    /// actions outright (a Watch cannot present a Face ID/passcode challenge),
+    /// so it is dropped from every ONE-SHOT action — plain Yes/No and numbered
+    /// option picks answer a single pending question and grant nothing lasting.
+    /// It is kept on STANDING-GRANT actions ("Yes, always") that hand the
+    /// daemon a persistent auto-approve permission, which still requires an
+    /// unlocked device.
     private func registerNotificationCategories() {
-        let auth: UNNotificationActionOptions = [.authenticationRequired]
-        let dest: UNNotificationActionOptions = [.authenticationRequired, .destructive]
+        let standingGrant: UNNotificationActionOptions = [.authenticationRequired]
+        let dest: UNNotificationActionOptions = [.destructive]
 
-        // Two-option: Yes / No
+        // Two-option: Yes / No — both one-shot, watch-answerable.
         let yn = UNNotificationCategory(
             identifier: "REMI_YN",
             actions: [
-                UNNotificationAction(identifier: "OPT_0", title: "Yes", options: auth),
+                UNNotificationAction(identifier: "OPT_0", title: "Yes", options: []),
                 UNNotificationAction(identifier: "OPT_1", title: "No",  options: dest),
             ],
             intentIdentifiers: [],
             options: []
         )
 
-        // Three-option: Yes / Yes, always / No
+        // Three-option: Yes / Yes, always / No. Only "Yes, always" grants a
+        // standing permission, so only it requires an unlocked device.
         let yna = UNNotificationCategory(
             identifier: "REMI_YNA",
             actions: [
-                UNNotificationAction(identifier: "OPT_0", title: "Yes",         options: auth),
-                UNNotificationAction(identifier: "OPT_1", title: "Yes, always", options: auth),
+                UNNotificationAction(identifier: "OPT_0", title: "Yes",         options: []),
+                UNNotificationAction(identifier: "OPT_1", title: "Yes, always", options: standingGrant),
                 UNNotificationAction(identifier: "OPT_2", title: "No",          options: dest),
             ],
             intentIdentifiers: [],
             options: []
         )
 
-        // Four-option: generic multi-choice (titles overridden at runtime by action data)
+        // Four-option: generic multi-choice (titles overridden at runtime by
+        // action data). Numbered picks are one-shot answers, not standing
+        // grants, so none require an unlocked device.
         let multi = UNNotificationCategory(
             identifier: "REMI_MULTI",
             actions: [
-                UNNotificationAction(identifier: "OPT_0", title: "Option 1", options: auth),
-                UNNotificationAction(identifier: "OPT_1", title: "Option 2", options: auth),
-                UNNotificationAction(identifier: "OPT_2", title: "Option 3", options: auth),
-                UNNotificationAction(identifier: "OPT_3", title: "Option 4", options: auth),
+                UNNotificationAction(identifier: "OPT_0", title: "Option 1", options: []),
+                UNNotificationAction(identifier: "OPT_1", title: "Option 2", options: []),
+                UNNotificationAction(identifier: "OPT_2", title: "Option 3", options: []),
+                UNNotificationAction(identifier: "OPT_3", title: "Option 4", options: []),
             ],
             intentIdentifiers: [],
             options: []
         )
 
         UNUserNotificationCenter.current().setNotificationCategories([yn, yna, multi])
+    }
+
+    /// #665: poll for the Capacitor bridge's notification router so
+    /// RemiAnswerRelay can be installed on a cold/background launch, not just
+    /// on applicationDidBecomeActive. `CAPBridgeViewController.bridge` stays
+    /// nil until `loadView()` runs; retry on the main queue rather than
+    /// assuming `makeKeyAndVisible()` already triggered it synchronously.
+    /// `RemiAnswerRelay.install` is idempotent, so this is safe to race
+    /// against the applicationDidBecomeActive call below.
+    private func installAnswerRelayWithRetry(attempt: Int = 0, maxAttempts: Int = 25) {
+        if let bridgeVC = window?.rootViewController as? CAPBridgeViewController,
+           bridgeVC.bridge?.notificationRouter != nil {
+            RemiAnswerRelay.shared.install(bridge: bridgeVC.bridge)
+            return
+        }
+        guard attempt < maxAttempts else {
+            NSLog("[remi] RemiAnswerRelay install: gave up after \(attempt) attempts (no notification router)")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.installAnswerRelayWithRetry(attempt: attempt + 1, maxAttempts: maxAttempts)
+        }
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -158,8 +195,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // #591 P2: wrap Capacitor's push notification handler so a lock-screen answer
-    // relays natively (silent, no app open). Deferred to here so it runs AFTER the
-    // push plugin's load() installed the original handler; install() is idempotent.
+    // relays natively (silent, no app open). install() is idempotent, so this is
+    // a redundant safety net alongside the didFinishLaunchingWithOptions retry
+    // (#665) for the case where the bridge wasn't ready yet at launch.
     func applicationDidBecomeActive(_ application: UIApplication) {
         if let bridgeVC = window?.rootViewController as? CAPBridgeViewController {
             RemiAnswerRelay.shared.install(bridge: bridgeVC.bridge)

--- a/packages/web/ios/App/App/AppDelegate.swift
+++ b/packages/web/ios/App/App/AppDelegate.swift
@@ -78,13 +78,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UNUserNotificationCenter.current().setNotificationCategories([yn, yna, multi])
     }
 
-    /// #665: poll for the Capacitor bridge's notification router so
-    /// RemiAnswerRelay can be installed on a cold/background launch, not just
-    /// on applicationDidBecomeActive. `CAPBridgeViewController.bridge` stays
-    /// nil until `loadView()` runs; retry on the main queue rather than
-    /// assuming `makeKeyAndVisible()` already triggered it synchronously.
-    /// `RemiAnswerRelay.install` is idempotent, so this is safe to race
-    /// against the applicationDidBecomeActive call below.
+    /// #665: install RemiAnswerRelay from the launch path itself, not just
+    /// applicationDidBecomeActive, so a background launch that exists solely
+    /// to deliver a notification action still gets it installed. In today's
+    /// Capacitor 8 lifecycle, `makeKeyAndVisible()` above triggers
+    /// `loadView()` synchronously, which registers plugins (including the
+    /// push handler) before this method runs, so attempt 0 succeeds. The
+    /// retry is a defensive backstop against that ordering changing (e.g. a
+    /// future move to the UIScene/SwiftUI app lifecycle) rather than a live
+    /// race today. `RemiAnswerRelay.install` is idempotent, so this is also
+    /// safe to race against the applicationDidBecomeActive call below.
     private func installAnswerRelayWithRetry(attempt: Int = 0, maxAttempts: Int = 25) {
         if let bridgeVC = window?.rootViewController as? CAPBridgeViewController,
            bridgeVC.bridge?.notificationRouter != nil {

--- a/packages/web/ios/App/App/RemiAnswerRelay.swift
+++ b/packages/web/ios/App/App/RemiAnswerRelay.swift
@@ -15,7 +15,8 @@ import Capacitor
 /// Gotchas handled (from Capacitor/NotificationRouter.swift):
 ///  - `pushNotificationHandler` is WEAK -> `shared` retains this instance.
 ///  - `didReceive` is synchronous and the router calls its completionHandler right
-///    after, so the async POST runs under its own `beginBackgroundTask`.
+///    after, so `relay()` runs the whole attempt (every guard plus the async
+///    POST) under one `beginBackgroundTask`, ended exactly once.
 ///  - install runs AFTER the push plugin's load() (called from a deferred hook).
 ///
 /// Inputs are bridged from JS via Capacitor Preferences (UserDefaults
@@ -59,10 +60,28 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
     // MARK: Relay
 
     private func relay(response: UNNotificationResponse) {
+        // didReceive is synchronous and the router calls its completion handler
+        // right after, so extend execution ourselves for the async work below
+        // (~30s budget) — every guard in this method and in post() can trigger
+        // an async notifyDeliveryFailure() or POST, so the task starts here,
+        // before the first guard, and is the single owner of its lifecycle: it
+        // ends exactly once, on whichever path (early return or post()'s async
+        // completion) runs. The expiry handler and the URLSession completion
+        // can fire on different queues, so serialize with a lock to avoid a
+        // double endBackgroundTask race.
+        let lock = NSLock()
+        var bgTask: UIBackgroundTaskIdentifier = .invalid
+        let endTask = {
+            lock.lock(); defer { lock.unlock() }
+            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
+        }
+        bgTask = UIApplication.shared.beginBackgroundTask(withName: "RemiAnswerRelay") { endTask() }
+
         let userInfo = response.notification.request.content.userInfo
         guard let sessionId = userInfo["sessionId"] as? String,
               let questionId = userInfo["questionId"] as? String else {
             NSLog("[remi] relay: push missing sessionId/questionId; ignoring")
+            endTask()
             return
         }
 
@@ -80,6 +99,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         }
         guard let answerValue = answer, !answerValue.isEmpty else {
             NSLog("[remi] relay: no actionable answer (action=\(response.actionIdentifier)); deferring to app")
+            endTask()
             return
         }
 
@@ -91,7 +111,8 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         // same limit the in-app reconnect has.
         guard let route = RemiNativeStore.route(forSession: sessionId), !route.wsUrl.isEmpty else {
             NSLog("[remi] relay: no stored daemon URL for session \(sessionId); cannot relay")
-            notifyDeliveryFailure()
+            notifyDeliveryFailure(questionId: questionId)
+            endTask()
             return
         }
         let claudeSessionId = (userInfo["claudeSessionId"] as? String) ?? route.claudeSessionId
@@ -99,16 +120,18 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         let message = "\(sessionId)|\(questionId)|\(answerValue)"
         guard let auth = RemiNativeStore.sign(message: message) else {
             NSLog("[remi] relay: no signing identity stored; cannot relay")
-            notifyDeliveryFailure()
+            notifyDeliveryFailure(questionId: questionId)
+            endTask()
             return
         }
 
         post(wsUrl: route.wsUrl, sessionId: sessionId, questionId: questionId,
-             answer: answerValue, claudeSessionId: claudeSessionId, auth: auth)
+             answer: answerValue, claudeSessionId: claudeSessionId, auth: auth, endTask: endTask)
     }
 
     private func post(wsUrl: String, sessionId: String, questionId: String,
-                      answer: String, claudeSessionId: String?, auth: RemiNativeStore.Auth) {
+                      answer: String, claudeSessionId: String?, auth: RemiNativeStore.Auth,
+                      endTask: @escaping () -> Void) {
         // Normalize the daemon ws(s):// URL to http(s):// and target the root
         // `/answer` endpoint (mirrors push-answer-relay.ts `answerUrl`).
         let base = wsUrl
@@ -116,7 +139,8 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
             .replacingOccurrences(of: "ws://", with: "http://")
         guard var comps = URLComponents(string: base) else {
             NSLog("[remi] relay: bad daemon URL \(base)")
-            notifyDeliveryFailure()
+            notifyDeliveryFailure(questionId: questionId)
+            endTask()
             return
         }
         comps.path = "/answer"
@@ -124,21 +148,10 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         comps.fragment = nil
         guard let url = comps.url else {
             NSLog("[remi] relay: cannot build /answer URL from \(base)")
-            notifyDeliveryFailure()
+            notifyDeliveryFailure(questionId: questionId)
+            endTask()
             return
         }
-
-        // didReceive is synchronous + the router completes immediately, so extend
-        // execution ourselves for the async POST (~30s budget). The expiry handler
-        // and the URLSession completion can fire on different queues, so serialize
-        // the end-task with a lock to avoid a double endBackgroundTask race.
-        let lock = NSLock()
-        var bgTask: UIBackgroundTaskIdentifier = .invalid
-        let endTask = {
-            lock.lock(); defer { lock.unlock() }
-            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
-        }
-        bgTask = UIApplication.shared.beginBackgroundTask(withName: "RemiAnswerRelay") { endTask() }
 
         var body: [String: Any] = [
             "sessionId": sessionId,
@@ -154,7 +167,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
 
         guard let payload = try? JSONSerialization.data(withJSONObject: body) else {
             NSLog("[remi] relay: failed to encode body")
-            notifyDeliveryFailure()
+            notifyDeliveryFailure(questionId: questionId)
             endTask()
             return
         }
@@ -170,10 +183,10 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
             let result = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
             if let err = err {
                 NSLog("[remi] relay: POST failed: \(err.localizedDescription)")
-                self?.notifyDeliveryFailure()
+                self?.notifyDeliveryFailure(questionId: questionId)
             } else if !(200...299).contains(status) {
                 NSLog("[remi] relay: POST status=\(status) result=\(result)")
-                self?.notifyDeliveryFailure()
+                self?.notifyDeliveryFailure(questionId: questionId)
             } else {
                 NSLog("[remi] relay: POST status=\(status) result=\(result)")
             }
@@ -188,13 +201,17 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
     /// so an NSLog-only failure would be invisible to the user. Mirrors the
     /// wording of the JS `notifyFailure()` in App.tsx, which shows the same
     /// message when a push answer can't be delivered from the web layer.
-    /// One notification per failed attempt; no retry loop (see #612 for the
-    /// signaling reverse-relay fallback, out of scope here).
-    private func notifyDeliveryFailure() {
+    /// The identifier is stable per question (falls back to a constant if the
+    /// push never carried one), so repeated failures for the same question
+    /// replace the prior notification instead of stacking duplicates. No
+    /// retry loop (see #612 for the signaling reverse-relay fallback, out of
+    /// scope here).
+    private func notifyDeliveryFailure(questionId: String?) {
         let content = UNMutableNotificationContent()
         content.title = "Answer not delivered"
         content.body = "Open Remi to respond to the question."
-        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        let identifier = "remi-answer-failure-\(questionId ?? "unknown")"
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
                 NSLog("[remi] relay: failed to schedule delivery-failure notification: \(error.localizedDescription)")

--- a/packages/web/ios/App/App/RemiAnswerRelay.swift
+++ b/packages/web/ios/App/App/RemiAnswerRelay.swift
@@ -91,6 +91,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         // same limit the in-app reconnect has.
         guard let route = RemiNativeStore.route(forSession: sessionId), !route.wsUrl.isEmpty else {
             NSLog("[remi] relay: no stored daemon URL for session \(sessionId); cannot relay")
+            notifyDeliveryFailure()
             return
         }
         let claudeSessionId = (userInfo["claudeSessionId"] as? String) ?? route.claudeSessionId
@@ -98,6 +99,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         let message = "\(sessionId)|\(questionId)|\(answerValue)"
         guard let auth = RemiNativeStore.sign(message: message) else {
             NSLog("[remi] relay: no signing identity stored; cannot relay")
+            notifyDeliveryFailure()
             return
         }
 
@@ -114,6 +116,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
             .replacingOccurrences(of: "ws://", with: "http://")
         guard var comps = URLComponents(string: base) else {
             NSLog("[remi] relay: bad daemon URL \(base)")
+            notifyDeliveryFailure()
             return
         }
         comps.path = "/answer"
@@ -121,6 +124,7 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         comps.fragment = nil
         guard let url = comps.url else {
             NSLog("[remi] relay: cannot build /answer URL from \(base)")
+            notifyDeliveryFailure()
             return
         }
 
@@ -149,7 +153,10 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         if let cid = claudeSessionId { body["claudeSessionId"] = cid }
 
         guard let payload = try? JSONSerialization.data(withJSONObject: body) else {
-            NSLog("[remi] relay: failed to encode body"); endTask(); return
+            NSLog("[remi] relay: failed to encode body")
+            notifyDeliveryFailure()
+            endTask()
+            return
         }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
@@ -158,16 +165,41 @@ final class RemiAnswerRelay: NSObject, NotificationHandlerProtocol {
         req.timeoutInterval = 20
 
         NSLog("[remi] relay: POST \(url.absoluteString) answer=\(answer)")
-        URLSession.shared.dataTask(with: req) { data, resp, err in
+        URLSession.shared.dataTask(with: req) { [weak self] data, resp, err in
             let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
             let result = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
             if let err = err {
                 NSLog("[remi] relay: POST failed: \(err.localizedDescription)")
+                self?.notifyDeliveryFailure()
+            } else if !(200...299).contains(status) {
+                NSLog("[remi] relay: POST status=\(status) result=\(result)")
+                self?.notifyDeliveryFailure()
             } else {
                 NSLog("[remi] relay: POST status=\(status) result=\(result)")
             }
             endTask()
         }.resume()
+    }
+
+    // MARK: Visible failure
+
+    /// #665: this native relay can run when the app never opens (a mirrored
+    /// Watch action or a cold/background launch that dies again right after),
+    /// so an NSLog-only failure would be invisible to the user. Mirrors the
+    /// wording of the JS `notifyFailure()` in App.tsx, which shows the same
+    /// message when a push answer can't be delivered from the web layer.
+    /// One notification per failed attempt; no retry loop (see #612 for the
+    /// signaling reverse-relay fallback, out of scope here).
+    private func notifyDeliveryFailure() {
+        let content = UNMutableNotificationContent()
+        content.title = "Answer not delivered"
+        content.body = "Open Remi to respond to the question."
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                NSLog("[remi] relay: failed to schedule delivery-failure notification: \(error.localizedDescription)")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes three related iOS gaps in the lock-screen / Apple Watch answer path (#665):

1. **Auth-flag policy (product decision).** All actions in `REMI_YN` / `REMI_YNA` / `REMI_MULTI` carried `.authenticationRequired`, which watchOS cannot satisfy for a mirrored notification (no Face ID/passcode challenge on the Watch), so every action was unavailable/inert there. Per team-lead decision: `.authenticationRequired` is dropped from every **one-shot** action (plain Yes, No, numbered option picks in `REMI_MULTI`) since those only answer a single pending question and grant nothing lasting. It is kept only on **standing-grant** actions — currently just "Yes, always" in `REMI_YNA`, which grants the daemon a persistent auto-approve permission and should still require an unlocked device.

2. **Cold-launch relay install.** `RemiAnswerRelay.shared.install(bridge:)` was only called from `applicationDidBecomeActive`, so a background launch that exists solely to deliver a notification action never installed the native relay. Added a bounded-retry install from `didFinishLaunchingWithOptions` (poll on the main queue every 200ms, up to 25 attempts / ~5s, for the Capacitor bridge's notification router to exist). `install()` was already idempotent, so this races safely against the existing `applicationDidBecomeActive` call. In today's Capacitor 8 lifecycle `loadView()` runs synchronously inside `makeKeyAndVisible()`, so attempt 0 succeeds in practice — the retry is a defensive backstop against that ordering changing, not a live race.

3. **Visible failure notification.** `RemiAnswerRelay.post()` only reported delivery failures via `NSLog`, invisible when the relay runs without the app ever opening. Added a local `UNNotification` ("Answer not delivered" / "Open Remi to respond to the question.", matching the wording of the JS `notifyFailure()` in `App.tsx`) on every real failure path: no stored daemon route, no signing identity, malformed daemon URL, JSON encode failure, network error, and non-2xx HTTP status. The notification identifier is stable per `questionId` (`remi-answer-failure-<questionId>`), so repeated failures for the same question replace the prior notification instead of stacking duplicates. One delivery attempt, no retry loop — the signaling reverse-relay fallback remains #612's scope.

4. **Background-task lifecycle (review fix).** `beginBackgroundTask` originally only started inside `post()`, so the four earlier guard failures in `relay()` (no stored route, no signing identity, plus two URL-construction guards in `post()` before the task existed) scheduled their async `notifyDeliveryFailure()` with no protection against the app being suspended mid-write. Moved `beginBackgroundTask` to the top of `relay()`, before its first guard, as the single owner of the task's lifecycle; `post()` now takes an `endTask` closure instead of managing its own task, and every path (all seven failure branches plus the success branch) ends the task exactly once.

## Files changed

- `packages/web/ios/App/App/AppDelegate.swift` — per-action auth-flag split (with inline rationale comments) + `installAnswerRelayWithRetry()` called from `didFinishLaunchingWithOptions`.
- `packages/web/ios/App/App/RemiAnswerRelay.swift` — `beginBackgroundTask` moved to `relay()` as the single lifecycle owner; `notifyDeliveryFailure(questionId:)` with a stable per-question identifier, wired into every failure branch in `relay()` and `post()`.

Swift/iOS only; no web, daemon, or signaling changes.

## Known limitation (no action here, tracked in #612)

This native relay's failure notification can duplicate the JS-layer `notifyFailure()` in `App.tsx` when both paths observe a correlated failure for the same answer (the pre-existing #591 dual-path architecture: native relay for cold/background delivery, JS `handlePushAnswer` for the foreground/app-open case). Consolidating the two failure-notification paths belongs to #612's scope, not this PR.

## Build verification

`xcodebuild -project packages/web/ios/App/App.xcodeproj -scheme App -destination 'generic/platform=iOS' -configuration Debug build CODE_SIGNING_ALLOWED=NO` (Xcode 26.4.1 at `/Volumes/S1/Applications/Xcode.app`) — **BUILD SUCCEEDED**, zero errors, zero warnings in the changed files. Re-verified after the review-fix commit.

## On-device validation required (not possible in this environment)

There is no Swift unit-test harness in this repo. The following must be validated on a real device/Watch before merge:

- [ ] **Lock-screen answer:** trigger a permission question, lock the phone, tap a Yes/No/numbered action from the lock screen, confirm it answers without unlocking.
- [ ] **Watch answer:** trigger a permission question, answer Yes/No/numbered option from a mirrored Apple Watch notification, confirm the daemon receives the answer (previously inert due to `.authenticationRequired`).
- [ ] **Cold-launch answer:** force-quit the app (or let it get jetsam-evicted), trigger a permission question, answer from the notification action without opening the app, confirm the daemon receives the answer via the native relay installed from `didFinishLaunchingWithOptions`.
- [ ] **Failure notification:** simulate a relay failure (e.g. stale/unreachable daemon route) and confirm the "Answer not delivered" local notification appears, and that repeated failures for the same question replace it rather than stacking.

Refs #665 (stays open pending on-device validation). Refs #612, #575.

