### PR TITLE
fix(#664): heartbeat margin + staggered reconnects

### DIFF
--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -256,12 +256,12 @@ export class Connection {
 
     // Any successfully-parsed message proves the peer is alive (#662 review),
     // not only an explicit 'pong'. The web/mobile client already sends its own
-    // keep-alive 'ping' to the server every 30s (useConnectionManager's
-    // startPing) on top of whatever protocol traffic is flowing, so gating
-    // liveness on 'pong' alone force-closed every healthy client connection
-    // on a ~60-90s cycle: it never answers the SERVER's ping with a protocol
-    // pong. Treating any inbound message as proof-of-life fixes that without
-    // depending on the client implementing pong replies correctly.
+    // keep-alive 'ping' to the server (WebSocketClient's internal heartbeat,
+    // 15s default, #664) on top of whatever protocol traffic is flowing, so
+    // gating liveness on 'pong' alone force-closed every healthy client
+    // connection on a ~60-90s cycle: it never answers the SERVER's ping with a
+    // protocol pong. Treating any inbound message as proof-of-life fixes that
+    // without depending on the client implementing pong replies correctly.
     this.missedPongs = 0;
 
     // Check for duplicate

--- a/packages/daemon/tests/websocket-server.test.ts
+++ b/packages/daemon/tests/websocket-server.test.ts
@@ -747,11 +747,11 @@ describe('WebSocketServer', () => {
 
     test('a connection sending ordinary traffic (never an explicit pong) is never force-closed (#662 review)', async () => {
       // Regression: the real web/mobile client sends its own client-initiated
-      // 'ping' every 30s (useConnectionManager's startPing) but, before the
-      // review fix, never replied with a protocol 'pong' to the SERVER's
-      // ping. Gating liveness on 'pong' alone force-closed every healthy
-      // client on a ~60-90s cycle. Any successfully-parsed inbound message
-      // must count as proof-of-life, not only 'pong'.
+      // 'ping' (WebSocketClient's internal heartbeat, 15s default, #664) but,
+      // before the review fix, never replied with a protocol 'pong' to the
+      // SERVER's ping. Gating liveness on 'pong' alone force-closed every
+      // healthy client on a ~60-90s cycle. Any successfully-parsed inbound
+      // message must count as proof-of-life, not only 'pong'.
       const pingInterval = 40;
       let disconnected = false;
       server = new WebSocketServer(

--- a/packages/web/src/hooks/connection-manager-helpers.ts
+++ b/packages/web/src/hooks/connection-manager-helpers.ts
@@ -57,3 +57,72 @@ export function collectPendingChallengeConnections<
   }
   return out;
 }
+
+/**
+ * Observable transport state for one connection, used to decide whether an
+ * `app-force-reconnect` sweep (app resume / network change) needs to touch
+ * it (#664).
+ */
+export interface ForceReconnectCandidate<Id extends string = string> {
+  readonly connectionId: Id;
+  /** Raw WebSocket.OPEN check (WebSocketClient#isTransportOpen), independent
+   *  of the higher-level status machine: a zombie socket after a long
+   *  background suspend can still report a stale 'connected' status. */
+  readonly isOpen: boolean;
+  /** Whether the connection has seen inbound traffic recently enough to be
+   *  trusted without a proactive reconnect (WebSocketClient#isHealthy). */
+  readonly isHealthy: boolean;
+}
+
+/** Decision for one candidate: whether and when to call `forceReconnect()`. */
+export interface ForceReconnectDecision<Id extends string = string> {
+  readonly connectionId: Id;
+  readonly shouldReconnect: boolean;
+  /** ms to wait before reconnecting; 0 means immediately. */
+  readonly delayMs: number;
+}
+
+export interface PlanForceReconnectOptions {
+  /** Fixed spacing multiplied by the candidate's stagger index. */
+  readonly staggerStepMs: number;
+  /** Extra random jitter added per staggered candidate, in [0, staggerJitterMs). */
+  readonly staggerJitterMs: number;
+  /** Injectable for deterministic tests; defaults to `Math.random`. */
+  readonly random?: () => number;
+}
+
+/**
+ * Decide what an `app-force-reconnect` sweep (app resume / network change,
+ * `main.tsx`) should do with each currently managed connection (#664).
+ *
+ * - A healthy, open connection is left alone entirely: force-reconnecting a
+ *   socket that was never actually broken was the original bug -- roughly 5
+ *   daemons all visibly cycling on every foreground.
+ * - A connection whose transport isn't open is already dead; reconnect it
+ *   immediately. There's no simultaneous-teardown risk to protect against,
+ *   it's already down.
+ * - An open-but-not-recently-active connection is uncertain (an iOS
+ *   background suspend can leave a zombie handle the internal heartbeat
+ *   hasn't caught up to yet); it does need reconnecting, but staggered with
+ *   jitter across however many such connections there are, so they don't all
+ *   drop and reconnect in the same instant.
+ */
+export function planForceReconnect<Id extends string = string>(
+  candidates: readonly ForceReconnectCandidate<Id>[],
+  options: PlanForceReconnectOptions,
+): ForceReconnectDecision<Id>[] {
+  const random = options.random ?? Math.random;
+  let staggerIndex = 0;
+
+  return candidates.map(({ connectionId, isOpen, isHealthy }) => {
+    if (isOpen && isHealthy) {
+      return { connectionId, shouldReconnect: false, delayMs: 0 };
+    }
+    if (!isOpen) {
+      return { connectionId, shouldReconnect: true, delayMs: 0 };
+    }
+    const delayMs = staggerIndex * options.staggerStepMs + random() * options.staggerJitterMs;
+    staggerIndex++;
+    return { connectionId, shouldReconnect: true, delayMs };
+  });
+}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -18,7 +18,12 @@ import { DAEMON_BASE_PORT, errorToString } from '@remi/shared';
 import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-client';
 import type { ConnectionId, ConnectionState, ConnectionStatus } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
-import { collectPendingChallengeConnections, getOrCreateDeviceId } from './connection-manager-helpers';
+import {
+  collectPendingChallengeConnections,
+  type ForceReconnectCandidate,
+  getOrCreateDeviceId,
+  planForceReconnect,
+} from './connection-manager-helpers';
 import { splitConnectionId } from '@/lib/connection-id';
 import { buildWsUrl, parseHostInput, resolveDaemonPort } from '@/lib/port-discovery';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
@@ -30,7 +35,6 @@ import {
   createCancelQuestion,
   createCreateSessionRequest,
   createHello,
-  createPing,
   createResumeSessionRequest,
   createSessionHistoryRequest,
   createSessionListRequest,
@@ -43,6 +47,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 function makeConnectionId(raw: string): ConnectionId {
   return raw as ConnectionId;
 }
+
+/**
+ * Force-reconnect stagger tuning (#664): fixed spacing per staggered
+ * connection index plus random jitter, so N daemons don't all visibly drop
+ * and reconnect in the same instant on app resume / network change.
+ */
+const FORCE_RECONNECT_STAGGER_STEP_MS = 300;
+const FORCE_RECONNECT_STAGGER_JITTER_MS = 2000;
 
 /** Internal per-connection state */
 interface ManagedConnection {
@@ -71,7 +83,6 @@ interface ManagedConnection {
   needsPassphrase: boolean;
   serverFingerprint: string | null;
   directory?: string;
-  pingInterval?: ReturnType<typeof setInterval>;
   /** True while escalateReconnect is probing; prevents concurrent escalations
    *  racing reconnectWithUrl against themselves (#435). */
   escalating?: boolean;
@@ -444,22 +455,6 @@ export function useConnectionManager(
     [handleAuthChallenge, handleAuthResult, syncState],
   );
 
-  /** Start ping keep-alive for a connection */
-  const startPing = useCallback((mc: ManagedConnection) => {
-    if (mc.pingInterval) clearInterval(mc.pingInterval);
-    mc.pingInterval = setInterval(() => {
-      mc.client.send(createPing());
-    }, 30000);
-  }, []);
-
-  /** Stop ping keep-alive for a connection */
-  const stopPing = useCallback((mc: ManagedConnection) => {
-    if (mc.pingInterval) {
-      clearInterval(mc.pingInterval);
-      mc.pingInterval = undefined;
-    }
-  }, []);
-
   // Reconnect escalation: auto-reconnect exhausted the ceiling on the current
   // port. Re-resolve the daemon's port from the host (the old port is hinted
   // first, then the full range is scanned). Reconnect on the winner, or fall
@@ -475,11 +470,11 @@ export function useConnectionManager(
       mc.escalating = true;
 
       const { host, port } = splitConnectionId(mc.connectionId);
-      // Set 'reconnecting' directly (the client emits onReconnectExhausted, not
-      // a status), and stop the old ping so it cannot fire during the probe.
+      // Set 'reconnecting' directly (the client emits onReconnectExhausted,
+      // not a status). The client's own keep-alive already stopped itself
+      // when the transport closed (WebSocketClient#handleClose).
       mc.status = 'reconnecting';
       mc.error = null;
-      stopPing(mc);
       syncState();
       console.debug(`[ConnectionManager] escalate ${mc.connectionId}: probing ${host}`);
 
@@ -492,7 +487,6 @@ export function useConnectionManager(
           console.warn(`[ConnectionManager] no daemon on ${host}; marking unreachable`);
           mc.status = 'unreachable';
           mc.error = new Error(`No daemon answered on ${host}`);
-          stopPing(mc);
           syncState();
           return;
         }
@@ -509,14 +503,13 @@ export function useConnectionManager(
           console.error(`[ConnectionManager] escalateReconnect failed on ${mc.connectionId}:`, err);
           mc.status = 'unreachable';
           mc.error = err instanceof Error ? err : new Error(String(err));
-          stopPing(mc);
           syncState();
         }
       } finally {
         mc.escalating = false;
       }
     },
-    [stopPing, syncState],
+    [syncState],
   );
 
   // Connect to a daemon (direct WebSocket)
@@ -537,7 +530,6 @@ export function useConnectionManager(
           return connectionId;
         }
         // Tear down the rest (error / disconnected / unreachable) before reconnecting.
-        stopPing(existing);
         existing.client.disconnect();
         connectionsMapRef.current.delete(connectionId);
       }
@@ -579,13 +571,11 @@ export function useConnectionManager(
 
           if (newStatus === 'connected') {
             mc.error = null;
-            startPing(mc);
           }
 
           if (newStatus === 'disconnected' || newStatus === 'reconnecting') {
             mc.sessionId = null;
             mc.helloSent = false;
-            stopPing(mc);
           }
 
           syncState();
@@ -608,7 +598,7 @@ export function useConnectionManager(
 
       return connectionId;
     },
-    [createMessageHandler, sendHello, startPing, stopPing, syncState, escalateReconnect],
+    [createMessageHandler, sendHello, syncState, escalateReconnect],
   );
 
   // Retry a connection that gave up ('unreachable'/'error'/'disconnected') by
@@ -636,23 +626,21 @@ export function useConnectionManager(
     (connectionId: ConnectionId) => {
       const mc = connectionsMapRef.current.get(connectionId);
       if (!mc) return;
-      stopPing(mc);
       mc.client.disconnect();
       connectionsMapRef.current.delete(connectionId);
       syncState();
     },
-    [stopPing, syncState],
+    [syncState],
   );
 
   // Disconnect all
   const disconnectAll = useCallback(() => {
     for (const mc of connectionsMapRef.current.values()) {
-      stopPing(mc);
       mc.client.disconnect();
     }
     connectionsMapRef.current.clear();
     syncState();
-  }, [stopPing, syncState]);
+  }, [syncState]);
 
   const sendToConnection = useCallback(
     (connectionId: ConnectionId, message: ProtocolMessage): boolean => {
@@ -857,13 +845,49 @@ export function useConnectionManager(
   const passphraseConnectionId = passphraseConnection?.connectionId ?? null;
   const passphraseServerFingerprint = passphraseConnection?.serverFingerprint ?? null;
 
-  // Force reconnect on network change or app resume (iOS)
+  // Force reconnect on network change or app resume (iOS, main.tsx). Before
+  // #664 this unconditionally force-closed EVERY connected/authenticating
+  // connection at once: with ~5 daemons, foregrounding the phone guaranteed a
+  // full simultaneous reconnect cycle even when every socket was still
+  // perfectly healthy. planForceReconnect (#664) decides per-connection
+  // whether a reconnect is even needed, and staggers the ones that are.
   useEffect(() => {
     const handleForceReconnect = () => {
+      const mcs: ManagedConnection[] = [];
+      const candidates: ForceReconnectCandidate<ConnectionId>[] = [];
       for (const mc of connectionsMapRef.current.values()) {
-        if (mc.status === 'connected' || mc.status === 'authenticating') {
+        if (mc.status !== 'connected' && mc.status !== 'authenticating') continue;
+        mcs.push(mc);
+        candidates.push({
+          connectionId: mc.connectionId,
+          isOpen: mc.client.isTransportOpen,
+          isHealthy: mc.client.isHealthy,
+        });
+      }
+      if (candidates.length === 0) return;
+
+      const plan = planForceReconnect(candidates, {
+        staggerStepMs: FORCE_RECONNECT_STAGGER_STEP_MS,
+        staggerJitterMs: FORCE_RECONNECT_STAGGER_JITTER_MS,
+      });
+      const byId = new Map(mcs.map((mc) => [mc.connectionId, mc]));
+
+      for (const decision of plan) {
+        if (!decision.shouldReconnect) continue;
+        const mc = byId.get(decision.connectionId);
+        if (!mc) continue;
+
+        if (decision.delayMs <= 0) {
           mc.client.forceReconnect();
+          continue;
         }
+        setTimeout(() => {
+          // Re-check the live map: the connection may have been replaced or
+          // torn down during the staggered delay.
+          if (connectionsMapRef.current.get(decision.connectionId) === mc) {
+            mc.client.forceReconnect();
+          }
+        }, decision.delayMs);
       }
     };
     document.addEventListener('app-force-reconnect', handleForceReconnect);
@@ -874,7 +898,6 @@ export function useConnectionManager(
   useEffect(() => {
     return () => {
       for (const mc of connectionsMapRef.current.values()) {
-        if (mc.pingInterval) clearInterval(mc.pingInterval);
         mc.client.disconnect();
       }
       connectionsMapRef.current.clear();

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -882,9 +882,12 @@ export function useConnectionManager(
           continue;
         }
         setTimeout(() => {
-          // Re-check the live map: the connection may have been replaced or
-          // torn down during the staggered delay.
-          if (connectionsMapRef.current.get(decision.connectionId) === mc) {
+          // Re-check both connection identity (it may have been replaced or
+          // torn down during the delay) and current health (isHealthy already
+          // implies the transport is open) -- a connection that self-healed
+          // during its stagger delay (e.g. its own heartbeat probe finally
+          // got a reply) should be left alone, not torn down anyway.
+          if (connectionsMapRef.current.get(decision.connectionId) === mc && !mc.client.isHealthy) {
             mc.client.forceReconnect();
           }
         }, decision.delayMs);

--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -6,7 +6,7 @@
 
 import type { ConnectionStatus } from '@/types';
 import type { ProtocolMessage } from '@remi/shared/protocol.ts';
-import { createPong, deserialize, serialize } from '@remi/shared/protocol.ts';
+import { createPing, createPong, deserialize, serialize } from '@remi/shared/protocol.ts';
 
 /** WebSocket client configuration */
 export interface WebSocketClientConfig {
@@ -22,7 +22,11 @@ export interface WebSocketClientConfig {
   readonly maxReconnectDelay?: number;
   /** Connection timeout in ms */
   readonly connectionTimeout?: number;
-  /** Heartbeat interval in ms (0 to disable). Closes stale connections that miss 2 heartbeats. */
+  /**
+   * Heartbeat interval in ms (0 to disable). Each tick sends the client's own
+   * `ping` probe and checks whether the previous one got any reply; closes
+   * the connection after `MAX_MISSED_HEARTBEATS` consecutive misses (#664).
+   */
   readonly heartbeatInterval?: number;
 }
 
@@ -55,6 +59,32 @@ export interface WebSocketClientEvents {
  */
 export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 6;
 
+/**
+ * Consecutive keep-alive probes allowed to go unanswered before the
+ * connection is treated as dead (#664). Each probe is the client's OWN
+ * outbound `ping`, sent every `heartbeatInterval`; the daemon always replies
+ * to a ping with a `pong` (connection.ts `handlePing`), so under a healthy
+ * network every probe gets some reply well inside one interval. This
+ * decouples client-side staleness detection from the server's independent
+ * keep-alive schedule -- the old bug was a passive silence watchdog whose
+ * 30s window had zero margin over the server's own 30s ping cadence, so any
+ * latency blip on the server's side force-closed a healthy socket. 3
+ * consecutive misses gives real tolerance for transient jitter while still
+ * catching a truly dead peer well inside the Bun-level idleTimeout backstop
+ * (120s, websocket-server.ts).
+ */
+const MAX_MISSED_HEARTBEATS = 3;
+
+/**
+ * Multiplier on `heartbeatInterval` used by `isHealthy` to decide whether a
+ * connection has seen traffic recently enough that a caller doing proactive
+ * housekeeping (e.g. an app-resume force-reconnect sweep, #664) can trust it
+ * without tearing it down. Looser than `MAX_MISSED_HEARTBEATS`, the reap
+ * threshold, on purpose: this only needs to rule out real doubt, not confirm
+ * death -- the internal heartbeat already owns the latter.
+ */
+const HEALTHY_WINDOW_MULTIPLIER = 2;
+
 /** Default configuration */
 const DEFAULT_CONFIG: Required<Omit<WebSocketClientConfig, 'url'>> = {
   autoReconnect: true,
@@ -80,6 +110,9 @@ export class WebSocketClient {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastDataReceived = 0;
   private missedHeartbeats = 0;
+  /** When the current cycle's keep-alive probe was sent; 0 if none is
+   *  outstanding yet (fresh connection, or heartbeat just (re)started). */
+  private lastPingSentAt = 0;
   private intentionalDisconnect = false;
   /** Live target URL. Starts at config.url; `reconnectWithUrl` rebinds it to a
    *  rediscovered port without recreating the client. */
@@ -104,6 +137,24 @@ export class WebSocketClient {
   /** Check if connected */
   get isConnected(): boolean {
     return this.status === 'connected';
+  }
+
+  /** Whether the underlying transport is currently open, independent of the
+   *  higher-level auth/connected status machine (#664): a status can lag a
+   *  zombie socket after a long background suspend, so a stampede-avoidance
+   *  caller needs the raw transport state to tell "already dead, reconnect
+   *  now" apart from "open but uncertain, worth staggering". */
+  get isTransportOpen(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /** Whether this connection is open and has seen inbound traffic recently
+   *  enough that a caller doing proactive housekeeping (e.g. an app-resume
+   *  force-reconnect sweep, #664) can trust it without tearing it down. */
+  get isHealthy(): boolean {
+    if (!this.isTransportOpen) return false;
+    if (this.config.heartbeatInterval <= 0) return true;
+    return Date.now() - this.lastDataReceived < this.config.heartbeatInterval * HEALTHY_WINDOW_MULTIPLIER;
   }
 
   /** Connect to the daemon */
@@ -331,7 +382,14 @@ export class WebSocketClient {
     }
   }
 
-  /** Start heartbeat monitoring. Detects dead connections that the OS hasn't closed yet. */
+  /**
+   * Start heartbeat monitoring. Detects dead connections that the OS hasn't
+   * closed yet by actively probing the peer rather than passively waiting
+   * for it to speak first (#664): each tick checks whether the PREVIOUS
+   * probe got any reply (any inbound message counts, not just an explicit
+   * pong -- handleMessage already treats any message as proof of life), then
+   * sends this cycle's probe.
+   */
   private startHeartbeat(): void {
     this.stopHeartbeat();
     const interval = this.config.heartbeatInterval;
@@ -343,20 +401,24 @@ export class WebSocketClient {
         return;
       }
 
-      const elapsed = Date.now() - this.lastDataReceived;
-      if (elapsed > interval) {
-        this.missedHeartbeats++;
-      } else {
-        this.missedHeartbeats = 0;
+      // Skip the miss check on the very first tick: no probe has gone out yet.
+      if (this.lastPingSentAt > 0) {
+        if (this.lastDataReceived < this.lastPingSentAt) {
+          this.missedHeartbeats++;
+        } else {
+          this.missedHeartbeats = 0;
+        }
       }
 
-      // If no data received for 2 heartbeat intervals, the connection is likely dead.
-      // Force-close so reconnection logic kicks in.
-      if (this.missedHeartbeats >= 2) {
+      if (this.missedHeartbeats >= MAX_MISSED_HEARTBEATS) {
         this.stopHeartbeat();
-        this.handleError(new Error('Connection stale: no data received'));
+        this.handleError(new Error('Connection stale: no reply to keep-alive ping'));
         this.ws?.close();
+        return;
       }
+
+      this.lastPingSentAt = Date.now();
+      this.send(createPing());
     }, interval);
   }
 
@@ -367,6 +429,7 @@ export class WebSocketClient {
       this.heartbeatTimer = null;
     }
     this.missedHeartbeats = 0;
+    this.lastPingSentAt = 0;
   }
 
   /** Clear all timers */

--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -68,10 +68,13 @@ export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 6;
  * decouples client-side staleness detection from the server's independent
  * keep-alive schedule -- the old bug was a passive silence watchdog whose
  * 30s window had zero margin over the server's own 30s ping cadence, so any
- * latency blip on the server's side force-closed a healthy socket. 3
- * consecutive misses gives real tolerance for transient jitter while still
- * catching a truly dead peer well inside the Bun-level idleTimeout backstop
- * (120s, websocket-server.ts).
+ * latency blip on the server's side force-closed a healthy socket.
+ *
+ * The first tick after connect only sends the first probe (there's nothing
+ * outstanding yet to check a reply against), so a fully silent peer is only
+ * confirmed dead on the 4th tick -- 4 * `heartbeatInterval` worst case
+ * (~60s at the 15s default), still comfortably inside the Bun-level
+ * idleTimeout backstop (120s, websocket-server.ts).
  */
 const MAX_MISSED_HEARTBEATS = 3;
 

--- a/packages/web/tests/lib/connection-manager.test.ts
+++ b/packages/web/tests/lib/connection-manager.test.ts
@@ -11,8 +11,10 @@ import { describe, expect, test } from 'bun:test';
 import {
   collectPendingChallengeConnections,
   DEVICE_ID_STORAGE_KEY,
+  type ForceReconnectCandidate,
   getOrCreateDeviceId,
   type KeyValueStorage,
+  planForceReconnect,
 } from '../../src/hooks/connection-manager-helpers';
 
 /** In-memory Storage-compatible fake so tests don't need a browser DOM. */
@@ -104,5 +106,111 @@ describe('getOrCreateDeviceId (#662)', () => {
     const idB = getOrCreateDeviceId(fakeStorage());
 
     expect(idA).not.toBe(idB);
+  });
+});
+
+/**
+ * Coverage for the reconnect-stampede fix (#664): on app resume / network
+ * change, `app-force-reconnect` used to unconditionally force-close every
+ * connected/authenticating connection at once -- with ~5 daemons that meant
+ * a guaranteed simultaneous visible reconnect cycle on every foreground.
+ * `planForceReconnect` decides per-connection whether a reconnect is even
+ * needed, and staggers the ones that are.
+ */
+describe('planForceReconnect (#664)', () => {
+  const candidate = (
+    connectionId: string,
+    isOpen: boolean,
+    isHealthy: boolean,
+  ): ForceReconnectCandidate => ({ connectionId, isOpen, isHealthy });
+
+  test('leaves a healthy, open connection alone entirely', () => {
+    const plan = planForceReconnect([candidate('a', true, true)], {
+      staggerStepMs: 300,
+      staggerJitterMs: 2000,
+    });
+
+    expect(plan).toEqual([{ connectionId: 'a', shouldReconnect: false, delayMs: 0 }]);
+  });
+
+  test('reconnects a not-open connection immediately, no stagger', () => {
+    const plan = planForceReconnect([candidate('a', false, false)], {
+      staggerStepMs: 300,
+      staggerJitterMs: 2000,
+    });
+
+    expect(plan).toEqual([{ connectionId: 'a', shouldReconnect: true, delayMs: 0 }]);
+  });
+
+  test('reconnects an open-but-unhealthy connection with a staggered delay', () => {
+    const plan = planForceReconnect([candidate('a', true, false)], {
+      staggerStepMs: 300,
+      staggerJitterMs: 2000,
+      random: () => 0.5,
+    });
+
+    expect(plan).toEqual([{ connectionId: 'a', shouldReconnect: true, delayMs: 1000 }]);
+  });
+
+  test('staggers multiple open-but-unhealthy connections across their index', () => {
+    const plan = planForceReconnect(
+      [
+        candidate('a', true, false),
+        candidate('b', true, false),
+        candidate('c', true, false),
+      ],
+      { staggerStepMs: 300, staggerJitterMs: 2000, random: () => 0 },
+    );
+
+    expect(plan.map((d) => d.delayMs)).toEqual([0, 300, 600]);
+  });
+
+  test('a healthy connection does not consume a stagger index (sibling unhealthy ones stay unaffected)', () => {
+    const plan = planForceReconnect(
+      [
+        candidate('healthy', true, true),
+        candidate('stale-1', true, false),
+        candidate('stale-2', true, false),
+      ],
+      { staggerStepMs: 300, staggerJitterMs: 0, random: () => 0 },
+    );
+
+    expect(plan).toEqual([
+      { connectionId: 'healthy', shouldReconnect: false, delayMs: 0 },
+      { connectionId: 'stale-1', shouldReconnect: true, delayMs: 0 },
+      { connectionId: 'stale-2', shouldReconnect: true, delayMs: 300 },
+    ]);
+  });
+
+  test('mixes immediate (dead) and staggered (uncertain) reconnects in one sweep', () => {
+    const plan = planForceReconnect(
+      [
+        candidate('healthy', true, true),
+        candidate('dead', false, false),
+        candidate('uncertain', true, false),
+      ],
+      { staggerStepMs: 300, staggerJitterMs: 0, random: () => 0 },
+    );
+
+    expect(plan).toEqual([
+      { connectionId: 'healthy', shouldReconnect: false, delayMs: 0 },
+      { connectionId: 'dead', shouldReconnect: true, delayMs: 0 },
+      { connectionId: 'uncertain', shouldReconnect: true, delayMs: 0 },
+    ]);
+  });
+
+  test('empty input produces an empty plan', () => {
+    expect(planForceReconnect([], { staggerStepMs: 300, staggerJitterMs: 2000 })).toEqual([]);
+  });
+
+  test('defaults to Math.random when no random fn is injected (delay stays within bounds)', () => {
+    const plan = planForceReconnect([candidate('a', true, false)], {
+      staggerStepMs: 300,
+      staggerJitterMs: 2000,
+    });
+
+    expect(plan[0]?.shouldReconnect).toBe(true);
+    expect(plan[0]?.delayMs).toBeGreaterThanOrEqual(0);
+    expect(plan[0]?.delayMs).toBeLessThan(2000);
   });
 });

--- a/packages/web/tests/lib/websocket-client.test.ts
+++ b/packages/web/tests/lib/websocket-client.test.ts
@@ -12,7 +12,7 @@ import type {
   PongMessage,
   ProtocolMessage,
 } from '@remi/shared/protocol.ts';
-import { createPing, deserialize, serialize } from '@remi/shared/protocol.ts';
+import { createPing, createPong, deserialize, serialize } from '@remi/shared/protocol.ts';
 import { DEFAULT_MAX_RECONNECT_ATTEMPTS, WebSocketClient } from '../../src/lib/websocket-client';
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -373,6 +373,154 @@ describe('WebSocketClient ping/pong liveness (#662 review)', () => {
       for (const id of pingIds) {
         expect(pongIdsSeen.has(id)).toBe(true);
       }
+    } finally {
+      server.stop();
+    }
+  });
+});
+
+/**
+ * Coverage for the #664 fix: the OLD heartbeat passively waited for silence
+ * to exceed a window EQUAL to the server's own independent 30s ping cadence
+ * (zero margin -- any latency blip on the server's side force-closed a
+ * healthy socket). The NEW heartbeat actively sends its own `ping` probe
+ * every interval and only counts a miss when the PREVIOUS probe got no
+ * reply, decoupling detection from the server's independent schedule and
+ * tolerating real jitter.
+ */
+describe('WebSocketClient heartbeat margin & round-trip liveness (#664)', () => {
+  test('does NOT disconnect a healthy connection whose replies are delayed past the old zero-margin window', async () => {
+    // 1.7x the heartbeat interval: strictly more than the OLD single-window
+    // margin (which was exactly 1x the server's cadence), on every single
+    // reply. The old passive-silence watchdog would have force-closed this
+    // within two ticks; the new round-trip model self-heals every cycle
+    // because SOME reply always eventually lands before the next check.
+    const interval = 100;
+    const replyDelay = Math.round(interval * 1.7);
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return undefined;
+        return new Response('no upgrade', { status: 400 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const raw = typeof data === 'string' ? data : data.toString();
+          const msg = deserialize(raw);
+          if (msg?.type === 'ping') {
+            setTimeout(() => {
+              ws.send(serialize(createPong((msg as PingMessage).id)));
+            }, replyDelay);
+          }
+        },
+        close() {},
+      },
+    });
+
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    let staleErrorSeen = false;
+    const client = track(
+      new WebSocketClient(
+        { url, heartbeatInterval: interval, connectionTimeout: 2000 },
+        {
+          onError: (err) => {
+            if (err.message.includes('stale')) staleErrorSeen = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      // Run for well over 10 heartbeat cycles -- long enough that the old
+      // zero-margin model would have reaped it many times over.
+      await wait(interval * 12);
+
+      expect(staleErrorSeen).toBe(false);
+      expect(client.isTransportOpen).toBe(true);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('detects a genuinely silent server (no pings, no replies at all) as stale within a bounded time', async () => {
+    const interval = 100;
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return undefined;
+        return new Response('no upgrade', { status: 400 });
+      },
+      websocket: {
+        // Never sends anything back, including replies to the client's own
+        // probes -- models a fully wedged peer (not just a slow one).
+        open() {},
+        message() {},
+        close() {},
+      },
+    });
+
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    let staleErrorSeen = false;
+    const client = track(
+      new WebSocketClient(
+        { url, heartbeatInterval: interval, connectionTimeout: 2000, autoReconnect: false },
+        {
+          onError: (err) => {
+            if (err.message.includes('stale')) staleErrorSeen = true;
+          },
+        },
+      ),
+    );
+
+    try {
+      client.connect();
+      const start = Date.now();
+      // Bounded: must trip well within a handful of heartbeat intervals, not
+      // linger anywhere near the Bun-level idleTimeout backstop (120s).
+      while (!staleErrorSeen && Date.now() - start < 5000) await wait(25);
+
+      expect(staleErrorSeen).toBe(true);
+      expect(client.isTransportOpen).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('isHealthy is true immediately after connecting and false once the socket is closed', async () => {
+    const server = liveWsServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const client = track(
+      new WebSocketClient({ url, heartbeatInterval: 5000, connectionTimeout: 2000 }),
+    );
+
+    try {
+      client.connect();
+      const start = Date.now();
+      while (!client.isTransportOpen && Date.now() - start < 2000) await wait(10);
+      expect(client.isTransportOpen).toBe(true);
+      expect(client.isHealthy).toBe(true);
+
+      client.disconnect();
+      expect(client.isTransportOpen).toBe(false);
+      expect(client.isHealthy).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test('isHealthy treats a disabled heartbeat (interval 0) as healthy whenever the transport is open', async () => {
+    const server = liveWsServer();
+    const url = `ws://127.0.0.1:${server.port}/ws`;
+    const client = track(new WebSocketClient({ url, heartbeatInterval: 0, connectionTimeout: 2000 }));
+
+    try {
+      client.connect();
+      const start = Date.now();
+      while (!client.isTransportOpen && Date.now() - start < 2000) await wait(10);
+      expect(client.isHealthy).toBe(true);
     } finally {
       server.stop();
     }


### PR DESCRIPTION
## What

Two related liveness/reconnect fixes on the web client (#664):

1. **Heartbeat margin.** `WebSocketClient`'s watchdog declared a connection
   stale after 30s of inbound silence -- the exact same cadence as the
   daemon's independent keepalive ping (`DEFAULT_PING_INTERVAL`,
   `connection.ts:134`), leaving zero margin. Any latency blip on the
   server's side force-closed a healthy socket. The heartbeat now actively
   sends its own `ping` every interval and counts *missed replies* (any
   inbound message counts, matching the existing "any message is proof of
   life" behavior) rather than passively watching for silence. This
   decouples client-side staleness detection from the server's independent
   schedule entirely -- the daemon always answers a `ping` with a `pong`
   (`connection.ts` `handlePing`), so a healthy connection gets some reply
   well inside one interval regardless of what else the server is doing.
   3 consecutive misses (vs. the old 2) before reaping, still comfortably
   inside the Bun-level `idleTimeout` backstop (120s).

2. **Reconnect stampede.** `app-force-reconnect` (dispatched on every
   `appStateChange` resume + network change, `main.tsx`) used to
   unconditionally `forceReconnect()` every connected/authenticating
   connection at once. With ~5 daemons that guaranteed a simultaneous
   visible reconnect cycle on every foreground, even when every socket was
   perfectly healthy. `planForceReconnect` (pure, in
   `connection-manager-helpers.ts`) now decides per-connection:
   - open + recently active -> left alone entirely
   - transport not open (already dead) -> reconnect immediately
   - open but not recently active (uncertain, e.g. a zombie handle after a
     long background suspend) -> reconnect, staggered with jitter across
     the connection's index so N daemons don't all drop in the same instant

   As part of this, the manager's separate 30s keepalive ping (`startPing`/
   `stopPing`/`mc.pingInterval`) is removed -- it's now redundant since
   `WebSocketClient` sends its own keepalive internally, and having two
   independent ping schedules was confusing and wasteful.

## Why

Both bugs together produced the "constant visible connect/disconnect/
reconnect cycling" reported in #664. They interact with the liveness
semantics from #662 (server pong-based reaper, PR #666 merged) and the
client-ack work in #663 (PR #679 merged) -- built on top of both.

Adjacent but explicitly out of scope: #682 (stale global error banner).
Nothing here should worsen it; the force-reconnect handler still calls
`forceReconnect()` (unchanged signature) for connections that need it, just
fewer of them and with a delay.

Refs #662, #666, #679, #682.

## Testing

- `bun run typecheck` -- clean
- `bun test packages/web` -- 281 pass, 0 fail (incl. 12 new/extended
  `websocket-client.test.ts` cases against real Bun WebSocket servers, no
  mocks: tolerates reply delays worse than the old zero-margin window
  without disconnecting, still detects a genuinely silent server as stale
  within a bounded time, `isHealthy`/`isTransportOpen` getters; 8 new pure
  unit tests for `planForceReconnect` covering skip/immediate/staggered
  decisions and multi-connection index staggering with injectable
  randomness for determinism)
- `cd packages/web && bun run build` -- clean
- `cd packages/web && bun run lint` -- same 3 errors / 2 warnings as
  baseline (`InputArea.tsx`, `useConnectionManager.ts`, `useWebSocket.ts`,
  `message-filter.ts`), all pre-existing and confirmed identical against
  develop before this change; no new lint issues introduced

Closes #664