### PR TITLE
fix(#718): structured suggestions, honest fallback, real Yes-always

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,13 +93,14 @@ See `.context/notification-and-session-flow.md` for the full flow diagram.
 - Signaling server (Cloudflare Worker) relays push payloads to APNS.
 - iOS categories `REMI_YN`, `REMI_YNA`, `REMI_MULTI` registered in `AppDelegate.swift`.
 
-**Constraints from real logs (2026-04-12 analysis):**
+**Constraints from real logs (2026-04-12 analysis, updated #718 2026-07-06):**
 
-- Bash `PermissionRequest` has `permission_suggestions=undefined` (no suggestions).
-- Notification message is plain text ("Claude needs your permission to use Bash"), no numbered options.
-- Claude Code always offers 3 options for permissions: Yes / Yes always / No.
+- Bash `PermissionRequest` may have `permission_suggestions=undefined` (no suggestions), a legacy plain-string label array (e.g. Edit's `["Yes","Always","No"]`), or — since ~Claude Code 2.0.54 — a STRUCTURED array of typed "permission update entries" (`addRules`, `addDirectories`, `setMode`, `removeRules`, `replaceRules`, `removeDirectories`, each carrying `behavior`/`destination`; ground truth: code.claude.com/docs/en/hooks).
+- Notification message is plain text ("Claude needs your permission to use Bash"), no numbered options, and never carries `permission_suggestions` at all.
+- Claude Code does NOT always offer a fixed option count. `optionsFromSuggestions` (hook-event-bridge.ts) builds a VARIABLE-count card: [Yes] + one option per USABLE structured suggestion + [No], capped at 4 total. With no usable suggestions of either shape, the daemon falls back to the honest Yes/No 2-set (`optionsAreFallback: true` on the `Question`) instead of fabricating a 3rd option.
 - Numbered option text appears only in the terminal UI, not in hook events.
-- `HookEventBridge` emits the default 3-option set immediately; no parsing or merge timer needed.
+- `HookEventBridge` emits the option set immediately; no parsing or merge timer needed.
+- A "Yes, always allow: ..." option answered on a HELD hook resolves it with `{behavior:"allow", updatedPermissions:[<the original permission_suggestions entry>]}` — echoing a received suggestion back is, per the hooks docs, "equivalent to the user selecting that 'always allow' option in the dialog." `QuestionOption.suggestionIndex` carries which original entry to echo.
 - Redeploy the signaling server after any `packages/signaling/` change.
 
 ### PTY-fallback question patterns

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -94,11 +94,22 @@ function fingerprint(text: string): string {
  * differ between the two sources (hook builds "Allow Bash: ls", PTY extracts
  * whatever appears above the numbered list), so structural matching is safer
  * than text dedup alone.
+ *
+ * Primary signal (#718 review): `question.optionsAreFallback`, when present,
+ * is authoritative — trust it either way, mirroring the same fix in the web
+ * client's `question-merge.ts`. The label heuristic below only runs when the
+ * flag is absent (a question from a caller that doesn't thread it through),
+ * and is inherently approximate for the reason its own doc comment on the
+ * shared type explains: once the fallback shrank to a plain 2-option Yes/No,
+ * a genuine "Yes"/"No"-labelled question can coincidentally match it by
+ * label alone.
  */
 export function looksLikeDefaultPermissionQuestion(question: {
   options: ReadonlyArray<{ label: string }>;
   allowsFreeText: boolean;
+  optionsAreFallback?: boolean | undefined;
 }): boolean {
+  if (question.optionsAreFallback !== undefined) return question.optionsAreFallback;
   if (question.allowsFreeText) return false;
   if (question.options.length !== DEFAULT_PERMISSION_LABELS.length) return false;
   const labels = question.options.map((o) => (o.label ?? '').toLowerCase().trim());

--- a/packages/daemon/src/api/question-dedup.ts
+++ b/packages/daemon/src/api/question-dedup.ts
@@ -20,7 +20,12 @@
  * which are usually <80 chars after normalization.
  */
 
-import { MAIN_AGENT_ID, QUESTION_DEDUP_WINDOW_MS, type Question } from '@remi/shared';
+import {
+  DEFAULT_PERMISSION_LABELS,
+  MAIN_AGENT_ID,
+  QUESTION_DEDUP_WINDOW_MS,
+  type Question,
+} from '@remi/shared';
 
 interface LastEmitted {
   fingerprint: string;
@@ -82,21 +87,22 @@ function fingerprint(text: string): string {
 }
 
 /**
- * True when a parsed question matches the shape of Claude Code's hardcoded
- * 3-option permission prompt (Yes / Yes-always / No). Used to drop redundant
- * PTY-parsed permission emissions when the hook bridge has already produced
- * the same question — text fingerprints differ between the two sources
- * (hook builds "Allow Bash: ls", PTY extracts whatever appears above the
- * numbered list), so structural matching is safer than text dedup alone.
+ * True when a parsed question matches the shape of the daemon's hardcoded
+ * Yes/No permission fallback (#718; a fabricated 3-set Yes/Yes-always/No
+ * pre-#718). Used to drop redundant PTY-parsed permission emissions when the
+ * hook bridge has already produced the same question — text fingerprints
+ * differ between the two sources (hook builds "Allow Bash: ls", PTY extracts
+ * whatever appears above the numbered list), so structural matching is safer
+ * than text dedup alone.
  */
 export function looksLikeDefaultPermissionQuestion(question: {
   options: ReadonlyArray<{ label: string }>;
   allowsFreeText: boolean;
 }): boolean {
   if (question.allowsFreeText) return false;
-  if (question.options.length !== 3) return false;
+  if (question.options.length !== DEFAULT_PERMISSION_LABELS.length) return false;
   const labels = question.options.map((o) => (o.label ?? '').toLowerCase().trim());
   const first = labels[0] ?? '';
-  const last = labels[2] ?? '';
+  const last = labels[labels.length - 1] ?? '';
   return first.startsWith('yes') && last.startsWith('no');
 }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -324,6 +324,14 @@ export class QuestionPresenceTracker {
             text: hookRecord.text || ptyQuestion.text,
             options: useHookOptions ? [...hookRecord.options] : [...ptyQuestion.options],
             agentId: ptyQuestion.agentId ?? hookRecord.agentId,
+            // #718 review: `optionsAreFallback` must describe whichever
+            // `options` ended up on the merged question, not silently inherit
+            // whatever `ptyQuestion` happened to carry from the `...ptyQuestion`
+            // spread above (a different, unrelated signal). When the hook's
+            // options won, mirror the hook record's own flag (true, or
+            // undefined for a real derived set); when the PTY's options won,
+            // they are concrete by construction, so this is always false.
+            optionsAreFallback: useHookOptions ? hookRecord.optionsAreFallback : false,
             // #626/#628: the PTY base carries none of the structured fields, so a
             // merge must preserve the hook record's AskUserQuestion structure +
             // lock-screen summary — else a merged card loses questions[]/summary.

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -257,6 +257,14 @@ export class QuestionPresenceTracker {
    * proceed?"). The PTY contributes `id` / `allowsFreeText` / `isAnswered` and
    * its presence is the push trigger (#497). The consumed hook entry is removed.
    *
+   * Options exception (#718): when the hook record's options are the daemon's
+   * honest Yes/No FALLBACK (`hookRecord.optionsAreFallback`, set when
+   * `permission_suggestions` had no usable entry) AND the PTY question has its
+   * own non-empty options, the PTY's options win instead — the PTY parsed the
+   * ACTUAL rendered prompt, so its options are strictly more trustworthy than
+   * a bare substitute. Text/agentId/kind/questions/submitLabel/summary still
+   * prefer the hook record as before; only the options selection changes.
+   *
    * Pending is mutated BEFORE the push so a re-entrant call cannot re-merge
    * the same record. Push errors are caught and logged but not rethrown — the
    * next PTY emit for the same prompt retries WITHOUT the hook merge (PTY's
@@ -303,6 +311,10 @@ export class QuestionPresenceTracker {
       this.pending.delete(recordKey);
     }
 
+    // #718: a fallback hook record must not overwrite the PTY's own options
+    // when it has some — the PTY parsed the actual rendered prompt.
+    const useHookOptions = !hookRecord?.optionsAreFallback || ptyQuestion.options.length === 0;
+
     const merged: Question =
       hookRecord && hookRecord.options.length > 0
         ? {
@@ -310,7 +322,7 @@ export class QuestionPresenceTracker {
             // The hook text carries the tool/command/agent context; the PTY's is
             // the bare terminal prompt. Use the hook's when it has one (#497).
             text: hookRecord.text || ptyQuestion.text,
-            options: [...hookRecord.options],
+            options: useHookOptions ? [...hookRecord.options] : [...ptyQuestion.options],
             agentId: ptyQuestion.agentId ?? hookRecord.agentId,
             // #626/#628: the PTY base carries none of the structured fields, so a
             // merge must preserve the hook record's AskUserQuestion structure +

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -255,6 +255,12 @@ interface PendingHold {
    *  MAIN holds and leaves this one intact -- its pushed card stays
    *  answerable via `resolveHeld`. */
   isSubagent: boolean;
+  /** The escalated input's own `permission_suggestions`, stashed so a later
+   *  `resolveHeld(..., suggestionIndex)` can echo the EXACT original entry
+   *  back as `updatedPermissions` (#718) -- Claude Code's hooks docs: echoing
+   *  a received suggestion "is equivalent to the user selecting that 'always
+   *  allow' option in the dialog." Undefined when the input carried none. */
+  suggestions: readonly unknown[] | undefined;
 }
 
 export class AutoApproveGate {
@@ -452,8 +458,19 @@ export class AutoApproveGate {
    * a multi-choice pick or a non-auto-approve session, takes the PTY path).
    * Clears the hold's timer and marks the permission handled so the #484 buffer
    * + #513 cue close exactly as for a silent auto-decision.
+   *
+   * `suggestionIndex` (#718): present when the user picked a suggestion-derived
+   * "Yes, always allow: ..." option. `decision` is still `'allow'` in that case
+   * (the caller maps isNo -> deny, everything else it can express -> allow);
+   * this resolves the hook with the RICHER `{behavior:'allow',
+   * updatedPermissions:[suggestions[suggestionIndex]]}` instead, echoing the
+   * exact original entry back to Claude Code so it actually persists the
+   * choice — the real "Yes, always" the bare `allow` could never express. A
+   * stale/out-of-range index (the hold's stashed suggestions no longer have
+   * that entry) degrades to a plain `allow` with a loud warning rather than
+   * silently dropping the escalation.
    */
-  resolveHeld(questionId: UUID, decision: 'allow' | 'deny'): boolean {
+  resolveHeld(questionId: UUID, decision: 'allow' | 'deny', suggestionIndex?: number): boolean {
     // #673: this is the NORMAL answer path (input-events.ts), so an open
     // escalation this question tracked is resolved now regardless of which
     // branch below runs -- clear it unconditionally, not just on the hit path.
@@ -469,9 +486,22 @@ export class AutoApproveGate {
     // removes it in handleAnswer's finally; a double-remove is idempotent.
     this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
     this.markHandled(hold.isSubagent);
-    hold.resolve(decision);
+    let resolvedDecision: PermissionDecision = decision;
+    let logSuffix: string = decision;
+    if (decision === 'allow' && suggestionIndex !== undefined) {
+      const suggestion = hold.suggestions?.[suggestionIndex];
+      if (suggestion !== undefined) {
+        resolvedDecision = { behavior: 'allow', updatedPermissions: [suggestion] };
+        logSuffix = 'allow (updatedPermissions echoed)';
+      } else {
+        logError(
+          `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)}: suggestionIndex ${suggestionIndex} missing from stashed permission_suggestions; falling back to plain allow`,
+        );
+      }
+    }
+    hold.resolve(resolvedDecision);
     log(
-      `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)} resolved: ${decision}`,
+      `[AutoApprove ${this.sessionTag}] Held hook ${questionId.slice(0, 8)} resolved: ${logSuffix}`,
     );
     return true;
   }
@@ -570,7 +600,14 @@ export class AutoApproveGate {
       // setTimeout keeps the event loop alive for the whole human-paced hold;
       // unref so a held hook never blocks daemon shutdown.
       timer.unref?.();
-      this.pendingHolds.set(qid, { resolve, timer, isSubagent: this.isSubagentEvent(input) });
+      this.pendingHolds.set(qid, {
+        resolve,
+        timer,
+        isSubagent: this.isSubagentEvent(input),
+        // #718: stashed so a later resolveHeld(..., suggestionIndex) can echo
+        // back the exact original entry the user picked.
+        suggestions: input.permission_suggestions,
+      });
     });
     // Phase 1 (#603, R1/R2): gate the hold on CONFIRMED delivery. A held hook is
     // only worth blocking Claude for if the user can actually be notified; if
@@ -664,7 +701,12 @@ export class AutoApproveGate {
         );
       }, holdUnconfirmedMs);
       timer.unref?.();
-      this.pendingHolds.set(qid, { resolve: hold.resolve, timer, isSubagent: hold.isSubagent });
+      this.pendingHolds.set(qid, {
+        resolve: hold.resolve,
+        timer,
+        isSubagent: hold.isSubagent,
+        suggestions: hold.suggestions,
+      });
       logError(
         `[AutoApprove ${this.sessionTag}] Held hook ${qid.slice(0, 8)} notification UNCONFIRMED (${reason}); holding ${Math.round(holdUnconfirmedMs / 1000)}s (hold_unconfirmed_timeout) with retry before fail-open`,
       );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1490,8 +1490,8 @@ const inputHandlers: InputHandlers = createInputHandlers({
   // #573: route a held-permission answer / release-to-passthrough / eval-cancel
   // to the RIGHT session's gate (the map is populated per session in
   // createNewSession).
-  resolveHeldPermission: (sessionId, questionId, decision) =>
-    sessionGateHandles.get(sessionId)?.resolveHeld(questionId, decision) ?? false,
+  resolveHeldPermission: (sessionId, questionId, decision, suggestionIndex) =>
+    sessionGateHandles.get(sessionId)?.resolveHeld(questionId, decision, suggestionIndex) ?? false,
   releaseHeldAsPassthrough: (sessionId, questionId) =>
     sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough(questionId) ?? false,
   // #617: a manual answer frees the GPU by cancelling ONLY that question's eval,

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -31,11 +31,16 @@ export interface InputHandlerDeps {
    * blocked on the hook, not rendering a prompt). Absent / false => the answer
    * takes the existing PTY-submit path (multi-choice pick, non-AA session, or
    * Part-B-disabled escalation that passed through). Session-keyed by cli.ts.
+   *
+   * `suggestionIndex` (#718): present when the answered option was derived
+   * from a structured `permission_suggestions` entry, so the hold resolves
+   * with a real `updatedPermissions` echo instead of a bare `allow`.
    */
   resolveHeldPermission?: (
     sessionId: UUID,
     questionId: UUID,
     decision: 'allow' | 'deny',
+    suggestionIndex?: number,
   ) => boolean;
   /**
    * Release a HELD binary PermissionRequest hook to 'passthrough' for `sessionId`
@@ -163,28 +168,48 @@ function resolveOption(
  */
 const noopSend: SendToConnection = () => false;
 
+/** Result of {@link mapAnswerToDecision}: the binary decision for the held
+ *  hook response, plus the suggestion index to echo back (#718) when the
+ *  answered option was derived from a structured `permission_suggestions`
+ *  entry. */
+interface AnswerDecision {
+  readonly decision: 'allow' | 'deny';
+  readonly suggestionIndex?: number;
+}
+
 /**
- * Map a resolved option to a binary allow/deny decision (#573). Reads the
- * option's `isYes` / `isNo` flags. Returns:
- *   - 'deny' for a no-shaped option;
- *   - 'allow' for a yes-shaped option ONLY when it is a one-time "Yes" — an
- *     "always"-shaped label ("Yes, always") is NOT mapped, because the binary
- *     PermissionRequest hook response can only express allow/deny, never the
- *     session-wide "always" the user picked. Downgrading it to a one-time allow
- *     would silently lose that choice, so it returns null and the caller takes
- *     the native PTY path (which can express "always" via the digit);
- *   - null otherwise (always-shaped, unknown value/label, or free text) -> PTY path.
+ * Map a resolved option to a binary allow/deny decision (#573, #718). Reads
+ * the option's `isYes` / `isNo` / `suggestionIndex` flags. Returns:
+ *   - `{decision:'deny'}` for a no-shaped option;
+ *   - `{decision:'allow', suggestionIndex}` for a suggestion-derived "Yes,
+ *     always allow: ..." option (#718) — the hold resolves with the real
+ *     `updatedPermissions` echo instead of a bare allow;
+ *   - `{decision:'allow'}` for a yes-shaped option ONLY when it is a one-time
+ *     "Yes" — an "always"-shaped label with no `suggestionIndex` is NOT
+ *     mapped, because the binary PermissionRequest hook response can only
+ *     express allow/deny/updatedPermissions, never a session-wide "always"
+ *     with no suggestion to echo. Downgrading it to a one-time allow would
+ *     silently lose that choice, so it returns null and the caller takes the
+ *     native PTY path (which can express "always" via the digit);
+ *   - null otherwise (always-shaped with no suggestion, unknown value/label,
+ *     or free text) -> PTY path.
  */
 function mapAnswerToDecision(
   options: readonly QuestionOption[],
   answer: string,
-): 'allow' | 'deny' | null {
+): AnswerDecision | null {
   const option = resolveOption(options, answer);
   if (!option) return null;
-  if (option.isNo) return 'deny';
-  // "always" cannot be expressed in the binary hook response, so a yes-shaped
-  // "always" option must NOT collapse to a one-time allow.
-  if (option.isYes && !option.label.toLowerCase().includes('always')) return 'allow';
+  if (option.isNo) return { decision: 'deny' };
+  if (option.suggestionIndex !== undefined) {
+    return { decision: 'allow', suggestionIndex: option.suggestionIndex };
+  }
+  // "always" cannot be expressed in the binary hook response without an
+  // accompanying suggestion to echo, so a yes-shaped "always" option must NOT
+  // collapse to a one-time allow.
+  if (option.isYes && !option.label.toLowerCase().includes('always')) {
+    return { decision: 'allow' };
+  }
   return null;
 }
 
@@ -468,13 +493,14 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     }
 
     // Model B (#573): if the auto-approve gate is HOLDING this permission's
-    // hook, a binary (one-time Yes / No) answer resolves it via the hook
-    // response — Claude is blocked on the hook and is NOT rendering a prompt,
-    // so a PTY submit would land in the wrong place. An answer the binary
-    // response cannot express ("Yes, always", a multi-choice pick, free text)
-    // first RELEASES the held hook to passthrough so Claude renders its native
-    // numbered prompt, then submits the digit (the only way to express
-    // "always" / a specific pick).
+    // hook, a binary (one-time Yes / No) or suggestion-derived "Yes, always
+    // allow: ..." answer (#718) resolves it via the hook response — Claude is
+    // blocked on the hook and is NOT rendering a prompt, so a PTY submit would
+    // land in the wrong place. An answer the hook response cannot express (a
+    // bare "always" with no suggestion to echo, a multi-choice pick, free
+    // text) first RELEASES the held hook to passthrough so Claude renders its
+    // native numbered prompt, then submits the digit (the only way to express
+    // those).
     //
     // The submit/hold-resolution + question removal are wrapped so the question
     // is ALWAYS consumed exactly once: if `submitInput` throws, the `finally`
@@ -484,7 +510,13 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     let hadHold = false;
     try {
       if (decision !== null) {
-        hadHold = resolveHeldPermission?.(session.sessionId, questionId, decision) ?? false;
+        hadHold =
+          resolveHeldPermission?.(
+            session.sessionId,
+            questionId,
+            decision.decision,
+            decision.suggestionIndex,
+          ) ?? false;
       }
       if (!hadHold) {
         // decision === null (always/pick/free-text) OR no hold for this question:

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -185,8 +185,13 @@ export interface SessionGateHandle {
    * caller then SKIPS the PTY inject — Claude is blocked on the hook, not
    * rendering); false when no hold exists (the answer takes the PTY path, e.g. a
    * multi-choice pick or a non-AA session).
+   *
+   * `suggestionIndex` (#718): present when the answered option was derived
+   * from a structured `permission_suggestions` entry ("Yes, always allow:
+   * ..."); forwarded to `AutoApproveGate.resolveHeld` so the hook resolves
+   * with the real `updatedPermissions` echo instead of a bare `allow`.
    */
-  resolveHeld: (questionId: UUID, decision: 'allow' | 'deny') => boolean;
+  resolveHeld: (questionId: UUID, decision: 'allow' | 'deny', suggestionIndex?: number) => boolean;
   /**
    * Release a held hook to 'passthrough' so Claude renders its native numbered
    * prompt (#573), for answers the binary hook response cannot express ("Yes,
@@ -735,7 +740,8 @@ export function setupHookBridge(
       hookServer.setPermissionResolver(null);
     },
     gate: {
-      resolveHeld: (questionId, decision) => autoApproveGate.resolveHeld(questionId, decision),
+      resolveHeld: (questionId, decision, suggestionIndex) =>
+        autoApproveGate.resolveHeld(questionId, decision, suggestionIndex),
       releaseHeldAsPassthrough: (questionId) =>
         autoApproveGate.releaseHeldAsPassthrough(questionId),
       cancelStale: (reason) => autoApproveGate.cancelStale(reason),

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -5,12 +5,19 @@
  * the OutputProcessor previously produced from terminal parsing.
  * This is the hook-based replacement for terminal output parsing.
  *
- * Permission question flow (verified from real hook logs 2026-04-12):
+ * Permission question flow (verified from real hook logs 2026-04-12, updated
+ * #718 for structured suggestions observed 2026-07-06):
  *   - PermissionRequest fires with tool_name, tool_input, and optionally
- *     permission_suggestions (e.g. ["Yes","Always","No"] for Edit).
+ *     permission_suggestions. This is either a legacy plain-string label set
+ *     (e.g. ["Yes","Always","No"] for Edit) OR, since ~Claude Code 2.0.54, a
+ *     STRUCTURED array of typed entries (`addRules`, `addDirectories`,
+ *     `setMode`, ...) — see `optionsFromSuggestions` for how each shape maps
+ *     to a variable-count option set (never a fixed 3). With NO usable
+ *     suggestions of either shape, the honest Yes/No 2-set substitutes.
  *   - Notification(permission_prompt) fires shortly after with a plain-text
  *     message like "Claude needs your permission to use Bash" (no numbered
- *     options; those appear only in the terminal UI).
+ *     options; those appear only in the terminal UI) — always the Yes/No
+ *     fallback, since this event never carries permission_suggestions.
  *   - Both events forward their question to onQuestion. The push gate is
  *     QuestionPresenceTracker (cli.ts wiring): hook events stash the
  *     metadata; PTY confirms presence and fires the push. If both events
@@ -43,10 +50,13 @@ export interface HookBridgeEvents {
   onSessionInfo: (claudeSessionId: string, transcriptPath: string) => void;
 }
 
-/** Default permission options. Claude Code always offers these for tool
- *  permissions; the Notification hook message never contains numbered options.
- *  Labels are imported from `@remi/shared` so the web client's question-merge
- *  guard recognises them as the bland fallback (#396). */
+/** Honest Yes/No fallback options (#718): used when a PermissionRequest
+ *  carries NO usable `permission_suggestions` (none at all, or every entry
+ *  filtered out). Labels are imported from `@remi/shared` so the web
+ *  client's question-merge guard recognises them as the bland fallback
+ *  (#396). Replaces the old fabricated Yes / Yes-always / No 3-set — the
+ *  daemon has no `permission_suggestions` entry to echo back for an
+ *  "always" choice here, so pretending one exists was dishonest (#718). */
 const DEFAULT_PERMISSION_OPTIONS: readonly QuestionOption[] = [
   {
     label: DEFAULT_PERMISSION_LABELS[0],
@@ -59,36 +69,154 @@ const DEFAULT_PERMISSION_OPTIONS: readonly QuestionOption[] = [
     label: DEFAULT_PERMISSION_LABELS[1],
     value: '2',
     isRecommended: false,
-    isYes: true,
-    isNo: false,
-  },
-  {
-    label: DEFAULT_PERMISSION_LABELS[2],
-    value: '3',
-    isRecommended: false,
     isYes: false,
     isNo: true,
   },
 ];
 
+/** Maximum options a permission card can show (iOS push-category/action
+ *  budget: `selectPushCategory` maps 2/3/4 options to REMI_YN/REMI_YNA/
+ *  REMI_MULTI; nothing beyond 4 has a category). Yes and No are always
+ *  present, so at most `MAX_PERMISSION_OPTIONS - 2` suggestion-derived
+ *  middle options are kept. */
+const MAX_PERMISSION_OPTIONS = 4;
+
+/** Approximate cap (characters) for a suggestion-derived option label
+ *  before truncation, so a long shell command or rule list can't blow out
+ *  the push notification body / iOS action button. */
+const SUGGESTION_LABEL_MAX = 80;
+
+function truncateLabel(label: string): string {
+  return label.length > SUGGESTION_LABEL_MAX
+    ? `${label.slice(0, SUGGESTION_LABEL_MAX - 3)}...`
+    : label;
+}
+
 /**
- * Build options from a PermissionRequest's `permission_suggestions`. The union
- * carries string labels (pickable) and structured objects (rule-suggestion
- * metadata the iOS card cannot render); only >= 2 string labels yield real
- * options, otherwise the default Yes / Yes, always / No 3-set substitutes.
+ * Build the label for ONE usable structured `permission_suggestions` entry
+ * (#718), or null when the entry is not a "yes"-shaped suggestion this card
+ * can safely render as a one-tap option: a deny/ask-behavior `addRules`, a
+ * `removeRules` / `replaceRules` / `removeDirectories` (these narrow or
+ * reset permissions — never a "yes" variant), or a `type` Claude Code has
+ * not documented yet (ground truth: code.claude.com/docs/en/hooks).
+ */
+function labelForStructuredSuggestion(entry: Record<string, unknown>): string | null {
+  const type = entry['type'];
+  if (type === 'addRules') {
+    if (entry['behavior'] !== 'allow') return null;
+    const rules = Array.isArray(entry['rules']) ? entry['rules'] : [];
+    const parts = rules
+      .map((rule): string | undefined => {
+        if (typeof rule !== 'object' || rule === null) return undefined;
+        const ruleContent = (rule as Record<string, unknown>)['ruleContent'];
+        const toolName = (rule as Record<string, unknown>)['toolName'];
+        if (typeof ruleContent === 'string' && ruleContent.length > 0) return ruleContent;
+        return typeof toolName === 'string' && toolName.length > 0 ? toolName : undefined;
+      })
+      .filter((s): s is string => s !== undefined);
+    if (parts.length === 0) return null;
+    const suffix = entry['destination'] === 'session' ? ' (this session)' : '';
+    return truncateLabel(`Yes, always allow: ${parts.join(', ')}${suffix}`);
+  }
+  if (type === 'addDirectories') {
+    const directories = Array.isArray(entry['directories'])
+      ? entry['directories'].filter((d): d is string => typeof d === 'string' && d.length > 0)
+      : [];
+    if (directories.length === 0) return null;
+    return truncateLabel(`Yes, allow directory ${directories.join(', ')}`);
+  }
+  if (type === 'setMode') {
+    const mode = entry['mode'];
+    if (typeof mode !== 'string' || mode.length === 0) return null;
+    return truncateLabel(`Yes, switch to ${mode} mode`);
+  }
+  return null;
+}
+
+/** Result of {@link optionsFromSuggestions}: the options to render, and
+ *  whether they are the honest fallback rather than a real derived set. */
+export interface PermissionOptionsResult {
+  readonly options: QuestionOption[];
+  /** True when `options` is the {@link DEFAULT_PERMISSION_OPTIONS} fallback
+   *  (#718): no usable suggestion contributed a middle option. Threaded onto
+   *  the emitted `Question` so the tracker's merge policy never lets this
+   *  bare fallback overwrite a concrete PTY-parsed set of options. */
+  readonly isFallback: boolean;
+}
+
+/**
+ * Build options from a PermissionRequest's `permission_suggestions` (#718).
+ * Two shapes:
+ *   - Legacy: >= 2 plain string labels (e.g. Edit's `["Yes","Always","No"]`)
+ *     map directly to options, unchanged since #574.
+ *   - Structured (Claude Code >= ~2.0.54): each USABLE entry (`addRules`
+ *     with `behavior:"allow"`, `addDirectories`, `setMode`) becomes ONE
+ *     middle option between a plain [Yes] and [No]; entries this card
+ *     cannot safely render as a one-tap "yes" are skipped (see
+ *     {@link labelForStructuredSuggestion}). Capped at
+ *     {@link MAX_PERMISSION_OPTIONS} total — the first usable suggestions
+ *     are kept, the rest dropped with a warning.
+ * With NO usable suggestions of either shape, the honest Yes/No fallback
+ * substitutes (`isFallback: true`) instead of a fabricated 3-set.
  * Exported so the mapping is unit-testable independent of the bridge.
  */
-export function optionsFromSuggestions(suggestions: unknown): QuestionOption[] {
+export function optionsFromSuggestions(suggestions: unknown): PermissionOptionsResult {
   const stringSuggestions = Array.isArray(suggestions)
     ? suggestions.filter((s): s is string => typeof s === 'string' && s.length > 0)
     : [];
-  if (stringSuggestions.length < 2) return [...DEFAULT_PERMISSION_OPTIONS];
-  return stringSuggestions.map((suggestion, idx) => {
-    const lower = suggestion.toLowerCase();
-    const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
-    const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
-    return { label: suggestion, value: String(idx + 1), isRecommended: idx === 0, isYes, isNo };
+  if (stringSuggestions.length >= 2) {
+    const options = stringSuggestions.map((suggestion, idx) => {
+      const lower = suggestion.toLowerCase();
+      const isYes = lower.startsWith('yes') || lower === 'allow' || lower === 'always';
+      const isNo = lower.startsWith('no') || lower === 'deny' || lower === 'reject';
+      return { label: suggestion, value: String(idx + 1), isRecommended: idx === 0, isYes, isNo };
+    });
+    return { options, isFallback: false };
+  }
+
+  const entries = Array.isArray(suggestions) ? suggestions : [];
+  const middleLabels: string[] = [];
+  const suggestionIndices: number[] = [];
+  entries.forEach((entry, idx) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return;
+    const label = labelForStructuredSuggestion(entry as Record<string, unknown>);
+    if (label === null) {
+      console.debug(
+        `[HookEventBridge] Skipping unusable permission_suggestions[${idx}] (type=${String((entry as Record<string, unknown>)['type'])})`,
+      );
+      return;
+    }
+    middleLabels.push(label);
+    suggestionIndices.push(idx);
   });
+
+  if (middleLabels.length === 0) {
+    return { options: [...DEFAULT_PERMISSION_OPTIONS], isFallback: true };
+  }
+
+  const maxMiddle = MAX_PERMISSION_OPTIONS - 2; // Yes + No are always present
+  if (middleLabels.length > maxMiddle) {
+    console.warn(
+      `[HookEventBridge] ${middleLabels.length} usable permission_suggestions exceed the ${MAX_PERMISSION_OPTIONS}-option card budget; keeping the first ${maxMiddle}, dropping ${middleLabels.length - maxMiddle}`,
+    );
+  }
+  const keptLabels = middleLabels.slice(0, maxMiddle);
+  const keptIndices = suggestionIndices.slice(0, maxMiddle);
+
+  let value = 1;
+  const options: QuestionOption[] = [
+    { label: 'Yes', value: String(value++), isRecommended: true, isYes: true, isNo: false },
+    ...keptLabels.map((label, i) => ({
+      label,
+      value: String(value++),
+      isRecommended: false,
+      isYes: true,
+      isNo: false,
+      suggestionIndex: keptIndices[i],
+    })),
+    { label: 'No', value: String(value++), isRecommended: false, isYes: false, isNo: true },
+  ];
+  return { options, isFallback: false };
 }
 
 export class HookEventBridge {
@@ -196,6 +324,10 @@ export class HookEventBridge {
         // Generic fallback: the tracker must let a richer PermissionRequest
         // for the same agent win over this text/options (#574).
         source: 'notification',
+        // #718: this generic Notification never carries permission_suggestions
+        // at all, so it is always the honest Yes/No fallback — never let it
+        // overwrite a PTY-parsed question's own options in the tracker merge.
+        optionsAreFallback: true,
       };
       this.events.onQuestion(question);
       this.events.onStatusChange('waiting');
@@ -263,6 +395,7 @@ export class HookEventBridge {
 
     let promptText: string;
     let options: QuestionOption[];
+    let optionsAreFallback = false;
     if (toolQuestion) {
       // Already phrased as a question, so no "Allow" prefix. A subagent prompt
       // still names the agent so the user knows WHO is asking.
@@ -277,7 +410,9 @@ export class HookEventBridge {
       // A subagent prompt names the agent, e.g.
       // "code-reviewer · Bash: git push origin main" vs "Allow Bash: ...".
       promptText = input.agent_type ? `${input.agent_type} · ${action}` : `Allow ${action}`;
-      options = optionsFromSuggestions(input.permission_suggestions);
+      const built = optionsFromSuggestions(input.permission_suggestions);
+      options = built.options;
+      optionsAreFallback = built.isFallback;
     }
 
     const questionId = generateId();
@@ -291,6 +426,9 @@ export class HookEventBridge {
       // Rich source: carries tool + command + agent context. The tracker
       // keeps this over a trailing generic notification for the same agent (#574).
       source: 'permission_request',
+      // #718: lets the tracker's merge policy keep a PTY-parsed question's own
+      // options instead of overwriting them with this bare fallback set.
+      ...(optionsAreFallback ? { optionsAreFallback: true } : {}),
       // #626: surface the full AskUserQuestion structure (all sub-questions with
       // headers, descriptions, multiSelect) so the client can render it properly.
       // text/options above still mirror questions[0] for back-compat.

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -93,6 +93,31 @@ function truncateLabel(label: string): string {
 }
 
 /**
+ * Disambiguate duplicate labels after truncation (#718 review). Two
+ * suggestions that share their first ~80 characters (e.g. two long `Bash`
+ * commands with the same prefix) would otherwise truncate to the IDENTICAL
+ * label. That is not just cosmetic: the lock-screen relay posts back the
+ * option's LABEL, and `resolveOption` (input-events.ts) matches an incoming
+ * answer by label before falling back to value, so a duplicate label would
+ * let the answer resolve to the WRONG option — echoing a different
+ * `permission_suggestions` entry (`suggestionIndex`) than the one the user
+ * actually picked. Appends " (2)", " (3)", ... to the 2nd+ occurrence of a
+ * duplicate, re-truncating the base so the total still fits the cap.
+ */
+function disambiguateLabels(labels: readonly string[]): string[] {
+  const seenCounts = new Map<string, number>();
+  return labels.map((label) => {
+    const occurrence = (seenCounts.get(label) ?? 0) + 1;
+    seenCounts.set(label, occurrence);
+    if (occurrence === 1) return label;
+    const suffix = ` (${occurrence})`;
+    const maxBaseLength = SUGGESTION_LABEL_MAX - suffix.length;
+    const base = label.length > maxBaseLength ? label.slice(0, maxBaseLength) : label;
+    return `${base}${suffix}`;
+  });
+}
+
+/**
  * Build the label for ONE usable structured `permission_suggestions` entry
  * (#718), or null when the entry is not a "yes"-shaped suggestion this card
  * can safely render as a one-tap option: a deny/ask-behavior `addRules`, a
@@ -200,7 +225,9 @@ export function optionsFromSuggestions(suggestions: unknown): PermissionOptionsR
       `[HookEventBridge] ${middleLabels.length} usable permission_suggestions exceed the ${MAX_PERMISSION_OPTIONS}-option card budget; keeping the first ${maxMiddle}, dropping ${middleLabels.length - maxMiddle}`,
     );
   }
-  const keptLabels = middleLabels.slice(0, maxMiddle);
+  // Disambiguate AFTER slicing to the cap (only the displayed labels need to
+  // be distinct) and BEFORE the labels are assigned to options / suggestionIndex.
+  const keptLabels = disambiguateLabels(middleLabels.slice(0, maxMiddle));
   const keptIndices = suggestionIndices.slice(0, maxMiddle);
 
   let value = 1;
@@ -388,9 +415,10 @@ export class HookEventBridge {
 
     // Question-bearing tools (AskUserQuestion, ExitPlanMode) carry the real
     // question + option labels in tool_input; surface those instead of the
-    // generic "Allow <tool>" + Yes / Yes, always / No (#597). The options are
-    // picks (1-based value, never isYes/isNo) so a user answer releases the held
-    // hook and submits the matching digit to Claude's native numbered prompt.
+    // generic "Allow <tool>" + whatever optionsFromSuggestions derives (or the
+    // honest Yes/No 2-set, #718; #597). The options are picks (1-based value,
+    // never isYes/isNo) so a user answer releases the held hook and submits
+    // the matching digit to Claude's native numbered prompt.
     const toolQuestion = extractToolQuestion(toolName, input.tool_input);
 
     let promptText: string;

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -55,13 +55,24 @@ type Listener<T> = (input: T) => void;
 
 /**
  * Synchronous decision for a PermissionRequest (#496). Claude Code BLOCKS on
- * the hook response and honors `hookSpecificOutput.decision.behavior`:
- *   - 'allow' / 'deny' => Claude proceeds WITHOUT rendering the prompt.
+ * the hook response and honors `hookSpecificOutput.decision`:
+ *   - 'allow' / 'deny' => Claude proceeds WITHOUT rendering the prompt, via
+ *                         `{behavior: decision}`.
  *   - 'passthrough'    => `{}` body; Claude renders the prompt as usual (the
  *                         resolver has already escalated to the user / injected
  *                         a multi-choice pick).
+ *   - `{behavior:'allow', updatedPermissions}` (#718) => Claude proceeds AND
+ *     persists the echoed `permission_suggestions` entry, exactly as if the
+ *     user had picked that "always allow" option in its own dialog (ground
+ *     truth: code.claude.com/docs/en/hooks). Produced when the user's answer
+ *     picked a suggestion-derived option on a HELD escalation
+ *     (`AutoApproveGate.resolveHeld` with a `suggestionIndex`).
  */
-export type PermissionDecision = 'allow' | 'deny' | 'passthrough';
+export type PermissionDecision =
+  | 'allow'
+  | 'deny'
+  | 'passthrough'
+  | { readonly behavior: 'allow'; readonly updatedPermissions: readonly unknown[] };
 
 export type PermissionResolver = (input: PermissionRequestHookInput) => Promise<PermissionDecision>;
 
@@ -243,19 +254,22 @@ export class HookServer {
   }
 
   /**
-   * Serialise a PermissionDecision into the Claude Code hook response. allow/deny
-   * use the verified `hookSpecificOutput.decision.behavior` shape; passthrough is
-   * the bare `{}` that lets Claude render the prompt.
+   * Serialise a PermissionDecision into the Claude Code hook response. allow/
+   * deny use the verified `hookSpecificOutput.decision.behavior` shape;
+   * passthrough is the bare `{}` that lets Claude render the prompt; the
+   * object variant (#718) passes its `{behavior:'allow', updatedPermissions}`
+   * through verbatim, so Claude persists the echoed suggestion.
    */
   private permissionDecisionResponse(decision: PermissionDecision): Response {
     const headers = { 'Content-Type': 'application/json' };
     if (decision === 'passthrough') {
       return new Response('{}', { status: 200, headers });
     }
+    const hookDecision = typeof decision === 'string' ? { behavior: decision } : decision;
     const body = JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PermissionRequest',
-        decision: { behavior: decision },
+        decision: hookDecision,
       },
     });
     return new Response(body, { status: 200, headers });

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -69,11 +69,34 @@ export interface SessionStartHookInput extends HookCommonInput {
 // --- 20 new events ---
 
 /**
- * One entry in `permission_suggestions`. Strings are the binary-label
- * shape (e.g. Edit's `["Yes", "Always", "No"]`). Objects carry tool-
- * specific structured options discriminated by `type` — for example
- * `{type:"addDirectories",...}` or `{type:"setMode",...}`. The wider
- * shape is open: callers must treat unknown `type` values as opaque.
+ * One entry in `permission_suggestions`. Strings are the legacy binary-label
+ * shape (e.g. Edit's `["Yes", "Always", "No"]`).
+ *
+ * Objects are a "permission update entry" (ground truth:
+ * code.claude.com/docs/en/hooks, #718) — the SAME shape Claude Code's own
+ * permission-update API uses, discriminated by `type`:
+ *   - `{type:"addRules", rules:[{toolName, ruleContent?}], behavior:"allow"|
+ *     "deny"|"ask", destination}` — add a rule; only `behavior:"allow"` is a
+ *     "yes"-shaped suggestion the daemon can render as a one-tap option.
+ *   - `{type:"replaceRules"|"removeRules", ...same shape}` — narrows/resets
+ *     rules; never a "yes" variant, always skipped.
+ *   - `{type:"setMode", mode, destination}` — switch permission mode (e.g.
+ *     "plan", "acceptEdits").
+ *   - `{type:"addDirectories"|"removeDirectories", directories:[...],
+ *     destination}` — grant/revoke directory access; only `addDirectories`
+ *     is a "yes" variant.
+ *   - `destination` is `"session" | "localSettings" | "projectSettings" |
+ *     "userSettings"` on every variant.
+ *
+ * `optionsFromSuggestions` (hook-event-bridge.ts) is the single place that
+ * interprets this union into option labels; an answer that picks a
+ * suggestion-derived option round-trips the ORIGINAL entry back to Claude
+ * Code as `hookSpecificOutput.decision.updatedPermissions` (real "Yes,
+ * always", #718) — per the docs, "a hook can echo one of the
+ * permission_suggestions it received as its own updatedPermissions output,
+ * which is equivalent to the user selecting that 'always allow' option in
+ * the dialog." The wider shape is open: callers must treat unknown `type`
+ * values as opaque and skip them rather than guess.
  */
 export type PermissionSuggestion = string | { type: string; [k: string]: unknown };
 

--- a/packages/daemon/src/hooks/tool-question.ts
+++ b/packages/daemon/src/hooks/tool-question.ts
@@ -2,9 +2,10 @@
  * Extract the real user-facing question + options a tool poses in its
  * PermissionRequest, for tools whose escalation is genuinely the user's decision
  * (AskUserQuestion, ExitPlanMode). Without this the `HookEventBridge` falls back
- * to "Allow <tool>" + the default Yes / Yes, always / No, which is wrong for a
- * multi-option plan/design question (#597) — the user sees a generic prompt and
- * the wrong choices on both the in-app card and the lock-screen notification.
+ * to "Allow <tool>" + whatever `optionsFromSuggestions` derives (or the honest
+ * Yes/No 2-set, #718), which is wrong for a multi-option plan/design question
+ * (#597) — the user sees a generic prompt and the wrong choices on both the
+ * in-app card and the lock-screen notification.
  *
  * The options are PICKS: `value` is the 1-based index and `isYes`/`isNo` are
  * always false. That routes a user's answer through the daemon's release-hook +

--- a/packages/daemon/src/notifications/push-dedup.ts
+++ b/packages/daemon/src/notifications/push-dedup.ts
@@ -11,8 +11,8 @@
  * `packages/web/src/lib/question-merge.ts`. Within
  * `QUESTION_DEDUP_WINDOW_MS`:
  *
- *   - new is default-3-set AND last was non-default → suppress
- *   - new is non-default AND last was default → fire (upgrade)
+ *   - new is the fallback shape AND last was non-default → suppress
+ *   - new is non-default AND last was the fallback shape → fire (upgrade)
  *   - new has strictly more options than last → fire (upgrade)
  *   - otherwise → suppress
  *
@@ -33,6 +33,10 @@ interface LastPush {
 export interface PushDedupQuestion {
   readonly options: ReadonlyArray<{ label: string }>;
   readonly allowsFreeText: boolean;
+  /** #718: authoritative fallback signal, threaded through to
+   *  `looksLikeDefaultPermissionQuestion` so it does not have to guess from
+   *  labels alone when the caller already knows the answer. */
+  readonly optionsAreFallback?: boolean | undefined;
 }
 
 export class PushDedup {

--- a/packages/daemon/src/parser/question-parser.ts
+++ b/packages/daemon/src/parser/question-parser.ts
@@ -204,14 +204,22 @@ function tryParseYesNo(lines: readonly string[]): ParseResult | null {
         detected: true,
         type: 'yes_no',
         confidence: 0.9,
-        question: createQuestion(
-          questionText,
-          [
-            createOption('Yes', 'y', true, true, false),
-            createOption('No', 'n', false, false, true),
-          ],
-          false,
-        ),
+        question: {
+          ...createQuestion(
+            questionText,
+            [
+              createOption('Yes', 'y', true, true, false),
+              createOption('No', 'n', false, false, true),
+            ],
+            false,
+          ),
+          // #718: a genuinely parsed subprocess (y/n) prompt, not the
+          // daemon's synthetic Yes/No fallback -- the two now share
+          // identical labels since the fallback shrank from a 3-set, so the
+          // web guard (question-merge.ts) needs this explicit signal to
+          // avoid misclassifying a real prompt as the bland default.
+          optionsAreFallback: false,
+        },
       };
     }
   }

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -181,21 +181,20 @@ describe('QuestionDedup', () => {
 });
 
 describe('looksLikeDefaultPermissionQuestion', () => {
-  test('matches Yes / Yes always / No', () => {
+  // #718: the daemon's fallback shrank from a fabricated 3-set (Yes / Yes,
+  // always / No) to the honest 2-set Yes/No, so this heuristic now matches
+  // on a 2-option Yes/No shape instead of 3.
+  test('matches Yes / No', () => {
     const question = {
-      options: [{ label: 'Yes' }, { label: 'Yes, always' }, { label: 'No' }],
+      options: [{ label: 'Yes' }, { label: 'No' }],
       allowsFreeText: false,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
   });
 
-  test('matches Yes / Yes-and-do-not-ask / No (real Claude wording)', () => {
+  test('matches Yes / No-and-tell-Claude (real Claude wording)', () => {
     const question = {
-      options: [
-        { label: 'Yes' },
-        { label: "Yes, and don't ask again this session" },
-        { label: 'No, and tell Claude what to do differently' },
-      ],
+      options: [{ label: 'Yes' }, { label: 'No, and tell Claude what to do differently' }],
       allowsFreeText: false,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
@@ -203,7 +202,7 @@ describe('looksLikeDefaultPermissionQuestion', () => {
 
   test('matches case-insensitively with whitespace', () => {
     const question = {
-      options: [{ label: '  YES  ' }, { label: 'yes ALWAYS' }, { label: 'no thanks' }],
+      options: [{ label: '  YES  ' }, { label: 'no thanks' }],
       allowsFreeText: false,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
@@ -217,9 +216,24 @@ describe('looksLikeDefaultPermissionQuestion', () => {
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
   });
 
-  test('does not match 2-option Y/N', () => {
+  test('a genuine 2-option Yes/No is indistinguishable from the fallback by label alone (#718)', () => {
+    // This heuristic operates on a bare {options, allowsFreeText} shape with
+    // no `optionsAreFallback` signal (unlike the web client's question-merge
+    // guard, which has that field to disambiguate) — a real PTY-parsed [y/n]
+    // prompt necessarily matches too. Documented tradeoff, not a design goal:
+    // PushDedup only uses this to decide whether an equal-or-lower-rank
+    // duplicate within the window should suppress, which is the desired
+    // outcome for two emissions of the very same on-screen 2-option prompt.
     const question = {
       options: [{ label: 'Yes' }, { label: 'No' }],
+      allowsFreeText: false,
+    };
+    expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+  });
+
+  test('does not match a 3-option suggestion-derived set (#718)', () => {
+    const question = {
+      options: [{ label: 'Yes' }, { label: 'Yes, always allow: rm -rf /tmp' }, { label: 'No' }],
       allowsFreeText: false,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
@@ -235,7 +249,7 @@ describe('looksLikeDefaultPermissionQuestion', () => {
 
   test('does not match free-text prompts', () => {
     const question = {
-      options: [{ label: 'Yes' }, { label: 'Yes, always' }, { label: 'No' }],
+      options: [{ label: 'Yes' }, { label: 'No' }],
       allowsFreeText: true,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);

--- a/packages/daemon/tests/api/question-dedup.test.ts
+++ b/packages/daemon/tests/api/question-dedup.test.ts
@@ -216,19 +216,52 @@ describe('looksLikeDefaultPermissionQuestion', () => {
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
   });
 
-  test('a genuine 2-option Yes/No is indistinguishable from the fallback by label alone (#718)', () => {
-    // This heuristic operates on a bare {options, allowsFreeText} shape with
-    // no `optionsAreFallback` signal (unlike the web client's question-merge
-    // guard, which has that field to disambiguate) — a real PTY-parsed [y/n]
-    // prompt necessarily matches too. Documented tradeoff, not a design goal:
-    // PushDedup only uses this to decide whether an equal-or-lower-rank
-    // duplicate within the window should suppress, which is the desired
-    // outcome for two emissions of the very same on-screen 2-option prompt.
+  test('WITH NO optionsAreFallback signal, a genuine 2-option Yes/No is indistinguishable from the fallback by label alone (#718)', () => {
+    // When the caller does not thread `optionsAreFallback` through at all
+    // (the flag is absent, not `false`), this heuristic falls back to the
+    // label match — a real PTY-parsed [y/n] prompt necessarily matches too.
+    // Documented tradeoff, not a design goal: PushDedup only uses this to
+    // decide whether an equal-or-lower-rank duplicate within the window
+    // should suppress, which is the desired outcome for two emissions of the
+    // very same on-screen 2-option prompt.
     const question = {
       options: [{ label: 'Yes' }, { label: 'No' }],
       allowsFreeText: false,
     };
     expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+  });
+
+  describe('optionsAreFallback is authoritative when present (#718 review)', () => {
+    test('optionsAreFallback: true wins even when the labels look nothing like the default', () => {
+      const question = {
+        options: [{ label: 'Refactor' }, { label: 'Patch' }],
+        allowsFreeText: false,
+        optionsAreFallback: true,
+      };
+      expect(looksLikeDefaultPermissionQuestion(question)).toBe(true);
+    });
+
+    test('optionsAreFallback: false overrides a label match that would otherwise say "default"', () => {
+      // The exact case the flag exists to fix: a genuine 2-option Yes/No
+      // question (e.g. from the PTY y/n parser, which sets this explicitly)
+      // must NOT be treated as the bland fallback merely because its labels
+      // happen to read Yes/No.
+      const question = {
+        options: [{ label: 'Yes' }, { label: 'No' }],
+        allowsFreeText: false,
+        optionsAreFallback: false,
+      };
+      expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
+    });
+
+    test('optionsAreFallback: false wins even over a 3-option shape (length check never runs)', () => {
+      const question = {
+        options: [{ label: 'Yes' }, { label: 'Maybe' }, { label: 'No' }],
+        allowsFreeText: false,
+        optionsAreFallback: false,
+      };
+      expect(looksLikeDefaultPermissionQuestion(question)).toBe(false);
+    });
   });
 
   test('does not match a 3-option suggestion-derived set (#718)', () => {

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -464,6 +464,92 @@ describe('QuestionPresenceTracker', () => {
     });
   });
 
+  describe('fallback options do not overwrite PTY truth (#718)', () => {
+    it('a fallback hook record loses its options to a concrete PTY option set (hook text still wins)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const fallbackHook: Question = {
+        ...makePermissionRequestHook('Allow Bash: git push'),
+        options: [
+          makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+          makeOption('No', '2', { isNo: true }),
+        ],
+        optionsAreFallback: true,
+      };
+      tracker.recordPendingHook(fallbackHook);
+
+      // The PTY parsed the ACTUAL rendered prompt: a real 2-option Yes/No
+      // with its own labels (e.g. Claude's real wording), not the hook's bare
+      // substitute.
+      const ptyQ: Question = {
+        ...makePTYQuestion('Do you want to proceed?'),
+        options: [
+          makeOption('Yes, and add to allowlist', 'y', { isYes: true }),
+          makeOption('No, ask every time', 'n', { isNo: true }),
+        ],
+      };
+      tracker.onPTYPromptVisible(ptyQ);
+
+      expect(pushes.length).toBe(1);
+      // Text still comes from the hook (tool + command context, #497).
+      expect(pushes[0]?.text).toBe('Allow Bash: git push');
+      // But the OPTIONS are the PTY's real ones, not the hook's fallback.
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual([
+        'Yes, and add to allowlist',
+        'No, ask every time',
+      ]);
+    });
+
+    it('a suggestion-derived (non-fallback) hook record still wins over the PTY options', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const structuredHook: Question = {
+        ...makePermissionRequestHook('Allow Bash: rm -rf /tmp/foo'),
+        options: [
+          makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+          makeOption('Yes, always allow: rm -rf /tmp/foo', '2', {
+            isYes: true,
+            suggestionIndex: 0,
+          }),
+          makeOption('No', '3', { isNo: true }),
+        ],
+        // optionsAreFallback intentionally absent: this is a real derived set.
+      };
+      tracker.recordPendingHook(structuredHook);
+
+      const ptyQ = makePTYQuestion('Do you want to proceed?');
+      tracker.onPTYPromptVisible(ptyQ);
+
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual([
+        'Yes',
+        'Yes, always allow: rm -rf /tmp/foo',
+        'No',
+      ]);
+      expect(pushes[0]?.options[1]?.suggestionIndex).toBe(0);
+    });
+
+    it('a fallback hook record keeps its own options when the PTY question has none', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const fallbackHook: Question = {
+        ...makePermissionRequestHook('Allow Bash: git push'),
+        options: [
+          makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+          makeOption('No', '2', { isNo: true }),
+        ],
+        optionsAreFallback: true,
+      };
+      tracker.recordPendingHook(fallbackHook);
+
+      const ptyQ: Question = { ...makePTYQuestion('Do you want to proceed?'), options: [] };
+      tracker.onPTYPromptVisible(ptyQ);
+
+      // No PTY options to prefer: the hook's fallback is still better than nothing.
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'No']);
+    });
+  });
+
   describe('auto-approve buffer (#484)', () => {
     it('PTY prompt during an eval is BUFFERED, not pushed', () => {
       const pushes: Question[] = [];

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -498,6 +498,47 @@ describe('QuestionPresenceTracker', () => {
         'Yes, and add to allowlist',
         'No, ask every time',
       ]);
+      // The merged question's own flag must describe what actually won: the
+      // PTY's options, which are concrete (#718 review).
+      expect(pushes[0]?.optionsAreFallback).toBe(false);
+    });
+
+    it('overrides a stale optionsAreFallback the PTY question itself happened to carry', () => {
+      // The PTY base is spread first (`...ptyQuestion`), so its OWN
+      // optionsAreFallback must not leak through when the hook's options win
+      // (#718 review) — the merged flag must reflect the hook record, not
+      // whatever the PTY parser separately decided about ITS OWN options.
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const structuredHook: Question = {
+        ...makePermissionRequestHook('Allow Bash: rm -rf /tmp/foo'),
+        options: [
+          makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+          makeOption('Yes, always allow: rm -rf /tmp/foo', '2', {
+            isYes: true,
+            suggestionIndex: 0,
+          }),
+          makeOption('No', '3', { isNo: true }),
+        ],
+        // Real derived set: no optionsAreFallback flag.
+      };
+      tracker.recordPendingHook(structuredHook);
+
+      const ptyQ: Question = {
+        ...makePTYQuestion('Do you want to proceed?'),
+        optionsAreFallback: false,
+      };
+      tracker.onPTYPromptVisible(ptyQ);
+
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual([
+        'Yes',
+        'Yes, always allow: rm -rf /tmp/foo',
+        'No',
+      ]);
+      // The hook's options won and the hook record has no fallback flag, so
+      // the merged question must not carry `false` (or any stale value)
+      // leaked from the PTY base.
+      expect(pushes[0]?.optionsAreFallback).toBeUndefined();
     });
 
     it('a suggestion-derived (non-fallback) hook record still wins over the PTY options', () => {
@@ -527,6 +568,7 @@ describe('QuestionPresenceTracker', () => {
         'No',
       ]);
       expect(pushes[0]?.options[1]?.suggestionIndex).toBe(0);
+      expect(pushes[0]?.optionsAreFallback).toBeUndefined();
     });
 
     it('a fallback hook record keeps its own options when the PTY question has none', () => {
@@ -547,6 +589,9 @@ describe('QuestionPresenceTracker', () => {
 
       // No PTY options to prefer: the hook's fallback is still better than nothing.
       expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'No']);
+      // The hook's own options won (no PTY options to prefer), so the merged
+      // flag mirrors the hook record's fallback flag.
+      expect(pushes[0]?.optionsAreFallback).toBe(true);
     });
   });
 

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -708,6 +708,44 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
     await pending;
   });
 
+  test('resolveHeld with a suggestionIndex echoes updatedPermissions with the EXACT original entry (#718)', async () => {
+    const suggestion = {
+      type: 'addRules',
+      rules: [{ toolName: 'Bash', ruleContent: 'git push' }],
+      behavior: 'allow',
+      destination: 'session',
+    };
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr({ permission_suggestions: [suggestion] }));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow', 0)).toBe(true);
+    const decision = await pending;
+    expect(decision).toEqual({ behavior: 'allow', updatedPermissions: [suggestion] });
+  });
+
+  test('resolveHeld with a stale/out-of-range suggestionIndex falls back to plain allow', async () => {
+    const suggestion = { type: 'addRules', rules: [{ toolName: 'Bash' }], behavior: 'allow' };
+    const gate = holdGate(evaluator(escalate));
+    // Only ONE suggestion was stashed with the hold; the answer path asks for
+    // index 5, which does not exist.
+    const pending = gate.resolvePermission(pr({ permission_suggestions: [suggestion] }));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow', 5)).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
+  test('resolveHeld without a suggestionIndex still resolves a plain allow (unchanged)', async () => {
+    const suggestion = { type: 'addRules', rules: [{ toolName: 'Bash' }], behavior: 'allow' };
+    const gate = holdGate(evaluator(escalate));
+    const pending = gate.resolvePermission(pr({ permission_suggestions: [suggestion] }));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
+    expect(await pending).toBe('allow');
+  });
+
   test('multi-choice escalate returns passthrough immediately (NO hold)', async () => {
     // 4+ string suggestions => multi-choice; the hook response cannot pick.
     const gate = holdGate(evaluator(escalate));

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -812,6 +812,55 @@ describe('createInputHandlers', () => {
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
+    test('a suggestion-derived "Yes, always allow" option threads suggestionIndex to resolveHeldPermission (#718)', async () => {
+      // Unlike the legacy "Yes, always" string-suggestion label (FIX 1 above),
+      // a #718 structured-suggestion-derived option carries a suggestionIndex,
+      // so it CAN resolve the held hook (with a real updatedPermissions echo)
+      // instead of falling back to the native PTY prompt.
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: rm -rf /tmp/foo',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          {
+            value: '2',
+            label: 'Yes, always allow: rm -rf /tmp/foo',
+            isRecommended: false,
+            isYes: true,
+            isNo: false,
+            suggestionIndex: 0,
+          },
+          { value: '3', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      const held: Array<{ decision: 'allow' | 'deny'; suggestionIndex: number | undefined }> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d, suggestionIndex) => {
+          held.push({ decision: d, suggestionIndex });
+          return true;
+        },
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, '2'); // the suggestion-derived option
+
+      expect(held).toEqual([{ decision: 'allow', suggestionIndex: 0 }]);
+      expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+    });
+
     test('a non-held answer still scoped-cancels its own question and submits to the PTY (#617)', async () => {
       const ptyCapture = { writes: [] as string[], submits: [] as string[] };
       const sessionId = sessionRegistry.createSessionId();

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -543,6 +543,47 @@ describe('HookEventBridge', () => {
       expect(label.endsWith('...')).toBe(true);
     });
 
+    it('disambiguates two suggestions that truncate to an identical label (#718 review)', () => {
+      // Two long commands sharing the first ~90 characters would otherwise
+      // both truncate to the SAME 80-char label. That is not just cosmetic:
+      // the lock-screen relay answers by LABEL, and resolveOption matches an
+      // answer to its option by label first, so identical labels would let
+      // an answer resolve to the WRONG suggestionIndex and echo the wrong
+      // permission_suggestions entry back to Claude Code.
+      const sharedPrefix = 'echo '.repeat(20); // 100 chars, identical for both
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: `${sharedPrefix}one` }],
+            behavior: 'allow',
+          },
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: `${sharedPrefix}two` }],
+            behavior: 'allow',
+          },
+        ],
+      } as PermissionRequestHookInput);
+
+      const opts = questions[0]?.options ?? [];
+      expect(opts).toHaveLength(4);
+      // Distinct labels: the 2nd occurrence gets an ordinal suffix.
+      expect(opts[1]?.label).not.toBe(opts[2]?.label);
+      expect(opts[2]?.label.endsWith(' (2)')).toBe(true);
+      // Each label still maps back to the CORRECT original suggestion.
+      expect(opts[1]?.suggestionIndex).toBe(0);
+      expect(opts[2]?.suggestionIndex).toBe(1);
+      // Total length still fits the cap even with the ordinal suffix appended.
+      expect(opts[2]?.label.length).toBeLessThanOrEqual(80);
+    });
+
     it('unknown/undocumented suggestion types are skipped, falling back to Yes/No', () => {
       const { bridge, questions } = createBridge();
 

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -72,7 +72,7 @@ describe('HookEventBridge', () => {
     expect(statuses).toEqual([{ status: 'thinking' }]);
   });
 
-  it('maps standalone Notification(permission_prompt) to 3-option question', () => {
+  it('maps standalone Notification(permission_prompt) to the honest Yes/No 2-set', () => {
     const { bridge, statuses, questions } = createBridge();
 
     bridge.handleNotification({
@@ -85,14 +85,14 @@ describe('HookEventBridge', () => {
     expect(statuses).toEqual([{ status: 'waiting' }]);
     expect(questions.length).toBe(1);
     expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
-    // Default 3-option set (not parsed from message)
-    expect(questions[0]?.options.length).toBe(3);
+    // Fallback 2-option set (not parsed from message); this event never
+    // carries permission_suggestions (#718).
+    expect(questions[0]?.options.length).toBe(2);
     expect(questions[0]?.options[0]?.label).toBe('Yes');
     expect(questions[0]?.options[0]?.isYes).toBe(true);
-    expect(questions[0]?.options[1]?.label).toBe('Yes, always');
-    expect(questions[0]?.options[1]?.isYes).toBe(true);
-    expect(questions[0]?.options[2]?.label).toBe('No');
-    expect(questions[0]?.options[2]?.isNo).toBe(true);
+    expect(questions[0]?.options[1]?.label).toBe('No');
+    expect(questions[0]?.options[1]?.isNo).toBe(true);
+    expect(questions[0]?.optionsAreFallback).toBe(true);
   });
 
   it('maps Notification(idle_prompt) to idle status', () => {
@@ -147,7 +147,10 @@ describe('HookEventBridge', () => {
     } as NotificationHookInput);
 
     expect(questions[0]?.text).toBe('Allow this action?');
-    expect(questions[0]?.options.length).toBe(3);
+    expect(questions[0]?.options.length).toBe(2);
+    // #718: a generic Notification never carries permission_suggestions, so
+    // it is always the honest Yes/No fallback.
+    expect(questions[0]?.optionsAreFallback).toBe(true);
   });
 
   it('hookHandlers returns handlers that delegate to bridge methods', () => {
@@ -275,25 +278,28 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.summary).toBeUndefined();
   });
 
-  // Inputs that yield fewer than 2 usable string labels: must fall back to
-  // the default 3-option set so the iOS card always renders something the
-  // user can act on. Object entries (e.g. {type:"addDirectories",...}) are
-  // an expected shape and are silently filtered out of UI options here;
-  // the auto-approve path receives the raw array separately and handles
-  // them via the multi-choice classifier.
+  // Inputs with NO usable suggestion of either shape (fewer than 2 string
+  // labels AND no structured entry this card can render as a one-tap "yes")
+  // must fall back to the honest Yes/No 2-set (#718) so the iOS card always
+  // renders something the user can act on, without fabricating a 3rd option
+  // the daemon has no way to actually persist.
   const fallbackCases: Array<[string, unknown]> = [
-    ['all non-string entries', [null, 42, { label: 'Yes' }]],
-    ['pure object array (addDirectories)', [{ type: 'addDirectories', directories: ['/x'] }]],
-    ['object + null', [{ type: 'setMode', mode: 'plan' }, null]],
-    ['single string + object', ['Yes', { type: 'addDirectories', directories: ['/x'] }]],
-    ['single valid element', ['Yes']],
+    ['all non-string, non-suggestion entries', [null, 42, { label: 'Yes' }]],
+    ['single valid string element (< 2 strings)', ['Yes']],
     ['empty array', []],
     ['string passed directly (not an array)', 'Yes'],
     ['number passed directly (not an array)', 7],
     ['array-like object', { 0: 'Yes', 1: 'No', length: 2 }],
+    ['addDirectories with no directories field', [{ type: 'addDirectories' }]],
+    ['setMode with no mode field', [{ type: 'setMode' }]],
+    ['addRules with behavior "ask" (not a yes-variant)', [{ type: 'addRules', behavior: 'ask' }]],
+    [
+      'only unusable types (removeRules, unknown)',
+      [{ type: 'removeRules' }, { type: 'someFutureType' }],
+    ],
   ];
   for (const [label, value] of fallbackCases) {
-    it(`PermissionRequest falls back to default options: ${label}`, () => {
+    it(`PermissionRequest falls back to the honest Yes/No 2-set: ${label}`, () => {
       const { bridge, statuses, questions } = createBridge();
 
       bridge.handlePermissionRequest({
@@ -306,12 +312,267 @@ describe('HookEventBridge', () => {
 
       expect(statuses).toEqual([{ status: 'waiting' }]);
       expect(questions.length).toBe(1);
-      expect(questions[0]?.options.length).toBe(3);
+      expect(questions[0]?.options.length).toBe(2);
       expect(questions[0]?.options[0]?.label).toBe('Yes');
-      expect(questions[0]?.options[1]?.label).toBe('Yes, always');
-      expect(questions[0]?.options[2]?.label).toBe('No');
+      expect(questions[0]?.options[1]?.label).toBe('No');
+      expect(questions[0]?.optionsAreFallback).toBe(true);
     });
   }
+
+  describe('structured permission_suggestions (#718)', () => {
+    it('addRules with behavior "allow" and destination "session" becomes a middle option', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/foo' },
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: 'rm -rf /tmp/foo' }],
+            behavior: 'allow',
+            destination: 'session',
+          },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.optionsAreFallback).toBeUndefined();
+      const opts = questions[0]?.options ?? [];
+      expect(opts.map((o) => o.label)).toEqual([
+        'Yes',
+        'Yes, always allow: rm -rf /tmp/foo (this session)',
+        'No',
+      ]);
+      expect(opts[1]?.isYes).toBe(true);
+      expect(opts[1]?.isNo).toBe(false);
+      expect(opts[1]?.suggestionIndex).toBe(0);
+    });
+
+    it('addRules with destination "localSettings" carries no "(this session)" suffix', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: 'git push' }],
+            behavior: 'allow',
+            destination: 'localSettings',
+          },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options[1]?.label).toBe('Yes, always allow: git push');
+    });
+
+    it('addRules falls back to toolName when a rule has no ruleContent', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Read',
+        tool_input: {},
+        permission_suggestions: [
+          { type: 'addRules', rules: [{ toolName: 'Read' }], behavior: 'allow' },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options[1]?.label).toBe('Yes, always allow: Read');
+    });
+
+    it('addRules with behavior "deny" is skipped (not a yes-variant)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          { type: 'addRules', rules: [{ toolName: 'Bash' }], behavior: 'deny' },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.length).toBe(2); // honest fallback, deny entry skipped
+      expect(questions[0]?.optionsAreFallback).toBe(true);
+    });
+
+    it('removeRules / replaceRules / removeDirectories are skipped (never yes-variants)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          { type: 'removeRules', rules: [{ toolName: 'Bash' }], behavior: 'allow' },
+          { type: 'replaceRules', rules: [{ toolName: 'Bash' }], behavior: 'allow' },
+          { type: 'removeDirectories', directories: ['/tmp'] },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.length).toBe(2);
+      expect(questions[0]?.optionsAreFallback).toBe(true);
+    });
+
+    it('addDirectories becomes a middle option naming the directories', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Read',
+        tool_input: {},
+        permission_suggestions: [
+          { type: 'addDirectories', directories: ['/tmp'], destination: 'session' },
+        ],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.map((o) => o.label)).toEqual([
+        'Yes',
+        'Yes, allow directory /tmp',
+        'No',
+      ]);
+      expect(questions[0]?.options[1]?.suggestionIndex).toBe(0);
+    });
+
+    it('setMode becomes a middle option naming the mode', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        // NOT ExitPlanMode/AskUserQuestion: those tools carry their own
+        // authored toolQuestion options and never reach optionsFromSuggestions.
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [{ type: 'setMode', mode: 'plan', destination: 'session' }],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.map((o) => o.label)).toEqual([
+        'Yes',
+        'Yes, switch to plan mode',
+        'No',
+      ]);
+    });
+
+    it('multiple usable suggestions each become their own middle option, in order', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          { type: 'addRules', rules: [{ toolName: 'Bash', ruleContent: 'ls' }], behavior: 'allow' },
+          { type: 'addDirectories', directories: ['/tmp'] },
+        ],
+      } as PermissionRequestHookInput);
+
+      const opts = questions[0]?.options ?? [];
+      expect(opts).toHaveLength(4);
+      expect(opts[1]?.label).toBe('Yes, always allow: ls');
+      expect(opts[1]?.suggestionIndex).toBe(0);
+      expect(opts[2]?.label).toBe('Yes, allow directory /tmp');
+      expect(opts[2]?.suggestionIndex).toBe(1);
+      expect(opts[3]?.label).toBe('No');
+    });
+
+    it('caps at 4 total options, keeping the first suggestions and dropping the rest', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: 'cmd-1' }],
+            behavior: 'allow',
+          },
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: 'cmd-2' }],
+            behavior: 'allow',
+          },
+          { type: 'addDirectories', directories: ['/tmp'] },
+        ],
+      } as PermissionRequestHookInput);
+
+      const opts = questions[0]?.options ?? [];
+      // Yes + 2 kept middles + No == 4 total; the 3rd suggestion is dropped.
+      expect(opts).toHaveLength(4);
+      expect(opts[1]?.label).toBe('Yes, always allow: cmd-1');
+      expect(opts[2]?.label).toBe('Yes, always allow: cmd-2');
+      expect(opts[3]?.label).toBe('No');
+      expect(opts.some((o) => o.label.includes('/tmp'))).toBe(false);
+    });
+
+    it('a long ruleContent is truncated to ~80 characters', () => {
+      const { bridge, questions } = createBridge();
+      const longCommand = 'x'.repeat(200);
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: longCommand }],
+            behavior: 'allow',
+          },
+        ],
+      } as PermissionRequestHookInput);
+
+      const label = questions[0]?.options[1]?.label ?? '';
+      expect(label.length).toBeLessThanOrEqual(80);
+      expect(label.endsWith('...')).toBe(true);
+    });
+
+    it('unknown/undocumented suggestion types are skipped, falling back to Yes/No', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: {},
+        permission_suggestions: [{ type: 'someBrandNewType', foo: 'bar' }],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.length).toBe(2);
+      expect(questions[0]?.optionsAreFallback).toBe(true);
+    });
+
+    it('legacy >= 2 plain-string suggestions still take the unchanged string path', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Edit',
+        tool_input: {},
+        permission_suggestions: ['Yes', 'Always', 'No'],
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
+      expect(questions[0]?.optionsAreFallback).toBeUndefined();
+    });
+  });
 
   // Mixed arrays where at least 2 string entries survive the filter:
   // render those strings as the option set. This accepts Claude Code's
@@ -343,7 +604,7 @@ describe('HookEventBridge', () => {
     });
   }
 
-  it('PermissionRequest without suggestions emits immediately with default 3 options', () => {
+  it('PermissionRequest without suggestions emits immediately with the honest Yes/No 2-set', () => {
     const { bridge, statuses, questions } = createBridge();
 
     bridge.handlePermissionRequest({
@@ -357,10 +618,10 @@ describe('HookEventBridge', () => {
     expect(statuses).toEqual([{ status: 'waiting' }]);
     expect(questions.length).toBe(1);
     expect(questions[0]?.text).toBe('Allow Bash: rm -rf /');
-    expect(questions[0]?.options.length).toBe(3);
+    expect(questions[0]?.options.length).toBe(2);
     expect(questions[0]?.options[0]?.label).toBe('Yes');
-    expect(questions[0]?.options[1]?.label).toBe('Yes, always');
-    expect(questions[0]?.options[2]?.label).toBe('No');
+    expect(questions[0]?.options[1]?.label).toBe('No');
+    expect(questions[0]?.optionsAreFallback).toBe(true);
   });
 
   it('a subagent PermissionRequest names the agent in the text (#497)', () => {
@@ -544,7 +805,7 @@ describe('HookEventBridge', () => {
 
       expect(questions.length).toBe(1);
       expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
-      expect(questions[0]?.options.length).toBe(3);
+      expect(questions[0]?.options.length).toBe(2);
     });
 
     it('PermissionRequest includes tool context in question text', () => {

--- a/packages/daemon/tests/hooks/hook-server.test.ts
+++ b/packages/daemon/tests/hooks/hook-server.test.ts
@@ -474,6 +474,28 @@ describe('HookServer', () => {
       });
     });
 
+    it('returns the object decision verbatim, echoing updatedPermissions (#718)', async () => {
+      const updatedPermissions = [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Bash', ruleContent: 'git push' }],
+          behavior: 'allow',
+          destination: 'session',
+        },
+      ];
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => ({ behavior: 'allow', updatedPermissions }));
+      server.start();
+      const res = await postPermission(port);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PermissionRequest',
+          decision: { behavior: 'allow', updatedPermissions },
+        },
+      });
+    });
+
     it("returns {} for 'passthrough' (Claude renders the prompt)", async () => {
       server = new HookServer({ port });
       server.setPermissionResolver(async () => 'passthrough');

--- a/packages/daemon/tests/hooks/tool-question.test.ts
+++ b/packages/daemon/tests/hooks/tool-question.test.ts
@@ -162,21 +162,38 @@ describe('extractToolQuestion', () => {
 
 describe('optionsFromSuggestions', () => {
   it('maps >= 2 string suggestions, flagging yes/no shape', () => {
-    const opts = optionsFromSuggestions(['Yes', 'Always', 'No']);
-    expect(opts.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
-    expect(opts.map((o) => o.value)).toEqual(['1', '2', '3']);
-    expect(opts[0]?.isYes).toBe(true);
-    expect(opts[1]?.isYes).toBe(true); // "Always"
-    expect(opts[2]?.isNo).toBe(true);
+    const { options, isFallback } = optionsFromSuggestions(['Yes', 'Always', 'No']);
+    expect(isFallback).toBe(false);
+    expect(options.map((o) => o.label)).toEqual(['Yes', 'Always', 'No']);
+    expect(options.map((o) => o.value)).toEqual(['1', '2', '3']);
+    expect(options[0]?.isYes).toBe(true);
+    expect(options[1]?.isYes).toBe(true); // "Always"
+    expect(options[2]?.isNo).toBe(true);
   });
 
-  it('falls back to the default 3-set when there are < 2 string suggestions', () => {
+  it('falls back to the honest Yes/No 2-set when there are no usable suggestions (#718)', () => {
     const def = optionsFromSuggestions(undefined);
-    expect(def).toHaveLength(3);
-    expect(def[0]?.isYes).toBe(true);
-    expect(def[2]?.isNo).toBe(true);
-    // Structured-only suggestions (no pickable strings) also fall back.
-    expect(optionsFromSuggestions([{ type: 'addDirectories' }])).toHaveLength(3);
-    expect(optionsFromSuggestions(['OnlyOne'])).toHaveLength(3);
+    expect(def.isFallback).toBe(true);
+    expect(def.options).toHaveLength(2);
+    expect(def.options[0]?.isYes).toBe(true);
+    expect(def.options[1]?.isNo).toBe(true);
+    // A structured entry missing the fields needed to render (no `directories`
+    // for addDirectories) is unusable, so this also falls back.
+    expect(optionsFromSuggestions([{ type: 'addDirectories' }]).isFallback).toBe(true);
+    // A single string can't take the >= 2-strings legacy path and isn't a
+    // structured object, so it contributes nothing either.
+    expect(optionsFromSuggestions(['OnlyOne']).isFallback).toBe(true);
+  });
+
+  it('builds a structured option for a usable addDirectories suggestion (#718)', () => {
+    const { options, isFallback } = optionsFromSuggestions([
+      { type: 'addDirectories', directories: ['/tmp'] },
+    ]);
+    expect(isFallback).toBe(false);
+    expect(options).toHaveLength(3);
+    expect(options[0]?.label).toBe('Yes');
+    expect(options[1]?.label).toBe('Yes, allow directory /tmp');
+    expect(options[1]?.suggestionIndex).toBe(0);
+    expect(options[2]?.label).toBe('No');
   });
 });

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -63,6 +63,13 @@ describe('selectPushCategory', () => {
     expect(selectPushCategory([yesOpt])).toBeUndefined();
     expect(selectPushCategory([])).toBeUndefined();
   });
+
+  test('#718: the honest 2-option Yes/No fallback selects REMI_YN, not REMI_YNA', () => {
+    // Category correctness falls out of the count-based mapping once the
+    // daemon's fallback is a genuine 2-set instead of a fabricated 3-set —
+    // no dispatcher change was needed, this just pins the observable result.
+    expect(selectPushCategory([yesOpt, noOpt])).toBe('REMI_YN');
+  });
 });
 
 describe('buildPushText (#574 issues 3+4)', () => {

--- a/packages/daemon/tests/notifications/push-dedup.test.ts
+++ b/packages/daemon/tests/notifications/push-dedup.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the push-trigger dedup (#409).
+ * Tests for the push-trigger dedup (#409, #718).
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -20,56 +20,59 @@ function q(options: readonly string[], allowsFreeText = false): Question {
   };
 }
 
-const defaultThreeSet = ['Yes', 'Yes, always', 'No'];
-const customThreeSet = [
-  'Yes',
-  "Yes, and don't ask again this session",
-  'No, and tell Claude what to do differently',
-];
+// #718: the daemon's fallback shrank from a fabricated 3-set (Yes / Yes,
+// always / No) to the honest Yes/No 2-set — so it is now the SAME shape
+// (2 options, "yes"/"no"-prefixed labels) `looksLikeDefaultPermissionQuestion`
+// treats as "default". A genuinely distinct 2-option prompt therefore needs
+// labels that do NOT both start with "yes"/"no" to be distinguishable from it.
+const defaultTwoSet = ['Yes', 'No'];
+const customTwoSet = ['Yes', "Don't allow"];
+// A real Edit-style 2-option set: distinctively worded but still yes/no-
+// prefixed, so the shape heuristic (by design) still treats it as "default".
+const editStyleTwoSet = ['Yes', 'No, and tell Claude what to do differently'];
 
 describe('PushDedup', () => {
   test('first push always fires', () => {
     const dedup = new PushDedup();
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
   });
 
-  test('default 3-set after default 3-set within window: suppressed', () => {
+  test('default 2-set after default 2-set within window: suppressed', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
     t += 100;
     // Same shape, same count → not richer, suppress.
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(false);
   });
 
   test('non-default after default within window: fires (upgrade)', () => {
-    // The bug case: PTY sees [y/n], emits 2-option Yes/No AFTER the
-    // hook bridge fired the default 3-set. The lock-screen options
-    // need to upgrade to the real Yes/No so tapping Yes maps to the
-    // correct value.
+    // The bug case: PTY sees a genuine prompt AFTER the hook bridge fired
+    // the default fallback. The lock-screen options need to upgrade to the
+    // real question so tapping an option maps to the correct value.
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
     t += 100;
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
   });
 
   test('default after non-default within window: suppressed', () => {
-    // The other ordering: PTY parser fires first with 2-option
-    // Yes/No, hook bridge fires the bland 3-set after. Suppress the
-    // bland duplicate; the user's first push already covers the
-    // prompt with the correct options.
+    // The other ordering: PTY parser fires first with a real question,
+    // hook bridge fires the bland fallback after. Suppress the bland
+    // duplicate; the user's first push already covers the prompt with the
+    // correct options.
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
     t += 100;
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(false);
   });
 
   test('strict-more-options upgrade fires', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
     t += 100;
     // Non-default, more options → upgrade.
     expect(dedup.shouldPush(q(['Refactor', 'Patch', 'Skip', 'Other']))).toBe(true);
@@ -78,42 +81,42 @@ describe('PushDedup', () => {
   test('equal-rank non-default twice within window: suppressed', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
     t += 100;
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(false);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(false);
   });
 
   test('beyond window: same rank fires', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
     t += 6000;
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
   });
 
   test('reset clears the baseline', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
     dedup.reset();
     t += 100;
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
   });
 
   test('boundary: exactly windowMs ago is treated as expired (strict <)', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
     t += 5000;
     // At the boundary, the prior baseline expires and the same-rank
     // emission fires as a new prompt cycle.
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(true);
   });
 
   test('upgrade re-arms baseline so subsequent equal-or-poorer is suppressed', () => {
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(['Yes', 'No']))).toBe(true);
+    expect(dedup.shouldPush(q(customTwoSet))).toBe(true);
     t += 100;
     // Upgrade to 4 options
     expect(dedup.shouldPush(q(['a', 'b', 'c', 'd']))).toBe(true);
@@ -121,19 +124,19 @@ describe('PushDedup', () => {
     // Subsequent 3-option non-default → not strictly more → suppress.
     expect(dedup.shouldPush(q(['a', 'b', 'c']))).toBe(false);
     t += 100;
-    // Default 3-set → still poorer → suppress.
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+    // Default 2-set → still poorer → suppress.
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(false);
   });
 
-  test('Edit-style 3-set with custom labels is treated as default (looksLikeDefault)', () => {
-    // looksLikeDefaultPermissionQuestion uses startsWith('yes')/('no'),
-    // so Edit's "[Yes, ..., No, ...]" matches default-shape. This is
-    // intentional: treating both as the same "binary permission shape"
-    // means a duplicate Edit-style emission within window is suppressed.
+  test('Edit-style 2-set with custom wording is treated as default (looksLikeDefault)', () => {
+    // looksLikeDefaultPermissionQuestion uses startsWith('yes')/('no'), so
+    // Edit's "[Yes, No, and ...]" matches default-shape by design: treating
+    // both as the same "binary permission shape" means a duplicate
+    // Edit-style emission within window is suppressed.
     let t = 1000;
     const dedup = new PushDedup(5000, () => t);
-    expect(dedup.shouldPush(q(customThreeSet))).toBe(true);
+    expect(dedup.shouldPush(q(editStyleTwoSet))).toBe(true);
     t += 100;
-    expect(dedup.shouldPush(q(defaultThreeSet))).toBe(false);
+    expect(dedup.shouldPush(q(defaultTwoSet))).toBe(false);
   });
 });

--- a/packages/daemon/tests/notifications/push-dedup.test.ts
+++ b/packages/daemon/tests/notifications/push-dedup.test.ts
@@ -10,13 +10,18 @@ function opt(label: string): QuestionOption {
   return { label, value: label, isRecommended: false, isYes: false, isNo: false };
 }
 
-function q(options: readonly string[], allowsFreeText = false): Question {
+function q(
+  options: readonly string[],
+  allowsFreeText = false,
+  optionsAreFallback?: boolean,
+): Question {
   return {
     id: 'q-id',
     text: 'prompt text',
     options: options.map(opt),
     allowsFreeText,
     isAnswered: false,
+    ...(optionsAreFallback !== undefined ? { optionsAreFallback } : {}),
   };
 }
 
@@ -138,5 +143,18 @@ describe('PushDedup', () => {
     expect(dedup.shouldPush(q(editStyleTwoSet))).toBe(true);
     t += 100;
     expect(dedup.shouldPush(q(defaultTwoSet))).toBe(false);
+  });
+
+  test('an explicit optionsAreFallback: false is authoritative over the label match (#718 review)', () => {
+    // Without the flag, a genuine Yes/No question is indistinguishable from
+    // the daemon's own fallback (both look "default"-shaped by label). A
+    // caller that KNOWS this is a real question (e.g. the PTY y/n parser)
+    // marks it optionsAreFallback: false, so it fires as an upgrade over a
+    // preceding real fallback push instead of being suppressed as "same shape".
+    let t = 1000;
+    const dedup = new PushDedup(5000, () => t);
+    expect(dedup.shouldPush(q(defaultTwoSet, false, true))).toBe(true);
+    t += 100;
+    expect(dedup.shouldPush(q(['Yes', 'No'], false, false))).toBe(true);
   });
 });

--- a/packages/daemon/tests/question-parser.test.ts
+++ b/packages/daemon/tests/question-parser.test.ts
@@ -76,6 +76,9 @@ describe('parseQuestion() - literal yes/no (subprocess prompts)', () => {
     expect(result.question?.options.length).toBe(2);
     expect(result.question?.options[0]?.isYes).toBe(true);
     expect(result.question?.options[1]?.isNo).toBe(true);
+    // #718: explicitly NOT the daemon's synthetic Yes/No fallback, even
+    // though the labels now coincide post-#718 (see question-merge.ts).
+    expect(result.question?.optionsAreFallback).toBe(false);
   });
 
   test('detects [y/n] pattern', () => {

--- a/packages/shared/src/permission-defaults.ts
+++ b/packages/shared/src/permission-defaults.ts
@@ -1,21 +1,28 @@
 /**
  * Hardcoded fallback values shared by the daemon's HookEventBridge and the
- * web client's question-merge guard (#396).
+ * web client's question-merge guard (#396, #718).
  *
  * Both layers need to know what the daemon emits when a `PermissionRequest`
- * arrives without `permission_suggestions`: the daemon uses these as the
- * default option labels; the client uses them to detect "this incoming
- * question is the bland fallback, not a richer custom 3-set worth keeping
- * over a freshly rendered multi-choice." Keeping the values in one place
- * prevents the two layers from drifting out of sync.
+ * arrives with NO usable `permission_suggestions` (none at all, or every
+ * entry filtered out): the daemon uses these as the default option labels;
+ * the client uses them to detect "this incoming question is the bland
+ * fallback, not a richer question worth keeping over a freshly rendered
+ * multi-choice." Keeping the values in one place prevents the two layers
+ * from drifting out of sync.
+ *
+ * #718: this used to be a fabricated 3-set (`['Yes', 'Yes, always', 'No']`)
+ * even though the daemon has no way to actually persist an "always" choice
+ * without a real `permission_suggestions` entry to echo back as
+ * `updatedPermissions`. It is now the honest 2-set the binary hook response
+ * can always express.
  */
 
 /**
- * Default option labels for permission prompts when Claude Code does not
- * provide `permission_suggestions`. Order matters: daemon assigns numeric
- * values 1-3 to the entries in this order.
+ * Default option labels for permission prompts when Claude Code sends no
+ * USABLE `permission_suggestions`. Order matters: daemon assigns numeric
+ * values 1-2 to the entries in this order.
  */
-export const DEFAULT_PERMISSION_LABELS = ['Yes', 'Yes, always', 'No'] as const;
+export const DEFAULT_PERMISSION_LABELS = ['Yes', 'No'] as const;
 
 /**
  * Window during which the daemon's `QuestionDedup` and the client's

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -216,6 +216,19 @@ export interface Question {
    * escalations with no model summary.
    */
   readonly summary?: string | undefined;
+
+  /**
+   * True when `options` is the daemon's honest Yes/No fallback (#718): Claude
+   * Code sent no USABLE `permission_suggestions` (none at all, or every entry
+   * was filtered out — deny/ask-behavior, an unsupported type), so the daemon
+   * substituted the plain binary set instead of a real suggestion-derived
+   * card. Consumed by `QuestionPresenceTracker.onPTYPromptVisible`'s merge
+   * policy: a fallback set must NOT overwrite a PTY-parsed question's own
+   * (possibly richer) options, unlike a real hook-derived set which always
+   * wins. Absent/false for every other question, including the legacy
+   * plain-string suggestion path.
+   */
+  readonly optionsAreFallback?: boolean | undefined;
 }
 
 /**
@@ -272,6 +285,19 @@ export interface QuestionOption {
    * Absent for plain permission options (Yes / Yes, always / No).
    */
   readonly description?: string | undefined;
+
+  /**
+   * Index into the ORIGINAL `permission_suggestions` array this option was
+   * derived from (#718). Present only for a structured-suggestion-derived
+   * "yes" option (e.g. "Yes, always allow: rm -rf ..."); absent for the
+   * plain Yes/No options and for the legacy plain-string suggestion path.
+   * The daemon threads this back through the answer path so picking the
+   * option can resolve a held PermissionRequest hook with
+   * `{behavior:"allow", updatedPermissions:[suggestions[suggestionIndex]]}` —
+   * the real "Yes, always" the Claude Code hooks docs describe, instead of a
+   * bare `allow` that persists nothing.
+   */
+  readonly suggestionIndex?: number | undefined;
 }
 
 /**

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -41,6 +41,7 @@ import {
   resolveQuestionCard,
 } from '@/lib/question-collection';
 import { dismissDeliveredNotification } from '@/lib/notifications';
+import { mapQuestionToUIQuestion } from '@/lib/question-mapping';
 import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
 import { shouldEvictCachedSession } from '@/lib/session-eviction';
@@ -54,7 +55,6 @@ import type {
   UIBullet,
   UIMessage,
   UIQuestion,
-  UIQuestionOption,
   UISession,
 } from '@/types';
 import { DEFAULT_SETTINGS } from '@/types';
@@ -777,48 +777,6 @@ function App() {
           break;
         }
         lastQuestionIdRef.current = q.id;
-        // Map daemon Question to UIQuestion.
-        // Use yes_no ONLY for exactly 2 options with clear yes+no.
-        // Use multi_option for 3+ options (even if they include yes/no).
-        // Use numbered for options without yes/no semantics.
-        let questionType: UIQuestion['type'] = 'free_text';
-        if (q.options.length > 0) {
-          if (q.options.length === 2) {
-            const hasYes = q.options.some((o) => o.isYes);
-            const hasNo = q.options.some((o) => o.isNo);
-            questionType = hasYes && hasNo ? 'yes_no' : 'multi_option';
-          } else {
-            // 3+ options: always show all of them
-            const hasYesNo = q.options.some((o) => o.isYes || o.isNo);
-            questionType = hasYesNo ? 'multi_option' : 'numbered';
-          }
-        }
-
-        // Build structured options with full metadata
-        const structuredOptions: UIQuestionOption[] = q.options.map((o) => ({
-          label: o.label,
-          value: o.value,
-          isYes: o.isYes || undefined,
-          isNo: o.isNo || undefined,
-          isRecommended: o.isRecommended || undefined,
-          description: o.description || undefined,
-        }));
-
-        // #626: carry the full AskUserQuestion structure (headers, per-option
-        // descriptions, multiSelect) so the card can render it properly.
-        const uiQuestions: UIQuestion['questions'] = q.questions?.map((step) => ({
-          ...(step.header ? { header: step.header } : {}),
-          text: step.text,
-          multiSelect: step.multiSelect,
-          options: step.options.map((o) => ({
-            label: o.label,
-            value: o.value,
-            isYes: o.isYes || undefined,
-            isNo: o.isNo || undefined,
-            isRecommended: o.isRecommended || undefined,
-            description: o.description || undefined,
-          })),
-        }));
 
         // sessionId is mandatory on the wire now (#437); never fall back to
         // the active session (that cross-contaminated when another session or
@@ -828,21 +786,10 @@ function App() {
           console.warn('[App] Dropping question with no sessionId');
           break;
         }
+        // Map daemon Question to UIQuestion (pure function, unit-tested in
+        // lib/question-mapping.test.ts).
+        const uiQuestion = mapQuestionToUIQuestion(q, questionSessionId);
         const questionAgentId = q.agentId;
-        const uiQuestion: UIQuestion = {
-          id: q.id,
-          sessionId: questionSessionId,
-          type: questionType,
-          prompt: q.text,
-          options: q.options.length > 0 ? q.options.map((o) => o.label) : undefined,
-          structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
-          timestamp: new Date().toISOString(),
-          agentId: questionAgentId,
-          ...(q.kind ? { kind: q.kind } : {}),
-          ...(uiQuestions && uiQuestions.length > 0 ? { questions: uiQuestions } : {}),
-          ...(q.submitLabel ? { submitLabel: q.submitLabel } : {}),
-          ...(q.optionsAreFallback ? { optionsAreFallback: true } : {}),
-        };
         const key = questionKey(questionSessionId, questionAgentId);
         setQuestions((prev) => {
           // Richer-wins guard (#396), scoped to this agent's slot. The daemon

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -841,6 +841,7 @@ function App() {
           ...(q.kind ? { kind: q.kind } : {}),
           ...(uiQuestions && uiQuestions.length > 0 ? { questions: uiQuestions } : {}),
           ...(q.submitLabel ? { submitLabel: q.submitLabel } : {}),
+          ...(q.optionsAreFallback ? { optionsAreFallback: true } : {}),
         };
         const key = questionKey(questionSessionId, questionAgentId);
         setQuestions((prev) => {

--- a/packages/web/src/lib/question-mapping.ts
+++ b/packages/web/src/lib/question-mapping.ts
@@ -1,0 +1,83 @@
+/**
+ * Maps a wire `Question` (daemon) to the client's `UIQuestion` shape.
+ *
+ * Extracted from App.tsx's `question` message handler (#718 review) so the
+ * mapping — in particular, faithfully carrying `optionsAreFallback` — is
+ * unit-testable independent of the WebSocket/React plumbing. Pure function,
+ * no side effects.
+ */
+
+import type { Question, UUID } from '@remi/shared';
+import type { UIQuestion, UIQuestionOption } from '@/types';
+
+/**
+ * Classify the UI question type from its option shape.
+ * yes_no ONLY for exactly 2 options with clear yes+no; multi_option for 3+
+ * options (even if they include yes/no); numbered for options without
+ * yes/no semantics; free_text when there are no options at all.
+ */
+function classifyQuestionType(options: Question['options']): UIQuestion['type'] {
+  if (options.length === 0) return 'free_text';
+  if (options.length === 2) {
+    const hasYes = options.some((o) => o.isYes);
+    const hasNo = options.some((o) => o.isNo);
+    return hasYes && hasNo ? 'yes_no' : 'multi_option';
+  }
+  // 3+ options: always show all of them.
+  const hasYesNo = options.some((o) => o.isYes || o.isNo);
+  return hasYesNo ? 'multi_option' : 'numbered';
+}
+
+function toUIQuestionOption(o: Question['options'][number]): UIQuestionOption {
+  return {
+    label: o.label,
+    value: o.value,
+    isYes: o.isYes || undefined,
+    isNo: o.isNo || undefined,
+    isRecommended: o.isRecommended || undefined,
+    description: o.description || undefined,
+  };
+}
+
+/**
+ * Map a daemon `Question` to a `UIQuestion`. `sessionId` is passed in
+ * separately (from the enclosing `QuestionMessage`) since the caller is
+ * responsible for the "sessionId is mandatory" guard (#437) before calling
+ * this — a malformed message with no sessionId is dropped upstream, never
+ * reaching this pure mapping.
+ */
+export function mapQuestionToUIQuestion(q: Question, sessionId: UUID): UIQuestion {
+  const structuredOptions = q.options.map(toUIQuestionOption);
+
+  // #626: carry the full AskUserQuestion structure (headers, per-option
+  // descriptions, multiSelect) so the card can render it properly.
+  const uiQuestions: UIQuestion['questions'] = q.questions?.map((step) => ({
+    ...(step.header ? { header: step.header } : {}),
+    text: step.text,
+    multiSelect: step.multiSelect,
+    options: step.options.map(toUIQuestionOption),
+  }));
+
+  return {
+    id: q.id,
+    sessionId,
+    type: classifyQuestionType(q.options),
+    prompt: q.text,
+    options: q.options.length > 0 ? q.options.map((o) => o.label) : undefined,
+    structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
+    timestamp: new Date().toISOString(),
+    agentId: q.agentId,
+    ...(q.kind ? { kind: q.kind } : {}),
+    ...(uiQuestions && uiQuestions.length > 0 ? { questions: uiQuestions } : {}),
+    ...(q.submitLabel ? { submitLabel: q.submitLabel } : {}),
+    // #718 review: carry an explicit `false` too, not just `true` — a naive
+    // `q.optionsAreFallback ? {...} : {}` collapses `false` (set by the PTY
+    // parser on a genuine y/n prompt) to `undefined`, which the question-merge
+    // guard treats as "no signal, fall back to label matching" instead of
+    // "authoritatively NOT the fallback" — misclassifying a real Yes/No
+    // question as the bland default (#407 class regression).
+    ...(q.optionsAreFallback !== undefined
+      ? { optionsAreFallback: q.optionsAreFallback }
+      : {}),
+  };
+}

--- a/packages/web/src/lib/question-merge.ts
+++ b/packages/web/src/lib/question-merge.ts
@@ -3,10 +3,10 @@
  * in #378).
  *
  * The daemon emits two questions for the same prompt cycle:
- * `HookEventBridge` (synchronous on `PermissionRequest`, often with the
- * default Yes / Yes-always / No 3-set when `permission_suggestions` is
- * undefined) and the PTY parser (terminal-extracted, frequently richer
- * with full-sentence options for plan-mode prompts). The two emissions
+ * `HookEventBridge` (synchronous on `PermissionRequest`, falling back to the
+ * default Yes / No 2-set when `permission_suggestions` has no usable entry,
+ * #718) and the PTY parser (terminal-extracted, frequently richer with
+ * full-sentence options for plan-mode prompts). The two emissions
  * arrive on the wire as separate `question` messages with different ids;
  * the consumer in `App.tsx` keys its question map by sessionId, so the
  * second arrival otherwise overwrites the first regardless of richness.
@@ -42,18 +42,31 @@ export interface ShouldKeepExistingOptions {
 }
 
 /**
- * Detects the daemon's hardcoded fallback labels. Strict literal match
- * (lowercased + trimmed) against `DEFAULT_PERMISSION_LABELS`; a richer
- * custom 3-set like Edit's "Yes, and don't ask again this session" /
- * "No, and tell Claude what to do differently" is intentionally NOT
- * classified as the bland default.
+ * Detects the daemon's hardcoded fallback (#718: the honest Yes/No 2-set
+ * substituted when `permission_suggestions` has no usable entry).
+ *
+ * Primary signal: `question.optionsAreFallback`, threaded verbatim from the
+ * wire `Question` (App.tsx). This is authoritative — trust it whenever the
+ * daemon set it either way. Shrinking the fallback to a plain 2-option
+ * Yes/No (from the old, distinctively-shaped 3-set) means a genuine
+ * suggestion-free PTY prompt that happens to render as "Yes"/"No" is now
+ * label-identical to the fallback, so label matching alone can no longer
+ * tell them apart; the explicit flag is what removes that ambiguity.
+ *
+ * The label match below only runs when the flag is entirely absent (a
+ * question from before this field existed, e.g. a stale cached replay) and
+ * is inherently approximate for exactly the reason above — a real 2-option
+ * Yes/No question with no flag at all collides with it by coincidence. That
+ * residual imprecision is accepted as a legacy-compatibility fallback, not a
+ * design goal.
  */
-function isDefaultThreeSetShape(question: UIQuestion): boolean {
+function isDefaultFallbackShape(question: UIQuestion): boolean {
+  if (question.optionsAreFallback !== undefined) return question.optionsAreFallback;
   const opts = question.structuredOptions;
-  if (!opts || opts.length !== 3) return false;
+  if (!opts || opts.length !== DEFAULT_PERMISSION_LABELS.length) return false;
   const labels = opts.map((o) => (o.label ?? '').toLowerCase().trim());
   const expected = DEFAULT_PERMISSION_LABELS.map((l) => l.toLowerCase());
-  return labels[0] === expected[0] && labels[1] === expected[1] && labels[2] === expected[2];
+  return labels.every((label, i) => label === expected[i]);
 }
 
 function optionCount(question: UIQuestion): number {
@@ -123,14 +136,16 @@ export function shouldKeepExisting(
 
   const existingCount = optionCount(existing);
   const incomingCount = optionCount(incoming);
-  const existingIsDefault = isDefaultThreeSetShape(existing);
-  const incomingIsDefault = isDefaultThreeSetShape(incoming);
+  const existingIsDefault = isDefaultFallbackShape(existing);
+  const incomingIsDefault = isDefaultFallbackShape(incoming);
 
-  // The daemon's hardcoded Yes / Yes-always / No is the bland fallback
-  // shape; it must never replace a non-default question regardless of
-  // option count (#407). The previous rule "more options = richer" let
-  // the 3-set replace a 2-option Yes/No emitted by the PTY parser, so
-  // the user saw three options for what they expected to be a yes/no.
+  // The daemon's hardcoded Yes / No is the bland fallback shape; it must
+  // never replace a non-default question regardless of option count (#407).
+  // The previous rule "more options = richer" let a fabricated 3-set replace
+  // a 2-option Yes/No emitted by the PTY parser, so the user saw three
+  // options for what they expected to be a yes/no (#718 removed the
+  // fabricated 3-set entirely, but the same overwrite risk applies to the
+  // honest 2-set fallback vs. a richer PTY-parsed set).
   if (incomingIsDefault && !existingIsDefault) {
     logSuppression('richer-shape', existing, incoming);
     return true;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -246,6 +246,12 @@ export interface UIQuestion {
   readonly submitting?: boolean;
   /** #627: the daemon could not auto-answer; the card invites Cancel / terminal. */
   readonly autoAnswerFailed?: boolean;
+  /** #718: mirrors `Question.optionsAreFallback` — true when `structuredOptions`
+   *  is the daemon's honest Yes/No fallback rather than a real PTY/suggestion-
+   *  derived set. Lets the #396 richer-wins guard (`question-merge.ts`)
+   *  distinguish the fallback from a genuine 2-option Yes/No question that
+   *  happens to share the same labels. */
+  readonly optionsAreFallback?: boolean;
 }
 
 /** App settings */

--- a/packages/web/tests/lib/question-mapping.test.ts
+++ b/packages/web/tests/lib/question-mapping.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the wire Question -> UIQuestion mapping (#718 review).
+ * Pure function; no mocks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+import { mapQuestionToUIQuestion } from '../../src/lib/question-mapping';
+
+const SID = 'session-1' as UUID;
+
+function opt(label: string, extras: Partial<QuestionOption> = {}): QuestionOption {
+  return {
+    label,
+    value: label,
+    isRecommended: false,
+    isYes: false,
+    isNo: false,
+    ...extras,
+  };
+}
+
+function question(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'q-1' as UUID,
+    text: 'Allow Bash: ls',
+    options: [],
+    allowsFreeText: false,
+    isAnswered: false,
+    ...overrides,
+  };
+}
+
+describe('mapQuestionToUIQuestion', () => {
+  test('maps id, sessionId, prompt, options, and structuredOptions', () => {
+    const q = question({
+      options: [opt('Yes', { isYes: true, isRecommended: true }), opt('No', { isNo: true })],
+    });
+    const ui = mapQuestionToUIQuestion(q, SID);
+
+    expect(ui.id).toBe(q.id);
+    expect(ui.sessionId).toBe(SID);
+    expect(ui.prompt).toBe('Allow Bash: ls');
+    expect(ui.options).toEqual(['Yes', 'No']);
+    expect(ui.structuredOptions).toEqual([
+      { label: 'Yes', value: 'Yes', isYes: true, isNo: undefined, isRecommended: true, description: undefined },
+      // isRecommended: false collapses to undefined (pre-existing `||`
+      // pattern, unchanged by this extraction).
+      { label: 'No', value: 'No', isYes: undefined, isNo: true, isRecommended: undefined, description: undefined },
+    ]);
+  });
+
+  test('carries agentId through (undefined for main)', () => {
+    expect(mapQuestionToUIQuestion(question(), SID).agentId).toBeUndefined();
+    expect(mapQuestionToUIQuestion(question({ agentId: 'agent-1' }), SID).agentId).toBe('agent-1');
+  });
+
+  describe('question type classification', () => {
+    test('no options -> free_text', () => {
+      expect(mapQuestionToUIQuestion(question({ options: [] }), SID).type).toBe('free_text');
+    });
+
+    test('exactly 2 options with yes+no -> yes_no', () => {
+      const q = question({ options: [opt('Yes', { isYes: true }), opt('No', { isNo: true })] });
+      expect(mapQuestionToUIQuestion(q, SID).type).toBe('yes_no');
+    });
+
+    test('exactly 2 options without both yes+no -> multi_option', () => {
+      const q = question({ options: [opt('Continue'), opt('Stop')] });
+      expect(mapQuestionToUIQuestion(q, SID).type).toBe('multi_option');
+    });
+
+    test('3+ options with yes/no semantics -> multi_option', () => {
+      const q = question({
+        options: [opt('Yes', { isYes: true }), opt('Yes, always', { isYes: true }), opt('No', { isNo: true })],
+      });
+      expect(mapQuestionToUIQuestion(q, SID).type).toBe('multi_option');
+    });
+
+    test('3+ options with no yes/no semantics -> numbered', () => {
+      const q = question({ options: [opt('dev'), opt('staging'), opt('prod')] });
+      expect(mapQuestionToUIQuestion(q, SID).type).toBe('numbered');
+    });
+  });
+
+  describe('optionsAreFallback (#718 review — critical)', () => {
+    test('true is carried through', () => {
+      const q = question({ optionsAreFallback: true });
+      expect(mapQuestionToUIQuestion(q, SID).optionsAreFallback).toBe(true);
+    });
+
+    test('explicit false is carried through, NOT collapsed to undefined', () => {
+      // The bug: `q.optionsAreFallback ? {...} : {}` drops an explicit
+      // `false` (set by question-parser.ts's tryParseYesNo on a genuine
+      // parsed y/n prompt), making it indistinguishable from "no signal" —
+      // which the question-merge guard treats as "fall back to label
+      // matching", misclassifying a real Yes/No prompt as the bland default.
+      const q = question({
+        options: [opt('Yes', { isYes: true }), opt('No', { isNo: true })],
+        optionsAreFallback: false,
+      });
+      const ui = mapQuestionToUIQuestion(q, SID);
+      expect(ui.optionsAreFallback).toBe(false);
+      expect('optionsAreFallback' in ui).toBe(true);
+    });
+
+    test('absent (undefined) on the wire question stays absent on the UI question', () => {
+      const ui = mapQuestionToUIQuestion(question(), SID);
+      expect(ui.optionsAreFallback).toBeUndefined();
+      expect('optionsAreFallback' in ui).toBe(false);
+    });
+  });
+
+  test('threads kind/questions/submitLabel for a multi_question (AskUserQuestion)', () => {
+    const q = question({
+      kind: 'multi_question',
+      submitLabel: 'Submit',
+      questions: [
+        {
+          header: 'Collab PI',
+          text: 'Who is the PI?',
+          multiSelect: false,
+          options: [opt('Scott', { description: 'EEGLAB founder' })],
+        },
+      ],
+    });
+    const ui = mapQuestionToUIQuestion(q, SID);
+
+    expect(ui.kind).toBe('multi_question');
+    expect(ui.submitLabel).toBe('Submit');
+    expect(ui.questions).toHaveLength(1);
+    expect(ui.questions?.[0]?.header).toBe('Collab PI');
+    expect(ui.questions?.[0]?.options[0]?.description).toBe('EEGLAB founder');
+  });
+
+  test('omits kind/questions/submitLabel when absent', () => {
+    const ui = mapQuestionToUIQuestion(question(), SID);
+    expect(ui.kind).toBeUndefined();
+    expect(ui.questions).toBeUndefined();
+    expect(ui.submitLabel).toBeUndefined();
+  });
+});

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the client-side richer-wins guard (#396).
+ * Tests for the client-side richer-wins guard (#396, #718).
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -19,6 +19,7 @@ function uiq(
     timestamp?: string;
     answeredWith?: string;
     resolvedReason?: UIQuestionResolvedReason;
+    optionsAreFallback?: boolean;
   } = {},
 ): UIQuestion {
   const structured: UIQuestionOption[] = options.map((o, i) => ({
@@ -39,10 +40,29 @@ function uiq(
     timestamp: ts,
     ...(extra.answeredWith !== undefined ? { answeredWith: extra.answeredWith } : {}),
     ...(extra.resolvedReason !== undefined ? { resolvedReason: extra.resolvedReason } : {}),
+    ...(extra.optionsAreFallback !== undefined
+      ? { optionsAreFallback: extra.optionsAreFallback }
+      : {}),
   };
 }
 
-const yesYesalwaysNo = [
+// #718: the daemon's honest fallback (no usable permission_suggestions),
+// explicitly flagged the way the real daemon/App.tsx wiring does.
+const yesNoFallback = (prompt = 'Allow Bash: ls') =>
+  uiq(
+    prompt,
+    [
+      { label: 'Yes', isYes: true },
+      { label: 'No', isNo: true },
+    ],
+    { optionsAreFallback: true },
+  );
+
+// A 3-option set that used to double as "the bland default" pre-#718 (when
+// the fallback itself was a 3-set). Under the new 2-option fallback shape
+// this is just an ordinary non-default set (e.g. a #718 suggestion-derived
+// card with one middle "always allow" option) — never flagged.
+const threeOptionNonDefault = [
   { label: 'Yes', isYes: true },
   { label: 'Yes, always', isYes: true },
   { label: 'No', isNo: true },
@@ -58,58 +78,68 @@ const fourSentenceOptions = [
 const fixedNow = (ms: number) => () => ms;
 
 describe('shouldKeepExisting', () => {
-  test('keeps a multi-choice when a default 3-set arrives next', () => {
+  test('keeps a multi-choice when a default fallback arrives next', () => {
     const existing = uiq('Which approach?', fourSentenceOptions);
-    const incoming = uiq('Claude needs your permission to use Bash', yesYesalwaysNo);
+    const incoming = yesNoFallback('Claude needs your permission to use Bash');
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
-  test('keeps a 3-set with custom labels when default 3-set arrives next', () => {
+  test('keeps a 3-set with custom labels when default fallback arrives next', () => {
     // Edit tool's permission_suggestions (rich) followed by the hook's
-    // default fallback (poor) at equal option count.
+    // honest fallback (poor) at equal-or-lower option count.
     const existing = uiq('Allow Edit: src/foo.ts', [
       { label: 'Yes' },
       { label: "Yes, and don't ask again this session" },
       { label: 'No, and tell Claude what to do differently' },
     ]);
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
   test('replaces when incoming has more options', () => {
-    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const existing = uiq('Allow Bash: ls', threeOptionNonDefault);
     const incoming = uiq('Pick a destination', fourSentenceOptions);
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
-  test('keeps a 2-option Yes/No when default 3-set arrives next (#407)', () => {
-    // The reported regression: PTY parser detects [y/n], emits 2-option
-    // Yes/No. Hook bridge then emits the bland default 3-set. Ranking by
-    // count alone made the 3-set "richer" and replaced the 2-option,
-    // showing three buttons for what the user expected to be a yes/no.
-    // The default-3-set must always lose to a non-default shape.
-    const existing = uiq('Continue?', [
-      { label: 'Yes', isYes: true },
-      { label: 'No', isNo: true },
-    ]);
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+  test('keeps a genuine 2-option Yes/No when the default fallback arrives next (#407, #718)', () => {
+    // The reported regression: the PTY parser detects a subprocess (y/n)
+    // prompt and emits a genuine 2-option Yes/No, explicitly flagged
+    // `optionsAreFallback: false` (question-parser.ts). Hook bridge then
+    // falls back to the honest Yes/No default (flagged true) for the SAME
+    // prompt cycle. Label/count alone can no longer tell these apart
+    // post-#718 (both are 2-option Yes/No) — `optionsAreFallback` is what
+    // lets the genuine one win.
+    const existing = uiq(
+      'Continue?',
+      [
+        { label: 'Yes', isYes: true },
+        { label: 'No', isNo: true },
+      ],
+      { optionsAreFallback: false },
+    );
+    const incoming = yesNoFallback();
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
-  test('replaces when existing is the bland default and incoming is non-default (#407)', () => {
-    // Symmetric: if the daemon's hook fired the 3-set first and the PTY
+  test('replaces when existing is the bland fallback and incoming is non-default (#407)', () => {
+    // Symmetric: if the daemon's hook fired the fallback first and the PTY
     // then surfaced a real 2-option Yes/No, the richer one wins.
-    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
-    const incoming = uiq('Continue?', [
-      { label: 'Yes', isYes: true },
-      { label: 'No', isNo: true },
-    ]);
+    const existing = yesNoFallback();
+    const incoming = uiq(
+      'Continue?',
+      [
+        { label: 'Yes', isYes: true },
+        { label: 'No', isNo: true },
+      ],
+      { optionsAreFallback: false },
+    );
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
-  test('replaces when both are default 3-sets (truly equivalent)', () => {
-    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
-    const incoming = uiq('Allow Edit: foo', yesYesalwaysNo);
+  test('replaces when both are default fallback sets (truly equivalent)', () => {
+    const existing = yesNoFallback('Allow Bash: ls');
+    const incoming = yesNoFallback('Allow Edit: foo');
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
@@ -117,14 +147,14 @@ describe('shouldKeepExisting', () => {
     const existing = uiq('Which approach?', fourSentenceOptions, {
       answeredWith: 'Refactor the authentication module',
     });
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
   test('replaces when existing is older than the freshness window', () => {
     const stale = new Date(1_000_000).toISOString();
     const existing = uiq('Old plan question', fourSentenceOptions, { timestamp: stale });
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     // 6 seconds later: stale, allow replacement.
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_006_001) })).toBe(false);
   });
@@ -133,34 +163,37 @@ describe('shouldKeepExisting', () => {
     const existing = uiq('Which approach?', fourSentenceOptions, {
       timestamp: new Date(1_000_000).toISOString(),
     });
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = uiq('Allow Bash: ls', threeOptionNonDefault);
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_004_999) })).toBe(true);
   });
 
-  test('replaces when incoming has same count and existing is also a 3-set default', () => {
-    // Edge case: identical default-shape pairs come through; the second
-    // is no worse than the first so we let it replace (last wins).
-    const existing = uiq('Allow Bash: ls', yesYesalwaysNo);
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+  test('replaces when incoming has same count as an ordinary 3-option set (truly equivalent)', () => {
+    // Edge case: identical non-default 3-option pairs come through; the
+    // second is no worse than the first so we let it replace (last wins).
+    const existing = uiq('Allow Bash: ls', threeOptionNonDefault);
+    const incoming = uiq('Allow Bash: ls', threeOptionNonDefault);
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
-  test('shape outranks count: keeps a 2-option Yes/No over a 3-set default (#407)', () => {
-    // Pre-#407 this asserted the opposite — that the default 3-set
-    // replaces the 2-option Yes/No. That was the bug: the bland default
-    // is the daemon's "no real options" fallback and must never replace
-    // a non-default shape regardless of count.
-    const existing = uiq('Run this?', [
-      { label: 'Yes', isYes: true },
-      { label: 'No', isNo: true },
-    ]);
-    const incoming = uiq('Run this?', yesYesalwaysNo);
+  test('shape outranks count: keeps a 2-option Yes/No over a default fallback (#407, #718)', () => {
+    // Pre-#407 this asserted the opposite — that the (then 3-set) default
+    // replaces the 2-option Yes/No. That was the bug: the bland fallback
+    // must never replace a non-default shape regardless of count.
+    const existing = uiq(
+      'Run this?',
+      [
+        { label: 'Yes', isYes: true },
+        { label: 'No', isNo: true },
+      ],
+      { optionsAreFallback: false },
+    );
+    const incoming = yesNoFallback('Run this?');
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
-  test('keeps 4-option richer when poorer 4-option arrives (not a default 3-set)', () => {
-    // Equal count but neither is the default 3-set shape — let it through.
-    // We only special-case the daemon's hardcoded fallback.
+  test('keeps 4-option richer when poorer 4-option arrives (not a default fallback)', () => {
+    // Equal count but neither is the daemon's fallback shape — let it
+    // through. We only special-case the daemon's hardcoded fallback.
     const existing = uiq('Pick a city', [
       { label: 'New York' },
       { label: 'San Francisco' },
@@ -178,7 +211,7 @@ describe('shouldKeepExisting', () => {
 
   test('malformed timestamp falls open and allows replacement (fail-closed)', () => {
     const existing = uiq('Plan', fourSentenceOptions, { timestamp: 'not-a-date' });
-    const incoming = uiq('Allow Bash', yesYesalwaysNo);
+    const incoming = yesNoFallback('Allow Bash');
     // A corrupted/legacy timestamp must not pin the UI: the guard
     // returns false so the new emission renders normally.
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
@@ -201,7 +234,7 @@ describe('shouldKeepExisting', () => {
       answeredWith: 'Refactor the authentication module',
     });
     // Different id; treat as a genuinely new prompt.
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
   });
 
@@ -212,7 +245,7 @@ describe('shouldKeepExisting', () => {
     // applies normally.
     const future = new Date(2_000_000).toISOString();
     const existing = uiq('Old plan', fourSentenceOptions, { timestamp: future });
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     // 6 seconds after the existing's claimed time => stale, replace.
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(2_006_001) })).toBe(false);
   });
@@ -221,36 +254,62 @@ describe('shouldKeepExisting', () => {
     const existing = uiq('Plan', fourSentenceOptions, {
       timestamp: new Date(1_000_000).toISOString(),
     });
-    const incoming = uiq('Allow Bash: ls', yesYesalwaysNo);
+    const incoming = yesNoFallback();
     // Strict >= boundary: 5000ms exactly is stale, allow replacement.
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_005_000) })).toBe(false);
   });
 
-  test('default-shape detection is case-insensitive', () => {
+  test('default-shape detection: an unflagged case-varied Yes/No is still caught by the label fallback', () => {
+    // No `optionsAreFallback` on either side (as if from a pre-#718 daemon):
+    // the guard falls back to its label heuristic, which is case-insensitive.
     const existing = uiq('Custom prompt', [
       { label: 'Yes' },
       { label: "Yes, and don't ask again this session" },
       { label: 'No' },
     ]);
-    const incoming = uiq('Allow Bash: ls', [
-      { label: '  YES  ' },
-      { label: 'yes, ALWAYS' },
-      { label: ' no ' },
-    ]);
+    const incoming = uiq('Allow Bash: ls', [{ label: '  YES  ' }, { label: ' no ' }]);
+    expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
+  });
+
+  test('an explicit optionsAreFallback: false overrides a label-coincidence match', () => {
+    // Even though the labels alone would match the fallback heuristic, an
+    // explicit `false` from the daemon is authoritative: this is a real
+    // question, not the bland substitute, so it must not be treated as
+    // "poorer" than another default-shaped arrival.
+    const existing = uiq(
+      'Which approach?',
+      [
+        { label: 'Refactor the authentication module' },
+        { label: 'Patch the immediate bug only' },
+        { label: 'Rewrite from scratch using a library' },
+        { label: 'Skip and document the issue' },
+      ],
+      { optionsAreFallback: false },
+    );
+    const incoming = uiq(
+      'Allow Bash: ls',
+      [
+        { label: 'Yes', isYes: true },
+        { label: 'No', isNo: true },
+      ],
+      { optionsAreFallback: false },
+    );
+    // Neither is the fallback (both explicitly false); falls through to
+    // count-based ranking — existing (4) beats incoming (2).
     expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
   });
 
   describe('resolved-elsewhere trace (#652)', () => {
     test('a resolvedReason trace never blocks a genuinely new prompt (different id)', () => {
       // A richer (4-option) trace would normally out-rank an incoming default
-      // 3-set; once resolved it must step aside so the live prompt shows.
+      // fallback; once resolved it must step aside so the live prompt shows.
       const existing = uiq('Which approach?', fourSentenceOptions, { resolvedReason: 'answered' });
-      const incoming = uiq('Claude needs your permission to use Bash', yesYesalwaysNo);
+      const incoming = yesNoFallback('Claude needs your permission to use Bash');
       expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(false);
     });
 
     test('a same-id replay keeps the resolved trace (no re-prompt)', () => {
-      const existing = uiq('Allow Bash: ls', yesYesalwaysNo, { resolvedReason: 'cancelled' });
+      const existing = uiq('Allow Bash: ls', threeOptionNonDefault, { resolvedReason: 'cancelled' });
       const incoming = { ...existing };
       expect(shouldKeepExisting(existing, incoming, { now: fixedNow(1_001_000) })).toBe(true);
     });


### PR DESCRIPTION
Closes #718.

## Problem

Claude Code sends structured `permission_suggestions` (addRules/addDirectories/setMode entries) since ~2.0.54; the daemon only parsed plain strings, so 432 recent prompts (soak log 2026-07-06) got a fabricated Yes / "Yes, always" / No 3-option card — wrong option counts on the app and lock screen (REMI_YNA for genuinely 2-option prompts), the fabricated set overwriting the PTY's correct parse in the tracker merge, and a "Yes, always" that persisted nothing.

## Fix

- **Structured suggestions become real options**: each usable entry (addRules with behavior allow, addDirectories, setMode) becomes one middle option between Yes and No, labeled from its content and destination ("Yes, always allow: rm -rf ... ", "Yes, allow directory /tmp", "Yes, switch to plan mode"); deny/ask/remove/replace/unknown entries are skipped; capped at 4 total options (iOS category budget) with a warn on drop. Legacy >=2-string suggestions unchanged.
- **Honest 2-option fallback**: with no usable suggestions the card is Yes/No (there is no suggestion to echo for an "always"), replacing the fabricated 3-set. `DEFAULT_PERMISSION_LABELS` updated in @remi/shared; web #396 bland-shape guard now trusts a new `optionsAreFallback` flag first (labels as legacy fallback), and the daemon PushDedup default-shape check follows the new length.
- **Fallback never overwrites PTY truth**: `Question.optionsAreFallback` threads into the tracker merge; a fallback hook record keeps contributing text/agent/summary but no longer clobbers concrete PTY-parsed options.
- **Real "Yes, always" end to end**: `QuestionOption.suggestionIndex` -> answer path (`mapAnswerToDecision`) -> `resolveHeld(id, 'allow', suggestionIndex)` -> hold resolves `{behavior:'allow', updatedPermissions:[<exact original entry>]}` -> hook-server serializes it verbatim. Per the official hooks docs this is equivalent to picking that "always allow" option in the terminal dialog. Works from the iOS lock screen today (the relay posts the real option label; no app change). Bare "always"-shaped options with no suggestion still take the passthrough+digit path (pre-existing #573 semantics preserved). Stale index degrades to plain allow with a loud log.
- Docs: AGENTS.md stale "always 3 options" bullet replaced; hook-types.ts documents the full permission-update-entry shape.

## Tests

13-case structured-suggestions block plus updates across hook-event-bridge, tool-question, question-presence-tracker (fallback-merge), auto-approve-gate (suggestionIndex echo), input-events, hook-server (object-decision serialization), notification-dispatcher (2-set -> REMI_YN), push-dedup, question-dedup, question-parser, and web question-merge. Full run: 3175 pass / 0 fail (SKIP_LLM_TESTS=1); typecheck, web tsc -b, and biome clean.

Found during develop-binary soak 2026-07-06. Companion: #719 (lock-screen dynamic action titles, NSE).
