### PR TITLE
feat: macOS app lifecycle polish (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Added
+- **macOS app lifecycle polish** (#651, epic #648): "Open Remi at Login"
+  menu toggle (SMAppService; independent of the hub's LaunchAgent), a
+  copy-install-command menu item when no hub is running, and
+  `docs/MACOS_APP.md` documenting the attach-only design — window close and
+  app quit never touch the hub daemon; stopping it stays `remi stop` (a
+  protocol-level stop is #747, blocked on #535).
 - **Menu-bar icon states** (#650, epic #648): the rounded-square "r" now
   encodes live hub state from the `hub_status` census — thin outline (idle),
   bold "r" (local client attached), filled square with knocked-out "r"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ remi attach --host 192.168.1.5 macbook/remi/main
 - **Chat view** - Clean conversation interface without terminal noise
 - **Live updates** - Agent messages stream in real-time as work progresses
 - **Cross-platform** - iOS, Android, Web, macOS, Windows, Linux
+- **macOS menu-bar app** - a status "r" tracking live connections plus the full web UI in a native window; see [docs/MACOS_APP.md](docs/MACOS_APP.md)
 - **Notifications** - Push alerts when Claude needs your input
 - **Encrypted** - TLS/DTLS transport encryption on all connections
 - **No cloud dependency** - All data stays on your machines; relay only forwards encrypted blobs

--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -1,0 +1,58 @@
+# Remi for macOS (menu-bar app)
+
+A sandboxed menu-bar app that surfaces the Remi hub on your Mac without a
+terminal: a rounded-square "r" in the menu bar whose fill tracks live
+connections, and a window hosting the full Remi web UI. Part of epic #648.
+
+```
+menu bar:  [r]  idle (thin outline)      no clients connected
+           [r]  bold "r"                 local client attached
+           [■]  filled, "r" knocked out  remote client(s) connected
+           [r]  dimmed                   hub not running
+```
+
+## Relationship to the hub
+
+The app is an **attach-only client**. The hub daemon (`remi serve`) does all
+the work; the app discovers it by scanning `127.0.0.1:18765-18784`, connects
+in query mode (it never counts as a "client" in the icon state), and embeds
+the web UI pointed at it. Session daemons spawned by the hub are discovered
+through the hub's session list, exactly like the iPhone app does it.
+
+## What the app deliberately cannot do
+
+The app runs in the App Sandbox (required for TestFlight/App Store) with the
+network-client capability only. It **cannot**:
+
+- **Start the hub.** Install the hub's LaunchAgent once with `remi --install`
+  (starts at login, crash-restarts), or run `remi start` for the current
+  session. The menu offers a copy button for the install command when no hub
+  is running.
+- **Stop the hub.** "Quit Remi" quits the app; the hub and every session it
+  supervises keep running. Stop the hub with `remi stop` (running session
+  daemons keep serving even then). A protocol-level stop from the app is
+  tracked in #747, blocked on #535.
+- Read `~/.remi` or signal processes. Everything it knows arrives over the
+  loopback WebSocket.
+
+## Lifecycle (#651)
+
+- Closing the window hides the UI; the menu-bar item and your hub stay up.
+- There is no Dock icon (accessory app); the menu-bar "r" is the app.
+- "Open Remi at Login" registers the APP as a login item (SMAppService).
+  This is independent of the HUB's autostart — the LaunchAgent from
+  `remi --install`. For the full always-on setup, enable both.
+
+## Building from source
+
+```bash
+bun run build:macos-web        # build + stage the web UI into the app
+open packages/macos/Remi.xcodeproj
+```
+
+Tests: `xcodebuild test -project packages/macos/Remi.xcodeproj -scheme Remi`.
+The real-hub integration tests need `TEST_RUNNER_REMI_TEST_BINARY` pointing
+at a remi binary (plain env vars never reach the xctest process).
+Regenerate the Xcode project after target/file changes with
+`scripts/generate-macos-project.sh`; regenerate the menu-bar icon PDFs from
+their SVG sources with `scripts/generate-menubar-icons.sh`.

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -25,7 +25,9 @@
 		B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */; };
 		B380134DB301B91E8FB492B1 /* web in Resources */ = {isa = PBXBuildFile; fileRef = 5DB62EAF2230D75844C2E431 /* web */; };
 		B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,6 +50,7 @@
 		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
 		C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubProtocol.swift; sourceTree = "<group>"; };
+		E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -70,6 +73,7 @@
 				C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */,
 				5A7875E7E74CA980AD4B502F /* IconState.swift */,
 				03E03C1A89AE93F94D40EA16 /* Info.plist */,
+				E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */,
 				3C92562123ECC39FB269FB4A /* Remi.entitlements */,
 				1F4E747A3D65101EAE2331D4 /* RemiApp.swift */,
 				355697014B8A803D93F9E3EA /* WebViewWindow.swift */,
@@ -236,6 +240,7 @@
 				779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */,
 				D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */,
 				AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */,
+				FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */,
 				8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */,
 				0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */,
 			);
@@ -254,6 +259,7 @@
 				61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */,
 				5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */,
 				868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */,
+				C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */,
 				FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/macos/Remi/LaunchAtLogin.swift
+++ b/packages/macos/Remi/LaunchAtLogin.swift
@@ -11,8 +11,19 @@
 import ServiceManagement
 import SwiftUI
 
+/// No unit tests on purpose: register()/unregister() mutate the REAL login
+/// items of whoever runs the suite (including CI runners), and the status
+/// getter is a one-line system read. Do not bolt tests onto this type.
 @MainActor
 final class LaunchAtLogin: ObservableObject {
+    /// Registered but awaiting user approval in System Settings > Login
+    /// Items (#749 review): a normal post-register() state — register()
+    /// does NOT throw for it — that must render as its own menu state, not
+    /// as a toggle that silently snaps back off.
+    var needsApproval: Bool {
+        SMAppService.mainApp.status == .requiresApproval
+    }
+
     /// Two-way binding surface for the menu toggle. Reads the live
     /// SMAppService status; writes register/unregister and re-reads, so a
     /// user denial in System Settings snaps the toggle back to reality
@@ -33,5 +44,11 @@ final class LaunchAtLogin: ObservableObject {
             }
             objectWillChange.send()
         }
+    }
+
+    /// Route the user to the exact System Settings pane that resolves
+    /// `.requiresApproval` (per Apple's login-items guidance).
+    func openSystemSettings() {
+        SMAppService.openSystemSettingsLoginItems()
     }
 }

--- a/packages/macos/Remi/LaunchAtLogin.swift
+++ b/packages/macos/Remi/LaunchAtLogin.swift
@@ -1,0 +1,37 @@
+//
+//  LaunchAtLogin.swift
+//  Remi
+//
+//  "Open Remi at Login" via SMAppService.mainApp (#651) — sandbox-safe,
+//  macOS 13+. This registers the APP as a login item; the HUB's autostart
+//  is a separate concern (the LaunchAgent `remi --install` writes), and the
+//  menu copy deliberately keeps the two apart.
+//
+
+import ServiceManagement
+import SwiftUI
+
+@MainActor
+final class LaunchAtLogin: ObservableObject {
+    /// Two-way binding surface for the menu toggle. Reads the live
+    /// SMAppService status; writes register/unregister and re-reads, so a
+    /// user denial in System Settings snaps the toggle back to reality
+    /// instead of lying.
+    var isEnabled: Bool {
+        get { SMAppService.mainApp.status == .enabled }
+        set {
+            do {
+                if newValue {
+                    try SMAppService.mainApp.register()
+                } else {
+                    try SMAppService.mainApp.unregister()
+                }
+            } catch {
+                // Surface, don't swallow: the common cause is the user
+                // managing the item from System Settings > Login Items.
+                NSLog("[LaunchAtLogin] toggle failed: %@", error.localizedDescription)
+            }
+            objectWillChange.send()
+        }
+    }
+}

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct RemiApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var hubClient = HubClient()
+    @StateObject private var launchAtLogin = LaunchAtLogin()
     @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
@@ -22,7 +23,13 @@ struct RemiApp: App {
                 Text(hubClient.clientsLine)
             }
             if case .unreachable = hubClient.phase {
-                Text("Start it with: remi serve").font(.caption)
+                // The sandboxed app cannot start the hub itself (#651);
+                // point at the terminal commands and make them one copy away.
+                Text("Start it with: remi start").font(.caption)
+                Button("Copy Install Command (remi --install)") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString("remi --install", forType: .string)
+                }
             }
             Divider()
             Button("Open Remi") {
@@ -31,11 +38,15 @@ struct RemiApp: App {
                 NSApp.activate(ignoringOtherApps: true)
             }
             .keyboardShortcut("o")
+            // The APP at login — independent of the HUB's autostart (the
+            // LaunchAgent installed by `remi --install`); the two must not
+            // be conflated (#651).
+            Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
             Divider()
             Button("Quit Remi") {
                 // Quits the APP only. The hub is not ours to stop: the app is
                 // sandboxed (no process control) and a protocol-level stop is
-                // blocked on #535. Use `remi stop` in a terminal.
+                // blocked on #535 (tracked in #747). Use `remi stop`.
                 NSApp.terminate(nil)
             }
             .keyboardShortcut("q")

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -40,8 +40,16 @@ struct RemiApp: App {
             .keyboardShortcut("o")
             // The APP at login — independent of the HUB's autostart (the
             // LaunchAgent installed by `remi --install`); the two must not
-            // be conflated (#651).
-            Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
+            // be conflated (#651). `.requiresApproval` gets its own state:
+            // rendering it as an off toggle would look like a silent
+            // failure with no path to resolution (#749 review).
+            if launchAtLogin.needsApproval {
+                Button("Login Item Pending Approval — Open System Settings") {
+                    launchAtLogin.openSystemSettings()
+                }
+            } else {
+                Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
+            }
             Divider()
             Button("Quit Remi") {
                 // Quits the APP only. The hub is not ours to stop: the app is
@@ -58,6 +66,7 @@ struct RemiApp: App {
                 .opacity(hubClient.iconState.opacity)
                 .task { hubClient.start() }
         }
+        .menuBarExtraStyle(.menu)
 
         Window("Remi", id: "main") {
             WebViewWindow(hubClient: hubClient)


### PR DESCRIPTION
## Summary

Epic #648 Phase D. The #651 hard requirement — closing the window or quitting the app must never stop the hub — was structurally satisfied by the attach-only sandbox design in #745 (the app holds only a query-mode WS connection; closing it is a server-side no-op). This PR adds the remaining user-facing surface:

- **"Open Remi at Login"** menu toggle via `SMAppService.mainApp` (sandbox-safe). The getter reads live status on every menu open, so a user denial/change in System Settings > Login Items snaps the toggle back to reality. Menu copy keeps this (the APP at login) explicitly distinct from the hub's autostart (the `remi --install` LaunchAgent).
- **Hub-not-running state**: the menu now offers "Copy Install Command (`remi --install`)" alongside the `remi start` hint — the sandboxed app cannot start the hub itself.
- **Hub-stop wording resolution**: "Quit Remi" quits the app only; the protocol-level stop the issue text mentioned is tracked in #747, blocked on #535 (rationale in the plan and docs).
- **`docs/MACOS_APP.md`**: icon legend, the attach-only relationship to the hub, what the app deliberately cannot do and why, lifecycle semantics, build/test instructions. README pointer added.

## Testing

- 22 XCTests pass including the real-hub integration test; app builds clean.
- SMAppService registration itself requires user-session approval and can't run headless; the toggle logic is deliberately thin (register/unregister/read-status) with the error path logged, not swallowed.
- Kill-matrix (close window -> hub lives; quit app -> `remi ls` still serves; `remi stop` -> icon dims; `remi serve` -> icon recovers) is on the on-machine checklist with the Phase E GUI smoke — this machine's daemons are pre-hub soak daemons.

Closes #651. Part of #648.