### PR TITLE
docs(#670): rewrite e2e transcript-binding oracle doc

### DIFF
--- a/tests/e2e/transcript-binding/README.md
+++ b/tests/e2e/transcript-binding/README.md
@@ -13,7 +13,7 @@ would.
 
 It is **not wired into CI** — it needs an authenticated `claude` and a trusted
 working directory, and it drives a TUI with timing-sensitive input. Run it by
-hand when changing the binding/rotation code or before flipping the binder flag.
+hand when changing the binding/rotation code.
 
 ## What it validates
 
@@ -25,6 +25,13 @@ distinguish scenarios by. Two scenarios remain, split by daemon topology:
 |---|---|---|
 | 1. Single daemon | fm-430, fm-438, fm-452, GAP-6 | binder drives the bind (`[Binder] Lock adopted from binding store`); `/clear` rotates exactly once, caught either by the hook path (`Claude restart detected`) or the re-arming dir-poll (`No-hooks rotation detected via dir poll`, the #452 backstop); rebound + watcher rearmed; follow-up routes to the new transcript; old transcript frozen; no "Transcript not found"; `/compact` does not rotate or over-fire the dir-poll |
 | 2. Two daemons, same cwd | fm-427, fm-451 | distinct binds, content segregated (ALPHA↔D1, BETA↔D2), per-port `remi:<port>` markers; zombie sibling (dead claude child, live wrapper) does **not** poison the other daemon's binding |
+
+Hooks are up in scenario 1, so whether the hook path or the dir-poll observes
+a `/clear` rotation first is a genuine race (a local `readdir` tick vs. a hook
+POST round-trip), not a bug either way — `run.sh` reports which mechanism won
+as informational rather than requiring the dir-poll specifically. Only fm-452
+(hooks forced **down**, manual-only) proves the dir-poll as the sole path; see
+`failure-mode-matrix.md`.
 
 See `failure-mode-matrix.md` for the full per-mode repro + oracle reference and
 the two non-negotiable traps (assert the on-disk id actually changed; in the

--- a/tests/e2e/transcript-binding/README.md
+++ b/tests/e2e/transcript-binding/README.md
@@ -17,11 +17,14 @@ hand when changing the binding/rotation code or before flipping the binder flag.
 
 ## What it validates
 
+The `TranscriptBinder` has run as the single, unconditional binding path since
+#503/#470 — there is no alternate path or shadow-comparison mode left to
+distinguish scenarios by. Two scenarios remain, split by daemon topology:
+
 | Scenario | Failure modes | Key checks |
 |---|---|---|
-| 1. Shadow (shipping default) | fm-430, fm-438, fm-435b, GAP-6 | binding correct; **0 `[ShadowBinder] DISAGREE`** on a normal session and across a `/clear`; rotation announced once; follow-up routes to the new transcript; old transcript frozen; `/compact` does not rotate |
-| 2. Drive (the binder itself) | fm-452, fm-438, GAP-6 | binder drives the bind (shadow suppressed); `/clear` caught by the **new re-arming dir-poll** (`No-hooks rotation detected via dir poll`), rebound + watcher rearmed; no "Transcript not found"; `/compact` does not over-fire the dir-poll |
-| 3. Two daemons, same cwd | fm-427, fm-451 | distinct binds, content segregated (ALPHA↔D1, BETA↔D2), per-port `remi:<port>` markers; zombie sibling (dead claude child, live wrapper) does **not** poison the other daemon's binding |
+| 1. Single daemon | fm-430, fm-438, fm-452, GAP-6 | binder drives the bind (`[Binder] Lock adopted from binding store`); `/clear` rotates exactly once, caught either by the hook path (`Claude restart detected`) or the re-arming dir-poll (`No-hooks rotation detected via dir poll`, the #452 backstop); rebound + watcher rearmed; follow-up routes to the new transcript; old transcript frozen; no "Transcript not found"; `/compact` does not rotate or over-fire the dir-poll |
+| 2. Two daemons, same cwd | fm-427, fm-451 | distinct binds, content segregated (ALPHA↔D1, BETA↔D2), per-port `remi:<port>` markers; zombie sibling (dead claude child, live wrapper) does **not** poison the other daemon's binding |
 
 See `failure-mode-matrix.md` for the full per-mode repro + oracle reference and
 the two non-negotiable traps (assert the on-disk id actually changed; in the
@@ -60,6 +63,9 @@ renders are left in the printed `E2E_STATE` dir for inspection.
   background `sleep`; it is both the input channel and the observer (the real
   client path). claude's composer treats the first burst as a bracketed paste,
   so a prompt is submitted with a **separate** Enter keystroke.
-- The oracle is the daemon log: `[ShadowBinder] DISAGREE` (shadow), the
-  `[Binder] …` rotation lines (drive), and `owned by port X, not Y; ignoring`
-  (marker-based sibling/zombie defer), plus the on-disk `<id>.jsonl` files.
+- The oracle is the daemon log: the `[Binder] …` bind/rotation lines
+  (`Lock adopted`, `Transcript from`, `Claude restart detected`, `No-hooks
+  rotation detected via dir poll`) and `owned by port X, not Y; ignoring`
+  (marker-based sibling/zombie defer), plus the on-disk `<id>.jsonl` files. See
+  `failure-mode-matrix.md` → "The oracle" for the full list and how it
+  changed after the shadow-mode differential harness was deleted (#470).

--- a/tests/e2e/transcript-binding/failure-mode-matrix.md
+++ b/tests/e2e/transcript-binding/failure-mode-matrix.md
@@ -37,12 +37,18 @@ the live daemon log plus the on-disk transcripts:
 - `[Binder] No-hooks rotation detected via dir poll: <old> -> <new> (<path>)` —
   a rotation the 1.5s re-arming dir-poll caught (the #452 backstop; it also
   frequently wins the race against the hook path even when hooks are up, since
-  it is a local `readdir` versus a hook POST round-trip).
+  it is a local `readdir` versus a hook POST round-trip). Because it is a race
+  in a hooks-up run, `run.sh`'s single-daemon scenario treats this line as
+  informational (reports whichever mechanism won) rather than requiring it —
+  only the hooks-**down** leg below forces the dir-poll to be the sole path.
 - `[Binder] rotation poll: <id> owned by port <p>, not <ours>; ignoring` —
   sibling-marker gate rejecting a foreign transcript during the poll.
-- `[Binder] Dropped foreign <event>: lock=<id> incoming=<id>` — sibling-marker
-  gate rejecting a foreign transcript at the hook-listener boundary
-  (`binder.admits()`).
+- `[Binder] Dropped foreign <event>: lock=<id> incoming=<id>` — logged from
+  `onHookEvent()`'s `classify() === 'foreign'` branch (transcript-binder.ts:373)
+  when the sibling-marker check rejects an incoming transcript as not ours.
+  (`binder.admits()` is a separate, pure boolean gate with no logging of its
+  own — it decides whether a listener processes an event at all, upstream of
+  this classification.)
 - the on-disk `<id>.jsonl` files themselves — an id actually changed, content
   segregated, the old file frozen.
 

--- a/tests/e2e/transcript-binding/failure-mode-matrix.md
+++ b/tests/e2e/transcript-binding/failure-mode-matrix.md
@@ -7,18 +7,44 @@ the epic #453 bug history (#321, #427/#428, #429/#430/#433, #438, #451, #452,
 
 ## The oracle
 
-The shadow binder (`REMI_TRANSCRIPT_BINDER_SHADOW=true`) computes decisions
-alongside the live old path and logs `[ShadowBinder] DISAGREE <event>: <diffs>`
-on any divergence in three fields only: durable-store **boundId**, **rotation**
-emitted-this-event, **watcherPath** (advisory). Silent on agreement. It is
-**hook-fed only** — silent when hooks are down.
+Before #470, a shadow-mode `TranscriptBinder` (`REMI_TRANSCRIPT_BINDER_SHADOW=true`)
+computed decisions alongside the still-driving old inline hook-binding path and
+logged `[ShadowBinder] DISAGREE <event>: <diffs>` on divergence in three fields
+(durable-store **boundId**, **rotation** emitted-this-event, **watcherPath**
+advisory) — the differential harness that proved the binder's behavior before it
+was allowed to drive. That comparison path, and the old inline path it compared
+against, were both deleted in #470 once the binder had soaked as the
+unconditional driver (#503, tagged 0.6.18-dev range). There is now a **single**
+binding path: the `TranscriptBinder` always runs in `'drive'` mode
+(`hook-bridge-setup.ts` constructs it with the literal `'drive'` mode, no flag).
+`REMI_TRANSCRIPT_BINDER_SHADOW` no longer exists anywhere in the daemon;
+`REMI_TRANSCRIPT_BINDER_ENABLED` is still read but only logs a one-line
+deprecation warning on `false` — it no longer restores an alternate path.
 
-`[ShadowBinder] DISAGREE` is a valid pass/fail signal **only** for:
-- **fm-438** — `rotation binder=false old=true` on the duplicate-carrying event (binder dedups the old path's double-emit).
-- **fm-430** — `rotation binder=true old=false` on the `/clear` SessionStart when the store raced ahead of the hook.
-- **fm-451** — `boundId binder=<new> old=<old>` when the old path defers on a false-live zombie sibling and the binder rebinds.
+Every failure mode below is validated **directly against the binder's own
+behavior**, not by disagreement with an alternate implementation. The oracle is
+the live daemon log plus the on-disk transcripts:
 
-It is **silent-by-design / not a bug** for fm-321 (no field captures admit-vs-drop), fm-427 (`watcherPath` is advisory; deterministic binding already agrees), and **structurally blind** for fm-452 (the dir-poll is disabled in shadow). Those are **drive-mode** validations.
+- `[Binder] Lock adopted from binding store: claude=<id>` — first bind, the
+  common case (cli.ts pre-writes the binding before spawn; the first hook event
+  finds it already in the store).
+- `[Binder] Transcript from <hook-or-DirPollRotation>: claude=<id>, transcript=<path>`
+  — first-adopt-via-event path (the store did not yet have the id when the
+  event arrived), or the tail of a dir-poll-driven rotation (fires with
+  `hook-or-DirPollRotation` = `DirPollRotation`).
+- `[Binder] Claude restart detected (ended=<bool>): <old> -> <new>` — a rotation
+  classified via a real hook event (`/clear`, `/resume`).
+- `[Binder] No-hooks rotation detected via dir poll: <old> -> <new> (<path>)` —
+  a rotation the 1.5s re-arming dir-poll caught (the #452 backstop; it also
+  frequently wins the race against the hook path even when hooks are up, since
+  it is a local `readdir` versus a hook POST round-trip).
+- `[Binder] rotation poll: <id> owned by port <p>, not <ours>; ignoring` —
+  sibling-marker gate rejecting a foreign transcript during the poll.
+- `[Binder] Dropped foreign <event>: lock=<id> incoming=<id>` — sibling-marker
+  gate rejecting a foreign transcript at the hook-listener boundary
+  (`binder.admits()`).
+- the on-disk `<id>.jsonl` files themselves — an id actually changed, content
+  segregated, the old file frozen.
 
 ## Two non-negotiable traps
 
@@ -32,25 +58,27 @@ It is **silent-by-design / not a bug** for fm-321 (no field captures admit-vs-dr
 
 ## Per-mode summary
 
-| Mode | Symptom (pre-epic) | Trigger | Oracle | Flag |
-|---|---|---|---|---|
-| **fm-321** sibling hook-lock cached | a daemon goes permanently deaf to its own claude with a sibling in the dir; killing the sibling never recovers it | two daemons same cwd; kill sibling; permission in survivor | drive: survivor processes its own PermissionRequest after sibling dies (shadow silent here) | drive |
-| **fm-427** cross-bind | daemon-B answers a question claude-A asked; "messages not from this session" | two daemons same cwd, fresh bindings | each binds its own `<uuid>.jsonl`; content segregated; co-located events classify `foreign` | both |
-| **fm-430** binding drift / STALE_BINDING | after `/clear`, second client stuck on old id, no `session_rotated` | single daemon; `/clear` (store pre-assigns new id before SessionStart) | shadow: `DISAGREE SessionStart rotation binder=true old=false`; drive: one `session_rotated`, binding updates | both |
-| **fm-438** double-emit | chat clears/reloads twice; or a stale re-emit re-binds to the dead id → STALE_BINDING | `/clear`, or kill+resume (store-race ordering), or A→B→A re-resume | exactly one rotation per A→B; shadow `DISAGREE rotation binder=false old=true` on the duplicate event | both |
-| **fm-451** zombie poisons sibling-defer | long session returns "Transcript for session not found" after `/clear`; log floods `Dropped foreign` | two daemons same cwd; kill one's inner claude child; `/clear` the other | victim rebinds + streams; `owned by port X, not Y; ignoring`; no "not found" | both |
-| **fm-452** no-hooks / slow-flush wedge | `/clear` with hooks down → locked-but-unwatched → "Transcript for session not found" | single daemon, hooks down; `/clear`; follow-up | drive: `[Binder] No-hooks rotation detected via dir poll`, watcher rearmed | **drive only** |
-| **fm-435** (a/c/d) false-positive questions, multi-question, fails-to-connect | phantom question cards; one question slot; retries a dead port | numbered-list prompt; concurrent subagent+main permission; occupy default port then attach | flag-independent (epic #435 phases 1/2/4); binder must be **inert** (no `[Binder]`/`[ShadowBinder]` lines) | off |
+| Mode | Symptom (pre-epic) | Trigger | Oracle |
+|---|---|---|---|
+| **fm-321** sibling hook-lock cached | a daemon goes permanently deaf to its own claude with a sibling in the dir; killing the sibling never recovers it | two daemons same cwd; kill sibling; permission in survivor | survivor processes its own PermissionRequest after sibling dies |
+| **fm-427** cross-bind | daemon-B answers a question claude-A asked; "messages not from this session" | two daemons same cwd, fresh bindings | each binds its own `<uuid>.jsonl`; content segregated; co-located events classify `foreign` |
+| **fm-430** binding drift / STALE_BINDING | after `/clear`, second client stuck on old id, no `session_rotated` | single daemon; `/clear` (store pre-assigns new id before SessionStart) | one `session_rotated`, binding updates; no double-emit even when the store raced ahead of the hook |
+| **fm-438** double-emit | chat clears/reloads twice; or a stale re-emit re-binds to the dead id → STALE_BINDING | `/clear`, or kill+resume (store-race ordering), or A→B→A re-resume | exactly one `[Binder] Claude restart detected` (or dir-poll equivalent) per A→B; `emitRotated`'s `lastAnnouncedRotationId` guard prevents a duplicate on the same id |
+| **fm-451** zombie poisons sibling-defer | long session returns "Transcript for session not found" after `/clear`; log floods `Dropped foreign` | two daemons same cwd; kill one's inner claude child; `/clear` the other | victim rebinds + streams; `owned by port X, not Y; ignoring`; no "not found" |
+| **fm-452** no-hooks / slow-flush wedge | `/clear` with hooks down → locked-but-unwatched → "Transcript for session not found" | single daemon, hooks down; `/clear`; follow-up | `[Binder] No-hooks rotation detected via dir poll`, watcher rearmed. The only failure mode that needs hooks **actually** disabled (not just racing the poll) — not automated in `run.sh`; see the manual leg below |
+| **fm-435** (a/c/d) false-positive questions, multi-question, fails-to-connect | phantom question cards; one question slot; retries a dead port | numbered-list prompt; concurrent subagent+main permission; occupy default port then attach | epic #435 phases 1/2/4 behavior (numbered prompt renders once; concurrent subagent+main permission both surface; a dead port is not retried), validated under the single always-on binder path. Pre-#470 this ran with the binder flagged **off** to prove the bug was unrelated to it; that isolation leg no longer exists — the binder can no longer be disabled (`REMI_TRANSCRIPT_BINDER_ENABLED` is a no-op, #470) |
 
 ## Minimal run order
 
-1. Two daemons, same cwd, **shadow** — fm-427 race + fm-451 zombie shadow leg.
-2. Two daemons, same cwd, **drive** — fm-427 + fm-451 + fm-321 recovery end-to-end.
-3. Single daemon, hooks up, **shadow**, one long session — fm-430 + fm-438 + A→B→A + `/compact` negative.
-4. Single daemon, hooks up, **drive**, one long session — the same, end-to-end + the positive binding invariant + the newly-wired dropped hooks.
-5. Single daemon, hooks **down**, **drive** — fm-452 (the only run exercising the dir-poll; highest value, lowest redundancy).
-6. Single daemon, binder **off** — fm-435 a/c/d (binder must be inert).
+1. Two daemons, same cwd — fm-427 cross-bind + fm-451 zombie recovery,
+   end-to-end.
+2. Single daemon, hooks up, one long session — fm-430 + fm-438 + A→B→A +
+   `/compact` negative, end-to-end, plus the positive binding invariant (bind,
+   follow-up routes to the rotated session, old transcript stays frozen).
+3. Single daemon, hooks **down** — fm-452 (the only run exercising the dir-poll
+   as the *sole* path; highest value, lowest redundancy). Manual only — the
+   harness has no way to actually disable hook delivery, only to race it.
 
-`run.sh` implements a practical subset (shadow + drive single-daemon, and the
-two-daemon cross-bind/zombie). The hooks-down (5) and binder-off (6) legs are
-documented here for manual execution.
+`run.sh` implements a practical subset: the single-daemon run (2) and the
+two-daemon cross-bind/zombie run (1). The hooks-down leg (3) is documented here
+for manual execution.

--- a/tests/e2e/transcript-binding/lib.sh
+++ b/tests/e2e/transcript-binding/lib.sh
@@ -22,19 +22,20 @@ mkdir -p "$E2E_STATE"
 # Strip ANSI/OSC so logs and renders are greppable.
 deansi() { sed -E 's/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\x1b\][0-9;]*\x07//g; s/\r//g'; }
 
-# start_daemon NAME CWD PORT MODE(shadow|drive|off)
+# start_daemon NAME CWD PORT
 # Launches a daemon with ANTHROPIC_MODEL=haiku (claude --model is not forwarded
 # by --daemon, but the daemon's env is, and claude honours ANTHROPIC_MODEL).
+#
+# The TranscriptBinder has run as the single, unconditional binding path since
+# #470/#503 — there is no shadow/drive/off mode to select anymore
+# (REMI_TRANSCRIPT_BINDER_SHADOW no longer exists;
+# REMI_TRANSCRIPT_BINDER_ENABLED is read but only logs a deprecation warning
+# on false, it no longer changes behavior). See failure-mode-matrix.md → "The
+# oracle".
 start_daemon() {
-  local name=$1 cwd=$2 port=$3 mode=$4
+  local name=$1 cwd=$2 port=$3
   local log="$E2E_STATE/$name.log"
   rm -f "$log"
-  local sh=false dr=false
-  case "$mode" in
-    shadow) sh=true ;;
-    drive)  dr=true ;;
-    off)    : ;;
-  esac
   cat > "$E2E_STATE/launch-$name.sh" <<LAUNCH
 #!/usr/bin/env bash
 cd "$cwd"
@@ -42,12 +43,10 @@ exec "$REMI_BIN" --daemon --bind 127.0.0.1 --port $port --no-auth --no-relay --n
 LAUNCH
   chmod +x "$E2E_STATE/launch-$name.sh"
   ANTHROPIC_MODEL=haiku \
-  REMI_TRANSCRIPT_BINDER_SHADOW=$sh \
-  REMI_TRANSCRIPT_BINDER_ENABLED=$dr \
     nohup bash "$E2E_STATE/launch-$name.sh" > "$log" 2>&1 &
   echo "$!" > "$E2E_STATE/$name.pid"
   echo "$port" > "$E2E_STATE/$name.port"
-  echo "daemon[$name] pid=$(cat "$E2E_STATE/$name.pid") port=$port mode=$mode log=$log"
+  echo "daemon[$name] pid=$(cat "$E2E_STATE/$name.pid") port=$port log=$log"
 }
 
 wait_ready() {

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -36,68 +36,45 @@ reset_cwd() {
 EXPLORE="Read README.md or list the files here, then give a 2-sentence summary. Read-only, do not modify anything."
 
 # ---------------------------------------------------------------------------
-echo "### Scenario 1: SHADOW (shipping default) — bind + /clear rotation + /compact"
+echo "### Scenario 1: SINGLE DAEMON — bind + /clear rotation (hook or dir-poll) + /compact"
 # ---------------------------------------------------------------------------
+# The TranscriptBinder is the single, unconditional binding path (#470/#503) —
+# there is no shadow/drive mode to select; every check below exercises the
+# real driving path. See failure-mode-matrix.md -> "The oracle".
 reset_cwd
-start_daemon s1 "$CWD" 18811 shadow; wait_ready s1 || exit 1
+start_daemon s1 "$CWD" 18811; wait_ready s1 || exit 1
 SID=$(session_id 18811); attach_start s1 18811 "$SID"; sleep 2
 prompt s1 "$EXPLORE"
-A=$(wait_bound "$CWD" 18811 8 100) || { bad "shadow: initial bind"; A=""; }
-[ -n "$A" ] && ok "shadow: claude bound (honoured pre-assigned --session-id): $A"
-check "shadow: 0 DISAGREE on a normal session" "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+A=$(wait_bound "$CWD" 18811 8 100) || { bad "initial bind"; A=""; }
+[ -n "$A" ] && ok "claude bound (honoured pre-assigned --session-id): $A"
+check "binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s1.log'"
 
 prompt s1 "/clear"
-wait_log s1 "restart detected" 25   # the new transcript file appears slightly before the daemon logs the rotation
+wait_log s1 "DirPollRotation|restart detected" 25
 B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
-check "shadow: /clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
-check "shadow: rotation announced exactly once (old path drives)" "[ \$(grep -c '\[Hooks\] Claude restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
-check "shadow: still 0 DISAGREE after /clear"        "[ \$(grep -c 'ShadowBinder] DISAGREE' '$E2E_STATE/s1.log') -eq 0 ]"
+check "/clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
+check "rotation announced exactly once" "[ \$(grep -c '\[Binder\] Claude restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
+check "no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_STATE/s1.log') -eq 0 ]"
 
 Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
 bb=$(wc -l < "$Bf" 2>/dev/null || echo 0); ab=$(wc -l < "$Af" 2>/dev/null || echo 0)
 prompt s1 "Say the word DELTA."
 for i in $(seq 1 20); do [ "$(wc -l < "$Bf" 2>/dev/null||echo 0)" -gt "$bb" ] && break; sleep 2; done
-check "shadow: follow-up landed in rotated session B" "[ \$(grep -c DELTA '$Bf' 2>/dev/null) -ge 1 ]"
-check "shadow: old session A stayed frozen"           "[ \$(wc -l < '$Af' 2>/dev/null) -eq $ab ]"
+check "follow-up landed in rotated session B" "[ \$(grep -c DELTA '$Bf' 2>/dev/null) -ge 1 ]"
+check "old session A stayed frozen"           "[ \$(wc -l < '$Af' 2>/dev/null) -eq $ab ]"
 
-rb=$(grep -c 'restart detected' "$E2E_STATE/s1.log")
+rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s1.log")
 prompt s1 "/compact"; sleep 12
-check "shadow: /compact did NOT rotate (no new restart)" "[ \$(grep -c 'restart detected' '$E2E_STATE/s1.log') -eq $rb ]"
+check "/compact did NOT rotate or over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s1.log') -eq $rc ]"
 attach_stop s1; stop_daemon s1
 
 # ---------------------------------------------------------------------------
-echo "### Scenario 2: DRIVE (the binder itself) — bind + /clear via dir-poll + /compact"
+echo "### Scenario 2: TWO daemons, same cwd — cross-bind (fm-427) + zombie (fm-451)"
 # ---------------------------------------------------------------------------
 reset_cwd
-start_daemon s2 "$CWD" 18812 drive; wait_ready s2 || exit 1
-SID=$(session_id 18812); attach_start s2 18812 "$SID"; sleep 2
-prompt s2 "$EXPLORE"
-A2=$(wait_bound "$CWD" 18812 8 100) || { bad "drive: initial bind"; A2=""; }
-check "drive: binder drove the bind" "grep -q 'Binder] Lock adopted' '$E2E_STATE/s2.log'"
-
-prompt s2 "/clear"
-wait_log s2 "DirPollRotation|restart detected" 25
-B2=$(bound_transcript "$CWD" 18812 2>/dev/null | awk '{print $1}')
-check "drive: /clear rotated (B != A)" "[ -n '$B2' ] && [ '$B2' != '$A2' ]"
-check "drive: new dir-poll detected the rotation (#452 machinery)" "grep -q 'No-hooks rotation detected via dir poll' '$E2E_STATE/s2.log'"
-check "drive: rebound + rearmed watcher on B" "grep -q 'Transcript from DirPollRotation' '$E2E_STATE/s2.log'"
-check "drive: no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_STATE/s2.log') -eq 0 ]"
-
-rc=$(grep -c 'rotation detected\|restart detected\|DirPollRotation' "$E2E_STATE/s2.log")
-prompt s2 "/compact"; sleep 12
-check "drive: /compact did NOT over-fire the dir-poll" "[ \$(grep -c 'rotation detected\|restart detected\|DirPollRotation' '$E2E_STATE/s2.log') -eq $rc ]"
-# Checked after events have flowed (a bind + a real rotation), so a leaked
-# shadow comparison would have had its chance to log.
-check "drive: shadow suppressed throughout (no [ShadowBinder] lines)" "[ \$(grep -c 'ShadowBinder' '$E2E_STATE/s2.log') -eq 0 ]"
-attach_stop s2; stop_daemon s2
-
-# ---------------------------------------------------------------------------
-echo "### Scenario 3: TWO daemons, same cwd — cross-bind (fm-427) + zombie (fm-451)"
-# ---------------------------------------------------------------------------
-reset_cwd
-start_daemon d1 "$CWD" 18813 drive; wait_ready d1 || exit 1
+start_daemon d1 "$CWD" 18813; wait_ready d1 || exit 1
 sleep 2   # stagger so the two daemons do not collide writing ~/.remi/sessions.json
-start_daemon d2 "$CWD" 18814 drive; wait_ready d2 || exit 1
+start_daemon d2 "$CWD" 18814; wait_ready d2 || exit 1
 S1=$(session_id 18813); S2=$(session_id 18814)
 attach_start d1 18813 "$S1"; attach_start d2 18814 "$S2"; sleep 2
 prompt d1 "Say the word ALPHA."

--- a/tests/e2e/transcript-binding/run.sh
+++ b/tests/e2e/transcript-binding/run.sh
@@ -55,6 +55,18 @@ B=$(bound_transcript "$CWD" 18811 2>/dev/null | awk '{print $1}')
 check "/clear rotated to a NEW id (B != A)" "[ -n '$B' ] && [ '$B' != '$A' ]"
 check "rotation announced exactly once" "[ \$(grep -c '\[Binder\] Claude restart detected' '$E2E_STATE/s1.log') -eq 1 ]"
 check "no Transcript-not-found wedge" "[ \$(grep -ci 'not found' '$E2E_STATE/s1.log') -eq 0 ]"
+# Hooks are up in this scenario, so which mechanism observes the /clear
+# rotation first is a genuine race (a local readdir tick vs. a hook POST
+# round-trip) — NOT a bug either way. The dir-poll firing is not required
+# here; only the hooks-DOWN leg (fm-452, manual, see failure-mode-matrix.md)
+# forces it to be the sole path. Report which mechanism won as informational,
+# but if the dir-poll DID engage, its own two log lines must both be present.
+if grep -q 'No-hooks rotation detected via dir poll' "$E2E_STATE/s1.log"; then
+  ok "dir-poll (#452 machinery) engaged this run: No-hooks rotation detected via dir poll"
+  check "dir-poll rebound + rearmed watcher on B" "grep -q 'Transcript from DirPollRotation' '$E2E_STATE/s1.log'"
+else
+  ok "hook path caught the rotation first this run (dir-poll backstop did not need to engage)"
+fi
 
 Bf=$(tdir_for "$CWD")/$B.jsonl; Af=$(tdir_for "$CWD")/$A.jsonl
 bb=$(wc -l < "$Bf" 2>/dev/null || echo 0); ab=$(wc -l < "$Af" 2>/dev/null || echo 0)


### PR DESCRIPTION
## What was stale

PR #669 (issue #470) deleted the shadow-mode differential wiring from
`hook-bridge-setup.ts` (`REMI_TRANSCRIPT_BINDER_SHADOW`, the old inline
hook-binding path, `compareAndLog`/`[ShadowBinder] DISAGREE`) once the
`TranscriptBinder` had soaked as the unconditional binding driver (#503).
The `TranscriptBinder` is now always constructed in `'drive'` mode, hardcoded,
with no flag.

`tests/e2e/transcript-binding/failure-mode-matrix.md` still documented the
deleted shadow-binder-as-oracle methodology as the way to validate each
historical failure mode. `run.sh`/`lib.sh` still toggled the now-inert
`REMI_TRANSCRIPT_BINDER_SHADOW`/`REMI_TRANSCRIPT_BINDER_ENABLED` env vars and
ran a whole "Scenario 1: SHADOW" that, since #470, behaves byte-identically
to "Scenario 2: DRIVE" (the env vars have zero effect on behavior now) —
including an assertion (`[ShadowBinder] DISAGREE` count == 0) that can never
be anything but vacuously true, and a rotation-count assertion
(`[Hooks] Claude restart detected`) that references the deleted old path's
log prefix and would always fail if actually run.

Verified against current code:
```
$ grep -rn "REMI_TRANSCRIPT_BINDER_SHADOW" packages/daemon/src
(no matches — removed outright in #470)

$ grep -rn "REMI_TRANSCRIPT_BINDER_ENABLED" packages/daemon/src/config/config.ts
(read, but only flips a deprecated no-op feature flag; #470 comment confirms)

$ grep -n "mode.*'drive'" packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
    { sessionId, workingDirectory },
    'drive',   // <- hardcoded, no flag

$ grep -n "\[Hooks\] Claude restart detected\|\[Binder\] Claude restart detected" packages/daemon/src -r
packages/daemon/src/transcript/transcript-binder.ts:  log(`[Binder] Claude restart detected ...`)
(the [Hooks]-prefixed line the doc/scripts referenced no longer exists)
```

## The new methodology

Rewrote `failure-mode-matrix.md`'s "The oracle" section: there is no longer a
two-path differential to disagree on, so each failure mode is validated
directly against the binder's own log lines (`Lock adopted`, `Transcript
from`, `Claude restart detected`, `No-hooks rotation detected via dir poll`,
`rotation poll: ... owned by port`) plus the on-disk transcripts. Dropped the
now-vestigial "Flag" column from the per-mode table (there is nothing left to
flag) and updated the fm-435 row to note the binder-off isolation leg no
longer exists (the binder can't be disabled anymore).

Updated `README.md`'s scenario table and "How it works" oracle bullet to
match.

Also fixed `run.sh`/`lib.sh` (the runnable harness the docs point readers at,
not just the prose): dropped the dead shadow/drive/off env-var plumbing from
`start_daemon`, merged the redundant SHADOW/DRIVE scenarios into one "Single
daemon" scenario (folding in the still-useful non-redundant checks from both:
follow-up routes to the rotated session, old transcript stays frozen), and
fixed the rotation-count assertion to grep the current `[Binder]` prefix
instead of the deleted `[Hooks]` one.

Kept the two non-negotiable traps section, the per-mode trigger/symptom
descriptions, and the minimal-run-order framing (now 2 legs instead of 6,
since shadow/drive/binder-off collapse into "the one path there is").

Closes #670

## Test plan

- [x] `typos tests/e2e/transcript-binding/` — clean (CI spelling gate)
- [x] `bash -n run.sh` / `bash -n lib.sh` — syntax OK
- Docs-only change to `tests/e2e/transcript-binding/*.md` + the manual e2e
  harness shell scripts (not part of any CI gate); no TypeScript source
  touched, so typecheck/`bun test` are unaffected.
- Not able to execute the harness itself in this environment (needs a real
  authenticated `claude` + a trusted working directory per its own
  prerequisites); reviewed by tracing the current `TranscriptBinder` log call
  sites against every string the doc/scripts assert on.