### PR TITLE
fix(#688): sticky active session selection

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -39,6 +39,7 @@ import { dismissDeliveredNotification } from '@/lib/notifications';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
 import { shouldEvictCachedSession } from '@/lib/session-eviction';
+import { autoSelectIfNone, evictIfActive, evictManyIfActive } from '@/lib/session-selection';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
 import type {
@@ -402,25 +403,25 @@ function App() {
           void syncNativeIdentity();
         }
 
-        // Reconnect-mid-rotation only: if the chat the user is CURRENTLY
-        // viewing belongs to this connection and the daemon came back with a
-        // new session id, follow it into the new session. A fresh connect (no
-        // chat open) must NOT bypass the session list -- land on the list so
-        // the user picks a session. Notification deep-links navigate via their
-        // own `push-notification-tap` handler, not here.
+        // If the chat the user is CURRENTLY viewing belongs to this
+        // connection and the daemon came back with a different session id,
+        // the `cleaned` filter above already dropped that old session from
+        // `sessions` for this connection -- it no longer resolves to
+        // anything. Fall back to the session list rather than silently
+        // follow into a session the user never picked (#688): a stray
+        // reconnect must never swap the user into a different live
+        // session's input box. `evictIfActive` is a no-op if the user has
+        // since navigated away from `oldActive` on their own. A fresh
+        // connect (no chat open) stays on the list either way. Notification
+        // deep-links navigate via their own `push-notification-tap` handler,
+        // not here.
         const oldActive = activeSessionIdRef.current;
-        if (oldActive !== message.sessionId) {
+        if (oldActive && oldActive !== message.sessionId) {
           const oldSession = sessionsRef.current.find((s) => s.id === oldActive);
-          // `oldActive &&` both gates on a chat being open (so a fresh connect
-          // stays on the list) and narrows oldActive to non-null for the
-          // cleanup below.
-          if (oldActive && oldSession?.connectionId === connectionId) {
-            setActiveSessionId(message.sessionId);
+          if (oldSession?.connectionId === connectionId) {
+            setActiveSessionId(evictIfActive(activeSessionIdRef.current, oldActive));
             setMessages((prev) => prev.filter((m) => m.sessionId !== oldActive));
             setQuestions((prev) => clearSessionQuestions(prev, oldActive));
-            // Load the followed session's transcript so the chat isn't left
-            // empty after a reconnect-mid-rotation adopt (#499).
-            ensureTranscriptLoaded(connectionId, message.sessionId);
           }
         }
         break;
@@ -884,11 +885,12 @@ function App() {
           const evictedIds = [...evictedSet];
           forgetEvictedSessions(evictedIds);
           for (const id of evictedIds) loadedTranscriptsRef.current.delete(id);
-          // If the active session was evicted, clear it so the UI doesn't sit on
-          // a dead session and re-request its (gone) transcript.
-          if (activeSessionIdRef.current && evictedSet.has(activeSessionIdRef.current)) {
-            setActiveSessionId(null);
-          }
+          // If the active session was evicted, clear it so the UI doesn't sit
+          // on a dead session and re-request its (gone) transcript. Routed
+          // through the same #688 rule as every other selection-changing
+          // path: a phantom sweep can only clear the active session, never
+          // swap it for a different live one.
+          setActiveSessionId(evictManyIfActive(activeSessionIdRef.current, evictedSet));
           console.warn('[App] Evicted stale phantom sessions (#577):', evictedIds);
         }
 
@@ -1154,9 +1156,14 @@ function App() {
           break;
         }
         // NOT_FOUND with a current-session redirect (#499): the requested
-        // session is stale (the daemon restarted or rotated past it). Follow the
-        // daemon to its current session and load it, instead of dead-ending on a
-        // "Transcript for session X not found" bubble the user can't escape.
+        // session is stale (the daemon restarted or rotated past it). The
+        // daemon's error carries no id for which request this was, so it
+        // cannot be correlated to a specific in-flight load (#688) -- only
+        // auto-follow when nothing is currently selected (matches the
+        // fresh-connect gate above); otherwise this would risk silently
+        // swapping whatever live session the user is looking at for the
+        // daemon's current one. The upsert below still makes the daemon's
+        // current session visible/tappable in the list either way.
         if (errorCode === 'NOT_FOUND') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const currentSessionId = asNonEmptyString(details?.['currentSessionId']) as
@@ -1204,12 +1211,20 @@ function App() {
             // session's already-rendered messages. ensureTranscriptLoaded gates
             // on the loaded marker, so it fetches only if not already loaded
             // (no wipe, no duplicate append) (#499 review).
-            setActiveSessionId(currentSessionId);
-            ensureTranscriptLoaded(connectionId, currentSessionId);
-            console.warn(
-              '[App] Stale transcript request; following daemon to current session',
-              currentSessionId,
-            );
+            const nextActive = autoSelectIfNone(activeSessionIdRef.current, currentSessionId);
+            if (nextActive !== activeSessionIdRef.current) {
+              setActiveSessionId(nextActive);
+              ensureTranscriptLoaded(connectionId, currentSessionId);
+              console.warn(
+                '[App] Stale transcript request; following daemon to current session',
+                currentSessionId,
+              );
+            } else {
+              console.warn(
+                '[App] Stale transcript request; daemon current session available but not followed (active selection present)',
+                currentSessionId,
+              );
+            }
             break;
           }
         }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1211,10 +1211,18 @@ function App() {
             // session's already-rendered messages. ensureTranscriptLoaded gates
             // on the loaded marker, so it fetches only if not already loaded
             // (no wipe, no duplicate append) (#499 review).
+            //
+            // Refresh and navigate are separate concerns (#688 review): the
+            // refresh must happen whenever currentSessionId is present --
+            // including when it's already the active session (e.g. a
+            // bindingRotated hello_ack cleared its loaded marker without a
+            // re-fetch) -- while navigation is gated on autoSelectIfNone so a
+            // stale/racy redirect never steals focus from a different
+            // explicit selection.
+            ensureTranscriptLoaded(connectionId, currentSessionId);
             const nextActive = autoSelectIfNone(activeSessionIdRef.current, currentSessionId);
             if (nextActive !== activeSessionIdRef.current) {
               setActiveSessionId(nextActive);
-              ensureTranscriptLoaded(connectionId, currentSessionId);
               console.warn(
                 '[App] Stale transcript request; following daemon to current session',
                 currentSessionId,

--- a/packages/web/src/lib/session-selection.ts
+++ b/packages/web/src/lib/session-selection.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure decision helpers for which session is "active" -- the one whose chat
+ * is on screen and whose input box is live (#688).
+ *
+ * The safety property this file exists to guarantee: with multiple live
+ * daemons/sessions aggregated into one client, a user's explicit choice of
+ * session must never be silently swapped for a DIFFERENT live session by a
+ * background event (`session_list_response` merge, `hello_ack` reconnect, a
+ * stale-transcript redirect, mDNS aggregation refresh). Only two kinds of
+ * automatic transition are allowed:
+ *   - clearing to `null` when the active session itself becomes invalid
+ *     (evicted / no longer known), so the UI falls back to the session list
+ *     instead of sitting on a ghost id or jumping to whatever else is live;
+ *   - landing on a specific session when NOTHING is currently selected
+ *     (fresh connect / stale-transcript redirect with no chat open) -- never
+ *     overriding an existing selection.
+ * An explicit user tap, notification-tap, or resume result is the only
+ * thing that may move the active session to a specific, different id; those
+ * call sites set it directly and do not need a helper here.
+ */
+
+export type SessionId = string;
+
+/**
+ * The active session no longer exists under its owning connection (phantom
+ * eviction, or a `hello_ack` reporting a different session for the same
+ * connection). Falls back to `null` ONLY when `evictedId` is the currently
+ * active session; a no-op otherwise -- some OTHER session vanishing must
+ * never disturb what the user is looking at.
+ */
+export function evictIfActive<T extends SessionId>(current: T | null, evictedId: T): T | null {
+  return current === evictedId ? null : current;
+}
+
+/**
+ * Same as {@link evictIfActive} for a batch of ids (a multi-daemon phantom
+ * sweep evaluated in one `session_list_response`).
+ */
+export function evictManyIfActive<T extends SessionId>(
+  current: T | null,
+  evictedIds: ReadonlySet<T>,
+): T | null {
+  return current !== null && evictedIds.has(current) ? null : current;
+}
+
+/**
+ * An automatic follow/restore candidate (a stale-transcript NOT_FOUND
+ * redirect, startup restoration of the last-used session). Takes effect
+ * ONLY when nothing is currently selected; once a session is active --
+ * explicitly picked, or itself auto-selected -- no later candidate may
+ * override it. Eviction is the only way back to `null`.
+ */
+export function autoSelectIfNone<T extends SessionId>(current: T | null, candidateId: T): T | null {
+  return current === null ? candidateId : current;
+}

--- a/packages/web/tests/lib/session-selection.test.ts
+++ b/packages/web/tests/lib/session-selection.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the active-session selection rules (#688). Pure functions; no
+ * mocks. These guarantee the safety property the bug report was about: an
+ * explicit user selection must never be silently swapped for a different
+ * live session by a background event, and the only automatic transitions
+ * allowed are "clear to null" (the active session vanished) and "land here
+ * because nothing was selected" (never overriding an existing pick).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { autoSelectIfNone, evictIfActive, evictManyIfActive } from '../../src/lib/session-selection';
+
+describe('autoSelectIfNone', () => {
+  test('initial auto-select: lands on the candidate when nothing is selected', () => {
+    expect(autoSelectIfNone(null, 'session-a')).toBe('session-a');
+  });
+
+  test('does not override an explicit selection with a different candidate', () => {
+    // The user is looking at session-a (e.g. a stale-transcript redirect
+    // arrives for a different, unrelated request) -- must stay put.
+    expect(autoSelectIfNone('session-a', 'session-b')).toBe('session-a');
+  });
+
+  test('is a no-op when the candidate equals the current selection', () => {
+    expect(autoSelectIfNone('session-a', 'session-a')).toBe('session-a');
+  });
+});
+
+describe('evictIfActive', () => {
+  test('selected session vanishes: clears to null, never switches to another', () => {
+    expect(evictIfActive('session-a', 'session-a')).toBeNull();
+  });
+
+  test('list refresh keeps explicit selection: a different session evicted is a no-op', () => {
+    expect(evictIfActive('session-a', 'session-b')).toBe('session-a');
+  });
+
+  test('no-op when nothing is selected', () => {
+    expect(evictIfActive(null, 'session-a')).toBeNull();
+  });
+});
+
+describe('evictManyIfActive', () => {
+  test('clears when the active session is in the evicted batch', () => {
+    expect(evictManyIfActive('session-a', new Set(['session-a', 'session-c']))).toBeNull();
+  });
+
+  test('multi-daemon aggregation update: keeps the active session when only other daemons phantom-evict', () => {
+    // conn-B and conn-C both reported phantom sessions this cycle; the
+    // user's active session belongs to conn-A and was not touched.
+    expect(evictManyIfActive('session-a', new Set(['session-b', 'session-c']))).toBe('session-a');
+  });
+
+  test('no-op on an empty eviction set', () => {
+    expect(evictManyIfActive('session-a', new Set())).toBe('session-a');
+  });
+
+  test('no-op when nothing is selected and the set is non-empty', () => {
+    expect(evictManyIfActive(null, new Set(['session-a']))).toBeNull();
+  });
+});
+
+describe('reconnect churn ordering (#688 scenario)', () => {
+  test('explicit selection survives a reconnect-resession churn, then a real eviction clears it', () => {
+    // 1. User explicitly selects session-a (modeled directly -- selection
+    //    itself is not gated, only automatic overrides are).
+    let active: string | null = 'session-a';
+
+    // 2. Reconnect churn: connection's hello_ack now reports session-b for
+    //    the same connection slot. Old behavior silently followed; #688
+    //    requires this to never move `active` to a DIFFERENT id -- eviction
+    //    only fires if session-a itself is what disappeared, which it did
+    //    (a resession drops the old session from the client's list), so it
+    //    clears to null rather than jumping to session-b.
+    active = evictIfActive(active, 'session-a');
+    expect(active).toBeNull();
+
+    // 3. A stray session_list_response arrives next; with nothing selected,
+    //    it must not resurrect a stale pick on its own (evictManyIfActive is
+    //    a pure no-op on null).
+    active = evictManyIfActive(active, new Set(['session-b']));
+    expect(active).toBeNull();
+
+    // 4. A stale-transcript redirect now offers session-c. Since nothing is
+    //    selected, this is the one case allowed to land automatically.
+    active = autoSelectIfNone(active, 'session-c');
+    expect(active).toBe('session-c');
+
+    // 5. Further churn for an unrelated session must not move it again.
+    active = autoSelectIfNone(active, 'session-d');
+    expect(active).toBe('session-c');
+  });
+
+  test('a session unrelated to the active one vanishing during churn never steals focus', () => {
+    let active: string | null = 'session-a';
+    // Several unrelated sessions evicted across a multi-daemon aggregation
+    // refresh while the user keeps looking at session-a.
+    active = evictManyIfActive(active, new Set(['session-x']));
+    active = evictIfActive(active, 'session-y');
+    active = autoSelectIfNone(active, 'session-z');
+    expect(active).toBe('session-a');
+  });
+});


### PR DESCRIPTION
## Root cause

With multiple live daemons/sessions aggregated in the web client, `activeSessionId` could be silently swapped to a DIFFERENT live session by a background event, presenting an enabled input box for a session the user never tapped. Three racing paths in `packages/web/src/App.tsx`, all in `handleMessage`:

1. **`hello_ack` reconnect-follow** (`App.tsx:406-425`, was `App.tsx:405-425` on develop): when a connection's `hello_ack` reported a session id different from the currently-active one for that same `connectionId`, the code unconditionally did `setActiveSessionId(message.sessionId)` to "follow" the daemon. With connectionId reuse across daemon restarts / multi-daemon churn, this could follow into a completely unrelated session the user never picked. It also left a real bug: the `cleaned` filter earlier in the same handler already drops the old active session from `sessions` for that connection, so without a fix the user would otherwise be staring at a session no longer in the list at all.

2. **`session_list_response` phantom eviction** (`App.tsx:888-891` on develop): correctly cleared `activeSessionId` to `null` when the active session was evicted, but did the check with an ad hoc inline `if` rather than a shared, tested rule — reviewed and kept intentionally consistent with the fix.

3. **NOT_FOUND stale-transcript redirect** (`App.tsx:1209-1210` on develop, `#499`): on a `NOT_FOUND` error with a `currentSessionId` redirect hint, the code unconditionally called `setActiveSessionId(currentSessionId)`. The daemon's error (`packages/daemon/src/cli/handlers/transcript-events.ts:164-180`) carries no id for which request this was for, so a stale/racy response for a request the user has since navigated away from could silently redirect them into a different live session.

## Fix

Extracted the selection decision into a pure, unit-tested helper module: `packages/web/src/lib/session-selection.ts`. The rule it encodes:

- The active session may **clear to `null`** only when it itself vanishes (evicted from the list, or its connection reattached to a different session) — never jump to a different live session instead.
- The active session may **auto-land on a candidate** only when nothing is currently selected (`activeSessionId === null`) — an explicit pick (tap, notification-tap, resume) is otherwise never overridden by discovery/reconnect/aggregation events.

All three racing paths in `App.tsx` are wired through the same three functions (`evictIfActive`, `evictManyIfActive`, `autoSelectIfNone`), so there is one source of truth for "when may the active session change automatically."

Behavior change from `#499`: the NOT_FOUND stale-transcript redirect no longer force-navigates when the user has an active selection (it still upserts the daemon's current session into the list so it's visible/tappable, and still auto-follows on a fresh connect with no chat open).

## Testing

- `packages/web/tests/lib/session-selection.test.ts` (new): 12 tests covering initial auto-select, list refresh keeping an explicit selection, the selected session vanishing (no silent switch), a reconnect-churn ordering scenario modeling the exact hello_ack race, and multi-daemon aggregation updates.
- `bun test packages/web/tests/` — 293 pass, 0 fail (full web lib suite, including the new file).
- `bun run typecheck` (root) — clean.
- `bunx eslint src/App.tsx src/lib/session-selection.ts` (packages/web) — no new errors.
- `bun run build` (packages/web) — clean.
- biome ignores `packages/web` per repo convention; ran via pre-commit hook (0 issues in the touched non-web scope).

Closes #688