### PR TITLE
fix(#711): Stop spares subagent holds and evals

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -349,6 +349,12 @@ export class AutoApproveGate {
    * in-flight evals. `SessionEnd` and `forceRelease` are real teardown and
    * always release/cancel everything (mainOnly absent/false) -- there is no
    * "the rest of the team is still going" case once the session has ended.
+   *
+   * Accepted tradeoff: if a teammate is killed WITHOUT Claude ever emitting
+   * its own `SessionEnd` for that team member (e.g. the whole process is
+   * torn down externally), its spared held card has no further release
+   * trigger and sits until the pre-existing `hold_timeout` (default 1800s)
+   * fails it open on its own timer -- bounded, not indefinite.
    */
   cancelStale(reason: string, opts?: { mainOnly?: boolean }): void {
     const mainOnly = opts?.mainOnly ?? false;
@@ -381,13 +387,13 @@ export class AutoApproveGate {
     // decisions a main eval cannot be in flight at Stop anyway (Claude blocks
     // on the hook while the gate evaluates it), so this is defensive; any eval
     // that IS running/queued at lead-Stop is a teammate's and must keep going.
-    let cancelledAny = false;
+    let cancelledCount = 0;
     for (const [evalId, isSubagent] of this.evalIsSubagentById) {
       if (isSubagent) continue;
-      if (this.deps.service.cancel(reason, evalId)) cancelledAny = true;
+      if (this.deps.service.cancel(reason, evalId)) cancelledCount += 1;
     }
-    if (cancelledAny) {
-      log(`[AutoApprove] Cancelled stale MAIN-context LLM eval: ${reason}`);
+    if (cancelledCount > 0) {
+      log(`[AutoApprove] Cancelled ${cancelledCount} stale MAIN-context LLM eval(s): ${reason}`);
     }
   }
 
@@ -936,6 +942,13 @@ export class AutoApproveGate {
     if (escalateModel) {
       let second: AutoApproveResult;
       try {
+        // #711: deliberately NOT tagged in evalIsSubagentById (no evalId passed) --
+        // the same "Claude blocks on the hook while the gate evaluates" invariant
+        // that keeps a MAIN primary eval from ever being in flight at Stop applies
+        // here too, since Claude is still blocked on this same hook response
+        // while the second opinion runs. A mainOnly Stop therefore has nothing to
+        // cancel for this call by construction; leaving it untracked is correct,
+        // not a gap.
         second = await service.evaluate(
           input.tool_name,
           input.tool_input,

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -63,6 +63,11 @@ interface ToolSignature {
   readonly toolName: string;
   readonly toolInputKey: string;
   readonly toolUseId: string | undefined;
+  /** #711: true when this signature's escalation was for a subagent/team-member
+   *  event (`input.agent_id` present). A mainOnly `cancelStale` (Stop) deletes
+   *  only main-tagged entries here, so a teammate's still-open escalation is
+   *  not wiped out just because the lead agent idled. */
+  readonly isSubagent: boolean;
 }
 
 /** An observed tool call to correlate against `openQuestionSignatures`. Same
@@ -158,8 +163,11 @@ export interface AutoApproveGateDeps {
    *  logged and absorbed (treated as `undefined`) rather than propagated. */
   escalate: (input: PermissionRequestHookInput, summary?: string) => UUID | undefined;
   /** Called right before the LLM eval starts, so the tracker can BUFFER the PTY
-   *  prompt until the verdict (don't push an auto-approved permission). #484. */
-  onEvalStart?: () => void;
+   *  prompt until the verdict (don't push an auto-approved permission). #484.
+   *  `ctx.isSubagent` (#711) tells the setup layer whether this eval belongs to
+   *  a subagent/team-member permission, so it can skip the client status-pill
+   *  broadcast for it (the #484 buffering itself is unaffected). */
+  onEvalStart?: (ctx: { isSubagent: boolean }) => void;
   /** Called when the verdict is escalate (the user must answer), so the tracker
    *  releases the buffered PTY prompt. #484. */
   onEscalate?: () => void;
@@ -178,8 +186,10 @@ export interface AutoApproveGateDeps {
    *  (tests / no-AA callers). #573 / #625 */
   onHeldEscalate?: (questionId: UUID) => void;
   /** Called when the permission was auto-approved/denied silently (inject
-   *  succeeded; the user never sees it). Drives the terminal "done" cue. #513. */
-  onHandled?: () => void;
+   *  succeeded; the user never sees it). Drives the terminal "done" cue. #513.
+   *  `ctx.isSubagent` (#711): same client-broadcast-only skip as `onEvalStart`
+   *  -- the terminal cue above still fires either way. */
+  onHandled?: (ctx: { isSubagent: boolean }) => void;
   /** Called when the eval ended without a verdict (cancelled — the user already
    *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
   onCancelled?: () => void;
@@ -239,6 +249,12 @@ export interface AutoApproveGateDeps {
 interface PendingHold {
   resolve: (decision: PermissionDecision) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** #711: true for a subagent/team-member escalation (`input.agent_id`
+   *  present at hold-creation time). A lead's `Stop` fires while teammates
+   *  keep working, so `cancelStale('Stop', { mainOnly: true })` releases only
+   *  MAIN holds and leaves this one intact -- its pushed card stays
+   *  answerable via `resolveHeld`. */
+  isSubagent: boolean;
 }
 
 export class AutoApproveGate {
@@ -269,6 +285,18 @@ export class AutoApproveGate {
    * longer the running one).
    */
   private readonly evalIdByQuestion = new Map<UUID, number>();
+
+  /**
+   * Subagent-ness of every primary eval currently in flight, keyed by its
+   * `evalId` (#711). Populated in `resolvePermission` right after the eval is
+   * stamped/started, deleted when that eval's own promise settles (evaluate()
+   * is documented never to throw, so its `.finally` always runs exactly once).
+   * Lets `cancelStale('Stop', { mainOnly: true })` cancel ONLY main-context
+   * evals: under synchronous decisions a main eval cannot be in flight at Stop
+   * (Claude blocks on the hook while the gate evaluates), so any eval still
+   * tracked here at lead-Stop is a teammate's and must survive.
+   */
+  private readonly evalIsSubagentById = new Map<number, boolean>();
 
   /**
    * Every OPEN escalation this gate has created (held OR passthrough), keyed
@@ -312,21 +340,54 @@ export class AutoApproveGate {
    * permission eval is still legitimately in flight, and auth_success /
    * elicitation_dialog don't carry "user answered" semantics either. No-op when no
    * service is configured.
+   *
+   * `opts.mainOnly` (#711) scopes the release/cancel to MAIN-context state
+   * only. `Stop` fires whenever the LEAD agent idles, even while teammates
+   * (subagent/`agent_id`-tagged escalations) are still running -- releasing/
+   * cancelling EVERYTHING on a lead Stop turned every teammate's already-
+   * pushed card phantom (answering it resolved nothing) and killed their
+   * in-flight evals. `SessionEnd` and `forceRelease` are real teardown and
+   * always release/cancel everything (mainOnly absent/false) -- there is no
+   * "the rest of the team is still going" case once the session has ended.
    */
-  cancelStale(reason: string): void {
-    // Release any held hooks first (#573): a Stop/SessionEnd means the session
-    // is going away, so a hook blocked on a human answer must fail open to
-    // passthrough rather than hang. A held hook cannot normally co-occur with
-    // Stop (Claude is blocked on the permission), but this is defensive.
-    this.releaseAllHolds('passthrough', reason);
-    // #673: the session is ending, so every OPEN escalation this gate has
-    // tracked (held above, or a passthrough one with no hold) is moot. This is
-    // the ONLY place `openQuestionSignatures` is wholesale-cleared rather than
-    // entry-by-entry; releaseAllHolds only touched the held subset above.
-    this.openQuestionSignatures.clear();
+  cancelStale(reason: string, opts?: { mainOnly?: boolean }): void {
+    const mainOnly = opts?.mainOnly ?? false;
+    // Release held hooks first (#573): a teardown means the session is going
+    // away, so a hook blocked on a human answer must fail open to passthrough
+    // rather than hang. mainOnly (#711) keeps subagent/team-member holds alive
+    // -- their hooks are still blocked in a still-running teammate and remain
+    // answerable via `resolveHeld`.
+    this.releaseAllHolds('passthrough', reason, mainOnly);
+    // #673 / #711: every OPEN escalation this gate has tracked (held above, or
+    // a passthrough one with no hold) is moot on a full teardown -- wholesale
+    // clear, as before. On a mainOnly Stop, only the MAIN-tagged entries are
+    // moot; a teammate's is not (its hold, if any, was just spared above, and
+    // its signature must stay trackable for external-resolution cancellation).
+    if (mainOnly) {
+      for (const [qid, sig] of this.openQuestionSignatures) {
+        if (!sig.isSubagent) this.openQuestionSignatures.delete(qid);
+      }
+    } else {
+      this.openQuestionSignatures.clear();
+    }
     if (this.deps.service === null) return;
-    if (this.deps.service.cancel(reason)) {
-      log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
+    if (!mainOnly) {
+      if (this.deps.service.cancel(reason)) {
+        log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
+      }
+      return;
+    }
+    // #711: cancel ONLY the in-flight evals tagged main. Under synchronous
+    // decisions a main eval cannot be in flight at Stop anyway (Claude blocks
+    // on the hook while the gate evaluates it), so this is defensive; any eval
+    // that IS running/queued at lead-Stop is a teammate's and must keep going.
+    let cancelledAny = false;
+    for (const [evalId, isSubagent] of this.evalIsSubagentById) {
+      if (isSubagent) continue;
+      if (this.deps.service.cancel(reason, evalId)) cancelledAny = true;
+    }
+    if (cancelledAny) {
+      log(`[AutoApprove] Cancelled stale MAIN-context LLM eval: ${reason}`);
     }
   }
 
@@ -401,7 +462,7 @@ export class AutoApproveGate {
     // handleAnswer find it "live" and misroute. The user-answer path also
     // removes it in handleAnswer's finally; a double-remove is idempotent.
     this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
-    this.markHandled();
+    this.markHandled(hold.isSubagent);
     hold.resolve(decision);
     log(
       `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)} resolved: ${decision}`,
@@ -425,14 +486,20 @@ export class AutoApproveGate {
     return this.releaseHeld(questionId, 'passthrough');
   }
 
-  /** Resolve every pending hold with one decision + reason, clearing timers and
-   *  emptying the map. Used by `cancelStale` (session teardown). */
-  private releaseAllHolds(decision: PermissionDecision, reason: string): void {
-    if (this.pendingHolds.size === 0) return;
+  /** Resolve pending holds with one decision + reason, clearing timers and
+   *  removing each released entry. Used by `cancelStale` (session teardown, or
+   *  a mainOnly-scoped Stop, #711) -- `mainOnly` releases only holds NOT
+   *  tagged subagent, leaving a teammate's hold (and its timer) intact so it
+   *  stays answerable via `resolveHeld`. */
+  private releaseAllHolds(decision: PermissionDecision, reason: string, mainOnly = false): void {
+    const targets = mainOnly
+      ? [...this.pendingHolds].filter(([, hold]) => !hold.isSubagent)
+      : [...this.pendingHolds];
+    if (targets.length === 0) return;
     log(
-      `[AutoApprove ${this.sessionTag}] Releasing ${this.pendingHolds.size} held hook(s) as ${decision} (${reason})`,
+      `[AutoApprove ${this.sessionTag}] Releasing ${targets.length} held hook(s) as ${decision} (${reason}${mainOnly ? ', main-only' : ''})`,
     );
-    for (const [qid, hold] of this.pendingHolds) {
+    for (const [qid, hold] of targets) {
       clearTimeout(hold.timer);
       // The session is going away (Stop/SessionEnd); dismiss the pushed card on
       // every client BEFORE resolving so it does not linger after the prompt is
@@ -440,8 +507,8 @@ export class AutoApproveGate {
       this.notifyResolved(qid, 'cancelled');
       this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
       hold.resolve(decision);
+      this.pendingHolds.delete(qid);
     }
-    this.pendingHolds.clear();
   }
 
   /**
@@ -497,7 +564,7 @@ export class AutoApproveGate {
       // setTimeout keeps the event loop alive for the whole human-paced hold;
       // unref so a held hook never blocks daemon shutdown.
       timer.unref?.();
-      this.pendingHolds.set(qid, { resolve, timer });
+      this.pendingHolds.set(qid, { resolve, timer, isSubagent: this.isSubagentEvent(input) });
     });
     // Phase 1 (#603, R1/R2): gate the hold on CONFIRMED delivery. A held hook is
     // only worth blocking Claude for if the user can actually be notified; if
@@ -591,7 +658,7 @@ export class AutoApproveGate {
         );
       }, holdUnconfirmedMs);
       timer.unref?.();
-      this.pendingHolds.set(qid, { resolve: hold.resolve, timer });
+      this.pendingHolds.set(qid, { resolve: hold.resolve, timer, isSubagent: hold.isSubagent });
       logError(
         `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNCONFIRMED (${reason}); holding ${Math.round(holdUnconfirmedMs / 1000)}s (hold_unconfirmed_timeout) with retry before fail-open`,
       );
@@ -697,8 +764,13 @@ export class AutoApproveGate {
    */
   async resolvePermission(input: PermissionRequestHookInput): Promise<PermissionDecision> {
     const { service, isInSubagentContext } = this.deps;
+    // #711: computed once and threaded through every markHandled/onEvalStart
+    // call below, so a held hold, an openQuestionSignatures entry, and the
+    // client status-pill cue all agree on whether THIS permission belongs to a
+    // subagent/team-member (`agent_id` present) or the main agent.
+    const isSubagent = this.isSubagentEvent(input);
 
-    if (this.isSubagentEvent(input)) {
+    if (isSubagent) {
       log(
         `[Hooks] Subagent PermissionRequest forwarded: agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
       );
@@ -735,8 +807,10 @@ export class AutoApproveGate {
 
     // Open the buffer/cue window (#484/#513). With synchronous decisions Claude
     // does not render the prompt during the eval, so the buffer rarely holds a
-    // PTY prompt now; the cue lifecycle still rides these signals.
-    this.safeCue('onEvalStart', this.deps.onEvalStart);
+    // PTY prompt now; the cue lifecycle still rides these signals. #711: ctx
+    // lets the setup layer skip the client status-pill broadcast for a
+    // subagent/team-member eval the user never saw asked.
+    this.safeCueWithArg('onEvalStart', this.deps.onEvalStart, { isSubagent });
 
     // Raw suggestions: the service does its own strict-string filtering; we
     // forward the raw shape so the multi-choice classifier can route a
@@ -744,14 +818,22 @@ export class AutoApproveGate {
     // Stamp a unique id so a held question (Part B) can be tied to THIS eval and
     // a manual answer cancels exactly it (#617).
     const evalId = ++this.evalSeq;
-    const evalPromise = service.evaluate(
-      input.tool_name,
-      input.tool_input,
-      this.sessionTag,
-      input.permission_suggestions as readonly unknown[] | undefined,
-      undefined,
-      evalId,
-    );
+    // #711: tag this eval's subagent-ness so a Stop can cancel ONLY main-context
+    // evals (`cancelStale('Stop', { mainOnly: true })`); the .finally always
+    // removes it once (evaluate() never rejects).
+    this.evalIsSubagentById.set(evalId, isSubagent);
+    const evalPromise = service
+      .evaluate(
+        input.tool_name,
+        input.tool_input,
+        this.sessionTag,
+        input.permission_suggestions as readonly unknown[] | undefined,
+        undefined,
+        evalId,
+      )
+      .finally(() => {
+        this.evalIsSubagentById.delete(evalId);
+      });
 
     // Part B (#573, ISOLATED behind push_hold_timeout): if the eval is still
     // running after push_hold_timeout AND this is a binary main-context
@@ -769,8 +851,9 @@ export class AutoApproveGate {
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
       if (isInSubagentContext()) {
-        if (this.isSubagentEvent(input)) {
-          this.markHandled();
+        if (isSubagent) {
+          // #711: a genuine subagent deny must not flap the client pill.
+          this.markHandled(true);
           return 'deny';
         }
         // #710: MAIN-tagged + stuck tracker == leak, not a real subagent
@@ -794,11 +877,11 @@ export class AutoApproveGate {
       return 'passthrough';
     }
     if (result.decision === 'approve') {
-      this.markHandled();
+      this.markHandled(isSubagent);
       return 'allow';
     }
     if (result.decision === 'deny') {
-      this.markHandled();
+      this.markHandled(isSubagent);
       return 'deny';
     }
     if (result.decision === 'pick') {
@@ -814,7 +897,7 @@ export class AutoApproveGate {
       if (
         await this.inject(input, String(result.pickIndex), `multichoice-pick-${result.pickIndex}`)
       ) {
-        this.markHandled();
+        this.markHandled(isSubagent);
         return 'passthrough';
       }
       return this.escalatePassthrough(input);
@@ -832,9 +915,10 @@ export class AutoApproveGate {
     // instead of deny — still answerable via the Model B hook response
     // (below), strictly better than a silent main-agent deny.
     if (isInSubagentContext()) {
-      if (this.isSubagentEvent(input)) {
+      if (isSubagent) {
         log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
-        this.markHandled();
+        // #711: a genuine subagent deny must not flap the client pill.
+        this.markHandled(true);
         return 'deny';
       }
       // Blanket-reset tradeoff (clears ALL tracked use_ids, not just the
@@ -870,12 +954,12 @@ export class AutoApproveGate {
       }
       if (second.decision === 'approve') {
         log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) approved`);
-        this.markHandled();
+        this.markHandled(isSubagent);
         return 'allow';
       }
       if (second.decision === 'deny') {
         log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) denied`);
-        this.markHandled();
+        this.markHandled(isSubagent);
         return 'deny';
       }
       if (second.decision === 'cancelled') {
@@ -1057,10 +1141,13 @@ export class AutoApproveGate {
    * silently (inject succeeded), so the user never sees it. Notifies the
    * tracker (closes the #484 buffer window) AND the terminal cue (#513). Every
    * silent-handle site routes through here so neither signal can be missed.
+   * `isSubagent` (#711) is forwarded to `onHandled` so the setup layer can skip
+   * the client status-pill broadcast for a subagent/team-member permission the
+   * user never saw asked -- the tracker + terminal cue still fire either way.
    */
-  private markHandled(): void {
+  private markHandled(isSubagent: boolean): void {
     this.deps.tracker.onAutoApproveHandled();
-    this.safeCue('onHandled', this.deps.onHandled);
+    this.safeCueWithArg('onHandled', this.deps.onHandled, { isSubagent });
   }
 
   /**
@@ -1218,6 +1305,9 @@ export class AutoApproveGate {
         toolName: observed.toolName,
         toolInputKey: stableToolInputKey(observed.toolInput),
         toolUseId: observed.toolUseId,
+        // #711: tags this OPEN escalation main vs subagent/team-member, so a
+        // mainOnly Stop (cancelStale) clears only main-tagged entries here.
+        isSubagent: this.isSubagentEvent(input),
       });
     }
     return questionId;

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -24,7 +24,11 @@
  * the bridge's `isInSubagentContext` + the router's `onPermissionRequest` as
  * callbacks; Stop/SessionEnd call `gate.cancelStale()` to abort an in-flight eval
  * when the Claude session actually ends. (Pre/PostToolUse deliberately do NOT
- * cancel — under synchronous decisions the eval is never stale; see #537.)
+ * cancel — under synchronous decisions the eval is never stale; see #537.) Stop
+ * passes `{ mainOnly: true }` (#711): it fires whenever the LEAD idles even
+ * while agent-team teammates keep working, so it releases/cancels only
+ * MAIN-context holds and evals, sparing a teammate's still-open escalation.
+ * SessionEnd is real teardown and stays unscoped (releases/cancels everything).
  *
  * This listener block IS the per-session hook router (admit-then-fan-out); a
  * formal HookRouter class is deferred to a later refactor (#470). The function
@@ -371,11 +375,15 @@ export function setupHookBridge(
       // #560: the same lifecycle drives the auto-approve cue in Claude's native
       // status line via the StatusWriter. A COUNT (start/end) replaces the old
       // shared title spinner, which raced under concurrent evals.
-      onEvalStart: () => {
+      onEvalStart: (ctx) => {
         tracker.onAutoApproveStart();
         deps.statusWriter?.autoApproveStart(Date.now());
         // #576: surface the in-flight eval on the client pill ('working').
-        broadcastAutoApproveStatus('evaluating');
+        // #711: skip the CLIENT broadcast for a subagent/team-member eval --
+        // the user never saw it asked, so flashing the pill to 'evaluating'
+        // for it reads as a phantom auto-approval. The tracker buffer + the
+        // StatusWriter terminal cue above still fire unconditionally.
+        if (!ctx.isSubagent) broadcastAutoApproveStatus('evaluating');
       },
       onEscalate: () => {
         tracker.onAutoApproveEscalate();
@@ -393,11 +401,12 @@ export function setupHookBridge(
       // held Question.id, so the tracker pushes that exact question immediately
       // (-> addQuestion + maybePush) under the id the hold is keyed by.
       onHeldEscalate: (questionId) => tracker.pushHeldHook(questionId),
-      onHandled: () => {
+      onHandled: (ctx) => {
         deps.statusWriter?.autoApproveEnd('approved', Date.now());
         // #576: the permission was silently allowed; tell clients so the pill
         // doesn't sit stale on 'evaluating' until the next hook fires.
-        broadcastAutoApproveStatus('approved');
+        // #711: same subagent skip as onEvalStart above -- see that comment.
+        if (!ctx.isSubagent) broadcastAutoApproveStatus('approved');
       },
       onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
       // #585: a held question that resolves without a user answer (Part-B late
@@ -633,7 +642,13 @@ export function setupHookBridge(
   hookServer.on('Stop', (input) => {
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
-    autoApproveGate.cancelStale('Stop');
+    // #711: mainOnly -- Stop fires whenever the LEAD agent idles, even while
+    // teammates (subagent/agent_id-tagged permission escalations) are still
+    // running. A wholesale cancelStale here released every teammate's
+    // already-pushed held card as passthrough (phantom: answering it resolved
+    // nothing) and killed their in-flight evals. SessionEnd below is real
+    // teardown and keeps the wholesale release/cancel.
+    autoApproveGate.cancelStale('Stop', { mainOnly: true });
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -953,6 +953,247 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #711: a lead agent's Stop fires whenever it idles even while agent-team
+// teammates (subagent/`agent_id`-tagged PermissionRequests) keep working. A
+// wholesale cancelStale('Stop') released every teammate's already-pushed held
+// card as passthrough (phantom -- answering it resolved nothing) and killed
+// their in-flight evals. `cancelStale('Stop', { mainOnly: true })` scopes the
+// release/cancel to MAIN-tagged holds + evals only; `SessionEnd` and
+// `forceRelease` are real teardown and keep releasing/cancelling everything.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+
+  function evaluator(result: AutoApproveResult): AutoApproveEvaluator {
+    return { evaluate: async () => result, cancel: () => true };
+  }
+
+  function gate(
+    service: AutoApproveEvaluator,
+    opts: {
+      holdMs?: number;
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: opts.holdMs ?? 60_000,
+        alwaysEscalateTools: new Set(),
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      ...over,
+    };
+  }
+
+  /** An `agent_id`-tagged override -- the sole discriminator `isSubagentEvent`
+   *  reads (#711). */
+  const teammate = { agent_id: 'teammate-1', agent_type: 'general-purpose' };
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    lastQuestionId = undefined;
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('(a) a SUBAGENT-tagged hold survives cancelStale(Stop, mainOnly) and stays resolvable', async () => {
+    const g = gate(evaluator(escalate));
+    const pending = g.resolvePermission(pr(teammate));
+    await new Promise((r) => setTimeout(r, 20));
+    const qid = lastQuestionId as UUID;
+
+    g.cancelStale('Stop', { mainOnly: true });
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(settled).toBe(false); // still held -- mainOnly spared it
+
+    expect(g.resolveHeld(qid, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('(b) a MAIN hold IS released on cancelStale(Stop, mainOnly), with notifyResolved(cancelled)', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate(evaluator(escalate), {
+      onResolved: (qid, reason) => resolvedLog.push({ qid, reason }),
+    });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qid = lastQuestionId as UUID;
+
+    g.cancelStale('Stop', { mainOnly: true });
+
+    expect(await pending).toBe('passthrough');
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+    expect(g.resolveHeld(qid, 'allow')).toBe(false); // the hold is gone
+  });
+
+  test('(c) SessionEnd (cancelStale with no opts) releases BOTH main and subagent holds', async () => {
+    const g = gate(evaluator(escalate));
+    const pendingMain = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qidMain = lastQuestionId as UUID;
+    const pendingSub = g.resolvePermission(pr(teammate));
+    await new Promise((r) => setTimeout(r, 20));
+    const qidSub = lastQuestionId as UUID;
+
+    g.cancelStale('SessionEnd');
+
+    expect(await pendingMain).toBe('passthrough');
+    expect(await pendingSub).toBe('passthrough');
+    expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
+    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
+  });
+
+  test('(e) forceRelease still releases BOTH main and subagent holds', async () => {
+    const g = gate(evaluator(escalate));
+    const pendingMain = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 20));
+    const qidMain = lastQuestionId as UUID;
+    const pendingSub = g.resolvePermission(pr(teammate));
+    await new Promise((r) => setTimeout(r, 20));
+    const qidSub = lastQuestionId as UUID;
+
+    g.forceRelease('remi unstick');
+
+    expect(await pendingMain).toBe('passthrough');
+    expect(await pendingSub).toBe('passthrough');
+    expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
+    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
+  });
+
+  test('cancelStale(Stop, mainOnly) cancels only the in-flight MAIN eval; a concurrent SUBAGENT eval keeps running and its late verdict still reconciles', async () => {
+    const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+    const resolvers = new Map<string, (r: AutoApproveResult) => void>();
+    const service: AutoApproveEvaluator = {
+      evaluate: (_toolName, toolInput) => {
+        const key = JSON.stringify(toolInput);
+        return new Promise<AutoApproveResult>((resolve) => {
+          resolvers.set(key, resolve);
+        });
+      },
+      cancel: (reason, evalId) => {
+        cancelLog.push({ reason, evalId });
+        return true;
+      },
+    };
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    // Part B (pushHoldMs) so BOTH evals are held early WHILE still running --
+    // the exact concurrent-teammate shape the #711 rationale is about.
+    const g = new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        holdMs: 60_000,
+        pushHoldMs: 10,
+        alwaysEscalateTools: new Set(),
+      },
+      SID,
+    );
+
+    const pendingMain = g.resolvePermission(pr({ tool_input: { command: 'echo main' } }));
+    await new Promise((r) => setTimeout(r, 20));
+    const pendingSub = g.resolvePermission(
+      pr({ tool_input: { command: 'echo sub' }, ...teammate }),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+
+    let subSettled = false;
+    void pendingSub.then(() => {
+      subSettled = true;
+    });
+
+    g.cancelStale('Stop', { mainOnly: true });
+
+    expect(await pendingMain).toBe('passthrough'); // main hold released + eval cancelled
+    await new Promise((r) => setTimeout(r, 10));
+    expect(subSettled).toBe(false); // subagent untouched: hold AND eval survive
+    expect(cancelLog).toHaveLength(1); // ONLY the main eval's cancel() call
+
+    // Prove the subagent eval was never aborted: its late verdict reconciles.
+    resolvers.get(JSON.stringify({ command: 'echo sub' }))?.(approve);
+    expect(await pendingSub).toBe('allow');
+  });
+
+  test('#711 onEvalStart/onHandled ctx carries isSubagent (true for agent_id, false for main)', async () => {
+    const ctxLog: Array<{ isSubagent: boolean }> = [];
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const g = new AutoApproveGate(
+      {
+        service: evaluator(approve),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => undefined,
+        onEvalStart: (ctx) => ctxLog.push(ctx),
+        onHandled: (ctx) => ctxLog.push(ctx),
+      },
+      SID,
+    );
+    expect(await g.resolvePermission(pr(teammate))).toBe('allow');
+    expect(await g.resolvePermission(pr())).toBe('allow');
+    expect(ctxLog).toEqual([
+      { isSubagent: true },
+      { isSubagent: true },
+      { isSubagent: false },
+      { isSubagent: false },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Part B (#573): slow-eval early push + hold. ISOLATED behind push_hold_timeout.
 // A deferred eval lets the test control whether the eval or the push-hold timer
 // wins the race deterministically.

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1790,6 +1790,38 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     expect(await gate.resolvePermission(pr())).toBe('passthrough');
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
+
+  // #711 review follow-up: onDeliveryUnconfirmed's short-window RE-ARM rebuilds
+  // the PendingHold entry (new timer, same resolve) -- prove that rebuild
+  // preserves `isSubagent`, not just the initial `createHold` tagging.
+  test('#711 a SUBAGENT hold re-armed via onDeliveryUnconfirmed keeps isSubagent tagged (survives mainOnly Stop)', async () => {
+    const gate = deliveryGate({
+      delivery: Promise.resolve('failed'),
+      deliveryConfirmMs: 20,
+      holdUnconfirmedMs: 500, // long enough to land cancelStale inside the re-armed window
+      holdMs: 60_000,
+    });
+    const pending = gate.resolvePermission(
+      pr({ agent_id: 'teammate-1', agent_type: 'general-purpose' }),
+    );
+    // Past deliveryConfirmMs: onDeliveryUnconfirmed has fired and re-armed the
+    // hold via `this.pendingHolds.set(qid, { resolve: hold.resolve, timer, isSubagent: hold.isSubagent })`.
+    await new Promise((r) => setTimeout(r, 60));
+
+    // If the re-arm dropped the isSubagent tag, mainOnly would wrongly treat
+    // this as a main hold and release it here.
+    gate.cancelStale('Stop', { mainOnly: true });
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false); // still held -- re-armed hold correctly tagged subagent
+
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2001,7 +2001,13 @@ describe('setupHookBridge', () => {
     expect(cancelLog).not.toContain('PostToolUse');
   });
 
-  test('Stop cancels stale auto-approve LLM eval', () => {
+  test('Stop cancels a stale in-flight MAIN auto-approve LLM eval (#711 mainOnly scope)', () => {
+    // #711: cancelStale('Stop') is now scoped to mainOnly -- it only cancels
+    // evals tagged main (no agent_id), so this test must have a real in-flight
+    // MAIN eval for Stop to catch. `firePermission` is fire-and-forget (not
+    // awaited): the gate stamps/tracks the eval's id SYNCHRONOUSLY before its
+    // first `await`, so by the time the very next line (`hookServer.fire('Stop', ...)`)
+    // runs, the eval is already tracked as in-flight and main-tagged.
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
     hookServer.fire('SessionStart', {
@@ -2011,12 +2017,47 @@ describe('setupHookBridge', () => {
       source: 'startup',
       model: 'test',
     });
+    void hookServer.firePermission({
+      session_id: 'claude-locked-stop',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
     hookServer.fire('Stop', {
       session_id: 'claude-locked-stop',
       hook_event_name: 'Stop',
       stop_hook_active: false,
     });
     expect(cancelLog).toContain('Stop');
+  });
+
+  test('#711 Stop with mainOnly does NOT cancel a still-running SUBAGENT (agent_id) eval', () => {
+    // The mirror of the test above: a teammate's PermissionRequest eval must
+    // survive a lead Stop -- it is untouched because it is tagged subagent,
+    // not because nothing was in flight.
+    const cancelLog: string[] = [];
+    build({ autoApprove: true, cancelLog });
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-locked-stop-sub',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'cancel-test-sub.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+    void hookServer.firePermission({
+      session_id: 'claude-locked-stop-sub',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      agent_id: 'teammate-1',
+      agent_type: 'general-purpose',
+    });
+    hookServer.fire('Stop', {
+      session_id: 'claude-locked-stop-sub',
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+    });
+    expect(cancelLog).not.toContain('Stop');
   });
 
   test('SessionEnd cancels stale auto-approve LLM eval', () => {
@@ -2684,6 +2725,35 @@ describe('setupHookBridge', () => {
       // onEscalate deliberately does NOT broadcast (the bridge's
       // handlePermissionRequest -> onStatusChange('waiting') already does);
       // and onHandled is not reached on an escalate verdict.
+      expect(statuses).not.toContain('approved');
+    });
+
+    test('#711 a SUBAGENT (agent_id) eval broadcasts NEITHER "evaluating" NOR "approved" (no phantom pill)', async () => {
+      const sendLog: ProtocolMessage[] = [];
+      build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 10, sendLog });
+
+      hookServer.fire('SessionStart', {
+        session_id: 'claude-aa-subagent',
+        hook_event_name: 'SessionStart',
+        transcript_path: path.join(tmpDir, 'aa-subagent.jsonl'),
+        source: 'startup',
+        model: 'test',
+      });
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-aa-subagent',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        agent_id: 'teammate-1',
+        agent_type: 'general-purpose',
+      });
+      expect(decision).toBe('allow');
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      // The tracker buffer + StatusWriter terminal cue still ran (decision is
+      // still 'allow'); only the CLIENT session_update broadcast is skipped.
+      expect(statuses).not.toContain('evaluating');
       expect(statuses).not.toContain('approved');
     });
 


### PR DESCRIPTION
Closes #711.

## Problem

In agent-team sessions the lead agent's Stop hook fires whenever the lead idles while teammates keep working. The Stop listener called `cancelStale('Stop')`, which released EVERY held permission hook as passthrough: 166 occurrences in the 0.6.18-dev.24 soak log. Teammates' already-pushed cards became phantom (answering resolved nothing), their in-flight evals were killed, and the released prompts re-rendered natively where the daemon could not see them. Separately, every subagent eval flashed the client status pill evaluating -> approved (6,187 subagent PermissionRequests in the soak log), reading as phantom approvals.

## Fix

- `PendingHold`, `ToolSignature`, and in-flight eval ids are tagged with subagent-ness (`input.agent_id` present) at creation; the delivery-unconfirmed re-arm preserves the tag.
- `cancelStale(reason, { mainOnly: true })` (Stop listener): releases only main holds (same notifyResolved + removeQuestion + passthrough semantics), deletes only main-tagged `openQuestionSignatures` entries, and cancels only main-tagged evals via `service.cancel(reason, evalId)`. Under synchronous decisions a main eval cannot be in flight at Stop (Claude blocks on the hook), so surviving evals are teammates' by construction.
- SessionEnd and `forceRelease` keep the wholesale release/cancel.
- `onEvalStart`/`onHandled` gate cues now carry `{ isSubagent }`; the setup layer skips the client `session_update` broadcast for subagent evals. Tracker buffering (#484) and StatusWriter terminal cues are unchanged.
- The two `isInSubagentContext()` deny branches tag `markHandled(true)` ("subagent by construction": the legacy nested-Task path never carries agent_id).

## Tests

- +241 lines in `auto-approve-gate.test.ts`: subagent hold survives mainOnly Stop and stays resolvable; main hold released with `notifyResolved('cancelled')`; SessionEnd releases both; forceRelease releases both; concurrent-eval test proving mainOnly cancels only the main eval while the subagent eval keeps running and reconciles; ctx-shape test for onEvalStart/onHandled.
- Reworked the stale "Stop cancels eval" test in `hook-bridge-setup.test.ts` (its premise — cancel fires with zero in-flight evals — is invalidated by scoping); added subagent-eval-survives-Stop and no-pill-broadcast-for-subagent tests.
- 161 pass in the two touched test files; 407 pass across the gate test dir (excluding the Ollama-dependent LLM-judgment tests, pre-existing); typecheck and biome clean.

Found during develop-binary soak 2026-07-06. Companions: #710 (tracker-leak main-agent denies), #712/#713 (PTY orphan-prompt fallback).
