### PR TITLE
feat(#663): client ack states + queued indicator

### DIFF
--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -960,16 +960,22 @@ export function createStructuredAgentOutput(
 
 /**
  * Create a user input message.
+ *
+ * `id` is optional and defaults to a fresh `generateId()`. Callers that need
+ * the ack/retry state machine (#663) pass the SAME id back in on a retry so
+ * the daemon's `MessageIdTracker` dedups a resend that already landed,
+ * making the retry idempotent instead of double-submitting to the PTY.
  */
 export function createUserInput(
   sessionId: UUID,
   content: string,
   raw?: boolean,
   claudeSessionId?: UUID,
+  id?: UUID,
 ): UserInputMessage {
   return {
     type: 'user_input',
-    id: generateId(),
+    id: id ?? generateId(),
     timestamp: now(),
     sessionId,
     content,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,13 @@ import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
 import { probeAuthInfo } from '@/lib/auth-probe';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
+import {
+  acknowledgeSend,
+  EMPTY_PENDING_SENDS,
+  type PendingSendMap,
+  sweepTimeouts,
+  trackSend,
+} from '@/lib/message-ack-tracker';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { clearNativeRoute, setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
@@ -237,6 +244,12 @@ function App() {
   const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
+  // Outstanding user_input sends awaiting their `ack`, keyed by message id
+  // (#663). Mutated by handleSend (track), the 'ack' case (acknowledge), and
+  // the sweep effect below (retry/fail on timeout). A ref, not state --
+  // updated every send/ack/tick and read by an interval, none of which
+  // should trigger a re-render on their own.
+  const pendingSendsRef = useRef<PendingSendMap>(EMPTY_PENDING_SENDS);
   // Fallback timer so the new-session sheet leaves its loading state even if the
   // daemon never answers session_history_request (#638 review).
   const historyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -343,6 +356,11 @@ function App() {
                     connectionId,
                     ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
                     ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
+                    // #662/#663: refresh on EVERY hello_ack, not just the
+                    // first -- this also fires when a queued connection is
+                    // promoted (fresh hello_ack with attachState: 'attached'),
+                    // which is how the read-only banner clears.
+                    ...(message.attachState !== undefined && { attachState: message.attachState }),
                   }
                 : s,
             );
@@ -362,6 +380,7 @@ function App() {
               preview: 'Connected',
               ...(ackClaudeSessionId !== undefined && { claudeSessionId: ackClaudeSessionId }),
               ...(ackTranscriptPath !== undefined && { transcriptPath: ackTranscriptPath }),
+              ...(message.attachState !== undefined && { attachState: message.attachState }),
             } satisfies UISession,
           ];
         });
@@ -1194,6 +1213,33 @@ function App() {
             break;
           }
         }
+        // NOT_ACTIVE_CONNECTION (#662/#663): this connection is read-only --
+        // another client holds the session's exclusive write lock -- and the
+        // input that triggered this error was never delivered to the PTY
+        // (the daemon still sent an `ack` for it separately; `ack` only means
+        // "the daemon received the frame", not "Claude saw it"). The error
+        // carries no messageId to flip a specific bubble to failed, so the
+        // fix is to refresh the persistent read-only banner (ChatView) rather
+        // than only a one-off chat bubble the user can miss or that scrolls
+        // away.
+        if (errorCode === 'NOT_ACTIVE_CONNECTION') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const queuedSessionId = asNonEmptyString(details?.['sessionId']);
+          if (queuedSessionId) {
+            setSessions((prev) =>
+              prev.map((s) =>
+                s.id === queuedSessionId && s.connectionId === connectionId
+                  ? { ...s, attachState: 'queued' }
+                  : s,
+              ),
+            );
+          }
+          console.warn(
+            '[App] NOT_ACTIVE_CONNECTION: input not delivered, session is read-only',
+            queuedSessionId,
+          );
+          break;
+        }
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;
@@ -1260,6 +1306,24 @@ function App() {
           isEditing: false,
         };
         setMessages((prev) => [...prev, errorMsg]);
+        break;
+      }
+
+      // #663: only `user_input` sends are tracked in pendingSendsRef (see
+      // handleSend), so an ack for anything else (hello, answer, ...) simply
+      // finds no match and no-ops here -- expected, not an error.
+      case 'ack': {
+        const { pending, matched } = acknowledgeSend(pendingSendsRef.current, message.ack.messageId);
+        pendingSendsRef.current = pending;
+        if (matched) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === message.ack.messageId && m.sender === 'user'
+                ? { ...m, state: 'delivered' as const }
+                : m,
+            ),
+          );
+        }
         break;
       }
 
@@ -1885,9 +1949,14 @@ function App() {
 
       const reply = replyContextsRef.current.get(activeSessionId);
       const wireContent = reply ? formatReplyMessage(reply, content) : content;
+      // Same id for the UI bubble AND the wire message (#663): the daemon's
+      // `ack.messageId` echoes back whatever id we send, so this is what
+      // lets an inbound ack find its bubble. Also what a retry reuses so
+      // the daemon's MessageIdTracker dedups it.
+      const messageId = generateId();
 
       const newMessage: UIMessage = {
-        id: generateId(),
+        id: messageId,
         sessionId: activeSessionId,
         sender: 'user',
         content: wireContent,
@@ -1905,11 +1974,18 @@ function App() {
         activeSessionId,
         wireContent,
         activeBinding as UUID | undefined,
+        messageId,
       );
       if (success) {
-        setMessages((prev) =>
-          prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'sent' } : m)),
-        );
+        setMessages((prev) => prev.map((m) => (m.id === messageId ? { ...m, state: 'sent' } : m)));
+        pendingSendsRef.current = trackSend(pendingSendsRef.current, {
+          messageId,
+          connectionId: connId,
+          sessionId: activeSessionId,
+          content: wireContent,
+          claudeSessionId: activeBinding,
+          sentAt: Date.now(),
+        });
         // Reply context is consumed on send; the next message starts clean
         // unless the user explicitly long-presses another message.
         if (reply) {
@@ -1922,7 +1998,7 @@ function App() {
         }
       } else {
         setMessages((prev) =>
-          prev.map((m) => (m.id === newMessage.id ? { ...m, state: 'delivered' as const } : m)),
+          prev.map((m) => (m.id === messageId ? { ...m, state: 'failed' as const } : m)),
         );
         const errorMsg: UIMessage = {
           id: generateId(),
@@ -1938,6 +2014,97 @@ function App() {
     },
     [activeSessionId, getActiveConnectionId, sendInput, sessions],
   );
+
+  // Tap-to-retry a 'failed' bubble (#663). Reuses the SAME message id so the
+  // daemon's MessageIdTracker dedups it if the original somehow did land.
+  // Re-enters the pending-sends tracker so the automatic retry/timeout sweep
+  // resumes watching it.
+  const handleRetryMessage = useCallback(
+    (message: UIMessage) => {
+      const sid = message.sessionId;
+      const connId =
+        sessionsRef.current.find((s) => s.id === sid)?.connectionId ?? getActiveConnectionId();
+      if (!connId) return;
+      const binding = sessionsRef.current.find((s) => s.id === sid)?.claudeSessionId;
+
+      setMessages((prev) =>
+        prev.map((m) => (m.id === message.id ? { ...m, state: 'sending' as const } : m)),
+      );
+
+      const success = sendInput(
+        connId,
+        sid,
+        message.content,
+        binding as UUID | undefined,
+        message.id,
+      );
+      if (success) {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === message.id ? { ...m, state: 'sent' as const } : m)),
+        );
+        pendingSendsRef.current = trackSend(pendingSendsRef.current, {
+          messageId: message.id,
+          connectionId: connId,
+          sessionId: sid,
+          content: message.content,
+          claudeSessionId: binding,
+          sentAt: Date.now(),
+        });
+      } else {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === message.id ? { ...m, state: 'failed' as const } : m)),
+        );
+      }
+    },
+    [getActiveConnectionId, sendInput],
+  );
+
+  // Ack-timeout sweep (#663): messages sent via handleSend/handleRetryMessage
+  // that don't get an `ack` within ACK_TIMEOUT_MS get one automatic retry
+  // (same message id), then flip to 'failed' if that also times out. Runs
+  // more frequently than the timeout itself so the UI transition lands
+  // close to the deadline rather than up to a full tick late.
+  useEffect(() => {
+    const ACK_SWEEP_INTERVAL_MS = 1000;
+    const interval = setInterval(() => {
+      const { pending, outcomes } = sweepTimeouts(pendingSendsRef.current, Date.now());
+      if (outcomes.length === 0) return;
+      pendingSendsRef.current = pending;
+
+      for (const outcome of outcomes) {
+        if (outcome.kind === 'failed') {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === outcome.entry.messageId ? { ...m, state: 'failed' as const } : m,
+            ),
+          );
+          continue;
+        }
+
+        // 'retry': resend with the SAME id. If the transport itself refuses
+        // (e.g. disconnected by now), don't wait for a second timeout to
+        // say so -- fail immediately, the outcome is already known.
+        const { entry } = outcome;
+        const resent = sendInput(
+          entry.connectionId as ConnectionId,
+          entry.sessionId as UUID,
+          entry.content,
+          entry.claudeSessionId as UUID | undefined,
+          entry.messageId as UUID,
+        );
+        if (!resent) {
+          pendingSendsRef.current = acknowledgeSend(
+            pendingSendsRef.current,
+            entry.messageId,
+          ).pending;
+          setMessages((prev) =>
+            prev.map((m) => (m.id === entry.messageId ? { ...m, state: 'failed' as const } : m)),
+          );
+        }
+      }
+    }, ACK_SWEEP_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [sendInput]);
 
   // Set the reply context for the current session: long-press on a
   // MessageBubble routes here. The InputArea shows a banner + clear
@@ -2280,6 +2447,7 @@ function App() {
       onCancelQuestion={handleCancelQuestion}
       onCancel={handleEscape}
       onReply={handleReply}
+      onRetryMessage={handleRetryMessage}
       replyContext={sessionReplyContext}
       onClearReply={handleClearReply}
       onBack={handleBack}

--- a/packages/web/src/components/chat/ChatView.tsx
+++ b/packages/web/src/components/chat/ChatView.tsx
@@ -11,6 +11,7 @@ import { hapticImpact } from '@/lib/haptics';
 import type { ReplyContext } from '@/lib/reply-format';
 import type { UIMessage, UIQuestion, UISession } from '@/types';
 import { clsx } from 'clsx';
+import { Lock } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { ChatHeader } from './ChatHeader';
 import { InputArea } from './InputArea';
@@ -44,6 +45,8 @@ interface ChatViewProps {
   /** Long-press on a message bubble fires this with the message; consumer
    *  records it as the active reply context for the session (#401). */
   readonly onReply?: (message: UIMessage) => void;
+  /** Tap-to-retry a 'failed' message bubble (#663). */
+  readonly onRetryMessage?: (message: UIMessage) => void;
   /** Active reply context for this session, if any (#401). */
   readonly replyContext?: ReplyContext | null;
   /** Clear the active reply context (X button on the InputArea banner). */
@@ -75,6 +78,7 @@ export function ChatView({
   onAuqAnswer,
   onCancelQuestion,
   onReply,
+  onRetryMessage,
   replyContext,
   onClearReply,
   onCancel,
@@ -103,6 +107,11 @@ export function ChatView({
     session.status === 'executing' ||
     session.status === 'evaluating';
   const isConnected = session.connectionStatus === 'connected';
+  // Read-only: this session's connection is queued behind another client
+  // holding the exclusive write lock (#662/#663). Rare -- the daemon
+  // FIFO-promotes on disconnect and same-device reconnects self-heal via
+  // reclaim -- but must be visible instead of silently dropping input.
+  const isQueued = session.attachState === 'queued';
 
   // Render a stack of QuestionCards (main + any subagent prompts, #437) pinned
   // at the top of the chat. A pending card needs a live connection; an
@@ -150,6 +159,15 @@ export function ChatView({
         onEndSession={onEndSession}
       />
 
+      {/* Read-only banner (#662/#663): another client holds the write lock.
+          Rendered above the question stack so it's the first thing noticed. */}
+      {isQueued && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-warning)]/10 px-4 py-2 text-xs text-[var(--color-warning)]">
+          <Lock className="size-3.5 shrink-0" />
+          <span>Read-only: another device is attached to this session. Waiting for control.</span>
+        </div>
+      )}
+
       {/* Pinned question stack -- the headline interaction. One card per
           concurrent prompt (main + any subagent prompts, #437). Kept above
           the scroll so the answer is always reachable without scrolling. */}
@@ -174,6 +192,7 @@ export function ChatView({
         onRetry={onRetry}
         onBulletExpand={onBulletExpand}
         onReply={onReply}
+        onRetryMessage={onRetryMessage}
         viewMode={viewMode}
         keyboardVisible={keyboardVisible}
         showTimestamps={showTimestamps}
@@ -190,14 +209,14 @@ export function ChatView({
           onCancel={onCancel}
           question={null}
           isAgentBusy={isAgentBusy}
-          disabled={!isConnected}
+          disabled={!isConnected || isQueued}
           replyContext={replyContext ?? null}
           onClearReply={onClearReply}
           // Session-scoped draft persistence so a half-typed message survives
           // app suspension on iOS (#226) and switching to a different session
           // doesn't leak the draft across.
           draftKey={`remi-draft-${session.id}`}
-          placeholder={!isConnected ? 'Not connected' : 'Type a message...'}
+          placeholder={!isConnected ? 'Not connected' : isQueued ? 'Read-only' : 'Type a message...'}
         />
       )}
     </div>

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -6,9 +6,8 @@
 
 import { useLongPress } from '@/hooks/useLongPress';
 import { hapticImpact } from '@/lib/haptics';
-import type { UIBullet, UIMessage } from '@/types';
+import type { UIBullet, UIMessage, UIMessageState } from '@/types';
 import type { TranscriptContentBlock } from '@remi/shared/protocol.ts';
-import type { MessageState } from '@remi/shared/types.ts';
 import { clsx } from 'clsx';
 import {
   AlertCircle,
@@ -19,6 +18,7 @@ import {
   FileText,
   Loader2,
   Pencil,
+  RotateCw,
   Terminal,
   Wrench,
 } from 'lucide-react';
@@ -32,11 +32,14 @@ interface MessageBubbleProps {
   readonly onBulletExpand?: (bulletId: number) => void;
   /** Long-press the bubble to set this message as the reply context (#401). */
   readonly onReply?: (message: UIMessage) => void;
+  /** Tap-to-retry a message stuck in the 'failed' state (#663): no ack
+   *  arrived within the timeout even after one automatic retry. */
+  readonly onRetryMessage?: (message: UIMessage) => void;
   readonly viewMode?: ViewMode;
 }
 
 /** Status icon based on message delivery state */
-function StatusIcon({ state }: { readonly state: MessageState }) {
+function StatusIcon({ state }: { readonly state: UIMessageState }) {
   switch (state) {
     case 'sending':
       return <Clock className="size-3.5 text-[var(--color-status-sending)]" />;
@@ -46,6 +49,8 @@ function StatusIcon({ state }: { readonly state: MessageState }) {
       return <CheckCheck className="size-3.5 text-[var(--color-status-delivered)]" />;
     case 'read':
       return <CheckCheck className="size-3.5 text-[var(--color-status-read)]" />;
+    case 'failed':
+      return <AlertCircle className="size-3.5 text-[var(--color-error)]" />;
     default:
       return null;
   }
@@ -258,6 +263,7 @@ export function MessageBubble({
   showTimestamp = true,
   onBulletExpand,
   onReply,
+  onRetryMessage,
   viewMode = 'compact',
 }: MessageBubbleProps) {
   const isUser = message.sender === 'user';
@@ -328,6 +334,8 @@ export function MessageBubble({
           message.isStreaming && 'animate-pulse',
           // Editing indicator
           message.isEditing && 'border-[var(--color-primary)] border-dashed',
+          // Failed-send indicator (#663): no ack within the timeout after retry.
+          message.state === 'failed' && 'border-[var(--color-error)]',
           // Long-press affordance hint on touch devices only.
           // `select-none` would break copy-paste on desktop; the
           // `pointer-coarse:` variant scopes the rule to touch input
@@ -382,8 +390,22 @@ export function MessageBubble({
             </span>
           )}
 
-          {/* Delivery status (only for user messages) */}
-          {isUser && <StatusIcon state={message.state} />}
+          {/* Delivery status (only for user messages). A failed send with a
+              retry handler renders as a tappable "Retry" affordance instead
+              of a bare icon (#663). */}
+          {isUser && message.state === 'failed' && onRetryMessage ? (
+            <button
+              type="button"
+              onClick={() => onRetryMessage(message)}
+              className="flex items-center gap-1 text-[10px] font-medium text-[var(--color-error)] hover:opacity-80"
+              aria-label="Retry sending message"
+            >
+              <RotateCw className="size-3" />
+              Retry
+            </button>
+          ) : (
+            isUser && <StatusIcon state={message.state} />
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -21,6 +21,8 @@ interface MessageListProps {
   readonly onBulletExpand?: (bulletId: number) => void;
   /** Long-press on a message bubble fires this with the message (#401). */
   readonly onReply?: (message: UIMessage) => void;
+  /** Tap-to-retry a 'failed' message bubble (#663). */
+  readonly onRetryMessage?: (message: UIMessage) => void;
   readonly viewMode?: ViewMode;
   readonly keyboardVisible?: boolean;
   readonly showTimestamps?: boolean;
@@ -128,6 +130,7 @@ export function MessageList({
   onRetry,
   onBulletExpand,
   onReply,
+  onRetryMessage,
   viewMode = 'compact',
   keyboardVisible = false,
   showTimestamps = true,
@@ -229,6 +232,7 @@ export function MessageList({
                   message={message}
                   onBulletExpand={onBulletExpand}
                   onReply={onReply}
+                  onRetryMessage={onRetryMessage}
                   viewMode={viewMode}
                   showTimestamp={showTimestamps}
                 />

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -103,12 +103,18 @@ export interface UseConnectionManagerReturn {
   reconnect: (connectionId: ConnectionId) => void;
   /** Disconnect all connections */
   disconnectAll: () => void;
-  /** Send user input routed to the correct connection */
+  /**
+   * Send user input routed to the correct connection. `id`, when passed,
+   * is used as the wire message id instead of generating a fresh one --
+   * callers retrying a timed-out send (#663) pass the ORIGINAL id back in
+   * so the daemon's dedup makes the retry idempotent.
+   */
   sendInput: (
     connectionId: ConnectionId,
     sessionId: UUID,
     content: string,
     claudeSessionId?: UUID,
+    id?: UUID,
   ) => boolean;
   /** Send a bare Esc keystroke to the session (interrupt / escape any prompt). */
   sendEscape: (connectionId: ConnectionId, sessionId: UUID, claudeSessionId?: UUID) => boolean;
@@ -668,10 +674,11 @@ export function useConnectionManager(
       sessionId: UUID,
       content: string,
       claudeSessionId?: UUID,
+      id?: UUID,
     ): boolean => {
       return sendToConnection(
         connectionId,
-        createUserInput(sessionId, content, undefined, claudeSessionId),
+        createUserInput(sessionId, content, undefined, claudeSessionId, id),
       );
     },
     [sendToConnection],

--- a/packages/web/src/lib/message-ack-tracker.ts
+++ b/packages/web/src/lib/message-ack-tracker.ts
@@ -1,0 +1,115 @@
+/**
+ * Outstanding-send tracking for the client-side ack timeout + retry state
+ * machine (#663).
+ *
+ * Background: the daemon has always sent an `ack` for every `user_input`
+ * it receives (`packages/daemon/src/server/connection.ts`, `sendAck`), but
+ * the web client never handled it -- `sending -> sent` was purely
+ * optimistic and never advanced to `delivered`. Combined with #662 (a
+ * queued/read-only connection can silently drop input), a message could
+ * look "sent" forever with no way to tell it never landed.
+ *
+ * This module is the pure bookkeeping half of the fix: given a message id
+ * handed to `sendInput`, track it here; when an `ack` arrives, match it;
+ * when no `ack` arrives within `ACK_TIMEOUT_MS`, resend once (same message
+ * id -- the daemon's `MessageIdTracker` dedups a resend that already
+ * landed, so this is safe even if only the ack was lost, not the input);
+ * a second timeout gives up and reports 'failed'. All state transitions
+ * are pure functions over a plain Map so they're unit-testable without a
+ * WebSocket, a timer, or React -- the caller (App.tsx) owns the ref, the
+ * `setInterval` sweep, and turning outcomes into UI state changes.
+ *
+ * Deliberately NOT covered here (out of scope for #663): 'read' receipts,
+ * and an offline outbox for sends attempted while fully disconnected (the
+ * issue calls that out as an optional follow-up).
+ */
+
+/** No `ack` within this long after a send (or a retry) times it out. */
+export const ACK_TIMEOUT_MS = 5000;
+
+/** A `user_input` sent to the daemon, awaiting its `ack`. */
+export interface PendingSend {
+  readonly messageId: string;
+  readonly connectionId: string;
+  readonly sessionId: string;
+  /** Wire content, exactly as sent -- resent verbatim on retry. */
+  readonly content: string;
+  readonly claudeSessionId?: string;
+  /** When this attempt (the original send, or the one retry) went out. */
+  readonly sentAt: number;
+  /** 0 = original send, 1 = the one automatic retry already attempted. */
+  readonly retryCount: number;
+}
+
+export type PendingSendMap = ReadonlyMap<string, PendingSend>;
+
+/** Empty map, for initializing the ref. */
+export const EMPTY_PENDING_SENDS: PendingSendMap = new Map();
+
+/** Start tracking a freshly-sent `user_input`. Returns a new map (does not mutate `pending`). */
+export function trackSend(
+  pending: PendingSendMap,
+  entry: Omit<PendingSend, 'retryCount'>,
+): PendingSendMap {
+  const next = new Map(pending);
+  next.set(entry.messageId, { ...entry, retryCount: 0 });
+  return next;
+}
+
+export interface AcknowledgeResult {
+  readonly pending: PendingSendMap;
+  /** False for an ack that doesn't match anything outstanding: a message
+   *  type we don't track (only `user_input` sends are tracked), or one
+   *  that already timed out to 'failed' (and was removed) before this ack
+   *  arrived. Callers should no-op the UI in that case. */
+  readonly matched: boolean;
+}
+
+/** An `ack` arrived for `messageId`. Stops tracking it. */
+export function acknowledgeSend(pending: PendingSendMap, messageId: string): AcknowledgeResult {
+  if (!pending.has(messageId)) {
+    return { pending, matched: false };
+  }
+  const next = new Map(pending);
+  next.delete(messageId);
+  return { pending: next, matched: true };
+}
+
+export type TimeoutOutcome =
+  /** First timeout: resend `entry` (same messageId) and keep waiting. */
+  | { readonly kind: 'retry'; readonly entry: PendingSend }
+  /** Second timeout (already retried once): give up. */
+  | { readonly kind: 'failed'; readonly entry: PendingSend };
+
+export interface SweepResult {
+  readonly pending: PendingSendMap;
+  readonly outcomes: readonly TimeoutOutcome[];
+}
+
+/**
+ * Find sends that have been outstanding longer than `timeoutMs` and advance
+ * them. Pure -- `now` is injected so callers (and tests) control time.
+ */
+export function sweepTimeouts(
+  pending: PendingSendMap,
+  now: number,
+  timeoutMs: number = ACK_TIMEOUT_MS,
+): SweepResult {
+  const next = new Map(pending);
+  const outcomes: TimeoutOutcome[] = [];
+
+  for (const [id, entry] of pending) {
+    if (now - entry.sentAt < timeoutMs) continue;
+
+    if (entry.retryCount === 0) {
+      const retried: PendingSend = { ...entry, sentAt: now, retryCount: entry.retryCount + 1 };
+      next.set(id, retried);
+      outcomes.push({ kind: 'retry', entry: retried });
+    } else {
+      next.delete(id);
+      outcomes.push({ kind: 'failed', entry });
+    }
+  }
+
+  return { pending: next, outcomes };
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -20,6 +20,14 @@ export type MessageSource = 'optimistic' | 'pty' | 'transcript';
  */
 export type UIQuestionResolvedReason = QuestionResolvedMessage['reason'];
 
+/**
+ * Client-side delivery state for a message bubble. Extends the wire-level
+ * `MessageState` with `'failed'` -- inferred locally when no `ack` arrives
+ * within the timeout after one automatic retry (#663). Never sent over the
+ * wire; the daemon only ever acks `'delivered'`.
+ */
+export type UIMessageState = MessageState | 'failed';
+
 /** Peer role in WebRTC connection */
 export type PeerRole = 'host' | 'client';
 
@@ -103,7 +111,7 @@ export interface UIMessage {
   readonly sender: MessageSender;
   readonly content: string;
   readonly timestamp: Timestamp;
-  readonly state: MessageState;
+  readonly state: UIMessageState;
   readonly isEditing: boolean;
   readonly editedAt?: Timestamp;
   readonly tool?: string;
@@ -169,6 +177,15 @@ export interface UISession {
   readonly agentType?: string;
   /** For a subagent view: false once it finished (transcript stays viewable). */
   readonly subagentActive?: boolean;
+  /**
+   * Whether this session's connection holds the exclusive write lock
+   * ('attached') or is read-only, queued behind another client
+   * ('queued') (#662/#663). Patched from `hello_ack.attachState` and
+   * refreshed by a `NOT_ACTIVE_CONNECTION` error. `undefined` (older
+   * daemon, or a hello_ack sent outside the attach flow) is treated as
+   * attached -- the pre-#662 assumption every hello_ack held the lock.
+   */
+  readonly attachState?: 'attached' | 'queued';
 }
 
 /** Structured option for a question */

--- a/packages/web/tests/lib/message-ack-tracker.test.ts
+++ b/packages/web/tests/lib/message-ack-tracker.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ACK_TIMEOUT_MS,
+  acknowledgeSend,
+  EMPTY_PENDING_SENDS,
+  type PendingSend,
+  sweepTimeouts,
+  trackSend,
+} from '../../src/lib/message-ack-tracker';
+
+const NOW = Date.parse('2026-07-03T00:00:00Z');
+
+const entry = (
+  messageId: string,
+  overrides: Partial<Omit<PendingSend, 'retryCount' | 'messageId'>> = {},
+) => ({
+  messageId,
+  connectionId: 'conn-A',
+  sessionId: 'session-1',
+  content: 'hello',
+  sentAt: NOW,
+  ...overrides,
+});
+
+describe('trackSend', () => {
+  test('adds an entry with retryCount 0', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    expect(pending.get('m1')).toEqual({ ...entry('m1'), retryCount: 0 });
+  });
+
+  test('does not mutate the input map', () => {
+    const before = EMPTY_PENDING_SENDS;
+    trackSend(before, entry('m1'));
+    expect(before.size).toBe(0);
+  });
+
+  test('tracking a new id with the same messageId overwrites the old entry', () => {
+    const first = trackSend(EMPTY_PENDING_SENDS, entry('m1', { content: 'first' }));
+    const second = trackSend(first, entry('m1', { content: 'second' }));
+    expect(second.get('m1')?.content).toBe('second');
+    expect(second.size).toBe(1);
+  });
+});
+
+describe('acknowledgeSend', () => {
+  test('matches and removes an outstanding send', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    const result = acknowledgeSend(pending, 'm1');
+    expect(result.matched).toBe(true);
+    expect(result.pending.has('m1')).toBe(false);
+  });
+
+  test('reports no match for an untracked id (e.g. ack for hello/answer)', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    const result = acknowledgeSend(pending, 'not-tracked');
+    expect(result.matched).toBe(false);
+    // Unrelated ack must not disturb what IS tracked.
+    expect(result.pending.has('m1')).toBe(true);
+  });
+
+  test('does not mutate the input map', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    acknowledgeSend(pending, 'm1');
+    expect(pending.has('m1')).toBe(true);
+  });
+
+  test('leaves other outstanding sends untouched', () => {
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    pending = trackSend(pending, entry('m2'));
+    const result = acknowledgeSend(pending, 'm1');
+    expect(result.pending.has('m1')).toBe(false);
+    expect(result.pending.has('m2')).toBe(true);
+  });
+});
+
+describe('sweepTimeouts', () => {
+  test('leaves a fresh send untouched', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const result = sweepTimeouts(pending, NOW + 1000);
+    expect(result.outcomes).toHaveLength(0);
+    expect(result.pending.get('m1')?.retryCount).toBe(0);
+  });
+
+  test('boundary: exactly at the timeout retries', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const result = sweepTimeouts(pending, NOW + ACK_TIMEOUT_MS);
+    expect(result.outcomes).toEqual([
+      { kind: 'retry', entry: { ...entry('m1'), sentAt: NOW + ACK_TIMEOUT_MS, retryCount: 1 } },
+    ]);
+  });
+
+  test('boundary: one ms under the timeout does not retry', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const result = sweepTimeouts(pending, NOW + ACK_TIMEOUT_MS - 1);
+    expect(result.outcomes).toHaveLength(0);
+  });
+
+  test('first timeout retries: bumps retryCount, resets sentAt, keeps waiting', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const t1 = NOW + ACK_TIMEOUT_MS;
+    const { pending: afterRetry, outcomes } = sweepTimeouts(pending, t1);
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toEqual({
+      kind: 'retry',
+      entry: { ...entry('m1'), sentAt: t1, retryCount: 1 },
+    });
+    expect(afterRetry.get('m1')).toEqual({ ...entry('m1'), sentAt: t1, retryCount: 1 });
+  });
+
+  test('second timeout (already retried) fails and removes the entry', () => {
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const t1 = NOW + ACK_TIMEOUT_MS;
+    ({ pending } = sweepTimeouts(pending, t1));
+
+    const t2 = t1 + ACK_TIMEOUT_MS;
+    const { pending: afterFail, outcomes } = sweepTimeouts(pending, t2);
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]?.kind).toBe('failed');
+    expect(outcomes[0]?.entry.messageId).toBe('m1');
+    expect(afterFail.has('m1')).toBe(false);
+  });
+
+  test('an ack between the retry and the second timeout stops the sweep from failing it', () => {
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const t1 = NOW + ACK_TIMEOUT_MS;
+    ({ pending } = sweepTimeouts(pending, t1));
+
+    // Ack arrives for the retried attempt.
+    ({ pending } = acknowledgeSend(pending, 'm1'));
+
+    const t2 = t1 + ACK_TIMEOUT_MS;
+    const { outcomes } = sweepTimeouts(pending, t2);
+    expect(outcomes).toHaveLength(0);
+  });
+
+  test('sweeps multiple outstanding sends independently', () => {
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    pending = trackSend(pending, entry('m2', { sentAt: NOW + 4000 }));
+
+    // m1 is over the timeout, m2 is not yet.
+    const { pending: after, outcomes } = sweepTimeouts(pending, NOW + ACK_TIMEOUT_MS);
+    expect(outcomes).toEqual([
+      { kind: 'retry', entry: { ...entry('m1'), sentAt: NOW + ACK_TIMEOUT_MS, retryCount: 1 } },
+    ]);
+    expect(after.get('m2')?.retryCount).toBe(0);
+  });
+
+  test('does not mutate the input map', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    sweepTimeouts(pending, NOW + ACK_TIMEOUT_MS);
+    expect(pending.get('m1')?.retryCount).toBe(0);
+  });
+
+  test('empty map sweeps to no outcomes', () => {
+    const { pending, outcomes } = sweepTimeouts(EMPTY_PENDING_SENDS, NOW + 100_000);
+    expect(outcomes).toHaveLength(0);
+    expect(pending.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The daemon has always sent an app-level `ack` for every `user_input`/`answer` (`packages/daemon/src/server/connection.ts` `sendAck` calls), but the web client never handled it: there was no `case 'ack'` in `App.tsx`'s message switch, so `sending -> sent` was purely optimistic and never advanced to `delivered`. Combined with #662, a message could be silently dropped at the daemon with no way for the user to tell.

This PR wires the ack into the client's message state machine, adds a timeout + one automatic retry + a `failed` terminal state with tap-to-retry, and renders the queued/read-only state introduced by #662's `hello_ack.attachState`.

- Ack wiring: new `case 'ack'` in `App.tsx#handleMessage` advances a matching user message from `sent` to `delivered`. Acks for anything else (hello, answer, etc.) simply find no match in the tracker and no-op.
- Ack timeout + retry: `packages/web/src/lib/message-ack-tracker.ts` is a small pure module (`trackSend` / `acknowledgeSend` / `sweepTimeouts`) that tracks outstanding `user_input` sends by message id. A 1s interval in `App.tsx` sweeps it: no ack within 5s (`ACK_TIMEOUT_MS`) triggers one automatic retry reusing the SAME message id (the daemon's `MessageIdTracker` dedups a resend that already landed, making it idempotent); a second timeout, or an immediate transport failure on the retry, flips the bubble to a new `'failed'` UI state.
- `createUserInput` (shared protocol) and `sendInput` (`useConnectionManager`) both gained an optional trailing `id` param so a retry (and the initial send) can control the wire message id instead of always generating a fresh one. This also lets the UI bubble id and the wire message id be the same value, which is what lets an inbound `ack.messageId` find its bubble.
- `UIMessageState = MessageState | 'failed'` (client-only; never sent over the wire) replaces the previous buggy behavior where a synchronously-failed send was mislabeled `'delivered'` in `handleSend`.
- `MessageBubble` renders `'failed'` as a tappable "Retry" affordance (in place of the status tick); `onRetryMessage` threads through `MessageList` / `ChatView` to `App.tsx#handleRetryMessage`, which resends with the same id.
- Queued/read-only state: `UISession.attachState` mirrors `hello_ack.attachState` (patched on every hello_ack, including the promotion push that clears it back to `'attached'`). `ChatView` renders a read-only banner and disables `InputArea` when `attachState === 'queued'`.
- `NOT_ACTIVE_CONNECTION` (the daemon's #662 error for input rejected because this connection is read-only) now sets `attachState: 'queued'` on the affected session instead of only falling through to a one-off system-bubble the user could miss. The error carries no messageId, so it can't flip a specific bubble -- the ack for that same input still arrives and the bubble still shows delivered; the banner is the primary signal that the content may not have reached Claude.

## Scope notes

- Only `user_input` sends get the ack/retry/failed treatment, per the issue -- `answer` sends are untouched.
- 'read' receipts are out of scope; the state machine stops at `sending -> sent -> delivered -> failed`.
- No offline outbox for sends attempted while fully disconnected (called out in the issue as an optional follow-up).
- Daemon and signaling packages are untouched except a tiny, backward-compatible optional param on `createUserInput` (`packages/shared/src/protocol.ts`).

## Testing

- New unit tests: `packages/web/tests/lib/message-ack-tracker.test.ts` (16 tests covering track/ack/timeout/retry/boundary cases, pure with injected `now`).
- `bun run typecheck` (root): clean.
- `bun test packages/web packages/shared`: 500 pass, 0 fail.
- `cd packages/web && bun run build`: clean (stricter tsconfig).
- `cd packages/web && bun run lint`: same 3 pre-existing errors / 2 warnings as unmodified `develop` (`InputArea.tsx`, `useConnectionManager.ts`, `useWebSocket.ts`, `message-filter.ts`); none introduced by this change, none in touched files.
- Relevant daemon tests re-run to confirm the `createUserInput` optional-param addition didn't regress anything: `connection-auth.test.ts`, `websocket-server.test.ts`, `websocket-server-loopback-auth.test.ts`, `cli/handlers/connection-events.test.ts`, `cli/handlers/input-events.test.ts` -- all pass.

## Manual validation checklist (web client against a real daemon)

- [ ] Send a message normally; bubble goes sending -> sent -> delivered (double-check) within ~1s on a healthy connection.
- [ ] Kill the daemon process right after sending (before the ack arrives); bubble auto-retries once at 5s, then flips to a red "Retry" affordance at ~10s if the daemon stays down.
- [ ] Tap "Retry" on a failed bubble with the daemon back up; it resends and reaches delivered.
- [ ] Open the same session from two clients (or two tabs); the second one should show the read-only banner ("Read-only: another device is attached...") and a disabled input with "Read-only" placeholder.
- [ ] Disconnect the first (attached) client; the second client's banner clears and input re-enables once the daemon promotes it (fresh `hello_ack` with `attachState: 'attached'`).
- [ ] Confirm a message typed into a queued/read-only session cannot be sent (input disabled) and, if forced via an in-flight race, that a `NOT_ACTIVE_CONNECTION` error refreshes the banner rather than only adding a chat bubble.

Closes #663
Refs #662, #666, #174