### PR TITLE
fix(#671): bind deviceId reclaim to client fingerprint

### DIFF
--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -36,6 +36,12 @@ export interface WebSocketPlatformData {
   readonly mode?: 'query' | 'attach' | undefined;
   /** Stable per-device identifier from the client's hello (#662). */
   readonly deviceId?: string | null;
+  /**
+   * Authenticated client fingerprint from the Ed25519 challenge-response
+   * (#671), null when this connection has no authenticated identity (auth
+   * disabled daemon-wide, or this peer was loopback-exempted from auth).
+   */
+  readonly clientFingerprint?: string | null;
 }
 
 export interface TelegramPlatformData {

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -102,6 +102,7 @@ export class WebSocketAdapter implements ConnectionAdapter {
             resumeSessionId: connection.connectionResumeSessionId,
             mode: connection.connectionMode,
             deviceId: connection.connectionDeviceId,
+            clientFingerprint: connection.connectionClientFingerprint,
           },
         };
         this.events.onConnect?.(connection.id, metadata);

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -21,6 +21,7 @@ import { errorToString } from '@remi/shared';
 import {
   createAuthChallenge,
   createAuthResult,
+  fingerprint,
   fromBase64,
   generateChallenge,
   importPublicKey,
@@ -28,6 +29,23 @@ import {
   verify,
 } from '@remi/shared';
 import { DuplicateKeyError, type IdentityStore } from './identity-store.ts';
+
+/**
+ * Outcome of `verifyResponse` (#671 follow-up). `result` is the wire
+ * `AuthResultMessage` to send back to the client, unchanged. `verifiedFingerprint`
+ * is set ONLY when `result.success` is true, and is always derived
+ * server-side from the Ed25519-verified `clientPublicKey` — never from
+ * `response.clientFingerprint`, which is a client-supplied, unverified wire
+ * field (documented as "for display" in the protocol type). Binding the
+ * unverified claim to a connection's identity would let an attacker who
+ * merely owns SOME valid keypair complete authentication while claiming to
+ * BE a different (victim) fingerprint, defeating any identity check
+ * (e.g. the same-device lock reclaim, #671) keyed off it.
+ */
+export interface VerifyResponseOutcome {
+  readonly result: AuthResultMessage;
+  readonly verifiedFingerprint?: string;
+}
 
 export type TofuMode = 'auto-accept' | 'reject';
 
@@ -62,45 +80,61 @@ export class Authenticator {
 
   /**
    * Verify a client's auth response.
-   * Returns an AuthResultMessage with success/failure.
+   * Returns a `VerifyResponseOutcome`: the wire `AuthResultMessage` plus,
+   * on success, the server-derived `verifiedFingerprint`.
    *
    * Order: verify signature first (bad sigs never trigger TOFU),
    * then check authorization, then TOFU if applicable.
+   *
+   * `response.clientFingerprint` is NEVER used for authorization or identity
+   * binding (#671): it is a client-supplied wire field, and Ed25519
+   * signature verification only proves possession of `clientPublicKey`, not
+   * that the claimed fingerprint actually hashes from that key. Every
+   * identity-bearing check here (authorized-keys lookup, TOFU, lastUsedAt,
+   * and the fingerprint returned to the caller) uses `derivedFingerprint`,
+   * computed server-side from the verified public key.
    */
   async verifyResponse(
     connectionId: string,
     response: AuthResponseMessage,
-  ): Promise<AuthResultMessage> {
+  ): Promise<VerifyResponseOutcome> {
     const challenge = this.pendingChallenges.get(connectionId);
     if (!challenge) {
-      return createAuthResult(false, undefined, 'NO_PENDING_CHALLENGE');
+      return { result: createAuthResult(false, undefined, 'NO_PENDING_CHALLENGE') };
     }
 
     // Remove challenge (one-time use)
     this.pendingChallenges.delete(connectionId);
 
     // Step 1: Verify the signature FIRST (before checking authorization)
+    let derivedFingerprint: string;
     try {
-      const clientPublicKey = await importPublicKey(fromBase64(response.clientPublicKey));
+      const clientPublicKeyRaw = fromBase64(response.clientPublicKey);
+      const clientPublicKey = await importPublicKey(clientPublicKeyRaw);
       const challengeData = fromBase64(challenge);
       const valid = await verify(clientPublicKey, challengeData, response.signature);
 
       if (!valid) {
-        return createAuthResult(false, undefined, 'INVALID_SIGNATURE');
+        return { result: createAuthResult(false, undefined, 'INVALID_SIGNATURE') };
       }
+
+      // Derive the fingerprint from the VERIFIED public key, not from the
+      // client's claim (#671) — this is the only fingerprint value ever
+      // treated as this client's identity from here on.
+      derivedFingerprint = await fingerprint(clientPublicKeyRaw);
     } catch (err) {
       const code = err instanceof DOMException ? 'INVALID_KEY_DATA' : 'VERIFICATION_ERROR';
-      return createAuthResult(false, undefined, code);
+      return { result: createAuthResult(false, undefined, code) };
     }
 
     // Step 2: Check if client's key is authorized
     let isAuthorized: boolean;
     try {
-      isAuthorized = this.store.isAuthorized(response.clientPublicKey, response.clientFingerprint);
+      isAuthorized = this.store.isAuthorized(response.clientPublicKey, derivedFingerprint);
     } catch (err) {
       const detail = errorToString(err);
       console.error(`Auth store error during verification: ${detail}`);
-      return createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`);
+      return { result: createAuthResult(false, undefined, `AUTH_STORE_ERROR: ${detail}`) };
     }
 
     // Step 3: TOFU - if not authorized and auto-accept is enabled, add the key
@@ -109,7 +143,7 @@ export class Authenticator {
         try {
           const label = `tofu-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-')}`;
           await this.store.addAuthorizedKey(response.clientPublicKey, label);
-          console.log(`New client auto-accepted (TOFU): ${response.clientFingerprint} [${label}]`);
+          console.log(`New client auto-accepted (TOFU): ${derivedFingerprint} [${label}]`);
           isAuthorized = true;
         } catch (err) {
           if (err instanceof DuplicateKeyError) {
@@ -118,26 +152,29 @@ export class Authenticator {
           } else {
             const detail = errorToString(err);
             console.error(`TOFU auto-accept failed: ${detail}`);
-            return createAuthResult(false, undefined, 'TOFU_FAILED');
+            return { result: createAuthResult(false, undefined, 'TOFU_FAILED') };
           }
         }
       } else {
-        return createAuthResult(false, undefined, 'UNKNOWN_KEY');
+        return { result: createAuthResult(false, undefined, 'UNKNOWN_KEY') };
       }
     }
 
     // Update lastUsedAt (non-critical; don't let failures break auth)
-    this.store.touchAuthorizedKey(response.clientFingerprint);
+    this.store.touchAuthorizedKey(derivedFingerprint);
 
     // Sign the same challenge with server's key for mutual authentication
     try {
       const challengeData = fromBase64(challenge);
       const serverSignature = await sign(this.identity.privateKey, challengeData);
-      return createAuthResult(true, serverSignature);
+      return {
+        result: createAuthResult(true, serverSignature),
+        verifiedFingerprint: derivedFingerprint,
+      };
     } catch (err) {
       const detail = errorToString(err);
       console.error(`Server failed to sign mutual auth challenge: ${detail}`);
-      return createAuthResult(false, undefined, 'SERVER_SIGN_ERROR');
+      return { result: createAuthResult(false, undefined, 'SERVER_SIGN_ERROR') };
     }
   }
 

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -71,9 +71,9 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       trackConnection(connectionId, metadata.adapterType);
       onConnectionAdded();
 
-      // resumeSessionId, mode, and deviceId are only carried by the websocket
-      // adapter. Telegram and relay clients have no equivalent (their adapter
-      // selects session ownership differently).
+      // resumeSessionId, mode, deviceId, and clientFingerprint are only
+      // carried by the websocket adapter. Telegram and relay clients have no
+      // equivalent (their adapter selects session ownership differently).
       const platformData = metadata.platformData;
       const resumeSessionId =
         platformData?.kind === 'websocket'
@@ -81,6 +81,14 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
           : undefined;
       const deviceId =
         platformData?.kind === 'websocket' ? (platformData.deviceId ?? undefined) : undefined;
+      // Authenticated identity bound to deviceId (#671); undefined when this
+      // connection has no authenticated identity (auth disabled, or a
+      // loopback-exempt peer) — attachConnection then falls back to
+      // deviceId-only reclaim matching.
+      const clientFingerprint =
+        platformData?.kind === 'websocket'
+          ? (platformData.clientFingerprint ?? undefined)
+          : undefined;
       const currentPrimary = getPrimarySessionId();
 
       // Unified connection flow: one session per daemon, both modes behave the same.
@@ -102,7 +110,12 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       if (currentPrimary) {
         // Only auto-attach if the client wants to attach, not a utility client like ls/kill.
         if (!isQueryMode) {
-          const result = sessionRegistry.attachConnection(currentPrimary, connectionId, deviceId);
+          const result = sessionRegistry.attachConnection(
+            currentPrimary,
+            connectionId,
+            deviceId,
+            clientFingerprint,
+          );
           if (result.success) {
             send(
               connectionId,

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -226,7 +226,7 @@ export class RelayAdapter implements ConnectionAdapter {
       return;
     }
 
-    const result = await this.config.authenticator.verifyResponse(
+    const { result } = await this.config.authenticator.verifyResponse(
       this.clientConnectionId,
       response,
     );

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -404,14 +404,20 @@ export class Connection {
       return;
     }
 
-    const result = await this.config.authenticator.verifyResponse(this.id, message);
+    const { result, verifiedFingerprint } = await this.config.authenticator.verifyResponse(
+      this.id,
+      message,
+    );
     this.send(result);
 
     if (result.success) {
-      // Auth passed; transition to 'connecting' (waiting for hello)
+      // Auth passed; transition to 'connecting' (waiting for hello). Bind the
+      // server-derived fingerprint (#671), never `message.clientFingerprint`
+      // — that field is client-claimed and unverified; the Authenticator
+      // guarantees `verifiedFingerprint` is set whenever `result.success`.
       this.state = 'connecting';
-      this.authenticatedFingerprint = message.clientFingerprint;
-      this.events.onAuthSuccess?.(message.clientFingerprint);
+      this.authenticatedFingerprint = verifiedFingerprint ?? null;
+      this.events.onAuthSuccess?.(this.authenticatedFingerprint ?? '');
     } else {
       this.events.onAuthFailed?.(result.error ?? 'unknown', message.clientFingerprint);
       this.close(`Authentication failed: ${result.error}`);

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -158,6 +158,11 @@ export class Connection {
   private resumeSessionId: UUID | null = null;
   private _mode: 'query' | undefined = undefined;
   private deviceId: string | null = null;
+  /** Authenticated client fingerprint from the Ed25519 challenge-response
+   *  (#671), null until `handleAuthResponse` succeeds. Stays null for the
+   *  lifetime of the connection when no authenticator is configured (auth
+   *  disabled, or this peer was loopback-exempted). */
+  private authenticatedFingerprint: string | null = null;
 
   private readonly ws: WebSocket;
   private readonly config: Required<ConnectionConfig> & {
@@ -236,6 +241,12 @@ export class Connection {
   /** Stable per-device identifier from the client's hello, if sent (#662). */
   get connectionDeviceId(): string | null {
     return this.deviceId;
+  }
+
+  /** Authenticated client fingerprint, if this connection completed the
+   *  Ed25519 challenge-response (#671). Null when unauthenticated. */
+  get connectionClientFingerprint(): string | null {
+    return this.authenticatedFingerprint;
   }
 
   /** Check if connection is active */
@@ -399,6 +410,7 @@ export class Connection {
     if (result.success) {
       // Auth passed; transition to 'connecting' (waiting for hello)
       this.state = 'connecting';
+      this.authenticatedFingerprint = message.clientFingerprint;
       this.events.onAuthSuccess?.(message.clientFingerprint);
     } else {
       this.events.onAuthFailed?.(result.error ?? 'unknown', message.clientFingerprint);

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -416,21 +416,26 @@ export class SessionRegistry {
   }
 
   /**
-   * Whether an incoming hello's `deviceId` (+ `clientFingerprint`, when the
-   * active connection has an authenticated identity to bind to) matches the
+   * Whether an incoming hello's `deviceId` + `clientFingerprint` match the
    * identity already recorded for the session's active connection (#671).
    *
    * `deviceId` alone is a client-supplied, self-reported string (persisted in
    * `localStorage`) with no cryptographic binding, so trusting it in
    * isolation lets any peer that can complete a hello (a hostile local
    * process, or an authenticated-but-different networked peer) evict the
-   * legitimate device by guessing or replaying its `deviceId`. When the
-   * active connection has a bound `clientFingerprint` (established via the
-   * Ed25519 challenge-response), the incoming `clientFingerprint` must match
-   * it too. When the active connection has NO bound fingerprint — auth is
-   * disabled daemon-wide, or this peer was loopback-exempted from auth —
-   * there is no authenticated identity to check against, so this falls back
-   * to today's `deviceId`-only comparison.
+   * legitimate device by guessing or replaying its `deviceId`.
+   *
+   * `clientFingerprint` must match via STRICT equality, where "both null"
+   * counts as a match: `null` means "no authenticated identity" (auth
+   * disabled daemon-wide, or this peer was loopback-exempted from auth), and
+   * a loopback peer reclaiming its own loopback-held lock (both null) is the
+   * original #666 feature this must keep working. Every other combination —
+   * fingerprint-bearing peer against a fingerprint-less active connection,
+   * fingerprint-less peer against a fingerprint-bound active connection, or
+   * two different fingerprints — is a genuine identity mismatch and must
+   * queue, not reclaim. A user switching transports (e.g. network-authenticated
+   * one moment, SSH-tunnel loopback the next) is an accepted, deliberate
+   * consequence: it queues FIFO instead of reclaiming.
    */
   private matchesActiveDevice(
     session: ManagedSession,
@@ -440,12 +445,7 @@ export class SessionRegistry {
     if (session.activeDeviceId === null || session.activeDeviceId !== deviceId) {
       return false;
     }
-    if (session.activeClientFingerprint !== null) {
-      return (
-        clientFingerprint !== undefined && clientFingerprint === session.activeClientFingerprint
-      );
-    }
-    return true;
+    return session.activeClientFingerprint === (clientFingerprint ?? null);
   }
 
   /**

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -39,17 +39,20 @@ export interface SessionRegistryConfig {
 
 /**
  * A connection waiting for the active connection to disconnect, plus the
- * deviceId its hello carried (#662). Carrying deviceId here (not just the
- * bare connectionId) means a queued connection that gets FIFO-promoted still
- * has its device identity on record afterward — so if IT later goes stale,
- * a genuine reconnect from the same device can still reclaim the lock
- * instead of falling back to queuing behind a connection that's gone for
- * good. Without this, only the FIRST-ever active connection's device got
- * reclaim protection; every promoted connection would lose it.
+ * deviceId (and, when authenticated, clientFingerprint) its hello carried
+ * (#662, #671). Carrying these here (not just the bare connectionId) means a
+ * queued connection that gets FIFO-promoted still has its identity on record
+ * afterward — so if IT later goes stale, a genuine reconnect from the same
+ * device can still reclaim the lock instead of falling back to queuing
+ * behind a connection that's gone for good. Without this, only the
+ * FIRST-ever active connection's identity got reclaim protection; every
+ * promoted connection would lose it.
  */
 interface WaitingConnection {
   readonly connectionId: UUID;
   readonly deviceId?: string;
+  /** Authenticated identity bound to this deviceId at hello time (#671). */
+  readonly clientFingerprint?: string;
 }
 
 /** Result of attempting to attach a connection to a session */
@@ -133,6 +136,18 @@ export interface ManagedSession {
    * the lock) from "a second writer" (queue behind the FIFO as before).
    */
   activeDeviceId: string | null;
+  /**
+   * Authenticated client fingerprint bound to the active connection at hello
+   * time (#671), null when the connection had no authenticated identity to
+   * bind (auth disabled daemon-wide, or this peer was loopback-exempted from
+   * auth). `deviceId` alone is client-supplied and replayable, so when this
+   * is non-null a reclaim attempt must match it too, not just `deviceId` —
+   * otherwise an authenticated-but-different peer could evict the legitimate
+   * device by guessing/replaying its deviceId. When null, there is no
+   * authenticated identity to bind to, so reclaim falls back to today's
+   * deviceId-only comparison.
+   */
+  activeClientFingerprint: string | null;
   /** When session was last disconnected (null if connected) */
   lastDisconnectedAt: Timestamp | null;
   /** Timeout handle for orphan cleanup */
@@ -223,6 +238,7 @@ export class SessionRegistry {
       lastActivityAt: createdAt,
       activeConnectionId: null,
       activeDeviceId: null,
+      activeClientFingerprint: null,
       lastDisconnectedAt: null,
       orphanTimeoutId: null,
       messageHistory: [],
@@ -296,9 +312,17 @@ export class SessionRegistry {
   /**
    * Attach a connection to the session. `deviceId`, when present and equal to
    * the device already holding the exclusive write lock, reclaims that lock
-   * instead of queuing behind it (#662) — see `reclaimForSameDevice`.
+   * instead of queuing behind it (#662) — see `reclaimForSameDevice`. When
+   * the active connection has a bound `clientFingerprint` (#671), reclaim
+   * additionally requires the incoming `clientFingerprint` to match it —
+   * see `matchesActiveDevice`.
    */
-  attachConnection(sessionId: UUID, connectionId: UUID, deviceId?: string): AttachResult {
+  attachConnection(
+    sessionId: UUID,
+    connectionId: UUID,
+    deviceId?: string,
+    clientFingerprint?: string,
+  ): AttachResult {
     if (this.session === null || this.session.sessionId !== sessionId) {
       return {
         success: false,
@@ -312,22 +336,27 @@ export class SessionRegistry {
     }
 
     if (this.session.activeConnectionId !== null) {
-      const sameDeviceReconnecting =
+      if (
         deviceId !== undefined &&
-        this.session.activeDeviceId !== null &&
-        this.session.activeDeviceId === deviceId;
-
-      if (sameDeviceReconnecting) {
-        return this.reclaimForSameDevice(this.session, connectionId, deviceId);
+        this.matchesActiveDevice(this.session, deviceId, clientFingerprint)
+      ) {
+        return this.reclaimForSameDevice(this.session, connectionId, deviceId, clientFingerprint);
       }
 
-      // Different (or unknown) device: provide replay history (read-only)
-      // and queue for write promotion when the active connection disconnects.
-      // Writes from queued connections are blocked at getSessionForConnection.
-      // deviceId travels with the queue entry (#662) so promotion still
-      // leaves this connection reclaimable if it later goes stale itself.
+      // Different (or unknown) device, or a fingerprint mismatch against an
+      // authenticated active connection (#671): provide replay history
+      // (read-only) and queue for write promotion when the active connection
+      // disconnects. Writes from queued connections are blocked at
+      // getSessionForConnection. deviceId/clientFingerprint travel with the
+      // queue entry (#662, #671) so promotion still leaves this connection
+      // reclaimable (under the same identity check) if it later goes stale
+      // itself.
       if (!this.waitingConnections.some((w) => w.connectionId === connectionId)) {
-        this.waitingConnections.push({ connectionId, ...(deviceId !== undefined && { deviceId }) });
+        this.waitingConnections.push({
+          connectionId,
+          ...(deviceId !== undefined && { deviceId }),
+          ...(clientFingerprint !== undefined && { clientFingerprint }),
+        });
       }
       const MAX_REPLAY_MESSAGES = 200;
       const replayMessages =
@@ -356,6 +385,7 @@ export class SessionRegistry {
     // Attach connection
     this.session.activeConnectionId = connectionId;
     this.session.activeDeviceId = deviceId ?? null;
+    this.session.activeClientFingerprint = clientFingerprint ?? null;
     this.session.lastDisconnectedAt = null;
     this.session.explicitlyDetached = false;
 
@@ -386,6 +416,39 @@ export class SessionRegistry {
   }
 
   /**
+   * Whether an incoming hello's `deviceId` (+ `clientFingerprint`, when the
+   * active connection has an authenticated identity to bind to) matches the
+   * identity already recorded for the session's active connection (#671).
+   *
+   * `deviceId` alone is a client-supplied, self-reported string (persisted in
+   * `localStorage`) with no cryptographic binding, so trusting it in
+   * isolation lets any peer that can complete a hello (a hostile local
+   * process, or an authenticated-but-different networked peer) evict the
+   * legitimate device by guessing or replaying its `deviceId`. When the
+   * active connection has a bound `clientFingerprint` (established via the
+   * Ed25519 challenge-response), the incoming `clientFingerprint` must match
+   * it too. When the active connection has NO bound fingerprint — auth is
+   * disabled daemon-wide, or this peer was loopback-exempted from auth —
+   * there is no authenticated identity to check against, so this falls back
+   * to today's `deviceId`-only comparison.
+   */
+  private matchesActiveDevice(
+    session: ManagedSession,
+    deviceId: string,
+    clientFingerprint?: string,
+  ): boolean {
+    if (session.activeDeviceId === null || session.activeDeviceId !== deviceId) {
+      return false;
+    }
+    if (session.activeClientFingerprint !== null) {
+      return (
+        clientFingerprint !== undefined && clientFingerprint === session.activeClientFingerprint
+      );
+    }
+    return true;
+  }
+
+  /**
    * Same physical device reconnecting while its own previous connection is
    * still marked active (#662) — a dead-socket reconnect (missed pongs, iOS
    * background, NAT drop) rather than a second writer. Evicts the stale
@@ -394,11 +457,15 @@ export class SessionRegistry {
    * likely never come back. `onConnectionReclaimed` tells the caller which
    * connection id is now stale so it can force-close the underlying
    * transport; the registry itself has no transport handle to do that.
+   *
+   * Callers must have already verified the identity match via
+   * `matchesActiveDevice` (#671).
    */
   private reclaimForSameDevice(
     session: ManagedSession,
     connectionId: UUID,
     deviceId: string,
+    clientFingerprint?: string,
   ): AttachResult {
     const staleId = session.activeConnectionId;
     if (staleId === null) {
@@ -409,6 +476,7 @@ export class SessionRegistry {
 
     session.activeConnectionId = connectionId;
     session.activeDeviceId = deviceId;
+    session.activeClientFingerprint = clientFingerprint ?? null;
     session.lastDisconnectedAt = null;
     session.explicitlyDetached = false;
 
@@ -457,16 +525,23 @@ export class SessionRegistry {
     // Detach connection
     this.session.activeConnectionId = null;
     this.session.activeDeviceId = null;
+    this.session.activeClientFingerprint = null;
     this.session.lastDisconnectedAt = now();
 
     // Try to promote the next waiting connection (loop until one succeeds or queue exhausted)
     while (this.waitingConnections.length > 0) {
       const next = this.waitingConnections.shift();
       if (!next) continue;
-      // Carrying deviceId through promotion (#662) means this connection
-      // stays reclaimable by the same device if it later goes stale itself,
-      // instead of only the original active connection getting that protection.
-      const result = this.attachConnection(sessionId, next.connectionId, next.deviceId);
+      // Carrying deviceId + clientFingerprint through promotion (#662, #671)
+      // means this connection stays reclaimable (under the same identity
+      // check) by the same device if it later goes stale itself, instead of
+      // only the original active connection getting that protection.
+      const result = this.attachConnection(
+        sessionId,
+        next.connectionId,
+        next.deviceId,
+        next.clientFingerprint,
+      );
       if (result.success) {
         try {
           this.events.onConnectionPromoted?.(sessionId, next.connectionId, result);
@@ -479,6 +554,7 @@ export class SessionRegistry {
           );
           this.session.activeConnectionId = null;
           this.session.activeDeviceId = null;
+          this.session.activeClientFingerprint = null;
           this.session.lastDisconnectedAt = now();
           continue;
         }

--- a/packages/daemon/tests/authenticator.test.ts
+++ b/packages/daemon/tests/authenticator.test.ts
@@ -84,7 +84,7 @@ describe('Authenticator', () => {
 
       const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
 
-      const result = await authenticator.verifyResponse('conn-1', response);
+      const { result } = await authenticator.verifyResponse('conn-1', response);
       expect(result.success).toBe(true);
       expect(result.serverSignature).toBeDefined();
       expect(result.error).toBeUndefined();
@@ -102,7 +102,7 @@ describe('Authenticator', () => {
 
       const response = createAuthResponse(unknownId.publicKey, signature, unknownId.fingerprint);
 
-      const result = await authenticator.verifyResponse('conn-1', response);
+      const { result } = await authenticator.verifyResponse('conn-1', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('UNKNOWN_KEY');
     });
@@ -116,7 +116,7 @@ describe('Authenticator', () => {
 
       const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
 
-      const result = await authenticator.verifyResponse('conn-1', response);
+      const { result } = await authenticator.verifyResponse('conn-1', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('INVALID_SIGNATURE');
     });
@@ -130,11 +130,11 @@ describe('Authenticator', () => {
       const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
 
       // First use succeeds
-      const result1 = await authenticator.verifyResponse('conn-1', response);
+      const { result: result1 } = await authenticator.verifyResponse('conn-1', response);
       expect(result1.success).toBe(true);
 
       // Second use fails (challenge consumed)
-      const result2 = await authenticator.verifyResponse('conn-1', response);
+      const { result: result2 } = await authenticator.verifyResponse('conn-1', response);
       expect(result2.success).toBe(false);
       expect(result2.error).toBe('NO_PENDING_CHALLENGE');
     });
@@ -148,7 +148,7 @@ describe('Authenticator', () => {
       const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
 
       // Try to use conn-2's response for conn-1 (conn-1's challenge was already consumed by conn-2's creation)
-      const result = await authenticator.verifyResponse('conn-999', response);
+      const { result } = await authenticator.verifyResponse('conn-999', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('NO_PENDING_CHALLENGE');
     });
@@ -178,7 +178,7 @@ describe('Authenticator', () => {
 
       const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
 
-      const result = await authenticator.verifyResponse('conn-1', response);
+      const { result } = await authenticator.verifyResponse('conn-1', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('NO_PENDING_CHALLENGE');
     });
@@ -222,7 +222,7 @@ describe('Authenticator', () => {
       const signature = await sign(unknownIdentity.privateKey, challengeData);
       const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
 
-      const result = await tofuAuthenticator.verifyResponse('conn-tofu', response);
+      const { result } = await tofuAuthenticator.verifyResponse('conn-tofu', response);
       expect(result.success).toBe(true);
       expect(result.serverSignature).toBeDefined();
     });
@@ -248,7 +248,7 @@ describe('Authenticator', () => {
       const signature = await sign(unknownIdentity.privateKey, wrongData.buffer);
       const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
 
-      const result = await tofuAuthenticator.verifyResponse('conn-tofu', response);
+      const { result } = await tofuAuthenticator.verifyResponse('conn-tofu', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('INVALID_SIGNATURE');
 
@@ -269,7 +269,7 @@ describe('Authenticator', () => {
       const signature = await sign(unknownIdentity.privateKey, challengeData);
       const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
 
-      const result = await rejectAuthenticator.verifyResponse('conn-reject', response);
+      const { result } = await rejectAuthenticator.verifyResponse('conn-reject', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('UNKNOWN_KEY');
     });
@@ -284,7 +284,7 @@ describe('Authenticator', () => {
       const signature = await sign(unknownIdentity.privateKey, challengeData);
       const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
 
-      const result = await tofuAuthenticator.verifyResponse('conn-existing', response);
+      const { result } = await tofuAuthenticator.verifyResponse('conn-existing', response);
       expect(result.success).toBe(true);
 
       // Should still have just one key entry (not duplicated)
@@ -305,7 +305,7 @@ describe('Authenticator', () => {
       const signature = await sign(unknownIdentity.privateKey, challengeData);
       const response = createAuthResponse(unknownPublicKeyBase64, signature, unknownFingerprint);
 
-      const result = await defaultAuth.verifyResponse('conn-default', response);
+      const { result } = await defaultAuth.verifyResponse('conn-default', response);
       expect(result.success).toBe(false);
       expect(result.error).toBe('UNKNOWN_KEY');
     });
@@ -321,7 +321,7 @@ describe('Authenticator', () => {
       await store.addAuthorizedKey(unknownPublicKeyBase64, 'concurrent-add');
 
       // TOFU should still succeed (catches DuplicateKeyError)
-      const result = await tofuAuthenticator.verifyResponse('conn-race', response);
+      const { result } = await tofuAuthenticator.verifyResponse('conn-race', response);
       expect(result.success).toBe(true);
     });
   });

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -386,6 +386,70 @@ describe('createConnectionHandlers', () => {
       expect(sessionRegistry.waitingConnectionCount).toBe(0);
       expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
     });
+
+    test('same deviceId + matching clientFingerprint reclaims (#671, auth on)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      const staleConn = generateId();
+      sessionRegistry.attachConnection(sessionId, staleConn, 'device-A', 'fp-alice');
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket', deviceId: 'device-A', clientFingerprint: 'fp-alice' },
+      });
+
+      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
+      expect(ack.attachState).toBe('attached');
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.waitingConnectionCount).toBe(0);
+      expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
+    });
+
+    test('same deviceId + DIFFERENT clientFingerprint is refused: queues, does not evict (#671)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      // Legitimate device holds the lock after authenticating.
+      const activeConn = generateId();
+      sessionRegistry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
+
+      // A different authenticated peer replays the same deviceId but cannot
+      // produce the matching fingerprint (it authenticated with its OWN key).
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket', deviceId: 'device-A', clientFingerprint: 'fp-mallory' },
+      });
+
+      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
+      expect(ack.attachState).toBe('queued');
+      // Legitimate device keeps the lock; nothing was evicted.
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
+      expect(sessionRegistry.getSessionForConnection(activeConn)?.sessionId).toBe(sessionId);
+    });
+
+    test('same deviceId with no clientFingerprint on either side still reclaims (#671, auth off)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      // Localhost daemon / loopback-exempt peer: no authenticator, so no
+      // clientFingerprint is ever produced on either side.
+      const staleConn = generateId();
+      sessionRegistry.attachConnection(sessionId, staleConn, 'device-A');
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket', deviceId: 'device-A' },
+      });
+
+      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
+      expect(ack.attachState).toBe('attached');
+      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
+    });
   });
 
   describe('onDisconnect', () => {

--- a/packages/daemon/tests/connection-auth.test.ts
+++ b/packages/daemon/tests/connection-auth.test.ts
@@ -174,6 +174,54 @@ describe('Connection auth state machine', () => {
       expect(helloAck).toBeDefined();
     });
 
+    test('exposes connectionClientFingerprint after successful auth (#671)', async () => {
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
+
+      expect(conn.connectionClientFingerprint).toBeNull();
+
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const challengeData = fromBase64(challenge.challenge);
+      const signature = await sign(clientIdentity.privateKey, challengeData);
+      const response = createAuthResponse(clientPublicKeyBase64, signature, clientFingerprint);
+      conn.handleMessage(serialize(response));
+      await new Promise((r) => setTimeout(r, 100));
+
+      // The value bound here is the REAL fingerprint derived from the
+      // client's Ed25519 key via the challenge-response, not a client-supplied
+      // string — this is what the same-device reclaim check (#671) binds
+      // deviceId to, so a peer without this exact key can never produce it.
+      expect(conn.connectionClientFingerprint).toBe(clientFingerprint);
+    });
+
+    test('two different authenticated clients get different connectionClientFingerprint values (#671)', async () => {
+      const otherIdFile = await createIdentity('otherpass');
+      const otherIdentity = await unlockIdentity(otherIdFile, 'otherpass');
+      await store.addAuthorizedKey(otherIdFile.publicKey, 'Other Client');
+
+      const wsA = new MockWebSocket();
+      const connA = new Connection(wsA as unknown as WebSocket, {}, { authenticator });
+      const challengeA = wsA.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const sigA = await sign(clientIdentity.privateKey, fromBase64(challengeA.challenge));
+      connA.handleMessage(
+        serialize(createAuthResponse(clientPublicKeyBase64, sigA, clientFingerprint)),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const wsB = new MockWebSocket();
+      const connB = new Connection(wsB as unknown as WebSocket, {}, { authenticator });
+      const challengeB = wsB.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const sigB = await sign(otherIdentity.privateKey, fromBase64(challengeB.challenge));
+      connB.handleMessage(
+        serialize(createAuthResponse(otherIdFile.publicKey, sigB, otherIdFile.fingerprint)),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(connA.connectionClientFingerprint).toBe(clientFingerprint);
+      expect(connB.connectionClientFingerprint).toBe(otherIdFile.fingerprint);
+      expect(connA.connectionClientFingerprint).not.toBe(connB.connectionClientFingerprint);
+    });
+
     test('rejects non-auth messages during authenticating state', () => {
       const ws = new MockWebSocket();
       const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
@@ -278,6 +326,21 @@ describe('Connection auth state machine', () => {
       expect(conn.connectionState).toBe('connecting');
       // No auth_challenge sent
       expect(ws.sentMessages.length).toBe(0);
+    });
+
+    test('connectionClientFingerprint stays null with no authenticator (#671)', () => {
+      // No authenticator configured (auth disabled daemon-wide, or the peer
+      // was loopback-exempted): there is no authenticated identity to bind,
+      // so the same-device reclaim check (#671) must fall back to
+      // deviceId-only matching for this connection.
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, {});
+
+      const hello = createHello('test-client', '1.0.0');
+      conn.handleMessage(serialize(hello));
+
+      expect(conn.connectionState).toBe('connected');
+      expect(conn.connectionClientFingerprint).toBeNull();
     });
 
     test('accepts hello and transitions to connected', () => {

--- a/packages/daemon/tests/connection-auth.test.ts
+++ b/packages/daemon/tests/connection-auth.test.ts
@@ -21,6 +21,7 @@ import {
   createPing,
   createUserInput,
   deserialize,
+  fingerprint,
   fromBase64,
   serialize,
   sign,
@@ -220,6 +221,81 @@ describe('Connection auth state machine', () => {
       expect(connA.connectionClientFingerprint).toBe(clientFingerprint);
       expect(connB.connectionClientFingerprint).toBe(otherIdFile.fingerprint);
       expect(connA.connectionClientFingerprint).not.toBe(connB.connectionClientFingerprint);
+    });
+
+    test('a forged clientFingerprint claim is ignored: the DERIVED fingerprint is bound, not the claim (#671 critical)', async () => {
+      // The client's Ed25519 signature only proves possession of
+      // clientPublicKey; AuthResponseMessage.clientFingerprint is a
+      // client-supplied wire field the signature says nothing about. An
+      // already-authorized client lying about its OWN fingerprint (claiming
+      // an arbitrary forged value instead of its real one) must still get
+      // its REAL, server-derived fingerprint bound to the connection.
+      const ws = new MockWebSocket();
+      const conn = new Connection(ws as unknown as WebSocket, {}, { authenticator });
+
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const signature = await sign(clientIdentity.privateKey, fromBase64(challenge.challenge));
+      const forgedClaim = 'forged-victim-fingerprint-0000';
+      conn.handleMessage(
+        serialize(createAuthResponse(clientPublicKeyBase64, signature, forgedClaim)),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(conn.connectionState).toBe('connecting');
+      expect(conn.connectionClientFingerprint).toBe(clientFingerprint);
+      expect(conn.connectionClientFingerprint).not.toBe(forgedClaim);
+    });
+
+    test('PoC: a fresh throwaway keypair cannot bind a forged victim fingerprint via TOFU (#671 critical)', async () => {
+      // Reproduces the reported exploit: an attacker who owns no authorized
+      // key generates a brand-new keypair, completes a perfectly valid
+      // signature over the challenge with it, and claims the VICTIM's real
+      // fingerprint in AuthResponseMessage.clientFingerprint. Before the fix,
+      // Connection bound that claim directly, so the attacker's connection
+      // would present as the victim's authenticated identity — which, paired
+      // with the victim's (guessable/replayable) deviceId, would pass the
+      // same-device reclaim check in SessionRegistry and evict the victim.
+      const tofuAuthenticator = new Authenticator({
+        identity: serverIdentity,
+        identityStore: store,
+        tofuMode: 'auto-accept',
+      });
+
+      const attackerIdFile = await createIdentity('attackerpass');
+      const attackerIdentity = await unlockIdentity(attackerIdFile, 'attackerpass');
+      // Deliberately NOT authorizing attackerIdFile.publicKey up front — TOFU
+      // is what lets a never-seen key complete authentication.
+
+      const ws = new MockWebSocket();
+      const conn = new Connection(
+        ws as unknown as WebSocket,
+        {},
+        {
+          authenticator: tofuAuthenticator,
+        },
+      );
+
+      const challenge = ws.sentMessages[0] as ProtocolMessage & { challenge: string };
+      const signature = await sign(attackerIdentity.privateKey, fromBase64(challenge.challenge));
+      // Attacker claims the VICTIM's real fingerprint (clientFingerprint, from
+      // the shared beforeEach) while signing with their OWN key.
+      conn.handleMessage(
+        serialize(createAuthResponse(attackerIdFile.publicKey, signature, clientFingerprint)),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Auth succeeds (TOFU auto-accepts the attacker's own, never-seen key)...
+      expect(conn.connectionState).toBe('connecting');
+      // ...but the identity bound to the connection is the attacker's OWN
+      // derived fingerprint, never the victim's claimed one.
+      const attackerDerivedFingerprint = await fingerprint(fromBase64(attackerIdFile.publicKey));
+      expect(conn.connectionClientFingerprint).toBe(attackerDerivedFingerprint);
+      expect(conn.connectionClientFingerprint).not.toBe(clientFingerprint);
+
+      // The authorized-keys store also recorded the attacker under their OWN
+      // correctly-derived fingerprint, not the forged claim (defense in depth
+      // in IdentityStore/createAuthorizedKey, unaffected by this fix).
+      expect(store.isAuthorized(attackerIdFile.publicKey, attackerDerivedFingerprint)).toBe(true);
     });
 
     test('rejects non-auth messages during authenticating state', () => {

--- a/packages/daemon/tests/relay-adapter-auth.test.ts
+++ b/packages/daemon/tests/relay-adapter-auth.test.ts
@@ -106,7 +106,7 @@ describe('RelayAdapter auth flow', () => {
       clientIdentity.fingerprint,
     );
 
-    const result = await authenticator.verifyResponse('conn-1', response);
+    const { result } = await authenticator.verifyResponse('conn-1', response);
     expect(result.success).toBe(true);
     expect(result.serverSignature).toBeDefined();
   });
@@ -126,7 +126,7 @@ describe('RelayAdapter auth flow', () => {
       unauthorizedIdentity.fingerprint,
     );
 
-    const result = await authenticator.verifyResponse('conn-1', response);
+    const { result } = await authenticator.verifyResponse('conn-1', response);
     expect(result.success).toBe(false);
     expect(result.error).toContain('UNKNOWN_KEY');
   });

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -455,6 +455,113 @@ describe('SessionRegistry', () => {
     });
   });
 
+  describe('fingerprint-bound reclaim (#671)', () => {
+    test('matching deviceId + matching clientFingerprint reclaims (auth on)', () => {
+      const sessionId = generateId();
+      const staleConn = generateId();
+      const newConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, staleConn, 'device-A', 'fp-alice');
+      const result = registry.attachConnection(sessionId, newConn, 'device-A', 'fp-alice');
+
+      expect(result.success).toBe(true);
+      expect(result.attachState).toBe('attached');
+      expect(registry.waitingConnectionCount).toBe(0);
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
+      expect(registry.getSessionForConnection(staleConn)).toBeUndefined();
+      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, staleConn, newConn);
+    });
+
+    test('matching deviceId + DIFFERENT clientFingerprint is refused: queues, no eviction', () => {
+      const sessionId = generateId();
+      const activeConn = generateId();
+      const attackerConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      // Legitimate device authenticates and holds the lock.
+      registry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
+
+      // A different authenticated peer replays/guesses the same deviceId but
+      // cannot produce the same fingerprint. Must be refused: queued, not
+      // evicted.
+      const result = registry.attachConnection(sessionId, attackerConn, 'device-A', 'fp-mallory');
+
+      expect(result.success).toBe(true);
+      expect(result.attachState).toBe('queued');
+      expect(registry.waitingConnectionCount).toBe(1);
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
+      expect(registry.getSessionForConnection(activeConn)?.sessionId).toBe(sessionId);
+      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
+    });
+
+    test('matching deviceId + active has a fingerprint but reconnect sends none: refused', () => {
+      // A downgrade attempt: the legitimate device authenticated once, but a
+      // later hello for the same deviceId arrives with no clientFingerprint
+      // at all (e.g. an unauthenticated connection). Must not reclaim.
+      const sessionId = generateId();
+      const activeConn = generateId();
+      const attackerConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
+      const result = registry.attachConnection(sessionId, attackerConn, 'device-A');
+
+      expect(result.attachState).toBe('queued');
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
+      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
+    });
+
+    test('matching deviceId with NO fingerprint on either side still reclaims (auth off)', () => {
+      // Localhost-only daemons (or loopback-exempt peers) never authenticate,
+      // so neither side ever carries a clientFingerprint. Falls back to
+      // today's deviceId-only reclaim.
+      const sessionId = generateId();
+      const staleConn = generateId();
+      const newConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, staleConn, 'device-A');
+      const result = registry.attachConnection(sessionId, newConn, 'device-A');
+
+      expect(result.success).toBe(true);
+      expect(result.attachState).toBe('attached');
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
+      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, staleConn, newConn);
+    });
+
+    test('a FIFO-promoted connection carries its clientFingerprint forward for later reclaim checks', () => {
+      // Mirrors the deviceId-through-promotion fix (#662): a connection
+      // promoted from the waiting queue must keep the SAME identity bar for
+      // a later reclaim attempt against it, not silently downgrade to
+      // deviceId-only just because it arrived via promotion.
+      const sessionId = generateId();
+      const connA = generateId();
+      const connB = generateId();
+      const attackerConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, connA); // active, no identity
+      registry.attachConnection(sessionId, connB, 'device-B', 'fp-bob'); // queued, authenticated
+
+      registry.detachConnection(connA); // connB promoted to active
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
+      expect(registry.getSession(sessionId)?.activeClientFingerprint).toBe('fp-bob');
+
+      // An attacker guesses device-B's id but cannot produce fp-bob.
+      const spoofed = registry.attachConnection(sessionId, attackerConn, 'device-B', 'fp-mallory');
+      expect(spoofed.attachState).toBe('queued');
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
+      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
+
+      // The real device-B reconnecting with the matching fingerprint still
+      // reclaims normally.
+      const genuine = registry.attachConnection(sessionId, generateId(), 'device-B', 'fp-bob');
+      expect(genuine.attachState).toBe('attached');
+      expect(events.onConnectionReclaimed).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('detachConnection()', () => {
     test('detaches connection and marks session orphaned', () => {
       const sessionId = generateId();

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -512,6 +512,27 @@ describe('SessionRegistry', () => {
       expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
     });
 
+    test('matching deviceId + active has NO fingerprint but reconnect sends one: refused', () => {
+      // The other mismatch direction: the active connection is loopback-
+      // exempt / unauthenticated (no bound identity), and a fingerprint-
+      // bearing (authenticated, networked) peer replays/guesses its deviceId.
+      // A networked peer must not be able to reclaim a loopback-held lock
+      // with deviceId alone just because the active side has nothing to
+      // check against — strict null==null equality means "one side null,
+      // the other not" is always a mismatch, never a free pass.
+      const sessionId = generateId();
+      const activeConn = generateId();
+      const attackerConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, activeConn, 'device-A'); // loopback, no fingerprint
+      const result = registry.attachConnection(sessionId, attackerConn, 'device-A', 'fp-mallory');
+
+      expect(result.attachState).toBe('queued');
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
+      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
+    });
+
     test('matching deviceId with NO fingerprint on either side still reclaims (auth off)', () => {
       // Localhost-only daemons (or loopback-exempt peers) never authenticate,
       // so neither side ever carries a clientFingerprint. Falls back to
@@ -559,6 +580,38 @@ describe('SessionRegistry', () => {
       const genuine = registry.attachConnection(sessionId, generateId(), 'device-B', 'fp-bob');
       expect(genuine.attachState).toBe('attached');
       expect(events.onConnectionReclaimed).toHaveBeenCalledTimes(1);
+    });
+
+    test('PoC: reclaim bound to the actual authenticated identity (not a forged claim) lands queued, victim untouched', () => {
+      // Mirrors connection-auth.test.ts's TOFU PoC one layer down: even if an
+      // attacker completed authentication while WIRE-claiming the victim's
+      // fingerprint, the fix means only their OWN server-derived fingerprint
+      // is ever bound to their connection (never the claim). So the value
+      // that actually reaches attachConnection for the attacker's connection
+      // is their own, genuinely different, fingerprint — the victim's lock
+      // must survive untouched.
+      const sessionId = generateId();
+      const victimConn = generateId();
+      const attackerConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+      registry.attachConnection(sessionId, victimConn, 'victim-device', 'fp-victim-real');
+
+      // Attacker replays/guesses the victim's deviceId; even though they
+      // WIRE-claimed 'fp-victim-real' during their own auth handshake, the
+      // daemon only ever binds the derived fingerprint of the key they
+      // actually control, which differs from the victim's.
+      const result = registry.attachConnection(
+        sessionId,
+        attackerConn,
+        'victim-device',
+        'fp-attacker-derived',
+      );
+
+      expect(result.attachState).toBe('queued');
+      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(victimConn);
+      expect(registry.getSessionForConnection(victimConn)?.sessionId).toBe(sessionId);
+      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Threat model

PR #666 added same-device lock reclaim: a reconnecting `hello` carrying a
`deviceId` matching the device already holding a session's exclusive write
lock evicts the stale connection and hands the lock straight to the new one.
`deviceId` is a client-supplied, self-reported string persisted in
`localStorage` with no cryptographic binding. `SessionRegistry.attachConnection`
compared it alone, so any peer that could complete a hello (a hostile local
process, or a networked peer already holding an authorized key but a
different physical device) could evict the legitimate device by
guessing/replaying its `deviceId` and take over the write lock.

## Change

- `Connection` now records the connection's authenticated `clientFingerprint`
  from the Ed25519 challenge-response (`handleAuthResponse`) and exposes it
  via `connectionClientFingerprint`, mirroring the existing `deviceId`
  pattern (`packages/daemon/src/server/connection.ts`).
- `WebSocketPlatformData.clientFingerprint` carries it through
  `AdapterMetadata` (`connection-adapter.ts`, `websocket-adapter.ts`).
- `connection-events.ts`'s `onConnect` extracts it the same way as `deviceId`
  and passes it to `sessionRegistry.attachConnection`.
- `SessionRegistry.attachConnection(sessionId, connectionId, deviceId?,
  clientFingerprint?)` gained a 4th param. `ManagedSession.activeClientFingerprint`
  records the identity bound to the active connection. A new
  `matchesActiveDevice` helper is the single reclaim gate:
  - If the active connection has a bound fingerprint (it authenticated),
    reclaim requires BOTH `deviceId` AND `clientFingerprint` to match.
  - If the active connection has no bound fingerprint (auth disabled
    daemon-wide, or this peer was loopback-exempted), there's no
    authenticated identity to check, so it falls back to today's
    `deviceId`-only comparison.
- FIFO `waitingConnections` queue entries now also carry `clientFingerprint`
  (`WaitingConnection`), and promotion passes it through to `attachConnection`
  exactly like `deviceId` already does. This was necessary: without it, a
  connection promoted from the queue (not the original active connection)
  would set `activeClientFingerprint` back to `null` on promotion, silently
  losing the fingerprint check the moment it later went stale itself — the
  exact same spoof, just reachable through the promoted-then-stale path
  instead of the original-active path. Fixed in the same pattern as #662's
  `deviceId`-through-promotion fix.

`onDetachSession` (the ungated tmux-style detach) is untouched, per the
issue's explicit scope note.

## Tests (no mocks)

- `packages/daemon/tests/session-registry.test.ts`: matching deviceId +
  matching fingerprint reclaims; matching deviceId + different fingerprint
  refuses (queues, no eviction); active has a fingerprint but reconnect sends
  none (refused); no fingerprint on either side still reclaims (auth off);
  a FIFO-promoted connection's bound fingerprint is still enforced against a
  later spoofed reclaim attempt.
- `packages/daemon/tests/cli/handlers/connection-events.test.ts`: the same
  three cases (match / mismatch / auth-off) through the actual `onConnect`
  handler and `platformData.clientFingerprint`.
- `packages/daemon/tests/connection-auth.test.ts`: a real Ed25519
  challenge-response handshake proving `Connection.connectionClientFingerprint`
  reflects the authenticated client's actual fingerprint (not a
  client-supplied value), that two different authenticated clients get
  different fingerprints, and that it stays `null` with no authenticator
  configured.

## Gate results

- `bun run typecheck`: clean
- `bunx biome check` (touched files): clean
- `bun test` on `session-registry.test.ts`, `cli/handlers/connection-events.test.ts`,
  `connection-auth.test.ts`, `authenticator.test.ts`, `websocket-server.test.ts`,
  `websocket-server-loopback-auth.test.ts`, `relay-adapter-auth.test.ts`: 186
  pass, 0 fail
- Full `packages/daemon` (excluding `tests/auto-approve`, which needs a local
  Ollama model and is unrelated) + `packages/shared` + `packages/signaling`:
  2405 pass, 0 fail

Part of the platform-robustness trust-boundary debt class (#548).

Closes #671