### PR TITLE
fix(#681): thread messageId through NOT_ACTIVE_CONNECTION

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -72,13 +72,16 @@ export interface AdapterEvents {
   /** Connection closed */
   onDisconnect: (connectionId: UUID, reason: string) => void;
 
-  /** User input received */
+  /** User input received. `messageId` is the wire message's own id (#681),
+   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
+   *  specific bubble that was dropped. */
   onUserInput: (
     connectionId: UUID,
     sessionId: UUID,
     content: string,
     raw?: boolean,
     claudeSessionId?: UUID,
+    messageId?: UUID,
   ) => void;
 
   /** Answer to question received. `extra` carries structured AskUserQuestion

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -111,8 +111,15 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (connectionId, sessionId, content, raw, claudeSessionId) => {
-        this.events.onUserInput?.(connectionId, sessionId, content, raw, claudeSessionId);
+      onUserInput: (connectionId, sessionId, content, raw, claudeSessionId, messageId) => {
+        this.events.onUserInput?.(
+          connectionId,
+          sessionId,
+          content,
+          raw,
+          claudeSessionId,
+          messageId,
+        );
       },
 
       onAnswer: (connectionId, sessionId, questionId, answer, claudeSessionId, extra) => {

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -547,6 +547,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       content: string,
       raw?: boolean,
       claudeSessionId?: UUID,
+      messageId?: UUID,
     ): Promise<void> => {
       log(`User input from ${connectionId}${raw ? ' (raw)' : ''}: ${content}`);
 
@@ -569,7 +570,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
             ? createError(
                 'NOT_ACTIVE_CONNECTION',
                 'This connection is read-only (another connection holds the session); input was not delivered.',
-                { sessionId },
+                // #681: carry the rejected input's own message id so the client
+                // can flip that SPECIFIC bubble to 'failed' -- the daemon acks
+                // user_input unconditionally before this check runs (connection.ts
+                // handleUserInput), so the sender otherwise sees a false
+                // "delivered" with only the read-only banner as a signal.
+                { sessionId, ...(messageId !== undefined && { messageId }) },
               )
             : createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
         );

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -337,12 +337,14 @@ export class RelayAdapter implements ConnectionAdapter {
         }
         const claudeId =
           typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
+        const messageId = typeof msg['id'] === 'string' ? msg['id'] : undefined;
         this.events.onUserInput?.(
           connectionId,
           msg['sessionId'],
           msg['content'],
           msg['raw'] === true,
           claudeId,
+          messageId,
         );
         break;
       }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -60,8 +60,16 @@ export interface ConnectionEvents {
   /** Connection closed */
   onDisconnect: (reason: string) => void;
 
-  /** User input received */
-  onUserInput: (sessionId: UUID, content: string, raw?: boolean, claudeSessionId?: UUID) => void;
+  /** User input received. `messageId` is the wire message's own id (#681),
+   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
+   *  specific bubble that was dropped. */
+  onUserInput: (
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+    messageId?: UUID,
+  ) => void;
 
   /** Answer to question received. `extra` carries the structured AskUserQuestion
    *  selections / cancel flag (#627); omitted for a plain single answer. */
@@ -457,6 +465,7 @@ export class Connection {
       message.content,
       message.raw,
       message.claudeSessionId,
+      message.id,
     );
   }
 

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -42,13 +42,16 @@ export interface ServerEvents {
   /** Client disconnected */
   onClientDisconnect: (connectionId: UUID, reason: string) => void;
 
-  /** User input from client */
+  /** User input from client. `messageId` is the wire message's own id (#681),
+   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
+   *  specific bubble that was dropped. */
   onUserInput: (
     connectionId: UUID,
     sessionId: UUID,
     content: string,
     raw?: boolean,
     claudeSessionId?: UUID,
+    messageId?: UUID,
   ) => void;
 
   /** Answer from client. `extra` carries structured AskUserQuestion selections /
@@ -531,8 +534,15 @@ export class WebSocketServer {
         this.events.onClientDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (sessionId, content, raw, claudeSessionId) => {
-        this.events.onUserInput?.(ws.data.connectionId, sessionId, content, raw, claudeSessionId);
+      onUserInput: (sessionId, content, raw, claudeSessionId, messageId) => {
+        this.events.onUserInput?.(
+          ws.data.connectionId,
+          sessionId,
+          content,
+          raw,
+          claudeSessionId,
+          messageId,
+        );
       },
 
       onAnswer: (sessionId, questionId, answer, claudeSessionId, extra) => {

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -167,11 +167,44 @@ describe('createInputHandlers', () => {
       const msg = sendCalls[0]?.message as {
         type: string;
         code?: string;
-        details?: { sessionId?: string };
+        details?: { sessionId?: string; messageId?: string };
       };
       expect(msg.type).toBe('error');
       expect(msg.code).toBe('NOT_ACTIVE_CONNECTION');
       expect(msg.details?.sessionId).toBe(sessionId);
+      // No messageId was passed in -- details must not carry a stray key.
+      expect(msg.details?.messageId).toBeUndefined();
+    });
+
+    test('NOT_ACTIVE_CONNECTION details carry the rejected input message id (#681)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY({ writes: [], submits: [] }),
+        fakeMessageAPI(new Map()),
+      );
+      const activeConn = generateId();
+      sessionRegistry.attachConnection(sessionId, activeConn);
+      // CID is a different connection queued behind the active one.
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const droppedMessageId = generateId();
+      await handlers.onUserInput(CID, sessionId, 'ignored', false, undefined, droppedMessageId);
+
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as {
+        type: string;
+        code?: string;
+        details?: { sessionId?: string; messageId?: string };
+      };
+      expect(msg.type).toBe('error');
+      expect(msg.code).toBe('NOT_ACTIVE_CONNECTION');
+      expect(msg.details?.sessionId).toBe(sessionId);
+      // The specific dropped message's id, so the client can flip that ONE
+      // bubble to 'failed' instead of only refreshing the read-only banner.
+      expect(msg.details?.messageId).toBe(droppedMessageId);
     });
 
     test('swallows pty.write errors and logs them (raw path)', async () => {

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -92,6 +92,58 @@ describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
     expect(calls[0]?.claudeSessionId).toBeUndefined();
   });
 
+  test('user_input with id forwards it as messageId, the 6th arg (#681)', () => {
+    const calls: Array<{ messageId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        _claudeSessionId?: string,
+        messageId?: string,
+      ) => {
+        calls.push({ messageId });
+      },
+    });
+
+    const msgId = 'aaaa1111-2222-3333-4444-555555555555';
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+      id: msgId,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.messageId).toBe(msgId);
+  });
+
+  test('user_input without id forwards messageId undefined', () => {
+    const calls: Array<{ messageId: string | undefined }> = [];
+    const adapter = makeAdapter({
+      onUserInput: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _content: string,
+        _raw?: boolean,
+        _claudeSessionId?: string,
+        messageId?: string,
+      ) => {
+        calls.push({ messageId });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'user_input',
+      sessionId: SID,
+      content: 'ls',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.messageId).toBeUndefined();
+  });
+
   test('answer with claudeSessionId is forwarded as the 5th arg', () => {
     const calls: Array<{ claudeSessionId: string | undefined }> = [];
     const adapter = makeAdapter({

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
   acknowledgeSend,
   EMPTY_PENDING_SENDS,
   type PendingSendMap,
+  rejectSend,
   sweepTimeouts,
   trackSend,
 } from '@/lib/message-ack-tracker';
@@ -1240,11 +1241,11 @@ function App() {
         // another client holds the session's exclusive write lock -- and the
         // input that triggered this error was never delivered to the PTY
         // (the daemon still sent an `ack` for it separately; `ack` only means
-        // "the daemon received the frame", not "Claude saw it"). The error
-        // carries no messageId to flip a specific bubble to failed, so the
-        // fix is to refresh the persistent read-only banner (ChatView) rather
-        // than only a one-off chat bubble the user can miss or that scrolls
-        // away.
+        // "the daemon received the frame", not "Claude saw it"). Refresh the
+        // persistent read-only banner (ChatView) AND, since #681, the error
+        // now carries the rejected input's own messageId -- flip that
+        // specific bubble to 'failed' so the user can tell which queued-era
+        // message(s) actually landed instead of relying on the banner alone.
         if (errorCode === 'NOT_ACTIVE_CONNECTION') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const queuedSessionId = asNonEmptyString(details?.['sessionId']);
@@ -1257,9 +1258,21 @@ function App() {
               ),
             );
           }
+          // The ack for this same input usually lands first (bubble already
+          // at 'delivered') since the daemon acks unconditionally before the
+          // async read-only check runs -- this rejection is authoritative
+          // and must win over that.
+          const rejectedMessageId = asNonEmptyString(details?.['messageId']);
+          if (rejectedMessageId) {
+            pendingSendsRef.current = rejectSend(pendingSendsRef.current, rejectedMessageId);
+            setMessages((prev) =>
+              prev.map((m) => (m.id === rejectedMessageId ? { ...m, state: 'failed' as const } : m)),
+            );
+          }
           console.warn(
             '[App] NOT_ACTIVE_CONNECTION: input not delivered, session is read-only',
             queuedSessionId,
+            rejectedMessageId,
           );
           break;
         }

--- a/packages/web/src/lib/message-ack-tracker.ts
+++ b/packages/web/src/lib/message-ack-tracker.ts
@@ -75,6 +75,27 @@ export function acknowledgeSend(pending: PendingSendMap, messageId: string): Ack
   return { pending: next, matched: true };
 }
 
+/**
+ * The daemon explicitly REJECTED `messageId` (#681, e.g. a `NOT_ACTIVE_CONNECTION`
+ * error naming this id): the send is authoritatively dead, not merely
+ * unacknowledged. Stops tracking it so a later `acknowledgeSend` (a stale ack
+ * that was already in flight) or `sweepTimeouts` retry/failure for the same id
+ * is a no-op instead of re-animating it -- the caller marks the message
+ * bubble 'failed' directly and that must WIN over anything the pending-map
+ * bookkeeping does afterward, including a bubble already at 'delivered' from
+ * an earlier ack. Idempotent: rejecting an id that isn't (or is no longer)
+ * tracked is a no-op, since by the time this fires the ack has usually
+ * already removed it from `pending`.
+ */
+export function rejectSend(pending: PendingSendMap, messageId: string): PendingSendMap {
+  if (!pending.has(messageId)) {
+    return pending;
+  }
+  const next = new Map(pending);
+  next.delete(messageId);
+  return next;
+}
+
 export type TimeoutOutcome =
   /** First timeout: resend `entry` (same messageId) and keep waiting. */
   | { readonly kind: 'retry'; readonly entry: PendingSend }

--- a/packages/web/tests/lib/message-ack-tracker.test.ts
+++ b/packages/web/tests/lib/message-ack-tracker.test.ts
@@ -4,6 +4,7 @@ import {
   acknowledgeSend,
   EMPTY_PENDING_SENDS,
   type PendingSend,
+  rejectSend,
   sweepTimeouts,
   trackSend,
 } from '../../src/lib/message-ack-tracker';
@@ -70,6 +71,59 @@ describe('acknowledgeSend', () => {
     const result = acknowledgeSend(pending, 'm1');
     expect(result.pending.has('m1')).toBe(false);
     expect(result.pending.has('m2')).toBe(true);
+  });
+});
+
+describe('rejectSend', () => {
+  test('removes an outstanding (unacknowledged) send', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    const next = rejectSend(pending, 'm1');
+    expect(next.has('m1')).toBe(false);
+  });
+
+  test('does not mutate the input map', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    rejectSend(pending, 'm1');
+    expect(pending.has('m1')).toBe(true);
+  });
+
+  test('leaves other outstanding sends untouched', () => {
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    pending = trackSend(pending, entry('m2'));
+    const next = rejectSend(pending, 'm1');
+    expect(next.has('m1')).toBe(false);
+    expect(next.has('m2')).toBe(true);
+  });
+
+  test('is a no-op for an id that was never tracked', () => {
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    const next = rejectSend(pending, 'never-tracked');
+    expect(next).toBe(pending);
+  });
+
+  test('delivered->failed: a rejection arriving after the ack already removed the entry is a harmless no-op', () => {
+    // Mirrors the #681 flow: the daemon acks user_input unconditionally
+    // (bubble flips 'sent' -> 'delivered', acknowledgeSend already removed
+    // it from the pending map) BEFORE the async read-only check runs and
+    // sends NOT_ACTIVE_CONNECTION. By the time rejectSend runs, the id is
+    // already gone -- rejectSend must not throw or resurrect it, and the
+    // caller forces the bubble to 'failed' independent of this map.
+    let pending = trackSend(EMPTY_PENDING_SENDS, entry('m1'));
+    ({ pending } = acknowledgeSend(pending, 'm1'));
+    expect(pending.has('m1')).toBe(false);
+
+    const afterReject = rejectSend(pending, 'm1');
+    expect(afterReject.has('m1')).toBe(false);
+  });
+
+  test('a rejection stops a subsequent sweep from retrying or failing the same id', () => {
+    // If the rejection instead raced an in-flight (unacked) retry, rejectSend
+    // must stop the sweep from later emitting a redundant retry/failed
+    // outcome for an id the caller already forced to 'failed'.
+    const pending = trackSend(EMPTY_PENDING_SENDS, entry('m1', { sentAt: NOW }));
+    const rejected = rejectSend(pending, 'm1');
+    const { outcomes } = sweepTimeouts(rejected, NOW + ACK_TIMEOUT_MS);
+    expect(outcomes).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up from #663 / PR #679 review. The daemon acks `user_input`
unconditionally before the async read-only-connection check runs
(`connection.ts` `handleUserInput` sends the ack, then later
`input-events.ts` `onUserInput` raises `NOT_ACTIVE_CONNECTION` if the
connection is queued/read-only). The error previously carried only
`{ sessionId }`, so a queued client's input showed a "delivered"
checkmark even though it was silently dropped, with no way to tell
which of several queued-era messages actually landed.

## Mechanism

- Thread `message.id` through `onUserInput`'s event signature as a new
  trailing optional `messageId` parameter, mirroring the existing
  `onBulletExpandRequest` precedent (which already passes its own
  message id as `requestId`):
  `packages/daemon/src/server/connection.ts` (`ConnectionEvents.onUserInput`,
  `handleUserInput`) -> `packages/daemon/src/server/websocket-server.ts`
  (`ServerEvents.onUserInput`, Connection wiring) ->
  `packages/daemon/src/adapters/connection-adapter.ts` (`AdapterEvents.onUserInput`)
  -> `packages/daemon/src/adapters/websocket-adapter.ts` (wiring) ->
  `packages/daemon/src/cli/handlers/input-events.ts` (`onUserInput` handler).
- `packages/daemon/src/remote/relay-adapter.ts`'s `user_input` case now also
  forwards `msg['id']` as `messageId`, matching its existing
  `bullet_expand_request` handling of `requestId`.
- `input-events.ts`'s `NOT_ACTIVE_CONNECTION` error details now include
  `messageId` (conditionally spread, so channels without a message id --
  Telegram -- don't get a stray `undefined` key).
- `packages/web/src/App.tsx`'s `NOT_ACTIVE_CONNECTION` handler flips the
  specific bubble (`details.messageId`) to `'failed'` in addition to the
  existing read-only banner refresh. The ack for the same input usually
  lands first (bubble already `'delivered'`) since the daemon acks before
  the async check runs; the rejection is authoritative and wins over that.
- `packages/web/src/lib/message-ack-tracker.ts` gains `rejectSend`, a pure
  function that stops tracking a rejected message id so a stale
  ack/timeout sweep can't resurrect it after the bubble is forced to
  `'failed'`.

## Tests

- `packages/daemon/tests/cli/handlers/input-events.test.ts`: new test
  asserting `NOT_ACTIVE_CONNECTION` details carry the rejected message id;
  existing test extended to assert no stray `messageId` key when one isn't
  passed.
- `packages/daemon/tests/relay-adapter-binding.test.ts`: new tests for
  `user_input` forwarding `id` as `messageId` (and forwarding `undefined`
  when absent).
- `packages/web/tests/lib/message-ack-tracker.test.ts`: 6 new tests for
  `rejectSend` (removes outstanding/tracked sends, no-op when untracked,
  no mutation, and the delivered->failed race: a rejection landing after
  the ack already removed the entry is a harmless no-op, and a rejection
  stops a later sweep from emitting a redundant retry/failed outcome).

## Gate results

- `bun run typecheck` (root): clean.
- `bunx biome check` (touched daemon files + full repo): clean; the 37
  pre-existing warnings on `bunx biome check .` are all in files this PR
  does not touch (`session-registry-file.ts` and unrelated test files).
- `cd packages/web && bunx eslint src/App.tsx src/lib/message-ack-tracker.ts`:
  clean, no new errors/warnings.
- `cd packages/web && bun run build`: clean.
- `bun test` on touched daemon test paths: 100 pass.
- Full daemon suite excluding `packages/daemon/tests/auto-approve/`:
  2076 pass, 0 fail.
- `bun test packages/web`: 313 pass, 0 fail (22 in
  `message-ack-tracker.test.ts`, up from 16).

Closes #681