### PR TITLE
fix(#672): fail-safe admission for foreign sessions

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -144,7 +144,7 @@ import { installSuspendHandler } from './cli/suspend-handler.ts';
 import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
-import { HookConfigManager, HookServer } from './hooks/index.ts';
+import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
@@ -1059,6 +1059,21 @@ const deviceTokenStore = new DeviceTokenStore(path.join(REMI_DIR, 'device-tokens
 deviceTokenStore.load();
 const deviceTokens = deviceTokenStore.map;
 
+// Daemon-wide fail-safe for a PermissionRequest no session on this daemon owns
+// (#672): shared by every session's hook bridge so its escalation rate-limit
+// is per foreign claude session id ACROSS the whole daemon, not reset per
+// session. See ForeignSessionEscalator's module doc for the ownership ladder.
+const foreignSessionEscalator = new ForeignSessionEscalator({
+  liveSessionsRegistry,
+  bindingStore,
+  deviceTokens,
+  pushConfig: () => ({
+    signalingUrl: cliSignalingUrl ?? remiConfig.network.signaling_url,
+    ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+  }),
+  currentPort: () => PORT,
+});
+
 // Hook infrastructure (initialized in wrapper mode when hooks are enabled)
 let HOOK_PORT = 0; // OS-assigned; actual port read from hookServer.port after start
 let hookServer: HookServer | null = null;
@@ -1283,6 +1298,7 @@ async function createNewSession(
         transcriptDiscovery,
         subagentViews,
         statusWriter,
+        foreignSessionEscalator,
         // #573: classify holdable escalations + the hold / slow-eval-push budgets
         // (seconds; the gate converts to ms and treats <=0 as disabled).
         alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -48,7 +48,7 @@ import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import { AutoApproveGate } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
-import type { HookServer } from '../../hooks/index.ts';
+import type { ForeignSessionEscalator, HookServer } from '../../hooks/index.ts';
 import type { DeliveryOutcome } from '../../notifications/notification-dispatcher.ts';
 import type {
   SessionBindingStore,
@@ -141,6 +141,17 @@ export interface HookBridgeDeps {
     questionId: UUID,
     reason: 'auto_approved' | 'auto_denied' | 'cancelled',
   ) => void;
+  /**
+   * Fail-safe fallback for a PermissionRequest that `binder.admits()` rejects
+   * (#672): decides whether a live sibling daemon owns the foreign session
+   * (stay silent) or it is genuinely unclaimed (fire a rate-limited,
+   * informational-only push — never an answerable Question, since an answer
+   * cannot be injected into a PTY we do not own). Shared across every session
+   * on this daemon so its rate-limit state is daemon-wide, not per-session.
+   * Absent => legacy debug-log-only passthrough (tests / callers that build
+   * their own bridge without daemon-wide escalation wiring).
+   */
+  foreignSessionEscalator?: ForeignSessionEscalator;
 }
 
 export interface HookBridgeArgs {
@@ -564,6 +575,11 @@ export function setupHookBridge(
           `incoming=${input.session_id?.slice(0, 8) ?? '-'} ` +
           `agent=${isSubagentEvent(input) ? (input.agent_id?.slice(0, 8) ?? 'subagent') : 'main'}`,
       );
+      // #672: fail-safe ladder for a foreign PermissionRequest — silent when a
+      // live sibling daemon owns it, an informational (non-answerable) push
+      // when it is genuinely unclaimed, error-only when ownership cannot be
+      // determined. Never affects the synchronous 'passthrough' below.
+      deps.foreignSessionEscalator?.handleUnadmitted(input, sessionId);
       return 'passthrough';
     }
     return autoApproveGate.resolvePermission(input);

--- a/packages/daemon/src/hooks/foreign-session-escalator.ts
+++ b/packages/daemon/src/hooks/foreign-session-escalator.ts
@@ -1,0 +1,213 @@
+/**
+ * ForeignSessionEscalator — the fail-safe fallback for a PermissionRequest hook
+ * that `TranscriptBinder.admits()` rejects (#672).
+ *
+ * Claude Code hooks are project-scoped: every `claude` process sharing a
+ * project directory fires PermissionRequest at every daemon watching that
+ * directory. `admits()` recognizes only events from our own session (exact
+ * id, a subagent sharing our transcript, or a marker-proven reclaim); anything
+ * else used to be dropped with a single debug-level log line and NOTHING else
+ * — no auto-approve evaluation, no escalation to the user. For a genuinely
+ * separate top-level session (a teammate, or any other unmanaged `claude`
+ * process in the same cwd), that means its permission prompts are silently
+ * lost: nobody evaluates them and nobody is told they are waiting.
+ *
+ * This class runs a three-way ownership ladder for such an event:
+ *
+ *   1. SIBLING — a DIFFERENT live remi daemon owns it (via the durable binding
+ *      store's reverse lookup, or the transcript's own port marker naming a
+ *      currently-live sibling). That daemon's own admission path handles it;
+ *      we stay silent.
+ *   2. UNCLAIMED — no live daemon claims it. Fire a rate-limited INFORMATIONAL
+ *      push so the user at least knows a permission prompt is stuck somewhere
+ *      unmanaged. This is NOT a `Question`: nothing here is answerable through
+ *      Remi. The hook for a foreign session is not ours to resolve — Claude
+ *      is blocked waiting in that OTHER process, not ours — so an "answer"
+ *      from the phone would have nowhere valid to go. Reusing the normal
+ *      Question/hold machinery would risk exactly that: an answer routed back
+ *      through OUR `resolveHeld` would inject into OUR PTY, the wrong session
+ *      entirely (the evil twin of #538). The push therefore carries no
+ *      `category` and no `options`: iOS only renders action buttons for the
+ *      three registered categories (REMI_YN / REMI_YNA / REMI_MULTI,
+ *      `AppDelegate.swift`), so a push with neither is a plain, dismiss-only
+ *      banner — tapping it can only open the app, never submit an answer.
+ *   3. UNKNOWN — ownership could not be determined (a registry/store read
+ *      failed). Log at ERROR level only; never escalate on an inconclusive
+ *      read, so a filesystem hiccup cannot turn into a notification storm.
+ *
+ * All of this runs from a synchronous hook resolver (`setPermissionResolver`)
+ * that must return 'passthrough' immediately regardless of what this class
+ * decides — `handleUnadmitted` performs its (cheap, synchronous) ownership
+ * check inline, then fires the push in the background without making the
+ * caller await it.
+ */
+
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import { errorToString } from '@remi/shared';
+
+import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
+import { log, logError } from '../cli/logger.ts';
+import type { PushConfig, PushFn } from '../notifications/notification-dispatcher.ts';
+import { sendPushTrigger } from '../notifications/push-client.ts';
+import type { SessionBindingStore } from '../session/index.ts';
+import { type SessionRegistryFile, claudeChildLooksAlive } from '../session/index.ts';
+import { readTranscriptOwnerPort } from '../transcript/transcript-owner.ts';
+import type { PermissionRequestHookInput } from './hook-types.ts';
+
+/** At most one informational escalation per foreign claude session_id within
+ *  this window, so a busy unclaimed session cannot spam the user's phone. */
+const DEFAULT_RATE_LIMIT_MS = 5 * 60_000;
+
+export interface ForeignSessionEscalatorDeps {
+  liveSessionsRegistry: SessionRegistryFile;
+  bindingStore: SessionBindingStore;
+  deviceTokens: Map<string, DeviceTokenEntry>;
+  pushConfig: () => PushConfig;
+  currentPort: () => number;
+  /** Test override for the push transport; defaults to the real sendPushTrigger. */
+  pushFn?: PushFn;
+  /** Test override for the rate-limit window (ms); defaults to 5 minutes. */
+  rateLimitMs?: number;
+  /** Test override clock; defaults to Date.now. */
+  now?: () => number;
+}
+
+export class ForeignSessionEscalator {
+  private readonly pushFn: PushFn;
+  private readonly rateLimitMs: number;
+  private readonly now: () => number;
+  /** Foreign claude session_id -> epoch ms of its last escalation. Pruned on
+   *  every check so the map never grows unbounded across a long daemon life. */
+  private readonly lastEscalated = new Map<string, number>();
+
+  constructor(private readonly deps: ForeignSessionEscalatorDeps) {
+    this.pushFn = deps.pushFn ?? sendPushTrigger;
+    this.rateLimitMs = deps.rateLimitMs ?? DEFAULT_RATE_LIMIT_MS;
+    this.now = deps.now ?? Date.now;
+  }
+
+  /**
+   * Called by a session's PermissionRequest resolver when `binder.admits()`
+   * rejected the event. `callerSessionId` is the remi session that DETECTED
+   * the foreign event (used only to route the informational push somewhere
+   * real; it is never treated as the owner of `input`).
+   */
+  handleUnadmitted(input: PermissionRequestHookInput, callerSessionId: UUID): void {
+    let ownership: 'sibling' | 'unclaimed';
+    try {
+      ownership = this.classifyOwnership(input);
+    } catch (err) {
+      logError(
+        `[ForeignSession] Could not determine ownership of ${input.session_id.slice(0, 8)} ` +
+          `(registry read failed); staying quiet to avoid an escalation storm: ${errorToString(err)}`,
+      );
+      return;
+    }
+    if (ownership === 'sibling') {
+      log(
+        `[ForeignSession] ${input.session_id.slice(0, 8)} (tool=${input.tool_name}) claimed by a live sibling daemon; staying silent`,
+      );
+      return;
+    }
+    if (!this.shouldEscalate(input.session_id)) {
+      log(
+        `[ForeignSession] Suppressing repeat escalation for ${input.session_id.slice(0, 8)} (rate-limited)`,
+      );
+      return;
+    }
+    // Fire-and-forget: the caller (a synchronous hook resolver) must not wait
+    // on a network push before returning its own decision.
+    void this.pushInformational(input, callerSessionId).catch((err) => {
+      logError(`[ForeignSession] Informational push threw: ${errorToString(err)}`);
+    });
+  }
+
+  /**
+   * Sibling-vs-unclaimed. Two independent signals, either sufficient to prove
+   * a live sibling daemon owns `input`:
+   *   (a) the durable binding store already maps this claude session id to a
+   *       DIFFERENT remi session, and that session's daemon is currently live
+   *       (cross-checked against the live-sessions registry, not just the
+   *       store's own coarser bookkeeping);
+   *   (b) the foreign transcript's `remi:<port>` marker names a port some
+   *       OTHER currently-live daemon is bound to.
+   * Deliberately NOT try/catch'd here: the caller wraps this call so a
+   * registry/store read failure is logged once at error level (case 3)
+   * instead of silently falling through to an escalation.
+   */
+  private classifyOwnership(input: PermissionRequestHookInput): 'sibling' | 'unclaimed' {
+    const live = this.deps.liveSessionsRegistry.listLive();
+
+    const stored = this.deps.bindingStore.getByClaudeSessionId(input.session_id);
+    if (stored) {
+      const owner = live.find((e) => e.sessionId === stored.remiSessionId);
+      if (owner && claudeChildLooksAlive(owner)) return 'sibling';
+    }
+
+    const ownerPort = readTranscriptOwnerPort(input.transcript_path);
+    if (ownerPort !== null && ownerPort !== this.deps.currentPort()) {
+      if (live.some((e) => e.wsPort === ownerPort && claudeChildLooksAlive(e))) {
+        return 'sibling';
+      }
+    }
+
+    return 'unclaimed';
+  }
+
+  /** Rate-limit gate: true (and records `now`) iff this claude session id has
+   *  not been escalated within the last `rateLimitMs`. */
+  private shouldEscalate(claudeSessionId: string): boolean {
+    const now = this.now();
+    for (const [id, at] of this.lastEscalated) {
+      if (now - at > this.rateLimitMs) this.lastEscalated.delete(id);
+    }
+    const last = this.lastEscalated.get(claudeSessionId);
+    if (last !== undefined && now - last < this.rateLimitMs) return false;
+    this.lastEscalated.set(claudeSessionId, now);
+    return true;
+  }
+
+  /**
+   * Fire a dismiss-only informational push (case 2). Deliberately NOT routed
+   * through `sessionRegistry.addQuestion` / the tracker's hold machinery: this
+   * is not a question anyone can answer through Remi. See the module doc for
+   * why no `category` / `options` are set.
+   */
+  private async pushInformational(
+    input: PermissionRequestHookInput,
+    callerSessionId: UUID,
+  ): Promise<void> {
+    const { deviceTokens, pushConfig } = this.deps;
+    const shortId = input.session_id.slice(0, 8);
+    if (deviceTokens.size === 0) {
+      log(
+        `[ForeignSession] No device tokens registered; cannot notify about unbound session ${shortId}`,
+      );
+      return;
+    }
+    const cfg = pushConfig();
+    const cwdHint = input.cwd ? path.basename(input.cwd) : undefined;
+    const title = `Unbound Claude session (${shortId})`;
+    const body = `${input.tool_name} requested permission in a Claude session Remi does not manage${cwdHint ? ` (${cwdHint})` : ''}. Not connected to Remi; answer it in that terminal directly.`;
+
+    const results = await Promise.allSettled(
+      [...deviceTokens.values()].map((dt) =>
+        this.pushFn(cfg.signalingUrl, dt.token, {
+          title,
+          body,
+          ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+          sessionId: callerSessionId,
+          // Deliberately no `category` / `options`: dismiss-only, no action
+          // buttons (see module doc). Also no `questionId` -- there is no
+          // Question backing this push for an answer to resolve against.
+        }),
+      ),
+    );
+    if (!results.some((r) => r.status === 'fulfilled')) {
+      logError(
+        `[ForeignSession] Escalation push failed for all device tokens (session ${shortId})`,
+      );
+    }
+  }
+}

--- a/packages/daemon/src/hooks/foreign-session-escalator.ts
+++ b/packages/daemon/src/hooks/foreign-session-escalator.ts
@@ -31,9 +31,26 @@
  *      three registered categories (REMI_YN / REMI_YNA / REMI_MULTI,
  *      `AppDelegate.swift`), so a push with neither is a plain, dismiss-only
  *      banner — tapping it can only open the app, never submit an answer.
- *   3. UNKNOWN — ownership could not be determined (a registry/store read
- *      failed). Log at ERROR level only; never escalate on an inconclusive
- *      read, so a filesystem hiccup cannot turn into a notification storm.
+ *   3. UNDETERMINED — ownership could not be proven either way: a
+ *      registry/store read failed, OR the transcript's marker is unreadable
+ *      AND the file is too recent to trust that as "genuinely markerless"
+ *      (see below). Log at ERROR level only; never escalate on an
+ *      inconclusive read, so a filesystem hiccup — or our own in-flight
+ *      rotation — cannot turn into a notification storm / a self-targeted
+ *      false alarm.
+ *
+ * MARKER-UNREADABLE SUB-CASE (post-review hardening): `readTranscriptOwnerPort`
+ * returning null does not by itself mean "no remi daemon manages this session."
+ * It can also mean OUR OWN transcript, seconds into a rotation (/clear,
+ * /resume), whose head marker Claude has not finished flushing yet — and with
+ * a sibling present in the directory, `TranscriptBinder.admits()` rejects our
+ * OWN PermissionRequest during exactly that window (the sibling-defer gate
+ * cannot yet prove the new transcript is ours either). Escalating in that
+ * window would push "Unbound Claude session" about the user's OWN, perfectly
+ * normal session. The fix: a null marker on a file young enough to still be
+ * mid-flush (MARKER_SETTLE_MS) classifies as UNDETERMINED, not UNCLAIMED; only
+ * a null marker on a file that has sat that way well past the settle window
+ * is treated as genuinely foreign.
  *
  * All of this runs from a synchronous hook resolver (`setPermissionResolver`)
  * that must return 'passthrough' immediately regardless of what this class
@@ -42,6 +59,7 @@
  * caller await it.
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { UUID } from '@remi/shared';
 import { errorToString } from '@remi/shared';
@@ -52,12 +70,22 @@ import type { PushConfig, PushFn } from '../notifications/notification-dispatche
 import { sendPushTrigger } from '../notifications/push-client.ts';
 import type { SessionBindingStore } from '../session/index.ts';
 import { type SessionRegistryFile, claudeChildLooksAlive } from '../session/index.ts';
-import { readTranscriptOwnerPort } from '../transcript/transcript-owner.ts';
+import { MARKER_SETTLE_MS, readTranscriptOwnerPort } from '../transcript/transcript-owner.ts';
 import type { PermissionRequestHookInput } from './hook-types.ts';
 
 /** At most one informational escalation per foreign claude session_id within
  *  this window, so a busy unclaimed session cannot spam the user's phone. */
 const DEFAULT_RATE_LIMIT_MS = 5 * 60_000;
+
+/**
+ * Hard ceiling on distinct foreign session_ids tracked for rate-limiting at
+ * once. The age-based prune in `shouldEscalate` only evicts entries OLDER
+ * than `rateLimitMs`, so a burst of many DISTINCT foreign session_ids within
+ * a single window (all fresh, none prunable yet) would otherwise grow the
+ * map unbounded. This is a second, independent bound: once exceeded, the
+ * OLDEST entries (by recorded timestamp) are evicted first.
+ */
+const MAX_TRACKED_FOREIGN_SESSIONS = 500;
 
 export interface ForeignSessionEscalatorDeps {
   liveSessionsRegistry: SessionRegistryFile;
@@ -69,13 +97,19 @@ export interface ForeignSessionEscalatorDeps {
   pushFn?: PushFn;
   /** Test override for the rate-limit window (ms); defaults to 5 minutes. */
   rateLimitMs?: number;
+  /** Test override for the marker-settle window (ms); defaults to the shared
+   *  MARKER_SETTLE_MS (10s) TranscriptBinder's dir-poll also uses. */
+  markerSettleMs?: number;
   /** Test override clock; defaults to Date.now. */
   now?: () => number;
 }
 
+type Ownership = 'sibling' | 'unclaimed' | 'undetermined';
+
 export class ForeignSessionEscalator {
   private readonly pushFn: PushFn;
   private readonly rateLimitMs: number;
+  private readonly markerSettleMs: number;
   private readonly now: () => number;
   /** Foreign claude session_id -> epoch ms of its last escalation. Pruned on
    *  every check so the map never grows unbounded across a long daemon life. */
@@ -84,6 +118,7 @@ export class ForeignSessionEscalator {
   constructor(private readonly deps: ForeignSessionEscalatorDeps) {
     this.pushFn = deps.pushFn ?? sendPushTrigger;
     this.rateLimitMs = deps.rateLimitMs ?? DEFAULT_RATE_LIMIT_MS;
+    this.markerSettleMs = deps.markerSettleMs ?? MARKER_SETTLE_MS;
     this.now = deps.now ?? Date.now;
   }
 
@@ -94,7 +129,7 @@ export class ForeignSessionEscalator {
    * real; it is never treated as the owner of `input`).
    */
   handleUnadmitted(input: PermissionRequestHookInput, callerSessionId: UUID): void {
-    let ownership: 'sibling' | 'unclaimed';
+    let ownership: Ownership;
     try {
       ownership = this.classifyOwnership(input);
     } catch (err) {
@@ -107,6 +142,12 @@ export class ForeignSessionEscalator {
     if (ownership === 'sibling') {
       log(
         `[ForeignSession] ${input.session_id.slice(0, 8)} (tool=${input.tool_name}) claimed by a live sibling daemon; staying silent`,
+      );
+      return;
+    }
+    if (ownership === 'undetermined') {
+      logError(
+        `[ForeignSession] Ownership of ${input.session_id.slice(0, 8)} (tool=${input.tool_name}) could not be proven yet (marker unreadable on a still-recent transcript -- possibly our own in-flight rotation); staying quiet rather than risk a false-alarm push`,
       );
       return;
     }
@@ -124,19 +165,28 @@ export class ForeignSessionEscalator {
   }
 
   /**
-   * Sibling-vs-unclaimed. Two independent signals, either sufficient to prove
-   * a live sibling daemon owns `input`:
+   * Sibling / unclaimed / undetermined. Two independent signals prove a live
+   * sibling daemon owns `input`:
    *   (a) the durable binding store already maps this claude session id to a
    *       DIFFERENT remi session, and that session's daemon is currently live
    *       (cross-checked against the live-sessions registry, not just the
    *       store's own coarser bookkeeping);
    *   (b) the foreign transcript's `remi:<port>` marker names a port some
-   *       OTHER currently-live daemon is bound to.
+   *       OTHER currently-live daemon is bound to. Unlike TranscriptBinder's
+   *       storedPort reclaim fallback (which trusts a value frozen at OUR
+   *       session's spawn time, arbitrarily long ago), every input to this
+   *       comparison is read fresh at decision time -- the incoming marker
+   *       AND the sibling's liveness -- so there is no stale/frozen value to
+   *       go stale between recording and use; a symmetric freshness gate here
+   *       would add no protection (post-review non-blocking item, addressed
+   *       by leaving this asymmetric on purpose).
+   * A null marker (unreadable) is NOT immediately 'unclaimed': see the module
+   * doc's "MARKER-UNREADABLE SUB-CASE".
    * Deliberately NOT try/catch'd here: the caller wraps this call so a
-   * registry/store read failure is logged once at error level (case 3)
-   * instead of silently falling through to an escalation.
+   * registry/store read failure is logged once at error level instead of
+   * silently falling through to an escalation.
    */
-  private classifyOwnership(input: PermissionRequestHookInput): 'sibling' | 'unclaimed' {
+  private classifyOwnership(input: PermissionRequestHookInput): Ownership {
     const live = this.deps.liveSessionsRegistry.listLive();
 
     const stored = this.deps.bindingStore.getByClaudeSessionId(input.session_id);
@@ -146,13 +196,34 @@ export class ForeignSessionEscalator {
     }
 
     const ownerPort = readTranscriptOwnerPort(input.transcript_path);
-    if (ownerPort !== null && ownerPort !== this.deps.currentPort()) {
-      if (live.some((e) => e.wsPort === ownerPort && claudeChildLooksAlive(e))) {
-        return 'sibling';
-      }
+    if (ownerPort === null) {
+      return this.markerMayStillBeSettling(input.transcript_path) ? 'undetermined' : 'unclaimed';
+    }
+
+    if (
+      ownerPort !== this.deps.currentPort() &&
+      live.some((e) => e.wsPort === ownerPort && claudeChildLooksAlive(e))
+    ) {
+      return 'sibling';
     }
 
     return 'unclaimed';
+  }
+
+  /**
+   * Whether `transcriptPath` is too fresh to trust a null marker read as
+   * proof of "genuinely markerless" (post-review). Mirrors the same
+   * MARKER_SETTLE_MS threshold TranscriptBinder's rotation dir-poll uses for
+   * the identical "still flushing vs. settled" question. An unreadable/missing
+   * file (stat failure) also returns true: fail toward NOT escalating on an
+   * inconclusive read, same philosophy as the registry-read-error case.
+   */
+  private markerMayStillBeSettling(transcriptPath: string): boolean {
+    try {
+      return Date.now() - fs.statSync(transcriptPath).mtimeMs <= this.markerSettleMs;
+    } catch {
+      return true;
+    }
   }
 
   /** Rate-limit gate: true (and records `now`) iff this claude session id has
@@ -165,7 +236,21 @@ export class ForeignSessionEscalator {
     const last = this.lastEscalated.get(claudeSessionId);
     if (last !== undefined && now - last < this.rateLimitMs) return false;
     this.lastEscalated.set(claudeSessionId, now);
+    this.evictOldestIfOverCap();
     return true;
+  }
+
+  /** Hard size cap, independent of the age-based prune above: a burst of many
+   *  distinct foreign session_ids within one rate-limit window are all
+   *  "fresh" and none would be pruned by age alone. Evicts the OLDEST entries
+   *  (by recorded timestamp) until back at the cap. */
+  private evictOldestIfOverCap(): void {
+    const over = this.lastEscalated.size - MAX_TRACKED_FOREIGN_SESSIONS;
+    if (over <= 0) return;
+    const oldestFirst = [...this.lastEscalated.entries()].sort((a, b) => a[1] - b[1]);
+    for (const [id] of oldestFirst.slice(0, over)) {
+      this.lastEscalated.delete(id);
+    }
   }
 
   /**

--- a/packages/daemon/src/hooks/index.ts
+++ b/packages/daemon/src/hooks/index.ts
@@ -7,6 +7,8 @@ export type {
 } from './hook-server.ts';
 export { HookConfigManager } from './hook-config-manager.ts';
 export { HookEventBridge } from './hook-event-bridge.ts';
+export { ForeignSessionEscalator } from './foreign-session-escalator.ts';
+export type { ForeignSessionEscalatorDeps } from './foreign-session-escalator.ts';
 export type { HookBridgeEvents } from './hook-event-bridge.ts';
 export type {
   HookInput,

--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -62,6 +62,19 @@ export class SessionBindingStore {
   }
 
   /**
+   * The port recorded for this remi session at spawn time (#672). Written once
+   * by `preAssign` and never refreshed on a later daemon restart, so it stays
+   * fixed at whatever port was live when the session was created — unlike the
+   * live `currentPort()`, which can drift to a different port after a restart
+   * (port-selection #146). Callers use this as a fallback ownership signal when
+   * a transcript's `remi:<port>` marker no longer matches the live port: the
+   * marker may still match the port THIS session originally ran on.
+   */
+  getStoredPort(remiSessionId: UUID): number | null {
+    return this.store.findByRemiSessionId(remiSessionId)?.port ?? null;
+  }
+
+  /**
    * Update the durable binding on rotation / first discovery. Delegates to
    * SessionStore.updateClaudeSessionId (a no-op when the record is absent, matching
    * today). Together with preAssign, the ONLY claudeSessionId writer.

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -517,7 +517,20 @@ export class TranscriptBinder {
   admits(event: BinderHookEvent): boolean {
     this.adoptLockFromStore();
     if (!this.currentBoundId) return !this.hasSiblingInDir();
-    if (event.session_id === this.currentBoundId) return true;
+    // #672: a bare session_id match is not, by itself, conclusive proof of
+    // ownership — when the event ALSO carries a transcript_path and we already
+    // have one bound (lastTranscriptPath), the two must agree. Without this, a
+    // stale/raced id collision (two daemons momentarily adopting the same
+    // claude session id) would admit an event whose transcript is provably a
+    // DIFFERENT file than the one we are bound to. A mismatch falls through to
+    // the subagent + marker checks below rather than failing outright, so a
+    // marker-proven rotation we have not caught up to yet still reclaims.
+    if (
+      event.session_id === this.currentBoundId &&
+      this.transcriptConsistentWithBinding(event.transcript_path)
+    ) {
+      return true;
+    }
     // #593: a SUBAGENT of our session (agent_id present) can carry a session_id
     // that differs from our lock — parallel/team subagents, or an empty
     // 00000000 id — while still sharing OUR main transcript. Admit it when its
@@ -539,6 +552,28 @@ export class TranscriptBinder {
     // stays genuinely foreign (a real sibling), where the 8KB head read is
     // bounded and acceptable.
     return this.incomingReclaimsViaMarker(event);
+  }
+
+  /**
+   * #672: whether an event's transcript_path agrees with the transcript we are
+   * ALREADY bound to. Deliberately permissive when either side is unknown: no
+   * event path (many hook types omit it), or no bound path yet (lock adopted
+   * from the store without ever seeing a binding event) both return true, so
+   * a bare id match still stands exactly as it did before this check existed.
+   * Only a REAL disagreement between two known paths counts as a mismatch.
+   */
+  private transcriptConsistentWithBinding(transcriptPath: string | undefined): boolean {
+    if (!transcriptPath || !this.lastTranscriptPath) return true;
+    try {
+      return path.resolve(transcriptPath) === path.resolve(this.lastTranscriptPath);
+    } catch (err) {
+      // Fail closed: an unresolvable path is treated as a mismatch, not a match,
+      // so the caller falls through to the stricter marker-based checks.
+      logError(
+        `[Binder] transcriptConsistentWithBinding failed (fail-closed): ${errorToString(err)}`,
+      );
+      return false;
+    }
   }
 
   /**
@@ -807,14 +842,34 @@ export class TranscriptBinder {
 
   /**
    * Whether the transcript named by an event was written by OUR Claude (the
-   * remi:<port> head marker matches our port). Ported verbatim from
-   * `hook-bridge-setup.ts:ownsTranscript`.
+   * remi:<port> head marker matches our port). Originally ported verbatim from
+   * `hook-bridge-setup.ts:ownsTranscript`; extended for #672 with a port-drift
+   * fallback (see below).
    */
   private ownsTranscript(transcriptPath: string | undefined): boolean {
-    return (
-      typeof transcriptPath === 'string' &&
-      readTranscriptOwnerPort(transcriptPath) === this.deps.currentPort()
-    );
+    if (typeof transcriptPath !== 'string') return false;
+    const ownerPort = readTranscriptOwnerPort(transcriptPath);
+    if (ownerPort === null) return false;
+    if (ownerPort === this.deps.currentPort()) return true;
+    // #672: currentPort() can drift to a different port after a daemon restart
+    // (port-selection #146). A transcript whose remi:<port> marker was baked
+    // under the PRE-restart port would then never match again even though it
+    // is genuinely ours. Fall back to the port durably recorded for THIS remi
+    // session at spawn time (SessionBindingStore.getStoredPort) — fixed at
+    // whatever port was live when this session was created, so it survives a
+    // later restart that moves currentPort() elsewhere. A sibling's transcript
+    // carries the SIBLING's port, never ours, so this stays false for it and
+    // cross-session isolation (#451) is preserved. `ownsTranscript` is called
+    // from paths with no surrounding try/catch (the #451 sibling-defer gate in
+    // onHookEvent/decide), so a disk read failure here must be swallowed rather
+    // than propagate into the hook dispatch loop.
+    try {
+      const storedPort = this.deps.bindingStore.getStoredPort(this.sessionId);
+      return storedPort !== null && ownerPort === storedPort;
+    } catch (err) {
+      logError(`[Binder] getStoredPort failed (fail-closed): ${errorToString(err)}`);
+      return false;
+    }
   }
 
   /** Subagent/team events carry agent_id. */

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -53,7 +53,7 @@ import type {
   SessionRegistryFile,
 } from '../session/index.ts';
 import type { TranscriptDiscovery } from './transcript-discovery.ts';
-import { readTranscriptOwnerPort } from './transcript-owner.ts';
+import { MARKER_SETTLE_MS, readTranscriptOwnerPort } from './transcript-owner.ts';
 import type { TranscriptWatcher } from './transcript-watcher.ts';
 
 /**
@@ -63,19 +63,6 @@ import type { TranscriptWatcher } from './transcript-watcher.ts';
  * readdir+stat on a ~tens-of-files dir is negligible CPU.
  */
 const ROTATION_POLL_INTERVAL_MS = 1500;
-/**
- * How long a NEW `.jsonl` may sit with an unreadable `remi:<port>` head marker
- * before we stop re-polling it. The marker-ready guard: an empty/unflushed file
- * reads `null` and is re-polled (it may still be flushing), never classified on
- * the empty edge. We discriminate "still flushing" from "settled non-remi file"
- * by the file's mtime AGE, not a tick count — so a slow-flushing OWN transcript
- * (or a transient EMFILE read) is NEVER permanently dropped within this window
- * (that permanent drop would be the exact #452 wedge: the kept fallback poll
- * only ever waits for the INITIAL transcript, not a rotated id). Only a file
- * settled-and-markerless for longer than this is recorded as seen. 10s is far
- * beyond Claude's synchronous create-to-marker gap.
- */
-const MARKER_SETTLE_MS = 10_000;
 /**
  * Freshness window for a dir-poll rotation candidate that already owns our port
  * marker (#518 follow-up). A real no-hooks rotation produces a FRESHLY-written
@@ -857,17 +844,62 @@ export class TranscriptBinder {
     // is genuinely ours. Fall back to the port durably recorded for THIS remi
     // session at spawn time (SessionBindingStore.getStoredPort) — fixed at
     // whatever port was live when this session was created, so it survives a
-    // later restart that moves currentPort() elsewhere. A sibling's transcript
-    // carries the SIBLING's port, never ours, so this stays false for it and
-    // cross-session isolation (#451) is preserved. `ownsTranscript` is called
-    // from paths with no surrounding try/catch (the #451 sibling-defer gate in
-    // onHookEvent/decide), so a disk read failure here must be swallowed rather
-    // than propagate into the hook dispatch loop.
+    // later restart that moves currentPort() elsewhere.
+    //
+    // HARDENED (post-review): a bare storedPort match is NOT enough on its own.
+    // findAvailableTcpPort reuses a dead session's port, so our own stale
+    // storedPort can later be handed to a completely different, LIVE sibling —
+    // trusting the match then would let that sibling's own fresh transcript
+    // hijack our binding (rebind us onto ITS session, gate then answering ITS
+    // permissions). Two gates close that, both required:
+    //   (1) no CURRENTLY LIVE session may hold ownerPort right now — if one
+    //       does, that daemon is the port's true current owner, so this
+    //       transcript is provably NOT a stale replay of our own old port;
+    //   (2) the transcript itself must be RECENT (MARKER_SETTLE_MS-scale
+    //       staleness, mirroring the dir-poll's ROTATION_FRESHNESS_MS
+    //       stale-vs-live distinction) — a genuine reclaim is always
+    //       accompanied by live hook activity, so freshness never penalizes
+    //       the legitimate case; it only rejects a truly dead, unrelated
+    //       historical file (e.g. a sibling whose Claude child has since
+    //       exited) that happens to share our old port.
+    // `ownsTranscript` is called from paths with no surrounding try/catch (the
+    // #451 sibling-defer gate in onHookEvent/decide), so a disk read failure
+    // anywhere in this fallback must be swallowed, not propagate into the hook
+    // dispatch loop.
     try {
       const storedPort = this.deps.bindingStore.getStoredPort(this.sessionId);
-      return storedPort !== null && ownerPort === storedPort;
+      if (storedPort === null || ownerPort !== storedPort) return false;
+      if (this.portClaimedByLiveSibling(ownerPort)) return false;
+      return !this.transcriptIsStale(transcriptPath);
     } catch (err) {
       logError(`[Binder] getStoredPort failed (fail-closed): ${errorToString(err)}`);
+      return false;
+    }
+  }
+
+  /**
+   * Whether a currently-live OTHER remi session (per liveSessionsRegistry) is
+   * bound to `port` right now (#672 review). Stops a stale, drifted
+   * storedPort match from hijacking a live sibling that has since been handed
+   * the SAME port by findAvailableTcpPort's dead-port reuse.
+   */
+  private portClaimedByLiveSibling(port: number): boolean {
+    return this.deps.liveSessionsRegistry
+      .listLive()
+      .some((e) => e.sessionId !== this.sessionId && e.wsPort === port && claudeChildLooksAlive(e));
+  }
+
+  /**
+   * Whether `transcriptPath`'s mtime is older than ROTATION_FRESHNESS_MS — the
+   * same stale-vs-live distinction the #518 dir-poll freshness gate makes
+   * (#672 review, applied here for the storedPort reclaim fallback). A stat
+   * failure (raced delete/rename) is treated as fresh: fail toward the
+   * narrower, already-marker-verified reclaim rather than toward rejecting it.
+   */
+  private transcriptIsStale(transcriptPath: string): boolean {
+    try {
+      return Date.now() - fs.statSync(transcriptPath).mtimeMs > ROTATION_FRESHNESS_MS;
+    } catch {
       return false;
     }
   }

--- a/packages/daemon/src/transcript/transcript-owner.ts
+++ b/packages/daemon/src/transcript/transcript-owner.ts
@@ -26,6 +26,17 @@ import { logError } from '../cli/logger.ts';
 /** Only the first few lines can hold the head marker; cap the read. */
 const HEAD_BYTES = 8192;
 
+/**
+ * How long a transcript may sit with an unreadable `remi:<port>` head marker
+ * before it is treated as genuinely (permanently) markerless rather than
+ * still-flushing. Shared home for a value both `TranscriptBinder`'s rotation
+ * dir-poll and `ForeignSessionEscalator`'s ownership ladder (#672 review) need:
+ * both must tell "still settling, ask again later" apart from "genuinely has
+ * no marker" using the same threshold. 10s is far beyond Claude's synchronous
+ * create-to-marker gap.
+ */
+export const MARKER_SETTLE_MS = 10_000;
+
 interface CustomTitleEntry {
   type?: string;
   customTitle?: string;

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -221,6 +221,10 @@ describe('setupHookBridge', () => {
        *  the (questionId, reason) the bridge forwarded. Defaults to undefined
        *  (dep not wired). */
       broadcastResolvedLog?: Array<{ questionId: UUID; reason: string }>;
+      /** Capture every foreignSessionEscalator.handleUnadmitted call (#672).
+       *  Each entry is the (input, callerSessionId) the resolver forwarded.
+       *  Defaults to undefined (dep not wired). */
+      foreignEscalationLog?: Array<{ input: unknown; sessionId: UUID }>;
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -300,6 +304,14 @@ describe('setupHookBridge', () => {
                 questionId: UUID,
                 reason: 'auto_approved' | 'auto_denied' | 'cancelled',
               ) => opts.broadcastResolvedLog?.push({ questionId, reason }),
+            }
+          : {}),
+        ...(opts.foreignEscalationLog
+          ? {
+              foreignSessionEscalator: {
+                handleUnadmitted: (input: unknown, sid: UUID) =>
+                  opts.foreignEscalationLog?.push({ input, sessionId: sid }),
+              } as unknown as import('../../../src/hooks/index.ts').ForeignSessionEscalator,
             }
           : {}),
       },
@@ -751,6 +763,70 @@ describe('setupHookBridge', () => {
         expect(ptySubmits).toEqual([]);
         resolve();
       }, 50);
+    });
+  });
+
+  describe('#672 foreignSessionEscalator wiring', () => {
+    function bindOurSession(): void {
+      sessionStore.save({
+        remiSessionId: SID,
+        claudeSessionId: 'claude-mine',
+        projectPath: tmpDir,
+        port: 8765,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    test('calls handleUnadmitted with the raw input + our sessionId when a PermissionRequest is NOT admitted', async () => {
+      bindOurSession();
+      const foreignEscalationLog: Array<{ input: unknown; sessionId: UUID }> = [];
+      build({ foreignEscalationLog });
+
+      const input = {
+        session_id: 'claude-someone-else',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /' },
+      };
+      const decision = await hookServer.firePermission(input);
+
+      expect(decision).toBe('passthrough');
+      expect(foreignEscalationLog).toHaveLength(1);
+      expect(foreignEscalationLog[0]?.sessionId).toBe(SID);
+      expect(foreignEscalationLog[0]?.input).toMatchObject({ session_id: 'claude-someone-else' });
+    });
+
+    test('does NOT call handleUnadmitted when the PermissionRequest IS admitted (our own session)', async () => {
+      bindOurSession();
+      const foreignEscalationLog: Array<{ input: unknown; sessionId: UUID }> = [];
+      build({ foreignEscalationLog, autoApprove: true, autoApproveDecision: 'approve' });
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-mine',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      expect(decision).toBe('allow');
+      expect(foreignEscalationLog).toHaveLength(0);
+    });
+
+    test('with no foreignSessionEscalator wired, a foreign PermissionRequest still passes through cleanly (no throw)', async () => {
+      bindOurSession();
+      build(); // no foreignEscalationLog -> dep left unwired
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-someone-else',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /' },
+      });
+
+      expect(decision).toBe('passthrough');
     });
   });
 

--- a/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
+++ b/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { UUID } from '@remi/shared';
+import type { DeviceTokenEntry } from '../../src/cli/handlers/trivial-events.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import {
+  ForeignSessionEscalator,
+  type ForeignSessionEscalatorDeps,
+} from '../../src/hooks/foreign-session-escalator.ts';
+import type { PermissionRequestHookInput } from '../../src/hooks/hook-types.ts';
+import type { PushTriggerOptions } from '../../src/notifications/push-client.ts';
+import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
+import { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
+import { SessionStore } from '../../src/session/session-store.ts';
+
+/**
+ * No-mock unit tests for ForeignSessionEscalator (#672). Real SessionStore /
+ * SessionBindingStore / SessionRegistryFile on tmp files; a fake push
+ * transport capturing calls instead of hitting the network.
+ */
+
+const OUR_SESSION_ID = 'aaaaaaaa-0000-0000-0000-000000000001' as UUID;
+
+function permissionInput(
+  overrides: Partial<PermissionRequestHookInput> = {},
+): PermissionRequestHookInput {
+  return {
+    session_id: 'foreign-claude-id',
+    transcript_path: '/tmp/does-not-matter.jsonl',
+    cwd: '/tmp/some-project',
+    permission_mode: 'default',
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'Bash',
+    tool_input: { command: 'ls' },
+    ...overrides,
+  };
+}
+
+describe('ForeignSessionEscalator (#672)', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let bindingStore: SessionBindingStore;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushCalls: Array<{ token: string; opts: PushTriggerOptions }>;
+  let nowMs: number;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-foreign-escalator-'));
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    bindingStore = new SessionBindingStore(sessionStore);
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
+    fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
+    deviceTokens = new Map();
+    pushCalls = [];
+    nowMs = 1_000_000;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function deps(overrides: Partial<ForeignSessionEscalatorDeps> = {}): ForeignSessionEscalatorDeps {
+    return {
+      liveSessionsRegistry,
+      bindingStore,
+      deviceTokens,
+      pushConfig: () => ({ signalingUrl: 'https://example.test' }),
+      currentPort: () => 8765,
+      pushFn: async (_signalingUrl, token, opts) => {
+        pushCalls.push({ token, opts });
+      },
+      now: () => nowMs,
+      ...overrides,
+    };
+  }
+
+  function registerToken(token = 'device-token-1'): void {
+    deviceTokens.set(token, {
+      token,
+      platform: 'ios',
+      registeredAt: Date.now(),
+      connectionId: 'conn-1' as UUID,
+    });
+  }
+
+  /** Wait a tick so the fire-and-forget push promise inside handleUnadmitted
+   *  has a chance to settle before assertions run. */
+  async function flush(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  function writeMarkedTranscript(name: string, port: number): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(
+      p,
+      `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${port}`, sessionId: 's' })}\n`,
+    );
+    return p;
+  }
+
+  // -------------------------------------------------------------------------
+  // Ladder step 1: sibling live daemon claims it -> silent.
+  // -------------------------------------------------------------------------
+
+  describe('sibling claim -> silent, no push', () => {
+    test('claimed via the durable binding store reverse lookup + a live registry entry', async () => {
+      registerToken();
+      bindingStore.preAssign({
+        remiSessionId: 'sibling-remi-session' as UUID,
+        claudeSessionId: 'foreign-claude-id',
+        projectPath: tmpDir,
+        port: 9999,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      liveSessionsRegistry.register({
+        sessionId: 'sibling-remi-session',
+        pid: process.pid,
+        wsPort: 9999,
+        hookPort: 10099,
+        projectPath: tmpDir,
+        name: 'sibling',
+        startedAt: new Date().toISOString(),
+      });
+
+      const escalator = new ForeignSessionEscalator(deps());
+      escalator.handleUnadmitted(
+        permissionInput({ session_id: 'foreign-claude-id' }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      expect(pushCalls).toHaveLength(0);
+    });
+
+    test('claimed via the transcript port marker naming a live sibling wsPort', async () => {
+      registerToken();
+      liveSessionsRegistry.register({
+        sessionId: 'sibling-remi-session',
+        pid: process.pid,
+        wsPort: 9999,
+        hookPort: 10099,
+        projectPath: tmpDir,
+        name: 'sibling',
+        startedAt: new Date().toISOString(),
+      });
+      const markedPath = writeMarkedTranscript('sibling.jsonl', 9999);
+
+      const escalator = new ForeignSessionEscalator(deps());
+      escalator.handleUnadmitted(
+        permissionInput({ session_id: 'unrelated-claude-id', transcript_path: markedPath }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      expect(pushCalls).toHaveLength(0);
+    });
+
+    test('a binding-store record for a DEAD remi session is NOT treated as a live sibling claim', async () => {
+      registerToken();
+      bindingStore.preAssign({
+        remiSessionId: 'dead-remi-session' as UUID,
+        claudeSessionId: 'foreign-claude-id',
+        projectPath: tmpDir,
+        port: 9999,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+      // No liveSessionsRegistry entry for 'dead-remi-session' at all -> not live.
+
+      const escalator = new ForeignSessionEscalator(deps());
+      escalator.handleUnadmitted(
+        permissionInput({ session_id: 'foreign-claude-id' }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      // Unclaimed by any LIVE daemon -> escalates (pushes), not silent.
+      expect(pushCalls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ladder step 2: unclaimed -> informational, dismiss-only push.
+  // -------------------------------------------------------------------------
+
+  describe('unclaimed -> rate-limited informational push', () => {
+    test('pushes a title/body with tool name + short session hash + cwd hint, no category/options/questionId', async () => {
+      registerToken();
+      const escalator = new ForeignSessionEscalator(deps());
+      escalator.handleUnadmitted(
+        permissionInput({
+          session_id: 'foreign-claude-id',
+          tool_name: 'Bash',
+          cwd: '/Users/dev/my-project',
+        }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      expect(pushCalls).toHaveLength(1);
+      const { opts } = pushCalls[0]!;
+      expect(opts.title).toContain('foreign-'); // short hash of the session id
+      expect(opts.body).toContain('Bash');
+      expect(opts.body).toContain('my-project');
+      expect(opts.category).toBeUndefined();
+      expect(opts.options).toBeUndefined();
+      expect(opts.questionId).toBeUndefined();
+      expect(opts.sessionId).toBe(OUR_SESSION_ID);
+    });
+
+    test('no device tokens registered -> no push attempted, no throw', async () => {
+      const escalator = new ForeignSessionEscalator(deps());
+      expect(() => escalator.handleUnadmitted(permissionInput(), OUR_SESSION_ID)).not.toThrow();
+      await flush();
+      expect(pushCalls).toHaveLength(0);
+    });
+
+    test('rate-limits repeated escalations for the SAME foreign session_id', async () => {
+      registerToken();
+      const escalator = new ForeignSessionEscalator(deps({ rateLimitMs: 60_000 }));
+      const input = permissionInput({ session_id: 'busy-foreign-session' });
+
+      escalator.handleUnadmitted(input, OUR_SESSION_ID);
+      await flush();
+      escalator.handleUnadmitted(input, OUR_SESSION_ID);
+      await flush();
+      escalator.handleUnadmitted(input, OUR_SESSION_ID);
+      await flush();
+
+      expect(pushCalls).toHaveLength(1);
+
+      // Advance the clock past the rate-limit window -> escalates again.
+      nowMs += 60_001;
+      escalator.handleUnadmitted(input, OUR_SESSION_ID);
+      await flush();
+      expect(pushCalls).toHaveLength(2);
+    });
+
+    test('rate-limit is keyed per foreign session_id, not global', async () => {
+      registerToken();
+      const escalator = new ForeignSessionEscalator(deps({ rateLimitMs: 60_000 }));
+
+      escalator.handleUnadmitted(permissionInput({ session_id: 'foreign-A' }), OUR_SESSION_ID);
+      await flush();
+      escalator.handleUnadmitted(permissionInput({ session_id: 'foreign-B' }), OUR_SESSION_ID);
+      await flush();
+
+      expect(pushCalls).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ladder step 3: ownership undetermined (a registry/store read failure) ->
+  // error-only, no escalation storm.
+  // -------------------------------------------------------------------------
+
+  describe('undetermined ownership (registry read error) -> no escalation', () => {
+    test('a sessions.json read failure logs and returns without pushing', async () => {
+      registerToken();
+      // Make sessions.json a DIRECTORY so SessionStore.read()'s fs.readFileSync
+      // throws a real (non-ENOENT, non-SyntaxError) I/O error, exercising the
+      // genuine failure path rather than a mock.
+      const brokenSessionsPath = path.join(tmpDir, 'broken-sessions.json');
+      fs.mkdirSync(brokenSessionsPath);
+      const brokenStore = new SessionBindingStore(new SessionStore(brokenSessionsPath));
+
+      const escalator = new ForeignSessionEscalator(deps({ bindingStore: brokenStore }));
+      expect(() => escalator.handleUnadmitted(permissionInput(), OUR_SESSION_ID)).not.toThrow();
+      await flush();
+
+      expect(pushCalls).toHaveLength(0);
+    });
+  });
+});

--- a/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
+++ b/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
@@ -23,21 +23,6 @@ import { SessionStore } from '../../src/session/session-store.ts';
 
 const OUR_SESSION_ID = 'aaaaaaaa-0000-0000-0000-000000000001' as UUID;
 
-function permissionInput(
-  overrides: Partial<PermissionRequestHookInput> = {},
-): PermissionRequestHookInput {
-  return {
-    session_id: 'foreign-claude-id',
-    transcript_path: '/tmp/does-not-matter.jsonl',
-    cwd: '/tmp/some-project',
-    permission_mode: 'default',
-    hook_event_name: 'PermissionRequest',
-    tool_name: 'Bash',
-    tool_input: { command: 'ls' },
-    ...overrides,
-  };
-}
-
 describe('ForeignSessionEscalator (#672)', () => {
   let tmpDir: string;
   let sessionStore: SessionStore;
@@ -46,6 +31,12 @@ describe('ForeignSessionEscalator (#672)', () => {
   let deviceTokens: Map<string, DeviceTokenEntry>;
   let pushCalls: Array<{ token: string; opts: PushTriggerOptions }>;
   let nowMs: number;
+  /** A real, unmarked, well-aged (60s old) transcript file -- the default
+   *  transcript_path for `permissionInput()`, so "unclaimed" tests exercise
+   *  a genuinely markerless, settled file rather than a nonexistent path
+   *  (which would always classify as 'undetermined' -- see the dedicated
+   *  "marker-not-yet-provable" describe block below). */
+  let staleUnmarkedPath: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-foreign-escalator-'));
@@ -56,6 +47,7 @@ describe('ForeignSessionEscalator (#672)', () => {
     deviceTokens = new Map();
     pushCalls = [];
     nowMs = 1_000_000;
+    staleUnmarkedPath = writeUnmarkedTranscript('stale-unmarked.jsonl', 60_000);
     configureLogger({ writeLog: () => {} });
   });
 
@@ -63,6 +55,21 @@ describe('ForeignSessionEscalator (#672)', () => {
     __resetLoggerForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  function permissionInput(
+    overrides: Partial<PermissionRequestHookInput> = {},
+  ): PermissionRequestHookInput {
+    return {
+      session_id: 'foreign-claude-id',
+      transcript_path: staleUnmarkedPath,
+      cwd: '/tmp/some-project',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      ...overrides,
+    };
+  }
 
   function deps(overrides: Partial<ForeignSessionEscalatorDeps> = {}): ForeignSessionEscalatorDeps {
     return {
@@ -101,6 +108,20 @@ describe('ForeignSessionEscalator (#672)', () => {
       p,
       `${JSON.stringify({ type: 'custom-title', customTitle: `remi:${port}`, sessionId: 's' })}\n`,
     );
+    return p;
+  }
+
+  /** A transcript with NO remi:<port> marker, backdated by `ageMs` (0 = just
+   *  written / "fresh"). Used to exercise the marker-unreadable tie-breaker:
+   *  a fresh markerless file is 'undetermined' (still possibly flushing); a
+   *  stale one is genuinely 'unclaimed'. */
+  function writeUnmarkedTranscript(name: string, ageMs = 0): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, `${JSON.stringify({ type: 'user', message: 'hi' })}\n`);
+    if (ageMs > 0) {
+      const backdated = new Date(Date.now() - ageMs);
+      fs.utimesSync(p, backdated, backdated);
+    }
     return p;
   }
 
@@ -258,11 +279,41 @@ describe('ForeignSessionEscalator (#672)', () => {
 
       expect(pushCalls).toHaveLength(2);
     });
+
+    test('rate-limit map evicts the oldest entries once the tracked-session cap is exceeded', async () => {
+      // Small cap via a dedicated escalator would require exposing the
+      // constant; instead exercise the REAL 500-cap end-to-end with a burst
+      // of distinct session ids, then confirm the oldest was evicted (a
+      // repeat of it re-escalates instead of staying rate-limited).
+      registerToken();
+      const escalator = new ForeignSessionEscalator(deps({ rateLimitMs: 10 * 60_000 }));
+      const firstId = 'burst-session-0000';
+      escalator.handleUnadmitted(permissionInput({ session_id: firstId }), OUR_SESSION_ID);
+      await flush();
+      expect(pushCalls).toHaveLength(1);
+
+      for (let i = 1; i <= 500; i++) {
+        nowMs += 1;
+        escalator.handleUnadmitted(
+          permissionInput({ session_id: `burst-session-${i}` }),
+          OUR_SESSION_ID,
+        );
+      }
+      await flush();
+
+      // The very first id should have been evicted by the size cap (not by
+      // age -- rateLimitMs is 10 minutes and only ~500ms have elapsed), so
+      // it is no longer tracked and escalates again immediately: 1 (firstId)
+      // + 500 (burst, all unique) + 1 (firstId re-fired after eviction).
+      nowMs += 1;
+      escalator.handleUnadmitted(permissionInput({ session_id: firstId }), OUR_SESSION_ID);
+      await flush();
+      expect(pushCalls).toHaveLength(502);
+    });
   });
 
   // -------------------------------------------------------------------------
-  // Ladder step 3: ownership undetermined (a registry/store read failure) ->
-  // error-only, no escalation storm.
+  // Ladder step 3a: registry/store read failure -> undetermined, error-only.
   // -------------------------------------------------------------------------
 
   describe('undetermined ownership (registry read error) -> no escalation', () => {
@@ -277,6 +328,62 @@ describe('ForeignSessionEscalator (#672)', () => {
 
       const escalator = new ForeignSessionEscalator(deps({ bindingStore: brokenStore }));
       expect(() => escalator.handleUnadmitted(permissionInput(), OUR_SESSION_ID)).not.toThrow();
+      await flush();
+
+      expect(pushCalls).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ladder step 3b (#672 review, critical 2): marker-not-yet-provable ->
+  // undetermined, NOT unclaimed. Regression coverage for the rotation-race
+  // false "unbound session" push about the user's OWN session.
+  // -------------------------------------------------------------------------
+
+  describe('undetermined ownership (marker not yet provable) -> no false-alarm push', () => {
+    test('a FRESH markerless transcript (possibly mid-flush) does NOT escalate', async () => {
+      registerToken();
+      // No sibling registered at all -- this is exactly the rotation-race
+      // shape: our own SessionStart just fired, the marker has not flushed
+      // yet, and there happens to be a sibling in the directory (irrelevant
+      // to classifyOwnership itself, which only sees the hook input).
+      const freshPath = writeUnmarkedTranscript('fresh-unmarked.jsonl', 0);
+      const escalator = new ForeignSessionEscalator(deps({ markerSettleMs: 10_000 }));
+
+      escalator.handleUnadmitted(
+        permissionInput({ session_id: 'our-own-rotating-session', transcript_path: freshPath }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      expect(pushCalls).toHaveLength(0);
+    });
+
+    test('a markerless transcript older than the settle window DOES escalate (genuinely foreign)', async () => {
+      registerToken();
+      const stalePath = writeUnmarkedTranscript('old-unmarked.jsonl', 20_000);
+      const escalator = new ForeignSessionEscalator(deps({ markerSettleMs: 10_000 }));
+
+      escalator.handleUnadmitted(
+        permissionInput({ session_id: 'genuinely-foreign-session', transcript_path: stalePath }),
+        OUR_SESSION_ID,
+      );
+      await flush();
+
+      expect(pushCalls).toHaveLength(1);
+    });
+
+    test('a missing transcript file is treated as undetermined, not unclaimed', async () => {
+      registerToken();
+      const escalator = new ForeignSessionEscalator(deps({ markerSettleMs: 10_000 }));
+
+      escalator.handleUnadmitted(
+        permissionInput({
+          session_id: 'session-with-vanished-transcript',
+          transcript_path: path.join(tmpDir, 'does-not-exist.jsonl'),
+        }),
+        OUR_SESSION_ID,
+      );
       await flush();
 
       expect(pushCalls).toHaveLength(0);

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1454,4 +1454,132 @@ describe('TranscriptBinder', () => {
       expect(admitted).toBe(false);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // #672 review (critical 1): port-reuse hijack. A storedPort match ALONE is
+  // not proof of ownership -- findAvailableTcpPort can hand our old,
+  // drifted-away port to a completely different LIVE sibling. Reproduces the
+  // reviewer's end-to-end repro: daemon X (SID) recorded storedPort 18775,
+  // drifted to live port 8765; a live sibling Y later legitimately gets
+  // assigned 18775 and writes remi:18775 to ITS OWN transcript. X must NOT
+  // treat Y's live transcript as its own and rebind onto Y's session.
+  // -------------------------------------------------------------------------
+
+  describe('#672 review: port-reuse hijack guard (live-sibling cross-check + freshness gate)', () => {
+    function recordStoredPort(port: number): void {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: null,
+        projectPath: tmpDir,
+        port,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    function bindOld(): TranscriptBinder {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'claude-OLD',
+        transcript_path: path.join(tmpDir, 'old.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+      return binder;
+    }
+
+    function registerLiveSibling(sessionId: string, wsPort: number): void {
+      liveSessionsRegistry.register({
+        sessionId,
+        pid: process.pid,
+        wsPort,
+        hookPort: wsPort + 1000,
+        projectPath: tmpDir,
+        name: 'sibling',
+        startedAt: new Date().toISOString(),
+      });
+    }
+
+    test('does NOT reclaim (admits stays false) when a LIVE sibling currently holds the recycled stored port', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      // A live sibling now legitimately runs on port 18775 (our old, drifted
+      // storedPort, recycled by findAvailableTcpPort) and writes ITS OWN
+      // remi:18775 transcript.
+      registerLiveSibling('sibling-remi-session', 18775);
+      const siblingPath = writeMarkedTranscript('sibling-live.jsonl', 18775);
+
+      const admitted = binder.admits({
+        session_id: 'claude-SIBLING-LIVE',
+        transcript_path: siblingPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('does NOT rebind via onHookEvent when a live sibling holds the recycled stored port', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      registerLiveSibling('sibling-remi-session-2', 18775);
+      const siblingPath = writeMarkedTranscript('sibling-live-2.jsonl', 18775);
+
+      binder.onHookEvent({
+        session_id: 'claude-SIBLING-LIVE-2',
+        transcript_path: siblingPath,
+        hook_event_name: 'PermissionRequest',
+      });
+
+      // The binder must still be bound to its ORIGINAL claude id -- no
+      // hijack, no watcher swap, no bindingStore rewrite onto the sibling.
+      expect(binder.snapshot().claudeSessionId).toBe('claude-OLD');
+    });
+
+    test('a zombie sibling (claude child exited) does not by itself block reclaim, but staleness does', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      // The sibling's Claude child has exited (a zombie daemon entry) --
+      // claudeChildLooksAlive() is false for it, so the live-sibling gate
+      // alone would NOT block this reclaim. The freshness gate is the second,
+      // independent layer: a transcript that hasn't been touched in a long
+      // time is rejected regardless of what the live registry says.
+      liveSessionsRegistry.register({
+        sessionId: 'zombie-sibling',
+        pid: process.pid,
+        wsPort: 18775,
+        hookPort: 19775,
+        projectPath: tmpDir,
+        name: 'zombie',
+        startedAt: new Date().toISOString(),
+        claudeChildPid: 999999,
+        claudeChildExited: true,
+      });
+      const oldPath = writeMarkedTranscript('zombie-old.jsonl', 18775);
+      const longAgo = new Date(Date.now() - 10 * 60_000); // 10 min, past ROTATION_FRESHNESS_MS
+      fs.utimesSync(oldPath, longAgo, longAgo);
+
+      const admitted = binder.admits({
+        session_id: 'claude-ZOMBIE-OLD',
+        transcript_path: oldPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('a FRESH stored-port transcript with no live sibling still reclaims (legitimate case unaffected)', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      // No live sibling registered anywhere; the transcript is freshly
+      // written (as it would be for a genuine, currently-active reclaim).
+      const freshPath = writeMarkedTranscript('fresh-legit.jsonl', 18775);
+
+      const admitted = binder.admits({
+        session_id: 'claude-LEGIT-FRESH',
+        transcript_path: freshPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+  });
 });

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -302,13 +302,21 @@ describe('TranscriptBinder', () => {
           transcript_path: writeMarkedTranscript('sibling.jsonl', 9999),
         }),
       ).toBe(false);
-      // Lock match -> admitted (no marker needed).
+      // Lock match with the SAME bound transcript -> admitted (no marker needed).
+      expect(
+        binder.admits({
+          session_id: 'claude-STALE',
+          transcript_path: path.join(tmpDir, 'stale.jsonl'),
+        }),
+      ).toBe(true);
+      // #672: lock match but a DIFFERENT, unmarked transcript_path -> the bare
+      // id match is no longer sufficient proof of ownership; rejected.
       expect(
         binder.admits({
           session_id: 'claude-STALE',
           transcript_path: path.join(tmpDir, 's.jsonl'),
         }),
-      ).toBe(true);
+      ).toBe(false);
     });
 
     test('restart: a different session_id after PTY exited classifies restart', () => {
@@ -1293,6 +1301,154 @@ describe('TranscriptBinder', () => {
         agent_id: 'agent-eeee',
         // named after the SIBLING's id, not ours; the file has no marker either
         transcript_path: path.join(tmpDir, 'sibling-claude.jsonl'),
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #672 (b): admission path 1 hardening — exact session_id match must ALSO
+  // agree on transcript_path when both are known.
+  // -------------------------------------------------------------------------
+
+  describe('#672 admission hardening: transcript_path must agree with an exact session_id match', () => {
+    function bindMain(mainPath: string): TranscriptBinder {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'main-claude',
+        transcript_path: mainPath,
+        hook_event_name: 'SessionStart',
+      });
+      return binder;
+    }
+
+    test('rejects an exact session_id match when the event transcript diverges (id-collision guard)', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const otherPath = path.join(tmpDir, 'other-unmarked.jsonl');
+      fs.writeFileSync(otherPath, '');
+      const admitted = binder.admits({
+        session_id: 'main-claude',
+        transcript_path: otherPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('still admits an exact session_id match when the event carries no transcript_path', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: 'main-claude',
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test('a divergent path that carries OUR OWN port marker still reclaims (not a leak)', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const rotatedPath = writeMarkedTranscript('rotated.jsonl', 8765);
+      const admitted = binder.admits({
+        session_id: 'main-claude',
+        transcript_path: rotatedPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test('unchanged: an exact session_id match with the SAME transcript_path still admits', () => {
+      const mainPath = path.join(tmpDir, 'main.jsonl');
+      const binder = bindMain(mainPath);
+      const admitted = binder.admits({
+        session_id: 'main-claude',
+        transcript_path: mainPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #672 (c): stale-marker reclaim defeated by port churn — fall back to the
+  // port durably recorded for THIS remi session (SessionBindingStore) when
+  // currentPort() has drifted since the transcript's marker was baked.
+  // -------------------------------------------------------------------------
+
+  describe('#672 stale-marker port-drift reclaim (fallback to bindingStore stored port)', () => {
+    /** deps().currentPort() is fixed at 8765 in this suite; simulate a remi
+     *  session that was ORIGINALLY created on a different port (18775) before a
+     *  daemon restart moved it to the live 8765 — the stored `port` field is
+     *  never refreshed after preAssign, so it stays at the pre-restart value. */
+    function recordStoredPort(port: number): void {
+      bindingStore.preAssign({
+        remiSessionId: SID,
+        claudeSessionId: null,
+        projectPath: tmpDir,
+        port,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        exitedAt: null,
+        exitCode: null,
+      });
+    }
+
+    function bindOld(): TranscriptBinder {
+      registerSession();
+      const binder = makeBinder();
+      binder.onHookEvent({
+        session_id: 'claude-OLD',
+        transcript_path: path.join(tmpDir, 'old.jsonl'),
+        hook_event_name: 'SessionStart',
+      });
+      return binder;
+    }
+
+    test('reclaims a foreign event whose marker matches our STORED (pre-drift) port via admits()', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      const stalePath = writeMarkedTranscript('stale.jsonl', 18775);
+      const admitted = binder.admits({
+        session_id: 'claude-STALE',
+        transcript_path: stalePath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(true);
+    });
+
+    test('reclaims via the onHookEvent drive path too (restart binds the new id)', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      const stalePath = writeMarkedTranscript('stale2.jsonl', 18775);
+      binder.onHookEvent({
+        session_id: 'claude-STALE-2',
+        transcript_path: stalePath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(binder.snapshot().claudeSessionId).toBe('claude-STALE-2');
+    });
+
+    test('does NOT reclaim when the marker matches neither the live port nor our stored port', () => {
+      recordStoredPort(18775);
+      const binder = bindOld();
+      const foreignPath = writeMarkedTranscript('foreign.jsonl', 9999);
+      const admitted = binder.admits({
+        session_id: 'claude-STRANGER',
+        transcript_path: foreignPath,
+        hook_event_name: 'PermissionRequest',
+      });
+      expect(admitted).toBe(false);
+    });
+
+    test('does NOT reclaim when no stored port is on record at all (no regression)', () => {
+      // No preAssign call: bindingStore has no row for SID at all.
+      const binder = bindOld();
+      const stalePath = writeMarkedTranscript('unrecorded.jsonl', 18775);
+      const admitted = binder.admits({
+        session_id: 'claude-UNRECORDED',
+        transcript_path: stalePath,
         hook_event_name: 'PermissionRequest',
       });
       expect(admitted).toBe(false);


### PR DESCRIPTION
## What

Three-part fix for #672 (foreign top-level sessions silently dropped, no AA eval, no escalation):

**(a) Fail-safe admission ladder** — new `ForeignSessionEscalator` (`packages/daemon/src/hooks/foreign-session-escalator.ts`), invoked from the `PermissionRequest` resolver in `hook-bridge-setup.ts` whenever `TranscriptBinder.admits()` rejects an event:
1. **Sibling claim** — a live sibling remi daemon owns the foreign claude session (checked via the durable binding store's reverse lookup + a live-sessions registry cross-check, and via the transcript's own `remi:<port>` marker naming another live daemon's port). Stays silent (debug log only), matching today's behavior — that daemon's own admission path handles it.
2. **Unclaimed** — no live daemon claims it. Fires a rate-limited (5 min per foreign `session_id`, in-memory, self-pruning) informational push.
3. **Undetermined** — a registry/store read failed. Logged at error level only; never escalates on an inconclusive read, so a filesystem hiccup cannot become a notification storm.

**(b) Admission path 1 hardening** (`transcript-binder.ts`, `admits()`) — an exact `session_id` match is no longer sufficient on its own: when the event also carries a `transcript_path` and we already have one bound, the two must agree. A mismatch falls through to the existing subagent/marker checks rather than failing outright, so a marker-proven rotation we have not caught up to yet still reclaims.

**(c) Port-drift reclaim fallback** (`transcript-binder.ts` `ownsTranscript()`, `session-binding-store.ts` new `getStoredPort()`) — `currentPort()` can drift to a different port after a daemon restart (port-selection #146), so a transcript's `remi:<port>` marker baked under the pre-restart port could never match again. Added a fallback to the port durably recorded for this remi session at spawn time (`SessionBindingStore.getStoredPort`), which survives a later restart that moves `currentPort()` elsewhere.

## Why: the informational-push representation

A foreign session's `PermissionRequest` hook is **not held by us** — Claude renders its own prompt in that other, unmanaged process. Reusing the normal `Question`/hold machinery (`sessionRegistry.addQuestion` + `resolveHeld`) would let an "answer" from the phone inject into **our own PTY** — the wrong session entirely (the evil twin of #538).

Instead, the escalation push carries **no `category` and no `options`, and is not registered as a `Question` anywhere**. iOS only renders action buttons for the three registered categories (`REMI_YN` / `REMI_YNA` / `REMI_MULTI` in `AppDelegate.swift`); a push with neither is a plain, dismiss-only banner — tapping it can only open the app, never submit an answer. No client-side (iOS/web) changes were needed for this.

## Sibling-check mechanism

Two independent, additive signals (either sufficient to prove a live sibling owns the event):
- **Durable binding store reverse lookup**: `SessionBindingStore.getByClaudeSessionId(session_id)` finds which `remiSessionId` durably owns this claude session id; cross-checked against `SessionRegistryFile.listLive()` + `claudeChildLooksAlive()` so a *dead* remi session's stale binding-store row is not mistaken for a live claim.
- **Transcript port marker**: if the transcript's `remi:<port>` marker names a port some *other* currently-live daemon is bound to, that daemon owns it.

Both checks are wrapped so a registry/store I/O failure is caught once (logged at error level) rather than silently escalating.

## Testing

- `bun run typecheck` — clean
- `bunx biome check packages/daemon` — clean (pre-existing `noNonNullAssertion` warnings only, non-blocking, same pattern already used elsewhere in the suite)
- `bun test packages/daemon/tests/transcript/ packages/daemon/tests/cli/ packages/daemon/tests/hooks/ packages/daemon/tests/session` — 1190 pass, 0 fail
- Did not touch `packages/daemon/tests/auto-approve/` (no auto-approve-gate.ts changes), per instructions.
- New/updated tests, no mocks (real `SessionStore`/`SessionBindingStore`/`SessionRegistryFile` on tmp dirs, real fs-based error conditions where needed):
  - `packages/daemon/tests/transcript/transcript-binder.test.ts` — (b) admission hardening (4 tests) + (c) port-drift reclaim (4 tests); updated one pre-existing test whose old assertion encoded the exact bug behavior (b) fixes.
  - `packages/daemon/tests/hooks/foreign-session-escalator.test.ts` — new file, full ladder coverage including a real EISDIR fs error (sessions.json path replaced with a directory) to exercise the "undetermined ownership" path without mocking.
  - `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` — wiring tests confirming `foreignSessionEscalator.handleUnadmitted` fires only when `admits()` rejects, and that the dep is optional (no-op, no throw, when unwired).

Closes #672