### PR TITLE
feat: surface daemon-vs-installed version drift (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Added
+- **Stale-daemon version drift surfaced** (#539, epic #648 phase 2): daemons
+  hold their binary for life, so an upgrade silently leaves running daemons
+  on old code. Every daemon now stamps its binary version into its
+  live-sessions entry, status file, and connection-time `hello_ack`
+  (`daemonVersion`); `remi ls` prints a per-daemon "runs remi vX; installed
+  binary is vY — restart to apply" warning and `remi status` shows the hub's
+  version with the same drift warning.
 - **Session-less hub: `remi serve`** (#542, epic #648 phase 1): a supervisor
   daemon that binds a port (18765 preferred, 20-port probe, `--port` to
   override), serves the machine's session list, and spawns

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -77,6 +77,7 @@ const statusWriter = new StatusWriter(
     repo: gitInfo.repo,
     branch: gitInfo.branch,
     autoApprove: { ...IDLE_AUTO_APPROVE },
+    version: REMI_VERSION,
   },
   {
     // daemon-status.json belongs EXCLUSIVELY to the hub (#542, #740 review):
@@ -481,6 +482,7 @@ if (
       ...(cliSignalingUrl !== undefined && { signalingUrl: cliSignalingUrl }),
       ...(cliPushSecret !== undefined && { pushSecret: cliPushSecret }),
       ...(cliOrphanTimeout !== undefined && { orphanTimeout: cliOrphanTimeout }),
+      remiVersion: REMI_VERSION,
     }),
   );
 }
@@ -498,6 +500,7 @@ if (cliSubcommand === 'ls') {
         ...(cliPort !== undefined && { port: cliPort }),
         ...(cliHost !== undefined && { host: cliHost }),
         network: cliNetwork,
+        remiVersion: REMI_VERSION,
       },
       liveSessionsRegistry,
     ),
@@ -1029,17 +1032,16 @@ const sessionRegistry = new SessionRegistry(
           : null;
       const sent = registry.sendRaw(
         connectionId,
-        createHelloAck(
-          '1.0.0',
-          sessionId,
-          {
+        createHelloAck('1.0.0', sessionId, {
+          resumeInfo: {
             isResume: result.replayMessages.length > 0,
             replayCount: result.replayMessages.length,
             nextBulletId: result.nextBulletId,
           },
-          { claudeSessionId: claudeId, transcriptPath: tpath },
-          result.attachState,
-        ),
+          binding: { claudeSessionId: claudeId, transcriptPath: tpath },
+          attachState: result.attachState,
+          daemonVersion: REMI_VERSION,
+        }),
       );
       if (!sent) {
         log(`Promoted connection ${connectionId} is unreachable; detaching`);
@@ -1628,6 +1630,7 @@ const connectionHandlers: ConnectionHandlers = createConnectionHandlers({
     updateRemiStatus({ connections: Math.max(0, remiStatus.connections - 1) }),
   cancelOrphanTimeout,
   send: sendToConnection,
+  remiVersion: REMI_VERSION,
 });
 
 const sharedEvents = {
@@ -2119,6 +2122,7 @@ if (cliDaemonMode) {
       projectPath: workingDirectory,
       name: path.basename(workingDirectory),
       startedAt: new Date().toISOString(),
+      version: REMI_VERSION,
     });
 
     // Create the PTY session
@@ -2318,6 +2322,7 @@ if (cliDaemonMode) {
       projectPath: workingDirectory,
       name: path.basename(workingDirectory),
       startedAt: new Date().toISOString(),
+      version: REMI_VERSION,
     });
 
     // Notify attached clients when a new dist/remi build replaces this binary

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -20,6 +20,8 @@ export interface StartDaemonOptions {
   readonly signalingUrl?: string;
   readonly pushSecret?: string;
   readonly orphanTimeout?: number;
+  /** This binary's remi version, for the `status` drift warning (#539). */
+  readonly remiVersion?: string;
 }
 
 /** Subcommands this handler owns. */
@@ -67,7 +69,7 @@ export async function runDaemonLifecycleCommand(
     return 0;
   }
   if (sub === 'status') {
-    dm.showDaemonStatus();
+    dm.showDaemonStatus(opts.remiVersion);
     return 0;
   }
   if (sub === 'logs') {

--- a/packages/daemon/src/cli/cmd-ls.ts
+++ b/packages/daemon/src/cli/cmd-ls.ts
@@ -24,6 +24,8 @@ export interface LsCommandOptions {
   readonly port?: number;
   readonly host?: string;
   readonly network?: boolean;
+  /** This binary's remi version, for the stale-daemon warning (#539). */
+  readonly remiVersion?: string;
 }
 
 /** Injectable ls-client helpers; the default loader lazy-imports the real ones. */
@@ -32,7 +34,10 @@ export interface LsClientHelpers {
   runLsClient: (args: { host: string; port: number }) => Promise<void>;
   runHostLs: (args: { host: string; ports: number[] }) => Promise<void>;
   getDefaultPortRange: () => number[];
-  runMultiPortLs: (args: { registry: SessionRegistryFile }) => Promise<void>;
+  runMultiPortLs: (args: {
+    registry: SessionRegistryFile;
+    installedVersion?: string;
+  }) => Promise<void>;
 }
 
 const defaultLoader = async (): Promise<LsClientHelpers> => import('./ls-client.ts');
@@ -66,7 +71,10 @@ export async function runLsCommand(
       return 0;
     }
     // No explicit port: discover all local remi sessions via live registry
-    await helpers.runMultiPortLs({ registry });
+    await helpers.runMultiPortLs({
+      registry,
+      ...(opts.remiVersion !== undefined && { installedVersion: opts.remiVersion }),
+    });
     return 0;
   } catch (err) {
     io.err(errorToString(err));

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -304,7 +304,22 @@ export function stopDaemon(): void {
   console.log('Daemon killed.');
 }
 
-export function showDaemonStatus(): void {
+/**
+ * One-line drift note when a running daemon's binary version differs from
+ * the installed binary (#539: a daemon holds its binary for life; upgrades
+ * only affect newly started daemons). Null when either side is unknown or
+ * they match. Exported for tests and shared by `remi status`/`remi ls`.
+ */
+export function formatVersionDrift(
+  runningVersion: string | undefined,
+  installedVersion: string | undefined,
+): string | null {
+  if (!runningVersion || !installedVersion) return null;
+  if (runningVersion === installedVersion) return null;
+  return `running remi ${runningVersion}; installed binary is ${installedVersion} — restart to apply`;
+}
+
+export function showDaemonStatus(installedVersion?: string): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
   if (!pid) {
     console.log('Daemon is not running.');
@@ -323,6 +338,14 @@ export function showDaemonStatus(): void {
     const adapters = status['adapters'];
     if (Array.isArray(adapters) && adapters.length > 0) {
       console.log(`  Adapters: ${adapters.join(', ')}`);
+    }
+    const version = status['version'];
+    if (typeof version === 'string' && version.length > 0) {
+      console.log(`  Version: ${version}`);
+      const drift = formatVersionDrift(version, installedVersion);
+      if (drift) {
+        console.log(`  WARNING: ${drift}`);
+      }
     }
   } else {
     console.log(`Daemon running (PID ${pid}), no status info available.`);

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -39,6 +39,10 @@ export interface ConnectionHandlerDeps {
   /** Cancel the SIGHUP orphan-shutdown timer after a remote client attaches. */
   cancelOrphanTimeout: () => void;
   send: SendToConnection;
+  /** The daemon's remi binary version, stamped on connection-time hello_acks
+   *  so clients can flag a daemon running older code than the installed
+   *  binary (#539). */
+  remiVersion: string;
 }
 
 export type ConnectionHandlers = ReturnType<typeof createConnectionHandlers>;
@@ -53,6 +57,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
     onConnectionRemoved,
     cancelOrphanTimeout,
     send,
+    remiVersion,
   } = deps;
 
   /** The current binding for hello_ack: {claudeSessionId, transcriptPath}. */
@@ -119,17 +124,16 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
           if (result.success) {
             send(
               connectionId,
-              createHelloAck(
-                '1.0.0',
-                currentPrimary,
-                {
+              createHelloAck('1.0.0', currentPrimary, {
+                resumeInfo: {
                   isResume: result.replayMessages.length > 0,
                   replayCount: result.replayMessages.length,
                   nextBulletId: result.nextBulletId,
                 },
-                currentBinding(),
-                result.attachState,
-              ),
+                binding: currentBinding(),
+                attachState: result.attachState,
+                daemonVersion: remiVersion,
+              }),
             );
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
@@ -145,7 +149,13 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
         // Query mode or attach failed (session busy); send hello_ack without
         // attach so utility clients (ls, kill) can still send requests. Still
         // carry the binding so the client follows the current session (#499).
-        send(connectionId, createHelloAck('1.0.0', currentPrimary, undefined, currentBinding()));
+        send(
+          connectionId,
+          createHelloAck('1.0.0', currentPrimary, {
+            binding: currentBinding(),
+            daemonVersion: remiVersion,
+          }),
+        );
         log(
           `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
         );
@@ -156,7 +166,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       // rather than erroring out. This is the normal steady state for a
       // session-less hub daemon (#542) and also covers the brief startup
       // window on an ordinary daemon before its primary session is created.
-      send(connectionId, createHelloAck('1.0.0', null));
+      send(connectionId, createHelloAck('1.0.0', null, { daemonVersion: remiVersion }));
       log(`Connection ${connectionId} connected session-less (no active session)`);
     },
 

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -87,9 +87,11 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
           send(
             connectionId,
             createHelloAck('1.0.0', targetSessionId as UUID, {
-              isResume: true,
-              replayCount: result.replayMessages.length,
-              nextBulletId: result.nextBulletId,
+              resumeInfo: {
+                isResume: true,
+                replayCount: result.replayMessages.length,
+                nextBulletId: result.nextBulletId,
+              },
             }),
           );
           if (result.replayMessages.length > 0) {
@@ -216,9 +218,7 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
           send(
             connectionId,
             createHelloAck('1.0.0', newSessionId, {
-              isResume: false,
-              replayCount: 0,
-              nextBulletId: 1,
+              resumeInfo: { isResume: false, replayCount: 0, nextBulletId: 1 },
             }),
           );
           log(`Session ${newSessionId} created via resume (claude: ${claudeSessionId})`);

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -634,6 +634,30 @@ export function formatAge(timestamp: Timestamp): string {
 export interface MultiPortLsOptions {
   readonly registry: SessionRegistryFile;
   readonly timeout?: number;
+  /** This binary's remi version; enables the stale-daemon warning (#539). */
+  readonly installedVersion?: string;
+}
+
+/**
+ * Warning lines for daemons whose recorded binary version differs from the
+ * installed binary (#539). One line per drifted daemon; empty when nothing
+ * drifted or versions are unknown (pre-#539 entries carry none). Exported
+ * for tests.
+ */
+export function formatVersionDriftWarnings(
+  entries: ReadonlyArray<{ name: string; wsPort: number; version?: string | undefined }>,
+  installedVersion: string | undefined,
+): string[] {
+  if (!installedVersion) return [];
+  const lines: string[] = [];
+  for (const entry of entries) {
+    if (entry.version && entry.version !== installedVersion) {
+      lines.push(
+        `  ! ${entry.name} (port ${entry.wsPort}) runs remi ${entry.version}; installed binary is ${installedVersion} — restart to apply`,
+      );
+    }
+  }
+  return lines;
 }
 
 /**
@@ -683,6 +707,16 @@ export async function runMultiPortLs(opts: MultiPortLsOptions): Promise<void> {
     r.sessions.map((session) => ({ session, port: r.port })),
   );
   renderSessionList(allEntries);
+
+  // Stale-daemon warning (#539): compare each live entry's recorded binary
+  // version against the binary running this `remi ls`.
+  const driftLines = formatVersionDriftWarnings(registry.listLive(), opts.installedVersion);
+  if (driftLines.length > 0) {
+    console.log('');
+    for (const line of driftLines) {
+      console.log(line);
+    }
+  }
 }
 
 /**

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -77,6 +77,13 @@ export interface RemiStatus {
    * rather than failing a strict shape check.
    */
   mode?: 'hub' | 'session';
+  /**
+   * The remi binary version this process runs (#539). A daemon holds its
+   * binary for life; `remi status`/`ls` compare this against the installed
+   * binary to flag stale daemons. Optional for the same mixed-version
+   * reasons as `mode`.
+   */
+  version?: string;
 }
 
 export interface StatusWriterDeps {

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -130,6 +130,9 @@ export interface ConnectionConfig {
   /** Server version to report */
   readonly serverVersion: string;
 
+  /** The daemon's remi binary version, stamped on hello_acks (#539). */
+  readonly daemonVersion?: string | undefined;
+
   /** Ping interval in ms */
   readonly pingInterval?: number;
 
@@ -180,6 +183,7 @@ export class Connection {
   private readonly config: Required<ConnectionConfig> & {
     skipHelloAck: boolean;
     authenticator: Authenticator | undefined;
+    daemonVersion: string | undefined;
   };
   private readonly events: Partial<ConnectionEvents>;
   private readonly messageTracker: MessageIdTracker;
@@ -208,6 +212,7 @@ export class Connection {
         (config.authenticator ? DEFAULT_AUTH_CONNECTION_TIMEOUT : DEFAULT_CONNECTION_TIMEOUT),
       skipHelloAck: config.skipHelloAck ?? false,
       authenticator: config.authenticator,
+      daemonVersion: config.daemonVersion,
     };
 
     // Set connection timeout (applies to both auth and hello phases)
@@ -462,7 +467,13 @@ export class Connection {
 
     // Send hello ack (unless skipHelloAck is set, which lets daemon handle it)
     if (!this.config.skipHelloAck) {
-      this.send(createHelloAck(this.config.serverVersion, this.sessionId));
+      this.send(
+        createHelloAck(this.config.serverVersion, this.sessionId, {
+          ...(this.config.daemonVersion !== undefined && {
+            daemonVersion: this.config.daemonVersion,
+          }),
+        }),
+      );
     }
 
     // Acknowledge the hello

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -130,9 +130,6 @@ export interface ConnectionConfig {
   /** Server version to report */
   readonly serverVersion: string;
 
-  /** The daemon's remi binary version, stamped on hello_acks (#539). */
-  readonly daemonVersion?: string | undefined;
-
   /** Ping interval in ms */
   readonly pingInterval?: number;
 
@@ -183,7 +180,6 @@ export class Connection {
   private readonly config: Required<ConnectionConfig> & {
     skipHelloAck: boolean;
     authenticator: Authenticator | undefined;
-    daemonVersion: string | undefined;
   };
   private readonly events: Partial<ConnectionEvents>;
   private readonly messageTracker: MessageIdTracker;
@@ -212,7 +208,6 @@ export class Connection {
         (config.authenticator ? DEFAULT_AUTH_CONNECTION_TIMEOUT : DEFAULT_CONNECTION_TIMEOUT),
       skipHelloAck: config.skipHelloAck ?? false,
       authenticator: config.authenticator,
-      daemonVersion: config.daemonVersion,
     };
 
     // Set connection timeout (applies to both auth and hello phases)
@@ -467,13 +462,10 @@ export class Connection {
 
     // Send hello ack (unless skipHelloAck is set, which lets daemon handle it)
     if (!this.config.skipHelloAck) {
-      this.send(
-        createHelloAck(this.config.serverVersion, this.sessionId, {
-          ...(this.config.daemonVersion !== undefined && {
-            daemonVersion: this.config.daemonVersion,
-          }),
-        }),
-      );
+      // No daemonVersion here (#539): the production daemon always sets
+      // skipHelloAck and acks via connection-events.ts, which stamps it.
+      // This branch only serves library consumers of WebSocketServer.
+      this.send(createHelloAck(this.config.serverVersion, this.sessionId));
     }
 
     // Acknowledge the hello

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -42,6 +42,12 @@ export interface LiveSessionEntry {
    * as live, the fail-safe for legacy entries).
    */
   readonly claudeChildExited?: boolean;
+  /**
+   * The remi binary version the registering daemon runs (#539). Absent on
+   * entries written by pre-#539 daemons. `remi ls` compares it against the
+   * installed binary to flag stale daemons.
+   */
+  readonly version?: string;
 }
 
 /**

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { readPidFileLive } from '../../src/cli/daemon-manager.ts';
+import { formatVersionDrift, readPidFileLive } from '../../src/cli/daemon-manager.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
@@ -114,5 +114,21 @@ describe('readPidFileLive (#542)', () => {
         }
       }
     }
+  });
+});
+
+describe('formatVersionDrift (#539)', () => {
+  test('flags a running/installed mismatch', () => {
+    const note = formatVersionDrift('0.6.18', '0.6.19-dev.2');
+    expect(note).toContain('0.6.18');
+    expect(note).toContain('0.6.19-dev.2');
+    expect(note).toContain('restart to apply');
+  });
+
+  test('silent on match or unknown versions', () => {
+    expect(formatVersionDrift('0.6.19', '0.6.19')).toBeNull();
+    expect(formatVersionDrift(undefined, '0.6.19')).toBeNull();
+    expect(formatVersionDrift('0.6.19', undefined)).toBeNull();
+    expect(formatVersionDrift('', '0.6.19')).toBeNull();
   });
 });

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -82,6 +82,7 @@ describe('createConnectionHandlers', () => {
         cancelOrphanCalls += 1;
       },
       send,
+      remiVersion: '9.9.9-test',
     });
   }
 
@@ -98,9 +99,15 @@ describe('createConnectionHandlers', () => {
       // acks the connection with sessionId: null instead of erroring, so a
       // client can sit connected until a session is created (#542).
       expect(sendCalls).toHaveLength(1);
-      const msg = sendCalls[0]?.message as { type: string; sessionId?: unknown };
+      const msg = sendCalls[0]?.message as {
+        type: string;
+        sessionId?: unknown;
+        daemonVersion?: unknown;
+      };
       expect(msg.type).toBe('hello_ack');
       expect(msg.sessionId).toBeNull();
+      // Connection-time acks carry the daemon's binary version (#539).
+      expect(msg.daemonVersion).toBe('9.9.9-test');
     });
 
     test('a primary session set still attaches normally (regression, #542)', async () => {

--- a/packages/daemon/tests/cli/ls-client.test.ts
+++ b/packages/daemon/tests/cli/ls-client.test.ts
@@ -13,6 +13,7 @@ import {
   fetchSessions,
   formatAge,
   formatDuration,
+  formatVersionDriftWarnings,
   getDefaultPortRange,
   getLocalAddresses,
   groupEndpointsByHost,
@@ -512,5 +513,32 @@ describe('groupEndpointsByHost', () => {
     ];
     const result = groupEndpointsByHost(endpoints);
     expect(result.size).toBe(2);
+  });
+});
+
+describe('formatVersionDriftWarnings (#539)', () => {
+  const entries = [
+    { name: 'proj-a', wsPort: 18765, version: '0.6.18' },
+    { name: 'proj-b', wsPort: 18766, version: '0.6.19-dev.2' },
+    { name: 'proj-c', wsPort: 18767 }, // pre-#539 entry, no version recorded
+  ];
+
+  test('one warning line per drifted daemon, matching entries silent', () => {
+    const lines = formatVersionDriftWarnings(entries, '0.6.19-dev.2');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('proj-a');
+    expect(lines[0]).toContain('18765');
+    expect(lines[0]).toContain('0.6.18');
+    expect(lines[0]).toContain('restart to apply');
+  });
+
+  test('silent when installed version is unknown', () => {
+    expect(formatVersionDriftWarnings(entries, undefined)).toEqual([]);
+  });
+
+  test('silent when everything matches', () => {
+    expect(
+      formatVersionDriftWarnings([{ name: 'x', wsPort: 1, version: '1.0.0' }], '1.0.0'),
+    ).toEqual([]);
   });
 });

--- a/packages/daemon/tests/integration/hub-serve.test.ts
+++ b/packages/daemon/tests/integration/hub-serve.test.ts
@@ -61,6 +61,9 @@ describe('remi serve hub (integration, #542)', () => {
     expect(status.sessionId).toBeNull();
     expect(status.mode).toBe('hub');
     expect(status.pid).toBe(hub.proc.pid);
+    // The daemon stamps its binary version for the stale-daemon check (#539).
+    expect(typeof status.version).toBe('string');
+    expect(status.version.length).toBeGreaterThan(0);
 
     // Protocol: session-less hello_ack, not a NO_SESSION error.
     const { ws, received } = await connectAndHello(hub.port);

--- a/packages/daemon/tests/protocol-messages.test.ts
+++ b/packages/daemon/tests/protocol-messages.test.ts
@@ -78,9 +78,7 @@ describe('Protocol factory functions', () => {
 
     test('includes resume info', () => {
       const msg = createHelloAck('1.0.0', 'session-1' as UUID, {
-        isResume: true,
-        replayCount: 5,
-        nextBulletId: 10,
+        resumeInfo: { isResume: true, replayCount: 5, nextBulletId: 10 },
       });
       expect(msg.isResume).toBe(true);
       expect(msg.replayCount).toBe(5);
@@ -89,9 +87,7 @@ describe('Protocol factory functions', () => {
 
     test('round-trips through serialize/deserialize', () => {
       const original = createHelloAck('1.0.0', 'session-1' as UUID, {
-        isResume: true,
-        replayCount: 3,
-        nextBulletId: 7,
+        resumeInfo: { isResume: true, replayCount: 3, nextBulletId: 7 },
       });
       const deserialized = deserialize(serialize(original));
       expect(deserialized).not.toBeNull();

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -56,6 +56,19 @@ describe('SessionRegistryFile', () => {
     expect(live[0]!.wsPort).toBe(entry.wsPort);
   });
 
+  test('version field persists through register/listLive (#539)', () => {
+    const versioned = makeEntry({ sessionId: 'versioned-entry', version: '0.6.19-dev.2' });
+    registry.register(versioned);
+    expect(registry.listLive()[0]!.version).toBe('0.6.19-dev.2');
+    registry.unregister(versioned.sessionId);
+
+    // Pre-#539 entries carry no version; the field stays absent, not junk.
+    registry.register(makeEntry({ sessionId: 'legacy-entry' }));
+    const live = registry.listLive();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.version).toBeUndefined();
+  });
+
   test('register multiple sessions', () => {
     const e1 = makeEntry({ sessionId: 'sess-1', wsPort: 18765 });
     const e2 = makeEntry({ sessionId: 'sess-2', wsPort: 18766 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -96,6 +96,7 @@ export type {
   SessionViewsMessage,
   SessionViewMeta,
   QuestionResolvedMessage,
+  CreateHelloAckOptions,
   CreateHelloOptions,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -175,6 +175,15 @@ export interface HelloAckMessage {
    * 'attached', which was the pre-#662 (buggy) assumption.
    */
   readonly attachState?: 'attached' | 'queued' | undefined;
+  /**
+   * The daemon's remi BINARY version (e.g. "0.6.19-dev.2") — distinct from
+   * `serverVersion`, which is the protocol version. Lets clients flag a
+   * daemon running older code than the installed binary (#539: daemons hold
+   * their binary for life; upgrades only affect new daemons). Sent on
+   * connection-time acks; may be absent on later acks (resume/promotion)
+   * and from pre-#539 daemons.
+   */
+  readonly daemonVersion?: string;
 }
 
 /** Agent output - message from Claude */
@@ -921,16 +930,26 @@ export function createHello(
   };
 }
 
+/** Optional fields for {@link createHelloAck} — an options object so adding
+ *  new optionals never requires threading `undefined` through positional
+ *  callsites (same rationale as {@link CreateHelloOptions}). */
+export interface CreateHelloAckOptions {
+  resumeInfo?: { isResume: boolean; replayCount: number; nextBulletId: number } | undefined;
+  binding?: { claudeSessionId: UUID | null; transcriptPath: string | null } | undefined;
+  attachState?: 'attached' | 'queued' | undefined;
+  /** The daemon's remi binary version (#539). */
+  daemonVersion?: string | undefined;
+}
+
 /**
  * Create a hello ack message.
  */
 export function createHelloAck(
   serverVersion: string,
   sessionId: UUID | null,
-  resumeInfo?: { isResume: boolean; replayCount: number; nextBulletId: number },
-  binding?: { claudeSessionId: UUID | null; transcriptPath: string | null },
-  attachState?: 'attached' | 'queued',
+  options: CreateHelloAckOptions = {},
 ): HelloAckMessage {
+  const { resumeInfo, binding, attachState, daemonVersion } = options;
   return {
     type: 'hello_ack',
     id: generateId(),
@@ -947,6 +966,7 @@ export function createHelloAck(
       transcriptPath: binding.transcriptPath,
     }),
     ...(attachState !== undefined && { attachState }),
+    ...(daemonVersion !== undefined && { daemonVersion }),
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -180,8 +180,8 @@ export interface HelloAckMessage {
    * `serverVersion`, which is the protocol version. Lets clients flag a
    * daemon running older code than the installed binary (#539: daemons hold
    * their binary for life; upgrades only affect new daemons). Sent on
-   * connection-time acks; may be absent on later acks (resume/promotion)
-   * and from pre-#539 daemons.
+   * connection-time and promotion acks; absent on resume acks and from
+   * pre-#539 daemons.
    */
   readonly daemonVersion?: string;
 }

--- a/packages/shared/tests/binding-protocol.test.ts
+++ b/packages/shared/tests/binding-protocol.test.ts
@@ -22,9 +22,11 @@ const QID = 'ques0000-0000-0000-0000-000000000003' as UUID;
 
 describe('binding fields on the wire (#429)', () => {
   test('hello_ack carries claudeSessionId + transcriptPath when binding present', () => {
-    const msg = createHelloAck('1.0.0', RID, undefined, {
-      claudeSessionId: CID,
-      transcriptPath: '/home/u/.claude/projects/-x/abc.jsonl',
+    const msg = createHelloAck('1.0.0', RID, {
+      binding: {
+        claudeSessionId: CID,
+        transcriptPath: '/home/u/.claude/projects/-x/abc.jsonl',
+      },
     });
     const round = deserialize(serialize(msg));
     if (round?.type !== 'hello_ack') throw new Error('wrong type');
@@ -33,9 +35,8 @@ describe('binding fields on the wire (#429)', () => {
   });
 
   test('hello_ack with null binding (no resolved id yet)', () => {
-    const msg = createHelloAck('1.0.0', RID, undefined, {
-      claudeSessionId: null,
-      transcriptPath: null,
+    const msg = createHelloAck('1.0.0', RID, {
+      binding: { claudeSessionId: null, transcriptPath: null },
     });
     const round = deserialize(serialize(msg));
     if (round?.type !== 'hello_ack') throw new Error('wrong type');

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -1287,9 +1287,7 @@ describe('Message factory functions', () => {
   describe('createHelloAck() with resume info', () => {
     test('includes resume info when provided', () => {
       const msg = createHelloAck('1.0.0', 'session-1', {
-        isResume: true,
-        replayCount: 5,
-        nextBulletId: 10,
+        resumeInfo: { isResume: true, replayCount: 5, nextBulletId: 10 },
       });
 
       expect(msg.isResume).toBe(true);
@@ -1305,12 +1303,26 @@ describe('Message factory functions', () => {
     });
   });
 
+  describe('createHelloAck() with daemonVersion (#539)', () => {
+    test('includes daemonVersion and round-trips', () => {
+      const msg = createHelloAck('1.0.0', 'session-1', { daemonVersion: '0.6.19-dev.2' });
+      expect(msg.daemonVersion).toBe('0.6.19-dev.2');
+      const round = deserialize(serialize(msg));
+      expect((round as typeof msg).daemonVersion).toBe('0.6.19-dev.2');
+    });
+
+    test('omits daemonVersion when not provided (pre-#539 wire shape)', () => {
+      const msg = createHelloAck('1.0.0', 'session-1');
+      expect('daemonVersion' in msg).toBe(false);
+    });
+  });
+
   describe('createHelloAck() with attachState (#662)', () => {
     test('includes attachState when provided', () => {
-      const attached = createHelloAck('1.0.0', 'session-1', undefined, undefined, 'attached');
+      const attached = createHelloAck('1.0.0', 'session-1', { attachState: 'attached' });
       expect(attached.attachState).toBe('attached');
 
-      const queued = createHelloAck('1.0.0', 'session-1', undefined, undefined, 'queued');
+      const queued = createHelloAck('1.0.0', 'session-1', { attachState: 'queued' });
       expect(queued.attachState).toBe('queued');
     });
 
@@ -1321,7 +1333,7 @@ describe('Message factory functions', () => {
     });
 
     test('attachState survives serialize/deserialize round-trip', () => {
-      const msg = createHelloAck('1.0.0', 'session-1', undefined, undefined, 'queued');
+      const msg = createHelloAck('1.0.0', 'session-1', { attachState: 'queued' });
       const serialized = serialize(msg);
       const deserialized = deserialize(serialized);
       expect(deserialized).not.toBeNull();


### PR DESCRIPTION
## Summary

Epic #648 phase 2. Daemons hold their binary for their whole life; `brew upgrade`/rebuilds only change what NEW daemons run. This caused "the escalate_model isn't working" (#522/#523-era): active daemons were pre-fix builds with no signal anywhere. Closes #539.

- Every daemon stamps `REMI_VERSION` into its live-sessions entry, its status file, and connection-time `hello_ack`s (new optional `daemonVersion` wire field; distinct from `serverVersion`, which is the protocol version).
- `remi ls` (local multi-port branch) prints one warning per drifted daemon: `! <name> (port N) runs remi vX; installed binary is vY — restart to apply`.
- `remi status` shows the hub's `Version:` plus the same drift warning.
- `createHelloAck`'s optional positionals folded into an options object (same rationale as `CreateHelloOptions` — new optionals never thread `undefined` through callsites again).

Absence is never flagged: pre-#539 entries/status files carry no version, so displays stay silent instead of guessing (verified live against this machine's six pre-#539 daemons: no spurious warnings, no Version line, nothing breaks).

## Testing

- New tests: `hello_ack` `daemonVersion` round-trip + omitted-by-default (wire back-compat), registry entry version persistence + legacy-entry absence, `formatVersionDrift` and `formatVersionDriftWarnings` (drift/match/unknown cases), connection-events ack carries the deps-injected version, hub integration test asserts the status file stamps a version.
- Full suite: 2569 pass; typecheck and biome clean.
- Live smoke against running pre-#539 daemons: `remi ls` and `remi status` degrade gracefully.

Not in scope: surfacing `daemonVersion` in the phone UI (field is on the wire now; client display is a follow-up), and the issue's bonus `remi restart-stale`.