### PR TITLE
feat: rotate remi and daemon logs at 10MB

### DIFF
--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
+import { rotateIfNeeded } from './log-rotation.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
@@ -148,6 +149,7 @@ export async function startDaemon(opts?: StartOptions): Promise<number> {
     spawnArgs.push(...opts.extraArgs);
   }
 
+  rotateIfNeeded(LOG_FILE);
   const logFd = fs.openSync(LOG_FILE, 'a');
   fs.writeSync(logFd, `\n--- Daemon starting at ${new Date().toISOString()} ---\n`);
 
@@ -341,6 +343,7 @@ export async function spawnRemiDaemon(
   }
   spawnArgs.push(...extraArgs);
 
+  rotateIfNeeded(LOG_FILE);
   const logFd = fs.openSync(LOG_FILE, 'a');
   fs.writeSync(logFd, `\n--- Spawning daemon on port ${port} at ${new Date().toISOString()} ---\n`);
 

--- a/packages/daemon/src/cli/log-file.ts
+++ b/packages/daemon/src/cli/log-file.ts
@@ -20,6 +20,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
+import { rotateIfNeeded } from './log-rotation.ts';
 
 let logFd: number | null = null;
 
@@ -60,6 +61,7 @@ export function startLogFileSession(
 ): LogSessionResult {
   try {
     fs.mkdirSync(path.dirname(primary), { recursive: true });
+    rotateIfNeeded(primary);
     const fd = fs.openSync(primary, 'a');
     fs.writeSync(fd, `\n--- Remi session started at ${new Date().toISOString()} ---\n`);
     logFd = fd;

--- a/packages/daemon/src/cli/log-rotation.ts
+++ b/packages/daemon/src/cli/log-rotation.ts
@@ -13,9 +13,16 @@
  * inode. Growth stays bounded in practice because opens are frequent (every
  * wrapper start, every daemon spawn), so the live file rarely has a chance
  * to grow far past the threshold before the next rotation check.
+ *
+ * No cross-process locking: two processes racing a rotation of the same
+ * file (e.g. concurrent `spawnRemiDaemon` calls) could interleave renames.
+ * Accepted for now — same tradeoff the port-selection code already makes
+ * elsewhere in this package, and worst case is a lost backup generation,
+ * not data loss or a crash.
  */
 
 import * as fs from 'node:fs';
+import { errorToString } from '@remi/shared';
 
 /** Default rotation threshold: 10MB. */
 export const LOG_MAX_BYTES = 10 * 1024 * 1024;
@@ -57,24 +64,42 @@ export function rotateIfNeeded(filePath: string, opts?: RotateOptions): boolean 
 
   try {
     fs.unlinkSync(`${filePath}.${keep}`);
-  } catch {
-    // No existing oldest backup to drop; nothing to do.
+  } catch (err) {
+    warnUnlessMissing(err, `drop oldest backup ${filePath}.${keep}`);
   }
 
   for (let n = keep - 1; n >= 1; n--) {
     try {
       fs.renameSync(`${filePath}.${n}`, `${filePath}.${n + 1}`);
-    } catch {
-      // No backup at this slot yet; nothing to shift.
+    } catch (err) {
+      warnUnlessMissing(err, `shift backup ${filePath}.${n} -> .${n + 1}`);
     }
   }
 
   try {
     fs.renameSync(filePath, `${filePath}.1`);
-  } catch {
-    // Best effort: if this fails, filePath stays in place and the next
-    // rotateIfNeeded call will retry.
+  } catch (err) {
+    // filePath was just confirmed to exist via statSync above, so any
+    // failure here (permissions, disk full, cross-device) is unexpected —
+    // surface it. filePath stays in place and the next rotateIfNeeded call
+    // will retry.
+    warn(`rotate ${filePath} -> .1`, err);
   }
 
   return true;
+}
+
+/** Logs unexpected fs errors; ENOENT ("nothing there yet") is expected and silent. */
+function warnUnlessMissing(err: unknown, op: string): void {
+  if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+  warn(op, err);
+}
+
+/** Best-effort stderr notice. Never throws — a rotation failure must never break logging. */
+function warn(op: string, err: unknown): void {
+  try {
+    console.error(`[remi] log rotation failed (${op}): ${errorToString(err)}`);
+  } catch {
+    // stderr may be unavailable; nothing more to do.
+  }
 }

--- a/packages/daemon/src/cli/log-rotation.ts
+++ b/packages/daemon/src/cli/log-rotation.ts
@@ -1,0 +1,80 @@
+/**
+ * Rotate-before-open log rotation for `~/.remi/remi.log` and
+ * `~/.remi/daemon.log`. Neither file was ever rotated (#726); on a
+ * long-running machine they grow unbounded (85MB / 24MB observed in the
+ * wild), which becomes untenable once an always-on hub (#542) keeps a
+ * daemon alive indefinitely.
+ *
+ * This is rotate-BEFORE-open only: call `rotateIfNeeded` immediately before
+ * the `fs.openSync(path, 'a')` that starts a new log-file or child-stdio
+ * session, never while a fd is already held open. A process that already
+ * holds the fd keeps writing to the renamed `.1` file until it restarts —
+ * rename-based rotation cannot retarget a live child-stdio fd to a new
+ * inode. Growth stays bounded in practice because opens are frequent (every
+ * wrapper start, every daemon spawn), so the live file rarely has a chance
+ * to grow far past the threshold before the next rotation check.
+ */
+
+import * as fs from 'node:fs';
+
+/** Default rotation threshold: 10MB. */
+export const LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Default number of rotated backups to retain (`.1` through `.keep`). */
+export const LOG_KEEP = 2;
+
+export interface RotateOptions {
+  /** Rotate once the file reaches this size in bytes. Default `LOG_MAX_BYTES`. */
+  readonly maxBytes?: number;
+  /** Number of rotated backups to retain. Default `LOG_KEEP`. */
+  readonly keep?: number;
+}
+
+/**
+ * Rotate `filePath` if it has reached `maxBytes`, shifting existing backups
+ * (`filePath.1` -> `filePath.2` -> ... -> dropped past `keep`) and renaming
+ * `filePath` itself to `filePath.1`. Never throws: every filesystem
+ * operation is individually try/caught, since a rotation failure must never
+ * break logging for the caller.
+ *
+ * Returns `false` if `filePath` does not exist, could not be stat'd, or is
+ * under the threshold. Returns `true` whenever rotation was warranted (size
+ * >= `maxBytes`), regardless of whether every individual shift/rename
+ * succeeded.
+ */
+export function rotateIfNeeded(filePath: string, opts?: RotateOptions): boolean {
+  const maxBytes = opts?.maxBytes ?? LOG_MAX_BYTES;
+  const keep = opts?.keep ?? LOG_KEEP;
+
+  let size: number;
+  try {
+    size = fs.statSync(filePath).size;
+  } catch {
+    return false;
+  }
+
+  if (size < maxBytes) return false;
+
+  try {
+    fs.unlinkSync(`${filePath}.${keep}`);
+  } catch {
+    // No existing oldest backup to drop; nothing to do.
+  }
+
+  for (let n = keep - 1; n >= 1; n--) {
+    try {
+      fs.renameSync(`${filePath}.${n}`, `${filePath}.${n + 1}`);
+    } catch {
+      // No backup at this slot yet; nothing to shift.
+    }
+  }
+
+  try {
+    fs.renameSync(filePath, `${filePath}.1`);
+  } catch {
+    // Best effort: if this fails, filePath stays in place and the next
+    // rotateIfNeeded call will retry.
+  }
+
+  return true;
+}

--- a/packages/daemon/tests/cli/log-file.test.ts
+++ b/packages/daemon/tests/cli/log-file.test.ts
@@ -97,6 +97,26 @@ describe('log-file session', () => {
     expect(getLogFd()).toBe(result.fd);
   });
 
+  test('rotates an oversized primary log before opening a fresh one', () => {
+    const primary = path.join(sandbox, 'remi.log');
+    // Genuinely exceed the default 10MB rotation threshold so the real
+    // startLogFileSession -> rotateIfNeeded call (no override) fires.
+    fs.writeFileSync(primary, Buffer.alloc(10 * 1024 * 1024 + 1, 'x'));
+
+    const result = startLogFileSession(primary);
+    expect(result.fd).not.toBeNull();
+    expect(result.path).toBe(primary);
+
+    // Old oversized content moved to the .1 backup.
+    expect(fs.existsSync(`${primary}.1`)).toBe(true);
+    expect(fs.statSync(`${primary}.1`).size).toBe(10 * 1024 * 1024 + 1);
+
+    // Fresh primary only has the new session header, not the old bulk.
+    const freshContent = fs.readFileSync(primary, 'utf-8');
+    expect(freshContent).toMatch(/^\n--- Remi session started at /);
+    expect(freshContent.length).toBeLessThan(1024);
+  });
+
   test('startLogFileSession without fallback returns null fd on failure', () => {
     const blocker = path.join(sandbox, 'blocker2');
     fs.writeFileSync(blocker, 'not a dir');

--- a/packages/daemon/tests/cli/log-rotation.test.ts
+++ b/packages/daemon/tests/cli/log-rotation.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { LOG_KEEP, LOG_MAX_BYTES, rotateIfNeeded } from '../../src/cli/log-rotation.ts';
+
+describe('rotateIfNeeded', () => {
+  let sandbox: string;
+  let target: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-log-rotation-'));
+    target = path.join(sandbox, 'remi.log');
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('exports the documented defaults', () => {
+    expect(LOG_MAX_BYTES).toBe(10 * 1024 * 1024);
+    expect(LOG_KEEP).toBe(2);
+  });
+
+  test('nonexistent path returns false and does nothing', () => {
+    expect(rotateIfNeeded(target)).toBe(false);
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.existsSync(`${target}.1`)).toBe(false);
+  });
+
+  test('file under the threshold is left untouched', () => {
+    fs.writeFileSync(target, 'small content');
+    expect(rotateIfNeeded(target, { maxBytes: 1024 })).toBe(false);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('small content');
+    expect(fs.existsSync(`${target}.1`)).toBe(false);
+  });
+
+  test('oversized file is renamed to .1 and the live path is gone', () => {
+    fs.writeFileSync(target, Buffer.alloc(2048, 'a'));
+    const result = rotateIfNeeded(target, { maxBytes: 1024 });
+    expect(result).toBe(true);
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.existsSync(`${target}.1`)).toBe(true);
+    expect(fs.readFileSync(`${target}.1`).length).toBe(2048);
+  });
+
+  test('existing .1 and .2 shift, oldest is dropped', () => {
+    fs.writeFileSync(target, 'current');
+    fs.writeFileSync(`${target}.1`, 'backup-1');
+    fs.writeFileSync(`${target}.2`, 'backup-2-oldest');
+
+    const result = rotateIfNeeded(target, { maxBytes: 1 });
+    expect(result).toBe(true);
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(`${target}.1`, 'utf-8')).toBe('current');
+    expect(fs.readFileSync(`${target}.2`, 'utf-8')).toBe('backup-1');
+    // The old backup-2 content ("backup-2-oldest") must be gone entirely.
+    expect(fs.existsSync(`${target}.3`)).toBe(false);
+  });
+
+  test('respects a custom keep count', () => {
+    fs.writeFileSync(target, 'current');
+    fs.writeFileSync(`${target}.1`, 'backup-1');
+
+    const result = rotateIfNeeded(target, { maxBytes: 1, keep: 1 });
+    expect(result).toBe(true);
+
+    // With keep=1, the old .1 is dropped entirely and current becomes the new .1.
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(`${target}.1`, 'utf-8')).toBe('current');
+    expect(fs.existsSync(`${target}.2`)).toBe(false);
+  });
+
+  test('respects a custom maxBytes override', () => {
+    fs.writeFileSync(target, Buffer.alloc(100));
+    expect(rotateIfNeeded(target, { maxBytes: 1000 })).toBe(false);
+    expect(rotateIfNeeded(target, { maxBytes: 50 })).toBe(true);
+    expect(fs.existsSync(`${target}.1`)).toBe(true);
+  });
+
+  test('never throws when the target is a directory instead of a file', () => {
+    const dirTarget = path.join(sandbox, 'not-a-file.log');
+    fs.mkdirSync(dirTarget);
+    expect(() => rotateIfNeeded(dirTarget, { maxBytes: 0 })).not.toThrow();
+  });
+});

--- a/packages/daemon/tests/cli/log-rotation.test.ts
+++ b/packages/daemon/tests/cli/log-rotation.test.ts
@@ -72,6 +72,31 @@ describe('rotateIfNeeded', () => {
     expect(fs.existsSync(`${target}.2`)).toBe(false);
   });
 
+  test('rotates a file exactly at the threshold (boundary is inclusive)', () => {
+    fs.writeFileSync(target, Buffer.alloc(1024));
+    const result = rotateIfNeeded(target, { maxBytes: 1024 });
+    expect(result).toBe(true);
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.existsSync(`${target}.1`)).toBe(true);
+  });
+
+  test('a failed rename is swallowed: target is left in place, still returns true', () => {
+    if (process.getuid?.() === 0) {
+      // Root bypasses directory write-permission checks; nothing to assert.
+      return;
+    }
+    fs.writeFileSync(target, Buffer.alloc(2048, 'a'));
+    fs.chmodSync(sandbox, 0o555); // read/execute only: rename inside it fails
+    try {
+      const result = rotateIfNeeded(target, { maxBytes: 1024 });
+      expect(result).toBe(true);
+      expect(fs.existsSync(target)).toBe(true);
+      expect(fs.existsSync(`${target}.1`)).toBe(false);
+    } finally {
+      fs.chmodSync(sandbox, 0o755); // restore so afterEach's rmSync can clean up
+    }
+  });
+
   test('respects a custom maxBytes override', () => {
     fs.writeFileSync(target, Buffer.alloc(100));
     expect(rotateIfNeeded(target, { maxBytes: 1000 })).toBe(false);


### PR DESCRIPTION
## Problem

Neither `~/.remi/remi.log` (wrapper-mode diagnostics, `packages/daemon/src/cli/log-file.ts`) nor `~/.remi/daemon.log` (daemon child-process stdio, `packages/daemon/src/cli/daemon-manager.ts`) was ever rotated. On a real machine these had grown to 85MB and 24MB respectively. The always-on hub design in #648 keeps a daemon alive indefinitely, which makes unbounded log growth untenable.

## Design: rotate-before-open

New module `packages/daemon/src/cli/log-rotation.ts` exports `rotateIfNeeded(filePath, opts?)`:

- Threshold `LOG_MAX_BYTES = 10MB`, retains `LOG_KEEP = 2` backups (`.1`, `.2`), both overridable per-call.
- `statSync`s the target; returns `false` if missing or under threshold.
- Otherwise shifts backups (`.1` -> `.2`, drops anything past `keep`) and renames the live file to `.1`, returning `true`.
- Every filesystem operation is individually try/caught — the function can never throw, since a rotation failure must never break logging for the caller.

Called immediately before the `fs.openSync(path, 'a')` at each of the three log-open call sites:
- `log-file.ts` `startLogFileSession` (before the primary open; the tmpdir fallback path is intentionally not rotated)
- `daemon-manager.ts` `startDaemon` and `spawnRemiDaemon` (both open `daemon.log` for child stdio)

**Documented limitation:** this is rotate-BEFORE-open only. A process that already holds the fd keeps writing to the renamed `.1` file until it restarts — rename-based rotation cannot retarget a live child-stdio fd to a new inode. Growth stays bounded in practice because opens are frequent (every wrapper start, every daemon spawn).

## Housekeeping check

Grepped for other readers of these paths. `daemon-manager.ts` `showDaemonLogs()` only calls `fs.existsSync(LOG_FILE)` and `tail -n <lines> "<LOG_FILE>"` against the live path — unaffected by a `.1`/`.2` sibling. The only `readdirSync` over a `~/.remi`-adjacent directory is `session-registry-file.ts`, which reads its own `LIVE_SESSIONS_DIR` subdirectory, not the directory holding the log files. No other code paths read `remi.log`/`daemon.log`.

## Tested

- New `packages/daemon/tests/cli/log-rotation.test.ts` (real tmp files via `fs.mkdtempSync`, no mocks): oversized file rotated to `.1` with live path gone, existing `.1`/`.2` shift with oldest dropped, under-threshold file untouched, nonexistent path returns `false`, custom `keep`/`maxBytes` overrides respected, never throws on a directory target.
- Extended `packages/daemon/tests/cli/log-file.test.ts` with an integration case: a genuinely 10MB+1-byte oversized primary log is rotated by `startLogFileSession` itself (default threshold, no override) before the fresh session opens.
- `bun run typecheck` clean.
- `bunx biome check` clean on all touched files.
- `bun test packages/daemon/tests/cli/` — 782 pass, 0 fail (includes the new/updated files plus `daemon-manager.test.ts` and the rest of the `cli` suite for regressions).

Closes #726