### PR TITLE
Status bar for attached sessions and real attach-state label

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -66,6 +66,12 @@ import { IDLE_AUTO_APPROVE, type RemiStatus, StatusWriter } from './cli/status-w
 
 const gitInfo = detectGitInfo();
 
+// #754/#755: the StatusWriter is constructed before the AdapterRegistry and
+// SessionRegistry exist, so its broadcast + attach-state deps are late-bound
+// through these slots (assigned right after the AdapterRegistry below).
+let remiStatusBroadcast: ((status: Readonly<RemiStatus>) => void) | null = null;
+let remiAttachState: (() => { attached: boolean; queuedCount: number } | null) | null = null;
+
 const statusWriter = new StatusWriter(
   {
     pid: process.pid,
@@ -91,6 +97,8 @@ const statusWriter = new StatusWriter(
       serveMode && process.env['REMI_SPAWNED_CHILD'] !== '1' ? DAEMON_STATUS_FILE : STATUS_FILE,
     isEnabled: () => isWrapperMode() || cliDaemonMode,
     writeLog: writeToLog,
+    getAttachState: () => remiAttachState?.() ?? null,
+    broadcast: (status) => remiStatusBroadcast?.(status),
   },
 );
 
@@ -106,6 +114,7 @@ import {
   createError,
   createHelloAck,
   createQuestionResolved,
+  createRemiStatus,
   createReplayBatch,
   createSessionUpdate,
 } from '@remi/shared';
@@ -1488,6 +1497,25 @@ const registry = new AdapterRegistry({
     updateRemiStatus({ adapters: remiStatus.adapters.filter((a) => a !== type) });
   },
 });
+
+// #754: every debounced status flush also reaches connected clients, so the
+// terminal attach client can draw the same reserved-row bar the wrapper does.
+remiStatusBroadcast = (status) => {
+  const primary = getPrimarySessionId();
+  if (!primary) return;
+  registry.broadcast(createRemiStatus(primary, status as RemiStatus));
+};
+// #755: attach state pulled from the session registry at flush time — the
+// exclusive PTY slot + FIFO queue, never the blunt connection counter.
+remiAttachState = () => {
+  const primary = getPrimarySessionId();
+  if (!primary) return { attached: false, queuedCount: 0 };
+  const session = sessionRegistry.getSession(primary);
+  return {
+    attached: (session?.activeConnectionId ?? null) !== null,
+    queuedCount: sessionRegistry.waitingConnectionCount,
+  };
+};
 
 /**
  * Cross-client question dismissal (#585, P7). Fired when a pending question stops

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -10,9 +10,10 @@ import {
   generateId,
   serialize,
 } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, RemiStatus, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 import { DetachScanner } from './detach-scanner.ts';
+import { StatusBar, childRows } from './status-bar.ts';
 
 export interface AttachClientOptions {
   host: string;
@@ -46,6 +47,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let rawPtyTimer: ReturnType<typeof setTimeout> | null = null;
   let detachPending = false;
   let detachAckTimer: ReturnType<typeof setTimeout> | null = null;
+  // #754: latest daemon status snapshot (remi_status broadcast) + the
+  // reserved-row bar rendering it — the same StatusBar the wrapper draws.
+  // Only on a real TTY: piped/test output must never receive bar escapes.
+  const statusBarEligible = process.stdout.isTTY === true;
+  let latestStatus: RemiStatus | null = null;
+  let statusBar: StatusBar | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -61,6 +68,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   }
 
   function restoreTerminal(): void {
+    // #754: halt the bar loop and clear its reserved row before anything else
+    // writes to the terminal, so the returned shell starts clean.
+    if (statusBar) {
+      statusBar.stop();
+      statusBar = null;
+    }
     if (detachAckTimer) {
       clearTimeout(detachAckTimer);
       detachAckTimer = null;
@@ -135,11 +148,42 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     }
   }
 
+  /**
+   * #754: start the reserved-row status bar once the first `remi_status`
+   * snapshot arrives (an older daemon never sends one, so no row is wasted).
+   * Reserving the row = reporting `rows - 1` to the daemon's PTY, exactly like
+   * wrapper mode; the StatusBar itself is the same class, drawing on this
+   * terminal's bottom row from the broadcast snapshots.
+   */
+  function startStatusBar(): void {
+    if (!statusBarEligible || statusBar !== null || resolved) return;
+    statusBar = new StatusBar({
+      getStdoutFd: () => (outputBroken ? null : outputFd),
+      getStatus: () => latestStatus as RemiStatus,
+      getSize: () => ({
+        cols: process.stdout.columns || 120,
+        rows: process.stdout.rows || 40,
+      }),
+      isEnabled: () => latestStatus !== null,
+      log: (msg) => process.stderr.write(`${msg}\n`),
+    });
+    statusBar.start();
+    const cols = process.stdout.columns || 120;
+    const rows = process.stdout.rows || 40;
+    sendMessage(createTerminalResize(cols, childRows(rows, true)));
+  }
+
   function renderMessage(msg: ProtocolMessage): void {
     switch (msg.type) {
       case 'raw_pty_output':
         receivedRawPty = true;
         writeRawBytes(msg.data);
+        break;
+      case 'remi_status':
+        // #754: display state only — never printed as text. The bar's own
+        // 250ms repaint loop reads the latest snapshot.
+        latestStatus = msg.status;
+        if (attachedSessionId) startStatusBar();
         break;
       case 'agent_output':
       case 'structured_agent_output':
@@ -235,11 +279,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         };
         process.stdin.on('data', stdinListener);
 
-        // Forward terminal resize
+        // Forward terminal resize. #754: while the status bar is up, its row
+        // stays reserved (report rows-1, mirroring wrapper mode's childRows).
         resizeListener = () => {
           const cols = process.stdout.columns || 120;
           const rows = process.stdout.rows || 40;
-          sendMessage(createTerminalResize(cols, rows));
+          sendMessage(createTerminalResize(cols, childRows(rows, statusBar !== null)));
         };
         process.stdout.on('resize', resizeListener);
 
@@ -253,9 +298,13 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
           sendMessage(createTerminalResize(cols - 1, rows));
           resizeNudgeTimer = setTimeout(() => {
             resizeNudgeTimer = null;
-            sendMessage(createTerminalResize(cols, rows));
+            sendMessage(createTerminalResize(cols, childRows(rows, statusBar !== null)));
           }, 50);
         }
+
+        // #754: a remi_status broadcast may have raced ahead of the (real)
+        // hello_ack; start the bar from the stored snapshot now.
+        if (latestStatus !== null) startStatusBar();
 
         // Warn if no raw PTY data arrives within a few seconds
         rawPtyTimer = setTimeout(() => {

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -81,7 +81,24 @@ export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): st
     state = 'approved';
   }
 
-  const clients = status.connections > 0 ? `${status.connections} client(s)` : 'no clients';
+  // #755: label from the REAL attach state (exclusive PTY slot + FIFO queue),
+  // not the raw connection counter — `connections` also counts query-mode
+  // utility clients (remi ls / kill / phone list polls), which is how the bar
+  // used to read "1 client(s)" with nobody attached. Fall back to the old
+  // counter label only when the attach fields are absent (older writer).
+  const queued = status.queuedCount ?? 0;
+  const clients =
+    status.attached === undefined
+      ? status.connections > 0
+        ? `${status.connections} client(s)`
+        : 'no clients'
+      : status.attached
+        ? queued > 0
+          ? `attached (+${queued} waiting)`
+          : 'attached'
+        : queued > 0
+          ? `${queued} waiting`
+          : 'no clients';
   const repoBranch = status.repo ? `${status.repo}:${status.branch}` : status.branch;
   const head = repoBranch ? `remi:${status.wsPort} ${repoBranch}` : `remi:${status.wsPort}`;
   return `${head} | ${clients} | ${state}`;

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -18,34 +18,17 @@
  */
 
 import * as fs from 'node:fs';
-import type { AgentStatus, UUID } from '@remi/shared';
+import type { AgentStatus, AutoApproveState, RemiStatus } from '@remi/shared';
 
 /** Session status surfaced in the status file. `starting` now lives in the
  *  shared `AgentStatus` (#576), so this is just an alias kept for callers. */
 export type RemiSessionStatus = AgentStatus;
 
-/**
- * Auto-approve eval state surfaced in Claude's native status line (#560).
- *
- * Driven by a COUNT (inc on eval start, dec on every end path), not a boolean
- * spinner — a count cannot get "stuck" the way the old shared TerminalIndicator
- * did when concurrent evals (parallel subagents / multiple sessions) interleaved
- * its start/stop. `inFlight > 0` => a permission is being decided right now.
- * Times are epoch SECONDS so the statusline shell script can compute elapsed
- * with `date +%s` (macOS `date` has no millisecond format).
- */
-export interface AutoApproveState {
-  /** Evals in flight on this daemon. 0 = idle. */
-  inFlight: number;
-  /** Epoch seconds the current in-flight batch began (set on 0->1, cleared on
-   *  1->0). The statusline shows `evaluating <now-sinceS>s`. */
-  sinceS: number;
-  /** Last settled verdict, for a post-eval cue. */
-  lastVerdict: 'approved' | 'escalated' | 'none';
-  /** Epoch seconds of the last verdict; the statusline fades 'approved' after a
-   *  few seconds and keeps 'escalated' (needs-you) until the next eval. */
-  lastVerdictAtS: number;
-}
+/** `AutoApproveState` and `RemiStatus` moved to @remi/shared (#754) so the
+ *  daemon can broadcast the snapshot to clients (`remi_status`) and the attach
+ *  client can render the same reserved-row bar. Re-exported for existing
+ *  daemon-side importers. */
+export type { AutoApproveState, RemiStatus };
 
 export const IDLE_AUTO_APPROVE: AutoApproveState = {
   inFlight: 0,
@@ -60,32 +43,6 @@ export const IDLE_AUTO_APPROVE: AutoApproveState = {
  *  the render in statusline-installer.ts). */
 export const ESCALATE_FRESH_S = 60;
 
-export interface RemiStatus {
-  pid: number;
-  connections: number;
-  sessionStatus: RemiSessionStatus;
-  adapters: string[];
-  wsPort: number;
-  sessionId: UUID | null;
-  repo: string;
-  branch: string;
-  autoApprove: AutoApproveState;
-  /**
-   * Distinguishes a session-less hub daemon (`remi serve`, #542) from an
-   * ordinary single-session daemon/wrapper process. Optional so an older
-   * writer/reader pair (mixed-version upgrade window) degrades gracefully
-   * rather than failing a strict shape check.
-   */
-  mode?: 'hub' | 'session';
-  /**
-   * The remi binary version this process runs (#539). A daemon holds its
-   * binary for life; `remi status`/`ls` compare this against the installed
-   * binary to flag stale daemons. Optional for the same mixed-version
-   * reasons as `mode`.
-   */
-  version?: string;
-}
-
 export interface StatusWriterDeps {
   /** Returns the path to write to. Called on every flush so caller can swap files at runtime. */
   readonly getTargetFile: () => string;
@@ -95,12 +52,29 @@ export interface StatusWriterDeps {
   readonly writeLog: (msg: string) => void;
   /** Debounce window in ms. Default 300. Tests override to 0. */
   readonly debounceMs?: number;
+  /**
+   * #755: live attach state, stamped into the status on every flush so the
+   * "attached / N waiting" label tracks the session registry (the source of
+   * truth: `activeConnectionId` / `waitingConnections`) rather than the blunt
+   * `connections` counter, which also counts query-mode utility clients.
+   * Pull-based because attach transitions happen in several places (attach,
+   * disconnect, FIFO auto-promotion) that don't all flow through cli.ts.
+   * Optional: tests and the earliest boot phase run without it.
+   */
+  readonly getAttachState?: () => { attached: boolean; queuedCount: number } | null;
+  /**
+   * #754: broadcast the freshly-flushed snapshot to connected clients
+   * (`remi_status`), on the same debounce as the disk write. Optional and
+   * throw-guarded: display state must never break the writer.
+   */
+  readonly broadcast?: (status: Readonly<RemiStatus>) => void;
 }
 
 export class StatusWriter {
   private readonly status: RemiStatus;
-  private readonly deps: Required<StatusWriterDeps>;
+  private readonly deps: StatusWriterDeps & { debounceMs: number };
   private errorLogged = false;
+  private broadcastErrorLogged = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(initial: RemiStatus, deps: StatusWriterDeps) {
@@ -199,6 +173,32 @@ export class StatusWriter {
   }
 
   private write(): void {
+    // #755: refresh the attach-state fields from the registry at flush time so
+    // every scheduled write (status changes, evals, connection churn) carries
+    // current values; a pull here beats scattering updates over every attach /
+    // disconnect / auto-promotion site.
+    try {
+      const attach = this.deps.getAttachState?.();
+      if (attach) {
+        this.status.attached = attach.attached;
+        this.status.queuedCount = attach.queuedCount;
+      }
+    } catch (err) {
+      if (!this.broadcastErrorLogged) {
+        this.deps.writeLog(`[error] Status attach-state read failed: ${err}`);
+        this.broadcastErrorLogged = true;
+      }
+    }
+    // #754: clients get the same debounced snapshot the disk gets, regardless
+    // of whether the file write itself is enabled.
+    try {
+      this.deps.broadcast?.(this.status);
+    } catch (err) {
+      if (!this.broadcastErrorLogged) {
+        this.deps.writeLog(`[error] Status broadcast failed: ${err}`);
+        this.broadcastErrorLogged = true;
+      }
+    }
     if (!this.deps.isEnabled()) return;
     const targetFile = this.deps.getTargetFile();
     const tmpFile = `${targetFile}.tmp`;

--- a/packages/daemon/src/cli/statusline-installer.ts
+++ b/packages/daemon/src/cli/statusline-installer.ts
@@ -34,10 +34,20 @@ REMI=""
 # avoid duplicating the remi fields just above the bar.
 REMI_STATUS_FILE="${remiDir}/status-\$REMI_PORT.json"
 if [ "\$REMI_STATUS_BAR" != "1" ] && [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
-  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH AA_INFLIGHT AA_SINCE AA_LASTV AA_LASTAT < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // "", .autoApprove.inFlight // 0, .autoApprove.sinceS // 0, .autoApprove.lastVerdict // "none", .autoApprove.lastVerdictAtS // 0] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
+  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH AA_INFLIGHT AA_SINCE AA_LASTV AA_LASTAT S_ATTACHED S_QUEUED < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // "", .autoApprove.inFlight // 0, .autoApprove.sinceS // 0, .autoApprove.lastVerdict // "none", .autoApprove.lastVerdictAtS // 0, (.attached | if . == null then "unset" else tostring end), .queuedCount // 0] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
   if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
+    # #755: label from the real attach state (exclusive PTY slot + queue), not
+    # the raw connection counter (which also counts remi ls / kill / phone
+    # list polls). "unset" = status file from an older daemon -> old label.
     CLIENT_INFO="no clients"
-    [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
+    if [ "\$S_ATTACHED" = "unset" ]; then
+      [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
+    elif [ "\$S_ATTACHED" = "true" ]; then
+      CLIENT_INFO="attached"
+      [ "\${S_QUEUED:-0}" != "0" ] && CLIENT_INFO="attached (+\${S_QUEUED} waiting)"
+    else
+      [ "\${S_QUEUED:-0}" != "0" ] && CLIENT_INFO="\${S_QUEUED} waiting"
+    fi
     # The status segment reflects auto-approve state when a permission is being
     # decided, otherwise Claude's agent status (#560). All arithmetic is guarded
     # (:-0) so a status file from an older daemon (no autoApprove key) renders

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -8,6 +8,7 @@ import {
   createHelloAck,
   createPing,
   createQuestion,
+  createRemiStatus,
   createReplayBatch,
   deserialize,
   generateId,
@@ -316,5 +317,73 @@ describe('runAttachClient', () => {
     // Question messages are suppressed in terminal attach mode;
     // the raw PTY output already contains the interactive prompt
     expect(output).not.toContain('Allow file edit?');
+  });
+
+  // #754: remi_status is display state for the reserved-row bar; on a non-TTY
+  // output (piped/tests) the bar never starts and nothing is printed.
+  test('consumes remi_status without printing when stdout is not a TTY', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 7,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(targetSessionId as UUID, {
+                    pid: 1,
+                    connections: 1,
+                    sessionStatus: 'thinking',
+                    adapters: ['ws'],
+                    wsPort: 19924,
+                    sessionId: targetSessionId as UUID,
+                    repo: 'remi',
+                    branch: 'develop',
+                    autoApprove: {
+                      inFlight: 0,
+                      sinceS: 0,
+                      lastVerdict: 'none',
+                      lastVerdictAtS: 0,
+                    },
+                    attached: true,
+                    queuedCount: 0,
+                  }),
+                ),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 7,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    // No bar escapes (reverse video / DECSTBM) and no bar label leaked. (The
+    // "[attached to session ...]" header is unrelated and expected.)
+    expect(output).not.toContain('| attached');
+    expect(output).not.toContain('\x1b[7m');
+    expect(output).not.toContain('\x1b[1;');
   });
 });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -51,9 +51,38 @@ describe('formatStatusBar', () => {
     expect(out).toBe('remi:19924 remi:develop | no clients | thinking');
   });
 
-  test('client count pluralizes', () => {
+  test('client count pluralizes (legacy fallback: no attach fields on the status)', () => {
     expect(formatStatusBar(mkStatus({ connections: 2 }), NOW_MS)).toContain('| 2 client(s) |');
     expect(formatStatusBar(mkStatus({ connections: 0 }), NOW_MS)).toContain('| no clients |');
+  });
+
+  // #755: with attach fields present, the label reads the REAL attach state
+  // (exclusive PTY slot + FIFO queue), never the raw connection counter,
+  // which also counts query-mode utility clients (remi ls / kill / polls).
+  test('attached session reads "attached", not a connection count', () => {
+    const out = formatStatusBar(
+      mkStatus({ connections: 3, attached: true, queuedCount: 0 }),
+      NOW_MS,
+    );
+    expect(out).toContain('| attached |');
+    expect(out).not.toContain('client(s)');
+  });
+
+  test('attached with queued viewers reads "attached (+N waiting)"', () => {
+    expect(
+      formatStatusBar(mkStatus({ connections: 3, attached: true, queuedCount: 2 }), NOW_MS),
+    ).toContain('| attached (+2 waiting) |');
+  });
+
+  test('not attached: queued-only shows "N waiting"; none shows "no clients" even with query connections', () => {
+    expect(
+      formatStatusBar(mkStatus({ connections: 2, attached: false, queuedCount: 1 }), NOW_MS),
+    ).toContain('| 1 waiting |');
+    // A `remi ls` poll bumped connections but nothing is attached or queued:
+    // the pre-#755 bar showed "1 client(s)" here.
+    expect(
+      formatStatusBar(mkStatus({ connections: 1, attached: false, queuedCount: 0 }), NOW_MS),
+    ).toContain('| no clients |');
   });
 
   test('in-flight eval shows evaluating with elapsed seconds', () => {

--- a/packages/daemon/tests/cli/status-writer.test.ts
+++ b/packages/daemon/tests/cli/status-writer.test.ts
@@ -257,4 +257,79 @@ describe('StatusWriter', () => {
     expect(w.state.autoApprove.inFlight).toBe(0); // back to idle, not stuck
     expect(w.state.autoApprove.sinceS).toBe(0);
   });
+
+  // #754/#755: every flush stamps live attach state and broadcasts the
+  // snapshot to clients on the same debounce as the disk write.
+  describe('broadcast + attach-state stamping (#754/#755)', () => {
+    test('flush stamps getAttachState fields and fires broadcast with them', () => {
+      const broadcasts: Array<{
+        attached: boolean | undefined;
+        queuedCount: number | undefined;
+      }> = [];
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        getAttachState: () => ({ attached: true, queuedCount: 2 }),
+        broadcast: (s) => broadcasts.push({ attached: s.attached, queuedCount: s.queuedCount }),
+      });
+      writer.flush();
+      expect(broadcasts).toEqual([{ attached: true, queuedCount: 2 }]);
+      const onDisk = JSON.parse(fs.readFileSync(target, 'utf-8'));
+      expect(onDisk.attached).toBe(true);
+      expect(onDisk.queuedCount).toBe(2);
+    });
+
+    test('broadcast fires even when the file write is disabled', () => {
+      let broadcastCount = 0;
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => false,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        broadcast: () => {
+          broadcastCount += 1;
+        },
+      });
+      writer.flush();
+      expect(broadcastCount).toBe(1);
+      expect(fs.existsSync(target)).toBe(false);
+    });
+
+    test('a throwing broadcast is logged once and never breaks the file write', () => {
+      const writer = new StatusWriter(baseStatus({ connections: 1 }), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        broadcast: () => {
+          throw new Error('registry down');
+        },
+      });
+      writer.flush();
+      writer.flush();
+      const onDisk = JSON.parse(fs.readFileSync(target, 'utf-8'));
+      expect(onDisk.connections).toBe(1); // file write survived
+      expect(logs.filter((l) => l.includes('Status broadcast failed'))).toHaveLength(1);
+    });
+
+    test('debounce collapses bursts into a single broadcast', async () => {
+      let broadcastCount = 0;
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 10,
+        broadcast: () => {
+          broadcastCount += 1;
+        },
+      });
+      writer.update({ connections: 1 });
+      writer.update({ connections: 2 });
+      writer.update({ connections: 3 });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(broadcastCount).toBe(1);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/statusline-installer.test.ts
+++ b/packages/daemon/tests/cli/statusline-installer.test.ts
@@ -42,6 +42,17 @@ describe('buildStatuslineScript', () => {
     expect(script).toContain('STATE="evaluating');
     expect(script).toContain('STATE="needs you"');
   });
+
+  test('labels the real attach state, keeping the counter label as legacy fallback (#755)', () => {
+    const script = buildStatuslineScript('/x');
+    // reads the attach fields; "unset" marks an older daemon's status file
+    expect(script).toContain('.attached');
+    expect(script).toContain('.queuedCount');
+    expect(script).toContain('CLIENT_INFO="attached"');
+    expect(script).toContain('waiting');
+    // legacy fallback stays for pre-#755 status files
+    expect(script).toContain('client(s)');
+  });
 });
 
 describe('installStatusLine', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,8 @@ export type {
   MessageState,
   MessageSender,
   AgentStatus,
+  AutoApproveState,
+  RemiStatus,
   Message,
   BulletType,
   Bullet,
@@ -97,6 +99,7 @@ export type {
   SessionViewsMessage,
   SessionViewMeta,
   QuestionResolvedMessage,
+  RemiStatusMessage,
   CreateHelloAckOptions,
   CreateHelloOptions,
 } from './protocol.ts';
@@ -151,6 +154,7 @@ export {
   createSessionRotated,
   createSessionViews,
   createQuestionResolved,
+  createRemiStatus,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -16,6 +16,7 @@ import type {
   DiscoverableSession,
   Message,
   Question,
+  RemiStatus,
   Session,
   StructuredMessage,
   Timestamp,
@@ -104,7 +105,8 @@ export type ProtocolMessage =
   | HubStatusMessage
   | SessionRotatedMessage
   | SessionViewsMessage
-  | QuestionResolvedMessage;
+  | QuestionResolvedMessage
+  | RemiStatusMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -334,6 +336,22 @@ export interface QuestionResolvedMessage {
   readonly questionId: UUID;
   /** Why it resolved, for diagnostics + client UX (all dismiss the card the same). */
   readonly reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
+}
+
+/**
+ * Daemon status snapshot broadcast (#754). Fired on the StatusWriter's
+ * debounced flush (and once to each newly attached connection), never
+ * recorded into replay history — it is ephemeral display state. The terminal
+ * attach client renders it on the same reserved-row status bar the wrapper
+ * draws; other clients may ignore it.
+ */
+export interface RemiStatusMessage {
+  readonly type: 'remi_status';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** The daemon's primary session the snapshot describes. */
+  readonly sessionId: UUID;
+  readonly status: RemiStatus;
 }
 
 /** Session state update */
@@ -909,6 +927,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'session_rotated',
     'session_views',
     'question_resolved',
+    'remi_status',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1217,6 +1236,22 @@ export function createQuestionResolved(
     sessionId,
     questionId,
     reason,
+  };
+}
+
+/**
+ * Create a daemon status snapshot broadcast (#754). The status object is
+ * copied shallowly (plus autoApprove one level deep) so a later in-place
+ * mutation of the daemon's live status cannot retroactively change a message
+ * already queued for serialization.
+ */
+export function createRemiStatus(sessionId: UUID, status: RemiStatus): RemiStatusMessage {
+  return {
+    type: 'remi_status',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    status: { ...status, autoApprove: { ...status.autoApprove } },
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -435,3 +435,69 @@ export interface DiscoverableSession {
   /** Hostname of the daemon hosting this session */
   readonly daemonHost?: string;
 }
+
+/**
+ * Auto-approve eval state surfaced in status displays (#560). Driven by a
+ * COUNT (inc on eval start, dec on every end path), not a boolean spinner —
+ * a count cannot get "stuck" when concurrent evals interleave start/stop.
+ * Times are epoch SECONDS so the statusline shell script can compute elapsed
+ * with `date +%s`.
+ *
+ * Lives in shared (#754) because the daemon broadcasts the full status
+ * snapshot to clients (`remi_status`), and the terminal attach client renders
+ * the same reserved-row bar the wrapper does.
+ */
+export interface AutoApproveState {
+  /** Evals in flight on this daemon. 0 = idle. */
+  inFlight: number;
+  /** Epoch seconds the current in-flight batch began (set on 0->1, cleared on
+   *  1->0). Status displays show `evaluating <now-sinceS>s`. */
+  sinceS: number;
+  /** Last settled verdict, for a post-eval cue. */
+  lastVerdict: 'approved' | 'escalated' | 'none';
+  /** Epoch seconds of the last verdict; displays fade 'approved' after a few
+   *  seconds and keep 'escalated' (needs-you) until the next eval. */
+  lastVerdictAtS: number;
+}
+
+/**
+ * The daemon's status snapshot: written (debounced) to the per-port status
+ * file the Claude statusline script reads, rendered on the wrapper's
+ * reserved-row status bar, and broadcast to clients as `remi_status` (#754)
+ * so an attach client can render the same bar.
+ */
+export interface RemiStatus {
+  pid: number;
+  connections: number;
+  sessionStatus: AgentStatus;
+  adapters: string[];
+  wsPort: number;
+  sessionId: UUID | null;
+  repo: string;
+  branch: string;
+  autoApprove: AutoApproveState;
+  /**
+   * #755: true when a client holds the session's exclusive PTY slot
+   * (`activeConnectionId !== null`) — the status label reads "attached".
+   * Unlike `connections`, this never counts query-mode utility clients
+   * (`remi ls` / `remi kill` / phone session-list polls). Optional so an
+   * older writer/reader pair degrades gracefully.
+   */
+  attached?: boolean;
+  /** #755: clients queued behind the active one (read-only viewers). */
+  queuedCount?: number;
+  /**
+   * Distinguishes a session-less hub daemon (`remi serve`, #542) from an
+   * ordinary single-session daemon/wrapper process. Optional so an older
+   * writer/reader pair (mixed-version upgrade window) degrades gracefully
+   * rather than failing a strict shape check.
+   */
+  mode?: 'hub' | 'session';
+  /**
+   * The remi binary version this process runs (#539). A daemon holds its
+   * binary for life; `remi status`/`ls` compare this against the installed
+   * binary to flag stale daemons. Optional for the same mixed-version
+   * reasons as `mode`.
+   */
+  version?: string;
+}

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -21,6 +21,7 @@ import {
   createPong,
   createQuestion,
   createQuestionResolved,
+  createRemiStatus,
   createReplayBatch,
   createResumeSessionRequest,
   createResumeSessionResponse,
@@ -406,6 +407,47 @@ describe('createQuestionResolved() (#585 P7)', () => {
         expect(parsed.reason).toBe(reason);
       }
     }
+  });
+});
+
+describe('createRemiStatus() (#754)', () => {
+  function mkRemiStatus() {
+    return {
+      pid: 1,
+      connections: 2,
+      sessionStatus: 'thinking' as const,
+      adapters: ['ws'],
+      wsPort: 19924,
+      sessionId: null,
+      repo: 'remi',
+      branch: 'develop',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'none' as const, lastVerdictAtS: 0 },
+      attached: true,
+      queuedCount: 1,
+    };
+  }
+
+  test('builds a well-formed remi_status message that round-trips', () => {
+    const sessionId = generateId();
+    const msg = createRemiStatus(sessionId, mkRemiStatus());
+    expect(msg.type).toBe('remi_status');
+    expect(msg.sessionId).toBe(sessionId);
+    const parsed = deserialize(serialize(msg));
+    expect(parsed?.type).toBe('remi_status');
+    if (parsed?.type === 'remi_status') {
+      expect(parsed.status.attached).toBe(true);
+      expect(parsed.status.queuedCount).toBe(1);
+      expect(parsed.status.autoApprove.lastVerdict).toBe('none');
+    }
+  });
+
+  test('snapshots the status: later mutation of the source does not leak into the message', () => {
+    const status = mkRemiStatus();
+    const msg = createRemiStatus(generateId(), status);
+    status.attached = false;
+    status.autoApprove.inFlight = 5;
+    expect(msg.status.attached).toBe(true);
+    expect(msg.status.autoApprove.inFlight).toBe(0);
   });
 });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1484,6 +1484,12 @@ function App() {
         break;
       }
 
+      case 'remi_status':
+        // #754: terminal status-bar snapshot; the web app renders session
+        // state from session_update/transcript flows instead. Explicitly
+        // ignored so the debounced broadcast doesn't spam the debug log.
+        break;
+
       default:
         console.debug(`[App] Unhandled message type: ${(message as { type: string }).type}`);
         break;


### PR DESCRIPTION
Closes #754. Closes #755. Part of epic #757.

The reserved-row status bar only existed in wrapper mode, drawn by the wrapper process directly on its own TTY; daemon-spawned (phone-created) sessions structurally had none, the attach client had no bar code, and the label counted every WebSocket connection (including `remi ls` / `remi kill` / phone list polls) as "N client(s)".

## #754 — bar on attach, rendered client-side

- `RemiStatus` + `AutoApproveState` move to `@remi/shared` (re-exported from `status-writer.ts` for existing importers); new `remi_status` protocol message + `createRemiStatus` factory. Broadcast-only, never recorded into replay history (ephemeral display state).
- `StatusWriter` broadcasts the snapshot on the same debounce as the disk write (`broadcast` dep, throw-guarded; fires even when the file write is disabled). cli.ts late-binds it to `AdapterRegistry.broadcast`. A new connection already triggers a flush via the connections counter, so a fresh attach gets its first snapshot within ~300ms with no extra plumbing.
- The attach client renders the identical `StatusBar` class from broadcast snapshots on a real TTY only, reserving the bottom row by reporting `rows - 1` (`childRows`, exactly like wrapper mode). The bar starts on the FIRST snapshot, so an older daemon wastes no row; it stops and clears the row on detach/close. Non-TTY output (pipes, tests) never receives bar escapes.

## #755 — label from real attach state

- `StatusWriter` stamps live attach state into every flush via a pull dep (`getAttachState`), sourced from the session registry's exclusive PTY slot (`activeConnectionId`) and FIFO queue (`waitingConnectionCount`) — attach transitions (attach, disconnect, auto-promotion) don't all flow through one place, so pulling at flush time beats scattering updates.
- Label (mirrored in `formatStatusBar` and the bash statusline script): attached -> `attached` / `attached (+N waiting)`; not attached -> `N waiting` / `no clients`. The old `N client(s)` counter label survives only as the fallback for status files written by older daemons.

## Tests

209 pass across shared protocol (round-trip, snapshot isolation), status-writer (stamping, broadcast-when-file-disabled, throw-guard, debounce collapse), status-bar labels (attached/waiting/no-clients with query connections present), statusline script content, attach-client non-TTY guard, connection-events. Web build clean (`remi_status` explicitly ignored in App.tsx).

Note: epic-branch PRs get no CI; suites run locally. Expect small merge conflicts with #760 in attach-client.ts renderMessage (resolved at merge).