### PR TITLE
fix(#687): merge unconfirmed messages back after resync

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -83,6 +83,13 @@ const LOCALSTORAGE_SESSION_DAEMONS_KEY = 'remi-session-daemons';
 // so this comfortably covers a real catch-up burst without mistaking a much
 // later, genuinely new turn for part of the same resync.
 const RESYNC_FLUSH_DEBOUNCE_MS = 1500;
+// Hard ceiling on how long survivors can sit stashed (armed once, at the
+// first stash for a session -- not reset by the debounce). Without this, a
+// session that keeps streaming transcript_content (e.g. a long mid-turn
+// response arriving as a live-watcher reload, which never sends
+// transcript_load_complete) re-arms RESYNC_FLUSH_DEBOUNCE_MS forever and the
+// failed bubble + Retry stay invisible for the whole turn (#687 review).
+const RESYNC_MAX_STASH_AGE_MS = 10000;
 
 /**
  * Narrow an unknown JSON value to a non-empty string. Used at the
@@ -273,18 +280,28 @@ function App() {
   // Unconfirmed messages stashed by clearSessionForRebind, keyed by session
   // id, awaiting re-merge into the freshly reloaded transcript (#687).
   const resyncSurvivorsRef = useRef<Map<UUID, readonly UIMessage[]>>(new Map());
+  // Debounced flush: re-armed on every transcript_content for the session.
   const resyncFlushTimersRef = useRef<Map<UUID, ReturnType<typeof setTimeout>>>(new Map());
+  // Hard-ceiling flush: armed once, at the first stash, never reset. Whichever
+  // of transcript_load_complete / debounce-quiet / this cap fires first wins
+  // (flushResyncSurvivors' delete-first guard makes the other two safe no-ops).
+  const resyncMaxAgeTimersRef = useRef<Map<UUID, ReturnType<typeof setTimeout>>>(new Map());
 
   // Flush timers must not outlive the component (React 18 StrictMode
   // double-invokes effects in dev, which would otherwise leak a duplicate
   // set of timers).
   useEffect(() => {
-    const timers = resyncFlushTimersRef.current;
+    const flushTimers = resyncFlushTimersRef.current;
+    const maxAgeTimers = resyncMaxAgeTimersRef.current;
     return () => {
-      for (const timer of timers.values()) {
+      for (const timer of flushTimers.values()) {
         clearTimeout(timer);
       }
-      timers.clear();
+      flushTimers.clear();
+      for (const timer of maxAgeTimers.values()) {
+        clearTimeout(timer);
+      }
+      maxAgeTimers.clear();
     };
   }, []);
 
@@ -308,24 +325,45 @@ function App() {
 
   // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
   const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
+    // Cancel and forget both resync timers for `sid`, if any -- shared by
+    // flushResyncSurvivors (a trigger just fired) and discardResyncStash (the
+    // session is gone, no trigger will ever fire).
+    const clearResyncTimers = (sid: UUID) => {
+      const flushTimer = resyncFlushTimersRef.current.get(sid);
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        resyncFlushTimersRef.current.delete(sid);
+      }
+      const maxAgeTimer = resyncMaxAgeTimersRef.current.get(sid);
+      if (maxAgeTimer) {
+        clearTimeout(maxAgeTimer);
+        resyncMaxAgeTimersRef.current.delete(sid);
+      }
+    };
+
     // Re-attach any unconfirmed messages stashed for `sid` by
     // clearSessionForRebind, now that a fresh reload has landed (#687).
-    // Cancels the fallback debounce timer since this call already IS the
-    // flush; idempotent no-op if nothing is pending.
+    // Cancels both resync timers since this call already IS the flush;
+    // idempotent no-op if nothing is pending (safe to call from more than
+    // one trigger -- see clearSessionForRebind).
     const flushResyncSurvivors = (sid: UUID) => {
       const survivors = resyncSurvivorsRef.current.get(sid);
       if (!survivors) return;
       resyncSurvivorsRef.current.delete(sid);
-      const timer = resyncFlushTimersRef.current.get(sid);
-      if (timer) {
-        clearTimeout(timer);
-        resyncFlushTimersRef.current.delete(sid);
-      }
+      clearResyncTimers(sid);
       setMessages((prev) => {
         const reloaded = prev.filter((m) => m.sessionId === sid);
         const others = prev.filter((m) => m.sessionId !== sid);
         return [...others, ...mergeResyncSurvivors(reloaded, survivors)];
       });
+    };
+
+    // The session is gone (kill_session_response success): drop any stashed
+    // survivors and their timers without flushing -- there is no message
+    // slice left to re-insert them into (#687 review finding 3).
+    const discardResyncStash = (sid: UUID) => {
+      resyncSurvivorsRef.current.delete(sid);
+      clearResyncTimers(sid);
     };
 
     // (Re)arm the fallback flush: if no further transcript_content for `sid`
@@ -349,7 +387,16 @@ function App() {
     // forget the loaded-transcript marker so the load gate re-pulls history.
     // Unconfirmed client-only messages (still-sending, unacked, or failed
     // sends and their failure notes) are stashed rather than dropped, so a
-    // resync never silently loses what the user typed (#687).
+    // resync never silently loses what the user typed (#687). Three
+    // independent triggers can flush the stash back in (flushResyncSurvivors'
+    // delete-first guard makes any of them safe to fire after another already
+    // has): transcript_load_complete (explicit "reload done" signal, the
+    // one-shot transcript_load_request path), the debounce below (no further
+    // transcript_content for a quiet period -- the fallback for the
+    // live-watcher reload path, which has no completion signal), and a hard
+    // RESYNC_MAX_STASH_AGE_MS cap armed once, here, so an actively-streaming
+    // session that keeps re-arming the debounce can't starve the flush
+    // indefinitely.
     const clearSessionForRebind = (sid: string) => {
       // Read messagesRef (not a setMessages updater) so the ref mutation +
       // schedule-flush decision below run synchronously against a value we
@@ -367,6 +414,12 @@ function App() {
       loadedTranscriptsRef.current.delete(sid);
       if (resyncSurvivorsRef.current.has(sid as UUID)) {
         scheduleResyncFlush(sid as UUID);
+        if (!resyncMaxAgeTimersRef.current.has(sid as UUID)) {
+          resyncMaxAgeTimersRef.current.set(
+            sid as UUID,
+            setTimeout(() => flushResyncSurvivors(sid as UUID), RESYNC_MAX_STASH_AGE_MS),
+          );
+        }
       }
     };
 
@@ -1055,6 +1108,12 @@ function App() {
         }
         const killedSessionId = pending?.sessionId ?? activeSessionIdRef.current ?? ('' as UUID);
         if (message.success) {
+          // Session torn down: drop any resync stash + timers for it rather
+          // than let a pending flush re-insert messages into a dead session's
+          // slice later (#687 review finding 3).
+          if (killedSessionId) {
+            discardResyncStash(killedSessionId);
+          }
           // Session torn down; refresh the list so the dead session drops off.
           const reqList = requestSessionListRef.current;
           if (reqList) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/message-ack-tracker';
 import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
+import { mergeResyncSurvivors, selectResyncSurvivors } from '@/lib/message-resync';
 import { clearNativeRoute, setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
 import { setSoundEnabled } from '@/lib/notifications';
 import { relayAnswerDirect } from '@/lib/push-answer-relay';
@@ -73,6 +74,15 @@ const LOCALSTORAGE_SETTINGS_KEY = 'remi-settings';
 // cold-start push answers so multi-daemon users do not silently answer the
 // wrong daemon. Issue #389 review.
 const LOCALSTORAGE_SESSION_DAEMONS_KEY = 'remi-session-daemons';
+// A resync wipe (clearSessionForRebind) stashes unconfirmed messages instead
+// of dropping them, then waits this long with no further transcript_content
+// for the session before flushing them back in (#687). A one-shot
+// transcript_load_complete flushes immediately instead of waiting out this
+// window; this is the fallback for the live-watcher reload path, which has
+// no equivalent "done" signal. Local disk reads finish well under a second,
+// so this comfortably covers a real catch-up burst without mistaking a much
+// later, genuinely new turn for part of the same resync.
+const RESYNC_FLUSH_DEBOUNCE_MS = 1500;
 
 /**
  * Narrow an unknown JSON value to a non-empty string. Used at the
@@ -260,6 +270,23 @@ function App() {
   const pendingKillsRef = useRef<
     Map<UUID, { sessionId: UUID; timeoutId: ReturnType<typeof setTimeout> }>
   >(new Map());
+  // Unconfirmed messages stashed by clearSessionForRebind, keyed by session
+  // id, awaiting re-merge into the freshly reloaded transcript (#687).
+  const resyncSurvivorsRef = useRef<Map<UUID, readonly UIMessage[]>>(new Map());
+  const resyncFlushTimersRef = useRef<Map<UUID, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Flush timers must not outlive the component (React 18 StrictMode
+  // double-invokes effects in dev, which would otherwise leak a duplicate
+  // set of timers).
+  useEffect(() => {
+    const timers = resyncFlushTimersRef.current;
+    return () => {
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+      timers.clear();
+    };
+  }, []);
 
   useEffect(() => {
     applyTheme(settings.theme);
@@ -281,14 +308,66 @@ function App() {
 
   // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
   const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
+    // Re-attach any unconfirmed messages stashed for `sid` by
+    // clearSessionForRebind, now that a fresh reload has landed (#687).
+    // Cancels the fallback debounce timer since this call already IS the
+    // flush; idempotent no-op if nothing is pending.
+    const flushResyncSurvivors = (sid: UUID) => {
+      const survivors = resyncSurvivorsRef.current.get(sid);
+      if (!survivors) return;
+      resyncSurvivorsRef.current.delete(sid);
+      const timer = resyncFlushTimersRef.current.get(sid);
+      if (timer) {
+        clearTimeout(timer);
+        resyncFlushTimersRef.current.delete(sid);
+      }
+      setMessages((prev) => {
+        const reloaded = prev.filter((m) => m.sessionId === sid);
+        const others = prev.filter((m) => m.sessionId !== sid);
+        return [...others, ...mergeResyncSurvivors(reloaded, survivors)];
+      });
+    };
+
+    // (Re)arm the fallback flush: if no further transcript_content for `sid`
+    // arrives within the debounce window, flush whatever reloaded so far.
+    // The live-watcher reload path (session_rotated / reconnect-mid-rotation)
+    // has no explicit "done" signal the way the one-shot transcript_load
+    // request/complete pair does, so this is what guarantees survivors are
+    // never stuck in the ref forever (#687).
+    const scheduleResyncFlush = (sid: UUID) => {
+      const existing = resyncFlushTimersRef.current.get(sid);
+      if (existing) clearTimeout(existing);
+      resyncFlushTimersRef.current.set(
+        sid,
+        setTimeout(() => flushResyncSurvivors(sid), RESYNC_FLUSH_DEBOUNCE_MS),
+      );
+    };
+
     // Drop a session's now-orphaned chat so its (new) transcript re-fetches.
     // Shared by session_rotated (live rotation) and hello_ack
     // (reconnect-mid-rotation, #439): both clear stale messages + questions and
     // forget the loaded-transcript marker so the load gate re-pulls history.
+    // Unconfirmed client-only messages (still-sending, unacked, or failed
+    // sends and their failure notes) are stashed rather than dropped, so a
+    // resync never silently loses what the user typed (#687).
     const clearSessionForRebind = (sid: string) => {
+      // Read messagesRef (not a setMessages updater) so the ref mutation +
+      // schedule-flush decision below run synchronously against a value we
+      // control -- a setState updater's execution is deferred by React (and
+      // can run twice under StrictMode), which would make an immediate
+      // `resyncSurvivorsRef.current.has(sid)` check after `setMessages(...)`
+      // see stale (pre-update) ref state.
+      const freshSurvivors = selectResyncSurvivors(messagesRef.current, sid);
+      if (freshSurvivors.length > 0) {
+        const existing = resyncSurvivorsRef.current.get(sid as UUID) ?? [];
+        resyncSurvivorsRef.current.set(sid as UUID, [...existing, ...freshSurvivors]);
+      }
       setMessages((prev) => prev.filter((m) => m.sessionId !== sid));
       setQuestions((prev) => clearSessionQuestions(prev, sid));
       loadedTranscriptsRef.current.delete(sid);
+      if (resyncSurvivorsRef.current.has(sid as UUID)) {
+        scheduleResyncFlush(sid as UUID);
+      }
     };
 
     // Fetch a session's transcript if we haven't already, so that FOLLOWING the
@@ -520,6 +599,12 @@ function App() {
         setSessions((prev) =>
           updateSessionActivity(prev, sessionId, activeSessionIdRef.current, structuredMsg.content),
         );
+        // A resync wipe is stashing survivors for this session (#687): each
+        // arrival re-arms the debounce so the flush waits for the reload
+        // burst to actually quiet down instead of firing mid-burst.
+        if (resyncSurvivorsRef.current.has(sessionId as UUID)) {
+          scheduleResyncFlush(sessionId as UUID);
+        }
         break;
       }
 
@@ -1019,6 +1104,12 @@ function App() {
         setSessions((prev) =>
           prev.map((s) => (s.id === message.sessionId ? { ...s, isLoadingTranscript: false } : s)),
         );
+        // Explicit "reload finished" signal (the one-shot transcript_load_request
+        // path): flush any stashed survivors now rather than waiting out the
+        // debounce (#687).
+        if (resyncSurvivorsRef.current.has(message.sessionId as UUID)) {
+          flushResyncSurvivors(message.sessionId as UUID);
+        }
         break;
       }
 
@@ -2031,6 +2122,9 @@ function App() {
           timestamp: new Date().toISOString(),
           state: 'delivered',
           isEditing: false,
+          // Ties this note to the failed send so a resync merge (#687) keeps
+          // them together -- both survive, or neither does.
+          relatedMessageId: messageId,
         };
         setMessages((prev) => [...prev, errorMsg]);
       }

--- a/packages/web/src/lib/message-resync.ts
+++ b/packages/web/src/lib/message-resync.ts
@@ -1,0 +1,98 @@
+/**
+ * Preserve client-only messages across a transcript resync (#687).
+ *
+ * `clearSessionForRebind` (App.tsx) wipes a session's messages whenever its
+ * Claude binding rotates -- live `/clear` or `/resume` (`session_rotated`),
+ * or a reconnect that discovers the daemon rebuilt the session against a new
+ * Claude process (`hello_ack` + `bindingRotated`, see session-binding.ts).
+ * The wipe exists so the freshly (re)loaded transcript repopulates from a
+ * known-clean slate instead of mixing in stale history from the old Claude
+ * session. That reload is authoritative for anything Claude actually saw --
+ * but a message the user typed while disconnected never reached Claude at
+ * all, so it has no transcript entry to be repopulated by. Wiping
+ * unconditionally is what #687 reports: a 'failed' bubble (and its "Failed
+ * to send" note) vanish with no trace and nothing left to retry.
+ *
+ * `selectResyncSurvivors` identifies exactly those never-confirmed messages
+ * so the caller can hold onto them instead of discarding them; the caller
+ * (App.tsx) stashes them in a ref for the duration of the resync, then calls
+ * `mergeResyncSurvivors` once the fresh reload has landed, re-attaching
+ * whichever survivors didn't turn out to have landed after all.
+ */
+
+import type { UIMessage } from '../types';
+
+/**
+ * A user message counts as "unconfirmed" if the daemon hasn't acked it yet
+ * ('sending', or 'sent' -- #663's post-send/pre-ack state) or the
+ * ack-timeout/immediate-send-failure path gave up on it ('failed'). A
+ * 'delivered' or 'read' message already has a daemon ack; if a rotation
+ * invalidates it, it legitimately belongs to the OLD conversation like any
+ * other pre-rotation history, not to otherwise-unrecoverable user intent.
+ */
+function isUnconfirmedUserMessage(m: UIMessage): boolean {
+  return m.sender === 'user' && (m.state === 'sending' || m.state === 'sent' || m.state === 'failed');
+}
+
+/**
+ * Messages belonging to `sessionId` that must survive a resync wipe:
+ * unconfirmed user sends, plus any system note attached to one via
+ * `relatedMessageId` (e.g. the "Failed to send message" bubble `handleSend`
+ * adds alongside a synchronous send failure). Order is preserved from
+ * `messages`. Returns an empty array when the session has nothing
+ * unconfirmed -- the common case, where the resync wipe is safe as-is.
+ */
+export function selectResyncSurvivors(
+  messages: readonly UIMessage[],
+  sessionId: string,
+): readonly UIMessage[] {
+  const sessionMessages = messages.filter((m) => m.sessionId === sessionId);
+  const unconfirmedIds = new Set(
+    sessionMessages.filter(isUnconfirmedUserMessage).map((m) => m.id),
+  );
+  if (unconfirmedIds.size === 0) return [];
+  return sessionMessages.filter(
+    (m) =>
+      unconfirmedIds.has(m.id) ||
+      (m.relatedMessageId !== undefined && unconfirmedIds.has(m.relatedMessageId)),
+  );
+}
+
+/**
+ * Re-attach `survivors` after a fresh transcript reload. A survivor is
+ * dropped instead of re-attached when it turns out to have landed after all
+ * -- a reloaded message with matching sender+content (the ack or its note
+ * was lost, not the send itself; the daemon's `MessageIdTracker` makes a
+ * same-id retry idempotent, but the reloaded transcript's entry ids are
+ * generated independently of the client's wire message id, so content is
+ * the only correlation available here -- same as the existing optimistic
+ * <-> transcript reconciliation in message-dedup.ts). A system note is kept
+ * only alongside the send it describes, never on its own.
+ *
+ * Ordering: survivors are appended after `reloaded` -- they are
+ * chronologically the newest thing that happened before the resync. If
+ * `reloaded` itself contains something even newer (e.g. a live rotation
+ * racing fresh Claude output), a plain append is accepted rather than
+ * attempting timestamp-perfect interleaving.
+ */
+export function mergeResyncSurvivors(
+  reloaded: readonly UIMessage[],
+  survivors: readonly UIMessage[],
+): readonly UIMessage[] {
+  if (survivors.length === 0) return reloaded;
+
+  const landedByContent = (m: UIMessage) =>
+    reloaded.some((r) => r.sender === m.sender && r.content === m.content);
+
+  const survivingUserIds = new Set(
+    survivors.filter((m) => m.sender === 'user' && !landedByContent(m)).map((m) => m.id),
+  );
+
+  const finalSurvivors = survivors.filter((m) => {
+    if (m.sender === 'user') return survivingUserIds.has(m.id);
+    if (m.relatedMessageId !== undefined) return survivingUserIds.has(m.relatedMessageId);
+    return true;
+  });
+
+  return [...reloaded, ...finalSurvivors];
+}

--- a/packages/web/src/lib/message-resync.ts
+++ b/packages/web/src/lib/message-resync.ts
@@ -59,15 +59,57 @@ export function selectResyncSurvivors(
 }
 
 /**
+ * Allowance for client/server clock drift when deciding whether a reloaded
+ * entry is recent enough to be a candidate match for a survivor's send (see
+ * `mergeResyncSurvivors`). The daemon is reached over a local network, so
+ * drift should be minor, but isn't assumed to be exactly zero.
+ */
+const CLOCK_SKEW_TOLERANCE_MS = 5000;
+
+/**
+ * Indices into `reloaded` that are content-eligible matches for `survivor`:
+ * same sender+content, AND timestamped at or after the survivor's own send
+ * (minus clock-skew tolerance). The timestamp floor is what excludes
+ * unrelated, already-landed history that merely happens to share the same
+ * text (e.g. the user replied "ok" three times earlier in the conversation,
+ * long before this survivor's own, unrelated "ok" was typed) -- a plain
+ * content match with no time bound would misclassify that old, unrelated
+ * send as "this one landed" and drop it.
+ */
+function candidateLandedIndices(survivor: UIMessage, reloaded: readonly UIMessage[]): number[] {
+  const cutoff = Date.parse(survivor.timestamp) - CLOCK_SKEW_TOLERANCE_MS;
+  const indices: number[] = [];
+  reloaded.forEach((r, i) => {
+    if (r.sender === survivor.sender && r.content === survivor.content) {
+      const rTime = Date.parse(r.timestamp);
+      // An unparseable timestamp can't be confirmed as at-or-after the
+      // survivor's send; treat it as not a match rather than risk a false
+      // positive (losing genuine user intent is worse than a rare
+      // stray duplicate).
+      if (!Number.isNaN(rTime) && rTime >= cutoff) indices.push(i);
+    }
+  });
+  return indices;
+}
+
+/**
  * Re-attach `survivors` after a fresh transcript reload. A survivor is
  * dropped instead of re-attached when it turns out to have landed after all
- * -- a reloaded message with matching sender+content (the ack or its note
- * was lost, not the send itself; the daemon's `MessageIdTracker` makes a
- * same-id retry idempotent, but the reloaded transcript's entry ids are
- * generated independently of the client's wire message id, so content is
- * the only correlation available here -- same as the existing optimistic
- * <-> transcript reconciliation in message-dedup.ts). A system note is kept
- * only alongside the send it describes, never on its own.
+ * -- a reloaded message with matching sender+content and a plausible
+ * timestamp (the ack or its note was lost, not the send itself; the
+ * daemon's `MessageIdTracker` makes a same-id retry idempotent, but the
+ * reloaded transcript's entry ids are generated independently of the
+ * client's wire message id, so content is the only correlation available
+ * here -- same as the existing optimistic <-> transcript reconciliation in
+ * message-dedup.ts). A system note is kept only alongside the send it
+ * describes, never on its own.
+ *
+ * Claim discipline: each reloaded entry can satisfy at most one survivor
+ * (first-come, in `survivors` order). Without this, two distinct sends with
+ * identical content -- one landed, one genuinely failed (e.g. the user typed
+ * "continue" twice) -- would BOTH match the single reloaded entry and both
+ * get dropped, reproducing the #687 bug class via duplicate content instead
+ * of via a resync wipe.
  *
  * Ordering: survivors are appended after `reloaded` -- they are
  * chronologically the newest thing that happened before the resync. If
@@ -81,12 +123,20 @@ export function mergeResyncSurvivors(
 ): readonly UIMessage[] {
   if (survivors.length === 0) return reloaded;
 
-  const landedByContent = (m: UIMessage) =>
-    reloaded.some((r) => r.sender === m.sender && r.content === m.content);
+  const claimedReloadedIndices = new Set<number>();
+  const survivingUserIds = new Set<UIMessage['id']>();
 
-  const survivingUserIds = new Set(
-    survivors.filter((m) => m.sender === 'user' && !landedByContent(m)).map((m) => m.id),
-  );
+  for (const m of survivors) {
+    if (m.sender !== 'user') continue;
+    const candidates = candidateLandedIndices(m, reloaded).filter(
+      (i) => !claimedReloadedIndices.has(i),
+    );
+    if (candidates.length > 0) {
+      claimedReloadedIndices.add(candidates[0]);
+    } else {
+      survivingUserIds.add(m.id);
+    }
+  }
 
   const finalSurvivors = survivors.filter((m) => {
     if (m.sender === 'user') return survivingUserIds.has(m.id);

--- a/packages/web/src/lib/message-resync.ts
+++ b/packages/web/src/lib/message-resync.ts
@@ -63,6 +63,18 @@ export function selectResyncSurvivors(
  * entry is recent enough to be a candidate match for a survivor's send (see
  * `mergeResyncSurvivors`). The daemon is reached over a local network, so
  * drift should be minor, but isn't assumed to be exactly zero.
+ *
+ * Known tradeoff: `survivor.timestamp` is the CLIENT's clock (set at
+ * `handleSend`); the reloaded entry's `timestamp` is the DAEMON's clock (from
+ * Claude Code's JSONL `createdAt`). These are two different machines' clocks,
+ * not just network latency -- a remote setup (phone over Wi-Fi/cellular to a
+ * dev machine, rather than same-machine/LAN) can plausibly drift past 5s.
+ * If it does, a genuinely-landed send gets wrongly rejected as a candidate
+ * match and is re-appended as a survivor alongside its own transcript twin:
+ * a non-destructive duplicate bubble (the failed-looking bubble plus its
+ * landed copy), not data loss. That's the accepted failure mode here --
+ * strictly better than the pre-fix behavior of silently dropping the
+ * message entirely.
  */
 const CLOCK_SKEW_TOLERANCE_MS = 5000;
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -131,6 +131,14 @@ export interface UIMessage {
   readonly lastBulletId?: number;
   /** Raw content blocks from transcript (Text, ToolUse, ToolResult) */
   readonly contentBlocks?: readonly import('@remi/shared/protocol.ts').TranscriptContentBlock[];
+  /**
+   * For a `sender: 'system'` note describing a failed send (e.g. "Failed to
+   * send message"): the `id` of the user message it describes. Lets a
+   * resync merge (#687) keep the note attached to its send -- both survive
+   * together, or neither does. Client-only bookkeeping; never sent over the
+   * wire.
+   */
+  readonly relatedMessageId?: UUID;
 }
 
 /** Session information for the UI */

--- a/packages/web/tests/lib/message-resync.test.ts
+++ b/packages/web/tests/lib/message-resync.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'bun:test';
+import { mergeResyncSurvivors, selectResyncSurvivors } from '../../src/lib/message-resync';
+import type { UIMessage } from '../../src/types';
+
+function makeUIMessage(overrides: Partial<UIMessage> = {}): UIMessage {
+  return {
+    id: 'msg-1' as UIMessage['id'],
+    sessionId: 'session-1' as UIMessage['sessionId'],
+    sender: 'user',
+    content: 'hello',
+    timestamp: '2024-01-01T00:00:00Z',
+    state: 'delivered',
+    isEditing: false,
+    ...overrides,
+  };
+}
+
+describe('selectResyncSurvivors', () => {
+  test('empty transcript: no messages for the session returns empty', () => {
+    expect(selectResyncSurvivors([], 'session-1')).toEqual([]);
+  });
+
+  test('a delivered/read message is not a survivor (already confirmed)', () => {
+    const messages = [
+      makeUIMessage({ id: 'm1' as UIMessage['id'], state: 'delivered' }),
+      makeUIMessage({ id: 'm2' as UIMessage['id'], state: 'read' }),
+    ];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([]);
+  });
+
+  test('a failed-only send survives, unrelated agent/system history does not', () => {
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], state: 'failed' });
+    const messages = [
+      makeUIMessage({ id: 'history' as UIMessage['id'], sender: 'agent', state: 'delivered' }),
+      failed,
+    ];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([failed]);
+  });
+
+  test('a failed send with its attached system note keeps both, in order', () => {
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], state: 'failed' });
+    const note = makeUIMessage({
+      id: 'note-1' as UIMessage['id'],
+      sender: 'system',
+      state: 'delivered',
+      content: 'Failed to send message: connection unavailable',
+      relatedMessageId: 'failed-1' as UIMessage['id'],
+    });
+    const messages = [failed, note];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([failed, note]);
+  });
+
+  test('in-flight sending and unacked sent messages both survive', () => {
+    const sending = makeUIMessage({ id: 'sending-1' as UIMessage['id'], state: 'sending' });
+    const sent = makeUIMessage({ id: 'sent-1' as UIMessage['id'], state: 'sent' });
+    const messages = [sending, sent];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([sending, sent]);
+  });
+
+  test('mixed landed (delivered) + failed: only the failed one survives', () => {
+    const delivered = makeUIMessage({ id: 'delivered-1' as UIMessage['id'], state: 'delivered' });
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], state: 'failed' });
+    const messages = [delivered, failed];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([failed]);
+  });
+
+  test('a system note whose related send is NOT a survivor is not pulled in', () => {
+    const note = makeUIMessage({
+      id: 'note-1' as UIMessage['id'],
+      sender: 'system',
+      state: 'delivered',
+      content: 'unrelated note',
+      relatedMessageId: 'some-other-delivered-id' as UIMessage['id'],
+    });
+    const messages = [note];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([]);
+  });
+
+  test('only considers messages for the requested sessionId', () => {
+    const failedHere = makeUIMessage({
+      id: 'failed-here' as UIMessage['id'],
+      sessionId: 'session-1' as UIMessage['sessionId'],
+      state: 'failed',
+    });
+    const failedElsewhere = makeUIMessage({
+      id: 'failed-elsewhere' as UIMessage['id'],
+      sessionId: 'session-2' as UIMessage['sessionId'],
+      state: 'failed',
+    });
+    const messages = [failedHere, failedElsewhere];
+    expect(selectResyncSurvivors(messages, 'session-1')).toEqual([failedHere]);
+  });
+
+  test('an agent message is never a survivor even if in a sending-like state', () => {
+    // Sanity check: only 'user'-sender messages are eligible; agent/system
+    // content is always authoritative from the transcript.
+    const agentMsg = makeUIMessage({
+      id: 'agent-1' as UIMessage['id'],
+      sender: 'agent',
+      state: 'sent' as UIMessage['state'],
+    });
+    expect(selectResyncSurvivors([agentMsg], 'session-1')).toEqual([]);
+  });
+});
+
+describe('mergeResyncSurvivors', () => {
+  test('no survivors: reloaded is returned unchanged', () => {
+    const reloaded = [makeUIMessage({ id: 'r1' as UIMessage['id'] })];
+    expect(mergeResyncSurvivors(reloaded, [])).toEqual(reloaded);
+  });
+
+  test('failed-only survivor is appended after the reloaded transcript', () => {
+    const reloaded = [
+      makeUIMessage({ id: 'r1' as UIMessage['id'], sender: 'agent', content: 'history' }),
+    ];
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], content: 'never sent' });
+    const merged = mergeResyncSurvivors(reloaded, [failed]);
+    expect(merged).toEqual([...reloaded, failed]);
+  });
+
+  test('empty reloaded transcript still appends survivors', () => {
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'] });
+    expect(mergeResyncSurvivors([], [failed])).toEqual([failed]);
+  });
+
+  test('a survivor whose content landed in the reload is deduped, not duplicated', () => {
+    const landed = makeUIMessage({
+      id: 'sent-1' as UIMessage['id'],
+      state: 'sent',
+      content: 'it actually made it',
+    });
+    // The transcript reload has an entry with the same sender+content but a
+    // server-generated id -- the ack was lost, not the send.
+    const reloadedEquivalent = makeUIMessage({
+      id: 'transcript-entry-9' as UIMessage['id'],
+      sender: 'user',
+      content: 'it actually made it',
+      state: 'read',
+      entryUuid: 'entry-9',
+    });
+    const merged = mergeResyncSurvivors([reloadedEquivalent], [landed]);
+    expect(merged).toEqual([reloadedEquivalent]);
+  });
+
+  test('mixed landed + failed: landed is deduped, failed survives', () => {
+    const landed = makeUIMessage({
+      id: 'sent-1' as UIMessage['id'],
+      state: 'sent',
+      content: 'landed after all',
+    });
+    const failed = makeUIMessage({
+      id: 'failed-1' as UIMessage['id'],
+      state: 'failed',
+      content: 'never made it',
+    });
+    const reloadedEquivalent = makeUIMessage({
+      id: 'transcript-entry-1' as UIMessage['id'],
+      content: 'landed after all',
+      state: 'read',
+      entryUuid: 'entry-1',
+    });
+    const merged = mergeResyncSurvivors([reloadedEquivalent], [landed, failed]);
+    expect(merged).toEqual([reloadedEquivalent, failed]);
+  });
+
+  test('a failed send + its note both dropped when the send turns out to have landed', () => {
+    const landed = makeUIMessage({
+      id: 'sent-1' as UIMessage['id'],
+      state: 'sent',
+      content: 'landed after all',
+    });
+    const note = makeUIMessage({
+      id: 'note-1' as UIMessage['id'],
+      sender: 'system',
+      content: 'Failed to send message: connection unavailable',
+      relatedMessageId: 'sent-1' as UIMessage['id'],
+    });
+    const reloadedEquivalent = makeUIMessage({
+      id: 'transcript-entry-1' as UIMessage['id'],
+      content: 'landed after all',
+      state: 'read',
+      entryUuid: 'entry-1',
+    });
+    const merged = mergeResyncSurvivors([reloadedEquivalent], [landed, note]);
+    expect(merged).toEqual([reloadedEquivalent]);
+  });
+
+  test('a failed send + its note both survive together when the send never landed', () => {
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], state: 'failed' });
+    const note = makeUIMessage({
+      id: 'note-1' as UIMessage['id'],
+      sender: 'system',
+      content: 'Failed to send message: connection unavailable',
+      relatedMessageId: 'failed-1' as UIMessage['id'],
+    });
+    const reloaded = [makeUIMessage({ id: 'r1' as UIMessage['id'], sender: 'agent' })];
+    const merged = mergeResyncSurvivors(reloaded, [failed, note]);
+    expect(merged).toEqual([...reloaded, failed, note]);
+  });
+
+  test('retry-after-merge lookup: the survivor keeps its original id post-merge', () => {
+    const failed = makeUIMessage({ id: 'failed-1' as UIMessage['id'], state: 'failed' });
+    const merged = mergeResyncSurvivors([], [failed]);
+    const lookedUp = merged.find((m) => m.id === 'failed-1');
+    expect(lookedUp).toEqual(failed);
+  });
+
+  test('preserves relative order of multiple survivors', () => {
+    const first = makeUIMessage({ id: 'a' as UIMessage['id'], content: 'first', state: 'failed' });
+    const second = makeUIMessage({
+      id: 'b' as UIMessage['id'],
+      content: 'second',
+      state: 'sending',
+    });
+    const merged = mergeResyncSurvivors([], [first, second]);
+    expect(merged).toEqual([first, second]);
+  });
+});

--- a/packages/web/tests/lib/message-resync.test.ts
+++ b/packages/web/tests/lib/message-resync.test.ts
@@ -163,6 +163,64 @@ describe('mergeResyncSurvivors', () => {
     expect(merged).toEqual([reloadedEquivalent, failed]);
   });
 
+  test('claim discipline: 2 survivors with identical content vs 1 reloaded entry -- only one is deduped', () => {
+    // Two distinct sends, same text (e.g. the user typed "continue" twice):
+    // one landed, one genuinely failed. A plain "does some reloaded entry
+    // match this content" check (no claim discipline) would match BOTH
+    // survivors against the single reloaded entry and drop both -- silently
+    // losing the one that really did fail.
+    const first = makeUIMessage({
+      id: 'attempt-1' as UIMessage['id'],
+      state: 'sent',
+      content: 'continue',
+      timestamp: '2024-01-01T00:00:00Z',
+    });
+    const second = makeUIMessage({
+      id: 'attempt-2' as UIMessage['id'],
+      state: 'failed',
+      content: 'continue',
+      timestamp: '2024-01-01T00:00:05Z',
+    });
+    const reloadedEquivalent = makeUIMessage({
+      id: 'transcript-entry-1' as UIMessage['id'],
+      content: 'continue',
+      state: 'read',
+      entryUuid: 'entry-1',
+      timestamp: '2024-01-01T00:00:01Z',
+    });
+    const merged = mergeResyncSurvivors([reloadedEquivalent], [first, second]);
+    // Exactly one of the two identical-content survivors is claimed by the
+    // single reloaded entry; the other is preserved, not silently dropped.
+    expect(merged).toHaveLength(2);
+    expect(merged).toContainEqual(reloadedEquivalent);
+    const remainingSurvivor = merged.find((m) => m.id !== reloadedEquivalent.id);
+    expect(remainingSurvivor).toBeDefined();
+    expect([first, second].some((s) => s.id === remainingSurvivor?.id)).toBe(true);
+  });
+
+  test('a failed survivor is NOT deduped against an unrelated earlier landed message with the same content', () => {
+    // The conversation already has an OLDER, already-landed "ok" (sent long
+    // before the outage). This survivor's own "ok" is a separate, later,
+    // genuinely-failed attempt that merely happens to share the same text --
+    // it must not be misclassified as "the same send that already landed".
+    const earlierLanded = makeUIMessage({
+      id: 'transcript-entry-old' as UIMessage['id'],
+      content: 'ok',
+      state: 'read',
+      entryUuid: 'entry-old',
+      timestamp: '2024-01-01T00:00:00Z',
+    });
+    const failed = makeUIMessage({
+      id: 'failed-1' as UIMessage['id'],
+      state: 'failed',
+      content: 'ok',
+      // Well after the earlier landed message -- not a plausible match for it.
+      timestamp: '2024-01-01T01:00:00Z',
+    });
+    const merged = mergeResyncSurvivors([earlierLanded], [failed]);
+    expect(merged).toEqual([earlierLanded, failed]);
+  });
+
   test('a failed send + its note both dropped when the send turns out to have landed', () => {
     const landed = makeUIMessage({
       id: 'sent-1' as UIMessage['id'],


### PR DESCRIPTION
## Summary

`clearSessionForRebind` (`App.tsx`) wipes a session's messages whenever its Claude binding rotates -- a live `/clear`/`/resume` (`session_rotated`), or a reconnect that discovers the daemon rebuilt the session against a new Claude process (`hello_ack` + `bindingRotated`). The wipe is unconditional today: it also drops client-only messages that never reached Claude at all -- a 'sending'/'sent' (unacked) or 'failed' send, and its attached "Failed to send message" note (#679's ack/failed states). The fresh transcript reload that follows has no record of them (they were never in the JSONL), so they vanish with nothing left to retry -- exactly the repro in #687 (kill the daemon, send a message so it flips to `failed` + Retry, restart the daemon, reconnect: the bubble and its note are gone).

## Mechanism

- **`packages/web/src/lib/message-resync.ts`** (new, pure, unit-tested):
  - `selectResyncSurvivors(messages, sessionId)` -- picks out unconfirmed user messages (`'sending'`/`'sent'`/`'failed'`) plus any system note attached to one via a new `relatedMessageId` field.
  - `mergeResyncSurvivors(reloaded, survivors)` -- re-attaches survivors after the reloaded transcript. Dedup uses **claim discipline**: each reloaded entry can satisfy at most one survivor (first-come), so two distinct sends with identical content (one landed, one genuinely failed -- e.g. the user typed "continue" twice) don't both match the same reloaded entry and both get dropped. A candidate match additionally requires the reloaded entry's timestamp to be at-or-after the survivor's own send time (minus a clock-skew tolerance), so an unrelated, already-landed message earlier in history that merely shares the same text can't falsely claim a later failed survivor. A system note only survives alongside the send it describes.
- **`packages/web/src/types/index.ts`**: `UIMessage.relatedMessageId?: UUID` -- client-only bookkeeping field linking a failed-send system note back to the message it describes.
- **`packages/web/src/App.tsx`**:
  - `clearSessionForRebind` now stashes survivors (computed from `messagesRef.current`, not a `setMessages` updater -- avoids a StrictMode/deferred-update timing hazard) into a ref keyed by session id, instead of dropping them.
  - Survivors flush back via whichever of three triggers fires first (`flushResyncSurvivors`'s delete-first guard makes the others safe no-ops after one fires): `transcript_load_complete` (the one-shot `transcript_load_request` path's explicit "done" signal), a `1500ms` debounce with no further `transcript_content` for the session (fallback for the live-watcher reload path used by `session_rotated`/reconnect, which has no equivalent "done" event; re-arms on every arrival), or a hard `10s` cap armed once at the first stash (so an actively-streaming session that keeps re-arming the debounce can't starve the flush for the whole turn).
  - `kill_session_response` (success) now discards a killed session's resync stash + timers via `discardResyncStash` so a pending flush can't re-insert messages into a dead session's slice.
  - `handleSend`'s synchronous-failure branch now tags its "Failed to send message" note with `relatedMessageId: messageId`.

Ordering: survivors are appended after the reloaded transcript (documented in `message-resync.ts`) -- they're chronologically the newest thing that happened before the resync. If the reload itself contains something even newer (e.g. a live rotation racing fresh Claude output, or a brand new send during the narrow pre-flush window), a plain append is accepted rather than attempting timestamp-perfect interleaving.

The SIGSTOP/ack-timeout path (`sweepTimeouts`, live-validated in #679) is untouched -- it never calls `clearSessionForRebind` (no reconnect/rebind happens), so none of this new code path is exercised by it.

## Known limitations

- The landed-match timestamp check compares two different machines' clocks: `survivor.timestamp` is the **client's** clock (set at `handleSend`), while the reloaded entry's `timestamp` is the **daemon's** clock (Claude Code's JSONL `createdAt`). On a remote setup (phone over Wi-Fi/cellular to a dev machine, rather than same-machine/LAN) drift can plausibly exceed the `5s` tolerance. If it does, a genuinely-landed send is wrongly rejected as a candidate match and gets re-appended as a survivor alongside its own transcript twin -- a non-destructive duplicate bubble (the failed-looking bubble plus its landed copy), not data loss. Accepted as strictly better than the pre-fix behavior of silently dropping the message.
- Two stash-discard coverage gaps (`evictIfActive` phantom-session eviction, and `handleClearMessages`) are tracked separately as a follow-up (#705) -- not addressed in this PR.
- The `hello_ack` stale-session eviction wipe (`App.tsx` ~497-505) has the same unconditional-wipe failure mode via a different trigger; out of scope here, being filed as its own follow-up issue by the reviewer.

## Testing

- New unit tests: `packages/web/tests/lib/message-resync.test.ts` (20 tests) -- failed-only, mixed landed+failed dedup, in-flight sending/sent, empty transcript, note-without-related-send, cross-session isolation, retry-after-merge id lookup, multi-survivor ordering, claim discipline (2 identical-content survivors vs 1 reloaded entry), and the unrelated-earlier-landed-message-with-same-content case.
- `bun run typecheck` (root): clean.
- `cd packages/web && bunx eslint src tests`: same pre-existing errors/warnings as unmodified `develop` (`InputArea.tsx`, `message-filter.ts`, `useConnectionManager.ts`); none introduced by this change, none in touched files.
- `cd packages/web && bun run build`: clean.
- `bun test packages/web packages/shared`: 558 pass, 0 fail (no regression, including `message-ack-tracker.test.ts` and `message-dedup.test.ts`).

Closes #687
