### PR TITLE
fix(#682): scope error banner, normalize duplicate connections

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,8 @@ import { ConnectModal, NewSessionModal, SessionList } from '@/components/session
 import { SettingsPanel } from '@/components/settings';
 import { parseConnectionId, useConnectionManager } from '@/hooks';
 import { probeAuthInfo } from '@/lib/auth-probe';
+import { deriveConnectionBannerError } from '@/lib/connection-banner';
+import { dedupeConnectionUrls } from '@/lib/connection-id';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import {
   acknowledgeSend,
@@ -1500,7 +1502,16 @@ function App() {
       const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
       if (stored) {
         const urls: string[] = JSON.parse(stored);
-        for (const url of urls) {
+        // Reconcile aliases persisted under different host spellings (e.g. a
+        // 'localhost' URL saved before a later 'ws://127.0.0.1:.../ws'
+        // connect) to one entry per daemon (#682): connecting to both would
+        // leave a stale duplicate manager entry that can drive a stale error
+        // banner even while the deduped survivor is healthy and attached.
+        const deduped = dedupeConnectionUrls(urls, parseConnectionId);
+        if (deduped.length !== urls.length) {
+          localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(deduped));
+        }
+        for (const url of deduped) {
           connectDirectRef.current(url);
         }
       }
@@ -2176,14 +2187,16 @@ function App() {
   const handleConnectDirect = useCallback(
     (url: string, directory?: string) => {
       connectDirect(url, directory);
-      // Persist connected URLs
+      // Persist connected URLs. Dedupe by normalized connectionId (#682) so
+      // reconnecting to the same daemon through a different host alias
+      // (e.g. '127.0.0.1' after a previously-stored 'localhost' URL) replaces
+      // the old entry instead of accumulating a second string that resolves
+      // to the same daemon.
       try {
         const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
         const urls: string[] = stored ? JSON.parse(stored) : [];
-        if (!urls.includes(url)) {
-          urls.push(url);
-        }
-        localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(urls));
+        const deduped = dedupeConnectionUrls([...urls, url], parseConnectionId);
+        localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(deduped));
       } catch (err) {
         console.warn('[App] Failed to persist connection URL:', err);
       }
@@ -2413,11 +2426,21 @@ function App() {
     URL.revokeObjectURL(url);
   }, [sessionMessages, activeSessionId]);
 
-  // Derive error from the most recently errored connection (if any)
+  // Derive error from the most recently errored connection (if any). Used
+  // for the ConnectModal's own connect-attempt feedback, which is
+  // deliberately global -- it's about the connection the user just tried,
+  // not about any particular chat session.
   const errorConnection = connections.find((c) => c.status === 'error');
   const error: string | null = errorConnection
     ? (errorConnection.error ?? `Connection error: ${errorConnection.connectionId}`)
     : null;
+
+  // Chat-view banner (#682): scoped to the connection serving the ACTIVE
+  // session, so an unrelated errored/duplicate connection can't pin a
+  // "Connection error" banner (and, via the same session.connectionStatus
+  // path the InputArea reads, disable the chat input) while the session on
+  // screen is healthy and attached.
+  const chatError = deriveConnectionBannerError(connections, activeSession?.connectionId ?? null);
 
   // Compute effective status for ConnectModal: show the latest connection's status
   const effectiveStatus = (() => {
@@ -2463,7 +2486,7 @@ function App() {
       session={activeSession}
       messages={sessionMessages}
       questions={sessionQuestions}
-      error={error}
+      error={chatError}
       onSend={handleSend}
       onAnswer={handleAnswer}
       onAuqAnswer={handleAuqAnswer}

--- a/packages/web/src/hooks/connection-manager-helpers.ts
+++ b/packages/web/src/hooks/connection-manager-helpers.ts
@@ -5,6 +5,7 @@
  * pulling in React, the WebSocket client, or identity-store side effects.
  */
 
+import type { ConnectionStatus } from '@/types';
 import { generateId } from '@remi/shared';
 
 /**
@@ -151,4 +152,28 @@ export function allocateStaggerSlot(usedSlots: ReadonlySet<number>): number {
   let slot = 0;
   while (usedSlots.has(slot)) slot++;
   return slot;
+}
+
+/** Statuses in which an existing manager entry is still doing something --
+ *  `connectDirect` must leave it alone rather than tearing it down for a
+ *  fresh attempt at the same (normalized) endpoint. */
+const LIVE_CONNECTION_STATUSES = new Set<ConnectionStatus>([
+  'connected',
+  'connecting',
+  'authenticating',
+  'reconnecting',
+]);
+
+/**
+ * Whether an existing manager entry should be torn down and replaced by a
+ * fresh `connectDirect` call to the same connectionId (#682). An
+ * 'error'/'disconnected'/'unreachable' entry is superseded -- e.g. a stale
+ * entry left behind by an earlier connect attempt through a host alias
+ * (`localhost`) is replaced the moment the same daemon is reached through a
+ * different alias (`127.0.0.1`) that normalizes to the same connectionId
+ * (`normalizeConnectionHost`). A still-live entry is left alone so a
+ * duplicate connect call can't interrupt it mid-handshake.
+ */
+export function isConnectionReplaceable(status: ConnectionStatus): boolean {
+  return !LIVE_CONNECTION_STATUSES.has(status);
 }

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -23,9 +23,10 @@ import {
   collectPendingChallengeConnections,
   type ForceReconnectCandidate,
   getOrCreateDeviceId,
+  isConnectionReplaceable,
   planForceReconnect,
 } from './connection-manager-helpers';
-import { splitConnectionId } from '@/lib/connection-id';
+import { normalizeConnectionHost, splitConnectionId } from '@/lib/connection-id';
 import { buildWsUrl, parseHostInput, resolveDaemonPort } from '@/lib/port-discovery';
 import { createAuthResponse, fromBase64, importPublicKey, sign, verify } from '@remi/shared';
 import type { AnswerSelection, ProtocolMessage } from '@remi/shared/protocol.ts';
@@ -191,12 +192,12 @@ export interface UseConnectionManagerReturn {
 export function parseConnectionId(url: string): ConnectionId {
   try {
     const parsed = new URL(url);
-    const host = parsed.hostname || 'localhost';
+    const host = normalizeConnectionHost(parsed.hostname || 'localhost');
     const port = parsed.port || String(DAEMON_BASE_PORT);
     return makeConnectionId(`${host}:${port}`);
   } catch (err) {
     console.warn(`[ConnectionManager] Failed to parse URL "${url}":`, err);
-    return makeConnectionId(url);
+    return makeConnectionId(normalizeConnectionHost(url));
   }
 }
 
@@ -536,13 +537,7 @@ export function useConnectionManager(
       // If already connected/connecting to this host:port, skip
       const existing = connectionsMapRef.current.get(connectionId);
       if (existing) {
-        const s = existing.status;
-        if (
-          s === 'connected' ||
-          s === 'connecting' ||
-          s === 'authenticating' ||
-          s === 'reconnecting'
-        ) {
+        if (!isConnectionReplaceable(existing.status)) {
           return connectionId;
         }
         // Tear down the rest (error / disconnected / unreachable) before reconnecting.

--- a/packages/web/src/lib/connection-banner.ts
+++ b/packages/web/src/lib/connection-banner.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helper for scoping the in-chat connection-error banner to the
+ * connection actually serving the active session (#682).
+ *
+ * Before this fix, the banner was derived globally: `connections.find(c =>
+ * c.status === 'error')`, regardless of which connection the current chat
+ * uses. With more than one daemon connection tracked (a stale/duplicate
+ * entry, or a genuinely separate second daemon), an unrelated errored
+ * connection could pin a "Connection error" banner and disable the chat
+ * input even while the session on screen was fully attached and healthy.
+ */
+
+/** Minimal shape this helper needs from a connection entry. */
+export interface BannerConnectionLike {
+  readonly connectionId: string;
+  readonly status: string;
+  readonly error: string | null;
+}
+
+/**
+ * Derive the connection-error banner text for the chat view. Scoped to the
+ * connection serving `activeConnectionId` (the active session's own
+ * connection) so a healthy attached daemon is never shadowed by a DIFFERENT
+ * daemon's error. Falls back to a global scan across all connections only
+ * when there is no active session to scope to (nothing session-specific to
+ * show yet).
+ */
+export function deriveConnectionBannerError<C extends BannerConnectionLike>(
+  connections: readonly C[],
+  activeConnectionId: string | null,
+): string | null {
+  if (activeConnectionId != null) {
+    const active = connections.find((c) => c.connectionId === activeConnectionId);
+    // No entry for the active session's connection, or it isn't errored:
+    // there is nothing session-specific to surface. Deliberately does NOT
+    // fall back to a global scan here -- a sibling daemon's error must never
+    // bleed into a session it doesn't serve.
+    if (!active || active.status !== 'error') return null;
+    return active.error ?? `Connection error: ${active.connectionId}`;
+  }
+
+  const errored = connections.find((c) => c.status === 'error');
+  if (!errored) return null;
+  return errored.error ?? `Connection error: ${errored.connectionId}`;
+}

--- a/packages/web/src/lib/connection-id.ts
+++ b/packages/web/src/lib/connection-id.ts
@@ -24,3 +24,48 @@ export function splitConnectionId(connectionId: ConnectionId): {
   const port = Number.parseInt(match[2] ?? '', 10);
   return { host: match[1] ?? raw, port: Number.isNaN(port) ? null : port };
 }
+
+/**
+ * Loopback host aliases that address the SAME daemon (#682). Without
+ * normalization, a `localhost` URL persisted from an earlier connect and a
+ * `127.0.0.1` URL typed later into the Connect modal produce two independent
+ * manager entries for one physical daemon; a stale/errored one can then end
+ * up driving the global error banner even while the other is healthy and
+ * attached. Collapsing every alias to one canonical form makes `parseConnectionId`
+ * return the identical `ConnectionId` for all of them, so `connectDirect`'s
+ * Map (keyed by `ConnectionId`) can never hold two entries for the same daemon.
+ */
+const LOOPBACK_HOST_ALIASES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+const CANONICAL_LOOPBACK_HOST = '127.0.0.1';
+
+/**
+ * Normalize a hostname for connectionId purposes: lowercase (hostnames are
+ * case-insensitive) and collapse loopback aliases to one canonical form. Only
+ * affects the bookkeeping key -- the actual WebSocket URL used for the
+ * transport is untouched, so this doesn't change which address is dialed.
+ */
+export function normalizeConnectionHost(host: string): string {
+  const lower = host.toLowerCase();
+  return LOOPBACK_HOST_ALIASES.has(lower) ? CANONICAL_LOOPBACK_HOST : lower;
+}
+
+/**
+ * Reconcile a persisted list of connection URLs (`remi-connections`) to one
+ * entry per normalized endpoint (#682). Two URL strings that normalize to the
+ * same connectionId -- e.g. a `localhost` URL saved in an earlier session
+ * alongside a `127.0.0.1` URL typed later -- must not both be retried on
+ * every launch; the LAST occurrence wins, since it reflects the most recent
+ * explicit connect. `toConnectionId` is injected (rather than imported)
+ * so this stays a leaf-level pure function with no dependency on the
+ * connection-manager hook.
+ */
+export function dedupeConnectionUrls(
+  urls: readonly string[],
+  toConnectionId: (url: string) => string,
+): string[] {
+  const byKey = new Map<string, string>();
+  for (const url of urls) {
+    byKey.set(toConnectionId(url), url);
+  }
+  return [...byKey.values()];
+}

--- a/packages/web/tests/lib/connection-banner.test.ts
+++ b/packages/web/tests/lib/connection-banner.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for deriveConnectionBannerError (#682). Pure function; no mocks.
+ *
+ * Before this fix, the in-chat error banner was derived globally
+ * (`connections.find(c => c.status === 'error')`), so an unrelated errored
+ * or duplicate manager entry could pin a "Connection error" banner even
+ * while the connection actually serving the active session was healthy and
+ * attached. This scopes the banner to the active session's own connection.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type BannerConnectionLike,
+  deriveConnectionBannerError,
+} from '../../src/lib/connection-banner';
+
+function conn(
+  connectionId: string,
+  status: string,
+  error: string | null = null,
+): BannerConnectionLike {
+  return { connectionId, status, error };
+}
+
+describe('deriveConnectionBannerError (#682)', () => {
+  test('active session healthy + a DIFFERENT connection errored -> no banner', () => {
+    const connections = [conn('healthy:1', 'connected'), conn('stale:2', 'error')];
+    expect(deriveConnectionBannerError(connections, 'healthy:1')).toBeNull();
+  });
+
+  test('active session itself errored -> banner with its own error message', () => {
+    const connections = [conn('bad:1', 'error', 'boom')];
+    expect(deriveConnectionBannerError(connections, 'bad:1')).toBe('boom');
+  });
+
+  test('active session errored with no explicit error message -> fallback text', () => {
+    const connections = [conn('bad:1', 'error')];
+    expect(deriveConnectionBannerError(connections, 'bad:1')).toBe('Connection error: bad:1');
+  });
+
+  test('no active session (null) falls back to a global scan', () => {
+    const connections = [conn('a:1', 'connected'), conn('b:2', 'error', 'daemon unreachable')];
+    expect(deriveConnectionBannerError(connections, null)).toBe('daemon unreachable');
+  });
+
+  test('no active session and nothing errored -> null', () => {
+    const connections = [conn('a:1', 'connected'), conn('b:2', 'connecting')];
+    expect(deriveConnectionBannerError(connections, null)).toBeNull();
+  });
+
+  test('active connectionId has no matching entry -> null, not a global fallback', () => {
+    // A sibling daemon erroring must never bleed into a session whose own
+    // connection entry is simply missing/gone.
+    const connections = [conn('other:1', 'error')];
+    expect(deriveConnectionBannerError(connections, 'missing:9')).toBeNull();
+  });
+
+  test('multiple errored siblings are all ignored when the active connection is healthy', () => {
+    const connections = [
+      conn('healthy:1', 'connected'),
+      conn('stale:2', 'error'),
+      conn('stale:3', 'error'),
+    ];
+    expect(deriveConnectionBannerError(connections, 'healthy:1')).toBeNull();
+  });
+
+  test('empty connections list -> null regardless of activeConnectionId', () => {
+    expect(deriveConnectionBannerError([], 'anything:1')).toBeNull();
+    expect(deriveConnectionBannerError([], null)).toBeNull();
+  });
+});

--- a/packages/web/tests/lib/connection-id.test.ts
+++ b/packages/web/tests/lib/connection-id.test.ts
@@ -2,10 +2,20 @@
  * Tests for splitConnectionId (#435 Phase 1 / P3). Pure function; no mocks.
  * This is the host/port extraction that feeds resolveDaemonPort in the
  * reconnect-escalation path, so its IPv6 handling must be correct.
+ *
+ * Also covers normalizeConnectionHost and dedupeConnectionUrls (#682): the
+ * host-alias normalization that keeps two connect attempts at the same
+ * physical daemon (e.g. 'localhost' vs '127.0.0.1') from producing two
+ * independent manager entries -- one of which can end up stale/errored and
+ * incorrectly drive the global connection banner.
  */
 
 import { describe, expect, test } from 'bun:test';
-import { splitConnectionId } from '../../src/lib/connection-id';
+import {
+  dedupeConnectionUrls,
+  normalizeConnectionHost,
+  splitConnectionId,
+} from '../../src/lib/connection-id';
 import type { ConnectionId } from '../../src/types';
 
 const cid = (s: string) => s as ConnectionId;
@@ -36,5 +46,77 @@ describe('splitConnectionId', () => {
 
   test('trailing non-numeric suffix is not treated as a port', () => {
     expect(splitConnectionId(cid('localhost:abc'))).toEqual({ host: 'localhost:abc', port: null });
+  });
+});
+
+describe('normalizeConnectionHost (#682)', () => {
+  test('collapses localhost and 127.0.0.1 to the same canonical host', () => {
+    expect(normalizeConnectionHost('localhost')).toBe('127.0.0.1');
+    expect(normalizeConnectionHost('127.0.0.1')).toBe('127.0.0.1');
+  });
+
+  test('collapses IPv6 loopback aliases (bracketed and unbracketed) too', () => {
+    expect(normalizeConnectionHost('::1')).toBe('127.0.0.1');
+    expect(normalizeConnectionHost('[::1]')).toBe('127.0.0.1');
+  });
+
+  test('is case-insensitive for loopback aliases', () => {
+    expect(normalizeConnectionHost('LOCALHOST')).toBe('127.0.0.1');
+    expect(normalizeConnectionHost('LocalHost')).toBe('127.0.0.1');
+  });
+
+  test('lowercases (but otherwise leaves alone) a non-loopback hostname', () => {
+    expect(normalizeConnectionHost('MyHost.Local')).toBe('myhost.local');
+  });
+
+  test('leaves a LAN IP untouched (already lowercase, not a loopback alias)', () => {
+    expect(normalizeConnectionHost('192.168.1.5')).toBe('192.168.1.5');
+  });
+});
+
+describe('dedupeConnectionUrls (#682)', () => {
+  // Fake keying function: strips everything but "host:port" so tests don't
+  // need the real parseConnectionId (which lives in useConnectionManager and
+  // would pull React/WebSocket deps into this pure-function test).
+  const toKey = (url: string): string => {
+    const parsed = new URL(url);
+    const host = normalizeConnectionHost(parsed.hostname);
+    return `${host}:${parsed.port}`;
+  };
+
+  test('collapses alias URLs for the same daemon, keeping the LAST one', () => {
+    const result = dedupeConnectionUrls(
+      ['ws://localhost:18765/ws', 'ws://127.0.0.1:18765/ws'],
+      toKey,
+    );
+    expect(result).toEqual(['ws://127.0.0.1:18765/ws']);
+  });
+
+  test('leaves distinct daemons alone, preserving first-seen order', () => {
+    const urls = ['ws://localhost:18765/ws', 'ws://192.168.1.5:18770/ws'];
+    expect(dedupeConnectionUrls(urls, toKey)).toEqual(urls);
+  });
+
+  test('a later duplicate replaces an earlier one in place (order preserved)', () => {
+    const result = dedupeConnectionUrls(
+      [
+        'ws://localhost:18765/ws',
+        'ws://192.168.1.5:18770/ws',
+        'ws://127.0.0.1:18765/ws',
+      ],
+      toKey,
+    );
+    // The localhost/127.0.0.1 pair collapses to one entry that keeps its
+    // ORIGINAL position (first), but with the LATEST url string.
+    expect(result).toEqual(['ws://127.0.0.1:18765/ws', 'ws://192.168.1.5:18770/ws']);
+  });
+
+  test('returns an empty array for empty input', () => {
+    expect(dedupeConnectionUrls([], toKey)).toEqual([]);
+  });
+
+  test('no-op when there are no duplicates', () => {
+    const urls = ['ws://192.168.1.5:18770/ws'];
+    expect(dedupeConnectionUrls(urls, toKey)).toEqual(urls);
   });
 });

--- a/packages/web/tests/lib/connection-manager.test.ts
+++ b/packages/web/tests/lib/connection-manager.test.ts
@@ -14,6 +14,7 @@ import {
   DEVICE_ID_STORAGE_KEY,
   type ForceReconnectCandidate,
   getOrCreateDeviceId,
+  isConnectionReplaceable,
   type KeyValueStorage,
   planForceReconnect,
 } from '../../src/hooks/connection-manager-helpers';
@@ -296,5 +297,42 @@ describe('allocateStaggerSlot (#685 review: bounded, collision-free per-connecti
     const used = new Set<number>([0, 1, 2]);
     used.clear();
     expect(allocateStaggerSlot(used)).toBe(0);
+  });
+});
+
+/**
+ * Coverage for #682: `connectDirect` must supersede a stale/errored manager
+ * entry when a fresh connect attempt targets the same connectionId (e.g. the
+ * same daemon reached through a different host alias that
+ * `normalizeConnectionHost` collapses to one key), but must never interrupt
+ * an entry that's already live.
+ */
+describe('isConnectionReplaceable (#682)', () => {
+  test('an errored entry is replaceable (superseded by a fresh connect)', () => {
+    expect(isConnectionReplaceable('error')).toBe(true);
+  });
+
+  test('a disconnected entry is replaceable', () => {
+    expect(isConnectionReplaceable('disconnected')).toBe(true);
+  });
+
+  test('an unreachable entry is replaceable', () => {
+    expect(isConnectionReplaceable('unreachable')).toBe(true);
+  });
+
+  test('a connected entry is NOT replaceable', () => {
+    expect(isConnectionReplaceable('connected')).toBe(false);
+  });
+
+  test('a connecting entry is NOT replaceable', () => {
+    expect(isConnectionReplaceable('connecting')).toBe(false);
+  });
+
+  test('an authenticating entry is NOT replaceable', () => {
+    expect(isConnectionReplaceable('authenticating')).toBe(false);
+  });
+
+  test('a reconnecting entry is NOT replaceable', () => {
+    expect(isConnectionReplaceable('reconnecting')).toBe(false);
   });
 });


### PR DESCRIPTION
## Mechanism

Root cause traced to `parseConnectionId` in `packages/web/src/hooks/useConnectionManager.ts:191` keying manager entries on the raw hostname from the connect URL, with no alias normalization. A daemon reached via `localhost` (e.g. a URL persisted from an earlier session, or the ConnectModal's default host value) and the SAME daemon reached via `127.0.0.1` (e.g. typed explicitly into the Connect modal) produced two independent `ManagedConnection` entries in `connectDirect`'s Map, keyed `localhost:<port>` and `127.0.0.1:<port>` respectively -- even though both address the identical physical daemon.

Two user-visible bugs followed from that:
1. `App.tsx`'s global error banner (`connections.find(c => c.status === 'error')`) picked up the stale/errored duplicate entry regardless of which connection the active session actually used, showing "Connection error: ..." even while the healthy duplicate was attached.
2. The same duplication could leave the active session's own `connectionId` field pointing at the wrong (errored) entry, since `session_list_response` merge logic (`session-dedup.ts`) intentionally keeps sessions from different `connectionId`s as separate rows (by design, for genuinely different daemons) -- it can't tell a host alias apart from a real second daemon.

## What changed

- `packages/web/src/lib/connection-id.ts`: added `normalizeConnectionHost` (collapses `localhost`/`127.0.0.1`/`::1`/`[::1]` to one canonical host, case-insensitive) and `dedupeConnectionUrls` (reconciles a list of connect URLs to one per normalized connectionId, keeping the last occurrence).
- `packages/web/src/hooks/useConnectionManager.ts`: `parseConnectionId` now normalizes the host before building the `ConnectionId` key, so `connectDirect`'s Map can never hold two entries for the same daemon regardless of which alias was used to reach it.
- `packages/web/src/hooks/connection-manager-helpers.ts`: extracted `isConnectionReplaceable(status)` from `connectDirect`'s inline check -- an `error`/`disconnected`/`unreachable` entry is superseded by a fresh connect attempt at the same (now-normalized) key; a live entry (`connected`/`connecting`/`authenticating`/`reconnecting`) is left alone.
- `packages/web/src/App.tsx`: the `remi-connections` localStorage list is deduped by normalized connectionId both on load (writing back if it changed) and whenever a new URL is persisted in `handleConnectDirect`, so alias duplicates don't keep piling up across restarts.
- `packages/web/src/lib/connection-banner.ts` (new): `deriveConnectionBannerError` scopes the chat-view error banner to the connection serving the ACTIVE session, falling back to a global scan only when no session is active. Wired into the `ChatView` `error` prop as a new `chatError` value; the `ConnectModal`'s own `error`/`effectiveStatus` props are left as the existing global scan since that's about the connection the user just attempted, not a specific chat session.

## Testing

- New/updated unit tests (no mocks): `packages/web/tests/lib/connection-id.test.ts` (`normalizeConnectionHost`, `dedupeConnectionUrls`), `packages/web/tests/lib/connection-manager.test.ts` (`isConnectionReplaceable`), `packages/web/tests/lib/connection-banner.test.ts` (new, `deriveConnectionBannerError`).
- `bun run typecheck` clean.
- `bunx eslint` on touched files: 0 new errors (2 pre-existing warnings in an untouched effect in `useConnectionManager.ts`).
- `cd packages/web && bun run build`: succeeds.
- `bun test packages/web`: 332 pass, 0 fail (up from the pre-existing baseline; all new tests included).

Not yet re-validated live on-device against the original repro; flagging for on-device retest before merge per the project's usual practice for connection-flow fixes.

Closes #682