### PR TITLE
fix(#676): re-arm rotation dir-poll on later bind

### DIFF
--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -1013,6 +1013,10 @@ export class TranscriptBinder {
    */
   private maybeRearmRotationPoll(storedId: string | null): void {
     if (storedId === null || this.mode === 'shadow' || this.closed) return;
+    // Not just a fast-path: armRotationPoll() below is ALREADY idempotent on
+    // this same check, but without it here the log line would fire on every
+    // hook event once armed, not just on the actual re-arm. This check exists
+    // to gate the log, not to prevent a double-arm.
     if (this.rotationPollTimer !== null) return; // already armed
     log(
       `[Binder] Re-arming rotation dir-poll from a later bindingStore read (missed at construction, #676): claude=${storedId.slice(0, 8)}`,

--- a/packages/daemon/src/transcript/transcript-binder.ts
+++ b/packages/daemon/src/transcript/transcript-binder.ts
@@ -175,6 +175,9 @@ export class TranscriptBinder {
    *  yet readable is re-polled until its file has been settled-and-markerless for
    *  this long (by mtime), then recorded as seen. Test-overridable. */
   private markerSettleMs: number = MARKER_SETTLE_MS;
+  /** Set by `close()`; a torn-down binder must never re-arm the dir-poll it just
+   *  cancelled, even if a stray hook event reaches it after teardown (#676). */
+  private closed = false;
 
   private readonly deps: TranscriptBinderDeps;
   private readonly sessionId: UUID;
@@ -785,6 +788,18 @@ export class TranscriptBinder {
   private adoptLockFromStore(): void {
     try {
       const storedId = this.deps.bindingStore.get(this.sessionId)?.claudeSessionId ?? null;
+      // #676: `setupHookBridge`'s pre-assigned-id read (which arms the #452
+      // dir-poll via `start()`) is wrapped in try/catch to survive a transient
+      // bindingStore/SessionStore throw. A throw there routes into the same
+      // "no pre-assigned id" branch as a legitimate null and `start()` is never
+      // called, permanently disarming the dir-poll for the session's whole
+      // lifetime. This read runs on every hook event (via `onHookEvent`/
+      // `admits`/`decide`) and already re-adopts a stored id the constructor
+      // missed, so it is the natural point to re-arm the dir-poll it missed —
+      // no restart required. Runs BEFORE the early-return below so it fires
+      // even when storedId already equals currentBoundId (the common
+      // steady-state adopt).
+      this.maybeRearmRotationPoll(storedId);
       if (storedId === null || storedId === this.currentBoundId) return;
       const previous = this.currentBoundId;
       this.currentBoundId = storedId;
@@ -947,6 +962,7 @@ export class TranscriptBinder {
    * cli.ts:822-829 and ensures the dir-poll never outlives the binder).
    */
   close(): void {
+    this.closed = true;
     this.teardownWatcher('close');
     this.cancelFallbackTimer();
     this.cancelRotationPoll();
@@ -984,6 +1000,24 @@ export class TranscriptBinder {
       () => this.rotationPollTick(),
       this.rotationPollIntervalMs,
     );
+  }
+
+  /**
+   * Re-arm path (#676). `armRotationPoll` is only ever called from `start()`
+   * (construction time) today; if that call was skipped — the pre-assigned-id
+   * read threw, or genuinely found no id yet — the dir-poll stays unarmed
+   * forever, even once a later read succeeds. Called from `adoptLockFromStore`
+   * on every hook event so a later successful read arms it instead. Idempotent
+   * (delegates to `armRotationPoll`'s own already-armed guard) and inert in
+   * shadow mode or after `close()`.
+   */
+  private maybeRearmRotationPoll(storedId: string | null): void {
+    if (storedId === null || this.mode === 'shadow' || this.closed) return;
+    if (this.rotationPollTimer !== null) return; // already armed
+    log(
+      `[Binder] Re-arming rotation dir-poll from a later bindingStore read (missed at construction, #676): claude=${storedId.slice(0, 8)}`,
+    );
+    this.armRotationPoll(storedId);
   }
 
   private cancelRotationPoll(): void {

--- a/packages/daemon/tests/transcript/transcript-binder.test.ts
+++ b/packages/daemon/tests/transcript/transcript-binder.test.ts
@@ -1150,6 +1150,169 @@ describe('TranscriptBinder', () => {
       binder.rotationPollTick();
       expect(rotations()).toHaveLength(0);
     });
+
+    // -----------------------------------------------------------------------
+    // Re-arm on a later bind (#676)
+    // -----------------------------------------------------------------------
+    describe('re-arm on later bind (#676)', () => {
+      /** Pre-assign a durable binding, mirroring cli.ts writing it before
+       *  Bun.spawn (#427). Construction's `start()` is intentionally NEVER
+       *  called by these tests — simulating the transient bindingStore/
+       *  SessionStore throw that routes into the same "no pre-assigned id"
+       *  branch as a legitimate null (#676), so the dir-poll is unarmed until
+       *  a later hook event's `adoptLockFromStore` re-adopts it. */
+      function preAssign(claudeSessionId: string | null): void {
+        bindingStore.preAssign({
+          remiSessionId: SID,
+          claudeSessionId,
+          projectPath: tmpDir,
+          port: 8765,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          exitedAt: null,
+          exitCode: null,
+        });
+      }
+
+      test('start() skipped at construction; the next hook event arms the dir-poll from the store read', () => {
+        registerSession();
+        preAssign('claude-A');
+        const binder = makeDriveBinder(); // NOT started
+
+        // The first hook event re-adopts the pre-assigned id from the store.
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: writeTranscript('claude-A', 8765),
+        });
+        expect(binder.snapshot().claudeSessionId).toBe('claude-A');
+
+        // Proof the dir-poll is now armed: a later no-hooks rotation the
+        // poll alone can catch (no further hook event feeds it) is detected.
+        writeTranscript('claude-B', 8765);
+        ptyState.running = false;
+        binder.rotationPollTick();
+
+        expect(rotations()).toEqual([
+          {
+            old: 'claude-A',
+            new: 'claude-B',
+            path: path.join(rotationDir(), 'claude-B.jsonl'),
+            reason: 'restart',
+          },
+        ]);
+        expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+        binder.close();
+      });
+
+      test('re-arm is idempotent: a second hook event does not double-arm', () => {
+        registerSession();
+        preAssign('claude-A');
+        const binder = makeDriveBinder(); // NOT started
+
+        // First event arms the poll (as above).
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: writeTranscript('claude-A', 8765),
+        });
+
+        // A second, already-bound ('match') event re-reads the store again —
+        // adoptLockFromStore runs on every event — and must be a no-op re-arm
+        // attempt rather than creating a second poll interval/seed-set.
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: path.join(rotationDir(), 'claude-A.jsonl'),
+        });
+
+        // A single rotation candidate must cross the wire exactly once even
+        // across repeated ticks; a double-arm would risk double-processing.
+        writeTranscript('claude-B', 8765);
+        ptyState.running = false;
+        binder.rotationPollTick();
+        binder.rotationPollTick();
+
+        expect(rotations()).toHaveLength(1);
+        expect(binder.snapshot().claudeSessionId).toBe('claude-B');
+        binder.close();
+      });
+
+      test('no binding in the store yet: the dir-poll stays unarmed until one actually lands', () => {
+        registerSession();
+        // No preAssign: the store has no record for this session at all, so
+        // `bindingStore.update()` in the first-adopt path below also no-ops
+        // (SessionStore.updateClaudeSessionId is a no-op on an absent record) —
+        // the binding genuinely does not exist yet, unlike the primary #676
+        // scenario where cli.ts already wrote it and only the READ failed.
+        const binder = makeDriveBinder(); // NOT started
+
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: writeTranscript('claude-A', 8765),
+        });
+
+        writeTranscript('claude-B', 8765);
+        ptyState.running = false;
+        binder.rotationPollTick();
+        expect(rotations()).toHaveLength(0); // still unarmed: no binding exists yet
+
+        // The binding now genuinely lands in the store (e.g. a delayed sibling
+        // write). The next hook event's adoptLockFromStore re-reads it and
+        // arms the dir-poll from there.
+        sessionStore.save({
+          remiSessionId: SID,
+          claudeSessionId: 'claude-A',
+          projectPath: tmpDir,
+          port: 8765,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          exitedAt: null,
+          exitCode: null,
+        });
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: path.join(rotationDir(), 'claude-A.jsonl'),
+        });
+        binder.rotationPollTick();
+        expect(rotations()).toHaveLength(1);
+        binder.close();
+      });
+
+      test('closed binder does not re-arm on a stray post-close event', () => {
+        registerSession();
+        preAssign('claude-A');
+        const binder = makeDriveBinder(); // NOT started
+        binder.close(); // torn down before any event ever arrives
+
+        binder.onHookEvent({
+          session_id: 'claude-A',
+          transcript_path: writeTranscript('claude-A', 8765),
+        });
+        writeTranscript('claude-B', 8765);
+        ptyState.running = false;
+        binder.rotationPollTick();
+        expect(rotations()).toHaveLength(0);
+      });
+
+      test('shadow mode never re-arms via the store-read path', () => {
+        registerSession();
+        preAssign('claude-A');
+        const binder = new TranscriptBinder(
+          deps(),
+          { sessionId: SID, workingDirectory: tmpDir },
+          'shadow',
+          { rotationPollIntervalMs: 20 },
+        );
+
+        binder.decide({
+          session_id: 'claude-A',
+          transcript_path: writeTranscript('claude-A', 8765),
+        });
+
+        writeTranscript('claude-B', 8765);
+        ptyState.running = false;
+        binder.rotationPollTick();
+        expect(rotations()).toHaveLength(0);
+      });
+    });
   });
 
   describe('ensureWatching', () => {


### PR DESCRIPTION
## Mechanism

Follow-up from #470 review. `setupHookBridge` (`packages/daemon/src/cli/session-phases/hook-bridge-setup.ts:490-506`) wraps the pre-assigned-`claudeSessionId` read in try/catch so a transient `bindingStore`/`SessionStore` throw (EMFILE-class) cannot crash `createNewSession`. But that throw routes into the same "no pre-assigned id, skip `start()`" branch as a legitimately-null id, and `binder.start()` is what arms both the fallback poll and the #452 rotation dir-poll. A transient flake at that one read therefore permanently disarmed the dir-poll safety net for the session's entire lifetime — only a restart re-armed it.

## What changed

`TranscriptBinder.adoptLockFromStore` (`packages/daemon/src/transcript/transcript-binder.ts:788`) now calls a new `maybeRearmRotationPoll(storedId)` on every read, before the existing early-return. `adoptLockFromStore` already runs on every hook event (`onHookEvent`/`admits`/`decide`) and re-adopts a stored id the constructor missed, so it is the natural point to re-arm the poll it also missed at construction:

- `maybeRearmRotationPoll` is a no-op when `storedId` is null, in shadow mode, after `close()`, or when the poll is already armed (delegates to `armRotationPoll`'s own idempotency guard) — so the normal path (id available at construction, `start()` runs as today) is unchanged.
- A new `closed` flag is set in `close()` so a stray post-teardown hook event can never resurrect the timer it just cancelled.

Scope is deliberately limited to the dir-poll (Case B, no-hooks rotation) per the issue — the fallback poll (Case A, "our pre-assigned file appears") isn't re-armed, because if hooks are actively firing (the only way `adoptLockFromStore` runs), the ordinary per-event first-adopt path already binds and starts the watcher; Case A's job is moot in that situation.

## How tested

Added `re-arm on later bind (#676)` describe block in `packages/daemon/tests/transcript/transcript-binder.test.ts` (real tmp-dir files, no mocks):
- construction without calling `start()` (simulating the try/catch-skip), then a hook event with a pre-assigned store binding arms the dir-poll, proven by a subsequent no-hooks rotation being caught.
- idempotency: a second hook event does not double-arm (single rotation emitted despite repeated ticks).
- no binding in the store at all: stays unarmed until one genuinely lands, then arms from the next event.
- a binder closed before any event ever arrives never re-arms.
- shadow mode never re-arms via the store-read path.

Gates run locally: `bun run typecheck`, `bunx biome check` (clean on touched files), `bun test packages/daemon/tests/transcript/transcript-binder.test.ts` (62 pass), `bun test packages/daemon/tests/cli/session-phases/{transcript-binder-drive,hook-bridge-setup}.test.ts` (66 pass), and the full daemon+shared suite excluding `packages/daemon/tests/auto-approve` (2309 pass, 0 fail).

Closes #676