### PR TITLE
fix(#673): cancel AA escalations resolved externally

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -264,14 +264,24 @@ export class AutoApproveGate {
    * Every OPEN escalation this gate has created (held OR passthrough), keyed
    * by `Question.id`, by its (tool_name, tool_input) signature (#673). Entry
    * lifecycle: created in `escalateToUser` on a successful escalation; removed
-   * unconditionally by the public `resolveHeld` / `releaseHeldAsPassthrough`
-   * (the normal answer path, whether or not a hold existed), by
-   * `cancelExternallyResolved` / the duplicate-re-request check in
-   * `escalateToUser` (both route through `resolveSupersededQuestion`), and
-   * wholesale-cleared by `cancelStale` (session end — nothing here is
-   * relevant once the session is gone). A stale entry is harmless (a signature
-   * match just triggers a redundant, idempotent cleanup), so this never needs
-   * to be perfectly pruned beyond those points.
+   * by exactly TWO owners, unconditionally (regardless of whether a hold
+   * existed), so no exit path can leak an entry:
+   *   - the public `resolveHeld` (a separate, non-delegating path — it owns
+   *     its own delete);
+   *   - the private `releaseHeld`, which EVERY other resolution path funnels
+   *     through: `releaseHeldAsPassthrough` (normal answer), `failOpenHeld`
+   *     (hold-timeout / undelivered-notification fail-open),
+   *     `reconcileLateVerdict`'s cancelled branch (Part B), and
+   *     `resolveSupersededQuestion` (#673's own external-resolution / stale
+   *     -duplicate cleanup).
+   * `cancelStale` and `forceRelease` additionally wholesale-clear the whole
+   * map (session end / force-release — nothing tracked is relevant after
+   * either). A stale entry is harmless (a signature match just triggers a
+   * redundant, idempotent cleanup), but MUST NOT be able to accumulate
+   * indefinitely: an un-deleted entry from a timed-out/cancelled hold would
+   * sit for the rest of the process lifetime and could fire a spurious
+   * `notifyResolved` for a question dead for hours on a much-later,
+   * unrelated duplicate of the same command.
    */
   private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
 
@@ -399,12 +409,9 @@ export class AutoApproveGate {
    * about to answer the native prompt, not a silent auto-decision).
    */
   releaseHeldAsPassthrough(questionId: UUID): boolean {
-    // #673: also the NORMAL answer path for a NON-held (passthrough-escalated)
-    // question -- input-events.ts calls this unconditionally on every answer,
-    // hold or not, so this is the ONE place that must unconditionally clear a
-    // passthrough-only entry (releaseHeld below no-ops before reaching any
-    // cleanup when there is no hold to release).
-    this.openQuestionSignatures.delete(questionId);
+    // #673: openQuestionSignatures cleanup lives in the private releaseHeld
+    // itself (the single owner every internal caller funnels through), so
+    // there is nothing extra to do here.
     return this.releaseHeld(questionId, 'passthrough');
   }
 
@@ -961,10 +968,22 @@ export class AutoApproveGate {
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
   }
 
-  /** Resolve a held hook with an arbitrary decision (incl. passthrough) WITHOUT
-   *  markHandled (used by Part B's cancelled reconciliation, where the verdict
-   *  was not a silent auto-decision). Returns true when a hold existed. */
+  /**
+   * Resolve a held hook with an arbitrary decision (incl. passthrough) WITHOUT
+   * markHandled (used by Part B's cancelled reconciliation, where the verdict
+   * was not a silent auto-decision). Returns true when a hold existed.
+   *
+   * #673: the SINGLE owner of `openQuestionSignatures` cleanup for every
+   * internal caller of this method -- `releaseHeldAsPassthrough`,
+   * `failOpenHeld` (hold-timeout / undelivered-notification fail-open),
+   * `reconcileLateVerdict`'s cancelled branch, and `resolveSupersededQuestion`
+   * (#673's own external-resolution cleanup) all funnel through here, so the
+   * delete must be UNCONDITIONAL (not gated on `hold` existing) or every one
+   * of those exit paths leaks an entry for the rest of the process lifetime.
+   * (`resolveHeld` is a separate, non-delegating path and owns its own delete.)
+   */
   private releaseHeld(questionId: UUID, decision: PermissionDecision): boolean {
+    this.openQuestionSignatures.delete(questionId);
     const hold = this.pendingHolds.get(questionId);
     if (!hold) return false;
     clearTimeout(hold.timer);
@@ -1129,6 +1148,15 @@ export class AutoApproveGate {
       // again -- that response already went to a stale hook call. Clean it up
       // BEFORE tracking the new one (the new questionId is not registered yet,
       // so this can never find/cancel itself).
+      //
+      // Baked-in assumption: Claude Code processes a turn's tool-permission
+      // hooks SEQUENTIALLY (verified against the cc-ref reference source,
+      // conversation.rs:370's sequential for-loop), so two identical-signature
+      // MAIN-context escalations can never be genuinely concurrent/live at
+      // once -- an incoming duplicate always means the earlier one is dead. If
+      // Claude Code ever parallelizes main-context tool-permission dispatch,
+      // this invariant breaks and this check would need a stronger key (e.g.
+      // requiring tool_use_id) before it could keep firing safely.
       this.cancelExternallyResolved(observed, 'duplicate-re-request');
       this.openQuestionSignatures.set(questionId, {
         toolName: observed.toolName,
@@ -1165,6 +1193,10 @@ export class AutoApproveGate {
    *  tool_use_id match (future-proofing: not sent by Claude Code today) over
    *  the tool_name + tool_input signature fallback. */
   private findOpenQuestionMatching(observed: ObservedToolCall): UUID | undefined {
+    // Fast path: called on EVERY admitted PreToolUse/PostToolUse, so the
+    // near-universal "no open escalation at all" case must not pay for a
+    // stableToolInputKey stringify it can never use.
+    if (this.openQuestionSignatures.size === 0) return undefined;
     const observedKey = stableToolInputKey(observed.toolInput);
     for (const [qid, sig] of this.openQuestionSignatures) {
       if (sig.toolName !== observed.toolName || sig.toolInputKey !== observedKey) continue;
@@ -1222,7 +1254,9 @@ export class AutoApproveGate {
       );
     }
     // notifyResolved is already throw-safe internally; no extra wrap needed.
+    // openQuestionSignatures cleanup already happened inside releaseHeld
+    // above (the single owner, unconditional even if no hold existed) --
+    // nothing further to delete here.
     this.notifyResolved(qid, 'cancelled');
-    this.openQuestionSignatures.delete(qid);
   }
 }

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -23,6 +23,28 @@
  * Both are read LIVE at each branch (never captured): the LLM eval is async, so the
  * subagent/Task context can open or close between the hook firing and the
  * `.then()`/`.catch()` running. Capturing would TOCTOU.
+ *
+ * #673: the gate also owns EXTERNAL-RESOLUTION cancellation. Every escalation
+ * this gate creates (held OR passthrough) is tracked in `openQuestionSignatures`
+ * by its (tool_name, tool_input) signature. Two triggers prove an open
+ * escalation was resolved WITHOUT going through Remi's own answer path:
+ *   - `cancelExternallyResolved`, called from PreToolUse/PostToolUse in
+ *     `hook-bridge-setup.ts` when the observed tool signature matches an open
+ *     escalation — the tool is now running, so the user must have answered it
+ *     directly in the terminal (a passthrough escalation was never held, so
+ *     Remi's own answer path never ran) or "the other process's own
+ *     permission mode" resolved it independently.
+ *   - a duplicate re-request: `escalateToUser` checks for an already-open
+ *     entry with the SAME signature before registering a new one — Claude
+ *     re-issuing the identical PermissionRequest proves the earlier one can
+ *     never be answered through its own hook response again.
+ * Both ALWAYS degrade to `releaseHeld(qid, 'passthrough')` — never a
+ * fabricated allow/deny — mirroring the existing fail-open philosophy: we
+ * cannot know what the user actually decided, so the safest response is "no
+ * decision from us," identical to a hold timing out. Own-session scope only:
+ * a foreign session's PermissionRequest never creates an entry here in the
+ * first place (post-#672 that stays entirely with ForeignSessionEscalator's
+ * informational-only push), so there is nothing for this gate to cancel for it.
  */
 
 import type { UUID } from '@remi/shared';
@@ -34,6 +56,50 @@ import { type DeliveryOutcome, isDelivered } from '../notifications/notification
 import type { SessionRegistry } from '../session/index.ts';
 import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
+
+/** The (tool_name, tool_input) signature of an OPEN escalation (#673),
+ *  tracked so an external-resolution signal can find and cancel it. */
+interface ToolSignature {
+  readonly toolName: string;
+  readonly toolInputKey: string;
+  readonly toolUseId: string | undefined;
+}
+
+/** An observed tool call to correlate against `openQuestionSignatures`. Same
+ *  shape whether it came from a PreToolUse/PostToolUse hook or (for the
+ *  duplicate-re-request path) a fresh PermissionRequest. */
+export interface ObservedToolCall {
+  readonly toolName: string;
+  readonly toolInput: Record<string, unknown>;
+  readonly toolUseId?: string | undefined;
+}
+
+/**
+ * A stable, key-order-independent JSON key for `tool_input` (#673). Two
+ * logically identical tool_input objects with keys in a different order must
+ * compare equal, so the signature match is not order-fragile.
+ */
+function stableToolInputKey(toolInput: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(canonicalize(toolInput));
+  } catch {
+    // Non-serializable input should not happen (tool_input comes from a
+    // parsed JSON hook payload); degrade to a key that can never match
+    // anything rather than throwing into the escalation path.
+    return `__unserializable__:${Math.random()}`;
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === 'object') {
+    const sortedEntries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, canonicalize((value as Record<string, unknown>)[key])] as const);
+    return Object.fromEntries(sortedEntries);
+  }
+  return value;
+}
 
 /**
  * Minimal seam the gate consumes. The real `AutoApproveService` satisfies it
@@ -194,6 +260,21 @@ export class AutoApproveGate {
    */
   private readonly evalIdByQuestion = new Map<UUID, number>();
 
+  /**
+   * Every OPEN escalation this gate has created (held OR passthrough), keyed
+   * by `Question.id`, by its (tool_name, tool_input) signature (#673). Entry
+   * lifecycle: created in `escalateToUser` on a successful escalation; removed
+   * unconditionally by the public `resolveHeld` / `releaseHeldAsPassthrough`
+   * (the normal answer path, whether or not a hold existed), by
+   * `cancelExternallyResolved` / the duplicate-re-request check in
+   * `escalateToUser` (both route through `resolveSupersededQuestion`), and
+   * wholesale-cleared by `cancelStale` (session end — nothing here is
+   * relevant once the session is gone). A stale entry is harmless (a signature
+   * match just triggers a redundant, idempotent cleanup), so this never needs
+   * to be perfectly pruned beyond those points.
+   */
+  private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
+
   constructor(
     private readonly deps: AutoApproveGateDeps,
     private readonly sessionId: UUID,
@@ -218,6 +299,11 @@ export class AutoApproveGate {
     // passthrough rather than hang. A held hook cannot normally co-occur with
     // Stop (Claude is blocked on the permission), but this is defensive.
     this.releaseAllHolds('passthrough', reason);
+    // #673: the session is ending, so every OPEN escalation this gate has
+    // tracked (held above, or a passthrough one with no hold) is moot. This is
+    // the ONLY place `openQuestionSignatures` is wholesale-cleared rather than
+    // entry-by-entry; releaseAllHolds only touched the held subset above.
+    this.openQuestionSignatures.clear();
     if (this.deps.service === null) return;
     if (this.deps.service.cancel(reason)) {
       log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
@@ -257,6 +343,9 @@ export class AutoApproveGate {
     const holds = this.pendingHolds.size;
     this.releaseAllHolds('passthrough', reason);
     this.evalIdByQuestion.clear();
+    // #673: mirrors cancelStale's wholesale clear -- a force-release is at
+    // least as final as a session end for bookkeeping purposes.
+    this.openQuestionSignatures.clear();
     const service = this.deps.service;
     if (service === null) return { holds, cancelled: false, drained: 0 };
     const cancelled = service.cancel(reason);
@@ -278,6 +367,10 @@ export class AutoApproveGate {
    * + #513 cue close exactly as for a silent auto-decision.
    */
   resolveHeld(questionId: UUID, decision: 'allow' | 'deny'): boolean {
+    // #673: this is the NORMAL answer path (input-events.ts), so an open
+    // escalation this question tracked is resolved now regardless of which
+    // branch below runs -- clear it unconditionally, not just on the hit path.
+    this.openQuestionSignatures.delete(questionId);
     const hold = this.pendingHolds.get(questionId);
     if (!hold) return false;
     clearTimeout(hold.timer);
@@ -306,6 +399,12 @@ export class AutoApproveGate {
    * about to answer the native prompt, not a silent auto-decision).
    */
   releaseHeldAsPassthrough(questionId: UUID): boolean {
+    // #673: also the NORMAL answer path for a NON-held (passthrough-escalated)
+    // question -- input-events.ts calls this unconditionally on every answer,
+    // hold or not, so this is the ONE place that must unconditionally clear a
+    // passthrough-only entry (releaseHeld below no-ops before reaching any
+    // cleanup when there is no hold to release).
+    this.openQuestionSignatures.delete(questionId);
     return this.releaseHeld(questionId, 'passthrough');
   }
 
@@ -1018,6 +1117,112 @@ export class AutoApproveGate {
       // terminal cue (#513, cosmetic); a cue throw must not break the finally.
       this.safeCue('onEscalate', this.deps.onEscalate);
     }
+    if (questionId) {
+      const observed: ObservedToolCall = {
+        toolName: input.tool_name,
+        toolInput: input.tool_input,
+        toolUseId: input.tool_use_id,
+      };
+      // #673 duplicate re-request: Claude re-issuing the IDENTICAL
+      // PermissionRequest (same tool signature) proves any earlier OPEN
+      // escalation for it can never be answered through its own hook response
+      // again -- that response already went to a stale hook call. Clean it up
+      // BEFORE tracking the new one (the new questionId is not registered yet,
+      // so this can never find/cancel itself).
+      this.cancelExternallyResolved(observed, 'duplicate-re-request');
+      this.openQuestionSignatures.set(questionId, {
+        toolName: observed.toolName,
+        toolInputKey: stableToolInputKey(observed.toolInput),
+        toolUseId: observed.toolUseId,
+      });
+    }
     return questionId;
+  }
+
+  /**
+   * #673: called when an external signal proves a currently-OPEN escalation
+   * (held or passthrough) was already resolved without going through Remi's
+   * own answer path. Two callers:
+   *   - `hook-bridge-setup.ts`'s PreToolUse/PostToolUse listeners, when the
+   *     observed tool signature matches an open escalation — the tool is now
+   *     running, so the permission was answered directly in the terminal (a
+   *     passthrough escalation is never held, so Remi's own answer path never
+   *     ran) or by the other process's own permission mode.
+   *   - `escalateToUser`, for a duplicate re-request of the SAME signature.
+   * Signature-scoped (exact tool_name + tool_input match, or exact
+   * tool_use_id match when both sides carry one) so it can only ever touch
+   * the ONE question it matches — never a DIFFERENT permission's still-running
+   * eval (#537's concern for why PreToolUse/PostToolUse don't cancel broadly).
+   * A no-op when no open escalation matches.
+   */
+  cancelExternallyResolved(observed: ObservedToolCall, reason: string): void {
+    const qid = this.findOpenQuestionMatching(observed);
+    if (!qid) return;
+    this.resolveSupersededQuestion(qid, reason);
+  }
+
+  /** Find an open escalation matching `observed`, preferring an exact
+   *  tool_use_id match (future-proofing: not sent by Claude Code today) over
+   *  the tool_name + tool_input signature fallback. */
+  private findOpenQuestionMatching(observed: ObservedToolCall): UUID | undefined {
+    const observedKey = stableToolInputKey(observed.toolInput);
+    for (const [qid, sig] of this.openQuestionSignatures) {
+      if (sig.toolName !== observed.toolName || sig.toolInputKey !== observedKey) continue;
+      // Signature agrees. Two DIFFERENT tool calls can legitimately share an
+      // identical (tool_name, tool_input) (e.g. two `ls` calls in a row) --
+      // if BOTH sides carry a tool_use_id, it must ALSO agree, or this is a
+      // known-different call and must NOT be treated as a match. When at
+      // least one side has no id, the signature alone is the best available
+      // proof.
+      if (observed.toolUseId !== undefined && sig.toolUseId !== undefined) {
+        if (observed.toolUseId === sig.toolUseId) return qid;
+        continue;
+      }
+      return qid;
+    }
+    return undefined;
+  }
+
+  /**
+   * Guarded cleanup for a question proven stale by an external signal (#673).
+   * ALWAYS degrades to `releaseHeld(qid, 'passthrough')` — never a fabricated
+   * allow/deny, matching the hold-timeout fail-open philosophy: we cannot know
+   * what the user actually decided, so "no decision from us" is the only safe
+   * response. Mirrors input-events.ts's own answer-cleanup sequence: each step
+   * independently try/catch'd so one failure can never skip the rest —
+   * `removeQuestion` in particular must always run even if the eval was
+   * already gone or the hold release throws, or the pushed card lingers.
+   */
+  private resolveSupersededQuestion(qid: UUID, reason: string): void {
+    log(
+      `[AutoApprove ${this.sessionTag}] Externally resolved ${qid.slice(0, 8)} (${reason}); clearing stale escalation`,
+    );
+    try {
+      this.releaseHeld(qid, 'passthrough');
+    } catch (err) {
+      logError(
+        `[AutoApprove ${this.sessionTag}] releaseHeld during external-resolve cleanup threw:`,
+        err,
+      );
+    }
+    try {
+      this.cancelEvalForQuestion(qid, reason);
+    } catch (err) {
+      logError(
+        `[AutoApprove ${this.sessionTag}] cancelEvalForQuestion during external-resolve cleanup threw:`,
+        err,
+      );
+    }
+    try {
+      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
+    } catch (err) {
+      logError(
+        `[AutoApprove ${this.sessionTag}] removeQuestion during external-resolve cleanup threw:`,
+        err,
+      );
+    }
+    // notifyResolved is already throw-safe internally; no extra wrap needed.
+    this.notifyResolved(qid, 'cancelled');
+    this.openQuestionSignatures.delete(qid);
   }
 }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -524,6 +524,20 @@ export function setupHookBridge(
     // otherwise abort the NEXT permission's eval mid-flight ("Decision dropped"),
     // dropping a decision that was about to approve. Only Stop/SessionEnd (a real
     // session-end) cancel an eval now.
+    //
+    // #673: distinct from the above -- this does NOT broadly cancel evals. A
+    // PreToolUse whose (tool_name, tool_input) signature matches a currently
+    // OPEN escalation/hold proves that EXACT permission was already resolved
+    // externally (answered directly in the terminal, bypassing Remi's own
+    // answer path, or the other process's own permission mode), so the tool
+    // is now running and the pushed card would otherwise linger as an
+    // unanswerable "needs you" notification. Signature-scoped: it can only
+    // ever match the ONE question with that exact signature, never a
+    // different permission's still-running eval, so it cannot regress #537.
+    autoApproveGate.cancelExternallyResolved(
+      { toolName: input.tool_name, toolInput: input.tool_input, toolUseId: input.tool_use_id },
+      'PreToolUse',
+    );
     handlers.onPreToolUse?.(input);
   });
   hookServer.on('PostToolUse', (input) => {
@@ -532,6 +546,13 @@ export function setupHookBridge(
     if (isSubagentEvent(input)) return;
     // See the PreToolUse note above: no cancelStale here (#537). The previous
     // tool's PostToolUse must not abort the next permission's in-flight eval.
+    // #673: same signature-scoped external-resolution cancel as PreToolUse
+    // above (a tool that has already FINISHED is at least as strong a signal
+    // that its permission was resolved elsewhere as one that just started).
+    autoApproveGate.cancelExternallyResolved(
+      { toolName: input.tool_name, toolInput: input.tool_input, toolUseId: input.tool_use_id },
+      'PostToolUse',
+    );
     handlers.onPostToolUse?.(input);
   });
   hookServer.on('Notification', (input) => {

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -83,6 +83,17 @@ export interface PermissionRequestHookInput extends HookCommonInput {
   tool_name: string;
   tool_input: Record<string, unknown>;
   permission_suggestions?: PermissionSuggestion[];
+  /**
+   * Cheap future-proofing (#673): NOT sent by Claude Code today (confirmed
+   * against the cc-ref reference source — the PermissionRequest struct there
+   * carries only tool_name/input/modes/reason, no tool_use_id), unlike
+   * PreToolUse/PostToolUse which already do. Declared as an optional
+   * passthrough field so that if a future Claude Code version adds it, the
+   * external-resolution correlation in AutoApproveGate can prefer an exact
+   * id match over the tool_name+tool_input signature fallback with zero
+   * further plumbing.
+   */
+  tool_use_id?: string;
 }
 
 /** Fired after a tool call fails */

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1824,6 +1824,63 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // Leak regression (PR #689 review): the private releaseHeld -- reached by
+  // failOpenHeld (hold-timeout / undelivered fail-open) and
+  // reconcileLateVerdict's cancelled branch (Part B) -- must delete the
+  // openQuestionSignatures entry UNCONDITIONALLY, not just when it happens to
+  // be called via the public wrappers. Proven behaviorally: if an entry
+  // leaked, a LATER duplicate re-request for the identical signature would
+  // find the dead entry and fire a SECOND, spurious notifyResolved('cancelled')
+  // for a question resolved (and possibly long gone) already.
+  // ---------------------------------------------------------------------------
+  describe('leak regression: hold-timeout and Part-B-cancelled must not leak entries', () => {
+    test('a timed-out hold does not leak: a later duplicate does not re-fire notifyResolved for it', async () => {
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 20, // short timeout so the hold fails open quickly
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pendingFirst = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 40)); // let the hold time out
+      expect(await pendingFirst).toBe('passthrough');
+      expect(resolvedLog).toHaveLength(1); // failOpenHeld's own notifyResolved
+
+      // A LATER duplicate for the SAME signature must find nothing -- the
+      // timed-out entry must already be gone, not leaked.
+      const pendingSecond = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(resolvedLog).toHaveLength(1); // still just one; no spurious re-fire
+      expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+      expect(await pendingSecond).toBe('allow');
+    });
+
+    test("Part-B's cancelled late-verdict reconciliation does not leak: a later duplicate does not re-fire notifyResolved", async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service, release } = multiDeferredEvaluator(cancelLog);
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(service, {
+        holdMs: 60_000,
+        pushHoldMs: 10, // Part B: push + hold early, while the eval keeps running
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20)); // early push + hold fires
+
+      // The late verdict is 'cancelled' -- Claude already advanced past the
+      // prompt during the slow eval; reconcileLateVerdict fails the hold open.
+      release({ command: 'git push' }, cancelled);
+      expect(await pending).toBe('passthrough');
+      expect(resolvedLog).toHaveLength(1); // reconcileLateVerdict's own notifyResolved
+
+      const pendingSecond = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(resolvedLog).toHaveLength(1); // no spurious re-fire for the dead entry
+      expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+      expect(await pendingSecond).toBe('allow');
+    });
+  });
+
   describe('teardown clears tracking', () => {
     test('cancelStale clears openQuestionSignatures (a later signature match is a harmless no-op)', async () => {
       const resolvedLog: Array<{ qid: UUID; reason: string }> = [];

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1494,3 +1494,381 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #673: the gate has no channel for "this permission was already resolved
+// elsewhere" -- cancelStale only fires on the bound session's own
+// PreToolUse/PostToolUse/Stop/SessionEnd, deliberately narrow (#537), so a
+// permission answered directly in the terminal (a passthrough escalation is
+// never held, so Remi's own answer path never runs) or resolved by a
+// duplicate re-request left a stale push with nothing to answer it. Fixed by
+// `cancelExternallyResolved`, called from PreToolUse/PostToolUse in
+// hook-bridge-setup.ts on a signature match, plus a duplicate-re-request
+// check inside `escalateToUser` itself.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate external-resolution cancel (#673)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let escalations: PermissionRequestHookInput[];
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  /** An evaluator with an INDEPENDENT deferred verdict per distinct
+   *  `tool_input`, so two concurrent evals (for two different permissions)
+   *  can be released separately. `cancelLog` records every `cancel()` call
+   *  with its reason, so a test can prove a specific eval was (or, for the
+   *  #537 regression, was NOT) cancelled. */
+  function multiDeferredEvaluator(
+    cancelLog: Array<{ reason: string; evalId: number | undefined }>,
+  ): {
+    service: AutoApproveEvaluator;
+    release: (toolInput: Record<string, unknown>, r: AutoApproveResult) => void;
+  } {
+    const resolvers = new Map<string, (r: AutoApproveResult) => void>();
+    const service: AutoApproveEvaluator = {
+      evaluate: (_toolName, toolInput) => {
+        const key = JSON.stringify(toolInput);
+        return new Promise<AutoApproveResult>((resolve) => {
+          resolvers.set(key, resolve);
+        });
+      },
+      cancel: (reason, evalId) => {
+        cancelLog.push({ reason, evalId });
+        return true;
+      },
+    };
+    return {
+      service,
+      release: (toolInput, r) => {
+        resolvers.get(JSON.stringify(toolInput))?.(r);
+      },
+    };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: {
+      holdMs?: number;
+      pushHoldMs?: number;
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        pushHoldMs: opts.pushHoldMs ?? 0,
+        alwaysEscalateTools: new Set(),
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    escalations = [];
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  describe('signature-scoped matching', () => {
+    test('a matching (tool_name, tool_input) cancels the held question -> passthrough, never a fabricated allow/deny', async () => {
+      const g = gate(evaluator(escalate), { holdMs: 60_000 });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(escalations).toHaveLength(1);
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' } },
+        'PreToolUse',
+      );
+
+      expect(await pending).toBe('passthrough');
+    });
+
+    test('same tool_name but DIFFERENT tool_input does NOT match', async () => {
+      const g = gate(evaluator(escalate), { holdMs: 60_000 });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const qid = lastQuestionId as UUID;
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'rm -rf /' } },
+        'PreToolUse',
+      );
+
+      // Untouched: the hold still resolves normally.
+      expect(g.resolveHeld(qid, 'allow')).toBe(true);
+      expect(await pending).toBe('allow');
+    });
+
+    test('different tool_name but SAME tool_input does NOT match', async () => {
+      const g = gate(evaluator(escalate), { holdMs: 60_000 });
+      const pending = g.resolvePermission(pr({ tool_name: 'Bash', tool_input: { path: 'x.ts' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const qid = lastQuestionId as UUID;
+
+      g.cancelExternallyResolved({ toolName: 'Edit', toolInput: { path: 'x.ts' } }, 'PreToolUse');
+
+      expect(g.resolveHeld(qid, 'allow')).toBe(true);
+      expect(await pending).toBe('allow');
+    });
+
+    test('key order in tool_input does not defeat the signature match', async () => {
+      const g = gate(evaluator(escalate), {
+        holdMs: 60_000,
+      });
+      const pending = g.resolvePermission(
+        pr({ tool_input: { command: 'ls', cwd: '/tmp', flags: '-la' } }),
+      );
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Same object, keys in a different order.
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { flags: '-la', command: 'ls', cwd: '/tmp' } },
+        'PreToolUse',
+      );
+
+      expect(await pending).toBe('passthrough');
+    });
+
+    test('an exact tool_use_id match disambiguates two open escalations that share (tool_name, tool_input)', async () => {
+      const g = gate(evaluator(escalate), { holdMs: 60_000 });
+      const pendingA = g.resolvePermission(
+        pr({ tool_input: { command: 'ls' }, tool_use_id: 'toolu_A' }),
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const qidA = lastQuestionId as UUID;
+      const pendingB = g.resolvePermission(
+        pr({ tool_input: { command: 'ls' }, tool_use_id: 'toolu_B' }),
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const qidB = lastQuestionId as UUID;
+      expect(qidA).not.toBe(qidB);
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'ls' }, toolUseId: 'toolu_A' },
+        'PreToolUse',
+      );
+
+      expect(await pendingA).toBe('passthrough');
+      // B is untouched -- still directly resolvable.
+      expect(g.resolveHeld(qidB, 'allow')).toBe(true);
+      expect(await pendingB).toBe('allow');
+    });
+  });
+
+  describe("#537 regression: never touches a DIFFERENT permission's in-flight eval", () => {
+    test("cancelling A does not resolve B, and B's eval keeps running and reconciles normally", async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service, release } = multiDeferredEvaluator(cancelLog);
+      // Part B (pushHoldMs) so BOTH A and B push+hold early WHILE their evals
+      // are still running -- the exact shape #537 is about.
+      const g = gate(service, { holdMs: 60_000, pushHoldMs: 10 });
+
+      const pendingA = g.resolvePermission(pr({ tool_input: { command: 'echo A' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const pendingB = g.resolvePermission(pr({ tool_input: { command: 'echo B' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(escalations).toHaveLength(2);
+
+      let bSettled = false;
+      void pendingB.then(() => {
+        bSettled = true;
+      });
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'echo A' } },
+        'PreToolUse',
+      );
+
+      expect(await pendingA).toBe('passthrough');
+      // B must be completely unaffected by A's cancellation.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(bSettled).toBe(false);
+      expect(cancelLog).toHaveLength(1); // ONLY A's eval was cancelled
+
+      // Prove B's eval was never aborted: its late verdict still reconciles.
+      release({ command: 'echo B' }, approve);
+      expect(await pendingB).toBe('allow');
+    });
+  });
+
+  describe('full cleanup sequence fires on a match', () => {
+    test('releases the hold, cancels the tracked eval, removes the sessionRegistry question, and fires onResolved(cancelled)', async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service } = multiDeferredEvaluator(cancelLog);
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(service, {
+        holdMs: 60_000,
+        pushHoldMs: 10, // Part B: an eval is tracked (evalIdByQuestion) for this held question
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const qid = lastQuestionId as UUID;
+      registry.addQuestion(SID, {
+        id: qid,
+        text: 'proceed?',
+        options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' } },
+        'PreToolUse',
+      );
+
+      expect(await pending).toBe('passthrough');
+      expect(registry.getQuestion(SID, qid)).toBeNull();
+      expect(cancelLog).toHaveLength(1);
+      expect(cancelLog[0]?.reason).toBe('PreToolUse');
+      expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+    });
+
+    test('a NEVER-HELD (holding disabled) escalation is also cleaned up via signature match', async () => {
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 0, // holding disabled -> createHold resolves 'passthrough' immediately, no pendingHolds entry
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const decision = await g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      expect(decision).toBe('passthrough');
+      const qid = lastQuestionId as UUID;
+      registry.addQuestion(SID, {
+        id: qid,
+        text: 'proceed?',
+        options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' } },
+        'PostToolUse',
+      );
+
+      expect(registry.getQuestion(SID, qid)).toBeNull();
+      expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+    });
+  });
+
+  describe('duplicate re-request', () => {
+    test('a second escalation for the SAME signature cancels the first, now-stale one', async () => {
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 60_000,
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pendingFirst = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const firstQid = lastQuestionId as UUID;
+      expect(escalations).toHaveLength(1);
+
+      // Claude re-issues the IDENTICAL PermissionRequest a second time.
+      const pendingSecond = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      const secondQid = lastQuestionId as UUID;
+      expect(secondQid).not.toBe(firstQid);
+      expect(escalations).toHaveLength(2);
+
+      // The FIRST hold was cleaned up automatically -- it can never be held
+      // open forever waiting for an answer that will route to the SECOND.
+      expect(await pendingFirst).toBe('passthrough');
+      expect(resolvedLog).toEqual([{ qid: firstQid, reason: 'cancelled' }]);
+
+      // The SECOND is unaffected and answerable normally.
+      expect(g.resolveHeld(secondQid, 'allow')).toBe(true);
+      expect(await pendingSecond).toBe('allow');
+    });
+  });
+
+  describe('teardown clears tracking', () => {
+    test('cancelStale clears openQuestionSignatures (a later signature match is a harmless no-op)', async () => {
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 60_000,
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      g.cancelStale('SessionEnd');
+      expect(await pending).toBe('passthrough');
+      expect(resolvedLog).toHaveLength(1); // cancelStale's own releaseAllHolds fired it once
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' } },
+        'PreToolUse',
+      );
+      // No double-resolution: the signature is no longer tracked.
+      expect(resolvedLog).toHaveLength(1);
+    });
+
+    test('forceRelease clears openQuestionSignatures', async () => {
+      const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 60_000,
+        onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+      g.forceRelease('remi unstick');
+      expect(await pending).toBe('passthrough');
+      expect(resolvedLog).toHaveLength(1);
+
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' } },
+        'PreToolUse',
+      );
+      expect(resolvedLog).toHaveLength(1);
+    });
+  });
+
+  test('no match -> harmless no-op (no throw, nothing resolved)', () => {
+    const g = gate(evaluator(escalate), { holdMs: 60_000 });
+    expect(() =>
+      g.cancelExternallyResolved({ toolName: 'Bash', toolInput: { command: 'ls' } }, 'PreToolUse'),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

`AutoApproveGate` had no channel for "this permission was already resolved elsewhere." `cancelStale()` only fires on the bound session's own `PreToolUse`/`PostToolUse`/`Stop`/`SessionEnd` (deliberately narrow, #537), so a permission resolved out-of-band raced the gate's independent verdict with no cancellation path -- if the verdict was `escalate`, the push fired regardless of the hook already having been answered somewhere else.

Two own-session scenarios this closes:
1. **A held-then-passthrough prompt answered directly in the terminal.** A passthrough escalation (multi-choice / design tool, or holding disabled) is never held (`pendingHolds`), so Remi's own WS answer path never runs for it. Previously that pushed `Question` just sat in `sessionRegistry` forever as an unanswerable "needs you" notification.
2. **A duplicate re-request.** Claude re-issues the identical `PermissionRequest` a second time; the earlier, now-orphaned escalation could never be answered through its own (already-superseded) hook response again.

## How

Every escalation the gate creates (held OR passthrough) is now tracked in a new `openQuestionSignatures` map, keyed by `Question.id`, by its `(tool_name, tool_input)` signature (a stable, key-order-independent JSON key). Two triggers clean up a stale entry, both funnelling through the same guarded cleanup sequence (mirrors `input-events.ts`'s own answer-cleanup: release any hold, cancel the tracked eval, remove the `sessionRegistry` question, dismiss the pushed card -- each step independently try/catch'd):

- **`cancelExternallyResolved`** (new public method), wired into the `PreToolUse` and `PostToolUse` listeners in `hook-bridge-setup.ts`. When the observed tool signature matches a currently open escalation, that permission has been resolved outside Remi. Signature-scoped (exact `tool_name` + `tool_input` match, or exact `tool_use_id` match when both sides carry one) so it can **only ever** touch the one question it matches -- it cannot regress #537 (a previous tool's `PreToolUse` must never abort a *different*, still-running eval).
- **A duplicate-re-request check inside `escalateToUser` itself**, which looks for an already-open entry with the same signature before registering the new one.

Both **always** degrade to `releaseHeld(qid, 'passthrough')` -- never a fabricated `allow`/`deny`. We cannot know what the user actually decided, so "no decision from us" (identical to a hold timing out) is the only safe response.

`cancelStale` and `forceRelease` now also wholesale-clear `openQuestionSignatures` (nothing tracked is relevant once the session ends or is force-released).

**Future-proofing:** `PermissionRequestHookInput` gains an optional `tool_use_id` field, matching `PreToolUse`/`PostToolUse`. Confirmed against the cc-ref reference source and live hook captures that Claude Code does **not** send it on `PermissionRequest` today -- so this is a no-op passthrough now, but if a future Claude Code version adds it, the signature-match code already prefers an exact id match over the `(tool_name, tool_input)` fallback with zero further plumbing.

## Scope

Own-session only, as agreed. A foreign session's `PermissionRequest` never creates an entry in `openQuestionSignatures` in the first place -- post-#672 that path stays entirely with `ForeignSessionEscalator`'s informational-only push (no hold, nothing to cancel), so there is nothing for this gate to do for it.

## Testing

- `bun run typecheck` -- clean
- `bunx biome check packages/daemon` -- clean (pre-existing, unrelated `noNonNullAssertion` warnings only)
- `bun test packages/daemon/tests/transcript/ packages/daemon/tests/cli/ packages/daemon/tests/hooks/ packages/daemon/tests/session packages/daemon/tests/auto-approve/` -> 1592 pass, 69 skip (env-gated LLM tests), 0 fail. Ran the full `auto-approve/` suite (not just non-LLM files) since this PR changes `auto-approve-gate.ts`; the 69 skips are the model-dependent tests that self-skip without a live LLM endpoint, unaffected by this change.
- New tests in `auto-approve-gate.test.ts` (`AutoApproveGate external-resolution cancel (#673)`, 20 new tests), no mocks (real `SessionRegistry`, real deferred-promise evaluators):
  - **Signature-scoped matching**: exact `(tool_name, tool_input)` match cancels; same name/different input does NOT match; different name/same input does NOT match; key-order in `tool_input` does not defeat the match; an exact `tool_use_id` match disambiguates two open escalations that otherwise share an identical signature (this test caught a real bug during development -- see below).
  - **#537 regression**: cancelling permission A's escalation never resolves permission B's still-held hold nor cancels B's still-running eval; B's late verdict still reconciles normally afterward.
  - **Full cleanup sequence**: hold released, tracked eval cancelled, `sessionRegistry` question removed, `onResolved('cancelled')` fired -- covering both a held escalation and a never-held (holding-disabled) one.
  - **Duplicate re-request**: a second escalation for the same signature cancels the first, stale one; the second remains normally answerable.
  - **Teardown**: `cancelStale` and `forceRelease` both clear the tracking map, so a later signature match after either is a harmless no-op (no double `onResolved`).

**Bug caught during test-writing:** the initial `findOpenQuestionMatching` implementation tried an exact `tool_use_id` match first, then unconditionally fell back to `(tool_name, tool_input)` matching. That fallback could wrongly match two genuinely *different* tool calls that happen to share an identical signature (e.g. two `ls` calls) but carry different `tool_use_id`s -- the duplicate-re-request check would then falsely cancel an unrelated, still-valid escalation. Fixed by folding both checks into one pass: a signature match is only accepted if BOTH sides lack a `tool_use_id`, or both carry one and it agrees; a known-different id on an otherwise-matching signature is explicitly skipped, not treated as a match.

Closes #673