### PR TITLE
test: defend #539 version stamping against regression

### DIFF
--- a/packages/daemon/tests/cli/cmd-ls.test.ts
+++ b/packages/daemon/tests/cli/cmd-ls.test.ts
@@ -111,9 +111,13 @@ describe('runLsCommand', () => {
     const { io } = makeIO();
     const { helpers, calls } = makeHelpers();
     const registry = makeRegistry([18765]);
-    await runLsCommand({}, registry, io, async () => helpers);
+    await runLsCommand({ remiVersion: '9.9.9-test' }, registry, io, async () => helpers);
     expect(calls[0]?.fn).toBe('runMultiPortLs');
-    expect((calls[0]?.args as { registry: SessionRegistryFile }).registry).toBe(registry);
+    const args = calls[0]?.args as { registry: SessionRegistryFile; installedVersion?: string };
+    expect(args.registry).toBe(registry);
+    // The installed-binary version threads through for the stale-daemon
+    // warning (#539); dropping it would silently disable drift detection.
+    expect(args.installedVersion).toBe('9.9.9-test');
   });
 
   test('REMI_PORT env acts as explicit port when --port is absent', async () => {

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -122,9 +122,15 @@ describe('createConnectionHandlers', () => {
       });
 
       expect(sendCalls).toHaveLength(1);
-      const msg = sendCalls[0]?.message as { type: string; sessionId?: unknown };
+      const msg = sendCalls[0]?.message as {
+        type: string;
+        sessionId?: unknown;
+        daemonVersion?: unknown;
+      };
       expect(msg.type).toBe('hello_ack');
       expect(msg.sessionId).toBe(sessionId);
+      // Every connection-time ack path stamps the binary version (#539).
+      expect(msg.daemonVersion).toBe('9.9.9-test');
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
     });
 
@@ -181,7 +187,10 @@ describe('createConnectionHandlers', () => {
       });
 
       expect(sendCalls).toHaveLength(1);
-      expect((sendCalls[0]?.message as { type: string }).type).toBe('hello_ack');
+      const queryAck = sendCalls[0]?.message as { type: string; daemonVersion?: unknown };
+      expect(queryAck.type).toBe('hello_ack');
+      // The query-mode/no-attach ack path also stamps the version (#539).
+      expect(queryAck.daemonVersion).toBe('9.9.9-test');
       expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
       expect(cancelOrphanCalls).toBe(0);
     });

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -94,6 +94,12 @@ describe('createResumeSessionHandlers', () => {
     const types = sendCalls.map((c) => c.message.type);
     expect(types).toContain('resume_session_response');
     expect(types).toContain('hello_ack');
+    // Documented contract (#539): resume acks OMIT daemonVersion — only
+    // connection-time and promotion acks carry it.
+    const resumeAck = sendCalls.find((c) => c.message.type === 'hello_ack')?.message as {
+      daemonVersion?: unknown;
+    };
+    expect('daemonVersion' in resumeAck).toBe(false);
     expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
   });
 

--- a/packages/daemon/tests/integration/hub-serve.test.ts
+++ b/packages/daemon/tests/integration/hub-serve.test.ts
@@ -70,6 +70,10 @@ describe('remi serve hub (integration, #542)', () => {
     const ack = received.find((m) => m.type === 'hello_ack');
     expect(ack).toBeDefined();
     expect((ack as { sessionId: unknown }).sessionId).toBeNull();
+    // The real subprocess stamps its binary version on the wire (#539).
+    const daemonVersion = (ack as { daemonVersion?: unknown }).daemonVersion;
+    expect(typeof daemonVersion).toBe('string');
+    expect((daemonVersion as string).length).toBeGreaterThan(0);
     expect(received.some((m) => m.type === 'error')).toBe(false);
 
     // Session list: empty sessions from a hub with no children.


### PR DESCRIPTION
## Summary

Follow-up to #743 from its (post-merge) test review: the drift feature's pure logic was well covered, but three of the four points where it reaches a wire message or CLI behavior had thin-to-zero assertions. Test-only change.

- `daemonVersion` now asserted on the attach-success and query-mode ack paths in connection-events tests (previously only session-less).
- `remi ls` flag threading (`remiVersion` -> `runMultiPortLs.installedVersion`) asserted through the existing call-recorder harness — dropping it would have silently disabled drift detection.
- The documented "resume acks omit daemonVersion" contract asserted.
- The hub integration test's REAL subprocess ack now asserts a non-empty `daemonVersion`.

Deliberately not covered (noted in the commit): the cli.ts promotion-callback ack (module scope; needs a two-client subprocess harness — the option-stamping it uses is covered at the factory level) and the `showDaemonStatus`/`runMultiPortLs` print bodies (they read real `~/.remi`/network; pre-existing untested pattern, their pure formatters are tested).

37 tests pass across the touched files; typecheck clean.