### PR TITLE
fix(#674): live-sessions projectPath malformed by unexpanded tilde

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1866,8 +1866,14 @@ if (cliDaemonMode) {
 
   mdnsPublisher = await startMdnsIfNeeded(console.log);
 
-  // Create the daemon's single session (one session per daemon)
-  const workingDirectory = cliDir ? path.resolve(cliDir) : process.cwd();
+  // Create the daemon's single session (one session per daemon).
+  // NOTE: when --dir/--recent was passed, we already `process.chdir()`'d to
+  // the tilde-expanded, validated directory above (see the `resolveDirectory`
+  // calls near the top of this file). Re-resolving the raw `cliDir` string
+  // here (which may still contain a literal `~`) against that NEW cwd used to
+  // produce a malformed concatenated path (#674); process.cwd() is always the
+  // correct value by this point.
+  const workingDirectory = process.cwd();
   const sessionId = sessionRegistry.createSessionId();
   setPrimarySessionId(sessionId);
 

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -13,18 +13,28 @@ import * as path from 'node:path';
 
 export type ResolveDirectoryResult = { resolved: string } | { error: string };
 
-export function resolveDirectory(inputPath: string | null | undefined): ResolveDirectoryResult {
-  if (!inputPath) {
-    return { resolved: process.cwd() };
-  }
-
+/**
+ * Expand a leading `~`/`~/` and resolve to an absolute path. Pure string
+ * manipulation, no filesystem access — safe to run against untrusted or
+ * legacy stored values (e.g. re-normalizing a `LiveSessionEntry.projectPath`
+ * read back off disk) as well as fresh CLI input.
+ */
+export function normalizeProjectPath(inputPath: string): string {
   let resolved = inputPath;
   if (resolved.startsWith('~/')) {
     resolved = path.join(os.homedir(), resolved.slice(2));
   } else if (resolved === '~') {
     resolved = os.homedir();
   }
-  resolved = path.resolve(resolved);
+  return path.resolve(resolved);
+}
+
+export function resolveDirectory(inputPath: string | null | undefined): ResolveDirectoryResult {
+  if (!inputPath) {
+    return { resolved: process.cwd() };
+  }
+
+  const resolved = normalizeProjectPath(inputPath);
   if (!fs.existsSync(resolved)) {
     return { error: `Directory not found: ${resolved}` };
   }

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -18,6 +18,11 @@ export type ResolveDirectoryResult = { resolved: string } | { error: string };
  * manipulation, no filesystem access — safe to run against untrusted or
  * legacy stored values (e.g. re-normalizing a `LiveSessionEntry.projectPath`
  * read back off disk) as well as fresh CLI input.
+ *
+ * Does NOT resolve symlinks (no realpath): two paths that are equivalent only
+ * through a symlinked segment (macOS `/tmp` vs `/private/tmp`) normalize to
+ * different strings and will not compare equal. Same blind spot as the exact
+ * string equality this replaced; acceptable for sibling-daemon detection.
  */
 export function normalizeProjectPath(inputPath: string): string {
   let resolved = inputPath;

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
+import { normalizeProjectPath } from '../cli/path-resolver.ts';
 import { findAvailableTcpPort } from './port-utils.ts';
 import { isProcessAlive } from './process-alive.ts';
 
@@ -103,12 +104,25 @@ export class SessionRegistryFile {
     }
   }
 
-  /** Register a live session (atomic write). */
+  /**
+   * Register a live session (atomic write). Normalizes `projectPath` (expands
+   * `~`, resolves to absolute) before persisting so a caller passing a raw,
+   * unexpanded path never writes a malformed entry (#674). Since `patchEntry`
+   * round-trips through this method, an on-disk entry that still carries a raw
+   * `~` also gets normalized the next time it's patched — but a value already
+   * mangled into an unrecoverable shape (e.g. a `~` concatenated mid-string
+   * onto another absolute path) cannot be un-concatenated after the fact; only
+   * preventing the write in the first place fixes that case.
+   */
   register(entry: LiveSessionEntry): void {
     this.ensureDir();
+    const normalized: LiveSessionEntry = {
+      ...entry,
+      projectPath: normalizeProjectPath(entry.projectPath),
+    };
     const filePath = path.join(this.dir, `${entry.sessionId}.json`);
     const tmpPath = `${filePath}.tmp`;
-    fs.writeFileSync(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
+    fs.writeFileSync(tmpPath, JSON.stringify(normalized, null, 2), 'utf-8');
     fs.renameSync(tmpPath, filePath);
   }
 

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -41,6 +41,7 @@ import type { ProtocolMessage, UUID } from '@remi/shared';
 
 import type { MessageAPI } from '../api/message-api.ts';
 import { log, logError } from '../cli/logger.ts';
+import { normalizeProjectPath } from '../cli/path-resolver.ts';
 import { startTranscriptFallback } from '../cli/transcript-fallback.ts';
 import { startTranscriptWatcher } from '../cli/transcript-watcher-setup.ts';
 import { classifySessionEvent } from '../hooks/session-lock-classifier.ts';
@@ -790,9 +791,12 @@ export class TranscriptBinder {
       );
       return true;
     }
+    // Normalize both sides: a legacy on-disk entry (or a sibling running an
+    // older binary) may still carry an unexpanded `~` (#674).
+    const ourDir = normalizeProjectPath(this.workingDirectory);
     return this.deps.liveSessionsRegistry.listLive().some(
       (e) =>
-        e.projectPath === this.workingDirectory &&
+        normalizeProjectPath(e.projectPath) === ourDir &&
         e.sessionId !== this.sessionId &&
         e.wsPort !== this.deps.currentPort() &&
         // A zombie (daemon alive, Claude dead) must not count as a sibling

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { resolveDirectory } from '../../src/cli/path-resolver.ts';
+import { normalizeProjectPath, resolveDirectory } from '../../src/cli/path-resolver.ts';
 
 describe('resolveDirectory', () => {
   let sandbox: string;
@@ -71,5 +71,47 @@ describe('resolveDirectory', () => {
     if ('error' in result) {
       expect(result.error).toStartWith('Not a directory: ');
     }
+  });
+});
+
+describe('normalizeProjectPath', () => {
+  test('expands `~/...` to an absolute home-relative path', () => {
+    expect(normalizeProjectPath('~/Documents/git/nemar/nemar-cli')).toBe(
+      path.join(os.homedir(), 'Documents/git/nemar/nemar-cli'),
+    );
+  });
+
+  test('expands bare `~` to the home directory', () => {
+    expect(normalizeProjectPath('~')).toBe(os.homedir());
+  });
+
+  test('leaves an already-absolute path unchanged (aside from normalization)', () => {
+    expect(normalizeProjectPath('/Users/yahya/Documents/git/nemar/nemar-cli')).toBe(
+      '/Users/yahya/Documents/git/nemar/nemar-cli',
+    );
+  });
+
+  test('tilde-form and absolute-form inputs for the same directory normalize identically (#674)', () => {
+    const tildeForm = '~/Documents/git/nemar/nemar-cli';
+    const absoluteForm = path.join(os.homedir(), 'Documents/git/nemar/nemar-cli');
+    expect(normalizeProjectPath(tildeForm)).toBe(normalizeProjectPath(absoluteForm));
+  });
+
+  test('does not attempt to fix an already-malformed concatenated path', () => {
+    // The exact shape observed live (#674): a tilde path resolved relative to
+    // a cwd that already ends in the same tail, instead of being expanded
+    // against $HOME. Once concatenated it no longer starts with `~`, so this
+    // documents that normalizeProjectPath cannot un-concatenate it after the
+    // fact — the fix must prevent this shape from being persisted at all.
+    const malformed = '/Users/yahya/Documents/git/nemar/nemar-cli/~/Documents/git/nemar/nemar-cli';
+    expect(normalizeProjectPath(malformed)).toBe(malformed);
+  });
+
+  test('does not touch the filesystem (safe on paths that do not exist)', () => {
+    const doesNotExist = '~/this-directory-almost-certainly-does-not-exist-674';
+    expect(() => normalizeProjectPath(doesNotExist)).not.toThrow();
+    expect(normalizeProjectPath(doesNotExist)).toBe(
+      path.join(os.homedir(), 'this-directory-almost-certainly-does-not-exist-674'),
+    );
   });
 });

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -278,6 +278,73 @@ describe('SessionRegistryFile', () => {
     expect(live[0]!.wsPort).toBe(18770);
   });
 
+  // ---- projectPath normalization (#674) -----------------------------------
+
+  describe('projectPath normalization', () => {
+    test('tilde-form projectPath round-trips to an absolute normalized path', () => {
+      registry.register(
+        makeEntry({ sessionId: 'tilde', projectPath: '~/Documents/git/nemar/nemar-cli' }),
+      );
+
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.projectPath).toBe(path.join(os.homedir(), 'Documents/git/nemar/nemar-cli'));
+    });
+
+    test('tilde-form and absolute-form registrations end up with an identical projectPath', () => {
+      const absolutePath = path.join(os.homedir(), 'Documents/git/nemar/nemar-cli');
+      registry.register(
+        makeEntry({ sessionId: 'a', projectPath: '~/Documents/git/nemar/nemar-cli' }),
+      );
+      registry.register(makeEntry({ sessionId: 'b', projectPath: absolutePath }));
+
+      const live = registry.listLive();
+      const a = live.find((e) => e.sessionId === 'a');
+      const b = live.find((e) => e.sessionId === 'b');
+      expect(a!.projectPath).toBe(b!.projectPath);
+    });
+
+    test('setClaudeChildPid self-heals a legacy entry that still carries a raw tilde', () => {
+      // A legacy entry written directly (bypassing register()'s
+      // normalization) that still starts with `~` CAN be normalized on the
+      // next patch, since patchEntry round-trips through register().
+      fs.writeFileSync(
+        path.join(tmpDir, 'legacy.json'),
+        JSON.stringify(
+          makeEntry({ sessionId: 'legacy', projectPath: '~/Documents/git/nemar/nemar-cli' }),
+        ),
+      );
+
+      registry.setClaudeChildPid('legacy', 4242);
+
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.projectPath).toBe(path.join(os.homedir(), 'Documents/git/nemar/nemar-cli'));
+      expect(live[0]!.claudeChildPid).toBe(4242);
+    });
+
+    test('setClaudeChildPid cannot un-concatenate an already-mangled projectPath', () => {
+      // The exact malformed shape reported live (#674): once a `~` has been
+      // concatenated mid-string onto another absolute path, the result no
+      // longer starts with `~`, so normalizeProjectPath cannot recover it.
+      // The guarantee is that FRESH projectPath values are normalized from now
+      // on, not that this specific garbage string self-repairs.
+      const malformed =
+        '/Users/yahya/Documents/git/nemar/nemar-cli/~/Documents/git/nemar/nemar-cli';
+      fs.writeFileSync(
+        path.join(tmpDir, 'legacy.json'),
+        JSON.stringify(makeEntry({ sessionId: 'legacy', projectPath: malformed })),
+      );
+
+      registry.setClaudeChildPid('legacy', 4242);
+
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.projectPath).toBe(malformed);
+      expect(live[0]!.claudeChildPid).toBe(4242);
+    });
+  });
+
   // ---- Claude-child liveness (#451) ---------------------------------------
 
   describe('Claude child liveness', () => {

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -354,6 +354,71 @@ describe('TranscriptBinder', () => {
   });
 
   // -------------------------------------------------------------------------
+  // hasSiblingInDir tilde/absolute normalization (#674)
+  // -------------------------------------------------------------------------
+
+  describe('hasSiblingInDir projectPath normalization (#674)', () => {
+    test('sibling with a tilde-form projectPath is still detected against an absolute workingDirectory', () => {
+      registerSession();
+      const ourDir = path.join(os.homedir(), 'remi-674-test-nemar-cli');
+      // The sibling's live-sessions entry carries an unexpanded `~` form of
+      // the same directory -- the exact shape a pre-fix daemon persisted
+      // live (#674). Before normalizing both sides, the plain string
+      // equality in hasSiblingInDir() would miss this match entirely.
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sib.json'),
+        JSON.stringify({
+          sessionId: 'sib-1',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18001,
+          projectPath: '~/remi-674-test-nemar-cli',
+          name: 'sib',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: ourDir },
+        'drive',
+      );
+      // No ownership marker -> with the sibling detected, this must defer.
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      };
+      expect(binder.decide(ev).classification).toBe('defer');
+    });
+
+    test('sibling with an absolute projectPath is still detected against a tilde-equivalent workingDirectory', () => {
+      registerSession();
+      const absoluteSiblingDir = path.join(os.homedir(), 'remi-674-test-nemar-cli-2');
+      fs.writeFileSync(
+        path.join(liveSessionsRegistry.dirPath, 'sib.json'),
+        JSON.stringify({
+          sessionId: 'sib-1',
+          pid: process.pid,
+          wsPort: 18999,
+          hookPort: 18001,
+          projectPath: absoluteSiblingDir,
+          name: 'sib',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const binder = new TranscriptBinder(
+        deps(),
+        { sessionId: SID, workingDirectory: '~/remi-674-test-nemar-cli-2' },
+        'drive',
+      );
+      const ev: BinderHookEvent = {
+        session_id: 'claude-A',
+        transcript_path: path.join(tmpDir, 'a.jsonl'),
+      };
+      expect(binder.decide(ev).classification).toBe('defer');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // rotation ordering
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Fixes a malformed `projectPath` in `~/.remi/live-sessions/*.json` of the
form `/abs/path/~/rest` (an unexpanded `~` concatenated mid-string onto
an absolute path), which broke the string-equality check in
`hasSiblingInDir()` for the affected daemon pair.

## Why

`remi new --dir X` already resolves `X` (tilde-expanded, validated) via
`resolveDirectory()` and `process.chdir()`s to it early in `cli.ts`. Later
in the same startup flow, the daemon re-derived its `workingDirectory` by
re-resolving the *raw*, still-tilde-containing `cliDir` string with
`path.resolve()` -- against the *new* (already-chdir'd) cwd. When the raw
value still literally started with `~`, this concatenated it onto the new
cwd instead of expanding it against `$HOME`, producing exactly the
malformed shape seen live:
`/Users/yahya/Documents/git/nemar/nemar-cli/~/Documents/git/nemar/nemar-cli`.

## Fix

- **Root cause** (`cli.ts`): stop re-resolving `cliDir`; `process.cwd()` is
  already correct by that point (chdir already ran).
- **Defense in depth**: extracted `normalizeProjectPath()` (tilde-expand +
  resolve, pure, no filesystem access) out of `resolveDirectory()`.
  - `SessionRegistryFile.register()` now normalizes `projectPath` before
    persisting, so any caller passing a raw path never writes a malformed
    entry, and a legacy raw-tilde entry self-heals the next time it's
    patched (`setClaudeChildPid`/`markClaudeChildExited`).
  - `TranscriptBinder.hasSiblingInDir()` normalizes both sides of its
    comparison, so a legacy or cross-version malformed entry (e.g. a
    sibling daemon still running an older binary during a rollout) is
    still detected as a sibling.

Note: an already-mangled concatenated string (no longer starting with
`~`) cannot be un-concatenated after the fact by any of the above --
only preventing the write in the first place fixes that shape. This is
documented and tested explicitly.

## Testing

- `bun run typecheck` -- clean
- `bunx biome check packages/daemon` -- 0 errors (same 36 pre-existing
  `noNonNullAssertion` warnings as before this change, all outside touched
  lines)
- `bun test packages/daemon/tests/transcript/ packages/daemon/tests/cli/ packages/daemon/tests/hooks/ packages/daemon/tests/session` -- 1171 pass, 0 fail
- New tests:
  - `normalizeProjectPath` unit tests (tilde/absolute equivalence, the
    exact malformed shape from live evidence, no-filesystem-access safety)
  - `SessionRegistryFile`: tilde-form `register()` round-trips to
    absolute; tilde-form and absolute-form registrations converge to the
    same value; `setClaudeChildPid` self-heals a legacy raw-tilde entry
    but (documented) cannot repair an already-mangled one
  - `TranscriptBinder.hasSiblingInDir`: a sibling is detected whichever
    side (ours or the sibling's registry entry) is in tilde form

Closes #674