### PR TITLE
fix: scope and drain auto-approve eval queue (#730)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -126,15 +126,40 @@ export interface AutoApproveEvaluator {
     permissionSuggestions?: readonly unknown[],
     modelOverride?: string,
     evalId?: number,
+    /** #730: this gate's own sessionId, so the shared daemon-wide service can
+     *  isolate concurrent sessions' evals — a queued/running eval belonging
+     *  to one session must never be cancelled or drained by another
+     *  session's `cancelStale` / `cancelEvalForQuestion`. Omitted only by
+     *  test doubles / direct-service unit tests that never mix scopes. */
+    scope?: string,
+    /** #730: tags a queued waiter so `drainScope(scope, {mainOnly: true})` can
+     *  spare it the same way `cancelStale`'s running-eval cancel already
+     *  spares a subagent eval via `evalIsSubagentById`. */
+    isSubagent?: boolean,
   ): Promise<AutoApproveResult>;
-  /** Abort an in-flight `evaluate`. With `evalId`, aborts ONLY when that id is the
-   *  eval currently running (#617 per-eval scoping); without it, aborts whatever
-   *  is in flight. Returns true if an abort was issued, false otherwise (idempotent). */
-  cancel(reason: string, evalId?: number): boolean;
+  /**
+   * Abort an in-flight `evaluate`. With `evalId`, aborts ONLY when that id is the
+   * eval currently running (#617 per-eval scoping); without it, aborts whatever
+   * is in flight. `scope` (#730) additionally requires the target belong to that
+   * scope, so two sessions can never cancel each other's work by accident.
+   * Omitting BOTH `evalId` and `scope` is a fully untargeted cancel — reserved
+   * for `forceRelease` (the documented `remi unstick` global escape hatch);
+   * every per-session caller here (`cancelStale`, `cancelEvalForQuestion`) passes
+   * its own scope. Returns true if an abort was issued, false otherwise
+   * (idempotent).
+   */
+  cancel(reason: string, evalId?: number, scope?: string): boolean;
   /** Drain queued evals so they escalate gracefully instead of seizing the freed
-   *  GPU (#617 force-release). Returns the number drained. Optional: a minimal
-   *  evaluator under test may omit it. */
+   *  GPU (#617 force-release). GLOBAL — every session's queue, not just this
+   *  gate's own. Returns the number drained. Optional: a minimal evaluator
+   *  under test may omit it. */
   drainQueue?(): number;
+  /** #730: drain only THIS scope's queued evals (optionally main-tagged only),
+   *  so `cancelStale` can drop a session's own moot queued work without
+   *  touching a sibling session's queue or (mainOnly) a teammate's still-
+   *  legitimate wait. Returns the number drained. Optional: a minimal
+   *  evaluator under test may omit it. */
+  drainScope?(scope: string, opts?: { mainOnly?: boolean }): number;
 }
 
 export interface AutoApproveGateDeps {
@@ -383,8 +408,22 @@ export class AutoApproveGate {
       this.openQuestionSignatures.clear();
     }
     if (this.deps.service === null) return;
+    // #730 (BUG 1 fix): drop THIS session's own QUEUED evals first -- work a
+    // teardown or a mainOnly Stop has already decided is moot must never
+    // survive in the shared FIFO to be promoted onto the GPU later just
+    // because the eval ahead of it happens to release around the same time.
+    // Scoped to this gate's own sessionId, so a sibling session's queue is
+    // untouched; mainOnly additionally spares a queued subagent/team-member
+    // eval, mirroring the running-eval loop below.
+    const drainedCount = this.deps.service.drainScope?.(this.sessionId, { mainOnly }) ?? 0;
+    if (drainedCount > 0) {
+      log(`[AutoApprove ${this.sessionTag}] Drained ${drainedCount} queued eval(s) (${reason})`);
+    }
     if (!mainOnly) {
-      if (this.deps.service.cancel(reason)) {
+      // #730 (BUG 3 fix): scoped to this session, so a SessionEnd here can
+      // never abort a DIFFERENT session's running eval just because it
+      // happens to be the one holding the shared (daemon-wide) slot.
+      if (this.deps.service.cancel(reason, undefined, this.sessionId)) {
         log(`[AutoApprove] Cancelled stale LLM eval: ${reason}`);
       }
       return;
@@ -393,10 +432,13 @@ export class AutoApproveGate {
     // decisions a main eval cannot be in flight at Stop anyway (Claude blocks
     // on the hook while the gate evaluates it), so this is defensive; any eval
     // that IS running/queued at lead-Stop is a teammate's and must keep going.
+    // #730 (BUG 2 fix): scoped, so an identically-numbered evalId belonging to
+    // a DIFFERENT session (evalId is only unique per-gate) can never be hit
+    // by mistake.
     let cancelledCount = 0;
     for (const [evalId, isSubagent] of this.evalIsSubagentById) {
       if (isSubagent) continue;
-      if (this.deps.service.cancel(reason, evalId)) cancelledCount += 1;
+      if (this.deps.service.cancel(reason, evalId, this.sessionId)) cancelledCount += 1;
     }
     if (cancelledCount > 0) {
       log(`[AutoApprove] Cancelled ${cancelledCount} stale MAIN-context LLM eval(s): ${reason}`);
@@ -417,7 +459,10 @@ export class AutoApproveGate {
     const evalId = this.evalIdByQuestion.get(questionId);
     if (evalId === undefined) return;
     this.evalIdByQuestion.delete(questionId);
-    if (this.deps.service?.cancel(reason, evalId)) {
+    // #730: scoped to this session's own sessionId, so this evalId can never
+    // collide with an identically-numbered eval belonging to a different
+    // session (evalId is only unique per-gate).
+    if (this.deps.service?.cancel(reason, evalId, this.sessionId)) {
       log(
         `[AutoApprove ${this.sessionTag}] Answer freed the eval for ${questionId.slice(0, 8)} (${reason})`,
       );
@@ -878,6 +923,10 @@ export class AutoApproveGate {
         input.permission_suggestions as readonly unknown[] | undefined,
         undefined,
         evalId,
+        // #730: this gate's own sessionId, so the shared daemon-wide service
+        // can isolate this eval from every other session's.
+        this.sessionId,
+        isSubagent,
       )
       .finally(() => {
         this.evalIsSubagentById.delete(evalId);
@@ -990,13 +1039,18 @@ export class AutoApproveGate {
         // here too, since Claude is still blocked on this same hook response
         // while the second opinion runs. A mainOnly Stop therefore has nothing to
         // cancel for this call by construction; leaving it untracked is correct,
-        // not a gap.
+        // not a gap. #730: scope IS passed (unlike evalId) so a full teardown's
+        // scoped, untargeted-by-evalId cancel can still abort this call if it is
+        // somehow still running.
         second = await service.evaluate(
           input.tool_name,
           input.tool_input,
           this.sessionTag,
           input.permission_suggestions as readonly unknown[] | undefined,
           escalateModel,
+          undefined,
+          this.sessionId,
+          isSubagent,
         );
       } catch (err) {
         logError(`[AutoApprove ${this.sessionTag}] escalate_model second opinion threw:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -28,6 +28,16 @@ type BinaryDecision = 'approve' | 'deny' | 'escalate';
 const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate']);
 
 /**
+ * Sentinel scope (#730) used when a caller omits `scope` from `evaluate()` /
+ * `cancel()` — a direct-service unit test, or any other caller that never
+ * mixes sessions. All such callers implicitly share this one scope, so their
+ * behavior is unchanged from before per-session scoping existed: a single
+ * caller's evalId is still enough to disambiguate. Only `AutoApproveGate`
+ * (the one production caller) passes a real scope, its own `sessionId`.
+ */
+const DEFAULT_SCOPE = '__default__';
+
+/**
  * Convert one `permission_suggestions` entry into an LLM-ready label, or
  * null when the entry carries no useful content. Strings pass through;
  * objects are JSON-serialised so the LLM can read a structured option like
@@ -122,24 +132,41 @@ export class AutoApproveService {
    *  queued. */
   private evalActive = false;
   private readonly evalQueue: Array<{
-    /** Id of the queued eval (#617), so cancel(reason, evalId) can drop a waiter
-     *  whose question was answered before it ever reached the GPU. */
+    /** Caller's scope (#730), normally an `AutoApproveGate`'s own sessionId —
+     *  see `DEFAULT_SCOPE`. Lets `drainScope` drop one session's queued
+     *  waiters without touching a sibling session's. */
+    scope: string;
+    /** Id of the queued eval (#617), so cancel(reason, evalId, scope) can drop
+     *  a waiter whose question was answered before it ever reached the GPU. */
     evalId: number | undefined;
+    /** Tags a subagent/team-member eval (#730), so `drainScope(scope,
+     *  {mainOnly: true})` can spare it the same way `cancelStale`'s running-
+     *  eval cancel already spares a subagent eval via `evalIsSubagentById`. */
+    isSubagent: boolean;
     /** Take the slot (becomes the running eval). */
     grant: () => void;
-    /** Resolve as NOT acquired -> the eval escalates gracefully (force-release /
-     *  answered-while-queued) instead of seizing the slot. */
-    deny: () => void;
+    /** Resolve as NOT acquired -> the eval escalates gracefully instead of
+     *  seizing the slot. The outcome distinguishes the global `drainQueue`
+     *  (force-release) from the scoped `drainScope` (#730, cancelStale) so
+     *  the escalation reasoning never misattributes one to the other. */
+    deny: (outcome: 'drained' | 'drained-scope') => void;
   }> = [];
   /** Active LLM call's controller; cleared in the eval finally block. cancel()
    *  aborts via this. Held alongside the active slot so they share the same
    *  lifecycle window. */
   private currentAbortController: AbortController | null = null;
+  /** Caller's scope (#730) for the eval currently holding the slot — see
+   *  `DEFAULT_SCOPE`. `cancel(reason, evalId, scope)` only aborts the running
+   *  eval when this matches the caller's own scope, so one session's teardown
+   *  can never abort a DIFFERENT session's eval just because it happens to be
+   *  the one holding the shared (daemon-wide) slot. null when idle. */
+  private currentScope: string | null = null;
   /** Caller-supplied id of the eval currently holding the slot (#617). Lets
-   *  `cancel(reason, evalId)` abort ONLY the targeted eval instead of whatever
-   *  happens to be running — so a manual answer for question X frees X's eval and
-   *  never a different permission's (the wrong-victim risk that forced the old
-   *  answer-cancel to be gated). null when the running eval supplied no id. */
+   *  `cancel(reason, evalId, scope)` abort ONLY the targeted eval instead of
+   *  whatever happens to be running — so a manual answer for question X frees
+   *  X's eval and never a different permission's (the wrong-victim risk that
+   *  forced the old answer-cancel to be gated). null when the running eval
+   *  supplied no id. */
   private currentEvalId: number | null = null;
   /** Set by cancel() so the catch block can distinguish a user-driven abort
    *  (Claude advanced past the prompt) from a timeout abort. */
@@ -180,9 +207,16 @@ export class AutoApproveService {
    * risking the ~600s hook budget); `'drained'` if force-release (#617) dropped
    * the waiter. When the slot is free it is taken immediately; otherwise the
    * caller is queued FIFO and granted by `releaseSlot`. `evalId` tags the waiter
-   * so a per-question cancel can drop it while still queued.
+   * so a per-question cancel can drop it while still queued; `scope` (#730)
+   * and `isSubagent` let `drainScope` drop it (or spare it, mainOnly) without
+   * touching a sibling session's queue.
    */
-  private acquireSlot(deadlineMs: number, evalId?: number): Promise<SlotOutcome> {
+  private acquireSlot(
+    deadlineMs: number,
+    scope: string,
+    evalId: number | undefined,
+    isSubagent: boolean,
+  ): Promise<SlotOutcome> {
     if (!this.evalActive) {
       this.evalActive = true;
       return Promise.resolve('acquired');
@@ -199,9 +233,16 @@ export class AutoApproveService {
         resolve(outcome);
       };
       const waiter = {
+        scope,
         evalId,
+        isSubagent,
         grant: () => settle('acquired'),
-        deny: () => settle('drained'),
+        // Accepts which 'drained' flavor happened (#730): the global
+        // `drainQueue` (forceRelease) vs. the scoped `drainScope`
+        // (cancelStale) produce DIFFERENT escalation reasoning below, so a
+        // log reader is never told "remi unstick" for a plain session
+        // teardown.
+        deny: (outcome: 'drained' | 'drained-scope') => settle(outcome),
       };
       this.evalQueue.push(waiter);
       if (deadlineMs > 0) {
@@ -238,7 +279,35 @@ export class AutoApproveService {
   drainQueue(): number {
     let drained = 0;
     for (let next = this.evalQueue.shift(); next; next = this.evalQueue.shift()) {
-      next.deny();
+      next.deny('drained');
+      drained++;
+    }
+    return drained;
+  }
+
+  /**
+   * Drain queued waiters belonging to `scope` (#730), resolving each as NOT
+   * acquired so its eval takes the graceful escalate path instead of
+   * eventually being promoted to the GPU for permission work `cancelStale`
+   * has already decided is moot (session ended, or a mainOnly Stop). Unlike
+   * `drainQueue` (the global `forceRelease`/`remi unstick` escape hatch) this
+   * never touches a sibling session's queue. `opts.mainOnly` additionally
+   * SPARES a subagent/team-member waiter — mirrors how `AutoApproveGate.
+   * cancelStale('Stop', {mainOnly:true})` already spares a subagent's RUNNING
+   * eval via `evalIsSubagentById`, so a lead's Stop can never starve a
+   * teammate's still-legitimate queued eval. Does NOT touch the eval
+   * currently holding the slot — `cancel()` targets that. Returns the number
+   * of waiters drained.
+   */
+  drainScope(scope: string, opts?: { mainOnly?: boolean }): number {
+    const mainOnly = opts?.mainOnly ?? false;
+    let drained = 0;
+    for (let i = this.evalQueue.length - 1; i >= 0; i--) {
+      const waiter = this.evalQueue[i];
+      if (!waiter || waiter.scope !== scope) continue;
+      if (mainOnly && waiter.isSubagent) continue;
+      this.evalQueue.splice(i, 1);
+      waiter.deny('drained-scope');
       drained++;
     }
     return drained;
@@ -275,6 +344,16 @@ export class AutoApproveService {
    *            hook. When present and shape qualifies as multi-choice (#399),
    *            evaluation is routed through the multi-choice path instead of
    *            the binary approve/deny path.
+   * @param scope #730: the caller's own scope (an `AutoApproveGate`'s
+   *            sessionId), so this shared daemon-wide service can isolate
+   *            concurrent sessions — `cancel()`/`drainScope()` can then act
+   *            on exactly this session's eval without risk of hitting a
+   *            different session's. Omitted callers (direct-service unit
+   *            tests) implicitly share `DEFAULT_SCOPE`.
+   * @param isSubagent #730: tags this eval as belonging to a subagent/team-
+   *            member permission (mirrors the gate's own `evalIsSubagentById`),
+   *            so a QUEUED waiter for it can be spared by
+   *            `drainScope(scope, {mainOnly: true})`.
    */
   async evaluate(
     toolName: string,
@@ -283,6 +362,8 @@ export class AutoApproveService {
     permissionSuggestions?: readonly unknown[],
     modelOverride?: string,
     evalId?: number,
+    scope?: string,
+    isSubagent?: boolean,
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     // modelOverride (#522: the escalate_model second opinion) replaces the base
@@ -290,6 +371,7 @@ export class AutoApproveService {
     const baseModel = modelOverride || this.llmConfig.model;
     const model = baseModel;
     const prefix = tag ? `[AutoApprove ${tag}]` : '[AutoApprove]';
+    const resolvedScope = scope ?? DEFAULT_SCOPE;
 
     const normalisedSuggestions = Array.isArray(permissionSuggestions)
       ? permissionSuggestions
@@ -384,18 +466,30 @@ export class AutoApproveService {
       // A second request QUEUES instead of escalating-on-busy; only a request
       // that waits past queue_timeout escalates gracefully so a deep burst
       // (parallel subagents) never risks the ~600s hook budget.
-      const slot = await this.acquireSlot(this.queueTimeoutMs, evalId);
+      const slot = await this.acquireSlot(
+        this.queueTimeoutMs,
+        resolvedScope,
+        evalId,
+        isSubagent ?? false,
+      );
       if (slot !== 'acquired') {
         const durationMs = Date.now() - start;
+        // #730: 'drained-scope' (cancelStale) gets its OWN reasoning, distinct
+        // from 'drained' (force-release/remi unstick) and from a per-question
+        // answered-while-queued cancel — a log reader must never be told
+        // "remi unstick" for a plain session teardown or Stop.
         const reasoning =
           slot === 'drained'
             ? 'force-released (remi unstick) before slot acquisition; escalating to user'
-            : `eval queue wait exceeded ${this.queueTimeoutMs}ms; escalating to user`;
+            : slot === 'drained-scope'
+              ? 'session queue drained (cancelStale) before slot acquisition; escalating to user'
+              : `eval queue wait exceeded ${this.queueTimeoutMs}ms; escalating to user`;
         this.logFn(`${prefix} ${toolName}: escalate (${durationMs}ms) - ${reasoning}`);
         return { decision: 'escalate', reasoning, durationMs, model };
       }
 
       this.currentAbortController = new AbortController();
+      this.currentScope = resolvedScope;
       this.currentEvalId = evalId ?? null;
       const externalSignal = this.currentAbortController.signal;
       // The heavy escalate_model gets its dedicated (longer) budget when set, so
@@ -502,6 +596,7 @@ export class AutoApproveService {
       } finally {
         if (raceTimer !== null) clearTimeout(raceTimer);
         this.currentAbortController = null;
+        this.currentScope = null;
         this.currentEvalId = null;
         this.releaseSlot();
       }
@@ -555,13 +650,29 @@ export class AutoApproveService {
    * answer never triggers a now-pointless LLM call. With no `evalId` it aborts
    * whatever is in flight (session teardown / force-release).
    *
+   * `scope` (#730): the caller's own scope (an `AutoApproveGate`'s sessionId).
+   * When given, an abort of the RUNNING eval fires ONLY if it ALSO belongs to
+   * that scope — this is what stops one session's SessionEnd (or a stale
+   * per-question cancel) from ever aborting a DIFFERENT session's eval just
+   * because it happens to be the one holding the single daemon-wide slot
+   * (`evalId` alone cannot tell — it is only unique per-gate, so two sessions
+   * can legitimately stamp the same number). A QUEUED waiter is likewise only
+   * dropped by `evalId` when its own `scope` also matches. Omitting `scope`
+   * skips this check entirely (matches ANY scope) — reserved for
+   * `forceRelease` (`remi unstick`), the one caller that is DELIBERATELY
+   * global; every per-session caller (`cancelStale`, `cancelEvalForQuestion`)
+   * must pass its own scope.
+   *
    * Returns true if a call was actually cancelled (running aborted or queued
    * dropped), false otherwise (idempotent, safe to call always).
    */
-  cancel(reason: string, evalId?: number): boolean {
-    // The running eval: abort when untargeted, or when the target matches.
+  cancel(reason: string, evalId?: number, scope?: string): boolean {
+    const scopeMatches = scope === undefined || this.currentScope === scope;
+    // The running eval: abort when untargeted (by evalId), or when the target
+    // matches — and, when a scope was given, only when it too matches.
     if (
       this.currentAbortController !== null &&
+      scopeMatches &&
       (evalId === undefined || this.currentEvalId === evalId)
     ) {
       this.cancelReason = reason;
@@ -570,11 +681,17 @@ export class AutoApproveService {
     }
     // A targeted eval still waiting for the slot: drop it so it escalates
     // instead of running after its question was already answered (#617).
+    // Scope-filtered the same way when given (#730).
     if (evalId !== undefined) {
-      const i = this.evalQueue.findIndex((w) => w.evalId === evalId);
+      const i = this.evalQueue.findIndex(
+        (w) => w.evalId === evalId && (scope === undefined || w.scope === scope),
+      );
       if (i !== -1) {
         const waiter = this.evalQueue.splice(i, 1)[0];
-        waiter?.deny();
+        // Same 'drained' outcome/reasoning as the global drainQueue (unchanged
+        // from before #730): this is the #617 answered-while-queued path, not
+        // a scoped cancelStale drain.
+        waiter?.deny('drained');
         return true;
       }
     }
@@ -582,6 +699,9 @@ export class AutoApproveService {
   }
 }
 
-/** Outcome of an `acquireSlot` request (#617): the eval ran, timed out waiting,
- *  or was dropped by force-release / a per-question cancel. */
-type SlotOutcome = 'acquired' | 'timeout' | 'drained';
+/** Outcome of an `acquireSlot` request: the eval ran, timed out waiting, was
+ *  dropped by force-release / a per-question cancel (#617, 'drained'), or was
+ *  dropped by a scoped `drainScope` (#730, 'drained-scope') — kept distinct
+ *  from 'drained' so the escalation reasoning never misattributes a plain
+ *  session teardown to `remi unstick`. */
+type SlotOutcome = 'acquired' | 'timeout' | 'drained' | 'drained-scope';

--- a/packages/daemon/tests/auto-approve/scope-isolation.test.ts
+++ b/packages/daemon/tests/auto-approve/scope-isolation.test.ts
@@ -370,7 +370,7 @@ describe('AutoApproveGate cross-session isolation via shared AutoApproveService 
     await Promise.all(registries.map((r) => r.shutdown()));
   });
 
-  test("cancelStale does not drain a sibling session's queued eval (#730 BUG 1)", async () => {
+  test("cancelStale never touches a sibling session's QUEUED eval (#730 cross-session isolation)", async () => {
     const service = new AutoApproveService(makeConfig(server), noLog);
     const SID_A = generateId() as UUID;
     const SID_B = generateId() as UUID;
@@ -409,7 +409,11 @@ describe('AutoApproveGate cross-session isolation via shared AutoApproveService 
     expect(await pendingB).toBe('allow');
   });
 
-  test("cancelStale(SessionEnd) does not cancel a sibling session's RUNNING eval (#730 BUG 3)", async () => {
+  // This single scenario proves BOTH named bugs end-to-end: A's own QUEUED
+  // eval is drained by A's cancelStale and never reaches the LLM (BUG 1 --
+  // requestCount stays 1), while B's RUNNING eval survives A's untargeted
+  // SessionEnd cancel (BUG 3).
+  test("cancelStale drains its OWN queued eval (#730 BUG 1) and spares a sibling's RUNNING eval (#730 BUG 3)", async () => {
     const service = new AutoApproveService(makeConfig(server), noLog);
     const SID_A = generateId() as UUID;
     const SID_B = generateId() as UUID;

--- a/packages/daemon/tests/auto-approve/scope-isolation.test.ts
+++ b/packages/daemon/tests/auto-approve/scope-isolation.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Regression tests for #730: `AutoApproveService` is a DAEMON-WIDE singleton
+ * shared by every session's `AutoApproveGate` (one eval slot, one FIFO queue,
+ * one GPU). Before this fix, nothing in the shared slot/queue bookkeeping knew
+ * which SESSION an eval belonged to:
+ *
+ *   - BUG 1: `AutoApproveGate.cancelStale` aborted only the session's own
+ *     RUNNING eval, never drained the session's own QUEUED waiters -- a moot
+ *     queued eval (for ended/resolved work) could still be promoted onto the
+ *     GPU and delay a live request.
+ *   - BUG 2: `evalId` is stamped per-gate (`AutoApproveGate.evalSeq`), so two
+ *     DIFFERENT sessions can legitimately stamp the same number; a targeted
+ *     cancel/drain had no session identity to disambiguate them.
+ *   - BUG 3: `cancelStale`'s untargeted (no evalId) cancel matched "whatever
+ *     eval is running" with no session check at all -- one session's
+ *     SessionEnd could abort a completely different session's live eval.
+ *
+ * Uses a REAL `AutoApproveService` against a real gated `Bun.serve` fixture
+ * (same pattern as serialize.test.ts) -- no mocks. The final two tests drive
+ * TWO real `AutoApproveGate` instances sharing ONE real `AutoApproveService`,
+ * mirroring the actual daemon-wide singleton wiring (hook-bridge-setup.ts),
+ * to prove the fix end-to-end through the real `cancelStale` call path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { UUID } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import { AutoApproveGate } from '../../src/auto-approve/auto-approve-gate.ts';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
+import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+interface GatedServer {
+  url: string;
+  /** Count of inbound LLM requests seen so far. */
+  requestCount: () => number;
+  /** Resolves the next time a request enters the server. Grab BEFORE the call. */
+  awaitNextRequest: () => Promise<void>;
+  /** Release the oldest held request with a valid approve response. */
+  releaseNext: () => void;
+  /** Release ALL currently-held requests (incl. ones whose client aborted --
+   *  a cancelled eval still leaves its server-side handler unresolved). */
+  releaseAll: () => void;
+  stop: () => void;
+}
+
+function startGatedServer(): GatedServer {
+  let count = 0;
+  const held: Array<(r: Response) => void> = [];
+  let nextResolver: (() => void) | null = null;
+  let next: Promise<void> = new Promise<void>((r) => {
+    nextResolver = r;
+  });
+  const approve = (): Response =>
+    new Response(
+      JSON.stringify({
+        choices: [{ message: { content: '{"decision":"approve","reasoning":"ok"}' } }],
+        model: 'test-model',
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  const server = Bun.serve({
+    port: 0,
+    fetch: (): Promise<Response> => {
+      count++;
+      nextResolver?.();
+      next = new Promise<void>((r) => {
+        nextResolver = r;
+      });
+      return new Promise<Response>((resolve) => {
+        held.push(resolve);
+      });
+    },
+  });
+  return {
+    url: `http://localhost:${server.port}/v1`,
+    requestCount: () => count,
+    awaitNextRequest: () => next,
+    releaseNext: () => {
+      const r = held.shift();
+      if (r) r(approve());
+    },
+    releaseAll: () => {
+      while (held.length > 0) {
+        held.shift()?.(approve());
+      }
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+function makeConfig(server: GatedServer): AutoApproveConfig {
+  return {
+    enabled: true,
+    provider: server.url,
+    model: 'test-model',
+    api_key: '',
+    base_url: server.url,
+    timeout: 30,
+    log_decisions: false,
+    allow: [],
+    deny: [],
+    approve_groups: [],
+    deny_groups: [],
+    instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
+    escalate_model: '',
+    escalate_timeout: 0,
+    queue_timeout: 240,
+    disable_thinking: false,
+    always_escalate_tools: [],
+    hold_timeout: 0,
+    push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
+  };
+}
+
+const noLog = (_msg: string): void => {};
+
+describe('AutoApproveService scope isolation (#730)', () => {
+  let server: GatedServer;
+
+  beforeEach(() => {
+    server = startGatedServer();
+  });
+  afterEach(() => {
+    server.stop();
+  });
+
+  test("cancel(reason, undefined, scope) aborts only that scope's running eval (#730 BUG 3)", async () => {
+    const svc = new AutoApproveService(makeConfig(server), noLog);
+    const r1 = server.awaitNextRequest();
+    // Scope A's eval acquires the slot; scope B's queues behind it.
+    const aP = svc.evaluate(
+      'Bash',
+      { command: 'cmdA' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'session-A',
+    );
+    const bP = svc.evaluate(
+      'Bash',
+      { command: 'cmdB' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'session-B',
+    );
+    await r1;
+    expect(server.requestCount()).toBe(1); // only A reached the LLM; B is queued
+
+    // A scoped, untargeted (no evalId) cancel for session B must NOT touch
+    // session A's running eval -- the old code had no scope check at all.
+    expect(svc.cancel('SessionEnd', undefined, 'session-B')).toBe(false);
+
+    // Grab the "next request" listener BEFORE triggering the cancel that
+    // frees the slot (matches serialize.test.ts's ordering) -- otherwise B's
+    // request can reach the server in the window before we start listening.
+    const r2 = server.awaitNextRequest();
+    // The scoped cancel for session A DOES abort it.
+    expect(svc.cancel('SessionEnd', undefined, 'session-A')).toBe(true);
+    const a = await aP;
+    expect(a.decision).toBe('cancelled');
+
+    // B is granted the freed slot and completes normally -- untouched.
+    await r2;
+    expect(server.requestCount()).toBe(2);
+    // releaseAll (not releaseNext): A's aborted fetch left its server-side
+    // handler unresolved (orphaned in `held`); releaseNext() would pop that
+    // stale holder instead of B's real one.
+    server.releaseAll();
+    const b = await bP;
+    expect(b.decision).toBe('approve');
+  });
+
+  test("drainScope(scope) drains only that scope's queued waiters (#730 BUG 1)", async () => {
+    const svc = new AutoApproveService(makeConfig(server), noLog);
+    const r1 = server.awaitNextRequest();
+    const running = svc.evaluate(
+      'Bash',
+      { command: 'running' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'holder',
+    );
+    const aQ1 = svc.evaluate('Bash', { command: 'aQ1' }, undefined, undefined, undefined, 101, 'A');
+    const aQ2 = svc.evaluate('Bash', { command: 'aQ2' }, undefined, undefined, undefined, 102, 'A');
+    const bQ1 = svc.evaluate('Bash', { command: 'bQ1' }, undefined, undefined, undefined, 201, 'B');
+    await r1;
+    expect(server.requestCount()).toBe(1); // only 'running' reached the LLM
+
+    expect(svc.drainScope('A')).toBe(2);
+    const a1 = await aQ1;
+    const a2 = await aQ2;
+    expect(a1.decision).toBe('escalate');
+    expect(a2.decision).toBe('escalate');
+    // Distinct reasoning from a global force-release drain (#730): a log
+    // reader must never be told "remi unstick" for a scoped session drain.
+    expect(a1.reasoning).toContain('session queue drained');
+    expect(a1.reasoning).not.toContain('remi unstick');
+    expect(server.requestCount()).toBe(1); // neither A waiter ever reached the LLM
+
+    // B's queued waiter is untouched: once the running eval releases, B is
+    // granted the slot in turn and completes normally.
+    const r2 = server.awaitNextRequest();
+    server.releaseNext();
+    expect((await running).decision).toBe('approve');
+    await r2;
+    expect(server.requestCount()).toBe(2);
+    server.releaseNext();
+    const b = await bQ1;
+    expect(b.decision).toBe('approve');
+  });
+
+  test('drainScope(scope, {mainOnly:true}) spares a subagent-tagged queued waiter (#711/#730)', async () => {
+    const svc = new AutoApproveService(makeConfig(server), noLog);
+    const r1 = server.awaitNextRequest();
+    const running = svc.evaluate(
+      'Bash',
+      { command: 'running' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'holder',
+    );
+    const mainQ = svc.evaluate(
+      'Bash',
+      { command: 'main' },
+      undefined,
+      undefined,
+      undefined,
+      301,
+      'A',
+      false,
+    );
+    const subQ = svc.evaluate(
+      'Bash',
+      { command: 'sub' },
+      undefined,
+      undefined,
+      undefined,
+      302,
+      'A',
+      true,
+    );
+    await r1;
+    expect(server.requestCount()).toBe(1);
+
+    expect(svc.drainScope('A', { mainOnly: true })).toBe(1);
+    const mainResult = await mainQ;
+    expect(mainResult.decision).toBe('escalate');
+
+    // The subagent-tagged waiter is spared -- still queued, not settled.
+    let subSettled = false;
+    void subQ.then(() => {
+      subSettled = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(subSettled).toBe(false);
+
+    // Release the running eval; the subagent waiter is granted next and
+    // completes normally, proving it was never dropped.
+    const r2 = server.awaitNextRequest();
+    server.releaseNext();
+    expect((await running).decision).toBe('approve');
+    await r2;
+    server.releaseNext();
+    expect((await subQ).decision).toBe('approve');
+  });
+
+  test("evalId collision across scopes: a targeted cancel from scope B never touches scope A's same-numbered eval (#730 BUG 2)", async () => {
+    const svc = new AutoApproveService(makeConfig(server), noLog);
+    const r1 = server.awaitNextRequest();
+    // Both scopes independently stamp evalId 1 -- exactly how two
+    // AutoApproveGate instances behave today (evalSeq is per-gate).
+    const aP = svc.evaluate('Bash', { command: 'cmdA' }, undefined, undefined, undefined, 1, 'A');
+    const bP = svc.evaluate('Bash', { command: 'cmdB' }, undefined, undefined, undefined, 1, 'B');
+    await r1;
+    expect(server.requestCount()).toBe(1); // A holds the slot; B (evalId 1 too) is queued
+
+    // Session B answers its own question (evalId 1): must drop ONLY B's
+    // queued waiter, never A's running eval of the same numbered id.
+    expect(svc.cancel('user-answered', 1, 'B')).toBe(true);
+    const b = await bP;
+    expect(b.decision).toBe('escalate');
+    expect(server.requestCount()).toBe(1); // B never reached the LLM
+
+    // A's running eval (also evalId 1) is untouched -- completes normally.
+    server.releaseNext();
+    const a = await aP;
+    expect(a.decision).toBe('approve');
+  });
+});
+
+describe('AutoApproveGate cross-session isolation via shared AutoApproveService (#730)', () => {
+  let server: GatedServer;
+  let tracker: QuestionPresenceTracker;
+  // SessionRegistry allows only ONE session per instance (throws otherwise --
+  // see session-registry.ts), so two concurrent sessions each get their OWN
+  // registry (mirrors the existing "per-session isolation" pattern in
+  // auto-approve-gate.test.ts). Both share the ONE real AutoApproveService
+  // under test, exactly like the daemon-wide singleton in production
+  // (hook-bridge-setup.ts).
+  let registries: SessionRegistry[];
+
+  function fakePTY(): PTYSession {
+    return {
+      id: generateId(),
+      isRunning: true,
+      write: () => {},
+      submitInput: async () => {},
+      close: async () => {},
+    } as unknown as PTYSession;
+  }
+
+  function pr(cmd: string): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: cmd },
+    };
+  }
+
+  function makeGate(service: AutoApproveService, sid: UUID): AutoApproveGate {
+    const registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    registries.push(registry);
+    registry.registerSession(sid, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => generateId(),
+      },
+      sid,
+    );
+  }
+
+  beforeEach(() => {
+    server = startGatedServer();
+    registries = [];
+    tracker = new QuestionPresenceTracker(() => {});
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    server.stop();
+    await Promise.all(registries.map((r) => r.shutdown()));
+  });
+
+  test("cancelStale does not drain a sibling session's queued eval (#730 BUG 1)", async () => {
+    const service = new AutoApproveService(makeConfig(server), noLog);
+    const SID_A = generateId() as UUID;
+    const SID_B = generateId() as UUID;
+    const gateA = makeGate(service, SID_A);
+    const gateB = makeGate(service, SID_B);
+
+    // A's eval acquires the only GPU slot.
+    const rA = server.awaitNextRequest();
+    const pendingA = gateA.resolvePermission(pr('echo a'));
+    await rA;
+    expect(server.requestCount()).toBe(1);
+
+    // B's eval queues behind A -- never reaches the LLM.
+    const pendingB = gateB.resolvePermission(pr('echo b'));
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Grab the "next request" listener BEFORE the teardown that frees the
+    // slot (matches serialize.test.ts's ordering) -- otherwise B's request
+    // can reach the server in the window before we start listening.
+    const rB = server.awaitNextRequest();
+
+    // Session A tears down: its OWN running eval is cancelled and its own
+    // (empty) queue is drained. Session B's merely-queued eval must survive.
+    gateA.cancelStale('SessionEnd');
+    expect(await pendingA).toBe('passthrough');
+
+    // B is promoted once A's slot frees and gets a REAL LLM verdict -- proof
+    // it was never swept up by A's teardown (a drained eval never reaches
+    // the LLM at all).
+    await rB;
+    expect(server.requestCount()).toBe(2);
+    // releaseAll (not releaseNext): A's aborted fetch left its server-side
+    // handler unresolved (orphaned in `held`); releaseNext() would pop that
+    // stale holder instead of B's real one.
+    server.releaseAll();
+    expect(await pendingB).toBe('allow');
+  });
+
+  test("cancelStale(SessionEnd) does not cancel a sibling session's RUNNING eval (#730 BUG 3)", async () => {
+    const service = new AutoApproveService(makeConfig(server), noLog);
+    const SID_A = generateId() as UUID;
+    const SID_B = generateId() as UUID;
+    const gateA = makeGate(service, SID_A);
+    const gateB = makeGate(service, SID_B);
+
+    // B's eval runs FIRST and holds the only GPU slot.
+    const rB = server.awaitNextRequest();
+    const pendingB = gateB.resolvePermission(pr('echo b'));
+    await rB;
+    expect(server.requestCount()).toBe(1);
+
+    // A's eval queues behind B, then A's session ends before its own eval
+    // ever ran.
+    const pendingA = gateA.resolvePermission(pr('echo a'));
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The old untargeted `service.cancel(reason)` matched "whatever is
+    // running" with no session check -- it would have aborted session B's
+    // live eval here. The fix scopes the cancel to session A.
+    gateA.cancelStale('SessionEnd');
+    expect(await pendingA).toBe('passthrough'); // A's own queued eval drained
+
+    // Session B's eval was NEVER aborted: it resolves to a REAL verdict. (An
+    // aborted eval can only resolve 'cancelled' -> 'passthrough', never
+    // 'allow'.)
+    server.releaseNext();
+    expect(await pendingB).toBe('allow');
+    expect(server.requestCount()).toBe(1); // B was never retried or re-run
+  });
+});


### PR DESCRIPTION
## Problem

`AutoApproveService` is a daemon-wide singleton (`cli.ts`); every session's `AutoApproveGate` shares the same eval slot and FIFO queue. Nothing in that shared bookkeeping knew which session an eval belonged to, producing three bugs:

1. **Queued-moot-evals never drained.** `AutoApproveGate.cancelStale` (`Stop`/`SessionEnd`) aborted only the session's own RUNNING eval, but never drained that session's own QUEUED waiters. A queued eval for work the session has already decided is moot (session ended, or the lead agent's `Stop`) could still get promoted onto the GPU later and delay a live request behind it.
2. **Cross-session `evalId` collision.** `evalId` is stamped per-gate (`AutoApproveGate.evalSeq`), so two different sessions can legitimately stamp the same number. A targeted cancel/drain had no session identity to disambiguate them, so a same-numbered eval belonging to a different session could theoretically be hit by mistake.
3. **Untargeted `SessionEnd` cancel.** `cancelStale`'s full (non-`mainOnly`) branch called `service.cancel(reason)` with no `evalId` at all — an untargeted cancel that matched "whatever eval is running" with **no session check whatsoever**. One session's teardown could abort a completely different session's live eval just because it happened to be the one holding the single shared slot.

## Fix

Threads a `scope` (the gate's own `sessionId`) through the service:

- The running-eval record is now `{scope, evalId, controller, reason}`-shaped (`currentScope` alongside the existing `currentEvalId`/`currentAbortController`).
- `cancel(reason, evalId?, scope?)`: when `scope` is given, an abort of the running eval only fires if it *also* belongs to that scope; a queued-waiter drop is likewise scope-filtered. Omitting `scope` (and `evalId`) is a fully untargeted cancel — reserved for `forceRelease`.
- New `drainScope(scope, opts?: {mainOnly?})`: drains only that scope's queued waiters, sparing a subagent/team-member-tagged waiter when `mainOnly` is set (mirrors the existing `mainOnly` handling of the running eval via `evalIsSubagentById`).
- `AutoApproveGate.cancelStale` now calls `drainScope(this.sessionId, {mainOnly})` before cancelling, and its cancel calls (`cancelStale`'s full branch, its `mainOnly` loop, and `cancelEvalForQuestion`) all pass `this.sessionId` as scope.
- The `'drained'` slot outcome is split into `'drained'` (global `drainQueue`/force-release — keeps its exact original "force-released (remi unstick)" reasoning) and `'drained-scope'` (the new scoped `drainScope` — distinct reasoning, "session queue drained (cancelStale)"), so a log reader is never told `remi unstick` for a plain session teardown.

## Invariants preserved

- **`forceRelease` (`remi unstick`) stays global**, by design — it calls the service's untargeted `cancel(reason)` (no scope) and the global `drainQueue()`, unchanged.
- **`escalate_model` second opinion stays untracked by `evalId`** (still never appears in `evalIsSubagentById`, so a `mainOnly` `Stop` still has nothing to cancel for it by construction) — it now carries `scope` only, so a *full* teardown's scoped cancel can still reach it if it's somehow still running.
- **A cancelled/drained eval never fabricates allow/deny** — it always resolves through the existing graceful escalate/cancelled paths; `reconcileLateVerdict` and the hold-release paths are untouched.
- Callers that omit `scope` (existing direct-service unit tests) implicitly share one internal default scope, so single-session test behavior is unchanged.

## Tested

- `bun run typecheck` — clean.
- `bunx biome check` on all touched files — clean.
- Full non-LLM `packages/daemon/tests/auto-approve/` suite (137 tests, 7 files) — all pass, including every pre-existing cancel/serialize/force-release/gate test unchanged.
- `packages/daemon/tests/cli/session-phases/` (103 tests, incl. `hook-bridge-setup.test.ts`) — all pass.
- New `packages/daemon/tests/auto-approve/scope-isolation.test.ts` (6 tests, real `AutoApproveService` + real gated `Bun.serve` fixture, no mocks): scoped cancel isolation, `drainScope` isolation, `drainScope` `mainOnly` sparing, cross-scope `evalId` collision, and two `AutoApproveGate`-level tests driving two real gates against one shared real service (mirroring the production daemon-wide singleton) proving `cancelStale` never touches a sibling session's queued or running eval.
- Excluded (per instructions, needs a live local model): the `describeOllama`-gated tests in `auto-approve-service.test.ts` and all of `llm-judgment.test.ts`. Confirmed via `git stash` that the one Ollama-gated test that ran locally (`instructions affect LLM decision`) fails identically on the unmodified `develop` code — a pre-existing live-model flake unrelated to this change.

Closes #730.