### PR TITLE
Render pending-question banners in remi attach

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1058,6 +1058,18 @@ const sessionRegistry = new SessionRegistry(
           log(`Failed to send replay batch to promoted connection ${connectionId}`);
         }
       }
+      // #753 (#760 review finding 2): a promoted connection was queued
+      // (read-only) while live questions may have arrived — those broadcasts
+      // only reach the active connection, so re-send the pending set now.
+      const resent = resendPendingQuestions(
+        (m) => registry.sendRaw(connectionId, m),
+        sessionId,
+        result.currentQuestions,
+        claudeId ?? undefined,
+      );
+      if (resent > 0) {
+        log(`Re-sent ${resent} pending question(s) to promoted connection ${connectionId}`);
+      }
       cancelOrphanTimeout();
     },
   },
@@ -1520,6 +1532,7 @@ const onQuestionResolved = (
   }
 };
 
+import { resendPendingQuestions } from './cli/handlers/pending-question-resend.ts';
 import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -142,14 +142,22 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   const banneredQuestionIds = new Set<string>();
 
   /**
-   * #753: print a pending question into the attached terminal. A HELD
+   * #753: print a pending HELD question into the attached terminal. A held
    * permission (Model B) blocks Claude inside the hook call, so no raw PTY
    * bytes for the prompt exist and the resize-nudge redraw has nothing to
-   * repaint — without this banner an attach shows only "waiting". Plain
-   * text through writeOutput (raw mode: \r\n), cyan so it stands apart from
-   * Claude's own output.
+   * repaint — without this banner an attach shows only "waiting". ONLY held
+   * questions banner (#760 review finding 1): every other question class
+   * renders natively in the raw PTY stream, and the daemon emits multiple
+   * `question` messages per visible prompt cycle (hook bridge + PTY parser,
+   * different ids), so bannering those would double- or triple-print around
+   * the native prompt — the exact noise the old blanket suppression avoided.
+   * Held questions also guarantee an idle PTY, so the banner can never
+   * interleave mid-ANSI-sequence with streaming output. Plain text through
+   * writeOutput (raw mode: \r\n), cyan so it stands apart from Claude's own
+   * output.
    */
   function renderQuestionBanner(question: Question): void {
+    if (question.held !== true) return;
     if (banneredQuestionIds.has(question.id)) return;
     banneredQuestionIds.add(question.id);
     const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -10,7 +10,7 @@ import {
   generateId,
   serialize,
 } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 import { DetachScanner } from './detach-scanner.ts';
 
@@ -135,22 +135,62 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     }
   }
 
-  function renderMessage(msg: ProtocolMessage): void {
+  // #753: question ids already shown as a banner, so a repeat delivery (the
+  // daemon re-sends the authoritative pending set after the replay batch; a
+  // reconnect could deliver it again) never double-prints, and a later
+  // question_resolved can acknowledge exactly the banners the user saw.
+  const banneredQuestionIds = new Set<string>();
+
+  /**
+   * #753: print a pending question into the attached terminal. A HELD
+   * permission (Model B) blocks Claude inside the hook call, so no raw PTY
+   * bytes for the prompt exist and the resize-nudge redraw has nothing to
+   * repaint — without this banner an attach shows only "waiting". Plain
+   * text through writeOutput (raw mode: \r\n), cyan so it stands apart from
+   * Claude's own output.
+   */
+  function renderQuestionBanner(question: Question): void {
+    if (banneredQuestionIds.has(question.id)) return;
+    banneredQuestionIds.add(question.id);
+    const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
+    const lines = [`\r\n\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
+    if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
+    lines.push(
+      `\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`,
+    );
+    writeOutput(lines.join(''));
+  }
+
+  function renderMessage(msg: ProtocolMessage, inReplay = false): void {
     switch (msg.type) {
       case 'raw_pty_output':
         receivedRawPty = true;
         writeRawBytes(msg.data);
         break;
+      case 'question':
+        // #753: LIVE questions only. Replayed history is not trustworthy for
+        // pendingness — question_resolved is broadcast-only (never recorded),
+        // so an already-answered question replays indistinguishably from a
+        // pending one. The daemon re-sends the authoritative pending set as
+        // live messages right after the replay batch, which is what lands here.
+        if (!inReplay) renderQuestionBanner(msg.question);
+        break;
+      case 'question_resolved':
+        // Only acknowledge questions this client actually bannered; resolved
+        // broadcasts for questions answered before attach are noise.
+        if (banneredQuestionIds.delete(msg.questionId)) {
+          writeOutput('\r\n\x1b[2m[remi] question answered\x1b[0m\r\n');
+        }
+        break;
       case 'agent_output':
       case 'structured_agent_output':
-      case 'question':
       case 'session_update':
       case 'transcript_content':
         // Suppressed; raw PTY output already provides the full terminal view
         break;
       case 'replay_batch':
         for (const m of msg.messages) {
-          renderMessage(m);
+          renderMessage(m, true);
         }
         break;
       case 'error':

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -13,7 +13,7 @@
  * consistent.
  */
 
-import { createError, createHelloAck, createReplayBatch } from '@remi/shared';
+import { createError, createHelloAck, createQuestion, createReplayBatch } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
@@ -147,6 +147,24 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
             onPeerConnect?.(connectionId, metadata);
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
+            }
+            // #753: replayed history cannot distinguish answered questions
+            // (question_resolved is broadcast-only, never recorded into
+            // messageHistory), so a client cannot trust replayed `question`
+            // messages for pendingness. Re-send the authoritative pending set
+            // as LIVE question messages after the replay; clients dedupe by
+            // question.id, and the terminal attach client renders these (and
+            // only these) as pending-question banners — the one signal that
+            // exists for a HELD hook, whose prompt never paints the PTY.
+            const pendingQuestions = sessionRegistry.getSession(currentPrimary)?.currentQuestions;
+            if (pendingQuestions !== undefined && pendingQuestions.size > 0) {
+              const claudeSessionId = currentBinding().claudeSessionId ?? undefined;
+              for (const question of pendingQuestions.values()) {
+                send(connectionId, createQuestion(question, currentPrimary, claudeSessionId));
+              }
+              log(
+                `Re-sent ${pendingQuestions.size} pending question(s) to connection ${connectionId}`,
+              );
             }
             cancelOrphanTimeout();
             log(

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -13,7 +13,7 @@
  * consistent.
  */
 
-import { createError, createHelloAck, createQuestion, createReplayBatch } from '@remi/shared';
+import { createError, createHelloAck, createReplayBatch } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
@@ -21,6 +21,7 @@ import type { SessionRegistry } from '../../session/index.ts';
 import type { CurrentOwnedSession } from '../current-session.ts';
 import { log } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
+import { resendPendingQuestions } from './pending-question-resend.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface ConnectionHandlerDeps {
@@ -148,23 +149,17 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
             }
-            // #753: replayed history cannot distinguish answered questions
-            // (question_resolved is broadcast-only, never recorded into
-            // messageHistory), so a client cannot trust replayed `question`
-            // messages for pendingness. Re-send the authoritative pending set
-            // as LIVE question messages after the replay; clients dedupe by
-            // question.id, and the terminal attach client renders these (and
-            // only these) as pending-question banners — the one signal that
-            // exists for a HELD hook, whose prompt never paints the PTY.
-            const pendingQuestions = sessionRegistry.getSession(currentPrimary)?.currentQuestions;
-            if (pendingQuestions !== undefined && pendingQuestions.size > 0) {
-              const claudeSessionId = currentBinding().claudeSessionId ?? undefined;
-              for (const question of pendingQuestions.values()) {
-                send(connectionId, createQuestion(question, currentPrimary, claudeSessionId));
-              }
-              log(
-                `Re-sent ${pendingQuestions.size} pending question(s) to connection ${connectionId}`,
-              );
+            // #753: re-send the authoritative pending set as LIVE question
+            // messages after the replay (see pending-question-resend.ts for
+            // why replayed history cannot be trusted for pendingness).
+            const resent = resendPendingQuestions(
+              (m) => send(connectionId, m),
+              currentPrimary,
+              result.currentQuestions,
+              currentBinding().claudeSessionId ?? undefined,
+            );
+            if (resent > 0) {
+              log(`Re-sent ${resent} pending question(s) to connection ${connectionId}`);
             }
             cancelOrphanTimeout();
             log(

--- a/packages/daemon/src/cli/handlers/pending-question-resend.ts
+++ b/packages/daemon/src/cli/handlers/pending-question-resend.ts
@@ -1,0 +1,34 @@
+/**
+ * #753: re-send the authoritative pending questions to a freshly attached
+ * (or promoted / resume-attached) connection, as LIVE `question` messages,
+ * right after the replay batch.
+ *
+ * Replayed history cannot be trusted for pendingness: `question_resolved` is
+ * broadcast-only and never recorded into `messageHistory`, so an
+ * already-answered question replays indistinguishably from a pending one.
+ * The registry's `currentQuestions` (returned by every successful
+ * `attachConnection`) is the source of truth. Clients dedupe by
+ * `question.id`; the terminal attach client banners the held ones (the class
+ * that never renders on the PTY).
+ *
+ * Shared by every attach surface (#760 review finding 2): the hello attach
+ * path (connection-events), the resume-request attach path
+ * (resume-session-events), and FIFO queue promotion (cli.ts
+ * onConnectionPromoted). A send failure is the caller's transport's problem;
+ * this helper only reports how many were attempted.
+ */
+
+import { createQuestion } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
+
+export function resendPendingQuestions(
+  send: (message: ProtocolMessage) => void,
+  sessionId: UUID,
+  pendingQuestions: readonly Question[],
+  claudeSessionId?: UUID,
+): number {
+  for (const question of pendingQuestions) {
+    send(createQuestion(question, sessionId, claudeSessionId));
+  }
+  return pendingQuestions.length;
+}

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -31,6 +31,7 @@ import type { SessionBindingStore, SessionRegistry, SessionStore } from '../../s
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import { resolveDirectory } from '../path-resolver.ts';
+import { resendPendingQuestions } from './pending-question-resend.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 /**
@@ -99,6 +100,17 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
               connectionId,
               createReplayBatch(targetSessionId as UUID, result.replayMessages, true),
             );
+          }
+          // #753 (#760 review finding 2): this attach surface needs the same
+          // live re-send as the hello attach path, or a session switched-to
+          // mid-held-question shows nothing.
+          const resent = resendPendingQuestions(
+            (m) => send(connectionId, m),
+            targetSessionId as UUID,
+            result.currentQuestions,
+          );
+          if (resent > 0) {
+            log(`Re-sent ${resent} pending question(s) to resumed connection ${connectionId}`);
           }
           log(`Session ${targetSessionId} still alive; attached connection`);
           return;

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -137,16 +137,21 @@ export function createMessageApiForSession(
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
       const claudeSessionId = getClaudeSessionId?.() ?? undefined;
+      // #753: stamp held-ness onto the question itself so every downstream
+      // copy (live message, registry entry, attach-time re-send) carries it —
+      // the terminal attach client banners ONLY held questions, the one class
+      // that never renders on the PTY.
+      const stamped: Question = opts?.held === true ? { ...question, held: true } : question;
       const msg: ProtocolMessage = {
         type: 'question',
         id: generateId(),
         timestamp: now(),
-        question,
+        question: stamped,
         sessionId: questionSessionId,
         ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
-      sessionRegistry.addQuestion(questionSessionId, question);
+      sessionRegistry.addQuestion(questionSessionId, stamped);
 
       // Push: a non-held question only pushes when no client is attached (the
       // client sees it in-app). A HELD escalation (#603 Phase 3) always also
@@ -157,7 +162,7 @@ export function createMessageApiForSession(
       // pushConfig/refreshDeviceTokens contract change surfacing as an
       // unhandled rejection (matches the escalator's #672 push guard).
       void notifications
-        .maybePush(questionSessionId, question, { held: opts?.held === true })
+        .maybePush(questionSessionId, stamped, { held: opts?.held === true })
         .catch((err) => {
           logError(`[Session ${sessionId}] Question push threw:`, err);
         });

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -266,7 +266,7 @@ describe('runAttachClient', () => {
     expect(pongMsg).toBeTruthy();
   });
 
-  function makeQuestion(text: string): Question {
+  function makeQuestion(text: string, held = true): Question {
     return {
       id: generateId() as UUID,
       text,
@@ -276,13 +276,14 @@ describe('runAttachClient', () => {
       ],
       allowsFreeText: false,
       isAnswered: false,
+      ...(held ? { held: true } : {}),
     };
   }
 
   // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
   // raw PTY bytes for the prompt ever exist — the LIVE question message is
   // the only signal an attached terminal gets, and it must render.
-  test('renders a banner for a LIVE question (held prompts never paint the PTY)', async () => {
+  test('renders a banner for a LIVE held question (held prompts never paint the PTY)', async () => {
     setupOutput();
     const targetSessionId = generateId();
     const question = makeQuestion('Allow file edit?');
@@ -328,6 +329,52 @@ describe('runAttachClient', () => {
     expect(output).toContain("run 'remi unstick'");
     // Bannered exactly once despite the duplicate delivery.
     expect(output.split('pending question: Allow file edit?').length).toBe(2);
+  });
+
+  // #760 review finding 1: the daemon emits multiple `question` messages per
+  // VISIBLE prompt cycle (hook bridge + PTY parser, different ids); only held
+  // questions — which never render natively — may banner.
+  test('does NOT banner a non-held live question (its prompt renders natively in raw PTY)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow Bash: ls?', /* held */ false);
+
+    server = Bun.serve({
+      port: TEST_PORT + 8,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 8,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).not.toContain('Allow Bash: ls?');
+    expect(output).not.toContain('pending question');
   });
 
   test('suppresses questions inside a replay batch (history cannot prove pendingness)', async () => {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -8,6 +8,7 @@ import {
   createHelloAck,
   createPing,
   createQuestion,
+  createQuestionResolved,
   createReplayBatch,
   deserialize,
   generateId,
@@ -265,12 +266,10 @@ describe('runAttachClient', () => {
     expect(pongMsg).toBeTruthy();
   });
 
-  test('suppresses question messages (raw PTY provides the interactive prompt)', async () => {
-    setupOutput();
-    const targetSessionId = generateId();
-    const question: Question = {
+  function makeQuestion(text: string): Question {
+    return {
       id: generateId() as UUID,
-      text: 'Allow file edit?',
+      text,
       options: [
         { label: 'Yes', value: 'yes', isRecommended: true, isYes: true, isNo: false },
         { label: 'No', value: 'no', isRecommended: false, isYes: false, isNo: true },
@@ -278,6 +277,15 @@ describe('runAttachClient', () => {
       allowsFreeText: false,
       isAnswered: false,
     };
+  }
+
+  // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
+  // raw PTY bytes for the prompt ever exist — the LIVE question message is
+  // the only signal an attached terminal gets, and it must render.
+  test('renders a banner for a LIVE question (held prompts never paint the PTY)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow file edit?');
 
     server = Bun.serve({
       port: TEST_PORT + 4,
@@ -295,6 +303,8 @@ describe('runAttachClient', () => {
           if (msg.type === 'hello') {
             ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
             setTimeout(() => {
+              // Duplicate delivery (daemon re-send + broadcast): renders once.
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
               ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
             }, 50);
             setTimeout(() => ws.close(), 200);
@@ -313,8 +323,113 @@ describe('runAttachClient', () => {
     });
 
     const output = readOutput();
-    // Question messages are suppressed in terminal attach mode;
-    // the raw PTY output already contains the interactive prompt
-    expect(output).not.toContain('Allow file edit?');
+    expect(output).toContain('[remi] pending question: Allow file edit?');
+    expect(output).toContain('1) Yes  2) No');
+    expect(output).toContain("run 'remi unstick'");
+    // Bannered exactly once despite the duplicate delivery.
+    expect(output.split('pending question: Allow file edit?').length).toBe(2);
+  });
+
+  test('suppresses questions inside a replay batch (history cannot prove pendingness)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Old replayed question?');
+
+    server = Bun.serve({
+      port: TEST_PORT + 5,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            ws.send(
+              serialize(
+                createReplayBatch(
+                  targetSessionId as UUID,
+                  [createQuestion(question, targetSessionId as UUID)],
+                  true,
+                ),
+              ),
+            );
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 5,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    // A replayed question may have been answered long ago (question_resolved
+    // is never recorded into history), so no banner.
+    expect(output).not.toContain('Old replayed question?');
+  });
+
+  test('acknowledges question_resolved only for questions it bannered', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow push?');
+    const unrelatedQuestionId = generateId() as UUID;
+
+    server = Bun.serve({
+      port: TEST_PORT + 6,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              // A resolved broadcast for a question never bannered: silent.
+              ws.send(
+                serialize(
+                  createQuestionResolved(targetSessionId as UUID, unrelatedQuestionId, 'answered'),
+                ),
+              );
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
+              ws.send(
+                serialize(createQuestionResolved(targetSessionId as UUID, question.id, 'answered')),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 250);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 6,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('[remi] pending question: Allow push?');
+    expect(output.split('[remi] question answered').length).toBe(2); // exactly once
   });
 });

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -275,6 +275,46 @@ describe('createConnectionHandlers', () => {
       expect(replay.messages?.length).toBe(2);
     });
 
+    test('#753: pending questions are re-sent as LIVE question messages after attach', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      // One question answered before this attach (must NOT be re-sent), one
+      // still pending (must arrive as a live `question` message).
+      const answeredId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: answeredId,
+        text: 'old, already answered?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      sessionRegistry.removeQuestion(sessionId, answeredId);
+      const pendingId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: pendingId,
+        text: 'Allow Bash: git push',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
+      expect(questionMsgs).toHaveLength(1);
+      const q = questionMsgs[0]?.message as { question: { id: UUID; text: string } };
+      expect(q.question.id).toBe(pendingId);
+      expect(q.question.text).toBe('Allow Bash: git push');
+      // Ordering: hello_ack first, live questions after (and after any replay).
+      expect(sendCalls[0]?.message.type).toBe('hello_ack');
+      expect(sendCalls[sendCalls.length - 1]?.message.type).toBe('question');
+    });
+
     test('second concurrent connection is queued and still receives helloAck + replay', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI(2));

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -103,6 +103,29 @@ describe('createResumeSessionHandlers', () => {
     expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
   });
 
+  test('#753: re-sends pending questions as live messages on the still-alive attach path', async () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+    const pendingId = 'aaaaaaaa-1111-2222-3333-444444444444' as UUID;
+    sessionRegistry.addQuestion(sessionId, {
+      id: pendingId,
+      text: 'Allow Bash: git push',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      held: true,
+    });
+
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, sessionId, REQ);
+
+    const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
+    expect(questionMsgs).toHaveLength(1);
+    const q = questionMsgs[0]?.message as { question: { id: UUID; held?: boolean } };
+    expect(q.question.id).toBe(pendingId);
+    expect(q.question.held).toBe(true); // held flag survives the re-send
+  });
+
   test('rejects when another session is active and the target does not match', async () => {
     const activeId = sessionRegistry.createSessionId();
     sessionRegistry.registerSession(activeId, '/other/dir', fakePTY(), fakeMessageAPI());

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -229,6 +229,18 @@ export interface Question {
    * plain-string suggestion path.
    */
   readonly optionsAreFallback?: boolean | undefined;
+
+  /**
+   * #753: true when the auto-approve gate is HOLDING this question's
+   * PermissionRequest hook (Model B) — Claude is blocked inside the hook call
+   * and never renders the prompt, so no PTY bytes for it exist. The terminal
+   * attach client banners exactly these (they are otherwise invisible in a
+   * terminal); non-held questions render natively and need no banner.
+   * Stamped once at question emission (message-api-setup) from the push
+   * options, so live messages, registry entries, and attach-time re-sends all
+   * carry it.
+   */
+  readonly held?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #753. Part of epic #757.

Attaching to a session with a pending held question showed nothing: a held hook (Model B) blocks Claude inside the hook call, so no raw PTY bytes for the prompt exist (the resize-nudge redraw has nothing to repaint), and the attach client explicitly discarded the `question` messages the daemon sent.

## Change

Two halves:

- **Daemon** (`connection-events.ts`): after the replay batch on attach, re-send the authoritative pending set (`sessionRegistry` `currentQuestions`) as live `question` messages. Replayed history cannot prove pendingness: `question_resolved` is broadcast-only and never recorded into `messageHistory`, so an answered question replays indistinguishably from a pending one (this is why the issue's original "client-only" fix sketch was insufficient). Clients dedupe by `question.id`; the web app's existing id-based dedup makes the re-send a no-op there.
- **Attach client** (`attach-client.ts`): live `question` messages render a cyan banner (question text, numbered option labels, and an "answer on your phone, or run 'remi unstick'" hint), deduped by question id. Questions inside `replay_batch` stay suppressed. A `question_resolved` for a bannered question prints a one-line "question answered" note; resolved broadcasts for questions never shown stay silent.

## Tests

Attach-client: live-question banner (rendered once despite duplicate delivery), replayed-question suppression, resolved-note gating. Connection-events: pending questions re-sent after hello_ack/replay, answered questions excluded, ordering asserted. 49 tests across the three touched suites pass; typecheck and biome clean.

Note: epic-branch PRs get no CI; suites run locally.