### PR TITLE
Dedupe answer deliveries to stop false failure notices

### DIFF
--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -18,6 +18,7 @@ import { type AuqRunOutcome, runAuqAnswer } from '../../hooks/auq-runner.ts';
 import { readPtyOutput, resetPtyOutput } from '../../pty/output-buffer.ts';
 import type { ManagedSession, SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
+import { ResolvedAnswerCache, answerCacheKey } from './resolved-answer-cache.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
@@ -231,6 +232,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
   const auqRuns = new Map<string, AbortController>();
   const auqRunKey = (sessionId: UUID, questionId: UUID): string => `${sessionId}:${questionId}`;
 
+  // #752: same-value duplicate deliveries of a successful answer (native POST +
+  // Capacitor JS path + signaling relay all fire per tap) report 'delivered'
+  // instead of 'stale', so the losing channel stops showing a false "Answer
+  // not delivered" notification.
+  const resolvedAnswers = new ResolvedAnswerCache();
+
   /**
    * Answer a structured AskUserQuestion (#627) by driving its interactive TUI.
    * The prompt is already on screen (Phase 1 escalates AUQ as passthrough), so the
@@ -305,6 +312,9 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     }
 
     if (outcome === 'closed' || outcome === 'submitted') {
+      // #752: the selections were applied; a duplicate delivery of this same
+      // tap must report 'delivered', not 'stale'.
+      resolvedAnswers.record(questionId, answerCacheKey('', selections));
       // Wrapped like the plain-answer path (below): if cancelAutoApproveForQuestion
       // throws, the question must still be consumed exactly once — removeQuestion +
       // the resolved broadcast run in `finally` so a throw here can never leave a
@@ -445,9 +455,23 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     // (not equality with a single slot) is the check, so answering one of
     // several concurrent prompts (main + subagent, #419) never invalidates
     // the others. Surface the drop so the iOS user gets a "not delivered"
-    // signal instead of silent failure.
+    // signal instead of silent failure — EXCEPT for a same-value duplicate of
+    // an answer that already applied (#752), which reports 'delivered'.
     const active = sessionRegistry.getQuestion(session.sessionId, questionId);
     if (active === null) {
+      // #752: a same-value duplicate of an answer that already applied is a
+      // SUCCESS, not a failure — the tap worked; this is just the losing
+      // delivery channel (native POST vs JS path vs signaling relay). Report
+      // 'delivered' so the client does not fire a false "Answer not
+      // delivered" notification. A different value (a genuine conflicting
+      // late answer) or an unknown/expired question still falls through to
+      // 'stale' below.
+      if (resolvedAnswers.matches(questionId, answerCacheKey(answer, extra?.selections))) {
+        log(
+          `[Answer] duplicate delivery for resolved question ${questionId.slice(0, 8)}; reporting delivered`,
+        );
+        return 'delivered';
+      }
       const pendingIds = [...session.currentQuestions.keys()];
       // #603 Phase 3: the question is gone from the registry (evicted under the
       // pending-question cap, or already removed), but its PermissionRequest hook
@@ -545,6 +569,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
           `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,
         );
       }
+
+      // #752: the answer applied (hold resolved or PTY submit succeeded) —
+      // recorded inside the try, directly after application, so a throwing
+      // submit is never recorded (its duplicate must keep reporting 'stale')
+      // and a later throw from the eval-cancel below cannot skip it.
+      resolvedAnswers.record(questionId, answerCacheKey(answer));
 
       // Free the GPU on EVERY answer (#617): cancel the eval for THIS question
       // unconditionally. Per-eval scoping (the eval id captured when the question

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -314,7 +314,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     if (outcome === 'closed' || outcome === 'submitted') {
       // #752: the selections were applied; a duplicate delivery of this same
       // tap must report 'delivered', not 'stale'.
-      resolvedAnswers.record(questionId, answerCacheKey('', selections));
+      resolvedAnswers.record(questionId, [answerCacheKey('', selections)]);
       // Wrapped like the plain-answer path (below): if cancelAutoApproveForQuestion
       // throws, the question must still be consumed exactly once — removeQuestion +
       // the resolved broadcast run in `finally` so a throw here can never leave a
@@ -573,8 +573,17 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // #752: the answer applied (hold resolved or PTY submit succeeded) —
       // recorded inside the try, directly after application, so a throwing
       // submit is never recorded (its duplicate must keep reporting 'stale')
-      // and a later throw from the eval-cancel below cannot skip it.
-      resolvedAnswers.record(questionId, answerCacheKey(answer));
+      // and a later throw from the eval-cancel below cannot skip it. Recorded
+      // under every spelling of the same decision: the in-app tap sends the
+      // option VALUE while a push action sends the LABEL, and the duplicate
+      // may arrive on the other surface (review #759 finding 1). The options
+      // are unavailable by the time the duplicate hits the stale check, so the
+      // equivalence is captured here.
+      const answeredOption = resolveOption(active.options, answer);
+      resolvedAnswers.record(questionId, [
+        answerCacheKey(answer),
+        ...(answeredOption ? [answeredOption.value, answeredOption.label] : []),
+      ]);
 
       // Free the GPU on EVERY answer (#617): cancel the eval for THIS question
       // unconditionally. Per-eval scoping (the eval id captured when the question

--- a/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
+++ b/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
@@ -30,9 +30,7 @@ const DEFAULT_MAX_ENTRIES = 500;
 
 /** Canonical cache key for an answer payload: the raw answer string, or a
  *  stable serialization of structured AskUserQuestion selections (#627),
- *  which carry the answer in `extra.selections` instead of `answer`.
- *  Duplicate deliveries of one tap carry byte-identical payloads on every
- *  channel, so exact matching suffices (no label/value normalization). */
+ *  which carry the answer in `extra.selections` instead of `answer`. */
 export function answerCacheKey(
   answer: string,
   selections?: readonly { questionIndex: number; optionIndices: readonly number[] }[],
@@ -44,7 +42,7 @@ export function answerCacheKey(
 }
 
 export class ResolvedAnswerCache {
-  private readonly entries = new Map<string, { key: string; atMs: number }>();
+  private readonly entries = new Map<string, { keys: ReadonlySet<string>; atMs: number }>();
   private readonly ttlMs: number;
   private readonly maxEntries: number;
   private readonly nowMs: () => number;
@@ -55,21 +53,33 @@ export class ResolvedAnswerCache {
     this.nowMs = opts.nowMs ?? Date.now;
   }
 
-  /** Record a successfully-applied answer for `questionId`. */
-  record(questionId: string, key: string): void {
+  /**
+   * Record a successfully-applied answer for `questionId` under EVERY key the
+   * same logical decision can arrive as. The channels are not byte-identical:
+   * an in-app tap sends the option VALUE ("1") while a push action sends the
+   * LABEL ("Yes") — both resolve to the same option when applied
+   * (`resolveOption` matches either field), so the dedup must accept either
+   * spelling too. Callers pass the raw answer plus the resolved option's
+   * value/label (review #759 finding 1); the question is gone by the time a
+   * duplicate arrives, so the equivalence must be captured at record time.
+   */
+  record(questionId: string, keys: readonly string[]): void {
     this.prune();
+    const set = new Set(keys.filter((k) => k.length > 0));
+    if (set.size === 0) return;
     // Delete-then-set keeps insertion order meaningful for eviction even if a
     // question were somehow re-recorded.
     this.entries.delete(questionId);
-    this.entries.set(questionId, { key, atMs: this.nowMs() });
+    this.entries.set(questionId, { keys: set, atMs: this.nowMs() });
     if (this.entries.size > this.maxEntries) {
       const oldest = this.entries.keys().next().value;
       if (oldest !== undefined) this.entries.delete(oldest);
     }
   }
 
-  /** True iff `questionId` was resolved with exactly this answer key within
-   *  the TTL — i.e. the incoming answer is a duplicate delivery of a success. */
+  /** True iff `questionId` was resolved with this answer (under any recorded
+   *  spelling) within the TTL — i.e. the incoming answer is a duplicate
+   *  delivery of a success. */
   matches(questionId: string, key: string): boolean {
     const entry = this.entries.get(questionId);
     if (!entry) return false;
@@ -77,7 +87,7 @@ export class ResolvedAnswerCache {
       this.entries.delete(questionId);
       return false;
     }
-    return entry.key === key;
+    return entry.keys.has(key);
   }
 
   private prune(): void {

--- a/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
+++ b/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
@@ -1,0 +1,94 @@
+/**
+ * #752: short-TTL memory of successfully-applied answers, keyed by questionId.
+ *
+ * Every lock-screen tap fires two-to-three independent deliveries of the same
+ * (sessionId, questionId, answer): the native Swift POST (RemiAnswerRelay),
+ * Capacitor's JS path (live WebSocket or `relayAnswerDirect` POST), and — for
+ * relay-connected daemons — a signaling-Worker-forwarded copy. The first copy
+ * to arrive resolves the question and synchronously removes it from the
+ * registry, so the loser deterministically saw `active === null`, got 'stale'
+ * (HTTP 409 / STALE_ANSWER), and both client layers translated that into an
+ * "Answer not delivered" notification — a false negative on essentially every
+ * tap where the app process was alive.
+ *
+ * This cache lets the answer core tell a same-value duplicate of a SUCCESSFUL
+ * answer ("report 'delivered'; the tap worked") apart from a genuinely
+ * unknown/expired/conflicting one (still 'stale'). Only successful
+ * applications are recorded — a throwing PTY submit or a cancel is not an
+ * applied answer, and a conflicting late answer (different value, e.g. "No"
+ * tapped on a second device after "Yes" already won) must keep failing loudly.
+ *
+ * TTL covers the observed redelivery window (signaling-relay copies have been
+ * seen re-forwarded on WebSocket reconnect minutes after the original); a
+ * same-value duplicate is honest to acknowledge no matter how late, so the
+ * bound exists for memory, not correctness. Insertion order doubles as the
+ * eviction order (Map preserves it; entries are never re-inserted).
+ */
+
+const DEFAULT_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_ENTRIES = 500;
+
+/** Canonical cache key for an answer payload: the raw answer string, or a
+ *  stable serialization of structured AskUserQuestion selections (#627),
+ *  which carry the answer in `extra.selections` instead of `answer`.
+ *  Duplicate deliveries of one tap carry byte-identical payloads on every
+ *  channel, so exact matching suffices (no label/value normalization). */
+export function answerCacheKey(
+  answer: string,
+  selections?: readonly { questionIndex: number; optionIndices: readonly number[] }[],
+): string {
+  if (selections && selections.length > 0) {
+    return `auq:${JSON.stringify(selections.map((s) => [s.questionIndex, [...s.optionIndices].sort((a, b) => a - b)]))}`;
+  }
+  return answer;
+}
+
+export class ResolvedAnswerCache {
+  private readonly entries = new Map<string, { key: string; atMs: number }>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly nowMs: () => number;
+
+  constructor(opts: { ttlMs?: number; maxEntries?: number; nowMs?: () => number } = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.nowMs = opts.nowMs ?? Date.now;
+  }
+
+  /** Record a successfully-applied answer for `questionId`. */
+  record(questionId: string, key: string): void {
+    this.prune();
+    // Delete-then-set keeps insertion order meaningful for eviction even if a
+    // question were somehow re-recorded.
+    this.entries.delete(questionId);
+    this.entries.set(questionId, { key, atMs: this.nowMs() });
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+  }
+
+  /** True iff `questionId` was resolved with exactly this answer key within
+   *  the TTL — i.e. the incoming answer is a duplicate delivery of a success. */
+  matches(questionId: string, key: string): boolean {
+    const entry = this.entries.get(questionId);
+    if (!entry) return false;
+    if (this.nowMs() - entry.atMs > this.ttlMs) {
+      this.entries.delete(questionId);
+      return false;
+    }
+    return entry.key === key;
+  }
+
+  private prune(): void {
+    const now = this.nowMs();
+    for (const [id, entry] of this.entries) {
+      if (now - entry.atMs > this.ttlMs) this.entries.delete(id);
+    }
+  }
+
+  /** Test-only: current entry count. */
+  sizeForTest(): number {
+    return this.entries.size;
+  }
+}

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1669,6 +1669,87 @@ describe('createInputHandlers', () => {
       const other = 'cccccccc-0000-0000-0000-000000000000' as UUID;
       expect(await handlers.relayAnswer(sessionId, other, 'Yes')).toBe('stale');
     });
+
+    test('cross-surface: in-app answers with the VALUE, the push duplicate arrives as the LABEL', async () => {
+      // The in-app card sends the option value ("1"); the push action sends
+      // the label ("Yes"). Same tap, different spelling — the cache records
+      // both at application time (#759 review finding 1).
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1'); // in-app value
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered'); // push label
+      expect(await handlers.relayAnswer(sessionId, QID, 'No')).toBe('stale'); // conflict stays loud
+    });
+
+    test('a duplicate of a HELD-hook-resolved answer reports delivered', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(held).toEqual(['allow']); // resolved via the hook, no PTY submit
+      expect(ptyCapture.submits).toEqual([]);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered'); // duplicate
+      expect(held).toEqual(['allow']); // hook not touched again
+    });
+
+    test('a duplicate AUQ selections delivery reports delivered', async () => {
+      // Mirror the structured-AUQ harness: the PTY echoes the closure marker
+      // on ENTER so the runner treats the answer as accepted.
+      const sessionId = sessionRegistry.createSessionId();
+      const writes: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: (content: string) => {
+          writes.push(content);
+          if (content === AUQ_KEYS.ENTER) {
+            appendPtyOutput(sessionId, "⏺ User answered Claude's questions:  ⎿ · Color → Red");
+          }
+        },
+        submitInput: async () => {},
+        close: async () => {},
+      } as unknown as PTYSession;
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI(new Map()));
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Color: pick one',
+        options: [{ value: '1', label: 'Red', isRecommended: true, isYes: false, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+        kind: 'multi_question',
+        questions: [
+          {
+            header: 'Color',
+            text: 'pick one',
+            multiSelect: false,
+            options: [{ value: '1', label: 'Red', isRecommended: true, isYes: false, isNo: false }],
+          },
+        ],
+      });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const selections = [{ questionIndex: 0, optionIndices: [0] }];
+
+      await handlers.onAnswer(CID, sessionId, QID, '', undefined, { selections });
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+
+      // The losing channel re-delivers the same selections (WS path; the HTTP
+      // relay never carries selections). A duplicate of an applied AUQ answer
+      // must not produce a STALE_ANSWER / AUQ error frame.
+      await handlers.onAnswer(CID, sessionId, QID, '', undefined, { selections });
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
   });
 
   describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1566,6 +1566,111 @@ describe('createInputHandlers', () => {
     });
   });
 
+  // #752: every lock-screen tap fires two-to-three deliveries of the same
+  // answer (native POST, Capacitor JS path, signaling relay). The first copy
+  // wins; the losers must report 'delivered' — NOT 'stale' (HTTP 409), which
+  // both client layers turned into a false "Answer not delivered" notification.
+  describe('duplicate answer deliveries (#752)', () => {
+    function registerYesNo(): { sessionId: UUID; ptyCapture: { submits: string[] } } {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      return { sessionId, ptyCapture };
+    }
+
+    test('a same-value relay duplicate after a relay success reports delivered, no re-submit', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      // The losing channel's copy: same tap, question already consumed.
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']); // nothing re-submitted
+    });
+
+    test('cross-channel: a WS answer then its relay duplicate reports delivered', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // in-app WS copy wins
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('a WS duplicate sends NO STALE_ANSWER error frame', async () => {
+      const { sessionId } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // duplicate
+
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('a CONFLICTING late answer (different value) still reports stale', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      // A second device answered "No" after "Yes" already won: must fail loudly.
+      expect(await handlers.relayAnswer(sessionId, QID, 'No')).toBe('stale');
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('a duplicate of a THROWING (never-applied) submit still reports stale', async () => {
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [{ value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
+      // The answer was never applied, so its duplicate is NOT a success echo.
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('stale');
+    });
+
+    test('an unknown question with no recorded answer still reports stale', async () => {
+      const { sessionId } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const other = 'cccccccc-0000-0000-0000-000000000000' as UUID;
+      expect(await handlers.relayAnswer(sessionId, other, 'Yes')).toBe('stale');
+    });
+  });
+
   describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {
     function registerWithQuestion(questionId: UUID): UUID {
       const ptyCapture = { writes: [] as string[], submits: [] as string[] };

--- a/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
+++ b/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ResolvedAnswerCache,
+  answerCacheKey,
+} from '../../../src/cli/handlers/resolved-answer-cache.ts';
+
+describe('ResolvedAnswerCache (#752)', () => {
+  test('a recorded answer matches the same value and rejects a different one', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', 'Yes');
+    expect(cache.matches('q1', 'Yes')).toBe(true);
+    expect(cache.matches('q1', 'No')).toBe(false); // conflicting late answer stays stale
+    expect(cache.matches('q2', 'Yes')).toBe(false); // unknown question
+  });
+
+  test('entries expire after the TTL', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ ttlMs: 100, nowMs: () => now });
+    cache.record('q1', 'Yes');
+    now += 99;
+    expect(cache.matches('q1', 'Yes')).toBe(true);
+    now += 2;
+    expect(cache.matches('q1', 'Yes')).toBe(false);
+    expect(cache.sizeForTest()).toBe(0); // expired entry dropped on read
+  });
+
+  test('the cache is bounded: the oldest entry is evicted past maxEntries', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ maxEntries: 2, nowMs: () => now });
+    cache.record('q1', 'a');
+    now += 1;
+    cache.record('q2', 'b');
+    now += 1;
+    cache.record('q3', 'c');
+    expect(cache.sizeForTest()).toBe(2);
+    expect(cache.matches('q1', 'a')).toBe(false); // evicted (oldest)
+    expect(cache.matches('q2', 'b')).toBe(true);
+    expect(cache.matches('q3', 'c')).toBe(true);
+  });
+
+  test('record prunes expired entries so dead questions never count toward the cap', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ ttlMs: 100, maxEntries: 10, nowMs: () => now });
+    cache.record('q1', 'a');
+    now += 200; // q1 expired
+    cache.record('q2', 'b');
+    expect(cache.sizeForTest()).toBe(1);
+  });
+
+  test('answerCacheKey: plain answers pass through, AUQ selections serialize stably', () => {
+    expect(answerCacheKey('Yes')).toBe('Yes');
+    // Option order inside one selection must not matter (multi-select taps
+    // may enumerate in a different order per channel).
+    const a = answerCacheKey('', [{ questionIndex: 0, optionIndices: [2, 0] }]);
+    const b = answerCacheKey('', [{ questionIndex: 0, optionIndices: [0, 2] }]);
+    expect(a).toBe(b);
+    // Different picks are different keys.
+    const c = answerCacheKey('', [{ questionIndex: 0, optionIndices: [1] }]);
+    expect(c).not.toBe(a);
+    // Selections win over the answer string (AUQ answers carry an empty/dummy answer).
+    expect(answerCacheKey('ignored', [{ questionIndex: 1, optionIndices: [0] }])).toContain('auq:');
+  });
+});

--- a/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
+++ b/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
@@ -7,16 +7,31 @@ import {
 describe('ResolvedAnswerCache (#752)', () => {
   test('a recorded answer matches the same value and rejects a different one', () => {
     const cache = new ResolvedAnswerCache();
-    cache.record('q1', 'Yes');
+    cache.record('q1', ['Yes']);
     expect(cache.matches('q1', 'Yes')).toBe(true);
     expect(cache.matches('q1', 'No')).toBe(false); // conflicting late answer stays stale
     expect(cache.matches('q2', 'Yes')).toBe(false); // unknown question
   });
 
+  test('multiple keys record every spelling of one decision (value vs label)', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', ['Yes', '1']);
+    expect(cache.matches('q1', 'Yes')).toBe(true); // push-action label
+    expect(cache.matches('q1', '1')).toBe(true); // in-app value
+    expect(cache.matches('q1', 'No')).toBe(false);
+  });
+
+  test('empty key lists record nothing', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', ['']);
+    expect(cache.sizeForTest()).toBe(0);
+    expect(cache.matches('q1', '')).toBe(false);
+  });
+
   test('entries expire after the TTL', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ ttlMs: 100, nowMs: () => now });
-    cache.record('q1', 'Yes');
+    cache.record('q1', ['Yes']);
     now += 99;
     expect(cache.matches('q1', 'Yes')).toBe(true);
     now += 2;
@@ -27,11 +42,11 @@ describe('ResolvedAnswerCache (#752)', () => {
   test('the cache is bounded: the oldest entry is evicted past maxEntries', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ maxEntries: 2, nowMs: () => now });
-    cache.record('q1', 'a');
+    cache.record('q1', ['a']);
     now += 1;
-    cache.record('q2', 'b');
+    cache.record('q2', ['b']);
     now += 1;
-    cache.record('q3', 'c');
+    cache.record('q3', ['c']);
     expect(cache.sizeForTest()).toBe(2);
     expect(cache.matches('q1', 'a')).toBe(false); // evicted (oldest)
     expect(cache.matches('q2', 'b')).toBe(true);
@@ -41,9 +56,9 @@ describe('ResolvedAnswerCache (#752)', () => {
   test('record prunes expired entries so dead questions never count toward the cap', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ ttlMs: 100, maxEntries: 10, nowMs: () => now });
-    cache.record('q1', 'a');
+    cache.record('q1', ['a']);
     now += 200; // q1 expired
-    cache.record('q2', 'b');
+    cache.record('q2', ['b']);
     expect(cache.sizeForTest()).toBe(1);
   });
 


### PR DESCRIPTION
Closes #752. Part of epic #757.

Every lock-screen tap fires two-to-three independent deliveries of the same (sessionId, questionId, answer): the native RemiAnswerRelay POST, Capacitor's JS path (live WebSocket or relayAnswerDirect POST), and, for relay-connected daemons, a signaling-forwarded copy. The first copy resolves the question and synchronously removes it from the registry, so the losing copies deterministically hit the stale check, received HTTP 409 / STALE_ANSWER, and both client layers translated any non-2xx into an "Answer not delivered" local notification. The 2026-07-08 soak log shows 25 such stale duplicates, several arriving minutes later on signaling reconnect.

## Change

New `ResolvedAnswerCache` (daemon-side, TTL 5 min, capped 500, insertion-order eviction): each successfully-applied answer is recorded by questionId (plain answers verbatim; AUQ selections via a stable serialization). At the stale check, a same-value duplicate now returns `delivered` (HTTP 200, no STALE_ANSWER frame). Unchanged and still loud:

- a CONFLICTING late answer (different value, e.g. "No" tapped on a second device after "Yes" won) stays `stale`;
- a duplicate of a throwing, never-applied submit stays `stale` (recording happens directly after successful application, inside the try);
- unknown/expired questions stay `stale`;
- cancel was already idempotent (gone question reports delivered) and is untouched.

The daemon is the only layer that can distinguish "duplicate of success" from "genuinely stale", so the fix lives here rather than special-casing 409s client-side.

## Tests

Cache unit suite (match/conflict/TTL/cap/prune/AUQ key stability) plus duplicate-delivery cases through both `onAnswer` (WS) and `relayAnswer` (HTTP): same-channel dup, cross-channel dup, conflicting value, throwing-submit dup, unknown question. 62 tests in the two touched files pass; typecheck and biome clean.

Note: epic-branch PRs get no CI; suites run locally.