### PR TITLE
feat(#719): NSE dynamic lock-screen action titles

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -9,4 +9,7 @@ extend-exclude = [
   "packages/daemon/tests/parser/fixtures/",
   # Captured AskUserQuestion TUI sessions (#627) — raw terminal bytes, not prose.
   "packages/daemon/tests/fixtures/auq/",
+  # Xcode project files are machine-format: 24-hex object IDs (e.g.
+  # "719E75D1BA17...") tokenize into false-positive "words" like BA (#719).
+  "*.pbxproj",
 ]

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -42,6 +42,28 @@ export function selectPushCategory(options: readonly QuestionOption[]): string |
   return undefined;
 }
 
+/**
+ * Whether a question qualifies for the NSE's per-notification dynamic
+ * category (#719): a single-question prompt (never a multi-sub-question
+ * AskUserQuestion form, which stays app-routed via its topic-list summary)
+ * with 2-4 options, each carrying a REAL label (not just a fallback value —
+ * the entire point of the dynamic category is showing the true option text).
+ *
+ * This is an ADDITIVE hint alongside `selectPushCategory`'s STATIC category,
+ * which is always sent unconditionally as the fallback. A client without the
+ * Notification Service Extension (or one where the NSE fails, races, or is
+ * simply not yet installed) ignores `dynOptions` entirely and falls back to
+ * the static category exactly as before #719 — never worse.
+ */
+export function selectDynOptions(question: Question): boolean {
+  if (question.kind === 'multi_question' && question.questions && question.questions.length > 1) {
+    return false;
+  }
+  const { options } = question;
+  if (options.length < 2 || options.length > 4) return false;
+  return options.every((o) => o.label.trim().length > 0);
+}
+
 /** Cap for the APNS title; iOS truncates visually but a hard cap keeps the
  *  payload bounded for long Bash commands. */
 const TITLE_MAX = 120;
@@ -339,6 +361,11 @@ export class NotificationDispatcher {
     // sending labels here does not break delivery. Fall back to the value when a
     // label is empty so the button still carries something answerable.
     const pushOptions = question.options.map((o) => o.label || o.value);
+    // #719: hint the NSE to build a per-notification dynamic category with the
+    // real option labels as action titles. `pushCategory` above is untouched —
+    // it remains the static fallback the NSE (and any client without one)
+    // falls back to.
+    const dynOptions = selectDynOptions(question);
     const { title, body } = buildPushText(sessionName, question);
     const opts = {
       title,
@@ -348,6 +375,7 @@ export class NotificationDispatcher {
       questionId: question.id,
       ...(pushCategory !== undefined ? { category: pushCategory } : {}),
       ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
+      ...(dynOptions ? { dynOptions: true } : {}),
     };
 
     const perToken = [...deviceTokens.values()].map((dt) =>

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -54,6 +54,14 @@ export function selectPushCategory(options: readonly QuestionOption[]): string |
  * Notification Service Extension (or one where the NSE fails, races, or is
  * simply not yet installed) ignores `dynOptions` entirely and falls back to
  * the static category exactly as before #719 — never worse.
+ *
+ * INVARIANT CHAIN (#719 review): this gate is the narrowest of three — the
+ * signaling worker's `wantsDynCategory` check and the NSE's own option-count
+ * ceiling both allow up to 6 options, a defensive upper bound so loosening
+ * THIS gate (2-4 -> up to 6) needs no worker/NSE change. Keep all three in
+ * sync if the ceiling itself ever moves: packages/signaling/src/index.ts
+ * (`wantsDynCategory`) and packages/web/ios/App/RemiNotificationService/
+ * NotificationService.swift (`buildDynamicCategory`'s `0...5` loop).
  */
 export function selectDynOptions(question: Question): boolean {
   if (question.kind === 'multi_question' && question.questions && question.questions.length > 1) {

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -25,6 +25,15 @@ export interface PushTriggerOptions {
   /** Answer values for action buttons: opt_0, opt_1, ... */
   options?: string[];
   /**
+   * Hint for the iOS Notification Service Extension (#719): when true (and
+   * `options` carries 2-4 real labels), the signaling worker sets
+   * `mutable-content: 1` so the NSE runs and can register a per-notification
+   * dynamic category showing the real labels as action titles. Purely
+   * additive — `category` above is still sent unconditionally as the static
+   * fallback for a missing/failed/racing NSE.
+   */
+  dynOptions?: boolean;
+  /**
    * Dismissal trigger (#585, P7). When true the signaling server sends a QUIET
    * `content-available` push (no alert) carrying the same `apns-collapse-id` =
    * questionId, so the device replaces/clears the lock-screen card for an
@@ -72,6 +81,9 @@ export async function sendPushTrigger(
   }
   if (opts.options && opts.options.length > 0) {
     payload['options'] = opts.options;
+  }
+  if (opts.dynOptions) {
+    payload['dynOptions'] = true;
   }
   if (opts.dismiss) {
     payload['dismiss'] = true;

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -9,6 +9,7 @@ import {
   isDelivered,
   isRetriablePushError,
   isTokenInvalidError,
+  selectDynOptions,
   selectPushCategory,
 } from '../../src/notifications/notification-dispatcher.ts';
 import type { PTYSession } from '../../src/pty/pty-session.ts';
@@ -69,6 +70,73 @@ describe('selectPushCategory', () => {
     // daemon's fallback is a genuine 2-set instead of a fabricated 3-set —
     // no dispatcher change was needed, this just pins the observable result.
     expect(selectPushCategory([yesOpt, noOpt])).toBe('REMI_YN');
+  });
+});
+
+describe('selectDynOptions (#719)', () => {
+  test('single-question AskUserQuestion with 3 options qualifies', () => {
+    const q: Question = {
+      id: 'q' as UUID,
+      text: 'DB: Which database?',
+      options: [
+        { value: '1', label: 'Postgres', isRecommended: true, isYes: false, isNo: false },
+        { value: '2', label: 'SQLite', isRecommended: false, isYes: false, isNo: false },
+        { value: '3', label: 'MySQL', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        {
+          header: 'DB',
+          text: 'Which database?',
+          multiSelect: false,
+          options: [],
+        },
+      ],
+    };
+    expect(selectDynOptions(q)).toBe(true);
+  });
+
+  test('a 4-option structured-suggestion permission card qualifies', () => {
+    expect(selectDynOptions(question('q', [yesOpt, yesAlwaysOpt, noOpt, yesOpt]))).toBe(true);
+  });
+
+  test('a multi-sub-question AskUserQuestion form does NOT qualify (stays app-routed)', () => {
+    const q: Question = {
+      id: 'q' as UUID,
+      text: 'Collab PI: Who is the PI?',
+      options: [
+        { value: '1', label: 'Scott', isRecommended: true, isYes: false, isNo: false },
+        { value: '2', label: 'Arnaud', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        { header: 'Collab PI', text: 'Who is the PI?', multiSelect: false, options: [] },
+        { header: 'Software focus', text: 'Which tools?', multiSelect: true, options: [] },
+      ],
+    };
+    expect(selectDynOptions(q)).toBe(false);
+  });
+
+  test('free-text (0 options) does NOT qualify', () => {
+    expect(selectDynOptions(question('q', []))).toBe(false);
+  });
+
+  test('5+ options does NOT qualify', () => {
+    const five = [yesOpt, noOpt, yesOpt, noOpt, yesOpt];
+    expect(selectDynOptions(question('q', five))).toBe(false);
+  });
+
+  test('an empty label disqualifies even though the push falls back to the value', () => {
+    const blankLabel: QuestionOption = { ...yesOpt, label: '' };
+    expect(selectDynOptions(question('q', [blankLabel, noOpt]))).toBe(false);
+  });
+
+  test('the honest 2-option Yes/No fallback qualifies', () => {
+    expect(selectDynOptions(question('q', [yesOpt, noOpt]))).toBe(true);
   });
 });
 
@@ -284,6 +352,41 @@ describe('NotificationDispatcher.maybePush', () => {
     expect(pushed).toHaveLength(1);
     expect(pushed[0]?.opts['options']).toEqual(['Yes', 'Yes, always', 'No']);
     expect(pushed[0]?.opts['category']).toBe('REMI_YNA');
+  });
+
+  // #719: the NSE dynamic-category hint rides alongside the static category.
+  test('carries dynOptions:true for a qualifying 2-4 option question', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().maybePush(SID, question('q1', defaultThreeSet, 'Allow Bash: git push'));
+
+    expect(pushed[0]?.opts['dynOptions']).toBe(true);
+    expect(pushed[0]?.opts['category']).toBe('REMI_YNA'); // static fallback unchanged
+  });
+
+  test('omits dynOptions for a multi-sub-question AskUserQuestion form', () => {
+    register(false);
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    const mq: Question = {
+      id: 'q1' as UUID,
+      text: 'Collab PI: Who is the PI?',
+      options: [
+        { value: '1', label: 'Scott', isRecommended: true, isYes: false, isNo: false },
+        { value: '2', label: 'Arnaud', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+      kind: 'multi_question',
+      questions: [
+        { header: 'Collab PI', text: 'Who is the PI?', multiSelect: false, options: [] },
+        { header: 'Software focus', text: 'Which tools?', multiSelect: true, options: [] },
+      ],
+    };
+    make().maybePush(SID, mq);
+
+    expect(pushed[0]?.opts['dynOptions']).toBeUndefined();
   });
 
   // #626: an AskUserQuestion must NOT get a count-based category (REMI_YN/YNA

--- a/packages/signaling/src/apns.ts
+++ b/packages/signaling/src/apns.ts
@@ -16,6 +16,14 @@ interface ApnsPayload {
   /** UNNotificationCategory identifier for action buttons (lock screen / Watch) */
   category?: string;
   /**
+   * `mutable-content: 1` (#719): lets the iOS Notification Service Extension
+   * intercept and mutate the notification (to register a per-notification
+   * dynamic category) before it displays. Only set when the payload carries
+   * `dynCategory` data for the NSE to act on; absent otherwise so a normal
+   * push's `aps` dict is byte-identical to pre-#719.
+   */
+  mutableContent?: boolean;
+  /**
    * Collapse identifier (#575, P4a). Sent as the `apns-collapse-id` header AND
    * used to de-dup at the device. A re-push for the same questionId replaces the
    * earlier notification instead of stacking a duplicate. Apple caps this at 64
@@ -108,6 +116,7 @@ export function buildApnsRequest(payload: ApnsPayload, jwt: string): ApnsRequest
         // wake opportunity.
         'content-available': 1,
         ...(payload.category ? { category: payload.category } : {}),
+        ...(payload.mutableContent ? { 'mutable-content': 1 } : {}),
       };
 
   const body = JSON.stringify({

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -46,6 +46,14 @@ interface PushRequestBody {
   category?: string;
   /** Answer values for action buttons: mapped to opt_0, opt_1, ... in APNS data */
   options?: string[];
+  /**
+   * NSE dynamic-category hint (#719): when true and `options` is non-empty,
+   * the push sets `mutable-content: 1` and a `dynCategory: "1"` data field so
+   * the iOS Notification Service Extension can register a per-notification
+   * category with the real option labels as action titles. Additive only —
+   * `category` is still sent as the static fallback for a missing/failed NSE.
+   */
+  dynOptions?: boolean;
   /** Reserved for future per-request sandbox override; daemon does not send this today */
   sandbox?: boolean;
   /**
@@ -281,6 +289,13 @@ export default {
           data[`opt_${idx}`] = String(val);
         });
       }
+      // #719: only meaningful alongside real options — a dynCategory hint with
+      // nothing in opt_0.. would just make the NSE run for no benefit.
+      const wantsDynCategory =
+        body.dynOptions === true && Array.isArray(body.options) && body.options.length > 0;
+      if (wantsDynCategory) {
+        data['dynCategory'] = '1';
+      }
       const category = body.category && body.category.length > 0 ? body.category : undefined;
 
       let result: { success: boolean; error?: string };
@@ -297,6 +312,10 @@ export default {
             sandbox,
             data: Object.keys(data).length > 0 ? data : undefined,
             category,
+            // #719: mutable-content lets the NSE intercept and mutate the
+            // notification before display (to attach the dynamic category);
+            // only set when there is something for it to build actions from.
+            ...(wantsDynCategory ? { mutableContent: true } : {}),
             // Collapse repeated pushes for the same question (#575, P4a).
             ...(body.questionId && body.questionId.length > 0
               ? { collapseId: body.questionId }

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -290,9 +290,18 @@ export default {
         });
       }
       // #719: only meaningful alongside real options — a dynCategory hint with
-      // nothing in opt_0.. would just make the NSE run for no benefit.
+      // nothing in opt_0.. would just make the NSE run for no benefit. The
+      // upper bound (6) is an INVARIANT CHAIN shared with the NSE's own
+      // option-count ceiling (NotificationService.swift's `0...5` loop) and is
+      // deliberately looser than the daemon's current 2-4 gate
+      // (notification-dispatcher.ts `selectDynOptions`), so loosening the
+      // daemon gate up to 6 needs no worker change. Keep all three in sync if
+      // the ceiling itself ever moves.
       const wantsDynCategory =
-        body.dynOptions === true && Array.isArray(body.options) && body.options.length > 0;
+        body.dynOptions === true &&
+        Array.isArray(body.options) &&
+        body.options.length >= 2 &&
+        body.options.length <= 6;
       if (wantsDynCategory) {
         data['dynCategory'] = '1';
       }

--- a/packages/signaling/tests/apns.test.ts
+++ b/packages/signaling/tests/apns.test.ts
@@ -25,6 +25,7 @@ function parseBody(body: string): {
     badge?: number;
     'content-available'?: number;
     category?: string;
+    'mutable-content'?: number;
   };
   [key: string]: unknown;
 } {
@@ -90,6 +91,20 @@ describe('buildApnsRequest (#575 P4a)', () => {
     expect(buildApnsRequest({ ...BASE, sandbox: true }, 'jwt').url).toContain(
       'api.sandbox.push.apple.com',
     );
+  });
+
+  test('omits mutable-content by default (#719, byte-identical to pre-#719)', () => {
+    const req = buildApnsRequest(BASE, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps['mutable-content']).toBeUndefined();
+  });
+
+  test('sets mutable-content: 1 when mutableContent is requested (#719)', () => {
+    const req = buildApnsRequest({ ...BASE, mutableContent: true }, 'jwt-token');
+    const payload = parseBody(req.body);
+    expect(payload.aps['mutable-content']).toBe(1);
+    // Coexists with the rest of the alert; not a silent/dismiss push.
+    expect(payload.aps.alert?.title).toBe(BASE.title);
   });
 
   test('always sets the standard APNS headers', () => {

--- a/packages/signaling/tests/push-dyn-category.test.ts
+++ b/packages/signaling/tests/push-dyn-category.test.ts
@@ -109,6 +109,30 @@ describe('/push NSE dynamic-category contract (#719)', () => {
     expect(parsed['opt_2']).toBe('No');
   });
 
+  test('7+ options exceeds the shared NSE ceiling (6) and gets no mutable-content/dynCategory', async () => {
+    // INVARIANT CHAIN (#719 review): this upper bound mirrors the NSE's own
+    // option-count ceiling (NotificationService.swift's `0...5` loop) so the
+    // worker never asks the NSE to run for a shape it cannot build actions
+    // from.
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-7',
+        options: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+        dynOptions: true,
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['mutable-content']).toBeUndefined();
+    expect(parsed['dynCategory']).toBeUndefined();
+    // The opt_N fields still ride along unconditionally — only the NSE hint is gated.
+    expect(parsed['opt_6']).toBe('G');
+  });
+
   test('dynOptions is a no-op without any options (nothing for the NSE to build)', async () => {
     const res = await worker.fetch(
       pushRequest({

--- a/packages/signaling/tests/push-dyn-category.test.ts
+++ b/packages/signaling/tests/push-dyn-category.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Worker-level tests for the NSE dynamic-category contract (#719).
+ *
+ * Drives the worker's `fetch` directly (no miniflare; bun's runtime provides
+ * `crypto.subtle` and `fetch`, which we stub for the Apple call). Confirms:
+ *   - `dynOptions: true` + non-empty `options` sets BOTH `mutable-content: 1`
+ *     in the aps dict AND a `dynCategory: "1"` data field, alongside the
+ *     unchanged `opt_0..opt_N` fields and the static `category`.
+ *   - the flag is STRICTLY ADDITIVE: absent (or false, or no options) produces
+ *     a payload with no `mutable-content` / `dynCategory` at all — byte-
+ *     identical to a pre-#719 push.
+ * Each test uses a unique CF-Connecting-IP to dodge the module-level per-IP
+ * push rate limiter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+}
+
+describe('/push NSE dynamic-category contract (#719)', () => {
+  let env: TestEnv;
+  let realFetch: typeof globalThis.fetch;
+  let appleRequests: Array<{ url: string; headers: Headers; body: string }>;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    env = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleRequests = [];
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        appleRequests.push({
+          url,
+          headers: new Headers(init?.headers),
+          body: String(init?.body ?? ''),
+        });
+        return new Response('', { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function pushRequest(body: Record<string, unknown>): Request {
+    ipCounter += 1;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': `203.0.113.${100 + ipCounter}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('dynOptions + options sets mutable-content and dynCategory alongside the static category', async () => {
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-1',
+        category: 'REMI_YNA',
+        options: ['Yes', 'Yes, always', 'No'],
+        dynOptions: true,
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    expect(appleRequests).toHaveLength(1);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['mutable-content']).toBe(1);
+    expect(parsed.aps.category).toBe('REMI_YNA'); // static fallback still present
+    expect(parsed['dynCategory']).toBe('1');
+    expect(parsed['opt_0']).toBe('Yes');
+    expect(parsed['opt_1']).toBe('Yes, always');
+    expect(parsed['opt_2']).toBe('No');
+  });
+
+  test('dynOptions is a no-op without any options (nothing for the NSE to build)', async () => {
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-2',
+        dynOptions: true,
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['mutable-content']).toBeUndefined();
+    expect(parsed['dynCategory']).toBeUndefined();
+  });
+
+  test('absent dynOptions is byte-identical to a pre-#719 push (no mutable-content, no dynCategory)', async () => {
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-3',
+        category: 'REMI_MULTI',
+        options: ['Postgres', 'SQLite', 'MySQL', 'MongoDB'],
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['mutable-content']).toBeUndefined();
+    expect(parsed['dynCategory']).toBeUndefined();
+    expect(parsed.aps.category).toBe('REMI_MULTI');
+    expect(parsed['opt_3']).toBe('MongoDB');
+  });
+
+  test('dynOptions: false is a no-op (explicit false, not just absent)', async () => {
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-4',
+        options: ['Yes', 'No'],
+        dynOptions: false,
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed.aps['mutable-content']).toBeUndefined();
+    expect(parsed['dynCategory']).toBeUndefined();
+  });
+});

--- a/packages/web/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/web/ios/App/App.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		719E2CB655107FC68F199158 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719E64400444FDDEA89A2D31 /* NotificationService.swift */; };
+		719E00D9ED2C8B34D435C48D /* RemiNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 719E9504608D5E667467CC91 /* RemiNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +28,9 @@
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		7624428F4554B48AC7C71AC4 /* RemiAnswerRelay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemiAnswerRelay.swift; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		719E64400444FDDEA89A2D31 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		719E8358DADBD8760BB6C4FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		719E9504608D5E667467CC91 /* RemiNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RemiNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,7 +42,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		719EC9031EC2424EDC60CEC3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		719EB7C7A07E1AC76C5C4BF4 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				719E00D9ED2C8B34D435C48D /* RemiNotificationService.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXGroup section */
 		504EC2FB1FED79650016851F = {
@@ -45,6 +71,7 @@
 			children = (
 				958DCC722DB07C7200EA8C5F /* debug.xcconfig */,
 				504EC3061FED79650016851F /* App */,
+				719E753360B1F170FE9E8746 /* RemiNotificationService */,
 				504EC3051FED79650016851F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,8 +80,18 @@
 			isa = PBXGroup;
 			children = (
 				504EC3041FED79650016851F /* App.app */,
+				719E9504608D5E667467CC91 /* RemiNotificationService.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		719E753360B1F170FE9E8746 /* RemiNotificationService */ = {
+			isa = PBXGroup;
+			children = (
+				719E64400444FDDEA89A2D31 /* NotificationService.swift */,
+				719E8358DADBD8760BB6C4FE /* Info.plist */,
+			);
+			path = RemiNotificationService;
 			sourceTree = "<group>";
 		};
 		504EC3061FED79650016851F /* App */ = {
@@ -81,10 +118,12 @@
 				504EC3001FED79650016851F /* Sources */,
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
+				719EB7C7A07E1AC76C5C4BF4 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				719EF7927D4AB83E2FB3D0BE /* PBXTargetDependency */,
 			);
 			name = App;
 			packageProductDependencies = (
@@ -93,6 +132,23 @@
 			productName = App;
 			productReference = 504EC3041FED79650016851F /* App.app */;
 			productType = "com.apple.product-type.application";
+		};
+		719EC54B6770DE57C8942996 /* RemiNotificationService */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 719E9B3E1E1225D6E977ECC8 /* Build configuration list for PBXNativeTarget "RemiNotificationService" */;
+			buildPhases = (
+				719E9A8E293AA00EA48EEAAB /* Sources */,
+				719EC9031EC2424EDC60CEC3 /* Frameworks */,
+				719E2CAB50D4F735F9E4841A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RemiNotificationService;
+			productName = RemiNotificationService;
+			productReference = 719E9504608D5E667467CC91 /* RemiNotificationService.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -106,6 +162,10 @@
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
+						ProvisioningStyle = Automatic;
+					};
+					719EC54B6770DE57C8942996 = {
+						CreatedOnToolsVersion = 16.0;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -126,6 +186,7 @@
 			projectRoot = "";
 			targets = (
 				504EC3031FED79650016851F /* App */,
+				719EC54B6770DE57C8942996 /* RemiNotificationService */,
 			);
 		};
 /* End PBXProject section */
@@ -142,6 +203,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		719E2CAB50D4F735F9E4841A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -154,7 +222,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		719E9A8E293AA00EA48EEAAB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				719E2CB655107FC68F199158 /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+		719E75D1BA174F56DC8BA5D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 504EC2FC1FED79650016851F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 719EC54B6770DE57C8942996;
+			remoteInfo = RemiNotificationService;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		719EF7927D4AB83E2FB3D0BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 719EC54B6770DE57C8942996 /* RemiNotificationService */;
+			targetProxy = 719E75D1BA174F56DC8BA5D7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		504EC3141FED79650016851F /* Debug */ = {
@@ -314,6 +408,51 @@
 			};
 			name = Release;
 		};
+		719E8D5C5E233298202C4681 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
+				DEVELOPMENT_TEAM = 9DQ459HAZB;
+				INFOPLIST_FILE = RemiNotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi.RemiNotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		719E6E36FC6610FC66A63E9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
+				DEVELOPMENT_TEAM = 9DQ459HAZB;
+				INFOPLIST_FILE = RemiNotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi.RemiNotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -331,6 +470,15 @@
 			buildConfigurations = (
 				504EC3171FED79650016851F /* Debug */,
 				504EC3181FED79650016851F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		719E9B3E1E1225D6E977ECC8 /* Build configuration list for PBXNativeTarget "RemiNotificationService" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				719E8D5C5E233298202C4681 /* Debug */,
+				719E6E36FC6610FC66A63E9A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/web/ios/App/RemiNotificationService/Info.plist
+++ b/packages/web/ios/App/RemiNotificationService/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>RemiNotificationService</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/web/ios/App/RemiNotificationService/NotificationService.swift
+++ b/packages/web/ios/App/RemiNotificationService/NotificationService.swift
@@ -19,16 +19,25 @@ import UserNotifications
 /// category's taps route identically to a static one's.
 ///
 /// GRACEFUL DEGRADATION (non-negotiable, #719): every guard below that is not
-/// satisfied, or the extension simply not running in time, falls through to
-/// delivering `bestAttemptContent` UNCHANGED — i.e. with whatever
-/// `categoryIdentifier` the daemon's push already set (a static category, or
-/// none). The daemon's `category` field is therefore a genuine fallback, not
-/// just today's behavior: this extension can only ADD a better lock-screen
+/// satisfied, the extension not running in time, OR the category
+/// registration racing and losing on read-back (see `buildDynamicCategory`),
+/// leaves `bestAttemptContent`'s `categoryIdentifier` UNCHANGED — i.e.
+/// whatever the daemon's push already set (a static category, or none). The
+/// daemon's `category` field is therefore a genuine fallback, not just
+/// today's behavior: this extension can only ADD a better lock-screen
 /// experience, never subtract one.
 class NotificationService: UNNotificationServiceExtension {
 
     var contentHandler: ((UNNotificationContent) -> Void)?
     var bestAttemptContent: UNMutableNotificationContent?
+
+    /// Serializes both delivery call sites — `didReceive`'s async completion
+    /// (invoked from whatever queue `getNotificationCategories` calls back
+    /// on) and `serviceExtensionTimeWillExpire` (called by the OS) — so the
+    /// check-then-clear in `deliver()` is atomic. `UNNotificationServiceExtension`
+    /// requires the content handler be invoked EXACTLY once; calling it twice
+    /// is undefined behavior, and without this the two sites can race.
+    private let deliveryQueue = DispatchQueue(label: "remi.nse.delivery")
 
     override func didReceive(
         _ request: UNNotificationRequest,
@@ -51,33 +60,42 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
-        // iOS gives ~30s total. If buildDynamicCategory's async
-        // getNotificationCategories/setNotificationCategories round trip
-        // hasn't completed yet, deliver bestAttemptContent AS-IS: it still
-        // carries whatever categoryIdentifier the daemon's push set (the
-        // static fallback), so a slow/expired NSE run degrades to exactly
-        // pre-#719 behavior rather than losing the notification.
+        // Synchronous (via deliver()'s deliveryQueue.sync): the OS may
+        // terminate this extension's process as soon as this method returns,
+        // so the content handler must be invoked BEFORE we return here, not
+        // queued for later.
         deliver()
     }
 
-    /// Delivers `bestAttemptContent` exactly once. `didReceive`'s own
-    /// completion and `serviceExtensionTimeWillExpire` can race (the OS may
-    /// call the latter right after the former fires); clearing both refs after
-    /// the first call makes a second call a no-op instead of double-invoking
-    /// `contentHandler`.
+    /// Delivers `bestAttemptContent` exactly once. Runs the check-then-clear
+    /// on `deliveryQueue` so a concurrent call from the other call site (see
+    /// the property doc above) observes a fully-cleared or fully-set state,
+    /// never a torn one — the second caller then sees `nil` and is a no-op
+    /// instead of double-invoking `contentHandler`.
     private func deliver() {
-        if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-            contentHandler(bestAttemptContent)
+        deliveryQueue.sync {
+            if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+                contentHandler(bestAttemptContent)
+            }
+            contentHandler = nil
+            bestAttemptContent = nil
         }
-        contentHandler = nil
-        bestAttemptContent = nil
     }
+
+    /// Process-wide cap on REMI_DYN_* categories accumulated in
+    /// `UNUserNotificationCenter`'s registered set over this extension
+    /// process's lifetime (#719 review). Without a cap, a long-lived process
+    /// handling many sequential/concurrent questions would grow the category
+    /// set without bound. 16 is generous headroom for concurrent teammate
+    /// questions while keeping the set finite.
+    private static let maxDynCategories = 16
+    private static let dynCategoryPrefix = "REMI_DYN_"
 
     /// Attempts to attach a dynamic category built from `opt_0..opt_N` in the
     /// notification's userInfo. ALWAYS calls `completion` exactly once — every
     /// guard failure calls it synchronously without touching `content` (so the
     /// daemon's original `categoryIdentifier` survives untouched), and the one
-    /// success path calls it from the `setNotificationCategories` callback.
+    /// success path calls it after the read-back barrier below resolves.
     private func buildDynamicCategory(
         for content: UNMutableNotificationContent,
         completion: @escaping () -> Void
@@ -85,9 +103,10 @@ class NotificationService: UNNotificationServiceExtension {
         let userInfo = content.userInfo
 
         // Gate: the daemon sets dynCategory="1" only for a single-question
-        // 2-4 option prompt with real labels (notification-dispatcher.ts
-        // computeDelivery, #719). Absent flag or missing/empty opt_0 -> leave
-        // the daemon's static `category` (aps.category) as the fallback.
+        // prompt with real labels, currently 2-4 options
+        // (notification-dispatcher.ts `selectDynOptions`, #719). Absent flag
+        // or missing/empty opt_0 -> leave the daemon's static `category`
+        // (aps.category) as the fallback.
         guard (userInfo["dynCategory"] as? String) == "1",
             let firstLabel = userInfo["opt_0"] as? String, !firstLabel.isEmpty
         else {
@@ -96,10 +115,12 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         // Collect opt_0..opt_N, stopping at the first missing/empty index or
-        // at index 5 (6 options max). The daemon's own gate today caps at 4
-        // options; this ceiling is a defensive upper bound matching the option
-        // count #719 originally scoped for AskUserQuestion picks, so a future
-        // loosening of the daemon gate does not require an NSE change.
+        // at index 5 (6 options max). INVARIANT CHAIN (#719 review): the
+        // daemon's `selectDynOptions` gates at 2-4 options today; the
+        // signaling worker's `wantsDynCategory` gate and this ceiling both
+        // allow up to 6 — a defensive upper bound so a future loosening of
+        // the daemon's gate (up to 6) needs no worker/NSE change. Keep all
+        // three in sync if the ceiling itself ever moves.
         var labels: [String] = []
         for i in 0...5 {
             guard let label = userInfo["opt_\(i)"] as? String, !label.isEmpty else { break }
@@ -111,10 +132,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         let actions = labels.enumerated().map { (idx, label) -> UNNotificationAction in
-            // A label starting with "No" (the honest Yes/No/Always fallback
-            // set, or a "No, cancel"-style pick) renders destructive (red),
-            // matching the static REMI_YN/YNA convention in AppDelegate.swift.
-            let destructive: UNNotificationActionOptions = label.hasPrefix("No") ? [.destructive] : []
+            let destructive: UNNotificationActionOptions = isNegativeLabel(label) ? [.destructive] : []
             return UNNotificationAction(
                 identifier: "OPT_\(idx)",
                 title: truncated(label, to: 24),
@@ -132,7 +150,7 @@ class NotificationService: UNNotificationServiceExtension {
         // orphaned category left registered from an earlier notification is
         // inert until a notification's categoryIdentifier references it again).
         let questionId = (userInfo["questionId"] as? String) ?? UUID().uuidString
-        let categoryId = "REMI_DYN_\(questionId)"
+        let categoryId = "\(Self.dynCategoryPrefix)\(questionId)"
         let category = UNNotificationCategory(
             identifier: categoryId,
             actions: actions,
@@ -145,20 +163,57 @@ class NotificationService: UNNotificationServiceExtension {
         // launch in AppDelegate.registerNotificationCategories). We read the
         // CURRENT category set via getNotificationCategories and UNION ours
         // in — never replace wholesale — specifically so a category this
-        // extension does not know about (e.g. one the app registered) is never
-        // dropped. Whether this extension's setNotificationCategories call
-        // lands in time for THIS notification's action buttons is itself a
-        // race against the ~30s extension budget and Apple's undocumented
-        // internal timing; if it loses, `content.categoryIdentifier` is never
-        // rewritten (still whatever the daemon's push set), which is exactly
-        // the static-category fallback #719 requires as the safety net.
+        // extension does not know about (e.g. one the app registered) is
+        // never dropped.
+        //
+        // WATCH MIRRORING UNVERIFIED (#719 review, on-device verification
+        // list): the app's static categories are known to mirror to a paired
+        // Apple Watch; whether a category registered from THIS EXTENSION
+        // process (rather than the main app process) mirrors the same way is
+        // NOT yet confirmed on-device.
         UNUserNotificationCenter.current().getNotificationCategories { existing in
             var merged = existing
+            let dynCategories = merged.filter { $0.identifier.hasPrefix(Self.dynCategoryPrefix) }
+            if dynCategories.count >= Self.maxDynCategories {
+                // Evict arbitrary excess (Set order is unspecified but that is
+                // fine here) so the process-wide set never grows unbounded.
+                // An evicted category only degrades an OLD, still-displayed
+                // notification back to no action buttons — tapping it still
+                // opens the app via the default action, never a crash or lost
+                // notification. Do NOT prune ALL other REMI_DYN_* categories:
+                // concurrent questions in flight need their own distinct
+                // categories so their action buttons don't clobber each other.
+                let excess = dynCategories.count - (Self.maxDynCategories - 1)
+                for cat in dynCategories.prefix(excess) {
+                    merged.remove(cat)
+                }
+            }
             merged.insert(category)
             UNUserNotificationCenter.current().setNotificationCategories(merged)
-            content.categoryIdentifier = categoryId
-            completion()
+
+            // READ-BACK BARRIER (#719 review): setNotificationCategories has
+            // no completion handler, so this is the only way to tell whether
+            // the registration actually landed before this notification
+            // displays. Read the set back and stamp `categoryIdentifier` ONLY
+            // if our category is confirmed present; if the registration raced
+            // and lost, leave `content.categoryIdentifier` untouched so the
+            // daemon's original static category (or none) — the safe
+            // fallback — is what displays, rather than an unresolved dynamic
+            // id that would render with NO action buttons at all.
+            UNUserNotificationCenter.current().getNotificationCategories { confirmed in
+                if confirmed.contains(where: { $0.identifier == categoryId }) {
+                    content.categoryIdentifier = categoryId
+                }
+                completion()
+            }
         }
+    }
+
+    /// True for an honest negative answer ("No", "No, thanks", "No, cancel")
+    /// — never for a label that merely starts with the letters "No", such as
+    /// "Norway" or "Node.js".
+    private func isNegativeLabel(_ label: String) -> Bool {
+        label == "No" || label.hasPrefix("No ") || label.hasPrefix("No,")
     }
 
     private func truncated(_ s: String, to maxLength: Int) -> String {

--- a/packages/web/ios/App/RemiNotificationService/NotificationService.swift
+++ b/packages/web/ios/App/RemiNotificationService/NotificationService.swift
@@ -1,0 +1,168 @@
+import UserNotifications
+
+/// #719 — Notification Service Extension (NSE).
+///
+/// Registers a PER-NOTIFICATION dynamic UNNotificationCategory whose action
+/// titles are the real option labels, for the two cases the three static
+/// categories (REMI_YN / REMI_YNA / REMI_MULTI, registered once at launch in
+/// AppDelegate.registerNotificationCategories) cannot express:
+///   - a single-question AskUserQuestion pick (arbitrary labels, e.g.
+///     "PostgreSQL" / "MySQL" / "MongoDB" — REMI_YN/YNA's hardcoded
+///     Yes/Yes-always/No titles would mislabel these).
+///   - a 4-option structured-suggestion permission card, whose static
+///     REMI_MULTI titles are the generic "Option 1..4" placeholders.
+///
+/// Runs in its OWN process, separate from the main app. `RemiAnswerRelay`
+/// (App/RemiAnswerRelay.swift) already handles ANY category's `OPT_n` action
+/// tap — it reads `response.actionIdentifier` and looks up `opt_<n>` in the
+/// notification's userInfo, with no category allowlist — so a dynamic
+/// category's taps route identically to a static one's.
+///
+/// GRACEFUL DEGRADATION (non-negotiable, #719): every guard below that is not
+/// satisfied, or the extension simply not running in time, falls through to
+/// delivering `bestAttemptContent` UNCHANGED — i.e. with whatever
+/// `categoryIdentifier` the daemon's push already set (a static category, or
+/// none). The daemon's `category` field is therefore a genuine fallback, not
+/// just today's behavior: this extension can only ADD a better lock-screen
+/// experience, never subtract one.
+class NotificationService: UNNotificationServiceExtension {
+
+    var contentHandler: ((UNNotificationContent) -> Void)?
+    var bestAttemptContent: UNMutableNotificationContent?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        self.contentHandler = contentHandler
+        bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
+
+        guard let bestAttemptContent = bestAttemptContent else {
+            // Not expected (mutableCopy() of a UNNotificationContent always
+            // succeeds), but the contract is "never drop the notification" —
+            // hand back the original content verbatim rather than risk it.
+            contentHandler(request.content)
+            return
+        }
+
+        buildDynamicCategory(for: bestAttemptContent) { [weak self] in
+            self?.deliver()
+        }
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        // iOS gives ~30s total. If buildDynamicCategory's async
+        // getNotificationCategories/setNotificationCategories round trip
+        // hasn't completed yet, deliver bestAttemptContent AS-IS: it still
+        // carries whatever categoryIdentifier the daemon's push set (the
+        // static fallback), so a slow/expired NSE run degrades to exactly
+        // pre-#719 behavior rather than losing the notification.
+        deliver()
+    }
+
+    /// Delivers `bestAttemptContent` exactly once. `didReceive`'s own
+    /// completion and `serviceExtensionTimeWillExpire` can race (the OS may
+    /// call the latter right after the former fires); clearing both refs after
+    /// the first call makes a second call a no-op instead of double-invoking
+    /// `contentHandler`.
+    private func deliver() {
+        if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+            contentHandler(bestAttemptContent)
+        }
+        contentHandler = nil
+        bestAttemptContent = nil
+    }
+
+    /// Attempts to attach a dynamic category built from `opt_0..opt_N` in the
+    /// notification's userInfo. ALWAYS calls `completion` exactly once — every
+    /// guard failure calls it synchronously without touching `content` (so the
+    /// daemon's original `categoryIdentifier` survives untouched), and the one
+    /// success path calls it from the `setNotificationCategories` callback.
+    private func buildDynamicCategory(
+        for content: UNMutableNotificationContent,
+        completion: @escaping () -> Void
+    ) {
+        let userInfo = content.userInfo
+
+        // Gate: the daemon sets dynCategory="1" only for a single-question
+        // 2-4 option prompt with real labels (notification-dispatcher.ts
+        // computeDelivery, #719). Absent flag or missing/empty opt_0 -> leave
+        // the daemon's static `category` (aps.category) as the fallback.
+        guard (userInfo["dynCategory"] as? String) == "1",
+            let firstLabel = userInfo["opt_0"] as? String, !firstLabel.isEmpty
+        else {
+            completion()
+            return
+        }
+
+        // Collect opt_0..opt_N, stopping at the first missing/empty index or
+        // at index 5 (6 options max). The daemon's own gate today caps at 4
+        // options; this ceiling is a defensive upper bound matching the option
+        // count #719 originally scoped for AskUserQuestion picks, so a future
+        // loosening of the daemon gate does not require an NSE change.
+        var labels: [String] = []
+        for i in 0...5 {
+            guard let label = userInfo["opt_\(i)"] as? String, !label.isEmpty else { break }
+            labels.append(label)
+        }
+        guard labels.count >= 2 else {
+            completion()
+            return
+        }
+
+        let actions = labels.enumerated().map { (idx, label) -> UNNotificationAction in
+            // A label starting with "No" (the honest Yes/No/Always fallback
+            // set, or a "No, cancel"-style pick) renders destructive (red),
+            // matching the static REMI_YN/YNA convention in AppDelegate.swift.
+            let destructive: UNNotificationActionOptions = label.hasPrefix("No") ? [.destructive] : []
+            return UNNotificationAction(
+                identifier: "OPT_\(idx)",
+                title: truncated(label, to: 24),
+                options: destructive
+            )
+        }
+        guard !actions.isEmpty else {
+            completion()
+            return
+        }
+
+        // Keyed by questionId so concurrent distinct questions never collide;
+        // falls back to a fresh UUID (still correct — just not de-duplicated
+        // against a retry of the identical question, which is harmless: an
+        // orphaned category left registered from an earlier notification is
+        // inert until a notification's categoryIdentifier references it again).
+        let questionId = (userInfo["questionId"] as? String) ?? UUID().uuidString
+        let categoryId = "REMI_DYN_\(questionId)"
+        let category = UNNotificationCategory(
+            identifier: categoryId,
+            actions: actions,
+            intentIdentifiers: [],
+            options: []
+        )
+
+        // KNOWN RACE (#719): this extension runs in its OWN process, separate
+        // from the main app (which registers REMI_YN/YNA/REMI_MULTI once at
+        // launch in AppDelegate.registerNotificationCategories). We read the
+        // CURRENT category set via getNotificationCategories and UNION ours
+        // in — never replace wholesale — specifically so a category this
+        // extension does not know about (e.g. one the app registered) is never
+        // dropped. Whether this extension's setNotificationCategories call
+        // lands in time for THIS notification's action buttons is itself a
+        // race against the ~30s extension budget and Apple's undocumented
+        // internal timing; if it loses, `content.categoryIdentifier` is never
+        // rewritten (still whatever the daemon's push set), which is exactly
+        // the static-category fallback #719 requires as the safety net.
+        UNUserNotificationCenter.current().getNotificationCategories { existing in
+            var merged = existing
+            merged.insert(category)
+            UNUserNotificationCenter.current().setNotificationCategories(merged)
+            content.categoryIdentifier = categoryId
+            completion()
+        }
+    }
+
+    private func truncated(_ s: String, to maxLength: Int) -> String {
+        guard s.count > maxLength else { return s }
+        return "\(s.prefix(maxLength))…"
+    }
+}


### PR DESCRIPTION
Closes #719.

## What

Lock-screen action buttons with the REAL option labels (truncated to 24 chars) for questions the three static iOS categories cannot express: single-question AskUserQuestion picks and 4-option structured-suggestion permission cards. User request from the 2026-07-06 soak: answerable multi-choice from the lock screen without opening the app.

## How (three layers, graceful degradation throughout)

- **Daemon**: `selectDynOptions` adds `dynOptions: true` to the push trigger for 2-4-option, non-form questions with real labels. The static `category` field is unchanged and remains the fallback.
- **Signaling worker**: `dynOptions` + options present sets `mutable-content: 1` in aps and `dynCategory: "1"` in the data fields. Strictly additive; absent flag produces byte-identical payloads. (Deploy after merge.)
- **iOS**: new `RemiNotificationService` extension target (bundle `live.yooz.remi.RemiNotificationService`, embedded in the app). On `dynCategory=1` it builds a per-notification `UNNotificationCategory` (`REMI_DYN_<questionId>`) from `opt_0..opt_N` with `OPT_n` action identifiers — the exact scheme `RemiAnswerRelay` already dispatches on (verified: no category allowlist there) — unions it with the existing registrations (never wholesale-replaces, so the app's static categories survive), and stamps `categoryIdentifier`. Every guard failure and the expiry handler deliver the original content unchanged, so a failed/slow NSE degrades to exactly pre-#719 behavior. AppDelegate and RemiAnswerRelay untouched.

## Verification

- `bun test packages/daemon/tests/notifications packages/signaling`: 188 pass / 0 fail (9 new daemon tests incl. maybePush integration; 6 new worker tests incl. a full-contract worker.fetch case). Typecheck + biome clean.
- `xcodebuild -scheme App -sdk iphonesimulator build`: BUILD SUCCEEDED — NotificationService.swift compiled (arm64+x86_64), `RemiNotificationService.appex` linked, embedded at `App.app/PlugIns/`, `ValidateEmbeddedBinary` passed.
- TestFlight pipeline checked: ExportOptions uses automatic signing + teamID only (no per-bundle provisioning dict), so the NSE exports transparently; `sync-app-version.mjs` verified to update the NSE's version keys together with the app's (round-tripped).

Note for iOS worktree bootstrapping: fresh worktrees lack the gitignored `CapApp-SPM` dir and Capacitor then falls back to the CocoaPods path; copy it from the primary checkout before `cap sync ios` (pre-existing, reproduced on unmodified develop).

Depends on #718 (merged). The 4-option REMI_MULTI generic-titles gap from the #720 review is covered here.
