### PR TITLE
fix(#710): pop subagent tracker on tagged PostToolUse

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -139,6 +139,16 @@ export interface AutoApproveGateDeps {
   tracker: QuestionPresenceTracker;
   /** Wraps `HookEventBridge.isInSubagentContext()`. Read live per branch (async TOCTOU). */
   isInSubagentContext: () => boolean;
+  /**
+   * Reset the subagent-context tracker (#710). Called ONLY when a MAIN-tagged
+   * PermissionRequest (`agent_id` absent) observes `isInSubagentContext()`
+   * stuck true — proof of a tracker leak (a dropped PostToolUse(Task/Agent)
+   * completion), never a real subagent prompt (those carry `agent_id` and
+   * default-deny instead). Optional so tests that don't wire it degrade to a
+   * no-op; the escalate-as-main recovery still happens without it, just
+   * without clearing the leaked state.
+   */
+  resetSubagentContext?: () => void;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -670,10 +680,17 @@ export class AutoApproveGate {
    *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
    *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
    *     prompt; the user answers).
-   *   - escalate / no-service in a SUBAGENT context -> 'deny' via the hook
-   *     response. This is the core fix: the old PTY-inject default-deny couldn't
-   *     tell whose prompt was on the PTY for parallel subagents and leaked; the
-   *     synchronous deny needs no PTY at all.
+   *   - escalate / no-service / eval-error in a SUBAGENT-TAGGED context
+   *     (`agent_id` present) -> 'deny' via the hook response. This is the core
+   *     fix: the old PTY-inject default-deny couldn't tell whose prompt was on
+   *     the PTY for parallel subagents and leaked; the synchronous deny needs
+   *     no PTY at all.
+   *   - the SAME three branches with `isInSubagentContext()` true but NO
+   *     `agent_id` on the input -> this is the #710 tracker-leak signature
+   *     (a PostToolUse(Task/Agent) completion tagged with the spawned agent's
+   *     own agent_id was dropped before popping the tracker), NOT a real
+   *     subagent prompt. Reset the tracker and escalate as main instead of
+   *     silently denying the main agent forever.
    *   - pick (multi-choice) -> inject the index + 'passthrough' (the hook
    *     response can't express "pick option N"; keep the PTY for this rare case).
    *   - cancelled -> 'passthrough' (the user already advanced).
@@ -691,8 +708,17 @@ export class AutoApproveGate {
     // leak); main escalates to the user (holding the hook when binary, #573).
     if (!service) {
       if (isInSubagentContext()) {
-        log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
-        return 'deny';
+        if (this.isSubagentEvent(input)) {
+          log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
+          return 'deny';
+        }
+        // #710: a MAIN-tagged event (no agent_id) reaching here means the
+        // tracker leaked, not a real subagent prompt. Reset and fall through
+        // to escalateMain below instead of denying the main agent.
+        logError(
+          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+        );
+        this.deps.resetSubagentContext?.();
       }
       return this.escalateMain(input);
     }
@@ -733,8 +759,16 @@ export class AutoApproveGate {
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
       if (isInSubagentContext()) {
-        this.markHandled();
-        return 'deny';
+        if (this.isSubagentEvent(input)) {
+          this.markHandled();
+          return 'deny';
+        }
+        // #710: MAIN-tagged + stuck tracker == leak, not a real subagent
+        // prompt. Reset and fall through to escalateMain below.
+        logError(
+          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, eval-error path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+        );
+        this.deps.resetSubagentContext?.();
       }
       return this.escalateMain(input);
     }
@@ -774,19 +808,27 @@ export class AutoApproveGate {
       return this.escalatePassthrough(input);
     }
     // escalate: a subagent prompt the user cannot answer is default-denied via
-    // the response (no hang, no PTY).
+    // the response (no hang, no PTY). A MAIN-tagged event (agent_id absent)
+    // reaching here with isInSubagentContext() true is NOT a real subagent
+    // prompt: it is the #710 tracker-leak signature (a PostToolUse(Task/Agent)
+    // completion stamped with the SPAWNED agent's own agent_id never popped
+    // the use_id an earlier untagged PreToolUse tracked). Denying it would
+    // silently drop the main agent's own prompts (including AskUserQuestion)
+    // forever, so reset the tracker and fall through to escalate as main
+    // instead. Tradeoff (#710): on a legacy Claude Code version that predates
+    // agent_id, a genuine synchronous subagent prompt would now escalate+hold
+    // instead of deny — still answerable via the Model B hook response
+    // (below), strictly better than a silent main-agent deny.
     if (isInSubagentContext()) {
-      if (!this.isSubagentEvent(input)) {
-        // A MAIN-agent event reaching here means the subagent-context tracker
-        // leaked (a PostToolUse(Task) was dropped). Surface it loudly — otherwise
-        // the main session silently denies every permission.
-        logError(
-          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}); denying. Possible subagent-context tracker leak.`,
-        );
+      if (this.isSubagentEvent(input)) {
+        log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
+        this.markHandled();
+        return 'deny';
       }
-      log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
-      this.markHandled();
-      return 'deny';
+      logError(
+        `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+      );
+      this.deps.resetSubagentContext?.();
     }
     // Second opinion (#522): the fast model would escalate, but a heavier
     // escalate_model may resolve it (honoring a broad approve policy) before we

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -715,6 +715,16 @@ export class AutoApproveGate {
         // #710: a MAIN-tagged event (no agent_id) reaching here means the
         // tracker leaked, not a real subagent prompt. Reset and fall through
         // to escalateMain below instead of denying the main agent.
+        //
+        // #716 (blanket-reset tradeoff): resetSubagentContext() clears ALL
+        // tracked use_ids, not just the leaked one -- it cannot tell which
+        // entry is stale. If a genuinely-running concurrent synchronous Task
+        // is ALSO open right now, its own later agent_id-tagged permission
+        // requests will see isInSubagentContext() false and escalate as main
+        // instead of default-denying. Accepted: (a) that escalation is
+        // held/answerable (Model B), the same way async/background subagents
+        // and team members already behave; (b) the alternative -- silently
+        // denying the MAIN agent -- is the #710 bug this reset exists to fix.
         logError(
           `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
         );
@@ -764,7 +774,9 @@ export class AutoApproveGate {
           return 'deny';
         }
         // #710: MAIN-tagged + stuck tracker == leak, not a real subagent
-        // prompt. Reset and fall through to escalateMain below.
+        // prompt. Reset and fall through to escalateMain below. Blanket-reset
+        // tradeoff (clears ALL tracked use_ids, not just the leaked one):
+        // see the no-service branch above (#716).
         logError(
           `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, eval-error path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
         );
@@ -825,8 +837,10 @@ export class AutoApproveGate {
         this.markHandled();
         return 'deny';
       }
+      // Blanket-reset tradeoff (clears ALL tracked use_ids, not just the
+      // leaked one): see the no-service branch above (#716).
       logError(
-        `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+        `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, escalate path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
       );
       this.deps.resetSubagentContext?.();
     }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -559,6 +559,13 @@ export function setupHookBridge(
       // its use_ids were never tracked in the first place (subagent PreToolUse
       // events are dropped without tracking, same as this listener's PreToolUse
       // sibling above).
+      //
+      // Residual gap (#716): this pop only runs when `binder.admits(input)`
+      // above is true. A Task-closing PostToolUse that `admits()` rejects (a
+      // rotation/sibling race) never reaches here and can still leak the
+      // tracked use_id -- bounded by the Stop/SessionEnd/StopFailure resets
+      // in hook-event-bridge.ts and by the gate's #710 leak-recovery
+      // escalate (reset + escalate as main instead of denying).
       hookBridge.noteSubagentToolEnd(input.tool_name, input.tool_use_id);
       return;
     }

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -357,6 +357,10 @@ export function setupHookBridge(
       sessionRegistry,
       tracker,
       isInSubagentContext: () => hookBridge.isInSubagentContext(),
+      // #710: lets the gate recover from a tracker leak (a MAIN-tagged
+      // PermissionRequest observing isInSubagentContext() stuck true) instead
+      // of denying the main agent forever.
+      resetSubagentContext: () => hookBridge.resetSubagentContext(),
       // Call the bridge DIRECTLY (not via the void-typed handlers map) so the
       // created Question.id flows back to the gate; a binary escalation holds
       // the hook keyed by it (#573). The bridge still does the onQuestion +
@@ -543,7 +547,21 @@ export function setupHookBridge(
   hookServer.on('PostToolUse', (input) => {
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
-    if (isSubagentEvent(input)) return;
+    if (isSubagentEvent(input)) {
+      // #710: the subagent-context tracker pop must see EVERY admitted
+      // PostToolUse, even one Claude Code stamps with the SPAWNED agent's own
+      // agent_id (its Task/Agent completion event) — that is exactly the
+      // event that closes the tool_use_id an earlier, untagged PreToolUse(Task)
+      // started tracking. Dropping it here without popping first leaked the
+      // tracked use_id forever, sticking isInSubagentContext() true and
+      // default-denying every later MAIN-agent PermissionRequest. Popping by
+      // tool_use_id is safe for a genuine subagent-internal PostToolUse too:
+      // its use_ids were never tracked in the first place (subagent PreToolUse
+      // events are dropped without tracking, same as this listener's PreToolUse
+      // sibling above).
+      hookBridge.noteSubagentToolEnd(input.tool_name, input.tool_use_id);
+      return;
+    }
     // See the PreToolUse note above: no cancelStale here (#537). The previous
     // tool's PostToolUse must not abort the next permission's in-flight eval.
     // #673: same signature-scoped external-resolution cancel as PreToolUse

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -119,6 +119,33 @@ export class HookEventBridge {
     return this.subagentContext.isInSubagentContext();
   }
 
+  /**
+   * Pop the tracker for a PostToolUse that `hook-bridge-setup.ts` drops for
+   * being subagent-tagged (`agent_id` present) BEFORE it would reach
+   * `handlePostToolUse` (#710). Claude Code may stamp the SPAWNED agent's own
+   * `agent_id` on the Task/Agent completion PostToolUse that closes the exact
+   * tool_use_id the untagged PreToolUse tracked when the Task started; without
+   * this call the use_id is never popped, `isInSubagentContext()` sticks true
+   * forever, and the gate default-denies every later MAIN-agent
+   * PermissionRequest. Safe for a genuine subagent-internal PostToolUse too:
+   * its use_ids were never tracked (subagent PreToolUse events are dropped
+   * without tracking), so popping them is a no-op.
+   */
+  noteSubagentToolEnd(toolName: string, toolUseId: string | undefined): void {
+    this.subagentContext.onPostToolUse(toolName, toolUseId);
+  }
+
+  /**
+   * Reset the subagent-context tracker (#710). Called by the auto-approve gate
+   * when a MAIN-tagged PermissionRequest (agent_id absent) observes
+   * `isInSubagentContext()` stuck true — proof the tracker leaked rather than
+   * a real subagent prompt — so the gate can recover instead of silently
+   * denying the main agent forever.
+   */
+  resetSubagentContext(): void {
+    this.subagentContext.reset();
+  }
+
   /** Returns HookServerEvents handlers wired to this bridge */
   hookHandlers(): Partial<HookServerEvents> {
     return {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -67,6 +67,10 @@ describe('AutoApproveGate', () => {
   let cancels: string[];
   let tracker: QuestionPresenceTracker;
   let subagent: boolean;
+  // #710: records resetSubagentContext() calls, so tests can assert the gate
+  // resets the leaked tracker ONLY for a MAIN-tagged event, never for a
+  // genuine subagent-tagged one.
+  let resets: number;
 
   function evaluator(
     result: AutoApproveResult,
@@ -97,6 +101,9 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
+        resetSubagentContext: () => {
+          resets++;
+        },
         escalate: (i) => {
           escalations.push(i);
           return generateId();
@@ -125,6 +132,9 @@ describe('AutoApproveGate', () => {
         sessionRegistry: registry,
         tracker,
         isInSubagentContext: () => subagent,
+        resetSubagentContext: () => {
+          resets++;
+        },
         escalate: (i) => {
           escalations.push(i);
           return generateId();
@@ -154,6 +164,7 @@ describe('AutoApproveGate', () => {
     escalations = [];
     cancels = [];
     subagent = false;
+    resets = 0;
     tracker = new QuestionPresenceTracker(() => {});
     configureLogger({ writeLog: () => {} });
   });
@@ -239,10 +250,44 @@ describe('AutoApproveGate', () => {
 
   test('escalate in subagent context default-denies via the response, no inject (#496)', async () => {
     subagent = true;
-    const d = await gateWith(evaluator(escalate)).resolvePermission(pr());
+    // #710: default-deny requires a genuinely subagent-TAGGED event
+    // (agent_id present), not just isInSubagentContext() true — otherwise a
+    // leaked tracker would deny the main agent forever.
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }));
     expect(d).toBe('deny');
     expect(submits).toHaveLength(0); // the core fix: deny without touching the PTY
     expect(escalations).toHaveLength(0);
+    expect(resets).toBe(0); // a real subagent event never resets the tracker
+  });
+
+  test('#710 regression: MAIN-tagged escalate with a stuck tracker resets it and escalates instead of denying', async () => {
+    // The bug: isInSubagentContext() stuck true (tracker leak) must NOT deny a
+    // MAIN-agent PermissionRequest (agent_id absent) — that silently ate the
+    // main agent's own AskUserQuestion/permission prompts in the 0.6.18-dev.24
+    // soak. The gate must recognize the missing agent_id as proof of a leak,
+    // reset the tracker, and escalate to the user like any other main event.
+    subagent = true;
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(1); // escalated as main, not denied
+    expect(resets).toBe(1); // tracker reset exactly once
+  });
+
+  test('#710 regression: MAIN-tagged no-service with a stuck tracker resets and escalates', async () => {
+    subagent = true;
+    const d = await gateWith(null).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+    expect(resets).toBe(1);
+  });
+
+  test('#710 regression: MAIN-tagged eval-error with a stuck tracker resets and escalates', async () => {
+    subagent = true;
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(1);
+    expect(resets).toBe(1);
   });
 
   test('cancelled clears the tracker pending and returns passthrough; no inject/escalate', async () => {
@@ -311,18 +356,24 @@ describe('AutoApproveGate', () => {
 
   test('eval rejection in subagent context default-denies via the response', async () => {
     subagent = true;
-    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(pr());
+    // #710: requires agent_id (a real subagent-tagged event); see the
+    // escalate-branch test above for the rationale.
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(
+      pr({ agent_id: 'agent-1' }),
+    );
     expect(d).toBe('deny');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(resets).toBe(0);
   });
 
   test('no service + subagent: default-deny via the response', async () => {
     subagent = true;
-    const d = await gateWith(null).resolvePermission(pr());
+    const d = await gateWith(null).resolvePermission(pr({ agent_id: 'agent-1' }));
     expect(d).toBe('deny');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(resets).toBe(0);
   });
 
   test('no service + main context: escalate to user, passthrough', async () => {
@@ -368,7 +419,8 @@ describe('AutoApproveGate', () => {
 
   test('escalate_model is NOT consulted in a subagent context (denies via response) (#522)', async () => {
     subagent = true;
-    const d = await gateWithSecondOpinion(approve).resolvePermission(pr());
+    // #710: a real subagent-tagged event (agent_id present).
+    const d = await gateWithSecondOpinion(approve).resolvePermission(pr({ agent_id: 'agent-1' }));
     // Subagent escalate denies directly; the second opinion (which would allow)
     // must not run, since the user could not answer a subagent prompt anyway.
     expect(d).toBe('deny');
@@ -425,7 +477,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     );
   }
 
-  function pr(): PermissionRequestHookInput {
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
     return {
       session_id: 'claude-test',
       transcript_path: '/tmp/t.jsonl',
@@ -434,6 +486,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
       hook_event_name: 'PermissionRequest',
       tool_name: 'Bash',
       tool_input: { command: 'ls' },
+      ...over,
     };
   }
 
@@ -481,7 +534,10 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
 
   test('subagent escalate->deny still fires handled (buffer + cue close), no inject', async () => {
     subagent = true;
-    expect(await gate(evaluator(escalate)).resolvePermission(pr())).toBe('deny');
+    // #710: default-deny requires a real subagent-tagged event (agent_id set).
+    expect(await gate(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }))).toBe(
+      'deny',
+    );
     // Subagent escalate default-denies via the RESPONSE (no inject) -> markHandled.
     expect(submits).toHaveLength(0);
     expect(events).toEqual(['start', 'handled']);

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -529,6 +529,50 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual([]);
   });
 
+  test('#710 regression: PostToolUse(Task) tagged with the spawned agent_id still pops the tracker', () => {
+    // The leak: PreToolUse(Task) fires untagged (main context) and tracks
+    // tool_use_id X. Claude Code may stamp the Task's OWN completion
+    // PostToolUse with the spawned agent's agent_id. Pre-fix, the PostToolUse
+    // listener's `if (isSubagentEvent(input)) return;` dropped that event
+    // BEFORE it reached handlers.onPostToolUse -> handlePostToolUse -> the
+    // tracker pop, so X was never popped and isInSubagentContext() stuck true
+    // forever. Post-fix, the subagent-tagged drop path pops via
+    // hookBridge.noteSubagentToolEnd() before returning.
+    build();
+    const bridge = bridgeHandles[bridgeHandles.length - 1]?.bridge;
+    if (!bridge) throw new Error('test setup: no bridge handle');
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-leak-1',
+      transcript_path: path.join(tmpDir, 'leak.jsonl'),
+      hook_event_name: 'SessionStart',
+    });
+
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-leak-1',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_use_id: 'tu_leak_1',
+      tool_input: { prompt: 'spawn subagent' },
+    });
+    expect(bridge.isInSubagentContext()).toBe(true);
+
+    // The Task's own completion event arrives tagged with the spawned agent's
+    // agent_id (the observed 0.6.18-dev.24 soak shape) — NOT untagged as the
+    // matching PreToolUse was.
+    hookServer.fire('PostToolUse', {
+      session_id: 'claude-leak-1',
+      hook_event_name: 'PostToolUse',
+      agent_id: 'spawned-agent-1',
+      tool_name: 'Task',
+      tool_use_id: 'tu_leak_1',
+      tool_input: {},
+      tool_response: { result: 'done' },
+    });
+
+    expect(bridge.isInSubagentContext()).toBe(false);
+  });
+
   test('PermissionRequest with auto-approve APPROVE returns "allow" (no inject) (#496)', async () => {
     build({ autoApprove: true });
 
@@ -1770,14 +1814,17 @@ describe('setupHookBridge', () => {
     expect(ptySubmits).toEqual([]);
   });
 
-  test('Phase 4 wiring: escalate + active Task context default-denies (no hang)', async () => {
-    // PR #424 review pr-test-analyzer Gap 2 (criticality 8): when
-    // auto-approve cannot decide ('escalate') AND a Task tool call is
-    // open on the main session, the bridge must inject '3' rather than
-    // surface a question (the user can't answer a subagent's prompt
-    // visible only to the subagent). With the TOCTOU fix from this
-    // commit, the subagent context is read live in the .then(), so a
-    // Task that opens mid-eval is correctly caught.
+  test('#710: escalate + active Task context but UNTAGGED PermissionRequest now escalates, not denies', async () => {
+    // PR #424 originally asserted this default-denied (pr-test-analyzer Gap 2):
+    // auto-approve escalates AND a Task tool call is open on the main session,
+    // with no agent_id on the PermissionRequest itself (the SubagentContextTracker
+    // legacy-support safety net). #710 changed the policy: an UNTAGGED event
+    // (agent_id absent) reaching the default-deny branch with
+    // isInSubagentContext() true is now treated as tracker-leak evidence, not a
+    // genuine legacy subagent — current Claude Code tags the Task's own
+    // PostToolUse completion with agent_id (the actual leak mechanism fixed by
+    // this issue), so escalating (holdable via Model B) is strictly safer than a
+    // silent main-agent deny. The bridge resets the tracker and escalates as main.
     build({ autoApprove: true, autoApproveDecision: 'escalate' });
 
     hookServer.fire('SessionStart', {
@@ -1797,8 +1844,7 @@ describe('setupHookBridge', () => {
       tool_use_id: 'tu_task_esc',
     });
 
-    // Subagent-internal Bash PermissionRequest (no agent_id; the
-    // Task-context safety net catches it).
+    // Untagged PermissionRequest while the tracker is (still) open.
     const decision = await hookServer.firePermission({
       session_id: 'claude-esc-task',
       hook_event_name: 'PermissionRequest',
@@ -1806,18 +1852,13 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    // #496: escalate in a subagent (Task) context -> 'deny' via the response —
-    // no hang, no PTY inject, no question.
-    expect(decision).toBe('deny');
+    expect(decision).toBe('passthrough');
     expect(ptySubmits).toEqual([]);
-    expect(messageApiLog.questionCalls).toBe(0);
+    expect(messageApiLog.questionCalls).toBe(1); // escalated to the user, not silently denied
   });
 
-  test('Phase 4 wiring: autoApproveThrows + active Task context default-denies', async () => {
-    // PR #424 review pr-test-analyzer Gap 3 (criticality 7): the
-    // .catch() handler's `if (hookBridge.isInSubagentContext())` branch.
-    // A dropped guard would route the catch through escalateToUser
-    // instead of inject-deny, hanging the subagent.
+  test('#710: autoApproveThrows + active Task context but UNTAGGED PermissionRequest now escalates, not denies', async () => {
+    // Mirrors the escalate case above for the eval-error (.catch) branch.
     build({ autoApprove: true, autoApproveThrows: true });
 
     hookServer.fire('SessionStart', {
@@ -1843,17 +1884,12 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    // #496: eval error in a subagent (Task) context -> 'deny' via the response.
-    expect(decision).toBe('deny');
+    expect(decision).toBe('passthrough');
     expect(ptySubmits).toEqual([]);
   });
 
-  test('Phase 4 wiring: no auto-approve + active Task context default-denies', async () => {
-    // PR #424 review pr-test-analyzer #4 (criticality 6): the
-    // synchronous fallback `if (hookBridge.isInSubagentContext())` at
-    // the bottom of the listener (no autoApproveService case). Uses a
-    // Task context, not an agent_id-tagged event, so the
-    // SubagentContextTracker bookkeeping is what carries the gate.
+  test('#710: no auto-approve + active Task context but UNTAGGED PermissionRequest now escalates, not denies', async () => {
+    // Mirrors the escalate case above for the no-service branch.
     build(); // no autoApprove
 
     hookServer.fire('SessionStart', {
@@ -1879,7 +1915,41 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    // #496: no auto-approve + subagent (Task) context -> 'deny' via the response.
+    expect(decision).toBe('passthrough');
+    expect(ptySubmits).toEqual([]);
+    expect(messageApiLog.questionCalls).toBe(1); // escalated to the user, not silently denied
+  });
+
+  test('#710: a genuinely subagent-TAGGED PermissionRequest (agent_id set) during an active Task context still default-denies', async () => {
+    // The still-valid case: agent_id present proves this really is a subagent
+    // prompt (not a leak), so it must keep default-denying via the response.
+    build({ autoApprove: true, autoApproveDecision: 'escalate' });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-esc-task-tagged',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'esctask-tagged.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-esc-task-tagged',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'general-purpose', prompt: 'do stuff' },
+      tool_use_id: 'tu_task_esc_tagged',
+    });
+
+    const decision = await hookServer.firePermission({
+      session_id: 'claude-esc-task-tagged',
+      agent_id: 'subagent-tagged-1',
+      agent_type: 'general-purpose',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    });
+
     expect(decision).toBe('deny');
     expect(ptySubmits).toEqual([]);
     expect(messageApiLog.questionCalls).toBe(0);

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -802,6 +802,65 @@ describe('HookEventBridge', () => {
       expect(bridge.isInSubagentContext()).toBe(false);
     });
 
+    it('noteSubagentToolEnd pops a tracked use_id without touching status (#710)', () => {
+      const { bridge, statuses } = createBridge();
+
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_note_1',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+      statuses.length = 0;
+
+      // The hook-bridge-setup listener calls this directly (instead of
+      // handlePostToolUse) for a PostToolUse it drops as subagent-tagged, so
+      // it must pop the tracker WITHOUT emitting the normal 'thinking' status.
+      bridge.noteSubagentToolEnd('Task', 'tu_note_1');
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+      expect(statuses).toEqual([]);
+    });
+
+    it('noteSubagentToolEnd on an untracked use_id is a no-op (genuine subagent-internal call)', () => {
+      const { bridge } = createBridge();
+
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_outer',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      // A subagent's own internal tool call was never tracked (its PreToolUse
+      // was dropped without tracking), so popping it must not affect the
+      // outer Task's tracked entry.
+      bridge.noteSubagentToolEnd('Bash', 'tu_inner_untracked');
+
+      expect(bridge.isInSubagentContext()).toBe(true);
+    });
+
+    it('resetSubagentContext clears tracked state (#710)', () => {
+      const { bridge } = createBridge();
+
+      bridge.handlePreToolUse({
+        ...makeCommon(),
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: {},
+        tool_use_id: 'tu_reset_1',
+      } as PreToolUseHookInput);
+      expect(bridge.isInSubagentContext()).toBe(true);
+
+      bridge.resetSubagentContext();
+
+      expect(bridge.isInSubagentContext()).toBe(false);
+    });
+
     it('handleSessionStart resets any stale state from prior session', () => {
       const { bridge } = createBridge();
       bridge.handlePreToolUse({


### PR DESCRIPTION
Closes #710.

## Problem

During the 0.6.18-dev.24 soak, the main agent's own PermissionRequests were silently auto-denied (4 occurrences, including an AskUserQuestion and a legitimate device-install Bash escalation):

```
[error] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=Bash); denying. Possible subagent-context tracker leak.
```

The `SubagentContextTracker` tracks `PreToolUse(Task|Agent)` tool_use_ids and pops them on the matching PostToolUse. The PostToolUse listener in hook-bridge-setup.ts drops subagent-tagged events BEFORE the pop, so a Task/Agent completion event stamped with the spawned agent's own agent_id leaks the tracked use_id. Once stuck, every later main-agent escalate verdict converts to a silent deny until the next Stop.

## Fix

1. The PostToolUse listener's subagent-drop path now pops the tracker by tool_use_id (`hookBridge.noteSubagentToolEnd`) before returning. Safe by construction: a genuine subagent-internal PostToolUse can never pop anything because subagent PreToolUse events are dropped without tracking.
2. The gate's three default-deny branches (no-service, eval-error, escalate-verdict) deny only when the input is actually subagent-tagged (`agent_id` present). A main-tagged event observing `isInSubagentContext()` true is the leak signature: log, reset the tracker (`resetSubagentContext` dep wired to the bridge), and escalate through the normal main path (second opinion included) instead of denying. Documented tradeoff: legacy Claude Code versions predating agent_id would escalate+hold a genuine synchronous subagent prompt instead of denying — still answerable via the Model B hook response, strictly better than silently denying the main agent.

## Tests

- Regression: PreToolUse(Task, untagged, use_id X) then PostToolUse(Task, tagged, use_id X) leaves `isInSubagentContext()` false.
- One test per deny branch proving a main-tagged event with a stuck tracker resets and escalates (deny never returned); sibling tests proving agent_id-tagged events still default-deny.
- Updated pre-existing tests that encoded the old untagged-deny behavior (they never set agent_id); each now exercises the tagged path explicitly.
- 298 pass in hooks + session-phases suites, 93 pass in the gate suite; typecheck and biome clean (37 pre-existing warnings in an untouched file).

Found during develop-binary soak 2026-07-06. Companions: #711/#714 (Stop spares subagent holds), #712/#713 (PTY orphan-prompt fallback).
