### PR TITLE
fix(#680): normalize SessionStore projectPath

### DIFF
--- a/packages/daemon/src/session/session-binding-store.ts
+++ b/packages/daemon/src/session/session-binding-store.ts
@@ -98,20 +98,20 @@ export class SessionBindingStore {
    * responsibility to populate correctly — the accessor does not own them.
    */
   preAssign(session: StoredSession): void {
-    this.store.save(session);
+    // Mirror from save()'s returned (normalized) record, not the raw input —
+    // otherwise a caller passing an unnormalized projectPath would seed
+    // TranscriptIndex with a value that silently diverges from what
+    // SessionStore actually persisted (#680 review).
+    const saved = this.store.save(session);
     // Seed the durable mirror at spawn so the binding is recoverable even if the
     // session never rotates and is later purged from sessions.json (#577).
-    if (session.claudeSessionId) {
-      this.transcriptIndex?.record(
-        session.remiSessionId,
-        session.claudeSessionId,
-        session.projectPath,
-      );
+    if (saved.claudeSessionId) {
+      this.transcriptIndex?.record(saved.remiSessionId, saved.claudeSessionId, saved.projectPath);
     } else if (this.transcriptIndex) {
       // No claude id yet (deferred to the first update() on hook adopt/rotation).
       // Log so the deferred index seed is traceable rather than silently skipped.
       log(
-        `[transcript-index] preAssign for ${session.remiSessionId} has no claudeSessionId yet; index seed deferred to update()`,
+        `[transcript-index] preAssign for ${saved.remiSessionId} has no claudeSessionId yet; index seed deferred to update()`,
       );
     }
   }

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -13,6 +13,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
 import type { UUID } from '@remi/shared';
+import { normalizeProjectPath } from '../cli/path-resolver.ts';
 import { isProcessAlive } from './process-alive.ts';
 
 export interface StoredSession {
@@ -65,6 +66,13 @@ export class SessionStore {
       // Normalize legacy entries that lack the pid field
       for (const s of data.sessions) {
         s.pid ??= null;
+        // Self-heal a tilde-form or otherwise unnormalized projectPath (#680):
+        // every read re-normalizes so a legacy entry (or one written by an
+        // older binary) becomes safe to `chdir`/compare against without a
+        // dedicated migration. Mirrors SessionRegistryFile's persist-side fix
+        // for #674; not written back to disk here, but any subsequent write()
+        // (save/markExited/updateClaudeSessionId/purge) persists the fix.
+        s.projectPath = normalizeProjectPath(s.projectPath);
       }
       return data.sessions;
     } catch (err) {
@@ -100,14 +108,24 @@ export class SessionStore {
     }
   }
 
-  /** Save or update a session record. Trims to MAX_SESSIONS. */
+  /**
+   * Save or update a session record. Trims to MAX_SESSIONS. Normalizes
+   * `projectPath` (expands `~`, resolves to absolute) before persisting, so a
+   * caller passing a raw, unexpanded path never writes a malformed entry that
+   * `--resume` would later `chdir` into (#680). Mirrors SessionRegistryFile's
+   * `register()` fix for the live-sessions registry (#674).
+   */
   save(session: StoredSession): void {
+    const normalized: StoredSession = {
+      ...session,
+      projectPath: normalizeProjectPath(session.projectPath),
+    };
     const sessions = this.read();
-    const idx = sessions.findIndex((s) => s.remiSessionId === session.remiSessionId);
+    const idx = sessions.findIndex((s) => s.remiSessionId === normalized.remiSessionId);
     if (idx >= 0) {
-      sessions[idx] = session;
+      sessions[idx] = normalized;
     } else {
-      sessions.push(session);
+      sessions.push(normalized);
     }
     // Trim oldest exited sessions if over limit
     if (sessions.length > MAX_SESSIONS) {

--- a/packages/daemon/src/session/session-store.ts
+++ b/packages/daemon/src/session/session-store.ts
@@ -114,8 +114,13 @@ export class SessionStore {
    * caller passing a raw, unexpanded path never writes a malformed entry that
    * `--resume` would later `chdir` into (#680). Mirrors SessionRegistryFile's
    * `register()` fix for the live-sessions registry (#674).
+   *
+   * Returns the normalized record so a caller that mirrors it elsewhere (e.g.
+   * `SessionBindingStore.preAssign` seeding `TranscriptIndex`) uses the same
+   * normalized `projectPath` this store actually persisted, instead of
+   * silently diverging from it (#680 review).
    */
-  save(session: StoredSession): void {
+  save(session: StoredSession): StoredSession {
     const normalized: StoredSession = {
       ...session,
       projectPath: normalizeProjectPath(session.projectPath),
@@ -135,9 +140,10 @@ export class SessionStore {
       const removeIds = new Set(exited.slice(0, toRemove).map((s) => s.remiSessionId));
       const trimmed = sessions.filter((s) => !removeIds.has(s.remiSessionId));
       this.write(trimmed);
-      return;
+      return normalized;
     }
     this.write(sessions);
+    return normalized;
   }
 
   /**

--- a/packages/daemon/tests/session-store.test.ts
+++ b/packages/daemon/tests/session-store.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { UUID } from '@remi/shared';
+import { normalizeProjectPath } from '../src/cli/path-resolver.ts';
 import { SessionStore, type StoredSession } from '../src/session/session-store.ts';
 
 function makeTmpPath(): string {
@@ -241,5 +242,68 @@ describe('SessionStore', () => {
     const aliveSession = sessions.find((s) => s.remiSessionId === alive.remiSessionId);
     expect(staleSession?.exitedAt).not.toBeNull();
     expect(aliveSession?.exitedAt).toBeNull();
+  });
+
+  describe('projectPath normalization (#680)', () => {
+    test('save normalizes a tilde-form projectPath before persisting', () => {
+      const session = makeSession({ projectPath: '~/Documents/git/nemar/nemar-cli' });
+      store.save(session);
+      const found = store.findByRemiSessionId(session.remiSessionId);
+      expect(found?.projectPath).toBe(path.join(os.homedir(), 'Documents/git/nemar/nemar-cli'));
+    });
+
+    test('tilde-form and absolute-form saves converge to the same projectPath', () => {
+      const tilde = makeSession({ projectPath: '~/Documents/git/nemar/nemar-cli' });
+      const absolute = makeSession({
+        projectPath: path.join(os.homedir(), 'Documents/git/nemar/nemar-cli'),
+      });
+      store.save(tilde);
+      store.save(absolute);
+      const foundTilde = store.findByRemiSessionId(tilde.remiSessionId);
+      const foundAbsolute = store.findByRemiSessionId(absolute.remiSessionId);
+      expect(foundTilde?.projectPath).toBe(foundAbsolute?.projectPath ?? '');
+    });
+
+    test('reading a legacy raw-tilde entry off disk self-heals projectPath', () => {
+      // Write a pre-#680 entry directly to disk, bypassing save()'s
+      // normalization, to simulate a value written by an older binary.
+      const legacy: StoredSession = makeSession({
+        projectPath: '~/Documents/git/nemar/nemar-cli',
+      });
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ version: 1, sessions: [legacy] }, null, 2),
+        'utf-8',
+      );
+
+      const found = store.findByRemiSessionId(legacy.remiSessionId);
+      expect(found?.projectPath).toBe(normalizeProjectPath(legacy.projectPath));
+
+      const listed = store.list();
+      expect(listed[0]?.projectPath).toBe(normalizeProjectPath(legacy.projectPath));
+
+      const recent = store.getMostRecent();
+      expect(recent?.projectPath).toBe(normalizeProjectPath(legacy.projectPath));
+    });
+
+    test('self-healed projectPath is persisted on the next write', () => {
+      const legacy: StoredSession = makeSession({
+        projectPath: '~/Documents/git/nemar/nemar-cli',
+      });
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ version: 1, sessions: [legacy] }, null, 2),
+        'utf-8',
+      );
+
+      store.markExited(legacy.remiSessionId, 0);
+
+      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
+        sessions: StoredSession[];
+      };
+      expect(raw.sessions[0]?.projectPath).toBe(normalizeProjectPath(legacy.projectPath));
+    });
   });
 });

--- a/packages/daemon/tests/session/session-binding-store.test.ts
+++ b/packages/daemon/tests/session/session-binding-store.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { UUID } from '@remi/shared';
+import { normalizeProjectPath } from '../../src/cli/path-resolver.ts';
 import { SessionBindingStore } from '../../src/session/session-binding-store.ts';
 import { SessionStore, type StoredSession } from '../../src/session/session-store.ts';
 import { TranscriptIndex } from '../../src/session/transcript-index.ts';
@@ -144,5 +145,21 @@ describe('SessionBindingStore', () => {
     const entry = index.get(session.remiSessionId);
     expect(entry?.claudeSessionId).toBe('claude-new');
     expect(entry?.projectPath).toBe(session.projectPath);
+  });
+
+  test('preAssign seeds TranscriptIndex with the NORMALIZED projectPath, not the raw input (#680)', () => {
+    // A caller passing an unnormalized (tilde-form) projectPath must not make
+    // TranscriptIndex diverge from what SessionStore actually persisted.
+    const indexPath = path.join(path.dirname(filePath), 'transcript-index.json');
+    const index = new TranscriptIndex(indexPath);
+    const withIndex = new SessionBindingStore(store, index);
+
+    const tildePath = '~/Documents/git/nemar/nemar-cli';
+    const session = makeSession({ claudeSessionId: 'claude-tilde', projectPath: tildePath });
+    withIndex.preAssign(session);
+
+    const expected = normalizeProjectPath(tildePath);
+    expect(store.findByRemiSessionId(session.remiSessionId)?.projectPath).toBe(expected);
+    expect(index.get(session.remiSessionId)?.projectPath).toBe(expected);
   });
 });


### PR DESCRIPTION
## What

`SessionStore` (`packages/daemon/src/session/session-store.ts`) persisted
`projectPath` as-is, with no normalization. `--resume` reads
`session.projectPath` straight off disk and `process.chdir()`s into it
(`cli.ts:618`); a tilde-form or otherwise unnormalized value there would
`chdir` to a wrong/nonexistent directory.

## Why

Follow-up from #674 / PR #678: that PR normalized `projectPath` in the
live-sessions registry (`SessionRegistryFile.register()`), but `SessionStore`
is a separate mechanism it did not touch. The only writer of
`SessionStore.save()` is `SessionBindingStore.preAssign()` (`cli.ts`'s
`workingDirectory = process.cwd()`, already normalized post-chdir), so this
isn't a live bug today, but nothing prevented a raw/legacy value from ever
reaching the store.

## Fix

`packages/daemon/src/session/session-store.ts`:
- `save()` (persist side): normalizes `projectPath` via `normalizeProjectPath`
  before writing, mirroring `SessionRegistryFile.register()`'s fix for #674.
- `read()` (read side): normalizes `projectPath` on every parsed entry,
  alongside the existing `s.pid ??= null` legacy-normalization already in
  that loop. Since every query method (`findByRemiSessionId`,
  `findByClaudeSessionId`, `list`, `getMostRecent`) goes through `read()`,
  this self-heals a legacy on-disk entry for all consumers in one place
  (including the `--resume` chdir at `cli.ts:618`) without a dedicated
  migration. The fix is persisted back to disk on the next write
  (`save`/`markExited`/`updateClaudeSessionId`/`purgeStale`).

Non-goal (documented in `normalizeProjectPath` itself, unchanged here):
symlink resolution (e.g. `/tmp` vs `/private/tmp`) is not attempted.

## Testing

- `bun run typecheck` -- clean
- `bunx biome check packages/daemon/src/session/session-store.ts packages/daemon/tests/session-store.test.ts` -- clean
- `bun test packages/daemon/tests/session-store.test.ts packages/daemon/tests/session/ packages/daemon/tests/session-registry-file.test.ts packages/daemon/tests/cli/path-resolver.test.ts packages/daemon/tests/cli/handlers/resume-session-events.test.ts` -- 115 pass, 0 fail
- `bun test packages/daemon/tests/transcript/ packages/daemon/tests/cli/ packages/daemon/tests/hooks/ packages/daemon/tests/session` -- 1202 pass, 0 fail
- New tests (`packages/daemon/tests/session-store.test.ts`): tilde-form `save()` normalizes before persisting; tilde-form and absolute-form saves converge to the same `projectPath`; reading a legacy raw-tilde entry written directly to disk self-heals through `findByRemiSessionId`/`list`/`getMostRecent`; the self-healed value is persisted back to disk on the next write

Closes #680