### PR TITLE
Park subagent escalations for PTY arbitration

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -98,6 +98,15 @@ export class QuestionPresenceTracker {
    *  candidate; with 2+ different-agent entries it pushes bare (no guessing). */
   private pending = new Map<string, Question>();
 
+  /** Keys of `pending` records PARKED by the gate awaiting PTY arbitration
+   *  (#751): a subagent-tagged escalation the gate answered 'passthrough'
+   *  instead of holding or denying. Unlike a normal pending record (an
+   *  in-flight gate escalation whose own push is imminent), a parked record
+   *  must NOT count as gate-owned in the #712 orphan check — the PTY render
+   *  IS its push trigger. Always a subset of `pending`'s keys; every
+   *  `pending` delete/clear site mirrors onto this set. */
+  private awaitingPTY = new Set<string>();
+
   /** True while a permission prompt is on the main PTY. Set by
    *  `onPTYPromptVisible`; reset by `onStatusChange` out of `'waiting'`
    *  AND by `clearPending` (the auto-approve cancelled branch confirms
@@ -189,6 +198,29 @@ export class QuestionPresenceTracker {
     // PTY-pairing fallback below).
     this.pending.delete(key);
     this.pending.set(key, question);
+    // A normal (gate-owned) record replaces any parked one for this agent;
+    // parkAwaitingPTY re-adds the flag after routing through here (#751).
+    this.awaitingPTY.delete(key);
+  }
+
+  /**
+   * Park a subagent-tagged permission question awaiting PTY arbitration
+   * (#751). The gate answered the hook 'passthrough' (no hold, no deny, no
+   * push): Claude runs its normal permission flow, so either the session
+   * allowlist absorbs the request silently (the record then expires on the
+   * next status transition, like any pending record) or the native prompt
+   * renders on the main PTY — `onOrphanPTYPrompt` recognizes the parked
+   * record, merges its rich labels onto the parsed prompt, and pushes
+   * immediately (no orphan debounce: hook + render is positive
+   * double-confirmation). The PTY is the arbiter of whether the user is
+   * asked.
+   */
+  parkAwaitingPTY(question: Question): void {
+    this.recordPendingHook(question);
+    // recordPendingHook may have kept a richer existing record instead of
+    // this one; the parked flag applies to whatever record now owns the key
+    // (both are hook-derived for the same agent's prompt cycle).
+    this.awaitingPTY.add(agentKey(question));
   }
 
   /**
@@ -231,6 +263,7 @@ export class QuestionPresenceTracker {
     // Consume BEFORE the push so a re-entrant call cannot re-push the same
     // record, and so a later onPTYPromptVisible has no record to merge.
     this.pending.delete(recordKey);
+    this.awaitingPTY.delete(recordKey);
     this.pushedHeldIds.add(questionId);
     try {
       // held: bypass the cosmetic dedup + deliver regardless of an attached
@@ -305,10 +338,12 @@ export class QuestionPresenceTracker {
       // can't stale-merge onto a later unrelated prompt (recordKey stays
       // undefined here, so the delete below would otherwise skip them).
       this.pending.clear();
+      this.awaitingPTY.clear();
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {
       this.pending.delete(recordKey);
+      this.awaitingPTY.delete(recordKey);
     }
 
     // #718: a fallback hook record must not overwrite the PTY's own options
@@ -390,6 +425,16 @@ export class QuestionPresenceTracker {
       this.bufferedDuringEval = ptyQuestion;
       return;
     }
+    // #751 PTY-arbiter: a parked subagent escalation whose prompt has now
+    // rendered. Merge + push IMMEDIATELY through the normal pair path — no
+    // orphan debounce (hook + render is positive double-confirmation) and no
+    // gate-owned / live-question suppression (an unrelated live card must not
+    // eat the one prompt class this parking exists to surface).
+    const parkedKey = this.matchAwaitingPTYKey(ptyQuestion);
+    if (parkedKey !== undefined) {
+      this.onPTYPromptVisible(ptyQuestion);
+      return;
+    }
     if (this.isGateOwnedCycle(ptyQuestion)) {
       console.debug(
         `[QuestionPresenceTracker] Orphan PTY prompt suppressed (gate owns this cycle): "${ptyQuestion.text.slice(0, 60)}"`,
@@ -412,7 +457,10 @@ export class QuestionPresenceTracker {
    *  as "no live questions" (fail-open: a possibly-redundant push is far
    *  better than crashing the daemon or silently swallowing a real orphan). */
   private isGateOwnedCycle(ptyQuestion: Question): boolean {
-    if (this.pending.has(agentKey(ptyQuestion))) return true;
+    // A parked record (#751) never claims ownership: its push TRIGGER is the
+    // PTY render this check would otherwise suppress.
+    const key = agentKey(ptyQuestion);
+    if (this.pending.has(key) && !this.awaitingPTY.has(key)) return true;
     try {
       return this.deps.hasLiveQuestions?.() ?? false;
     } catch (err) {
@@ -472,6 +520,7 @@ export class QuestionPresenceTracker {
   onStatusChange(status: AgentStatus): void {
     if (status !== 'waiting') {
       this.pending.clear();
+      this.awaitingPTY.clear();
       this.ptyShowingQuestion = false;
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
@@ -534,6 +583,7 @@ export class QuestionPresenceTracker {
    */
   clearPending(): void {
     this.pending.clear();
+    this.awaitingPTY.clear();
     this.ptyShowingQuestion = false;
     this.autoApproveInFlight = false;
     this.bufferedDuringEval = null;
@@ -541,6 +591,22 @@ export class QuestionPresenceTracker {
     // #712: the prompt was answered in-terminal or the session is rotating —
     // either way an armed orphan timer for it must not fire a stale push.
     this.cancelOrphanTimer();
+  }
+
+  /** Match a rendered PTY prompt to a PARKED (#751 awaiting-PTY) record: an
+   *  exact agent-key match, or the sole-candidate fallback (exactly one
+   *  pending record and it is parked — PTY prompts rarely name their agent,
+   *  mirroring `onPTYPromptVisible`'s own pairing heuristic). With 2+ pending
+   *  records and no exact match, no guess is made here; the prompt falls to
+   *  the normal owned/orphan logic. */
+  private matchAwaitingPTYKey(ptyQuestion: Question): string | undefined {
+    const key = agentKey(ptyQuestion);
+    if (this.awaitingPTY.has(key) && this.pending.has(key)) return key;
+    if (this.pending.size === 1) {
+      const sole = [...this.pending.keys()][0] as string;
+      if (this.awaitingPTY.has(sole)) return sole;
+    }
+    return undefined;
   }
 
   /** Cancel any armed orphan-prompt debounce timer and discard its candidate. */
@@ -575,6 +641,11 @@ export class QuestionPresenceTracker {
   /** Test-only: number of distinct agents with a pending hook record. */
   pendingCountForTest(): number {
     return this.pending.size;
+  }
+
+  /** Test-only: number of pending records parked awaiting PTY arbitration (#751). */
+  awaitingPTYCountForTest(): number {
+    return this.awaitingPTY.size;
   }
 
   /** Test-only: whether an orphan-prompt debounce timer is currently armed. */

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -174,11 +174,21 @@ export interface AutoApproveGateDeps {
    * PermissionRequest (`agent_id` absent) observes `isInSubagentContext()`
    * stuck true — proof of a tracker leak (a dropped PostToolUse(Task/Agent)
    * completion), never a real subagent prompt (those carry `agent_id` and
-   * default-deny instead). Optional so tests that don't wire it degrade to a
-   * no-op; the escalate-as-main recovery still happens without it, just
-   * without clearing the leaked state.
+   * park for PTY arbitration instead, #751). Optional so tests that don't
+   * wire it degrade to a no-op; the escalate-as-main recovery still happens
+   * without it, just without clearing the leaked state.
    */
   resetSubagentContext?: () => void;
+  /**
+   * Park a subagent-tagged escalation for PTY arbitration (#751): stash its
+   * rich question in the `QuestionPresenceTracker` (via
+   * `parkAwaitingPTY(hookBridge.buildPermissionQuestion(input))`) WITHOUT
+   * pushing or registering it. The gate answers the hook 'passthrough'; the
+   * question only surfaces if Claude's native prompt actually renders on the
+   * PTY. Optional so tests that don't wire it degrade to a plain passthrough
+   * (the rendered prompt then pushes bare via the #712 orphan path).
+   */
+  parkForPTY?: (input: PermissionRequestHookInput) => void;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -880,11 +890,19 @@ export class AutoApproveGate {
    *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
    *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
    *     prompt; the user answers).
-   *   - escalate / no-service / eval-error in a SUBAGENT-TAGGED context
-   *     (`agent_id` present) -> 'deny' via the hook response. This is the core
-   *     fix: the old PTY-inject default-deny couldn't tell whose prompt was on
-   *     the PTY for parallel subagents and leaked; the synchronous deny needs
-   *     no PTY at all.
+   *   - escalate / no-service / eval-error / pick on a SUBAGENT-TAGGED event
+   *     (`agent_id` present) -> park the rich question in the presence
+   *     tracker + 'passthrough' (#751 PTY-arbiter), REGARDLESS of
+   *     `isInSubagentContext()` (the tracker only brackets synchronous
+   *     Task/Agent spawns, so team members and async/background subagents
+   *     always observe it false — the tag on the event itself is the truth).
+   *     Claude then runs its NORMAL permission flow: the session allowlist
+   *     may absorb the request silently, or the native prompt renders on the
+   *     main PTY and the tracker merges the parked labels onto it and pushes
+   *     (answers inject; nothing is held). Replaces both prior behaviors:
+   *     silent default-deny (sync-Task shape, broke teammates with no trace)
+   *     and hold+push-as-main (async/team shape, pushed cards for prompts
+   *     the user never saw asked).
    *   - the SAME three branches with `isInSubagentContext()` true but NO
    *     `agent_id` on the input -> this is the #710 tracker-leak signature
    *     (a PostToolUse(Task/Agent) completion tagged with the spawned agent's
@@ -909,29 +927,28 @@ export class AutoApproveGate {
       );
     }
 
-    // No auto-approve: subagent default-denies via the response (no PTY, no
-    // leak); main escalates to the user (holding the hook when binary, #573).
+    // No auto-approve: main escalates to the user (holding the hook when
+    // binary, #573); a subagent-tagged event parks for PTY arbitration (#751).
     if (!service) {
+      if (isSubagent) {
+        log(
+          `[AutoApprove ${this.sessionTag}] Subagent PermissionRequest without auto-approve; parking for PTY arbitration`,
+        );
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
       if (isInSubagentContext()) {
-        if (this.isSubagentEvent(input)) {
-          log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
-          return 'deny';
-        }
-        // #710: a MAIN-tagged event (no agent_id) reaching here means the
-        // tracker leaked, not a real subagent prompt. Reset and fall through
-        // to escalateMain below instead of denying the main agent.
+        // #710: a MAIN-tagged event (no agent_id) with the tracker stuck true
+        // means the tracker leaked, not a real subagent prompt. Reset it so
+        // the leak cannot linger (a genuine sync-Task bracket pops on its own
+        // PostToolUse; only a leak survives to be observed here).
         //
         // #716 (blanket-reset tradeoff): resetSubagentContext() clears ALL
         // tracked use_ids, not just the leaked one -- it cannot tell which
-        // entry is stale. If a genuinely-running concurrent synchronous Task
-        // is ALSO open right now, its own later agent_id-tagged permission
-        // requests will see isInSubagentContext() false and escalate as main
-        // instead of default-denying. Accepted: (a) that escalation is
-        // held/answerable (Model B), the same way async/background subagents
-        // and team members already behave; (b) the alternative -- silently
-        // denying the MAIN agent -- is the #710 bug this reset exists to fix.
+        // entry is stale. Post-#751 that is harmless for routing: subagent
+        // routing keys on the event's own agent_id, never on the tracker.
         logError(
-          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker. Possible subagent-context tracker leak.`,
         );
         this.deps.resetSubagentContext?.();
       }
@@ -987,12 +1004,14 @@ export class AutoApproveGate {
       result = await evalPromise;
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
+      // #751: a subagent-tagged event the eval could not decide parks for
+      // PTY arbitration (keys on the event's own agent_id alone; the
+      // tracker is sync-Task-only -- see resolvePermission's doc).
+      if (isSubagent) {
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
       if (isInSubagentContext()) {
-        if (isSubagent) {
-          // #711: a genuine subagent deny must not flap the client pill.
-          this.markHandled(true);
-          return 'deny';
-        }
         // #710: MAIN-tagged + stuck tracker == leak, not a real subagent
         // prompt. Reset and fall through to escalateMain below. Blanket-reset
         // tradeoff (clears ALL tracked use_ids, not just the leaked one):
@@ -1023,10 +1042,21 @@ export class AutoApproveGate {
     }
     if (result.decision === 'pick') {
       // Multi-choice pick (#399): the response can't express it, so render the
-      // prompt (passthrough) and inject the 1-based index into the PTY. The
-      // index was validated against options length upstream. The discriminated
-      // union guarantees pickIndex, but guard defensively: a malformed result
-      // must escalate, not silently fall through to the subagent-deny below.
+      // prompt (passthrough) and inject the 1-based index into the PTY.
+      //
+      // #751: a subagent's prompt is never on the main PTY at decision time
+      // (the hook is blocked on this very response), so the inject below
+      // would either be dropped or -- worse, when an unrelated MAIN prompt is
+      // visible -- type into the wrong prompt. Park for PTY arbitration
+      // instead: the pick verdict is forfeited and the user answers the
+      // rendered prompt (terminal or merged push card).
+      if (isSubagent) {
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
+      // The index was validated against options length upstream. The
+      // discriminated union guarantees pickIndex, but guard defensively: a
+      // malformed result must escalate, not silently fall through.
       if (result.pickIndex === undefined) {
         logError(`[AutoApprove ${this.sessionTag}] pick result missing pickIndex; escalating`);
         return this.escalatePassthrough(input);
@@ -1039,27 +1069,30 @@ export class AutoApproveGate {
       }
       return this.escalatePassthrough(input);
     }
-    // escalate: a subagent prompt the user cannot answer is default-denied via
-    // the response (no hang, no PTY). A MAIN-tagged event (agent_id absent)
-    // reaching here with isInSubagentContext() true is NOT a real subagent
-    // prompt: it is the #710 tracker-leak signature (a PostToolUse(Task/Agent)
-    // completion stamped with the SPAWNED agent's own agent_id never popped
-    // the use_id an earlier untagged PreToolUse tracked). Denying it would
-    // silently drop the main agent's own prompts (including AskUserQuestion)
-    // forever, so reset the tracker and fall through to escalate as main
-    // instead. Tradeoff (#710): on a legacy Claude Code version that predates
-    // agent_id, a genuine synchronous subagent prompt would now escalate+hold
-    // instead of deny — still answerable via the Model B hook response
-    // (below), strictly better than a silent main-agent deny.
+    // escalate on a subagent-tagged event: park for PTY arbitration (#751).
+    // Keys on the event's own agent_id alone -- the SubagentContextTracker
+    // only brackets SYNCHRONOUS Task/Agent spawns, so team members and
+    // async/background subagents always observe isInSubagentContext() false;
+    // the old AND-gate escalated their prompts to the phone as if they were
+    // the main agent's, while the sync-Task shape silently default-denied.
+    // The second opinion below is skipped deliberately: the hook answer is
+    // 'passthrough' either way, so a heavier model buys nothing here.
+    if (isSubagent) {
+      log(
+        `[AutoApprove ${this.sessionTag}] Subagent escalate; parking for PTY arbitration (agent=${input.agent_id?.slice(0, 8)})`,
+      );
+      this.parkSubagentForPTY(input);
+      return 'passthrough';
+    }
+    // A MAIN-tagged event (agent_id absent) with isInSubagentContext() true is
+    // NOT a real subagent prompt: it is the #710 tracker-leak signature (a
+    // PostToolUse(Task/Agent) completion stamped with the SPAWNED agent's own
+    // agent_id never popped the use_id an earlier untagged PreToolUse tracked).
+    // Denying it would silently drop the main agent's own prompts (including
+    // AskUserQuestion) forever, so reset the tracker and fall through to
+    // escalate as main instead. Blanket-reset tradeoff (clears ALL tracked
+    // use_ids, not just the leaked one): see the no-service branch above (#716).
     if (isInSubagentContext()) {
-      if (isSubagent) {
-        log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
-        // #711: a genuine subagent deny must not flap the client pill.
-        this.markHandled(true);
-        return 'deny';
-      }
-      // Blanket-reset tradeoff (clears ALL tracked use_ids, not just the
-      // leaked one): see the no-service branch above (#716).
       logError(
         `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, escalate path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
       );
@@ -1159,10 +1192,17 @@ export class AutoApproveGate {
     const pushHoldMs = this.deps.pushHoldMs ?? 0;
     // Disabled, or this escalation could not be answered via the hook response
     // anyway (multi-choice/design), or a subagent prompt the user can't answer:
-    // do not arm the race. Subagent context is read live (it may close before
-    // the verdict), but arming an early USER push for a subagent prompt would be
-    // wrong, so gate on the current value here.
-    if (pushHoldMs <= 0 || !this.isBinaryEscalation(input) || this.deps.isInSubagentContext()) {
+    // do not arm the race. #751: the subagent check keys on the event's own
+    // agent_id (the tracker misses async/team spawns); the tracker is ALSO
+    // consulted live (it may close before the verdict) to cover legacy events
+    // without agent_id, since arming an early USER push for a subagent prompt
+    // would be wrong either way.
+    if (
+      pushHoldMs <= 0 ||
+      !this.isBinaryEscalation(input) ||
+      this.isSubagentEvent(input) ||
+      this.deps.isInSubagentContext()
+    ) {
       return null;
     }
 
@@ -1300,6 +1340,35 @@ export class AutoApproveGate {
   private markHandled(isSubagent: boolean): void {
     this.deps.tracker.onAutoApproveHandled();
     this.safeCueWithArg('onHandled', this.deps.onHandled, { isSubagent });
+  }
+
+  /**
+   * #751 PTY-arbiter routing for a subagent-tagged permission the gate cannot
+   * decide (escalate verdict, eval error, forfeited pick, or no auto-approve):
+   * park the rich question in the presence tracker, then close the #484
+   * buffer window via the onEscalate cue (semantically this IS an escalation,
+   * just PTY-mediated; the terminal statusline reads 'escalated'). The caller
+   * answers the hook 'passthrough': Claude runs its normal permission flow,
+   * so the session allowlist may absorb the request silently, or the native
+   * prompt renders on the main PTY and the tracker pairs the parked record
+   * with it and pushes the merged card (answers inject; nothing is held).
+   * Park FIRST, cue SECOND — the cue may release a buffered PTY prompt whose
+   * pair+push must be able to find the record (mirrors escalateToUser).
+   *
+   * A parkForPTY throw is absorbed: the passthrough still stands, and the
+   * rendered prompt degrades to a bare #712 orphan push instead of a merged
+   * one.
+   */
+  private parkSubagentForPTY(input: PermissionRequestHookInput): void {
+    try {
+      this.deps.parkForPTY?.(input);
+    } catch (err) {
+      logError(
+        `[AutoApprove ${this.sessionTag}] parkForPTY threw (prompt will fall to the orphan push path):`,
+        err,
+      );
+    }
+    this.safeCue('onEscalate', this.deps.onEscalate);
   }
 
   /**

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -382,6 +382,11 @@ export function setupHookBridge(
       // the hook keyed by it (#573). The bridge still does the onQuestion +
       // status side effects exactly as before.
       escalate: (i, summary) => hookBridge.handlePermissionRequest(i, summary),
+      // #751 PTY-arbiter: a subagent-tagged escalation the gate cannot decide
+      // parks its rich question (same builder as a real escalation, minus the
+      // push/registration side effects) and answers 'passthrough'; the tracker
+      // pushes it only if Claude's native prompt actually renders on the PTY.
+      parkForPTY: (i) => tracker.parkAwaitingPTY(hookBridge.buildPermissionQuestion(i)),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -411,6 +411,20 @@ export class HookEventBridge {
     // prompt that does not render on the user's PTY does not push, and
     // one that does is genuinely answerable. The tracker handles both
     // cases; this method now only builds the question payload.
+    const question = this.buildPermissionQuestion(input, summary);
+    this.events.onQuestion(question);
+    this.events.onStatusChange('waiting');
+    return question.id;
+  }
+
+  /**
+   * Build the rich Question payload for a PermissionRequest WITHOUT firing the
+   * onQuestion/onStatusChange side effects. Used by `handlePermissionRequest`
+   * (escalation: push + register) and by the gate's #751 PTY-arbiter parking
+   * (`QuestionPresenceTracker.parkAwaitingPTY`), where the question must only
+   * surface if Claude's native prompt actually renders on the PTY.
+   */
+  buildPermissionQuestion(input: PermissionRequestHookInput, summary?: string): Question {
     const toolName = input.tool_name || 'unknown tool';
 
     // Question-bearing tools (AskUserQuestion, ExitPlanMode) carry the real
@@ -443,9 +457,8 @@ export class HookEventBridge {
       optionsAreFallback = built.isFallback;
     }
 
-    const questionId = generateId();
-    this.events.onQuestion({
-      id: questionId,
+    return {
+      id: generateId(),
       text: promptText,
       options,
       allowsFreeText: false,
@@ -471,9 +484,7 @@ export class HookEventBridge {
       // (e.g. "Force-push to main?"). AskUserQuestion carries authored content, so a
       // summary is only threaded for non-AUQ permission escalations.
       ...(summary ? { summary } : {}),
-    });
-    this.events.onStatusChange('waiting');
-    return questionId;
+    };
   }
 
   handlePostToolUseFailure(input: PostToolUseFailureHookInput): void {

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -865,4 +865,102 @@ describe('QuestionPresenceTracker', () => {
       expect(pushes.length).toBe(1);
     });
   });
+
+  describe('awaiting-PTY parking (#751)', () => {
+    const DEBOUNCE_MS = 20;
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    it('a parked record + rendered prompt pushes IMMEDIATELY, merged, no debounce', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('reviewer · Bash: git push'));
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+
+      // Hook + render is positive double-confirmation: no orphan debounce.
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('reviewer · Bash: git push'); // merged rich label
+      expect(tracker.hasPendingForTest()).toBe(false); // record consumed
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+    });
+
+    it('an unrelated LIVE question does not suppress a parked prompt (bypasses gate-owned check)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => true, // e.g. a held main card is open
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Edit: config.toml'),
+        agentId: 'agent-1',
+      });
+
+      // The PTY prompt does not name the agent: sole-candidate pairing applies.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to make this edit?'));
+
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('agent · Edit: config.toml');
+    });
+
+    it("status leaving 'waiting' expires a parked record (allowlist absorbed the request)", async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
+
+      tracker.onStatusChange('executing'); // Claude proceeded; prompt never rendered
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+
+      // A later prompt is a plain orphan again: debounced, pushed bare.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('unrelated later prompt'));
+      expect(pushes.length).toBe(0);
+      await wait(DEBOUNCE_MS * 2);
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('unrelated later prompt');
+    });
+
+    it('a NORMAL pending record for the prompt agent still suppresses (echo protection intact)', async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      // A normal gate escalation is mid-flight for main; a parked record
+      // exists for a different agent. The unnamed PTY prompt matches main's
+      // normal record -> gate-owned -> suppressed (not stolen by the parked one).
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Write: notes.md'),
+        agentId: 'agent-1',
+      });
+
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      await wait(DEBOUNCE_MS * 2);
+
+      expect(pushes.length).toBe(0);
+    });
+
+    it('a normal recordPendingHook for the same agent clears the parked flag', async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
+      // A real gate escalation for the same agent takes over the prompt cycle.
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: ls'));
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+
+      // Its render echo is suppressed like any gate-owned cycle.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      await wait(DEBOUNCE_MS * 2);
+      expect(pushes.length).toBe(0);
+    });
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -71,6 +71,9 @@ describe('AutoApproveGate', () => {
   // resets the leaked tracker ONLY for a MAIN-tagged event, never for a
   // genuine subagent-tagged one.
   let resets: number;
+  // #751: records parkForPTY() calls (subagent escalations parked for PTY
+  // arbitration instead of held/denied).
+  let parks: PermissionRequestHookInput[];
 
   function evaluator(
     result: AutoApproveResult,
@@ -108,6 +111,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
+        parkForPTY: (i) => {
+          parks.push(i);
+        },
       },
       SID,
     );
@@ -139,6 +145,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
+        parkForPTY: (i) => {
+          parks.push(i);
+        },
         escalateModel: 'big-model',
       },
       SID,
@@ -165,6 +174,7 @@ describe('AutoApproveGate', () => {
     cancels = [];
     subagent = false;
     resets = 0;
+    parks = [];
     tracker = new QuestionPresenceTracker(() => {});
     configureLogger({ writeLog: () => {} });
   });
@@ -248,15 +258,18 @@ describe('AutoApproveGate', () => {
     expect(onEscalateCalls).toBe(1);
   });
 
-  test('escalate in subagent context default-denies via the response, no inject (#496)', async () => {
+  test('#751: subagent-tagged escalate parks for PTY arbitration (sync-Task shape, tracker true)', async () => {
     subagent = true;
-    // #710: default-deny requires a genuinely subagent-TAGGED event
-    // (agent_id present), not just isInSubagentContext() true — otherwise a
-    // leaked tracker would deny the main agent forever.
+    // A subagent-tagged escalate no longer denies (silent teammate breakage)
+    // nor holds/pushes (cards for prompts the user never saw): it parks the
+    // rich question and answers 'passthrough', so Claude's normal permission
+    // flow decides whether the prompt renders — the PTY is the arbiter.
     const d = await gateWith(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }));
-    expect(d).toBe('deny');
-    expect(submits).toHaveLength(0); // the core fix: deny without touching the PTY
-    expect(escalations).toHaveLength(0);
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0); // nothing injected
+    expect(escalations).toHaveLength(0); // no immediate push
+    expect(parks).toHaveLength(1); // parked awaiting PTY render
+    expect(parks[0]?.agent_id).toBe('agent-1');
     expect(resets).toBe(0); // a real subagent event never resets the tracker
   });
 
@@ -354,25 +367,25 @@ describe('AutoApproveGate', () => {
     expect(escalations).toHaveLength(1);
   });
 
-  test('eval rejection in subagent context default-denies via the response', async () => {
+  test('#751: eval rejection on a subagent-tagged event parks + passthrough', async () => {
     subagent = true;
-    // #710: requires agent_id (a real subagent-tagged event); see the
-    // escalate-branch test above for the rationale.
     const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(
       pr({ agent_id: 'agent-1' }),
     );
-    expect(d).toBe('deny');
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
     expect(resets).toBe(0);
   });
 
-  test('no service + subagent: default-deny via the response', async () => {
+  test('#751: no service + subagent-tagged event parks + passthrough', async () => {
     subagent = true;
     const d = await gateWith(null).resolvePermission(pr({ agent_id: 'agent-1' }));
-    expect(d).toBe('deny');
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
     expect(resets).toBe(0);
   });
 
@@ -417,13 +430,88 @@ describe('AutoApproveGate', () => {
     expect(tracker.hasPendingForTest()).toBe(false); // pending cleared
   });
 
-  test('escalate_model is NOT consulted in a subagent context (denies via response) (#522)', async () => {
+  test('escalate_model is NOT consulted for a subagent-tagged event (parks instead) (#522/#751)', async () => {
     subagent = true;
-    // #710: a real subagent-tagged event (agent_id present).
     const d = await gateWithSecondOpinion(approve).resolvePermission(pr({ agent_id: 'agent-1' }));
-    // Subagent escalate denies directly; the second opinion (which would allow)
-    // must not run, since the user could not answer a subagent prompt anyway.
-    expect(d).toBe('deny');
+    // Subagent escalate parks + passthrough; the second opinion (which would
+    // allow) must not run — the hook answer is passthrough either way.
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+  });
+
+  // #751 regression: routing keys on the event's own agent_id ALONE. The
+  // SubagentContextTracker only brackets SYNCHRONOUS Task/Agent spawns, so
+  // team members and async/background subagents always observe
+  // isInSubagentContext() false (the production shape of the 2026-07-08
+  // soak). AND-gating on the tracker escalated their prompts to the phone
+  // as if they were the main agent's (hold + push).
+  test('#751: subagent-tagged escalate with tracker FALSE parks + passthrough (team/async shape)', async () => {
+    subagent = false; // async/team spawn: the tracker never bracketed it
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0); // never pushed as a main-agent card
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0); // no leak: nothing to reset
+  });
+
+  test('#751: subagent-tagged eval-error with tracker FALSE parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(
+      pr({ agent_id: 'agent-1' }),
+    );
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0);
+  });
+
+  test('#751: subagent-tagged no-service with tracker FALSE parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(null).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0);
+  });
+
+  test('#751: subagent-tagged pick forfeits the inject and parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(evaluator(pick(2))).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0); // never types into the main PTY
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+  });
+
+  test('#751: a parkForPTY throw is absorbed; the passthrough still stands', async () => {
+    subagent = false;
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const g = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: () => {
+          throw new Error('test: tracker down');
+        },
+      },
+      SID,
+    );
+    const d = await g.resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
     expect(escalations).toHaveLength(0);
   });
 
@@ -532,15 +620,16 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     expect(events).toEqual(['start', 'escalate']);
   });
 
-  test('subagent escalate->deny still fires handled (buffer + cue close), no inject', async () => {
+  test('#751: subagent escalate parks -> fires start then escalate (buffer closes), no inject', async () => {
     subagent = true;
-    // #710: default-deny requires a real subagent-tagged event (agent_id set).
     expect(await gate(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }))).toBe(
-      'deny',
+      'passthrough',
     );
-    // Subagent escalate default-denies via the RESPONSE (no inject) -> markHandled.
+    // Parking is semantically an escalation (PTY-mediated): the onEscalate cue
+    // must close the #484 buffer window opened by onEvalStart, or every later
+    // prompt in the session would buffer forever.
     expect(submits).toHaveLength(0);
-    expect(events).toEqual(['start', 'handled']);
+    expect(events).toEqual(['start', 'escalate']);
   });
 
   test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {
@@ -1069,23 +1158,16 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
     await registry.shutdown();
   });
 
-  test('(a) a SUBAGENT-tagged hold survives cancelStale(Stop, mainOnly) and stays resolvable', async () => {
+  test('(a) #751: a SUBAGENT-tagged escalate never holds -- parks + passthrough immediately', async () => {
+    // Pre-#751 this shape (agent_id present, tracker false) created a held
+    // teammate card that (#711) had to survive a mainOnly Stop. Post-#751 no
+    // subagent hold exists at all: the question parks for PTY arbitration and
+    // the hook resolves passthrough at once, so there is nothing for Stop to
+    // spare or for the user to answer until the prompt renders.
     const g = gate(evaluator(escalate));
-    const pending = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qid = lastQuestionId as UUID;
-
-    g.cancelStale('Stop', { mainOnly: true });
-
-    let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
-    await new Promise((r) => setTimeout(r, 10));
-    expect(settled).toBe(false); // still held -- mainOnly spared it
-
-    expect(g.resolveHeld(qid, 'allow')).toBe(true);
-    expect(await pending).toBe('allow');
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
+    expect(lastQuestionId).toBeUndefined(); // no escalate() call, no card
+    g.cancelStale('Stop', { mainOnly: true }); // nothing to release; must not throw
   });
 
   test('(b) a MAIN hold IS released on cancelStale(Stop, mainOnly), with notifyResolved(cancelled)', async () => {
@@ -1104,38 +1186,32 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
     expect(g.resolveHeld(qid, 'allow')).toBe(false); // the hold is gone
   });
 
-  test('(c) SessionEnd (cancelStale with no opts) releases BOTH main and subagent holds', async () => {
+  test('(c) SessionEnd (cancelStale with no opts) releases a main hold; a concurrent subagent event parked (#751)', async () => {
     const g = gate(evaluator(escalate));
     const pendingMain = g.resolvePermission(pr());
     await new Promise((r) => setTimeout(r, 20));
     const qidMain = lastQuestionId as UUID;
-    const pendingSub = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qidSub = lastQuestionId as UUID;
+    // #751: the subagent event resolves passthrough immediately (parked), so
+    // teardown only ever has the main hold to release.
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
 
     g.cancelStale('SessionEnd');
 
     expect(await pendingMain).toBe('passthrough');
-    expect(await pendingSub).toBe('passthrough');
     expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
-    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
   });
 
-  test('(e) forceRelease still releases BOTH main and subagent holds', async () => {
+  test('(e) forceRelease still releases a main hold; a concurrent subagent event parked (#751)', async () => {
     const g = gate(evaluator(escalate));
     const pendingMain = g.resolvePermission(pr());
     await new Promise((r) => setTimeout(r, 20));
     const qidMain = lastQuestionId as UUID;
-    const pendingSub = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qidSub = lastQuestionId as UUID;
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
 
     g.forceRelease('remi unstick');
 
     expect(await pendingMain).toBe('passthrough');
-    expect(await pendingSub).toBe('passthrough');
     expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
-    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
   });
 
   test('cancelStale(Stop, mainOnly) cancels only the in-flight MAIN eval; a concurrent SUBAGENT eval keeps running and its late verdict still reconciles', async () => {
@@ -1377,6 +1453,22 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
     expect(escalations).toHaveLength(1);
     g.resolveHeld(lastQuestionId as UUID, 'allow');
     expect(await pending).toBe('allow');
+  });
+
+  test('#751: a subagent-tagged slow eval never arms the early push (tracker FALSE)', async () => {
+    // The gate() harness pins isInSubagentContext() false, which is exactly
+    // the async/team-spawn shape: the tag on the event itself must veto the
+    // early USER push+hold, and the late escalate verdict then parks.
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission({ ...pr(), agent_id: 'agent-1' });
+
+    await new Promise((r) => setTimeout(r, 40)); // past the push-hold timer
+    expect(escalations).toHaveLength(0); // no early push for a subagent prompt
+
+    release(escalate);
+    expect(await pending).toBe('passthrough'); // #751 parks + passthrough, still no push
+    expect(escalations).toHaveLength(0);
   });
 });
 
@@ -1840,36 +1932,24 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
 
-  // #711 review follow-up: onDeliveryUnconfirmed's short-window RE-ARM rebuilds
-  // the PendingHold entry (new timer, same resolve) -- prove that rebuild
-  // preserves `isSubagent`, not just the initial `createHold` tagging.
-  test('#711 a SUBAGENT hold re-armed via onDeliveryUnconfirmed keeps isSubagent tagged (survives mainOnly Stop)', async () => {
+  // #751: a subagent-tagged escalation never enters the hold/delivery-gating
+  // machinery at all -- it parks for PTY arbitration and resolves passthrough
+  // before any delivery probe or hold timer can arm. (Pre-#751 this shape
+  // created a re-armable subagent hold whose isSubagent tag had to survive
+  // the onDeliveryUnconfirmed rebuild.)
+  test('#751 a SUBAGENT-tagged escalation bypasses delivery gating entirely (parks, no hold)', async () => {
     const gate = deliveryGate({
       delivery: Promise.resolve('failed'),
       deliveryConfirmMs: 20,
-      holdUnconfirmedMs: 500, // long enough to land cancelStale inside the re-armed window
+      holdUnconfirmedMs: 500,
       holdMs: 60_000,
     });
     const pending = gate.resolvePermission(
       pr({ agent_id: 'teammate-1', agent_type: 'general-purpose' }),
     );
-    // Past deliveryConfirmMs: onDeliveryUnconfirmed has fired and re-armed the
-    // hold via `this.pendingHolds.set(qid, { resolve: hold.resolve, timer, isSubagent: hold.isSubagent })`.
-    await new Promise((r) => setTimeout(r, 60));
-
-    // If the re-arm dropped the isSubagent tag, mainOnly would wrongly treat
-    // this as a main hold and release it here.
-    gate.cancelStale('Stop', { mainOnly: true });
-
-    let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(settled).toBe(false); // still held -- re-armed hold correctly tagged subagent
-
-    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
-    expect(await pending).toBe('allow');
+    expect(await pending).toBe('passthrough'); // immediate: no hold, no delivery probe
+    expect(lastQuestionId).toBeUndefined(); // no escalate() call, no pushed card
+    gate.cancelStale('Stop', { mainOnly: true }); // nothing held; must not throw
   });
 });
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1920,9 +1920,12 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.questionCalls).toBe(1); // escalated to the user, not silently denied
   });
 
-  test('#710: a genuinely subagent-TAGGED PermissionRequest (agent_id set) during an active Task context still default-denies', async () => {
-    // The still-valid case: agent_id present proves this really is a subagent
-    // prompt (not a leak), so it must keep default-denying via the response.
+  test('#751: a genuinely subagent-TAGGED PermissionRequest (agent_id set) during an active Task context parks + passthrough', async () => {
+    // agent_id present proves this really is a subagent prompt (not a leak).
+    // #751 PTY-arbiter: instead of the old default-deny (silent teammate
+    // breakage), the gate parks the rich question and answers 'passthrough' --
+    // no PTY inject, no immediate push/registration; the question surfaces
+    // only if Claude's native prompt renders on the PTY.
     build({ autoApprove: true, autoApproveDecision: 'escalate' });
 
     hookServer.fire('SessionStart', {
@@ -1950,9 +1953,14 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    expect(decision).toBe('deny');
+    expect(decision).toBe('passthrough');
     expect(ptySubmits).toEqual([]);
-    expect(messageApiLog.questionCalls).toBe(0);
+    // The park routes through recordPendingHook, which this harness's
+    // PassthroughTracker collapses into an immediate PTY-visible push — i.e.
+    // the simulated terminal rendered the prompt, so the parked question
+    // surfaced. True park-until-render semantics are covered in
+    // tests/api/question-presence-tracker.test.ts ("awaiting-PTY parking").
+    expect(messageApiLog.questionCalls).toBe(1);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #751. Part of epic #757.

## Direction change from the issue as filed

#751 was filed proposing deny-on-agent_id. Two inputs changed the design:

1. User decision: the PTY should be the arbiter — a subagent question the gate cannot decide should surface exactly when (and only when) Claude's own prompt renders in the terminal, not be silently denied and not be pushed as a phone card the terminal never showed.
2. Claude Code ground truth (official hooks/agent-teams docs): there is no lead-agent auto-approval for tool permissions; a passthrough hook response sends the request through the normal flow (session allowlist, then the interactive prompt in the main terminal). Team-teammate requests fire no PermissionRequest hooks at all (anthropics/claude-code#23983) and already ride the PTY-only orphan path.

## What changed

- `auto-approve-gate.ts`: subagent-tagged (agent_id present) escalate verdict / eval error / forfeited pick / no-service now call `parkSubagentForPTY` and answer `passthrough`. No hold, no immediate push, no deny. Keys on the event's own agent_id alone (the SubagentContextTracker is sync-Task-only, so the old AND-gate misrouted team/async spawns as main). LLM approve/deny verdicts unchanged (still resolve silently). Part B early push and the escalate_model second opinion are skipped for subagent-tagged events. #710 main-tagged leak recovery unchanged.
- `question-presence-tracker.ts`: new `parkAwaitingPTY` state — a parked record does not count as gate-owned in the #712 orphan check; a rendered prompt matching a parked record pushes IMMEDIATELY through the normal merge path (rich labels; no orphan debounce; an unrelated live question cannot suppress it). Parked records expire with the existing pending-record lifecycle (status leaves waiting / clearPending).
- `hook-event-bridge.ts`: `buildPermissionQuestion` factored out of `handlePermissionRequest` so parking reuses the exact question builder (labels, structured suggestions, AUQ forms) without push/registration side effects.

## Behavior matrix (subagent-tagged, gate cannot decide)

| Before | After |
|---|---|
| sync-Task shape (tracker true): silent deny, teammate breaks, no trace | passthrough; prompt renders natively; merged card pushes |
| team/async shape (tracker false): held + pushed as main-agent card, terminal blank | same passthrough flow; terminal shows the real prompt |
| allowlist-covered request | absorbed silently, parked record expires (no push at all) |

## Tests

Gate (109), tracker (52, incl. 5 new parking tests), hooks + hook-bridge-setup + hold/scope/force-release/roundtrip suites: 461 pass. The #711 subagent-hold tests were rewritten: subagent holds no longer exist by construction, so mainOnly Stop-scoping coverage now targets in-flight subagent evals (still spared) and the park path.

Note: epic-branch PRs get no CI; suites run locally.