### PR TITLE
fix: correct typo failing spelling gate

### DIFF
--- a/packages/web/src/lib/message-resync.ts
+++ b/packages/web/src/lib/message-resync.ts
@@ -94,7 +94,7 @@ function candidateLandedIndices(survivor: UIMessage, reloaded: readonly UIMessag
   reloaded.forEach((r, i) => {
     if (r.sender === survivor.sender && r.content === survivor.content) {
       const rTime = Date.parse(r.timestamp);
-      // An unparseable timestamp can't be confirmed as at-or-after the
+      // An unparsable timestamp can't be confirmed as at-or-after the
       // survivor's send; treat it as not a match rather than risk a false
       // positive (losing genuine user intent is worse than a rare
       // stray duplicate).


### PR DESCRIPTION
One-word comment fix: unparseable -> unparsable in packages/web/src/lib/message-resync.ts:97.

The typo landed on develop via PR #701 (merged while the Spelling check was red - process slip, gate output was not treated as blocking). Every subsequent PR would fail the typos gate until this lands. Verified locally with typos (clean).

No behavior change; comment text only.