### PR TITLE
fix: push handoff notice on hold timeout (#733)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -210,6 +210,15 @@ export interface AutoApproveGateDeps {
    *  (`pushedHeldIds`), so it can never double-push. Absent => no immediate push
    *  (tests / no-AA callers). #573 / #625 */
   onHeldEscalate?: (questionId: UUID) => void;
+  /** Called when a HELD question's hold-timeout expires unanswered, JUST BEFORE
+   *  it fails open to passthrough (#733). Fired only on the TIMEOUT path — never
+   *  on the undeliverable fail-open (#603 delivery gate), where the push channel
+   *  is already known broken and a handoff push would be pointless. The question
+   *  is still registered in sessionRegistry when this fires, so the callback can
+   *  read its text to build a "moved to the terminal" handoff notification.
+   *  Without it, the timeout is SILENT on the phone: the card is dismissed and
+   *  nothing says the prompt now waits in the terminal. Throw-safe (safeCue). */
+  onHoldTimeout?: (questionId: UUID) => void;
   /** Called when the permission was auto-approved/denied silently (inject
    *  succeeded; the user never sees it). Drives the terminal "done" cue. #513.
    *  `ctx.isSubagent` (#711): same client-broadcast-only skip as `onEvalStart`
@@ -640,6 +649,14 @@ export class AutoApproveGate {
     this.safeCueWithArg('onHeldEscalate', this.deps.onHeldEscalate, qid);
     const decision = new Promise<PermissionDecision>((resolve) => {
       const timer = setTimeout(() => {
+        // #733: tell the phone the prompt is MOVING to the terminal before the
+        // card is dismissed — while the question is still in sessionRegistry so
+        // the handoff push can carry its text. Guarded on the hold still being
+        // live so an already-answered/cancelled hold never fires a stale
+        // handoff (failOpenHeld below no-ops the same way).
+        if (this.pendingHolds.has(qid)) {
+          this.safeCueWithArg('onHoldTimeout', this.deps.onHoldTimeout, qid);
+        }
         this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} timed out -> passthrough`);
       }, holdMs);
       // setTimeout keeps the event loop alive for the whole human-paced hold;

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -309,6 +309,15 @@ export class AutoApproveGate {
    * path clears the timer and deletes the entry, so it never leaks.
    */
   private readonly pendingHolds = new Map<UUID, PendingHold>();
+  /**
+   * Held question ids whose notification was CONFIRMED delivered (#603 probe
+   * resolved in_app/pushed). The #733 hold-timeout handoff cue fires only for
+   * these (or when delivery gating is disabled entirely): "timed out waiting
+   * for you" is only meaningful if the user was actually notified — a hold
+   * whose delivery was never confirmed is the undeliverable machinery's
+   * problem, not a handoff. Entries are dropped in `releaseHeld`.
+   */
+  private readonly confirmedDeliveries = new Set<UUID>();
 
   /** Monotonic id stamped on each primary eval (#617), so a held question can be
    *  tied to the exact eval running for it and a manual answer cancels only that
@@ -529,6 +538,7 @@ export class AutoApproveGate {
     // escalation this question tracked is resolved now regardless of which
     // branch below runs -- clear it unconditionally, not just on the hit path.
     this.openQuestionSignatures.delete(questionId);
+    this.confirmedDeliveries.delete(questionId); // #733: same unconditional cleanup
     const hold = this.pendingHolds.get(questionId);
     if (!hold) return false;
     clearTimeout(hold.timer);
@@ -652,9 +662,16 @@ export class AutoApproveGate {
         // #733: tell the phone the prompt is MOVING to the terminal before the
         // card is dismissed — while the question is still in sessionRegistry so
         // the handoff push can carry its text. Guarded on the hold still being
-        // live so an already-answered/cancelled hold never fires a stale
-        // handoff (failOpenHeld below no-ops the same way).
-        if (this.pendingHolds.has(qid)) {
+        // live (an answered/cancelled hold never fires a stale handoff;
+        // failOpenHeld below no-ops the same way) AND on the user having been
+        // reachable: either delivery was CONFIRMED (in_app/pushed), or delivery
+        // gating is disabled so there is no confirmation signal at all (legacy
+        // hold — assume the push went out). A hold whose delivery was pending/
+        // failed is the #603 undeliverable machinery's territory — pushing
+        // "timed out waiting for you" at someone who was never notified would
+        // be noise on a channel that is likely broken anyway.
+        const gatingDisabled = (this.deps.deliveryConfirmMs ?? 0) <= 0;
+        if (this.pendingHolds.has(qid) && (gatingDisabled || this.confirmedDeliveries.has(qid))) {
           this.safeCueWithArg('onHoldTimeout', this.deps.onHoldTimeout, qid);
         }
         this.failOpenHeld(qid, `Held hook ${qid.slice(0, 8)} timed out -> passthrough`);
@@ -728,7 +745,13 @@ export class AutoApproveGate {
         // The hold may already be resolved (user answered, Part-B verdict, or a
         // cancel) — then there is nothing to gate.
         if (!this.pendingHolds.has(qid)) return;
-        if (result !== 'timeout' && isDelivered(result)) return; // confirmed: keep holding
+        if (result !== 'timeout' && isDelivered(result)) {
+          // Confirmed: keep holding — and remember it, so a later hold-timeout
+          // knows the user really WAS notified and a #733 handoff notice is
+          // meaningful (see the cue gate in createHold).
+          this.confirmedDeliveries.add(qid);
+          return;
+        }
         this.onDeliveryUnconfirmed(qid, result);
       })
       .catch((err) => {
@@ -1250,6 +1273,9 @@ export class AutoApproveGate {
    */
   private releaseHeld(questionId: UUID, decision: PermissionDecision): boolean {
     this.openQuestionSignatures.delete(questionId);
+    // #733: unconditional for the same leak reason as the signature delete
+    // above — every hold exit path funnels through here.
+    this.confirmedDeliveries.delete(questionId);
     const hold = this.pendingHolds.get(questionId);
     if (!hold) return false;
     clearTimeout(hold.timer);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1318,6 +1318,9 @@ async function createNewSession(
         // AA-enabled guard as holdTimeoutSec — gating is only meaningful when the
         // gate can hold. The dispatcher records the per-question delivery outcome.
         awaitDelivery: (questionId) => notifications.awaitDelivery(questionId),
+        // #733: when a held escalation times out unanswered, tell the phone the
+        // prompt moved to the terminal instead of silently dismissing the card.
+        onHoldTimeout: (questionId) => notifications.pushHoldTimeoutHandoff(sessionId, questionId),
         deliveryConfirmSec: autoApproveService
           ? remiConfig.auto_approve.delivery_confirm_timeout
           : 0,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -122,6 +122,13 @@ export interface HookBridgeDeps {
    */
   awaitDelivery?: (questionId: UUID) => Promise<DeliveryOutcome> | undefined;
   /**
+   * Hold-timeout handoff notice (#733). Wired from this session's
+   * `NotificationDispatcher.pushHoldTimeoutHandoff`: when a held escalation
+   * expires unanswered and moves to the native terminal prompt, tell the phone
+   * so the timeout is not silent. Absent => no handoff push (tests).
+   */
+  onHoldTimeout?: (questionId: UUID) => void;
+  /**
    * Seconds to wait for a held escalation's delivery to be confirmed before
    * treating it as undeliverable (epic #603 Phase 1). From
    * `config.auto_approve.delivery_confirm_timeout`. 0 / absent => no gating.
@@ -432,6 +439,9 @@ export function setupHookBridge(
       // #603 Phase 1: gate a held hook on confirmed notification delivery, so a
       // dead push channel fails open fast instead of stalling for holdMs.
       ...(deps.awaitDelivery ? { awaitDelivery: deps.awaitDelivery } : {}),
+      // #733: hold-timeout handoff notice — the phone learns the prompt moved
+      // to the terminal instead of the card just silently vanishing.
+      ...(deps.onHoldTimeout ? { onHoldTimeout: deps.onHoldTimeout } : {}),
       deliveryConfirmMs: (deps.deliveryConfirmSec ?? 0) * 1000,
       holdUnconfirmedMs: (deps.holdUnconfirmedSec ?? 0) * 1000,
     },

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -474,6 +474,58 @@ export class NotificationDispatcher {
   }
 
   /**
+   * Alert push telling the user a held escalation TIMED OUT and its prompt has
+   * moved to the terminal (#733). Fired by the gate's `onHoldTimeout` cue just
+   * before the hold fails open, while the question is still registered — so the
+   * body can carry the actual ask. Without this, a timeout is silent on the
+   * phone: the card's dismissal collapses it away and nothing says the agent is
+   * now blocked on a native terminal prompt.
+   *
+   * Deliberate differences from `maybePush`:
+   *  - always pushes (no attached-client skip, no dedup): this is a one-shot
+   *    state-change notice, and an attached client only sees the card VANISH;
+   *  - no category/options/dynOptions: there is nothing to answer from the
+   *    lock screen anymore — tapping opens the app;
+   *  - collapse key is `handoff-<questionId>`, NOT the question id, so the
+   *    original card's quiet dismissal (collapse-id = question id) cannot
+   *    collapse this notice away.
+   */
+  pushHoldTimeoutHandoff(questionSessionId: UUID, questionId: UUID): void {
+    const { deviceTokens, pushConfig, sessionRegistry } = this.deps;
+    if (deviceTokens.size === 0) return;
+    const session = sessionRegistry.getSession(this.sessionId);
+    const question = session?.currentQuestions.get(questionId);
+    const sessionName = session?.name || 'Agent';
+    const ask =
+      normalizeNotificationText(question?.summary || question?.text || '') ||
+      'a permission request';
+    const title = `${sessionName}: answer in the terminal`.slice(0, TITLE_MAX);
+    const body = `Timed out waiting for you — the prompt moved to the terminal: ${ask}`.slice(
+      0,
+      BODY_MAX,
+    );
+    const cfg = pushConfig();
+    const pushSessionId = this.deps.getPrimarySessionId() ?? questionSessionId;
+    for (const dt of deviceTokens.values()) {
+      void this.pushOnceWithRetry(
+        cfg.signalingUrl,
+        dt.token,
+        {
+          title,
+          body,
+          ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
+          sessionId: pushSessionId,
+          questionId: `handoff-${questionId}`,
+        },
+        {
+          sent: `Push timeout-handoff sent for question ${questionId}`,
+          failed: `Push timeout-handoff failed for question ${questionId}`,
+        },
+      );
+    }
+  }
+
+  /**
    * Fire a QUIET APNS dismissal for a resolved question (#585, P7). Sends a
    * `content-available` push (no alert, no sound) keyed by `apns-collapse-id` =
    * questionId so a suspended device replaces/clears the earlier lock-screen card

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1617,6 +1617,12 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
    *  the test controls. `delivery` is what `awaitDelivery` resolves to (or
    *  undefined for "no delivery signal recorded"). `evalNeverSettles` + a
    *  `pushHoldMs` exercise the Part-B early-push path combined with the gate. */
+  // #733 invariant: the timeout-handoff cue must NEVER fire on the
+  // undeliverable fail-open paths (the push channel is already known broken,
+  // so a handoff push would be pointless). Every deliveryGate() wires the cue
+  // into this shared recorder; the fail-open tests assert it stays empty.
+  let holdTimeoutCues: UUID[];
+
   function deliveryGate(opts: {
     delivery: Promise<DeliveryOutcome> | undefined;
     deliveryConfirmMs?: number;
@@ -1650,6 +1656,7 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
         awaitDelivery: () => opts.delivery,
         deliveryConfirmMs: opts.deliveryConfirmMs ?? 0,
         holdUnconfirmedMs: opts.holdUnconfirmedMs ?? 0,
+        onHoldTimeout: (id) => holdTimeoutCues.push(id),
         ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
         alwaysEscalateTools: new Set(['AskUserQuestion', 'ExitPlanMode']),
       },
@@ -1661,12 +1668,16 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
     escalations = [];
     lastQuestionId = undefined;
+    holdTimeoutCues = [];
     configureLogger({ writeLog: () => {} });
   });
 
   afterEach(async () => {
     __resetLoggerForTests();
     await registry.shutdown();
+    // #733: no delivery-gate fail-open in this block may EVER have fired the
+    // timeout-handoff cue — it belongs exclusively to the hold-timeout path.
+    expect(holdTimeoutCues).toEqual([]);
   });
 
   test('undelivered (failed push) fails the hold open fast, not after hold_timeout', async () => {

--- a/packages/daemon/tests/auto-approve/hold-hook.test.ts
+++ b/packages/daemon/tests/auto-approve/hold-hook.test.ts
@@ -150,6 +150,89 @@ describe('Model B hold over a real HookServer (#573)', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({}); // passthrough = bare {}
   });
+
+  test('#733: hold timeout fires onHoldTimeout once, then fails open to passthrough', async () => {
+    // Dedicated gate/server with a FAST hold so the timeout path runs for real.
+    const timeoutCue: UUID[] = [];
+    let qid: UUID | undefined;
+    const fastGate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          qid = generateId();
+          return qid;
+        },
+        onHoldTimeout: (id) => timeoutCue.push(id),
+        holdMs: 80,
+        alwaysEscalateTools: new Set<string>(),
+      },
+      SID,
+    );
+    const fastServer = new HookServer({ port: 0 });
+    fastServer.setPermissionResolver((input) => fastGate.resolvePermission(input));
+    fastServer.start();
+    try {
+      const res = await fetch(fastServer.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: permissionBody(),
+      });
+      // The hold expired unanswered: handoff cue fired exactly once with the
+      // held question's id, BEFORE the fail-open resolved the hook to
+      // passthrough (bare {}).
+      expect(await res.json()).toEqual({});
+      expect(qid).toBeDefined();
+      expect(timeoutCue).toEqual([qid as UUID]);
+    } finally {
+      fastServer.stop();
+    }
+  });
+
+  test('#733: an answered hold never fires onHoldTimeout', async () => {
+    const timeoutCue: UUID[] = [];
+    let qid: UUID | undefined;
+    const cueGate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          qid = generateId();
+          return qid;
+        },
+        onHoldTimeout: (id) => timeoutCue.push(id),
+        holdMs: 120,
+        alwaysEscalateTools: new Set<string>(),
+      },
+      SID,
+    );
+    const cueServer = new HookServer({ port: 0 });
+    cueServer.setPermissionResolver((input) => cueGate.resolvePermission(input));
+    cueServer.start();
+    try {
+      const post = fetch(cueServer.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: permissionBody(),
+      });
+      await waitFor(() => qid !== undefined);
+      cueGate.resolveHeld(qid as UUID, 'allow');
+      const body = (await (await post).json()) as {
+        hookSpecificOutput?: { decision?: { behavior?: string } };
+      };
+      expect(body.hookSpecificOutput?.decision?.behavior).toBe('allow');
+      // Give the (cancelled) hold timer window a chance to elapse: the cue must
+      // stay silent because the hold was answered, not timed out.
+      await new Promise((r) => setTimeout(r, 200));
+      expect(timeoutCue).toEqual([]);
+    } finally {
+      cueServer.stop();
+    }
+  });
 });
 
 /** Poll `cond` up to ~1s; throw if it never becomes true (real timing, no mock). */

--- a/packages/daemon/tests/auto-approve/hold-hook.test.ts
+++ b/packages/daemon/tests/auto-approve/hold-hook.test.ts
@@ -191,6 +191,48 @@ describe('Model B hold over a real HookServer (#573)', () => {
     }
   });
 
+  test('#733: with delivery gating ON, a CONFIRMED delivery still fires the cue on timeout', async () => {
+    // The cue is gated on the user having been reachable: confirmed delivery
+    // ('pushed') + hold expiry => handoff fires. (The inverse — unconfirmed
+    // delivery never fires it — is pinned by the delivery-gating describe
+    // block's afterEach invariant in auto-approve-gate.test.ts.)
+    const timeoutCue: UUID[] = [];
+    let qid: UUID | undefined;
+    const gatedGate = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          qid = generateId();
+          return qid;
+        },
+        onHoldTimeout: (id) => timeoutCue.push(id),
+        holdMs: 120,
+        awaitDelivery: () => Promise.resolve('pushed' as const),
+        deliveryConfirmMs: 5000,
+        alwaysEscalateTools: new Set<string>(),
+      },
+      SID,
+    );
+    const gatedServer = new HookServer({ port: 0 });
+    gatedServer.setPermissionResolver((input) => gatedGate.resolvePermission(input));
+    gatedServer.start();
+    try {
+      const res = await fetch(gatedServer.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: permissionBody(),
+      });
+      expect(await res.json()).toEqual({}); // timed out -> passthrough
+      expect(qid).toBeDefined();
+      expect(timeoutCue).toEqual([qid as UUID]);
+    } finally {
+      gatedServer.stop();
+    }
+  });
+
   test('#733: an answered hold never fires onHoldTimeout', async () => {
     const timeoutCue: UUID[] = [];
     let qid: UUID | undefined;

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -579,6 +579,83 @@ describe('NotificationDispatcher.dismiss (#585 P7)', () => {
   });
 });
 
+describe('NotificationDispatcher.pushHoldTimeoutHandoff (#733)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+  const QID = 'q0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (_url, token, opts) => {
+    pushed.push({ token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('carries the ask, a handoff collapse key, and NO answer category', async () => {
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+    registry.addQuestion(SID, question(QID, [yesOpt, noOpt], 'Allow Bash: rm -rf .venv?'));
+
+    make().pushHoldTimeoutHandoff(SID, QID);
+    // pushOnceWithRetry resolves on a microtask; flush it.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(pushed).toHaveLength(1);
+    const opts = pushed[0]?.opts as Record<string, unknown>;
+    expect(String(opts['title'])).toContain('answer in the terminal');
+    expect(String(opts['body'])).toContain('Allow Bash: rm -rf .venv?');
+    // Distinct collapse key: the original card's quiet dismissal (collapse-id
+    // = the question id) must NOT collapse this handoff notice away.
+    expect(opts['questionId']).toBe(`handoff-${QID}`);
+    expect(opts['category']).toBeUndefined();
+    expect(opts['options']).toBeUndefined();
+    expect(opts['dynOptions']).toBeUndefined();
+  });
+
+  test('question already gone from the registry: still pushes with a generic ask', async () => {
+    deviceTokens.set('a', { token: 'a', platform: 'ios', registeredAt: 1, connectionId: SID });
+
+    make().pushHoldTimeoutHandoff(SID, QID);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(pushed).toHaveLength(1);
+    expect(String(pushed[0]?.opts['body'])).toContain('a permission request');
+  });
+
+  test('no device tokens: no-op', () => {
+    make().pushHoldTimeoutHandoff(SID, QID);
+    expect(pushed).toHaveLength(0);
+  });
+});
+
 describe('NotificationDispatcher delivery outcome (#603 Phase 1)', () => {
   let registry: SessionRegistry;
   let deviceTokens: Map<string, DeviceTokenEntry>;


### PR DESCRIPTION
Closes #733.

Soak finding 2026-07-06/07 (session remi:18770, five occurrences): a held escalation that expires at hold_timeout (default 30m) passes through to the native terminal prompt — correct Model B behavior — but the phone experience is a silent card dismissal. Nothing says the question is still real and now waiting in the terminal. Combined with #734 (foregrounded app shows no banners), escalations died silently all night.

## Changes

- `AutoApproveGate`: new throw-safe `onHoldTimeout` cue, fired in the hold timer ONLY on the timeout path (never on the #603 undeliverable fail-open, where the push channel is already known broken), before the card dismissal — while the question is still registered so its text is available.
- `NotificationDispatcher.pushHoldTimeoutHandoff`: alert push "<session>: answer in the terminal / Timed out waiting for you — the prompt moved to the terminal: <ask>". Deliberately always pushes (no attached-client skip, no dedup — an attached client only sees the card vanish), carries no category/options (nothing left to answer from the lock screen), and uses collapse key `handoff-<questionId>` so the original card's quiet dismissal cannot collapse the notice away.
- Wired per session in cli.ts/hook-bridge-setup alongside the existing awaitDelivery plumbing.

## Tested

- Gate over a REAL loopback HookServer (existing hold-hook harness, no mocks): timeout fires the cue exactly once with the held question id then resolves passthrough; an answered hold never fires it.
- Dispatcher: handoff carries the ask + handoff collapse key + no category/options/dynOptions; generic ask when the question is already gone; no-op with no tokens.
- 205 tests across notifications + hold-hook + session-phases suites pass; typecheck + biome clean.