### PR TITLE
feat: macOS menu-bar app shell (#649)

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -1,0 +1,49 @@
+# macOS menu-bar app build + tests (#649, epic #648).
+#
+# Path-filtered and NOT a required gate (plan decision: promote once flake
+# behavior on macos runners is known). The ubuntu gates still cover the
+# packages/web + packages/shared halves of any PR touching this area.
+name: macOS App
+
+on:
+  pull_request:
+    paths:
+      - "packages/macos/**"
+      - "packages/web/src/lib/native-host.ts"
+      - "scripts/stage-macos-web.sh"
+      - ".github/workflows/macos-app.yml"
+
+jobs:
+  build-test:
+    name: Build and Test (macOS)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Pinned: bun 1.3.12 --compile ships silent-exit binaries.
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Stage web bundle
+        run: bun run build:macos-web
+
+      - name: Build daemon binary (for integration tests)
+        run: bun run build:binary
+
+      - name: Build and test app
+        working-directory: packages/macos
+        env:
+          # TEST_RUNNER_ prefix: xcodebuild strips it and passes the variable
+          # into the xctest process (plain env vars never reach the runner).
+          TEST_RUNNER_REMI_TEST_BINARY: ${{ github.workspace }}/dist/remi
+        run: |
+          xcodebuild test \
+            -project Remi.xcodeproj \
+            -scheme Remi \
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,8 @@ playwright-report/
 
 # epic-dev local state (never committed)
 .claude/*.local.md
+
+# macOS app (packages/macos): staged web bundle + Xcode build artifacts
+packages/macos/Remi/Resources/web/*
+!packages/macos/Remi/Resources/web/.gitkeep
+packages/macos/DerivedData/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Added
+- **macOS menu-bar app shell** (#649, epic #648): `packages/macos/` — a
+  sandboxed, attach-only SwiftUI accessory app (`MenuBarExtra` + window)
+  hosting the existing web UI in a WKWebView over a bundled
+  `remi-app://localhost` origin. Discovers the local hub by port scan,
+  connects query-mode (never counted as a client), and injects the hub URL
+  into the web app via `window.__REMI_NATIVE__`. Closing the window or
+  quitting the app never touches the hub daemon (#651 groundwork); the app
+  cannot stop the hub by design (sandbox; use `remi stop`). Build via
+  `bun run build:macos-web` then Xcode; tests in `RemiTests` (real-hub
+  integration gated on `TEST_RUNNER_REMI_TEST_BINARY`).
 - **`hub_status` census broadcast** (#650, epic #648): hub-mode daemons now
   tell every client how many local and remote (non-query) clients are
   connected and how many child session daemons are live — the data source

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,4 +12,6 @@ extend-exclude = [
   # Xcode project files are machine-format: 24-hex object IDs (e.g.
   # "719E75D1BA17...") tokenize into false-positive "words" like BA (#719).
   "*.pbxproj",
+  # Same 24-hex BlueprintIdentifier issue in generated scheme files (#649).
+  "*.xcscheme",
 ]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:all": "bun run build:darwin-arm64 && bun run build:darwin-x64 && bun run build:linux-x64 && bun run build:linux-arm64",
     "install:local": "mkdir -p ~/.local/bin && cp dist/remi ~/.local/bin/remi",
     "app:version": "bun scripts/sync-app-version.mjs",
+    "build:macos-web": "bash scripts/stage-macos-web.sh",
     "testflight:ios": "bash scripts/testflight-ios.sh",
     "prepare": "lefthook install"
   },

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -1,0 +1,478 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
+		477C35A4907835166E4AECF6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
+		5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
+		61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */; };
+		7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */; };
+		779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
+		787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */; };
+		868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */; };
+		8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4E747A3D65101EAE2331D4 /* RemiApp.swift */; };
+		954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */; };
+		A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
+		AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		B380134DB301B91E8FB492B1 /* web in Resources */ = {isa = PBXBuildFile; fileRef = 5DB62EAF2230D75844C2E431 /* web */; };
+		B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		03E03C1A89AE93F94D40EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1F4E747A3D65101EAE2331D4 /* RemiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemiApp.swift; sourceTree = "<group>"; };
+		355697014B8A803D93F9E3EA /* WebViewWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewWindow.swift; sourceTree = "<group>"; };
+		385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubProtocolTests.swift; sourceTree = "<group>"; };
+		3C92562123ECC39FB269FB4A /* Remi.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Remi.entitlements; sourceTree = "<group>"; };
+		4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandlerTests.swift; sourceTree = "<group>"; };
+		5012C3ED6BF23506A3E5406C /* Remi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Remi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A7875E7E74CA980AD4B502F /* IconState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconState.swift; sourceTree = "<group>"; };
+		5DB62EAF2230D75844C2E431 /* web */ = {isa = PBXFileReference; lastKnownFileType = folder; name = web; path = Remi/Resources/web; sourceTree = SOURCE_ROOT; };
+		69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClientIntegrationTests.swift; sourceTree = "<group>"; };
+		6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStateTests.swift; sourceTree = "<group>"; };
+		734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		81CA6F64B5FFA6B90233A956 /* HubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClient.swift; sourceTree = "<group>"; };
+		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
+		C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubProtocol.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		364BBE56F2F49E1C3A22A22B = {
+			isa = PBXGroup;
+			children = (
+				AB3D9F531B6A4A622EDC05D1 /* Remi */,
+				C7F38A4D8AF6DC703EE13673 /* RemiTests */,
+				DB291654E0C27C18415F3098 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AB3D9F531B6A4A622EDC05D1 /* Remi */ = {
+			isa = PBXGroup;
+			children = (
+				C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */,
+				B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */,
+				81CA6F64B5FFA6B90233A956 /* HubClient.swift */,
+				C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */,
+				5A7875E7E74CA980AD4B502F /* IconState.swift */,
+				03E03C1A89AE93F94D40EA16 /* Info.plist */,
+				3C92562123ECC39FB269FB4A /* Remi.entitlements */,
+				1F4E747A3D65101EAE2331D4 /* RemiApp.swift */,
+				355697014B8A803D93F9E3EA /* WebViewWindow.swift */,
+				ECC1B78C2B42CFA4F799B774 /* Resources */,
+			);
+			path = Remi;
+			sourceTree = "<group>";
+		};
+		C7F38A4D8AF6DC703EE13673 /* RemiTests */ = {
+			isa = PBXGroup;
+			children = (
+				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
+				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
+				385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */,
+				6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */,
+			);
+			path = RemiTests;
+			sourceTree = "<group>";
+		};
+		DB291654E0C27C18415F3098 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5012C3ED6BF23506A3E5406C /* Remi.app */,
+				734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ECC1B78C2B42CFA4F799B774 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				5DB62EAF2230D75844C2E431 /* web */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1EF7CD188C7ACB54DC714BA7 /* Remi */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D84164CCD9B076A5A7904D1B /* Build configuration list for PBXNativeTarget "Remi" */;
+			buildPhases = (
+				FEA09EEC3A923EA9AD490962 /* Verify staged web bundle */,
+				C2E051E6BE6A8D71555247B8 /* Sources */,
+				F528F22A827CA73C9AC50A7D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Remi;
+			packageProductDependencies = (
+			);
+			productName = Remi;
+			productReference = 5012C3ED6BF23506A3E5406C /* Remi.app */;
+			productType = "com.apple.product-type.application";
+		};
+		FE8929E73DED99F24AB4F5A8 /* RemiTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF7C876D99FF1D3D15C35063 /* Build configuration list for PBXNativeTarget "RemiTests" */;
+			buildPhases = (
+				FDC3E244B25455445874C428 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RemiTests;
+			packageProductDependencies = (
+			);
+			productName = RemiTests;
+			productReference = 734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7897341F649EDB7595E3B052 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					1EF7CD188C7ACB54DC714BA7 = {
+						DevelopmentTeam = 9DQ459HAZB;
+					};
+					FE8929E73DED99F24AB4F5A8 = {
+						DevelopmentTeam = 9DQ459HAZB;
+					};
+				};
+			};
+			buildConfigurationList = 1E625220A00187EB79480C42 /* Build configuration list for PBXProject "Remi" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 364BBE56F2F49E1C3A22A22B;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = DB291654E0C27C18415F3098 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1EF7CD188C7ACB54DC714BA7 /* Remi */,
+				FE8929E73DED99F24AB4F5A8 /* RemiTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F528F22A827CA73C9AC50A7D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B380134DB301B91E8FB492B1 /* web in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		FEA09EEC3A923EA9AD490962 /* Verify staged web bundle */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Verify staged web bundle";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ ! -f \"${SRCROOT}/Remi/Resources/web/index.html\" ]; then\n  echo \"error: web bundle not staged. Run: bun run build:macos-web (repo root)\"\n  exit 1\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C2E051E6BE6A8D71555247B8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */,
+				A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */,
+				779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */,
+				D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */,
+				AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */,
+				8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */,
+				0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDC3E244B25455445874C428 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */,
+				787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */,
+				477C35A4907835166E4AECF6 /* HubClient.swift in Sources */,
+				7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */,
+				B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */,
+				61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */,
+				5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */,
+				868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */,
+				FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		30973D7A3FA8F495BB07A415 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Remi/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi.tests;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		39D14F70D9CE0C5D317ECE8E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Remi/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi.tests;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		5DC2A7FF7F7818A0669B4A99 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 9DQ459HAZB;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Release;
+		};
+		63571BBD768AB5EBB7DE6798 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 9DQ459HAZB;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Debug;
+		};
+		E0C991C711F983BD70198873 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Remi/Remi.entitlements;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 4;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Remi/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi;
+				PRODUCT_NAME = Remi;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		E54506BA894C2E53100F1B95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Remi/Remi.entitlements;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 4;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Remi/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = live.yooz.remi;
+				PRODUCT_NAME = Remi;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1E625220A00187EB79480C42 /* Build configuration list for PBXProject "Remi" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				63571BBD768AB5EBB7DE6798 /* Debug */,
+				5DC2A7FF7F7818A0669B4A99 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D84164CCD9B076A5A7904D1B /* Build configuration list for PBXNativeTarget "Remi" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0C991C711F983BD70198873 /* Debug */,
+				E54506BA894C2E53100F1B95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		EF7C876D99FF1D3D15C35063 /* Build configuration list for PBXNativeTarget "RemiTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				39D14F70D9CE0C5D317ECE8E /* Debug */,
+				30973D7A3FA8F495BB07A415 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7897341F649EDB7595E3B052 /* Project object */;
+}

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,6 +20,7 @@
 		954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */; };
 		A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */; };
 		B380134DB301B91E8FB492B1 /* web in Resources */ = {isa = PBXBuildFile; fileRef = 5DB62EAF2230D75844C2E431 /* web */; };
 		B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
 		D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
@@ -39,6 +40,7 @@
 		69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClientIntegrationTests.swift; sourceTree = "<group>"; };
 		6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStateTests.swift; sourceTree = "<group>"; };
 		734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandlerServingTests.swift; sourceTree = "<group>"; };
 		81CA6F64B5FFA6B90233A956 /* HubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClient.swift; sourceTree = "<group>"; };
 		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
 		C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 		C7F38A4D8AF6DC703EE13673 /* RemiTests */ = {
 			isa = PBXGroup;
 			children = (
+				7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */,
 				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
 				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
 				385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */,
@@ -229,6 +232,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */,
+				B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */,
 				787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */,
 				477C35A4907835166E4AECF6 /* HubClient.swift in Sources */,
 				7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */,

--- a/packages/macos/Remi.xcodeproj/xcshareddata/xcschemes/Remi.xcscheme
+++ b/packages/macos/Remi.xcodeproj/xcshareddata/xcschemes/Remi.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF7CD188C7ACB54DC714BA7"
+               BuildableName = "Remi.app"
+               BlueprintName = "Remi"
+               ReferencedContainer = "container:Remi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FE8929E73DED99F24AB4F5A8"
+               BuildableName = "RemiTests.xctest"
+               BlueprintName = "RemiTests"
+               ReferencedContainer = "container:Remi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EF7CD188C7ACB54DC714BA7"
+            BuildableName = "Remi.app"
+            BlueprintName = "Remi"
+            ReferencedContainer = "container:Remi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FE8929E73DED99F24AB4F5A8"
+               BuildableName = "RemiTests.xctest"
+               BlueprintName = "RemiTests"
+               ReferencedContainer = "container:Remi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EF7CD188C7ACB54DC714BA7"
+            BuildableName = "Remi.app"
+            BlueprintName = "Remi"
+            ReferencedContainer = "container:Remi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EF7CD188C7ACB54DC714BA7"
+            BuildableName = "Remi.app"
+            BlueprintName = "Remi"
+            ReferencedContainer = "container:Remi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/macos/Remi/AppDelegate.swift
+++ b/packages/macos/Remi/AppDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  AppDelegate.swift
+//  Remi
+//
+//  Accessory-app lifecycle (#651): the menu-bar item is the app's identity;
+//  closing the web-UI window must never terminate anything, and the app
+//  never owns the hub daemon (it is an attach-only sandboxed client).
+//
+
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // LSUIElement in Info.plist already makes this an accessory app
+        // (no Dock icon); set explicitly so the policy survives plist edits.
+        NSApp.setActivationPolicy(.accessory)
+    }
+
+    /// Window close dismisses UI only (#651 hard requirement). Accessory
+    /// apps default to this, but pin it explicitly.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+}

--- a/packages/macos/Remi/DistSchemeHandler.swift
+++ b/packages/macos/Remi/DistSchemeHandler.swift
@@ -1,0 +1,90 @@
+//
+//  DistSchemeHandler.swift
+//  Remi
+//
+//  Serves the bundled web UI (packages/web dist, staged into the app's
+//  Resources/web by scripts/stage-macos-web.sh) over the custom scheme
+//  `remi-app://localhost` (#649). A stable custom-scheme origin gives the
+//  web app persistent localStorage (the Capacitor-proven pattern) and avoids
+//  file:// origin restrictions. The UI is deliberately NOT served from the
+//  hub's HTTP server: that would couple UI version to the daemon binary.
+//
+
+import Foundation
+import WebKit
+
+final class DistSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "remi-app"
+
+    /// Root of the staged web bundle inside the app bundle.
+    private let webRoot: URL
+
+    init(webRoot: URL? = nil) {
+        self.webRoot =
+            webRoot
+            ?? Bundle.main.resourceURL!.appendingPathComponent("web", isDirectory: true)
+    }
+
+    /// Map a request path to a file inside the web root. SPA fallback: any
+    /// path without a file extension (a client-side route) serves index.html.
+    /// Exported logic kept pure for unit testing.
+    nonisolated static func resolve(path: String, webRoot: URL) -> URL {
+        var relative = path
+        while relative.hasPrefix("/") { relative.removeFirst() }
+        if relative.isEmpty { relative = "index.html" }
+
+        let candidate = webRoot.appendingPathComponent(relative)
+        // Path traversal guard: the resolved file must stay inside webRoot.
+        let normalized = candidate.standardizedFileURL.path
+        guard normalized.hasPrefix(webRoot.standardizedFileURL.path) else {
+            return webRoot.appendingPathComponent("index.html")
+        }
+        if (relative as NSString).pathExtension.isEmpty {
+            return webRoot.appendingPathComponent("index.html")
+        }
+        return candidate
+    }
+
+    nonisolated static func mimeType(forExtension ext: String) -> String {
+        switch ext.lowercased() {
+        case "html": return "text/html"
+        case "js", "mjs": return "text/javascript"
+        case "css": return "text/css"
+        case "json", "map": return "application/json"
+        case "svg": return "image/svg+xml"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "gif": return "image/gif"
+        case "ico": return "image/x-icon"
+        case "woff": return "font/woff"
+        case "woff2": return "font/woff2"
+        case "ttf": return "font/ttf"
+        case "wasm": return "application/wasm"
+        case "txt": return "text/plain"
+        default: return "application/octet-stream"
+        }
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(URLError(.badURL))
+            return
+        }
+        let fileURL = Self.resolve(path: url.path, webRoot: webRoot)
+        guard let data = try? Data(contentsOf: fileURL) else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+        let mime = Self.mimeType(forExtension: fileURL.pathExtension)
+        let response = URLResponse(
+            url: url, mimeType: mime, expectedContentLength: data.count,
+            textEncodingName: mime.hasPrefix("text/") ? "utf-8" : nil)
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        // Reads are synchronous and small; nothing to cancel.
+    }
+}

--- a/packages/macos/Remi/DistSchemeHandler.swift
+++ b/packages/macos/Remi/DistSchemeHandler.swift
@@ -19,6 +19,11 @@ final class DistSchemeHandler: NSObject, WKURLSchemeHandler {
     /// Root of the staged web bundle inside the app bundle.
     private let webRoot: URL
 
+    /// Tasks WebKit has stopped. Calling didReceive/didFinish on a stopped
+    /// task throws an NSException, and reads complete off-main (#745
+    /// review), so completion must check membership on the main thread.
+    private var stoppedTasks = Set<ObjectIdentifier>()
+
     init(webRoot: URL? = nil) {
         self.webRoot =
             webRoot
@@ -35,8 +40,13 @@ final class DistSchemeHandler: NSObject, WKURLSchemeHandler {
 
         let candidate = webRoot.appendingPathComponent(relative)
         // Path traversal guard: the resolved file must stay inside webRoot.
+        // Boundary-aware comparison (#745 review): a raw hasPrefix check let
+        // "/../web-evil/x" pass against a root ending in ".../web", because
+        // "web-evil" shares the "web" prefix. Require the root itself or a
+        // path-separator boundary.
         let normalized = candidate.standardizedFileURL.path
-        guard normalized.hasPrefix(webRoot.standardizedFileURL.path) else {
+        let rootPath = webRoot.standardizedFileURL.path
+        guard normalized == rootPath || normalized.hasPrefix(rootPath + "/") else {
             return webRoot.appendingPathComponent("index.html")
         }
         if (relative as NSString).pathExtension.isEmpty {
@@ -71,20 +81,35 @@ final class DistSchemeHandler: NSObject, WKURLSchemeHandler {
             return
         }
         let fileURL = Self.resolve(path: url.path, webRoot: webRoot)
-        guard let data = try? Data(contentsOf: fileURL) else {
-            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
-            return
+        // Read off-main (#745 review): scheme-handler callbacks arrive on
+        // the main thread, and a full-bundle reload would otherwise stack
+        // synchronous disk reads into UI hitches. Deliver back on main,
+        // skipping tasks WebKit stopped mid-read.
+        let taskId = ObjectIdentifier(urlSchemeTask)
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let data = try? Data(contentsOf: fileURL)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard !self.stoppedTasks.contains(taskId) else {
+                    self.stoppedTasks.remove(taskId)
+                    return
+                }
+                guard let data else {
+                    urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+                    return
+                }
+                let mime = Self.mimeType(forExtension: fileURL.pathExtension)
+                let response = URLResponse(
+                    url: url, mimeType: mime, expectedContentLength: data.count,
+                    textEncodingName: mime.hasPrefix("text/") ? "utf-8" : nil)
+                urlSchemeTask.didReceive(response)
+                urlSchemeTask.didReceive(data)
+                urlSchemeTask.didFinish()
+            }
         }
-        let mime = Self.mimeType(forExtension: fileURL.pathExtension)
-        let response = URLResponse(
-            url: url, mimeType: mime, expectedContentLength: data.count,
-            textEncodingName: mime.hasPrefix("text/") ? "utf-8" : nil)
-        urlSchemeTask.didReceive(response)
-        urlSchemeTask.didReceive(data)
-        urlSchemeTask.didFinish()
     }
 
     func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
-        // Reads are synchronous and small; nothing to cancel.
+        stoppedTasks.insert(ObjectIdentifier(urlSchemeTask))
     }
 }

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -86,6 +86,12 @@ final class HubClient: ObservableObject {
     private var consecutiveFailures = 0
     private var reconnectDelay: TimeInterval = 1
     private var started = false
+    /// Port of the most recent successful connection. Survives the phase
+    /// flip to .unreachable (#745 review: deriving the hint from `phase`
+    /// inside scheduleReconnect always read nil, making hint-first reconnect
+    /// dead code). Never cleared — a stale hint is harmless, it just gets
+    /// probed first.
+    private var lastConnectedPort: Int?
 
     /// Stable client id, persisted so the daemon sees one device (#662).
     private let clientId: String = {
@@ -113,12 +119,21 @@ final class HubClient: ObservableObject {
         phase = .scanning
         let ports = Self.scanOrder(hintPort: hintPort, ports: scanPorts)
         let responders = await Self.probe(ports: ports)
-        guard let port = responders.first else {
+        guard let port = Self.choosePort(responders: responders, hint: hintPort) else {
             phase = .unreachable
             scheduleReconnect()
             return
         }
         connect(to: port)
+    }
+
+    /// The hint (last known hub) wins when it still answers; otherwise the
+    /// lowest responder. Pure — probe() returns responders in ascending
+    /// order regardless of scan order, so honoring the hint must happen
+    /// here, not in the scan ordering (#745 review).
+    nonisolated static func choosePort(responders: [Int], hint: Int?) -> Int? {
+        if let hint, responders.contains(hint) { return hint }
+        return responders.first
     }
 
     /// Hint port (last known hub) first, then the rest of the range.
@@ -208,6 +223,7 @@ final class HubClient: ObservableObject {
             // hangs on exactly that (#542). Absent => treat as session peer.
             let isHub = Self.helloAckHasNullSessionId(data)
             phase = .connected(port: port, isHub: isHub)
+            lastConnectedPort = port
             consecutiveFailures = 0
             reconnectDelay = 1
             startPingTimer()
@@ -263,6 +279,10 @@ final class HubClient: ObservableObject {
         task = nil
         pingTimer?.invalidate()
         pingTimer = nil
+        // The rescan timer must die with the connection (#745 review): left
+        // running, its in-flight probe could race the backoff reconnect and
+        // leave an orphaned socket behind.
+        stopBackgroundRescan()
         localClients = 0
         remoteClients = 0
         sessions = 0
@@ -277,16 +297,11 @@ final class HubClient: ObservableObject {
         // After 3 straight failures do a full range rescan; before that,
         // retry with the last known port first.
         let hint: Int? = Self.shouldUseHint(consecutiveFailures: consecutiveFailures)
-            ? lastKnownPort : nil
+            ? lastConnectedPort : nil
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             await self?.scanAndConnect(preferring: hint)
         }
-    }
-
-    private var lastKnownPort: Int? {
-        if case let .connected(port, _) = phase { return port }
-        return nil
     }
 
     private func startBackgroundRescan() {
@@ -301,12 +316,17 @@ final class HubClient: ObservableObject {
                 }
                 let responders = await Self.probe(
                     ports: Self.scanOrder(hintPort: nil, ports: self.scanPorts))
+                // Re-check AFTER the ~1.5s probe await (#745 review): the
+                // connection can drop mid-probe, and racing the backoff
+                // reconnect from handleDisconnect would orphan a socket.
+                guard case let .connected(currentPort, isHub: false) = self.phase else { return }
                 // Reconnect from scratch if anything else responds; the
                 // hello_ack will tell us whether we found a real hub.
-                if let candidate = responders.first, candidate != self.lastKnownPort {
+                if let candidate = responders.first(where: { $0 != currentPort }) {
                     self.task?.cancel(with: .goingAway, reason: nil)
                     self.task = nil
                     self.pingTimer?.invalidate()
+                    self.pingTimer = nil
                     self.connect(to: candidate)
                 }
             }

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -29,6 +29,15 @@ final class HubClient: ObservableObject {
     nonisolated static let basePort = 18765
     nonisolated static let portRange = 20
 
+    /// Ports this client scans. Injectable so tests can point a REAL
+    /// HubClient at an isolated test hub without the scan latching onto
+    /// whatever daemons happen to live on the standard range.
+    private let scanPorts: [Int]
+
+    init(scanPorts: [Int] = Array(basePort..<(basePort + portRange))) {
+        self.scanPorts = scanPorts
+    }
+
     enum Phase: Equatable {
         case scanning
         case connected(port: Int, isHub: Bool)
@@ -102,7 +111,7 @@ final class HubClient: ObservableObject {
     /// responders win over session daemons; lowest port breaks ties.
     private func scanAndConnect(preferring hintPort: Int? = nil) async {
         phase = .scanning
-        let ports = Self.scanOrder(hintPort: hintPort)
+        let ports = Self.scanOrder(hintPort: hintPort, ports: scanPorts)
         let responders = await Self.probe(ports: ports)
         guard let port = responders.first else {
             phase = .unreachable
@@ -113,10 +122,22 @@ final class HubClient: ObservableObject {
     }
 
     /// Hint port (last known hub) first, then the rest of the range.
-    nonisolated static func scanOrder(hintPort: Int?) -> [Int] {
-        let range = Array(basePort..<(basePort + portRange))
-        guard let hint = hintPort, range.contains(hint) else { return range }
-        return [hint] + range.filter { $0 != hint }
+    nonisolated static func scanOrder(
+        hintPort: Int?, ports: [Int] = Array(basePort..<(basePort + portRange))
+    ) -> [Int] {
+        guard let hint = hintPort, ports.contains(hint) else { return ports }
+        return [hint] + ports.filter { $0 != hint }
+    }
+
+    /// Exponential backoff, capped (pure; exported for tests).
+    nonisolated static func nextReconnectDelay(after current: TimeInterval) -> TimeInterval {
+        min(current * 2, 30)
+    }
+
+    /// Retry the last known port until 3 straight failures, then rescan the
+    /// whole range (pure; exported for tests).
+    nonisolated static func shouldUseHint(consecutiveFailures: Int) -> Bool {
+        consecutiveFailures < 3
     }
 
     /// HTTP-probe `/auth-info` on each port (1.5 s timeout, mirroring the web
@@ -252,10 +273,11 @@ final class HubClient: ObservableObject {
 
     private func scheduleReconnect() {
         let delay = reconnectDelay
-        reconnectDelay = min(reconnectDelay * 2, 30)
+        reconnectDelay = Self.nextReconnectDelay(after: reconnectDelay)
         // After 3 straight failures do a full range rescan; before that,
         // retry with the last known port first.
-        let hint: Int? = consecutiveFailures < 3 ? lastKnownPort : nil
+        let hint: Int? = Self.shouldUseHint(consecutiveFailures: consecutiveFailures)
+            ? lastKnownPort : nil
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             await self?.scanAndConnect(preferring: hint)
@@ -277,7 +299,8 @@ final class HubClient: ObservableObject {
                     self.stopBackgroundRescan()
                     return
                 }
-                let responders = await Self.probe(ports: Self.scanOrder(hintPort: nil))
+                let responders = await Self.probe(
+                    ports: Self.scanOrder(hintPort: nil, ports: self.scanPorts))
                 // Reconnect from scratch if anything else responds; the
                 // hello_ack will tell us whether we found a real hub.
                 if let candidate = responders.first, candidate != self.lastKnownPort {

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -1,0 +1,304 @@
+//
+//  HubClient.swift
+//  Remi
+//
+//  Attach-only hub monitor (#649). Discovers the local remi hub by probing
+//  the daemon port range over HTTP (`/auth-info`, mirroring the web client's
+//  port-discovery semantics), holds a query-mode WebSocket to it, and
+//  publishes the `hub_status` census for the menu bar.
+//
+//  The app is sandboxed (App Sandbox + network.client only): it can never
+//  spawn `remi` or read ~/.remi, so scanning localhost ports is the ONLY
+//  discovery channel. See docs/MACOS_APP.md.
+//
+//  Hub race note (#649 plan, risk 3): a legacy single-session daemon can
+//  hold the preferred port while the hub sits higher in the range. Whatever
+//  answers first still works as the web UI's seed connection, but only a
+//  session-less peer (hello_ack.sessionId == nil) counts as a hub; while the
+//  current peer is not a hub, a slow background rescan keeps looking for one
+//  to promote to.
+//
+
+import Foundation
+
+@MainActor
+final class HubClient: ObservableObject {
+    /// Daemon port range: DAEMON_BASE_PORT 18765, 20-port probe
+    /// (packages/shared/src/daemon-ports.ts). `nonisolated` so the
+    /// nonisolated scan helpers can read them (immutable, Sendable).
+    nonisolated static let basePort = 18765
+    nonisolated static let portRange = 20
+
+    enum Phase: Equatable {
+        case scanning
+        case connected(port: Int, isHub: Bool)
+        case unreachable
+    }
+
+    @Published private(set) var phase: Phase = .scanning
+    @Published private(set) var localClients = 0
+    @Published private(set) var remoteClients = 0
+    @Published private(set) var sessions = 0
+    @Published private(set) var hubVersion: String?
+
+    var iconState: IconState {
+        switch phase {
+        case .connected(_, isHub: true):
+            return IconState.derive(
+                reachable: true, localClients: localClients, remoteClients: remoteClients)
+        default:
+            return .unreachable
+        }
+    }
+
+    /// The URL the embedded web UI should connect to, e.g. ws://127.0.0.1:18765.
+    var hubURL: String? {
+        guard case let .connected(port, _) = phase else { return nil }
+        return "ws://127.0.0.1:\(port)"
+    }
+
+    var menuStatusLine: String {
+        switch phase {
+        case .scanning:
+            return "Hub: looking…"
+        case .unreachable:
+            return "Hub: not running"
+        case let .connected(port, isHub):
+            guard isHub else { return "Session daemon on \(port) (no hub)" }
+            let sessionsPart = sessions == 1 ? "1 session" : "\(sessions) sessions"
+            return "Hub: running on \(port) · \(sessionsPart)"
+        }
+    }
+
+    private var task: URLSessionWebSocketTask?
+    private var pingTimer: Timer?
+    private var rescanTimer: Timer?
+    private var missedPongs = 0
+    private var consecutiveFailures = 0
+    private var reconnectDelay: TimeInterval = 1
+    private var started = false
+
+    /// Stable client id, persisted so the daemon sees one device (#662).
+    private let clientId: String = {
+        let key = "remi.clientId"
+        if let existing = UserDefaults.standard.string(forKey: key) { return existing }
+        let fresh = UUID().uuidString.lowercased()
+        UserDefaults.standard.set(fresh, forKey: key)
+        return fresh
+    }()
+
+    private let clientVersion =
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+
+    func start() {
+        guard !started else { return }
+        started = true
+        Task { await scanAndConnect() }
+    }
+
+    // MARK: - Discovery
+
+    /// Probe every port in the daemon range in parallel; hub (session-less)
+    /// responders win over session daemons; lowest port breaks ties.
+    private func scanAndConnect(preferring hintPort: Int? = nil) async {
+        phase = .scanning
+        let ports = Self.scanOrder(hintPort: hintPort)
+        let responders = await Self.probe(ports: ports)
+        guard let port = responders.first else {
+            phase = .unreachable
+            scheduleReconnect()
+            return
+        }
+        connect(to: port)
+    }
+
+    /// Hint port (last known hub) first, then the rest of the range.
+    nonisolated static func scanOrder(hintPort: Int?) -> [Int] {
+        let range = Array(basePort..<(basePort + portRange))
+        guard let hint = hintPort, range.contains(hint) else { return range }
+        return [hint] + range.filter { $0 != hint }
+    }
+
+    /// HTTP-probe `/auth-info` on each port (1.5 s timeout, mirroring the web
+    /// client's port discovery); returns responding ports in ascending order.
+    nonisolated static func probe(ports: [Int]) async -> [Int] {
+        await withTaskGroup(of: Int?.self) { group in
+            for port in ports {
+                group.addTask {
+                    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/auth-info")!)
+                    request.timeoutInterval = 1.5
+                    do {
+                        let (_, response) = try await URLSession.shared.data(for: request)
+                        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                            return nil
+                        }
+                        return port
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+            var found: [Int] = []
+            for await port in group {
+                if let port { found.append(port) }
+            }
+            return found.sorted()
+        }
+    }
+
+    // MARK: - Connection
+
+    private func connect(to port: Int) {
+        let url = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: url)
+        self.task = task
+        task.resume()
+
+        sendJSON(HelloFrame(clientVersion: clientVersion, clientId: clientId))
+        receiveLoop(task: task, port: port)
+    }
+
+    private func receiveLoop(task: URLSessionWebSocketTask, port: Int) {
+        task.receive { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self, self.task === task else { return }
+                switch result {
+                case let .success(message):
+                    if case let .string(text) = message {
+                        self.handleFrame(text, port: port)
+                    }
+                    self.receiveLoop(task: task, port: port)
+                case .failure:
+                    self.handleDisconnect()
+                }
+            }
+        }
+    }
+
+    private func handleFrame(_ text: String, port: Int) {
+        guard let data = text.data(using: .utf8),
+            let envelope = try? JSONDecoder().decode(IncomingFrameType.self, from: data)
+        else { return }
+
+        switch envelope.type {
+        case "hello_ack":
+            // Explicit-null detection: JSONDecoder cannot distinguish absent
+            // from null through `String?`, and the hub/session distinction
+            // hangs on exactly that (#542). Absent => treat as session peer.
+            let isHub = Self.helloAckHasNullSessionId(data)
+            phase = .connected(port: port, isHub: isHub)
+            consecutiveFailures = 0
+            reconnectDelay = 1
+            startPingTimer()
+            if !isHub {
+                // A session daemon answered; keep looking for a real hub in
+                // the background (60 s cadence) and promote when one appears.
+                startBackgroundRescan()
+            } else {
+                stopBackgroundRescan()
+            }
+        case "hub_status":
+            if let status = try? JSONDecoder().decode(HubStatusFrame.self, from: data) {
+                localClients = status.localClients
+                remoteClients = status.remoteClients
+                sessions = status.sessions
+                hubVersion = status.hubVersion
+            }
+        case "pong":
+            missedPongs = 0
+        default:
+            break
+        }
+    }
+
+    /// True only when the ack carries a LITERAL `"sessionId": null`.
+    nonisolated static func helloAckHasNullSessionId(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let value = object["sessionId"]
+        else { return false }
+        return value is NSNull
+    }
+
+    // MARK: - Liveness + reconnect
+
+    private func startPingTimer() {
+        pingTimer?.invalidate()
+        missedPongs = 0
+        pingTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.missedPongs += 1
+                if self.missedPongs > 2 {
+                    self.handleDisconnect()
+                } else {
+                    self.sendJSON(PingFrame())
+                }
+            }
+        }
+    }
+
+    private func handleDisconnect() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        pingTimer?.invalidate()
+        pingTimer = nil
+        localClients = 0
+        remoteClients = 0
+        sessions = 0
+        phase = .unreachable
+        consecutiveFailures += 1
+        scheduleReconnect()
+    }
+
+    private func scheduleReconnect() {
+        let delay = reconnectDelay
+        reconnectDelay = min(reconnectDelay * 2, 30)
+        // After 3 straight failures do a full range rescan; before that,
+        // retry with the last known port first.
+        let hint: Int? = consecutiveFailures < 3 ? lastKnownPort : nil
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            await self?.scanAndConnect(preferring: hint)
+        }
+    }
+
+    private var lastKnownPort: Int? {
+        if case let .connected(port, _) = phase { return port }
+        return nil
+    }
+
+    private func startBackgroundRescan() {
+        stopBackgroundRescan()
+        rescanTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // Only meaningful while attached to a non-hub peer.
+                guard case .connected(_, isHub: false) = self.phase else {
+                    self.stopBackgroundRescan()
+                    return
+                }
+                let responders = await Self.probe(ports: Self.scanOrder(hintPort: nil))
+                // Reconnect from scratch if anything else responds; the
+                // hello_ack will tell us whether we found a real hub.
+                if let candidate = responders.first, candidate != self.lastKnownPort {
+                    self.task?.cancel(with: .goingAway, reason: nil)
+                    self.task = nil
+                    self.pingTimer?.invalidate()
+                    self.connect(to: candidate)
+                }
+            }
+        }
+    }
+
+    private func stopBackgroundRescan() {
+        rescanTimer?.invalidate()
+        rescanTimer = nil
+    }
+
+    private func sendJSON<T: Encodable>(_ frame: T) {
+        guard let task, let data = try? JSONEncoder().encode(frame),
+            let text = String(data: data, encoding: .utf8)
+        else { return }
+        task.send(.string(text)) { _ in }
+    }
+}

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -19,10 +19,16 @@ import Foundation
 enum HubProtocol {
     static let protocolVersion = "1.0.0"
 
-    static func isoTimestamp(_ date: Date = Date()) -> String {
+    /// Shared formatter (thread-safe per Foundation docs); allocating one
+    /// per call was wasteful (#745 review).
+    private static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    static func isoTimestamp(_ date: Date = Date()) -> String {
+        isoFormatter.string(from: date)
     }
 
     static func newId() -> String {

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -1,0 +1,93 @@
+//
+//  HubProtocol.swift
+//  Remi
+//
+//  Minimal Codable surface of the remi WebSocket protocol (#649): just the
+//  frames the menu-bar shell needs. The app is a query-mode client — it never
+//  attaches, sends input, or answers questions; the embedded web UI has the
+//  full protocol stack.
+//
+//  Wire facts (packages/shared/src/protocol.ts):
+//  - timestamps are ISO8601 strings with fractional seconds
+//  - ids are lowercase UUID strings
+//  - a hub answers hello with hello_ack{sessionId: null}; a session daemon
+//    answers with a non-null sessionId
+//
+
+import Foundation
+
+enum HubProtocol {
+    static let protocolVersion = "1.0.0"
+
+    static func isoTimestamp(_ date: Date = Date()) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    static func newId() -> String {
+        UUID().uuidString.lowercased()
+    }
+}
+
+/// Outgoing `hello`, always query-mode: utility clients never auto-attach and
+/// (#650) are excluded from the hub's client census, so the app's own monitor
+/// connection can never flip the icon to "local client attached".
+struct HelloFrame: Encodable {
+    let type = "hello"
+    let id: String
+    let timestamp: String
+    let clientVersion: String
+    let clientId: String
+    let mode = "query"
+
+    init(clientVersion: String, clientId: String) {
+        self.id = HubProtocol.newId()
+        self.timestamp = HubProtocol.isoTimestamp()
+        self.clientVersion = clientVersion
+        self.clientId = clientId
+    }
+}
+
+/// Outgoing `ping` (protocol-level liveness; see protocol.ts ping/pong).
+struct PingFrame: Encodable {
+    let type = "ping"
+    let id: String
+    let timestamp: String
+
+    init() {
+        self.id = HubProtocol.newId()
+        self.timestamp = HubProtocol.isoTimestamp()
+    }
+}
+
+/// Incoming frame envelope: decode the `type` first, then the payload we
+/// care about. Unknown types are ignored (mirror of the TS isValidMessage
+/// forward-compat rule).
+struct IncomingFrameType: Decodable {
+    let type: String
+}
+
+/// Incoming `hello_ack`. `sessionId` null means the peer is a session-less
+/// hub (#542); non-null means a legacy single-session daemon answered.
+struct HelloAckFrame: Decodable {
+    let type: String
+    let sessionId: String?
+    let serverVersion: String
+    /// The daemon's remi binary version (#539); absent pre-#539.
+    let daemonVersion: String?
+}
+
+/// Incoming `hub_status` census (#650): the icon-state data source.
+struct HubStatusFrame: Decodable {
+    let type: String
+    let localClients: Int
+    let remoteClients: Int
+    let sessions: Int
+    let hubVersion: String
+}
+
+/// Incoming `pong`.
+struct PongFrame: Decodable {
+    let type: String
+}

--- a/packages/macos/Remi/IconState.swift
+++ b/packages/macos/Remi/IconState.swift
@@ -1,0 +1,46 @@
+//
+//  IconState.swift
+//  Remi
+//
+//  Pure reducer for the menu-bar icon (#650): (reachable, localClients,
+//  remoteClients) -> which glyph renders and how. Precedence, per the icon
+//  spec: unreachable (dimmed idle) > remote (filled, knocked-out "r") >
+//  local (hollow "r" stroke) > idle (plain outline).
+//
+//  Phase B ships SF-Symbol placeholders; Phase C swaps in the custom
+//  rounded-square "r" template assets without touching this reducer.
+//
+
+import Foundation
+
+enum IconState: Equatable {
+    case unreachable
+    case idle
+    case localAttached
+    case remoteConnected
+
+    static func derive(reachable: Bool, localClients: Int, remoteClients: Int) -> IconState {
+        if !reachable { return .unreachable }
+        if remoteClients > 0 { return .remoteConnected }
+        if localClients > 0 { return .localAttached }
+        return .idle
+    }
+
+    /// SF Symbol placeholder per state (Phase B). Phase C replaces these
+    /// with the custom template assets (menubar-idle/-local/-remote).
+    var systemImageName: String {
+        switch self {
+        case .unreachable, .idle:
+            return "r.square"
+        case .localAttached:
+            return "r.square.on.square"
+        case .remoteConnected:
+            return "r.square.fill"
+        }
+    }
+
+    /// Unreachable renders the idle glyph dimmed.
+    var opacity: Double {
+        self == .unreachable ? 0.4 : 1.0
+    }
+}

--- a/packages/macos/Remi/Info.plist
+++ b/packages/macos/Remi/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Remi</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <!-- Menu-bar accessory app: no Dock icon; window close never quits
+         (#651). The menu-bar "r" is the app's identity. -->
+    <key>LSUIElement</key>
+    <true/>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <!-- Same declaration as the iOS app: standard encryption only. -->
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+    <!-- The WKWebView talks ws://127.0.0.1 and the scanner probes
+         http://127.0.0.1; ATS treats loopback as local networking. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/packages/macos/Remi/Remi.entitlements
+++ b/packages/macos/Remi/Remi.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- App Sandbox is mandatory for TestFlight/App Store validation. The
+         app is an attach-only client: network.client (localhost WS + HTTP
+         probes) is the ONLY capability it needs. It can never spawn remi,
+         read ~/.remi, or signal processes - by design (#649/#651). -->
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -1,0 +1,54 @@
+//
+//  RemiApp.swift
+//  Remi
+//
+//  Menu-bar shell for the Remi hub (#649, epic #648). A thin, sandboxed,
+//  attach-only client: the hub daemon (`remi serve`) does the work; this
+//  surfaces it on the Mac without a terminal.
+//
+
+import SwiftUI
+
+@main
+struct RemiApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @StateObject private var hubClient = HubClient()
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Scene {
+        MenuBarExtra {
+            Text(hubClient.menuStatusLine)
+            if case .unreachable = hubClient.phase {
+                Text("Start it with: remi serve").font(.caption)
+            }
+            Divider()
+            Button("Open Remi") {
+                openWindow(id: "main")
+                // Accessory apps do not come forward on openWindow alone.
+                NSApp.activate(ignoringOtherApps: true)
+            }
+            .keyboardShortcut("o")
+            Divider()
+            Button("Quit Remi") {
+                // Quits the APP only. The hub is not ours to stop: the app is
+                // sandboxed (no process control) and a protocol-level stop is
+                // blocked on #535. Use `remi stop` in a terminal.
+                NSApp.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        } label: {
+            // The label renders at launch (unlike the lazily-built menu
+            // content), so this is the reliable startup hook for an
+            // accessory app with no initial window.
+            Image(systemName: hubClient.iconState.systemImageName)
+                .opacity(hubClient.iconState.opacity)
+                .task { hubClient.start() }
+        }
+
+        Window("Remi", id: "main") {
+            WebViewWindow(hubClient: hubClient)
+                .frame(minWidth: 720, minHeight: 480)
+        }
+        .defaultSize(width: 1100, height: 760)
+    }
+}

--- a/packages/macos/Remi/WebViewWindow.swift
+++ b/packages/macos/Remi/WebViewWindow.swift
@@ -52,21 +52,22 @@ struct WebViewWindow: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        // The web app manages its own connection lifecycle after mount; a
-        // late hub discovery is handled by reloading once when the hub URL
-        // first becomes known and the page loaded without one.
-        guard let hubUrl = hubClient.hubURL else { return }
-        if context.coordinator.lastInjectedHubUrl == nil {
-            context.coordinator.lastInjectedHubUrl = hubUrl
-            let configuration = webView.configuration
-            configuration.userContentController.removeAllUserScripts()
-            configuration.userContentController.addUserScript(
-                WKUserScript(
-                    source: Self.nativeBootstrapScript(hubUrl: hubUrl),
-                    injectionTime: .atDocumentStart,
-                    forMainFrameOnly: true))
-            webView.reload()
-        }
+        // Re-inject + reload on EVERY hub URL change (#745 review; design
+        // doc: "a moved hub port never leaves stale state behind") — late
+        // first discovery, hub restart on a new port, or session-daemon ->
+        // hub promotion. The inequality guard keeps the frequent SwiftUI
+        // update passes from looping reloads.
+        guard let hubUrl = hubClient.hubURL, hubUrl != context.coordinator.lastInjectedHubUrl
+        else { return }
+        context.coordinator.lastInjectedHubUrl = hubUrl
+        let configuration = webView.configuration
+        configuration.userContentController.removeAllUserScripts()
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: Self.nativeBootstrapScript(hubUrl: hubUrl),
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true))
+        webView.reload()
     }
 
     func makeCoordinator() -> Coordinator {

--- a/packages/macos/Remi/WebViewWindow.swift
+++ b/packages/macos/Remi/WebViewWindow.swift
@@ -1,0 +1,82 @@
+//
+//  WebViewWindow.swift
+//  Remi
+//
+//  WKWebView host for the bundled web UI (#649). The view is a thin shell:
+//  the web app has the full protocol/identity stack; the native side only
+//  points it at the discovered hub via an injected global.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebViewWindow: NSViewRepresentable {
+    @ObservedObject var hubClient: HubClient
+
+    /// The injected native handoff. Re-built per page load so a moved hub
+    /// port never leaves stale state behind; the web side merges this URL
+    /// into its stored connections on mount.
+    nonisolated static func nativeBootstrapScript(hubUrl: String?) -> String {
+        let urlLiteral: String
+        if let hubUrl {
+            // hubUrl is machine-built (ws://127.0.0.1:<port>), never
+            // user-controlled; JSON-encode defensively anyway.
+            // .withoutEscapingSlashes: default JSON escapes / as \/ which is
+            // valid JS but gratuitously unreadable in the injected script.
+            let data = try? JSONSerialization.data(
+                withJSONObject: [hubUrl], options: [.withoutEscapingSlashes])
+            let encoded = data.flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
+            urlLiteral = "\(encoded)[0]"
+        } else {
+            urlLiteral = "null"
+        }
+        return """
+            window.__REMI_NATIVE__ = { platform: 'macos-menubar', hubUrl: \(urlLiteral) };
+            """
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.setURLSchemeHandler(
+            DistSchemeHandler(), forURLScheme: DistSchemeHandler.scheme)
+
+        let script = WKUserScript(
+            source: Self.nativeBootstrapScript(hubUrl: hubClient.hubURL),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true)
+        configuration.userContentController.addUserScript(script)
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.load(URLRequest(url: URL(string: "\(DistSchemeHandler.scheme)://localhost/index.html")!))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        // The web app manages its own connection lifecycle after mount; a
+        // late hub discovery is handled by reloading once when the hub URL
+        // first becomes known and the page loaded without one.
+        guard let hubUrl = hubClient.hubURL else { return }
+        if context.coordinator.lastInjectedHubUrl == nil {
+            context.coordinator.lastInjectedHubUrl = hubUrl
+            let configuration = webView.configuration
+            configuration.userContentController.removeAllUserScripts()
+            configuration.userContentController.addUserScript(
+                WKUserScript(
+                    source: Self.nativeBootstrapScript(hubUrl: hubUrl),
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: true))
+            webView.reload()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(lastInjectedHubUrl: hubClient.hubURL)
+    }
+
+    final class Coordinator {
+        var lastInjectedHubUrl: String?
+        init(lastInjectedHubUrl: String?) {
+            self.lastInjectedHubUrl = lastInjectedHubUrl
+        }
+    }
+}

--- a/packages/macos/RemiTests/DistSchemeHandlerServingTests.swift
+++ b/packages/macos/RemiTests/DistSchemeHandlerServingTests.swift
@@ -1,0 +1,89 @@
+//
+//  DistSchemeHandlerServingTests.swift
+//  RemiTests
+//
+//  Exercises the ACTUAL serving path (webView(_:start:)) against a real
+//  temp-directory web root with real files (#745 review) — not just the
+//  pure resolve/mime helpers. The recorder conforms to the WKURLSchemeTask
+//  protocol to capture what production code hands WebKit; the files, reads,
+//  and MIME decisions are all real.
+//
+
+import WebKit
+import XCTest
+
+/// Captures the scheme handler's responses. WKWebView never renders here;
+/// this is the protocol seam WebKit itself defines.
+private final class RecordingSchemeTask: NSObject, WKURLSchemeTask {
+    let request: URLRequest
+    private(set) var response: URLResponse?
+    private(set) var body = Data()
+    private(set) var finished = false
+    private(set) var error: Error?
+
+    init(url: String) {
+        self.request = URLRequest(url: URL(string: url)!)
+    }
+
+    func didReceive(_ response: URLResponse) { self.response = response }
+    func didReceive(_ data: Data) { body.append(data) }
+    func didFinish() { finished = true }
+    func didFailWithError(_ error: Error) { self.error = error }
+}
+
+final class DistSchemeHandlerServingTests: XCTestCase {
+    private var webRoot: URL!
+    private var handler: DistSchemeHandler!
+    private let webView = WKWebView()
+
+    override func setUpWithError() throws {
+        webRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remi-webroot-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: webRoot.appendingPathComponent("assets"), withIntermediateDirectories: true)
+        try Data("<html>remi</html>".utf8)
+            .write(to: webRoot.appendingPathComponent("index.html"))
+        try Data("console.log('app')".utf8)
+            .write(to: webRoot.appendingPathComponent("assets/app.js"))
+        handler = DistSchemeHandler(webRoot: webRoot)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: webRoot)
+    }
+
+    func testServesRealFileWithMimeAndBody() {
+        let task = RecordingSchemeTask(url: "remi-app://localhost/assets/app.js")
+        handler.webView(webView, start: task)
+        XCTAssertTrue(task.finished)
+        XCTAssertNil(task.error)
+        XCTAssertEqual(task.response?.mimeType, "text/javascript")
+        XCTAssertEqual(String(data: task.body, encoding: .utf8), "console.log('app')")
+    }
+
+    func testSPARouteServesIndexHtmlWithTextEncoding() {
+        let task = RecordingSchemeTask(url: "remi-app://localhost/sessions/abc123")
+        handler.webView(webView, start: task)
+        XCTAssertTrue(task.finished)
+        XCTAssertEqual(task.response?.mimeType, "text/html")
+        XCTAssertEqual(task.response?.textEncodingName, "utf-8")
+        XCTAssertEqual(String(data: task.body, encoding: .utf8), "<html>remi</html>")
+    }
+
+    func testMissingFileFailsInsteadOfHanging() {
+        let task = RecordingSchemeTask(url: "remi-app://localhost/assets/missing.js")
+        handler.webView(webView, start: task)
+        XCTAssertFalse(task.finished)
+        XCTAssertNotNil(task.error)
+    }
+
+    func testReconnectPolicyHelpers() {
+        // Pure backoff/hint helpers extracted per the same review pass.
+        XCTAssertEqual(HubClient.nextReconnectDelay(after: 1), 2)
+        XCTAssertEqual(HubClient.nextReconnectDelay(after: 16), 30)
+        XCTAssertEqual(HubClient.nextReconnectDelay(after: 30), 30)
+        XCTAssertTrue(HubClient.shouldUseHint(consecutiveFailures: 0))
+        XCTAssertTrue(HubClient.shouldUseHint(consecutiveFailures: 2))
+        XCTAssertFalse(HubClient.shouldUseHint(consecutiveFailures: 3))
+    }
+}

--- a/packages/macos/RemiTests/DistSchemeHandlerServingTests.swift
+++ b/packages/macos/RemiTests/DistSchemeHandlerServingTests.swift
@@ -13,22 +13,31 @@ import WebKit
 import XCTest
 
 /// Captures the scheme handler's responses. WKWebView never renders here;
-/// this is the protocol seam WebKit itself defines.
+/// this is the protocol seam WebKit itself defines. Serving completes
+/// off-main (#745 review), so completion fulfills an expectation.
 private final class RecordingSchemeTask: NSObject, WKURLSchemeTask {
     let request: URLRequest
+    let done: XCTestExpectation
     private(set) var response: URLResponse?
     private(set) var body = Data()
     private(set) var finished = false
     private(set) var error: Error?
 
-    init(url: String) {
+    init(url: String, done: XCTestExpectation) {
         self.request = URLRequest(url: URL(string: url)!)
+        self.done = done
     }
 
     func didReceive(_ response: URLResponse) { self.response = response }
     func didReceive(_ data: Data) { body.append(data) }
-    func didFinish() { finished = true }
-    func didFailWithError(_ error: Error) { self.error = error }
+    func didFinish() {
+        finished = true
+        done.fulfill()
+    }
+    func didFailWithError(_ error: Error) {
+        self.error = error
+        done.fulfill()
+    }
 }
 
 final class DistSchemeHandlerServingTests: XCTestCase {
@@ -53,8 +62,10 @@ final class DistSchemeHandlerServingTests: XCTestCase {
     }
 
     func testServesRealFileWithMimeAndBody() {
-        let task = RecordingSchemeTask(url: "remi-app://localhost/assets/app.js")
+        let task = RecordingSchemeTask(
+            url: "remi-app://localhost/assets/app.js", done: expectation(description: "served"))
         handler.webView(webView, start: task)
+        wait(for: [task.done], timeout: 5)
         XCTAssertTrue(task.finished)
         XCTAssertNil(task.error)
         XCTAssertEqual(task.response?.mimeType, "text/javascript")
@@ -62,8 +73,10 @@ final class DistSchemeHandlerServingTests: XCTestCase {
     }
 
     func testSPARouteServesIndexHtmlWithTextEncoding() {
-        let task = RecordingSchemeTask(url: "remi-app://localhost/sessions/abc123")
+        let task = RecordingSchemeTask(
+            url: "remi-app://localhost/sessions/abc123", done: expectation(description: "served"))
         handler.webView(webView, start: task)
+        wait(for: [task.done], timeout: 5)
         XCTAssertTrue(task.finished)
         XCTAssertEqual(task.response?.mimeType, "text/html")
         XCTAssertEqual(task.response?.textEncodingName, "utf-8")
@@ -71,10 +84,26 @@ final class DistSchemeHandlerServingTests: XCTestCase {
     }
 
     func testMissingFileFailsInsteadOfHanging() {
-        let task = RecordingSchemeTask(url: "remi-app://localhost/assets/missing.js")
+        let task = RecordingSchemeTask(
+            url: "remi-app://localhost/assets/missing.js", done: expectation(description: "failed"))
         handler.webView(webView, start: task)
+        wait(for: [task.done], timeout: 5)
         XCTAssertFalse(task.finished)
         XCTAssertNotNil(task.error)
+    }
+
+    func testStoppedTaskIsNeverTouchedAfterStop() {
+        // WebKit throws if didReceive/didFinish land on a stopped task; the
+        // off-main read must drop delivery for stopped tasks (#745 review).
+        let done = expectation(description: "silently dropped")
+        done.isInverted = true
+        let task = RecordingSchemeTask(url: "remi-app://localhost/assets/app.js", done: done)
+        handler.webView(webView, start: task)
+        handler.webView(webView, stop: task)
+        wait(for: [done], timeout: 1)
+        XCTAssertFalse(task.finished)
+        XCTAssertNil(task.error)
+        XCTAssertNil(task.response)
     }
 
     func testReconnectPolicyHelpers() {

--- a/packages/macos/RemiTests/DistSchemeHandlerTests.swift
+++ b/packages/macos/RemiTests/DistSchemeHandlerTests.swift
@@ -1,0 +1,67 @@
+//
+//  DistSchemeHandlerTests.swift
+//  RemiTests
+//
+//  Path resolution (SPA fallback, traversal guard) and MIME mapping for the
+//  bundled-web scheme handler (#649), plus the native bootstrap script
+//  injected into the WKWebView.
+//
+
+import XCTest
+
+
+final class DistSchemeHandlerTests: XCTestCase {
+    private let root = URL(fileURLWithPath: "/bundle/Resources/web", isDirectory: true)
+
+    func testResolvesFilesAndSPARoutes() {
+        XCTAssertEqual(
+            DistSchemeHandler.resolve(path: "/index.html", webRoot: root).lastPathComponent,
+            "index.html")
+        XCTAssertEqual(
+            DistSchemeHandler.resolve(path: "/assets/app-abc123.js", webRoot: root).path,
+            "/bundle/Resources/web/assets/app-abc123.js")
+        // Client-side routes (no extension) fall back to index.html.
+        XCTAssertEqual(
+            DistSchemeHandler.resolve(path: "/sessions/abc", webRoot: root).lastPathComponent,
+            "index.html")
+        XCTAssertEqual(
+            DistSchemeHandler.resolve(path: "/", webRoot: root).lastPathComponent, "index.html")
+        XCTAssertEqual(
+            DistSchemeHandler.resolve(path: "", webRoot: root).lastPathComponent, "index.html")
+    }
+
+    func testPathTraversalStaysInWebRoot() {
+        let resolved = DistSchemeHandler.resolve(path: "/../../etc/passwd", webRoot: root)
+        XCTAssertTrue(resolved.standardizedFileURL.path.hasPrefix(root.path))
+        XCTAssertEqual(resolved.lastPathComponent, "index.html")
+    }
+
+    func testMimeTypes() {
+        XCTAssertEqual(DistSchemeHandler.mimeType(forExtension: "html"), "text/html")
+        XCTAssertEqual(DistSchemeHandler.mimeType(forExtension: "js"), "text/javascript")
+        XCTAssertEqual(DistSchemeHandler.mimeType(forExtension: "css"), "text/css")
+        XCTAssertEqual(DistSchemeHandler.mimeType(forExtension: "svg"), "image/svg+xml")
+        XCTAssertEqual(DistSchemeHandler.mimeType(forExtension: "woff2"), "font/woff2")
+        XCTAssertEqual(
+            DistSchemeHandler.mimeType(forExtension: "weird"), "application/octet-stream")
+    }
+
+    func testNativeBootstrapScript() {
+        let with = WebViewWindow.nativeBootstrapScript(hubUrl: "ws://127.0.0.1:18765")
+        XCTAssertTrue(with.contains("window.__REMI_NATIVE__"))
+        XCTAssertTrue(with.contains("'macos-menubar'"))
+        XCTAssertTrue(with.contains("ws://127.0.0.1:18765"))
+
+        let without = WebViewWindow.nativeBootstrapScript(hubUrl: nil)
+        XCTAssertTrue(without.contains("hubUrl: null"))
+    }
+
+    func testScanOrderPrefersHint() {
+        XCTAssertEqual(HubClient.scanOrder(hintPort: 18770).first, 18770)
+        XCTAssertEqual(HubClient.scanOrder(hintPort: nil).first, HubClient.basePort)
+        // Out-of-range hints are ignored.
+        XCTAssertEqual(HubClient.scanOrder(hintPort: 9999).first, HubClient.basePort)
+        XCTAssertEqual(HubClient.scanOrder(hintPort: nil).count, HubClient.portRange)
+        XCTAssertEqual(HubClient.scanOrder(hintPort: 18770).count, HubClient.portRange)
+    }
+}

--- a/packages/macos/RemiTests/DistSchemeHandlerTests.swift
+++ b/packages/macos/RemiTests/DistSchemeHandlerTests.swift
@@ -32,8 +32,28 @@ final class DistSchemeHandlerTests: XCTestCase {
 
     func testPathTraversalStaysInWebRoot() {
         let resolved = DistSchemeHandler.resolve(path: "/../../etc/passwd", webRoot: root)
-        XCTAssertTrue(resolved.standardizedFileURL.path.hasPrefix(root.path))
+        XCTAssertTrue(resolved.standardizedFileURL.path.hasPrefix(root.path + "/"))
         XCTAssertEqual(resolved.lastPathComponent, "index.html")
+    }
+
+    func testSiblingPrefixCollisionCannotEscape() {
+        // #745 review (critical): "/bundle/Resources/web-evil/…" shares the
+        // raw string prefix of a root ending in ".../web"; the guard must be
+        // path-boundary aware, not substring-based.
+        let resolved = DistSchemeHandler.resolve(path: "/../web-evil/secret.txt", webRoot: root)
+        XCTAssertEqual(resolved, root.appendingPathComponent("index.html"))
+
+        let dotted = DistSchemeHandler.resolve(path: "/../web.bak/secret.txt", webRoot: root)
+        XCTAssertEqual(dotted, root.appendingPathComponent("index.html"))
+    }
+
+    func testChoosePortPrefersLiveHint() {
+        // #745 review: probe() returns ascending responders, so the
+        // last-known-hub preference must be applied at selection time.
+        XCTAssertEqual(HubClient.choosePort(responders: [18765, 18771], hint: 18771), 18771)
+        XCTAssertEqual(HubClient.choosePort(responders: [18765, 18771], hint: nil), 18765)
+        XCTAssertEqual(HubClient.choosePort(responders: [18765], hint: 18771), 18765)
+        XCTAssertNil(HubClient.choosePort(responders: [], hint: 18771))
     }
 
     func testMimeTypes() {

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -103,5 +103,41 @@ final class HubClientIntegrationTests: XCTestCase {
         XCTAssertTrue(sawHubAck, "never received a session-less hello_ack")
         XCTAssertTrue(sawHubStatus, "never received the hub_status census")
         ws.cancel(with: .goingAway, reason: nil)
+
+        // 3. End-to-end through the REAL HubClient (#745 review): scan ->
+        //    connect -> handshake -> hub_status all the way to the published
+        //    state the menu bar reads. scanPorts injected so the client
+        //    cannot latch onto unrelated daemons on the standard range.
+        let client = await MainActor.run { HubClient(scanPorts: [port]) }
+        await MainActor.run { client.start() }
+        var connectedAsHub = false
+        for _ in 0..<60 {  // up to ~15 s
+            let phase = await MainActor.run { client.phase }
+            if case .connected(let p, let isHub) = phase, isHub {
+                XCTAssertEqual(p, port)
+                connectedAsHub = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(connectedAsHub, "HubClient never reached connected(isHub: true)")
+        // hub_status published: a fresh hub has no sessions and this
+        // query-mode client never counts itself.
+        var censusSeen = false
+        for _ in 0..<20 {
+            let (sessions, local, version) = await MainActor.run {
+                (client.sessions, client.localClients, client.hubVersion)
+            }
+            if version != nil {
+                XCTAssertEqual(sessions, 0)
+                XCTAssertEqual(local, 0)
+                censusSeen = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(censusSeen, "hub_status never reached the published state")
+        let statusLine = await MainActor.run { client.menuStatusLine }
+        XCTAssertTrue(statusLine.contains("running on \(port)"), statusLine)
     }
 }

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -1,0 +1,107 @@
+//
+//  HubClientIntegrationTests.swift
+//  RemiTests
+//
+//  Real-hub integration (#649, no mocks): spawns `REMI_TEST_BINARY serve`
+//  with an isolated $HOME, then drives the ACTUAL discovery + handshake path
+//  (HTTP probe -> ws hello -> hello_ack null-sessionId detection).
+//
+//  Skipped unless REMI_TEST_BINARY points at a remi binary. xcodebuild only
+//  forwards env vars carrying the TEST_RUNNER_ prefix into the test process:
+//    TEST_RUNNER_REMI_TEST_BINARY=$PWD/dist/remi xcodebuild test -project \
+//      packages/macos/Remi.xcodeproj -scheme Remi
+//  CI (macos-app.yml) builds the daemon binary and exports the variable so
+//  these run for real.
+//
+
+import XCTest
+
+
+final class HubClientIntegrationTests: XCTestCase {
+    private var process: Process?
+    private var homeDir: URL?
+
+    override func tearDown() {
+        process?.terminate()
+        process?.waitUntilExit()
+        if let homeDir { try? FileManager.default.removeItem(at: homeDir) }
+        super.tearDown()
+    }
+
+    private func requireBinary() throws -> String {
+        guard let binary = ProcessInfo.processInfo.environment["REMI_TEST_BINARY"],
+            FileManager.default.isExecutableFile(atPath: binary)
+        else {
+            throw XCTSkip("REMI_TEST_BINARY not set; skipping real-hub integration test")
+        }
+        return binary
+    }
+
+    func testDiscoversRealHubAndDetectsSessionlessAck() async throws {
+        let binary = try requireBinary()
+        // Port inside the app's scan range but above the common live ones.
+        let port = 18781
+
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remi-macos-it-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        homeDir = home
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = [
+            "serve", "--port", String(port), "--bind", "127.0.0.1",
+            "--no-mdns", "--no-relay", "--no-telegram", "--no-auth",
+        ]
+        var env = ProcessInfo.processInfo.environment
+        env["HOME"] = home.path
+        env.removeValue(forKey: "REMI_PORT")
+        env.removeValue(forKey: "REMI_SPAWNED_CHILD")
+        proc.environment = env
+        proc.standardOutput = Pipe()
+        proc.standardError = Pipe()
+        try proc.run()
+        process = proc
+
+        // 1. The scanner finds the hub via the real HTTP probe.
+        var responders: [Int] = []
+        for _ in 0..<40 {  // up to ~10 s for the hub to boot
+            responders = await HubClient.probe(ports: HubClient.scanOrder(hintPort: port))
+            if responders.contains(port) { break }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(responders.contains(port), "scan never found the hub on \(port)")
+
+        // 2. Real WS handshake: query hello -> hello_ack with LITERAL null
+        //    sessionId (the hub marker), skipping unknown frames (e.g. ack).
+        let ws = URLSession.shared.webSocketTask(
+            with: URL(string: "ws://127.0.0.1:\(port)/ws")!)
+        ws.resume()
+        let hello = HelloFrame(clientVersion: "0.1.0-test", clientId: "it-client")
+        let helloData = try JSONEncoder().encode(hello)
+        try await ws.send(.string(String(data: helloData, encoding: .utf8)!))
+
+        var sawHubAck = false
+        var sawHubStatus = false
+        for _ in 0..<10 {
+            let message = try await ws.receive()
+            guard case let .string(text) = message else { continue }
+            let data = Data(text.utf8)
+            guard
+                let envelope = try? JSONDecoder().decode(IncomingFrameType.self, from: data)
+            else { continue }
+            if envelope.type == "hello_ack" {
+                sawHubAck = HubClient.helloAckHasNullSessionId(data)
+            }
+            if envelope.type == "hub_status" {
+                let status = try JSONDecoder().decode(HubStatusFrame.self, from: data)
+                XCTAssertEqual(status.localClients, 0)  // query client never counts
+                sawHubStatus = true
+            }
+            if sawHubAck && sawHubStatus { break }
+        }
+        XCTAssertTrue(sawHubAck, "never received a session-less hello_ack")
+        XCTAssertTrue(sawHubStatus, "never received the hub_status census")
+        ws.cancel(with: .goingAway, reason: nil)
+    }
+}

--- a/packages/macos/RemiTests/HubProtocolTests.swift
+++ b/packages/macos/RemiTests/HubProtocolTests.swift
@@ -1,0 +1,88 @@
+//
+//  HubProtocolTests.swift
+//  RemiTests
+//
+//  Decoding against REAL frames captured from a live hub (remi
+//  0.6.19-dev.4, 2026-07-07) — not invented shapes. Capture method:
+//  query-mode hello to `remi serve`, raw frames logged.
+//
+
+import XCTest
+
+
+final class HubProtocolTests: XCTestCase {
+    // Captured verbatim from a live hub session.
+    private let helloAckFixture = """
+        {"type":"hello_ack","id":"b165ec10-6d38-4fc1-b733-fcabd58d1430","timestamp":"2026-07-08T01:29:44.322Z","serverVersion":"1.0.0","sessionId":null,"daemonVersion":"0.6.19-dev.4"}
+        """
+    private let hubStatusFixture = """
+        {"type":"hub_status","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-08T01:29:44.322Z","localClients":0,"remoteClients":0,"sessions":0,"hubVersion":"0.6.19-dev.4"}
+        """
+    /// A message-delivery ack (#663) arrives BEFORE hello_ack on a real
+    /// connection; the client must skip unknown types without failing.
+    private let ackFixture = """
+        {"type":"ack","id":"68002817-a987-4df3-81fb-d5b9273c4878","timestamp":"2026-07-08T01:29:44.321Z","ack":{"messageId":"9f717fd0-b097-4457-9f3b-42cc40c9d3c2","state":"delivered","timestamp":"2026-07-08T01:29:44.321Z"}}
+        """
+
+    func testDecodesRealHelloAckWithNullSessionId() throws {
+        let data = Data(helloAckFixture.utf8)
+        let ack = try JSONDecoder().decode(HelloAckFrame.self, from: data)
+        XCTAssertEqual(ack.type, "hello_ack")
+        XCTAssertNil(ack.sessionId)
+        XCTAssertEqual(ack.serverVersion, "1.0.0")
+        XCTAssertEqual(ack.daemonVersion, "0.6.19-dev.4")
+        // The hub marker: a LITERAL null, not an absent key.
+        XCTAssertTrue(HubClient.helloAckHasNullSessionId(data))
+    }
+
+    func testAbsentSessionIdIsNotAHubMarker() {
+        // A pre-#542 daemon or malformed frame without the key must not be
+        // mistaken for a session-less hub.
+        let noKey = Data(#"{"type":"hello_ack","serverVersion":"1.0.0"}"#.utf8)
+        XCTAssertFalse(HubClient.helloAckHasNullSessionId(noKey))
+        let nonNull = Data(
+            #"{"type":"hello_ack","serverVersion":"1.0.0","sessionId":"abc"}"#.utf8)
+        XCTAssertFalse(HubClient.helloAckHasNullSessionId(nonNull))
+    }
+
+    func testDecodesRealHubStatus() throws {
+        let status = try JSONDecoder().decode(
+            HubStatusFrame.self, from: Data(hubStatusFixture.utf8))
+        XCTAssertEqual(status.localClients, 0)
+        XCTAssertEqual(status.remoteClients, 0)
+        XCTAssertEqual(status.sessions, 0)
+        XCTAssertEqual(status.hubVersion, "0.6.19-dev.4")
+    }
+
+    func testUnknownFrameTypeOnlyNeedsTheEnvelope() throws {
+        let envelope = try JSONDecoder().decode(
+            IncomingFrameType.self, from: Data(ackFixture.utf8))
+        XCTAssertEqual(envelope.type, "ack")
+    }
+
+    func testHelloFrameEncodesQueryModeAndWireBasics() throws {
+        let hello = HelloFrame(clientVersion: "0.1.0", clientId: "client-1")
+        let data = try JSONEncoder().encode(hello)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["type"] as? String, "hello")
+        XCTAssertEqual(object["mode"] as? String, "query")
+        XCTAssertEqual(object["clientVersion"] as? String, "0.1.0")
+        // ISO8601 with fractional seconds, per protocol.ts now().
+        let timestamp = try XCTUnwrap(object["timestamp"] as? String)
+        XCTAssertNotNil(
+            ISO8601DateFormatter.withFractionalSeconds.date(from: timestamp))
+        // Lowercase UUID id.
+        let id = try XCTUnwrap(object["id"] as? String)
+        XCTAssertEqual(id, id.lowercased())
+        XCTAssertNotNil(UUID(uuidString: id))
+    }
+}
+
+extension ISO8601DateFormatter {
+    static let withFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/packages/macos/RemiTests/IconStateTests.swift
+++ b/packages/macos/RemiTests/IconStateTests.swift
@@ -1,0 +1,37 @@
+//
+//  IconStateTests.swift
+//  RemiTests
+//
+//  Table test for the icon-state reducer (#650 precedence:
+//  unreachable > remote > local > idle).
+//
+
+import XCTest
+
+
+final class IconStateTests: XCTestCase {
+    func testPrecedenceTable() {
+        let cases: [(reachable: Bool, local: Int, remote: Int, expected: IconState)] = [
+            (false, 0, 0, .unreachable),
+            (false, 3, 2, .unreachable),  // unreachable wins over everything
+            (true, 0, 0, .idle),
+            (true, 1, 0, .localAttached),
+            (true, 5, 0, .localAttached),
+            (true, 0, 1, .remoteConnected),
+            (true, 2, 1, .remoteConnected),  // remote wins over local
+        ]
+        for c in cases {
+            XCTAssertEqual(
+                IconState.derive(
+                    reachable: c.reachable, localClients: c.local, remoteClients: c.remote),
+                c.expected,
+                "reachable=\(c.reachable) local=\(c.local) remote=\(c.remote)")
+        }
+    }
+
+    func testUnreachableDims() {
+        XCTAssertEqual(IconState.unreachable.opacity, 0.4)
+        XCTAssertEqual(IconState.idle.opacity, 1.0)
+        XCTAssertEqual(IconState.remoteConnected.opacity, 1.0)
+    }
+}

--- a/packages/macos/project.yml
+++ b/packages/macos/project.yml
@@ -1,0 +1,73 @@
+# xcodegen source for Remi.xcodeproj (#649). The GENERATED project is
+# checked in — xcodegen is NOT a build dependency; this file exists so the
+# project can be regenerated deterministically (`xcodegen generate` in this
+# directory) when targets/files change.
+name: Remi
+options:
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    DEVELOPMENT_TEAM: 9DQ459HAZB
+targets:
+  Remi:
+    type: application
+    platform: macOS
+    sources:
+      - path: Remi
+        excludes:
+          - "Resources/web/**"
+      # Staged web bundle (scripts/stage-macos-web.sh). Folder reference so
+      # the whole dist tree lands in Resources/web verbatim.
+      - path: Remi/Resources/web
+        type: folder
+        buildPhase: resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: live.yooz.remi
+        PRODUCT_NAME: Remi
+        INFOPLIST_FILE: Remi/Info.plist
+        GENERATE_INFOPLIST_FILE: NO
+        CODE_SIGN_ENTITLEMENTS: Remi/Remi.entitlements
+        ENABLE_HARDENED_RUNTIME: YES
+        MARKETING_VERSION: 0.1.0
+        CURRENT_PROJECT_VERSION: 4
+        ENABLE_USER_SCRIPT_SANDBOXING: YES
+    preBuildScripts:
+      - name: Verify staged web bundle
+        script: |
+          if [ ! -f "${SRCROOT}/Remi/Resources/web/index.html" ]; then
+            echo "error: web bundle not staged. Run: bun run build:macos-web (repo root)"
+            exit 1
+          fi
+        basedOnDependencyAnalysis: false
+  RemiTests:
+    type: bundle.unit-test
+    platform: macOS
+    # UN-hosted tests: app sources compile INTO the test bundle (excluding
+    # the @main entry) instead of using the app as TEST_HOST. A hosted-app
+    # failure deadlocks XCTest's issue recording inside the accessory app's
+    # run loop (observed live: a failed assert hung xcodebuild forever) —
+    # unacceptable for CI. Plain xctest bundles fail fast.
+    sources:
+      - path: RemiTests
+      - path: Remi
+        excludes:
+          - "RemiApp.swift"
+          - "AppDelegate.swift"
+          - "Resources/web/**"
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: live.yooz.remi.tests
+        GENERATE_INFOPLIST_FILE: YES
+schemes:
+  Remi:
+    build:
+      targets:
+        Remi: all
+        RemiTests: [test]
+    test:
+      targets:
+        - RemiTests

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,6 +13,7 @@ import { type AckWaiters, awaitAck, resolveAckWaiter } from '@/lib/ack-waiter';
 import { probeAuthInfo } from '@/lib/auth-probe';
 import { deriveConnectionBannerError } from '@/lib/connection-banner';
 import { dedupeConnectionUrls } from '@/lib/connection-id';
+import { nativeHubUrlToConnect } from '@/lib/native-host';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from '@/lib/identity-client';
 import {
   acknowledgeSend,
@@ -1629,6 +1630,7 @@ function App() {
   }, [connectDirect]);
 
   useEffect(() => {
+    let restored: string[] = [];
     try {
       const stored = localStorage.getItem(LOCALSTORAGE_CONNECTIONS_KEY);
       if (stored) {
@@ -1642,12 +1644,19 @@ function App() {
         if (deduped.length !== urls.length) {
           localStorage.setItem(LOCALSTORAGE_CONNECTIONS_KEY, JSON.stringify(deduped));
         }
+        restored = deduped;
         for (const url of deduped) {
           connectDirectRef.current(url);
         }
       }
     } catch (err) {
       console.warn('[App] Failed to restore connections from localStorage:', err);
+    }
+    // Native-shell handoff (#649): the macOS menu-bar app injects the hub
+    // URL it discovered; connect unless the restored set already covers it.
+    const nativeUrl = nativeHubUrlToConnect(restored, window.__REMI_NATIVE__, parseConnectionId);
+    if (nativeUrl) {
+      connectDirectRef.current(nativeUrl);
     }
   }, []);
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1654,6 +1654,8 @@ function App() {
     }
     // Native-shell handoff (#649): the macOS menu-bar app injects the hub
     // URL it discovered; connect unless the restored set already covers it.
+    // If the localStorage read above threw, `restored` stays [] and the
+    // handoff always fires — the right fallback (the hub is the seed).
     const nativeUrl = nativeHubUrlToConnect(restored, window.__REMI_NATIVE__, parseConnectionId);
     if (nativeUrl) {
       connectDirectRef.current(nativeUrl);

--- a/packages/web/src/lib/native-host.ts
+++ b/packages/web/src/lib/native-host.ts
@@ -1,0 +1,44 @@
+/**
+ * Native-shell handoff (#649): the macOS menu-bar app hosts this web UI in a
+ * WKWebView and injects `window.__REMI_NATIVE__` (a WKUserScript at document
+ * start) carrying the hub WebSocket URL it discovered by port scan. The web
+ * app merges that URL into its own restored connections on mount; child
+ * session daemons are then found through the normal `daemonPorts` flow.
+ *
+ * Injected fresh on every load with the CURRENT hub URL, so a moved hub port
+ * never leaves stale state behind (unlike seeding localStorage from native,
+ * which would couple the native side to web-side dedup/normalization).
+ */
+
+export interface RemiNativeHost {
+  /** e.g. 'macos-menubar' */
+  readonly platform: string;
+  /** ws://127.0.0.1:<port> of the discovered hub; null while undiscovered. */
+  readonly hubUrl: string | null;
+}
+
+declare global {
+  interface Window {
+    __REMI_NATIVE__?: RemiNativeHost;
+  }
+}
+
+/**
+ * Decide whether the native-provided hub URL needs a fresh connect after the
+ * stored connections were restored. Pure; `toConnectionId` is injected the
+ * same way dedupeConnectionUrls does it, so host-spelling aliases
+ * (localhost vs 127.0.0.1) collapse before comparison.
+ */
+export function nativeHubUrlToConnect(
+  restoredUrls: readonly string[],
+  native: RemiNativeHost | undefined,
+  toConnectionId: (url: string) => string,
+): string | null {
+  const hubUrl = native?.hubUrl;
+  if (!hubUrl) return null;
+  const hubId = toConnectionId(hubUrl);
+  for (const url of restoredUrls) {
+    if (toConnectionId(url) === hubId) return null;
+  }
+  return hubUrl;
+}

--- a/packages/web/tests/lib/native-host.test.ts
+++ b/packages/web/tests/lib/native-host.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Native-shell hub handoff merge decision (#649): connect to the injected
+ * hub URL only when the restored connections do not already cover it
+ * (host-spelling aliases collapse through the injected toConnectionId).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { nativeHubUrlToConnect } from '../../src/lib/native-host';
+
+/** Simple id: host:port with localhost/127.0.0.1 collapsed, path ignored. */
+function toId(url: string): string {
+  const u = new URL(url.replace(/^ws/, 'http'));
+  const host = u.hostname === 'localhost' ? '127.0.0.1' : u.hostname;
+  return `${host}:${u.port}`;
+}
+
+describe('nativeHubUrlToConnect (#649)', () => {
+  test('connects when the hub is not among restored connections', () => {
+    expect(
+      nativeHubUrlToConnect(
+        ['ws://127.0.0.1:18766/ws'],
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765' },
+        toId,
+      ),
+    ).toBe('ws://127.0.0.1:18765');
+  });
+
+  test('no-op when already restored, including alias spellings', () => {
+    expect(
+      nativeHubUrlToConnect(
+        ['ws://localhost:18765/ws'],
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765' },
+        toId,
+      ),
+    ).toBeNull();
+  });
+
+  test('no-op outside the native shell or before discovery', () => {
+    expect(nativeHubUrlToConnect([], undefined, toId)).toBeNull();
+    expect(
+      nativeHubUrlToConnect([], { platform: 'macos-menubar', hubUrl: null }, toId),
+    ).toBeNull();
+  });
+
+  test('empty restored list still connects', () => {
+    expect(
+      nativeHubUrlToConnect(
+        [],
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18770' },
+        toId,
+      ),
+    ).toBe('ws://127.0.0.1:18770');
+  });
+});

--- a/scripts/generate-macos-project.sh
+++ b/scripts/generate-macos-project.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Regenerate packages/macos/Remi.xcodeproj from project.yml (#649).
+#
+# Wraps `xcodegen generate` with one portability fix: xcodegen run under a
+# new Xcode emits objectVersion 77 (Xcode 16.3+-only format), which older
+# xcodebuilds (e.g. the macos-14 CI runner) refuse to open. The project uses
+# no 77-only constructs, so pinning the version down keeps it readable
+# everywhere. Always regenerate through this script, not bare xcodegen.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/packages/macos"
+
+xcodegen generate
+
+PBXPROJ="Remi.xcodeproj/project.pbxproj"
+sed -i '' 's/objectVersion = [0-9]*;/objectVersion = 56;/' "$PBXPROJ"
+echo "Pinned $(grep -m1 objectVersion "$PBXPROJ" | tr -d '\t')"

--- a/scripts/stage-macos-web.sh
+++ b/scripts/stage-macos-web.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Stage the built web UI into the macOS app's Resources (#649).
+#
+# The Xcode target carries packages/macos/Remi/Resources/web as a folder
+# reference; this script populates it from packages/web/dist. Xcode itself
+# never invokes bun (PATH/sandbox fragility) — a pre-build phase only
+# VERIFIES index.html exists and points here when it does not.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT_DIR/packages/web"
+STAGE_DIR="$ROOT_DIR/packages/macos/Remi/Resources/web"
+
+echo "[1/2] Building web UI..."
+(cd "$WEB_DIR" && bun run build)
+
+echo "[2/2] Staging dist -> $STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+rsync -a --delete --exclude .gitkeep "$WEB_DIR/dist/" "$STAGE_DIR/"
+
+echo "Staged $(find "$STAGE_DIR" -type f | wc -l | tr -d ' ') files."


### PR DESCRIPTION
## Summary

Epic #648 Phase B (plan: `.context/plan-macos-app-648.md`): `packages/macos/` — the native macOS shell for Remi. A sandboxed, attach-only SwiftUI accessory app: menu-bar item + a resizable window hosting the existing web UI. The hub daemon does the work; this surfaces it on the Mac without a terminal.

**Architecture (all constraints from the adopted plan):**
- App Sandbox + `network.client` only (TestFlight requires sandbox); the app can never spawn `remi`, read `~/.remi`, or stop the hub — it discovers the hub by port-scanning `127.0.0.1:18765..18784` via `/auth-info` (mirroring the web client's port discovery) and connects with a query-mode hello, so it is never counted in the #650 census.
- A hub is detected by the LITERAL `"sessionId": null` in `hello_ack` (#542); if a legacy session daemon answers first, a 60s background rescan keeps looking for a real hub to promote to.
- The web UI ships inside the app (staged `packages/web/dist` served over `remi-app://localhost` by a `WKURLSchemeHandler` — stable origin for localStorage, SPA fallback, path-traversal guard). A `WKUserScript` injects `window.__REMI_NATIVE__ = {platform, hubUrl}`; the web side merges that URL into its restored connections through a new pure helper (`nativeHubUrlToConnect`), and child daemons arrive via the existing `daemonPorts` flow. Web change is ~10 lines plus the helper.
- Lifecycle (#651 groundwork): `LSUIElement` accessory app, window close never terminates, "Quit Remi" quits the app only (hub-stop is deliberately absent: blocked on #535; menu documents `remi stop`).
- `IconState` reducer with SF Symbol placeholders; the custom three-state "r" template assets land in Phase C (#650 stays open).

**Project mechanics:** checked-in `Remi.xcodeproj` generated from a checked-in `project.yml` (xcodegen is a regeneration tool, not a build dependency); `bun run build:macos-web` stages the web bundle (Xcode only VERIFIES it exists — no bun inside Xcode); `macos-app.yml` CI is path-filtered and non-required per the plan (macos-14 runner, builds the daemon binary and runs the integration test for real).

## Testing

- 12 XCTest unit tests + 1 real-hub integration test, all passing locally on Xcode 26.4.1.
- Protocol tests decode REAL captured wire frames (including the `ack` frame that precedes `hello_ack` on a live connection — discovered during capture, the client's unknown-type tolerance handles it).
- Integration test spawns a real `remi serve` under an isolated `$HOME`, drives the actual probe scan + WS handshake, and asserts session-less detection + census receipt. Gated on `TEST_RUNNER_REMI_TEST_BINARY` (the `TEST_RUNNER_` prefix is required — plain env vars never reach the xctest process; documented in the test header and CI).
- Tests are deliberately UN-hosted (app sources compile into the test bundle): a hosted-app assertion failure deadlocks XCTest's issue recording inside the accessory app's run loop — observed live, xcodebuild hung indefinitely. Un-hosted bundles fail fast, which CI needs.
- Web: `nativeHubUrlToConnect` bun tests (4), web build + full bun suite + typecheck green.
- Manual GUI smoke (menu-bar item, web UI in window, hub connection end-to-end) deferred to the on-machine checklist before Phase E TestFlight — this machine's daemons are pre-hub soak daemons.

Part of #649/#648.