### PR TITLE
fix(#685): stagger heartbeat-close reconnects

### DIFF
--- a/packages/web/src/hooks/connection-manager-helpers.ts
+++ b/packages/web/src/hooks/connection-manager-helpers.ts
@@ -126,3 +126,29 @@ export function planForceReconnect<Id extends string = string>(
     return { connectionId, shouldReconnect: true, delayMs };
   });
 }
+
+/**
+ * Allocate the smallest stagger slot not already in `usedSlots` (#685
+ * review). Each live `WebSocketClient` gets a fixed per-connection offset
+ * (`slot * stepMs`, see `useConnectionManager`'s `CONNECTION_STAGGER_STEP_MS`)
+ * added to its automatic heartbeat-reconnect delay, so N daemons that go
+ * stale at ~the same wall-clock tick don't cluster their reconnects. A
+ * monotonically-growing counter (the first version of this fix) assigns a
+ * FRESH index to every connection ever created, including one that's
+ * repeatedly torn down and recreated while stuck 'unreachable' (the real
+ * trigger: `App.tsx`'s `session_list_response` handler re-calls
+ * `connectDirect` for every sibling daemon port on every reconnect / app
+ * resume). Clamping that ever-growing counter at a ceiling then assigns TWO
+ * live connections the identical offset once the counter passes the
+ * ceiling -- reintroducing the exact clustering bug this fix exists to
+ * prevent. Reusing the smallest FREE slot instead keeps every currently
+ * live connection's offset distinct and bounded by how many are live RIGHT
+ * NOW, never by how many have ever existed. The caller must release a
+ * connection's slot (remove it from `usedSlots`) when that connection is
+ * torn down, so a later connection can reuse it.
+ */
+export function allocateStaggerSlot(usedSlots: ReadonlySet<number>): number {
+  let slot = 0;
+  while (usedSlots.has(slot)) slot++;
+  return slot;
+}

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -19,6 +19,7 @@ import { WebSocketClient, type WebSocketClientConfig } from '@/lib/websocket-cli
 import type { ConnectionId, ConnectionState, ConnectionStatus } from '@/types';
 import type { UnlockedIdentity } from '@remi/shared';
 import {
+  allocateStaggerSlot,
   collectPendingChallengeConnections,
   type ForceReconnectCandidate,
   getOrCreateDeviceId,
@@ -50,22 +51,13 @@ function makeConnectionId(raw: string): ConnectionId {
 
 /**
  * Stagger tuning shared by both reconnect-stampede fixes: fixed spacing per
- * connection index, so N daemons don't all visibly drop and reconnect in the
+ * connection slot, so N daemons don't all visibly drop and reconnect in the
  * same instant -- whether triggered by an explicit app-force-reconnect sweep
  * (#664, `staggerStepMs` below) or by each connection's own heartbeat
  * independently detecting staleness (#685, `reconnectStaggerMs` below).
  */
 const CONNECTION_STAGGER_STEP_MS = 300;
 const FORCE_RECONNECT_STAGGER_JITTER_MS = 2000;
-
-/**
- * Ceiling on the per-connection heartbeat-reconnect stagger offset (#685).
- * `nextStaggerIndexRef` grows monotonically with every distinct connection
- * ever created (`connectDirect`), not just the currently-live ones, so a
- * long session that adds/removes many connections over time is bounded here
- * rather than growing the offset unboundedly.
- */
-const HEARTBEAT_STAGGER_CEILING_MS = 3000;
 
 /** Internal per-connection state */
 interface ManagedConnection {
@@ -97,6 +89,11 @@ interface ManagedConnection {
   /** True while escalateReconnect is probing; prevents concurrent escalations
    *  racing reconnectWithUrl against themselves (#435). */
   escalating?: boolean;
+  /** Heartbeat-reconnect stagger slot allocated to this connection's
+   *  `WebSocketClient` (#685, `allocateStaggerSlot`). Released back to
+   *  `usedStaggerSlotsRef` when this connection is torn down, so a later
+   *  connection can reuse it instead of growing the offset forever. */
+  staggerSlot: number;
 }
 
 /** Hook options */
@@ -244,10 +241,14 @@ export function useConnectionManager(
   const onMessageRef = useRef(onMessage);
   const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
   const autoReconnectRef = useRef(autoReconnect);
-  /** Monotonic counter assigning each new WebSocketClient a distinct
-   *  heartbeat-reconnect stagger offset (#685). See CONNECTION_STAGGER_STEP_MS
-   *  / HEARTBEAT_STAGGER_CEILING_MS. */
-  const nextStaggerIndexRef = useRef(0);
+  /** Stagger slots currently held by live connections (#685,
+   *  `allocateStaggerSlot`). Each new WebSocketClient claims the smallest
+   *  free slot for its heartbeat-reconnect offset (`slot *
+   *  CONNECTION_STAGGER_STEP_MS`); a connection's slot is released back to
+   *  this set when it's torn down, so a long session that repeatedly
+   *  recreates a still-unreachable connection can't grow offsets forever or
+   *  collide with a stable sibling. */
+  const usedStaggerSlotsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     onMessageRef.current = onMessage;
@@ -547,7 +548,26 @@ export function useConnectionManager(
         // Tear down the rest (error / disconnected / unreachable) before reconnecting.
         existing.client.disconnect();
         connectionsMapRef.current.delete(connectionId);
+        // Free its stagger slot: this connection may be recreated repeatedly
+        // (e.g. App.tsx's session_list_response handler re-calling
+        // connectDirect for a still-unreachable sibling port on every
+        // reconnect / app resume) -- without releasing the slot here, a
+        // monotonic-counter design would hand it a fresh, ever-growing
+        // offset each time (#685 review).
+        usedStaggerSlotsRef.current.delete(existing.staggerSlot);
       }
+
+      // Each connection gets a distinct offset so that if several daemons'
+      // heartbeats independently detect staleness at ~the same wall-clock
+      // tick, their automatic reconnects don't cluster within the same
+      // few-hundred-ms window (#685). The slot is reused from the pool of
+      // currently-free slots (not a monotonic counter), so it stays bounded
+      // by how many connections are live RIGHT NOW and never collides with
+      // a live sibling no matter how many connect/disconnect cycles a long
+      // session goes through.
+      const staggerSlot = allocateStaggerSlot(usedStaggerSlotsRef.current);
+      usedStaggerSlotsRef.current.add(staggerSlot);
+      const reconnectStaggerMs = staggerSlot * CONNECTION_STAGGER_STEP_MS;
 
       const mc: ManagedConnection = {
         // client is initialized after this object because WebSocketClient callbacks
@@ -565,17 +585,8 @@ export function useConnectionManager(
         needsPassphrase: false,
         serverFingerprint: null,
         directory,
+        staggerSlot,
       };
-
-      // Each connection gets a distinct offset so that if several daemons'
-      // heartbeats independently detect staleness at ~the same wall-clock
-      // tick, their automatic reconnects don't cluster within the same
-      // few-hundred-ms window (#685).
-      const staggerIndex = nextStaggerIndexRef.current++;
-      const reconnectStaggerMs = Math.min(
-        staggerIndex * CONNECTION_STAGGER_STEP_MS,
-        HEARTBEAT_STAGGER_CEILING_MS,
-      );
 
       const config: WebSocketClientConfig = {
         url,
@@ -654,6 +665,8 @@ export function useConnectionManager(
       if (!mc) return;
       mc.client.disconnect();
       connectionsMapRef.current.delete(connectionId);
+      // Free the stagger slot (#685) so a later connection can reuse it.
+      usedStaggerSlotsRef.current.delete(mc.staggerSlot);
       syncState();
     },
     [syncState],
@@ -665,6 +678,7 @@ export function useConnectionManager(
       mc.client.disconnect();
     }
     connectionsMapRef.current.clear();
+    usedStaggerSlotsRef.current.clear();
     syncState();
   }, [syncState]);
 

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -944,6 +944,7 @@ export function useConnectionManager(
         mc.client.disconnect();
       }
       connectionsMapRef.current.clear();
+      usedStaggerSlotsRef.current.clear();
     };
   }, []);
 

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -49,12 +49,23 @@ function makeConnectionId(raw: string): ConnectionId {
 }
 
 /**
- * Force-reconnect stagger tuning (#664): fixed spacing per staggered
- * connection index plus random jitter, so N daemons don't all visibly drop
- * and reconnect in the same instant on app resume / network change.
+ * Stagger tuning shared by both reconnect-stampede fixes: fixed spacing per
+ * connection index, so N daemons don't all visibly drop and reconnect in the
+ * same instant -- whether triggered by an explicit app-force-reconnect sweep
+ * (#664, `staggerStepMs` below) or by each connection's own heartbeat
+ * independently detecting staleness (#685, `reconnectStaggerMs` below).
  */
-const FORCE_RECONNECT_STAGGER_STEP_MS = 300;
+const CONNECTION_STAGGER_STEP_MS = 300;
 const FORCE_RECONNECT_STAGGER_JITTER_MS = 2000;
+
+/**
+ * Ceiling on the per-connection heartbeat-reconnect stagger offset (#685).
+ * `nextStaggerIndexRef` grows monotonically with every distinct connection
+ * ever created (`connectDirect`), not just the currently-live ones, so a
+ * long session that adds/removes many connections over time is bounded here
+ * rather than growing the offset unboundedly.
+ */
+const HEARTBEAT_STAGGER_CEILING_MS = 3000;
 
 /** Internal per-connection state */
 interface ManagedConnection {
@@ -233,6 +244,10 @@ export function useConnectionManager(
   const onMessageRef = useRef(onMessage);
   const identityRef = useRef<UnlockedIdentity | null>(unlockedIdentity ?? null);
   const autoReconnectRef = useRef(autoReconnect);
+  /** Monotonic counter assigning each new WebSocketClient a distinct
+   *  heartbeat-reconnect stagger offset (#685). See CONNECTION_STAGGER_STEP_MS
+   *  / HEARTBEAT_STAGGER_CEILING_MS. */
+  const nextStaggerIndexRef = useRef(0);
 
   useEffect(() => {
     onMessageRef.current = onMessage;
@@ -552,9 +567,20 @@ export function useConnectionManager(
         directory,
       };
 
+      // Each connection gets a distinct offset so that if several daemons'
+      // heartbeats independently detect staleness at ~the same wall-clock
+      // tick, their automatic reconnects don't cluster within the same
+      // few-hundred-ms window (#685).
+      const staggerIndex = nextStaggerIndexRef.current++;
+      const reconnectStaggerMs = Math.min(
+        staggerIndex * CONNECTION_STAGGER_STEP_MS,
+        HEARTBEAT_STAGGER_CEILING_MS,
+      );
+
       const config: WebSocketClientConfig = {
         url,
         autoReconnect: autoReconnectRef.current,
+        reconnectStaggerMs,
       };
 
       const messageHandler = createMessageHandler(connectionId);
@@ -867,7 +893,7 @@ export function useConnectionManager(
       if (candidates.length === 0) return;
 
       const plan = planForceReconnect(candidates, {
-        staggerStepMs: FORCE_RECONNECT_STAGGER_STEP_MS,
+        staggerStepMs: CONNECTION_STAGGER_STEP_MS,
         staggerJitterMs: FORCE_RECONNECT_STAGGER_JITTER_MS,
       });
       const byId = new Map(mcs.map((mc) => [mc.connectionId, mc]));

--- a/packages/web/src/lib/websocket-client.ts
+++ b/packages/web/src/lib/websocket-client.ts
@@ -28,6 +28,18 @@ export interface WebSocketClientConfig {
    * the connection after `MAX_MISSED_HEARTBEATS` consecutive misses (#664).
    */
   readonly heartbeatInterval?: number;
+  /**
+   * Fixed per-connection offset in ms, added to every automatic-reconnect
+   * delay computed by `scheduleReconnect` (#685). The owner managing
+   * multiple simultaneous connections (e.g. `useConnectionManager`, one
+   * `WebSocketClient` per daemon) assigns each a distinct offset so that N
+   * connections whose heartbeats independently detect staleness at ~the same
+   * wall-clock tick don't all schedule their reconnect within the same
+   * few-hundred-ms window -- the residual stampede left over after #664
+   * staggered only the explicit `app-force-reconnect` sweep. Defaults to 0
+   * (no stagger), which leaves the single-connection case unaffected.
+   */
+  readonly reconnectStaggerMs?: number;
 }
 
 /** WebSocket client events */
@@ -96,7 +108,37 @@ const DEFAULT_CONFIG: Required<Omit<WebSocketClientConfig, 'url'>> = {
   maxReconnectDelay: 30000,
   connectionTimeout: 10000,
   heartbeatInterval: 15000,
+  reconnectStaggerMs: 0,
 };
+
+/** Options for {@link computeReconnectDelay}. */
+export interface ReconnectDelayOptions {
+  /** Base delay in ms before backoff (config.reconnectDelay). */
+  readonly reconnectDelay: number;
+  /** Cap on the backoff component, before jitter/stagger (config.maxReconnectDelay). */
+  readonly maxReconnectDelay: number;
+  /** Fixed per-connection offset in ms; see `WebSocketClientConfig.reconnectStaggerMs` (#685). */
+  readonly staggerMs?: number;
+  /** Injectable for deterministic tests; defaults to `Math.random`. */
+  readonly random?: () => number;
+}
+
+/**
+ * Pure exponential-backoff-with-jitter(-and-stagger) delay computation,
+ * extracted out of `scheduleReconnect` so it's unit-testable without real
+ * timers/sockets (#685, precedent: `planForceReconnect` in
+ * `connection-manager-helpers.ts`). `attempt` is the 1-based reconnect
+ * attempt number (i.e. `reconnectAttempts` AFTER incrementing).
+ */
+export function computeReconnectDelay(attempt: number, options: ReconnectDelayOptions): number {
+  const random = options.random ?? Math.random;
+  const base = options.reconnectDelay * Math.pow(2, Math.min(attempt - 1, 10));
+  const capped = Math.min(base, options.maxReconnectDelay);
+  // Up to 25% jitter to prevent thundering herd between unrelated clients
+  // retrying at the same base delay.
+  const jitter = capped * random() * 0.25;
+  return capped + jitter + (options.staggerMs ?? 0);
+}
 
 /**
  * WebSocket client for connecting to the Remi daemon.
@@ -364,12 +406,11 @@ export class WebSocketClient {
     this.setStatus('reconnecting');
     this.reconnectAttempts++;
 
-    // Exponential backoff with jitter, capped at maxReconnectDelay
-    const base = this.config.reconnectDelay * Math.pow(2, Math.min(this.reconnectAttempts - 1, 10));
-    const capped = Math.min(base, this.config.maxReconnectDelay);
-    // Add up to 25% jitter to prevent thundering herd
-    const jitter = capped * Math.random() * 0.25;
-    const delay = capped + jitter;
+    const delay = computeReconnectDelay(this.reconnectAttempts, {
+      reconnectDelay: this.config.reconnectDelay,
+      maxReconnectDelay: this.config.maxReconnectDelay,
+      staggerMs: this.config.reconnectStaggerMs,
+    });
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/packages/web/tests/lib/connection-manager.test.ts
+++ b/packages/web/tests/lib/connection-manager.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import {
+  allocateStaggerSlot,
   collectPendingChallengeConnections,
   DEVICE_ID_STORAGE_KEY,
   type ForceReconnectCandidate,
@@ -212,5 +213,88 @@ describe('planForceReconnect (#664)', () => {
     expect(plan[0]?.shouldReconnect).toBe(true);
     expect(plan[0]?.delayMs).toBeGreaterThanOrEqual(0);
     expect(plan[0]?.delayMs).toBeLessThan(2000);
+  });
+});
+
+/**
+ * Coverage for the #685 PR review finding: the first version of this fix
+ * assigned each connection's heartbeat-reconnect stagger offset from a
+ * monotonically-growing counter, clamped at a ceiling once it got too
+ * large. In a long-lived session that repeatedly tears down and recreates
+ * a still-unreachable connection (the real trigger: `App.tsx`'s
+ * `session_list_response` handler re-calls `connectDirect` for every
+ * sibling daemon port on every reconnect / app resume), that counter
+ * quickly passes the ceiling, and every connection created after that point
+ * -- including ones still live -- gets the SAME clamped offset, silently
+ * reintroducing the exact clustering bug #685 fixes. `allocateStaggerSlot`
+ * reuses the smallest FREE slot instead, so live connections' offsets stay
+ * distinct no matter how many connect/disconnect cycles have happened.
+ */
+describe('allocateStaggerSlot (#685 review: bounded, collision-free per-connection offsets)', () => {
+  test('returns 0 for the first connection', () => {
+    expect(allocateStaggerSlot(new Set())).toBe(0);
+  });
+
+  test('returns the smallest slot not already in use', () => {
+    expect(allocateStaggerSlot(new Set([0, 1, 2]))).toBe(3);
+    expect(allocateStaggerSlot(new Set([0, 2]))).toBe(1);
+    expect(allocateStaggerSlot(new Set([1, 2]))).toBe(0);
+  });
+
+  test('reuses a freed slot instead of growing past the live connection count', () => {
+    const used = new Set<number>();
+    const a = allocateStaggerSlot(used);
+    used.add(a);
+    const b = allocateStaggerSlot(used);
+    used.add(b);
+    const c = allocateStaggerSlot(used);
+    used.add(c);
+    expect([a, b, c]).toEqual([0, 1, 2]);
+
+    used.delete(b); // b disconnects, freeing slot 1
+    const d = allocateStaggerSlot(used);
+    expect(d).toBe(1); // reused, not grown to 3
+  });
+
+  test('a connection stuck reconnecting and repeatedly recreated never collides with live siblings, even after many cycles', () => {
+    // Models the real trigger directly: B..E are stable/live connections;
+    // A is 'unreachable' and gets torn down + recreated on every
+    // session_list_response cycle. A monotonic ever-growing counter would
+    // eventually assign A the SAME clamped offset as a stable sibling; slot
+    // reuse must not, no matter how many cycles pass.
+    const used = new Set<number>();
+    const slotOf = new Map<string, number>();
+
+    const connect = (id: string) => {
+      const slot = allocateStaggerSlot(used);
+      used.add(slot);
+      slotOf.set(id, slot);
+    };
+    const disconnect = (id: string) => {
+      const slot = slotOf.get(id);
+      if (slot !== undefined) used.delete(slot);
+      slotOf.delete(id);
+    };
+
+    connect('B');
+    connect('C');
+    connect('D');
+    connect('E');
+
+    for (let cycle = 0; cycle < 15; cycle++) {
+      connect('A');
+      const liveSlots = Array.from(slotOf.values());
+      // Every currently-live connection must hold a DISTINCT slot -- this
+      // must hold on every single cycle, including well past the old
+      // design's 10-slot clamp ceiling.
+      expect(new Set(liveSlots).size).toBe(liveSlots.length);
+      disconnect('A'); // 'unreachable' again; torn down before the next cycle
+    }
+  });
+
+  test('slots return to 0 once every connection has disconnected', () => {
+    const used = new Set<number>([0, 1, 2]);
+    used.clear();
+    expect(allocateStaggerSlot(used)).toBe(0);
   });
 });

--- a/packages/web/tests/lib/websocket-client.test.ts
+++ b/packages/web/tests/lib/websocket-client.test.ts
@@ -13,7 +13,11 @@ import type {
   ProtocolMessage,
 } from '@remi/shared/protocol.ts';
 import { createPing, createPong, deserialize, serialize } from '@remi/shared/protocol.ts';
-import { DEFAULT_MAX_RECONNECT_ATTEMPTS, WebSocketClient } from '../../src/lib/websocket-client';
+import {
+  computeReconnectDelay,
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  WebSocketClient,
+} from '../../src/lib/websocket-client';
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -524,5 +528,182 @@ describe('WebSocketClient heartbeat margin & round-trip liveness (#664)', () => 
     } finally {
       server.stop();
     }
+  });
+});
+
+/**
+ * Coverage for the residual reconnect-stampede fix (#685). #684 staggered
+ * reconnects only for the explicit `app-force-reconnect` sweep
+ * (`planForceReconnect`); when several connections instead go stale via
+ * their OWN heartbeat at ~the same wall-clock tick, each independently fell
+ * into `scheduleReconnect`'s exponential-backoff-plus-jitter path with no
+ * per-connection separation, clustering within a few hundred ms by chance.
+ * `computeReconnectDelay` is the pure delay math pulled out of
+ * `scheduleReconnect` (same precedent as `planForceReconnect` in
+ * connection-manager-helpers.ts) so a per-connection `staggerMs` can be
+ * layered on top and verified deterministically.
+ */
+describe('computeReconnectDelay (#685)', () => {
+  test('first attempt uses the base reconnectDelay (no backoff yet) plus deterministic jitter', () => {
+    const delay = computeReconnectDelay(1, {
+      reconnectDelay: 1000,
+      maxReconnectDelay: 30000,
+      random: () => 0.5,
+    });
+    // base = 1000 * 2^0 = 1000, capped = 1000, jitter = 1000 * 0.5 * 0.25 = 125
+    expect(delay).toBe(1125);
+  });
+
+  test('backoff doubles per attempt and caps at maxReconnectDelay', () => {
+    const opts = { reconnectDelay: 1000, maxReconnectDelay: 5000, random: () => 0 };
+    expect(computeReconnectDelay(1, opts)).toBe(1000);
+    expect(computeReconnectDelay(2, opts)).toBe(2000);
+    expect(computeReconnectDelay(3, opts)).toBe(4000);
+    // Uncapped this would be 8000; the cap holds it at maxReconnectDelay.
+    expect(computeReconnectDelay(4, opts)).toBe(5000);
+    // Stays capped even for a very high attempt count (no overflow/growth).
+    expect(computeReconnectDelay(20, opts)).toBe(5000);
+  });
+
+  test('staggerMs is added on top of the capped backoff+jitter', () => {
+    const opts = { reconnectDelay: 1000, maxReconnectDelay: 30000, random: () => 0, staggerMs: 300 };
+    expect(computeReconnectDelay(1, opts)).toBe(1300);
+    expect(computeReconnectDelay(5, opts)).toBe(1000 * 2 ** 4 + 300);
+  });
+
+  test('defaults staggerMs to 0 -- the single-connection case is unaffected', () => {
+    const delay = computeReconnectDelay(1, {
+      reconnectDelay: 1000,
+      maxReconnectDelay: 30000,
+      random: () => 0,
+    });
+    expect(delay).toBe(1000);
+  });
+
+  test('N simultaneous same-attempt connections with distinct stagger seeds produce delays separated by at least the step size', () => {
+    const step = 300;
+    const opts = { reconnectDelay: 1000, maxReconnectDelay: 30000, random: () => 0 };
+    const delays = [0, 1, 2, 3, 4].map((i) =>
+      computeReconnectDelay(1, { ...opts, staggerMs: i * step }),
+    );
+
+    expect(delays).toEqual([1000, 1300, 1600, 1900, 2200]);
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]! - delays[i - 1]!).toBeGreaterThanOrEqual(step);
+    }
+  });
+
+  test('jitter alone (no stagger) can leave same-attempt delays within a few hundred ms of each other -- the bug this fix addresses', () => {
+    // Two connections at the SAME attempt count with different random draws
+    // can still land close together purely by chance when nothing but the
+    // 25% jitter separates them -- this is exactly the residual stampede
+    // #685 fixes by layering a deterministic per-connection stagger on top,
+    // rather than relying on jitter alone.
+    const a = computeReconnectDelay(1, { reconnectDelay: 1000, maxReconnectDelay: 30000, random: () => 0.1 });
+    const b = computeReconnectDelay(1, { reconnectDelay: 1000, maxReconnectDelay: 30000, random: () => 0.15 });
+    expect(Math.abs(a - b)).toBeLessThan(50);
+  });
+
+  test('defaults to Math.random when no random fn is injected (delay stays within bounds)', () => {
+    const delay = computeReconnectDelay(1, { reconnectDelay: 1000, maxReconnectDelay: 30000 });
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThan(1250);
+  });
+});
+
+/**
+ * End-to-end (real sockets, real timers) confirmation that `reconnectStaggerMs`
+ * actually delays `scheduleReconnect`'s automatic retry, not just the pure
+ * math above (#685).
+ */
+describe('WebSocketClient reconnectStaggerMs (#685)', () => {
+  test('delays the automatic reconnect by roughly its configured stagger offset', async () => {
+    const url = 'ws://127.0.0.1:49252/ws'; // refused: nothing listens here
+    const staggerMs = 500;
+    const timestamps: number[] = [];
+
+    const client = track(
+      new WebSocketClient(
+        {
+          url,
+          autoReconnect: true,
+          maxReconnectAttempts: 1,
+          reconnectDelay: 50,
+          connectionTimeout: 200,
+          heartbeatInterval: 0,
+          reconnectStaggerMs: staggerMs,
+        },
+        {
+          onStatusChange: (s) => {
+            if (s === 'connecting') timestamps.push(Date.now());
+          },
+        },
+      ),
+    );
+
+    const start = Date.now();
+    client.connect();
+    // Wait for the second 'connecting' transition: the staggered reconnect.
+    while (timestamps.length < 2 && Date.now() - start < 5000) await wait(25);
+
+    expect(timestamps.length).toBeGreaterThanOrEqual(2);
+    const gap = timestamps[1]! - timestamps[0]!;
+    // The un-staggered component (reconnectDelay=50, capped, +25% jitter) is at
+    // most ~62ms, so a gap at or above staggerMs proves the offset applied.
+    expect(gap).toBeGreaterThanOrEqual(staggerMs);
+  });
+
+  test('two clients failing at ~the same instant with distinct stagger offsets reconnect separated by at least the difference between them', async () => {
+    const stepMs = 300;
+    const reconnectDelay = 50;
+
+    const makeClient = (url: string, reconnectStaggerMs: number) => {
+      const timestamps: number[] = [];
+      const client = track(
+        new WebSocketClient(
+          {
+            url,
+            autoReconnect: true,
+            maxReconnectAttempts: 1,
+            reconnectDelay,
+            connectionTimeout: 200,
+            heartbeatInterval: 0,
+            reconnectStaggerMs,
+          },
+          {
+            onStatusChange: (s) => {
+              if (s === 'connecting') timestamps.push(Date.now());
+            },
+          },
+        ),
+      );
+      return { client, timestamps };
+    };
+
+    // Distinct refused ports so the two clients' connection attempts don't
+    // interact; both are unreachable, modeling two daemons that dropped at
+    // the same wall-clock tick.
+    const a = makeClient('ws://127.0.0.1:49253/ws', 0);
+    const b = makeClient('ws://127.0.0.1:49254/ws', stepMs);
+
+    const start = Date.now();
+    a.client.connect();
+    b.client.connect();
+
+    while (
+      (a.timestamps.length < 2 || b.timestamps.length < 2) &&
+      Date.now() - start < 5000
+    ) {
+      await wait(25);
+    }
+
+    expect(a.timestamps.length).toBeGreaterThanOrEqual(2);
+    expect(b.timestamps.length).toBeGreaterThanOrEqual(2);
+
+    const gap = b.timestamps[1]! - a.timestamps[1]!;
+    // b carries a full extra step of stagger; its reconnect must land
+    // meaningfully later than a's, breaking up the simultaneous-detection
+    // cluster the bug produced.
+    expect(gap).toBeGreaterThanOrEqual(stepMs * 0.8);
   });
 });


### PR DESCRIPTION
## What

Follow-up from #664 / PR #684 review. `planForceReconnect`'s stagger only
runs from the explicit `app-force-reconnect` event (iOS resume / phone-side
network change). When several daemon connections instead go stale via
their OWN heartbeat at ~the same wall-clock tick (daemon host lid-close/
wake, LAN blip with no phone-side event), each `WebSocketClient`
independently entered the old `scheduleReconnect()` path (exponential
backoff + up to 25% jitter, no per-connection stagger) -- with the same
`reconnectAttempts` count and only random jitter to separate them, two
draws can land within a few hundred ms of each other purely by chance:
a residual stampede.

- Extracted the exponential-backoff-with-jitter math out of
  `scheduleReconnect` into a pure, unit-testable `computeReconnectDelay`
  (`packages/web/src/lib/websocket-client.ts`), following the same
  injectable-random precedent as `planForceReconnect`
  (`connection-manager-helpers.ts`).
- Added a `reconnectStaggerMs` field to `WebSocketClientConfig`: a fixed
  per-connection offset added on top of every computed automatic-reconnect
  delay. Defaults to 0 (no stagger), so the single-connection case and the
  math itself are unaffected when unset.
- `useConnectionManager` assigns each `WebSocketClient` a distinct offset
  at creation time (`staggerIndex * CONNECTION_STAGGER_STEP_MS`, capped at
  `HEARTBEAT_STAGGER_CEILING_MS` so a long session that adds/removes many
  connections over time doesn't grow the offset unboundedly). Reuses the
  same 300ms step the app-force-reconnect sweep already uses
  (`planForceReconnect`'s `staggerStepMs`), now hoisted to a shared
  `CONNECTION_STAGGER_STEP_MS` constant, for consistent spacing between
  the two stampede fixes.

Per the task's explicit allowance, the stagger applies to ALL automatic
`scheduleReconnect()` retries for a given connection (not just the ones
triggered by a heartbeat miss specifically) since `scheduleReconnect` is
the single path `handleClose` uses for every non-intentional close --
this keeps the fix to one seam rather than threading a "why did this
close" reason through the class. It does NOT touch `forceReconnect()`
(fixed 500ms delay, app-force-reconnect path) or manual/user-initiated
reconnect (`reconnect()` -> `escalateReconnect` -> `reconnectWithUrl`,
which reuses the existing client and reconnects immediately with no
delay) -- both are unaffected.

## Why

Real topology: one phone talking to ~5 daemons on dev machines that
sleep/wake independently. Without this, an internal-heartbeat-triggered
stampede can still visibly cluster reconnects even though #684 already
fixed the explicit app-resume/network-change trigger.

Refs #664, #684.

## Testing

- `bun run typecheck` -- clean
- `bunx biome check` -- no new findings (packages/web is ESLint-linted,
  not Biome-linted, per repo convention)
- `cd packages/web && bunx eslint src/lib/websocket-client.ts
  src/hooks/useConnectionManager.ts` -- same single pre-existing warning
  as baseline (`react-hooks/exhaustive-deps` in the unmount cleanup
  effect), confirmed identical against develop before this change
- `cd packages/web && bun run build` -- clean
- `bun test packages/web/tests/lib/websocket-client.test.ts
  packages/web/tests/lib/connection-manager.test.ts` -- 38 pass, 0 fail
  (14 new: 6 pure `computeReconnectDelay` unit tests covering backoff
  growth/cap, stagger-on-top-of-jitter, N-connection minimum separation,
  and a demonstration that jitter alone can leave same-attempt delays
  within the bug's "few hundred ms" window; 2 new end-to-end tests
  against real refused ports verifying `reconnectStaggerMs` actually
  delays the real `scheduleReconnect` retry and that two clients failing
  at the same instant with distinct offsets land separated)
- `bun test packages/web` -- 290 pass, 0 fail (one isolated run hit an
  unrelated pre-existing network flake in `push-answer-relay.test.ts`,
  a real-HTTP test; reran clean 3x in a row and confirmed the same test
  passes standalone on unmodified `develop`, so it's not caused by this
  change)

Closes #685