### PR TITLE
Epic: 2026-07-08 soak fixes (subagent routing, answer idempotency, attach visibility, status bar)

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -98,6 +98,15 @@ export class QuestionPresenceTracker {
    *  candidate; with 2+ different-agent entries it pushes bare (no guessing). */
   private pending = new Map<string, Question>();
 
+  /** Keys of `pending` records PARKED by the gate awaiting PTY arbitration
+   *  (#751): a subagent-tagged escalation the gate answered 'passthrough'
+   *  instead of holding or denying. Unlike a normal pending record (an
+   *  in-flight gate escalation whose own push is imminent), a parked record
+   *  must NOT count as gate-owned in the #712 orphan check — the PTY render
+   *  IS its push trigger. Always a subset of `pending`'s keys; every
+   *  `pending` delete/clear site mirrors onto this set. */
+  private awaitingPTY = new Set<string>();
+
   /** True while a permission prompt is on the main PTY. Set by
    *  `onPTYPromptVisible`; reset by `onStatusChange` out of `'waiting'`
    *  AND by `clearPending` (the auto-approve cancelled branch confirms
@@ -189,6 +198,29 @@ export class QuestionPresenceTracker {
     // PTY-pairing fallback below).
     this.pending.delete(key);
     this.pending.set(key, question);
+    // A normal (gate-owned) record replaces any parked one for this agent;
+    // parkAwaitingPTY re-adds the flag after routing through here (#751).
+    this.awaitingPTY.delete(key);
+  }
+
+  /**
+   * Park a subagent-tagged permission question awaiting PTY arbitration
+   * (#751). The gate answered the hook 'passthrough' (no hold, no deny, no
+   * push): Claude runs its normal permission flow, so either the session
+   * allowlist absorbs the request silently (the record then expires on the
+   * next status transition, like any pending record) or the native prompt
+   * renders on the main PTY — `onOrphanPTYPrompt` recognizes the parked
+   * record, merges its rich labels onto the parsed prompt, and pushes
+   * immediately (no orphan debounce: hook + render is positive
+   * double-confirmation). The PTY is the arbiter of whether the user is
+   * asked.
+   */
+  parkAwaitingPTY(question: Question): void {
+    this.recordPendingHook(question);
+    // recordPendingHook may have kept a richer existing record instead of
+    // this one; the parked flag applies to whatever record now owns the key
+    // (both are hook-derived for the same agent's prompt cycle).
+    this.awaitingPTY.add(agentKey(question));
   }
 
   /**
@@ -231,6 +263,7 @@ export class QuestionPresenceTracker {
     // Consume BEFORE the push so a re-entrant call cannot re-push the same
     // record, and so a later onPTYPromptVisible has no record to merge.
     this.pending.delete(recordKey);
+    this.awaitingPTY.delete(recordKey);
     this.pushedHeldIds.add(questionId);
     try {
       // held: bypass the cosmetic dedup + deliver regardless of an attached
@@ -305,10 +338,12 @@ export class QuestionPresenceTracker {
       // can't stale-merge onto a later unrelated prompt (recordKey stays
       // undefined here, so the delete below would otherwise skip them).
       this.pending.clear();
+      this.awaitingPTY.clear();
     }
     const hookRecord = recordKey !== undefined ? this.pending.get(recordKey) : undefined;
     if (recordKey !== undefined) {
       this.pending.delete(recordKey);
+      this.awaitingPTY.delete(recordKey);
     }
 
     // #718: a fallback hook record must not overwrite the PTY's own options
@@ -390,6 +425,16 @@ export class QuestionPresenceTracker {
       this.bufferedDuringEval = ptyQuestion;
       return;
     }
+    // #751 PTY-arbiter: a parked subagent escalation whose prompt has now
+    // rendered. Merge + push IMMEDIATELY through the normal pair path — no
+    // orphan debounce (hook + render is positive double-confirmation) and no
+    // gate-owned / live-question suppression (an unrelated live card must not
+    // eat the one prompt class this parking exists to surface).
+    const parkedKey = this.matchAwaitingPTYKey(ptyQuestion);
+    if (parkedKey !== undefined) {
+      this.onPTYPromptVisible(ptyQuestion);
+      return;
+    }
     if (this.isGateOwnedCycle(ptyQuestion)) {
       console.debug(
         `[QuestionPresenceTracker] Orphan PTY prompt suppressed (gate owns this cycle): "${ptyQuestion.text.slice(0, 60)}"`,
@@ -412,7 +457,10 @@ export class QuestionPresenceTracker {
    *  as "no live questions" (fail-open: a possibly-redundant push is far
    *  better than crashing the daemon or silently swallowing a real orphan). */
   private isGateOwnedCycle(ptyQuestion: Question): boolean {
-    if (this.pending.has(agentKey(ptyQuestion))) return true;
+    // A parked record (#751) never claims ownership: its push TRIGGER is the
+    // PTY render this check would otherwise suppress.
+    const key = agentKey(ptyQuestion);
+    if (this.pending.has(key) && !this.awaitingPTY.has(key)) return true;
     try {
       return this.deps.hasLiveQuestions?.() ?? false;
     } catch (err) {
@@ -472,6 +520,7 @@ export class QuestionPresenceTracker {
   onStatusChange(status: AgentStatus): void {
     if (status !== 'waiting') {
       this.pending.clear();
+      this.awaitingPTY.clear();
       this.ptyShowingQuestion = false;
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
@@ -534,6 +583,7 @@ export class QuestionPresenceTracker {
    */
   clearPending(): void {
     this.pending.clear();
+    this.awaitingPTY.clear();
     this.ptyShowingQuestion = false;
     this.autoApproveInFlight = false;
     this.bufferedDuringEval = null;
@@ -541,6 +591,22 @@ export class QuestionPresenceTracker {
     // #712: the prompt was answered in-terminal or the session is rotating —
     // either way an armed orphan timer for it must not fire a stale push.
     this.cancelOrphanTimer();
+  }
+
+  /** Match a rendered PTY prompt to a PARKED (#751 awaiting-PTY) record: an
+   *  exact agent-key match, or the sole-candidate fallback (exactly one
+   *  pending record and it is parked — PTY prompts rarely name their agent,
+   *  mirroring `onPTYPromptVisible`'s own pairing heuristic). With 2+ pending
+   *  records and no exact match, no guess is made here; the prompt falls to
+   *  the normal owned/orphan logic. */
+  private matchAwaitingPTYKey(ptyQuestion: Question): string | undefined {
+    const key = agentKey(ptyQuestion);
+    if (this.awaitingPTY.has(key) && this.pending.has(key)) return key;
+    if (this.pending.size === 1) {
+      const sole = [...this.pending.keys()][0] as string;
+      if (this.awaitingPTY.has(sole)) return sole;
+    }
+    return undefined;
   }
 
   /** Cancel any armed orphan-prompt debounce timer and discard its candidate. */
@@ -575,6 +641,11 @@ export class QuestionPresenceTracker {
   /** Test-only: number of distinct agents with a pending hook record. */
   pendingCountForTest(): number {
     return this.pending.size;
+  }
+
+  /** Test-only: number of pending records parked awaiting PTY arbitration (#751). */
+  awaitingPTYCountForTest(): number {
+    return this.awaitingPTY.size;
   }
 
   /** Test-only: whether an orphan-prompt debounce timer is currently armed. */

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -174,11 +174,21 @@ export interface AutoApproveGateDeps {
    * PermissionRequest (`agent_id` absent) observes `isInSubagentContext()`
    * stuck true — proof of a tracker leak (a dropped PostToolUse(Task/Agent)
    * completion), never a real subagent prompt (those carry `agent_id` and
-   * default-deny instead). Optional so tests that don't wire it degrade to a
-   * no-op; the escalate-as-main recovery still happens without it, just
-   * without clearing the leaked state.
+   * park for PTY arbitration instead, #751). Optional so tests that don't
+   * wire it degrade to a no-op; the escalate-as-main recovery still happens
+   * without it, just without clearing the leaked state.
    */
   resetSubagentContext?: () => void;
+  /**
+   * Park a subagent-tagged escalation for PTY arbitration (#751): stash its
+   * rich question in the `QuestionPresenceTracker` (via
+   * `parkAwaitingPTY(hookBridge.buildPermissionQuestion(input))`) WITHOUT
+   * pushing or registering it. The gate answers the hook 'passthrough'; the
+   * question only surfaces if Claude's native prompt actually renders on the
+   * PTY. Optional so tests that don't wire it degrade to a plain passthrough
+   * (the rendered prompt then pushes bare via the #712 orphan path).
+   */
+  parkForPTY?: (input: PermissionRequestHookInput) => void;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -880,11 +890,19 @@ export class AutoApproveGate {
    *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
    *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
    *     prompt; the user answers).
-   *   - escalate / no-service / eval-error in a SUBAGENT-TAGGED context
-   *     (`agent_id` present) -> 'deny' via the hook response. This is the core
-   *     fix: the old PTY-inject default-deny couldn't tell whose prompt was on
-   *     the PTY for parallel subagents and leaked; the synchronous deny needs
-   *     no PTY at all.
+   *   - escalate / no-service / eval-error / pick on a SUBAGENT-TAGGED event
+   *     (`agent_id` present) -> park the rich question in the presence
+   *     tracker + 'passthrough' (#751 PTY-arbiter), REGARDLESS of
+   *     `isInSubagentContext()` (the tracker only brackets synchronous
+   *     Task/Agent spawns, so team members and async/background subagents
+   *     always observe it false — the tag on the event itself is the truth).
+   *     Claude then runs its NORMAL permission flow: the session allowlist
+   *     may absorb the request silently, or the native prompt renders on the
+   *     main PTY and the tracker merges the parked labels onto it and pushes
+   *     (answers inject; nothing is held). Replaces both prior behaviors:
+   *     silent default-deny (sync-Task shape, broke teammates with no trace)
+   *     and hold+push-as-main (async/team shape, pushed cards for prompts
+   *     the user never saw asked).
    *   - the SAME three branches with `isInSubagentContext()` true but NO
    *     `agent_id` on the input -> this is the #710 tracker-leak signature
    *     (a PostToolUse(Task/Agent) completion tagged with the spawned agent's
@@ -909,29 +927,28 @@ export class AutoApproveGate {
       );
     }
 
-    // No auto-approve: subagent default-denies via the response (no PTY, no
-    // leak); main escalates to the user (holding the hook when binary, #573).
+    // No auto-approve: main escalates to the user (holding the hook when
+    // binary, #573); a subagent-tagged event parks for PTY arbitration (#751).
     if (!service) {
+      if (isSubagent) {
+        log(
+          `[AutoApprove ${this.sessionTag}] Subagent PermissionRequest without auto-approve; parking for PTY arbitration`,
+        );
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
       if (isInSubagentContext()) {
-        if (this.isSubagentEvent(input)) {
-          log(`[${this.sessionTag}] Subagent context without auto-approve; default-deny`);
-          return 'deny';
-        }
-        // #710: a MAIN-tagged event (no agent_id) reaching here means the
-        // tracker leaked, not a real subagent prompt. Reset and fall through
-        // to escalateMain below instead of denying the main agent.
+        // #710: a MAIN-tagged event (no agent_id) with the tracker stuck true
+        // means the tracker leaked, not a real subagent prompt. Reset it so
+        // the leak cannot linger (a genuine sync-Task bracket pops on its own
+        // PostToolUse; only a leak survives to be observed here).
         //
         // #716 (blanket-reset tradeoff): resetSubagentContext() clears ALL
         // tracked use_ids, not just the leaked one -- it cannot tell which
-        // entry is stale. If a genuinely-running concurrent synchronous Task
-        // is ALSO open right now, its own later agent_id-tagged permission
-        // requests will see isInSubagentContext() false and escalate as main
-        // instead of default-denying. Accepted: (a) that escalation is
-        // held/answerable (Model B), the same way async/background subagents
-        // and team members already behave; (b) the alternative -- silently
-        // denying the MAIN agent -- is the #710 bug this reset exists to fix.
+        // entry is stale. Post-#751 that is harmless for routing: subagent
+        // routing keys on the event's own agent_id, never on the tracker.
         logError(
-          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
+          `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, no-service path); resetting tracker. Possible subagent-context tracker leak.`,
         );
         this.deps.resetSubagentContext?.();
       }
@@ -987,12 +1004,14 @@ export class AutoApproveGate {
       result = await evalPromise;
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Unexpected error:`, err);
+      // #751: a subagent-tagged event the eval could not decide parks for
+      // PTY arbitration (keys on the event's own agent_id alone; the
+      // tracker is sync-Task-only -- see resolvePermission's doc).
+      if (isSubagent) {
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
       if (isInSubagentContext()) {
-        if (isSubagent) {
-          // #711: a genuine subagent deny must not flap the client pill.
-          this.markHandled(true);
-          return 'deny';
-        }
         // #710: MAIN-tagged + stuck tracker == leak, not a real subagent
         // prompt. Reset and fall through to escalateMain below. Blanket-reset
         // tradeoff (clears ALL tracked use_ids, not just the leaked one):
@@ -1023,10 +1042,21 @@ export class AutoApproveGate {
     }
     if (result.decision === 'pick') {
       // Multi-choice pick (#399): the response can't express it, so render the
-      // prompt (passthrough) and inject the 1-based index into the PTY. The
-      // index was validated against options length upstream. The discriminated
-      // union guarantees pickIndex, but guard defensively: a malformed result
-      // must escalate, not silently fall through to the subagent-deny below.
+      // prompt (passthrough) and inject the 1-based index into the PTY.
+      //
+      // #751: a subagent's prompt is never on the main PTY at decision time
+      // (the hook is blocked on this very response), so the inject below
+      // would either be dropped or -- worse, when an unrelated MAIN prompt is
+      // visible -- type into the wrong prompt. Park for PTY arbitration
+      // instead: the pick verdict is forfeited and the user answers the
+      // rendered prompt (terminal or merged push card).
+      if (isSubagent) {
+        this.parkSubagentForPTY(input);
+        return 'passthrough';
+      }
+      // The index was validated against options length upstream. The
+      // discriminated union guarantees pickIndex, but guard defensively: a
+      // malformed result must escalate, not silently fall through.
       if (result.pickIndex === undefined) {
         logError(`[AutoApprove ${this.sessionTag}] pick result missing pickIndex; escalating`);
         return this.escalatePassthrough(input);
@@ -1039,27 +1069,30 @@ export class AutoApproveGate {
       }
       return this.escalatePassthrough(input);
     }
-    // escalate: a subagent prompt the user cannot answer is default-denied via
-    // the response (no hang, no PTY). A MAIN-tagged event (agent_id absent)
-    // reaching here with isInSubagentContext() true is NOT a real subagent
-    // prompt: it is the #710 tracker-leak signature (a PostToolUse(Task/Agent)
-    // completion stamped with the SPAWNED agent's own agent_id never popped
-    // the use_id an earlier untagged PreToolUse tracked). Denying it would
-    // silently drop the main agent's own prompts (including AskUserQuestion)
-    // forever, so reset the tracker and fall through to escalate as main
-    // instead. Tradeoff (#710): on a legacy Claude Code version that predates
-    // agent_id, a genuine synchronous subagent prompt would now escalate+hold
-    // instead of deny — still answerable via the Model B hook response
-    // (below), strictly better than a silent main-agent deny.
+    // escalate on a subagent-tagged event: park for PTY arbitration (#751).
+    // Keys on the event's own agent_id alone -- the SubagentContextTracker
+    // only brackets SYNCHRONOUS Task/Agent spawns, so team members and
+    // async/background subagents always observe isInSubagentContext() false;
+    // the old AND-gate escalated their prompts to the phone as if they were
+    // the main agent's, while the sync-Task shape silently default-denied.
+    // The second opinion below is skipped deliberately: the hook answer is
+    // 'passthrough' either way, so a heavier model buys nothing here.
+    if (isSubagent) {
+      log(
+        `[AutoApprove ${this.sessionTag}] Subagent escalate; parking for PTY arbitration (agent=${input.agent_id?.slice(0, 8)})`,
+      );
+      this.parkSubagentForPTY(input);
+      return 'passthrough';
+    }
+    // A MAIN-tagged event (agent_id absent) with isInSubagentContext() true is
+    // NOT a real subagent prompt: it is the #710 tracker-leak signature (a
+    // PostToolUse(Task/Agent) completion stamped with the SPAWNED agent's own
+    // agent_id never popped the use_id an earlier untagged PreToolUse tracked).
+    // Denying it would silently drop the main agent's own prompts (including
+    // AskUserQuestion) forever, so reset the tracker and fall through to
+    // escalate as main instead. Blanket-reset tradeoff (clears ALL tracked
+    // use_ids, not just the leaked one): see the no-service branch above (#716).
     if (isInSubagentContext()) {
-      if (isSubagent) {
-        log(`[AutoApprove ${this.sessionTag}] Subagent context; escalate->deny to prevent hang`);
-        // #711: a genuine subagent deny must not flap the client pill.
-        this.markHandled(true);
-        return 'deny';
-      }
-      // Blanket-reset tradeoff (clears ALL tracked use_ids, not just the
-      // leaked one): see the no-service branch above (#716).
       logError(
         `[AutoApprove ${this.sessionTag}] isInSubagentContext() true for a MAIN-agent PermissionRequest (tool=${input.tool_name}, escalate path); resetting tracker and escalating. Possible subagent-context tracker leak.`,
       );
@@ -1159,10 +1192,17 @@ export class AutoApproveGate {
     const pushHoldMs = this.deps.pushHoldMs ?? 0;
     // Disabled, or this escalation could not be answered via the hook response
     // anyway (multi-choice/design), or a subagent prompt the user can't answer:
-    // do not arm the race. Subagent context is read live (it may close before
-    // the verdict), but arming an early USER push for a subagent prompt would be
-    // wrong, so gate on the current value here.
-    if (pushHoldMs <= 0 || !this.isBinaryEscalation(input) || this.deps.isInSubagentContext()) {
+    // do not arm the race. #751: the subagent check keys on the event's own
+    // agent_id (the tracker misses async/team spawns); the tracker is ALSO
+    // consulted live (it may close before the verdict) to cover legacy events
+    // without agent_id, since arming an early USER push for a subagent prompt
+    // would be wrong either way.
+    if (
+      pushHoldMs <= 0 ||
+      !this.isBinaryEscalation(input) ||
+      this.isSubagentEvent(input) ||
+      this.deps.isInSubagentContext()
+    ) {
       return null;
     }
 
@@ -1300,6 +1340,35 @@ export class AutoApproveGate {
   private markHandled(isSubagent: boolean): void {
     this.deps.tracker.onAutoApproveHandled();
     this.safeCueWithArg('onHandled', this.deps.onHandled, { isSubagent });
+  }
+
+  /**
+   * #751 PTY-arbiter routing for a subagent-tagged permission the gate cannot
+   * decide (escalate verdict, eval error, forfeited pick, or no auto-approve):
+   * park the rich question in the presence tracker, then close the #484
+   * buffer window via the onEscalate cue (semantically this IS an escalation,
+   * just PTY-mediated; the terminal statusline reads 'escalated'). The caller
+   * answers the hook 'passthrough': Claude runs its normal permission flow,
+   * so the session allowlist may absorb the request silently, or the native
+   * prompt renders on the main PTY and the tracker pairs the parked record
+   * with it and pushes the merged card (answers inject; nothing is held).
+   * Park FIRST, cue SECOND — the cue may release a buffered PTY prompt whose
+   * pair+push must be able to find the record (mirrors escalateToUser).
+   *
+   * A parkForPTY throw is absorbed: the passthrough still stands, and the
+   * rendered prompt degrades to a bare #712 orphan push instead of a merged
+   * one.
+   */
+  private parkSubagentForPTY(input: PermissionRequestHookInput): void {
+    try {
+      this.deps.parkForPTY?.(input);
+    } catch (err) {
+      logError(
+        `[AutoApprove ${this.sessionTag}] parkForPTY threw (prompt will fall to the orphan push path):`,
+        err,
+      );
+    }
+    this.safeCue('onEscalate', this.deps.onEscalate);
   }
 
   /**

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -66,6 +66,12 @@ import { IDLE_AUTO_APPROVE, type RemiStatus, StatusWriter } from './cli/status-w
 
 const gitInfo = detectGitInfo();
 
+// #754/#755: the StatusWriter is constructed before the AdapterRegistry and
+// SessionRegistry exist, so its broadcast + attach-state deps are late-bound
+// through these slots (assigned right after the AdapterRegistry below).
+let remiStatusBroadcast: ((status: Readonly<RemiStatus>) => void) | null = null;
+let remiAttachState: (() => { attached: boolean; queuedCount: number } | null) | null = null;
+
 const statusWriter = new StatusWriter(
   {
     pid: process.pid,
@@ -91,6 +97,8 @@ const statusWriter = new StatusWriter(
       serveMode && process.env['REMI_SPAWNED_CHILD'] !== '1' ? DAEMON_STATUS_FILE : STATUS_FILE,
     isEnabled: () => isWrapperMode() || cliDaemonMode,
     writeLog: writeToLog,
+    getAttachState: () => remiAttachState?.() ?? null,
+    broadcast: (status) => remiStatusBroadcast?.(status),
   },
 );
 
@@ -106,6 +114,7 @@ import {
   createError,
   createHelloAck,
   createQuestionResolved,
+  createRemiStatus,
   createReplayBatch,
   createSessionUpdate,
 } from '@remi/shared';
@@ -1488,6 +1497,25 @@ const registry = new AdapterRegistry({
     updateRemiStatus({ adapters: remiStatus.adapters.filter((a) => a !== type) });
   },
 });
+
+// #754: every debounced status flush also reaches connected clients, so the
+// terminal attach client can draw the same reserved-row bar the wrapper does.
+remiStatusBroadcast = (status) => {
+  const primary = getPrimarySessionId();
+  if (!primary) return;
+  registry.broadcast(createRemiStatus(primary, status as RemiStatus));
+};
+// #755: attach state pulled from the session registry at flush time — the
+// exclusive PTY slot + FIFO queue, never the blunt connection counter.
+remiAttachState = () => {
+  const primary = getPrimarySessionId();
+  if (!primary) return { attached: false, queuedCount: 0 };
+  const session = sessionRegistry.getSession(primary);
+  return {
+    attached: (session?.activeConnectionId ?? null) !== null,
+    queuedCount: sessionRegistry.waitingConnectionCount,
+  };
+};
 
 /**
  * Cross-client question dismissal (#585, P7). Fired when a pending question stops

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1058,6 +1058,18 @@ const sessionRegistry = new SessionRegistry(
           log(`Failed to send replay batch to promoted connection ${connectionId}`);
         }
       }
+      // #753 (#760 review finding 2): a promoted connection was queued
+      // (read-only) while live questions may have arrived — those broadcasts
+      // only reach the active connection, so re-send the pending set now.
+      const resent = resendPendingQuestions(
+        (m) => registry.sendRaw(connectionId, m),
+        sessionId,
+        result.currentQuestions,
+        claudeId ?? undefined,
+      );
+      if (resent > 0) {
+        log(`Re-sent ${resent} pending question(s) to promoted connection ${connectionId}`);
+      }
       cancelOrphanTimeout();
     },
   },
@@ -1520,6 +1532,7 @@ const onQuestionResolved = (
   }
 };
 
+import { resendPendingQuestions } from './cli/handlers/pending-question-resend.ts';
 import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -10,9 +10,10 @@ import {
   generateId,
   serialize,
 } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, RemiStatus, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 import { DetachScanner } from './detach-scanner.ts';
+import { StatusBar, childRows } from './status-bar.ts';
 
 export interface AttachClientOptions {
   host: string;
@@ -46,6 +47,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   let rawPtyTimer: ReturnType<typeof setTimeout> | null = null;
   let detachPending = false;
   let detachAckTimer: ReturnType<typeof setTimeout> | null = null;
+  // #754: latest daemon status snapshot (remi_status broadcast) + the
+  // reserved-row bar rendering it — the same StatusBar the wrapper draws.
+  // Only on a real TTY: piped/test output must never receive bar escapes.
+  const statusBarEligible = process.stdout.isTTY === true;
+  let latestStatus: RemiStatus | null = null;
+  let statusBar: StatusBar | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -61,6 +68,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   }
 
   function restoreTerminal(): void {
+    // #754: halt the bar loop and clear its reserved row before anything else
+    // writes to the terminal, so the returned shell starts clean.
+    if (statusBar) {
+      statusBar.stop();
+      statusBar = null;
+    }
     if (detachAckTimer) {
       clearTimeout(detachAckTimer);
       detachAckTimer = null;
@@ -135,11 +148,42 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     }
   }
 
+  /**
+   * #754: start the reserved-row status bar once the first `remi_status`
+   * snapshot arrives (an older daemon never sends one, so no row is wasted).
+   * Reserving the row = reporting `rows - 1` to the daemon's PTY, exactly like
+   * wrapper mode; the StatusBar itself is the same class, drawing on this
+   * terminal's bottom row from the broadcast snapshots.
+   */
+  function startStatusBar(): void {
+    if (!statusBarEligible || statusBar !== null || resolved) return;
+    statusBar = new StatusBar({
+      getStdoutFd: () => (outputBroken ? null : outputFd),
+      getStatus: () => latestStatus as RemiStatus,
+      getSize: () => ({
+        cols: process.stdout.columns || 120,
+        rows: process.stdout.rows || 40,
+      }),
+      isEnabled: () => latestStatus !== null,
+      log: (msg) => process.stderr.write(`${msg}\n`),
+    });
+    statusBar.start();
+    const cols = process.stdout.columns || 120;
+    const rows = process.stdout.rows || 40;
+    sendMessage(createTerminalResize(cols, childRows(rows, true)));
+  }
+
   function renderMessage(msg: ProtocolMessage): void {
     switch (msg.type) {
       case 'raw_pty_output':
         receivedRawPty = true;
         writeRawBytes(msg.data);
+        break;
+      case 'remi_status':
+        // #754: display state only — never printed as text. The bar's own
+        // 250ms repaint loop reads the latest snapshot.
+        latestStatus = msg.status;
+        if (attachedSessionId) startStatusBar();
         break;
       case 'agent_output':
       case 'structured_agent_output':
@@ -235,11 +279,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         };
         process.stdin.on('data', stdinListener);
 
-        // Forward terminal resize
+        // Forward terminal resize. #754: while the status bar is up, its row
+        // stays reserved (report rows-1, mirroring wrapper mode's childRows).
         resizeListener = () => {
           const cols = process.stdout.columns || 120;
           const rows = process.stdout.rows || 40;
-          sendMessage(createTerminalResize(cols, rows));
+          sendMessage(createTerminalResize(cols, childRows(rows, statusBar !== null)));
         };
         process.stdout.on('resize', resizeListener);
 
@@ -253,9 +298,13 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
           sendMessage(createTerminalResize(cols - 1, rows));
           resizeNudgeTimer = setTimeout(() => {
             resizeNudgeTimer = null;
-            sendMessage(createTerminalResize(cols, rows));
+            sendMessage(createTerminalResize(cols, childRows(rows, statusBar !== null)));
           }, 50);
         }
+
+        // #754: a remi_status broadcast may have raced ahead of the (real)
+        // hello_ack; start the bar from the stored snapshot now.
+        if (latestStatus !== null) startStatusBar();
 
         // Warn if no raw PTY data arrives within a few seconds
         rawPtyTimer = setTimeout(() => {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -142,14 +142,22 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   const banneredQuestionIds = new Set<string>();
 
   /**
-   * #753: print a pending question into the attached terminal. A HELD
+   * #753: print a pending HELD question into the attached terminal. A held
    * permission (Model B) blocks Claude inside the hook call, so no raw PTY
    * bytes for the prompt exist and the resize-nudge redraw has nothing to
-   * repaint — without this banner an attach shows only "waiting". Plain
-   * text through writeOutput (raw mode: \r\n), cyan so it stands apart from
-   * Claude's own output.
+   * repaint — without this banner an attach shows only "waiting". ONLY held
+   * questions banner (#760 review finding 1): every other question class
+   * renders natively in the raw PTY stream, and the daemon emits multiple
+   * `question` messages per visible prompt cycle (hook bridge + PTY parser,
+   * different ids), so bannering those would double- or triple-print around
+   * the native prompt — the exact noise the old blanket suppression avoided.
+   * Held questions also guarantee an idle PTY, so the banner can never
+   * interleave mid-ANSI-sequence with streaming output. Plain text through
+   * writeOutput (raw mode: \r\n), cyan so it stands apart from Claude's own
+   * output.
    */
   function renderQuestionBanner(question: Question): void {
+    if (question.held !== true) return;
     if (banneredQuestionIds.has(question.id)) return;
     banneredQuestionIds.add(question.id);
     const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -10,7 +10,7 @@ import {
   generateId,
   serialize,
 } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 import { DetachScanner } from './detach-scanner.ts';
 
@@ -135,22 +135,62 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     }
   }
 
-  function renderMessage(msg: ProtocolMessage): void {
+  // #753: question ids already shown as a banner, so a repeat delivery (the
+  // daemon re-sends the authoritative pending set after the replay batch; a
+  // reconnect could deliver it again) never double-prints, and a later
+  // question_resolved can acknowledge exactly the banners the user saw.
+  const banneredQuestionIds = new Set<string>();
+
+  /**
+   * #753: print a pending question into the attached terminal. A HELD
+   * permission (Model B) blocks Claude inside the hook call, so no raw PTY
+   * bytes for the prompt exist and the resize-nudge redraw has nothing to
+   * repaint — without this banner an attach shows only "waiting". Plain
+   * text through writeOutput (raw mode: \r\n), cyan so it stands apart from
+   * Claude's own output.
+   */
+  function renderQuestionBanner(question: Question): void {
+    if (banneredQuestionIds.has(question.id)) return;
+    banneredQuestionIds.add(question.id);
+    const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
+    const lines = [`\r\n\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
+    if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
+    lines.push(
+      `\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`,
+    );
+    writeOutput(lines.join(''));
+  }
+
+  function renderMessage(msg: ProtocolMessage, inReplay = false): void {
     switch (msg.type) {
       case 'raw_pty_output':
         receivedRawPty = true;
         writeRawBytes(msg.data);
         break;
+      case 'question':
+        // #753: LIVE questions only. Replayed history is not trustworthy for
+        // pendingness — question_resolved is broadcast-only (never recorded),
+        // so an already-answered question replays indistinguishably from a
+        // pending one. The daemon re-sends the authoritative pending set as
+        // live messages right after the replay batch, which is what lands here.
+        if (!inReplay) renderQuestionBanner(msg.question);
+        break;
+      case 'question_resolved':
+        // Only acknowledge questions this client actually bannered; resolved
+        // broadcasts for questions answered before attach are noise.
+        if (banneredQuestionIds.delete(msg.questionId)) {
+          writeOutput('\r\n\x1b[2m[remi] question answered\x1b[0m\r\n');
+        }
+        break;
       case 'agent_output':
       case 'structured_agent_output':
-      case 'question':
       case 'session_update':
       case 'transcript_content':
         // Suppressed; raw PTY output already provides the full terminal view
         break;
       case 'replay_batch':
         for (const m of msg.messages) {
-          renderMessage(m);
+          renderMessage(m, true);
         }
         break;
       case 'error':

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -13,7 +13,7 @@
  * consistent.
  */
 
-import { createError, createHelloAck, createReplayBatch } from '@remi/shared';
+import { createError, createHelloAck, createQuestion, createReplayBatch } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
@@ -147,6 +147,24 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
             onPeerConnect?.(connectionId, metadata);
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
+            }
+            // #753: replayed history cannot distinguish answered questions
+            // (question_resolved is broadcast-only, never recorded into
+            // messageHistory), so a client cannot trust replayed `question`
+            // messages for pendingness. Re-send the authoritative pending set
+            // as LIVE question messages after the replay; clients dedupe by
+            // question.id, and the terminal attach client renders these (and
+            // only these) as pending-question banners — the one signal that
+            // exists for a HELD hook, whose prompt never paints the PTY.
+            const pendingQuestions = sessionRegistry.getSession(currentPrimary)?.currentQuestions;
+            if (pendingQuestions !== undefined && pendingQuestions.size > 0) {
+              const claudeSessionId = currentBinding().claudeSessionId ?? undefined;
+              for (const question of pendingQuestions.values()) {
+                send(connectionId, createQuestion(question, currentPrimary, claudeSessionId));
+              }
+              log(
+                `Re-sent ${pendingQuestions.size} pending question(s) to connection ${connectionId}`,
+              );
             }
             cancelOrphanTimeout();
             log(

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -13,7 +13,7 @@
  * consistent.
  */
 
-import { createError, createHelloAck, createQuestion, createReplayBatch } from '@remi/shared';
+import { createError, createHelloAck, createReplayBatch } from '@remi/shared';
 import type { UUID } from '@remi/shared';
 
 import type { AdapterMetadata } from '../../adapters/index.ts';
@@ -21,6 +21,7 @@ import type { SessionRegistry } from '../../session/index.ts';
 import type { CurrentOwnedSession } from '../current-session.ts';
 import { log } from '../logger.ts';
 import { getPrimarySessionId } from '../session-state.ts';
+import { resendPendingQuestions } from './pending-question-resend.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface ConnectionHandlerDeps {
@@ -148,23 +149,17 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
             if (result.replayMessages.length > 0) {
               send(connectionId, createReplayBatch(currentPrimary, result.replayMessages, true));
             }
-            // #753: replayed history cannot distinguish answered questions
-            // (question_resolved is broadcast-only, never recorded into
-            // messageHistory), so a client cannot trust replayed `question`
-            // messages for pendingness. Re-send the authoritative pending set
-            // as LIVE question messages after the replay; clients dedupe by
-            // question.id, and the terminal attach client renders these (and
-            // only these) as pending-question banners — the one signal that
-            // exists for a HELD hook, whose prompt never paints the PTY.
-            const pendingQuestions = sessionRegistry.getSession(currentPrimary)?.currentQuestions;
-            if (pendingQuestions !== undefined && pendingQuestions.size > 0) {
-              const claudeSessionId = currentBinding().claudeSessionId ?? undefined;
-              for (const question of pendingQuestions.values()) {
-                send(connectionId, createQuestion(question, currentPrimary, claudeSessionId));
-              }
-              log(
-                `Re-sent ${pendingQuestions.size} pending question(s) to connection ${connectionId}`,
-              );
+            // #753: re-send the authoritative pending set as LIVE question
+            // messages after the replay (see pending-question-resend.ts for
+            // why replayed history cannot be trusted for pendingness).
+            const resent = resendPendingQuestions(
+              (m) => send(connectionId, m),
+              currentPrimary,
+              result.currentQuestions,
+              currentBinding().claudeSessionId ?? undefined,
+            );
+            if (resent > 0) {
+              log(`Re-sent ${resent} pending question(s) to connection ${connectionId}`);
             }
             cancelOrphanTimeout();
             log(

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -18,6 +18,7 @@ import { type AuqRunOutcome, runAuqAnswer } from '../../hooks/auq-runner.ts';
 import { readPtyOutput, resetPtyOutput } from '../../pty/output-buffer.ts';
 import type { ManagedSession, SessionBindingStore, SessionRegistry } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
+import { ResolvedAnswerCache, answerCacheKey } from './resolved-answer-cache.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface InputHandlerDeps {
@@ -231,6 +232,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
   const auqRuns = new Map<string, AbortController>();
   const auqRunKey = (sessionId: UUID, questionId: UUID): string => `${sessionId}:${questionId}`;
 
+  // #752: same-value duplicate deliveries of a successful answer (native POST +
+  // Capacitor JS path + signaling relay all fire per tap) report 'delivered'
+  // instead of 'stale', so the losing channel stops showing a false "Answer
+  // not delivered" notification.
+  const resolvedAnswers = new ResolvedAnswerCache();
+
   /**
    * Answer a structured AskUserQuestion (#627) by driving its interactive TUI.
    * The prompt is already on screen (Phase 1 escalates AUQ as passthrough), so the
@@ -305,6 +312,9 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     }
 
     if (outcome === 'closed' || outcome === 'submitted') {
+      // #752: the selections were applied; a duplicate delivery of this same
+      // tap must report 'delivered', not 'stale'.
+      resolvedAnswers.record(questionId, answerCacheKey('', selections));
       // Wrapped like the plain-answer path (below): if cancelAutoApproveForQuestion
       // throws, the question must still be consumed exactly once — removeQuestion +
       // the resolved broadcast run in `finally` so a throw here can never leave a
@@ -445,9 +455,23 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     // (not equality with a single slot) is the check, so answering one of
     // several concurrent prompts (main + subagent, #419) never invalidates
     // the others. Surface the drop so the iOS user gets a "not delivered"
-    // signal instead of silent failure.
+    // signal instead of silent failure — EXCEPT for a same-value duplicate of
+    // an answer that already applied (#752), which reports 'delivered'.
     const active = sessionRegistry.getQuestion(session.sessionId, questionId);
     if (active === null) {
+      // #752: a same-value duplicate of an answer that already applied is a
+      // SUCCESS, not a failure — the tap worked; this is just the losing
+      // delivery channel (native POST vs JS path vs signaling relay). Report
+      // 'delivered' so the client does not fire a false "Answer not
+      // delivered" notification. A different value (a genuine conflicting
+      // late answer) or an unknown/expired question still falls through to
+      // 'stale' below.
+      if (resolvedAnswers.matches(questionId, answerCacheKey(answer, extra?.selections))) {
+        log(
+          `[Answer] duplicate delivery for resolved question ${questionId.slice(0, 8)}; reporting delivered`,
+        );
+        return 'delivered';
+      }
       const pendingIds = [...session.currentQuestions.keys()];
       // #603 Phase 3: the question is gone from the registry (evicted under the
       // pending-question cap, or already removed), but its PermissionRequest hook
@@ -545,6 +569,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
           `Resolved held permission ${questionId.slice(0, 8)} via hook response: ${decision} (no PTY submit)`,
         );
       }
+
+      // #752: the answer applied (hold resolved or PTY submit succeeded) —
+      // recorded inside the try, directly after application, so a throwing
+      // submit is never recorded (its duplicate must keep reporting 'stale')
+      // and a later throw from the eval-cancel below cannot skip it.
+      resolvedAnswers.record(questionId, answerCacheKey(answer));
 
       // Free the GPU on EVERY answer (#617): cancel the eval for THIS question
       // unconditionally. Per-eval scoping (the eval id captured when the question

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -314,7 +314,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     if (outcome === 'closed' || outcome === 'submitted') {
       // #752: the selections were applied; a duplicate delivery of this same
       // tap must report 'delivered', not 'stale'.
-      resolvedAnswers.record(questionId, answerCacheKey('', selections));
+      resolvedAnswers.record(questionId, [answerCacheKey('', selections)]);
       // Wrapped like the plain-answer path (below): if cancelAutoApproveForQuestion
       // throws, the question must still be consumed exactly once — removeQuestion +
       // the resolved broadcast run in `finally` so a throw here can never leave a
@@ -573,8 +573,17 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       // #752: the answer applied (hold resolved or PTY submit succeeded) —
       // recorded inside the try, directly after application, so a throwing
       // submit is never recorded (its duplicate must keep reporting 'stale')
-      // and a later throw from the eval-cancel below cannot skip it.
-      resolvedAnswers.record(questionId, answerCacheKey(answer));
+      // and a later throw from the eval-cancel below cannot skip it. Recorded
+      // under every spelling of the same decision: the in-app tap sends the
+      // option VALUE while a push action sends the LABEL, and the duplicate
+      // may arrive on the other surface (review #759 finding 1). The options
+      // are unavailable by the time the duplicate hits the stale check, so the
+      // equivalence is captured here.
+      const answeredOption = resolveOption(active.options, answer);
+      resolvedAnswers.record(questionId, [
+        answerCacheKey(answer),
+        ...(answeredOption ? [answeredOption.value, answeredOption.label] : []),
+      ]);
 
       // Free the GPU on EVERY answer (#617): cancel the eval for THIS question
       // unconditionally. Per-eval scoping (the eval id captured when the question

--- a/packages/daemon/src/cli/handlers/pending-question-resend.ts
+++ b/packages/daemon/src/cli/handlers/pending-question-resend.ts
@@ -1,0 +1,34 @@
+/**
+ * #753: re-send the authoritative pending questions to a freshly attached
+ * (or promoted / resume-attached) connection, as LIVE `question` messages,
+ * right after the replay batch.
+ *
+ * Replayed history cannot be trusted for pendingness: `question_resolved` is
+ * broadcast-only and never recorded into `messageHistory`, so an
+ * already-answered question replays indistinguishably from a pending one.
+ * The registry's `currentQuestions` (returned by every successful
+ * `attachConnection`) is the source of truth. Clients dedupe by
+ * `question.id`; the terminal attach client banners the held ones (the class
+ * that never renders on the PTY).
+ *
+ * Shared by every attach surface (#760 review finding 2): the hello attach
+ * path (connection-events), the resume-request attach path
+ * (resume-session-events), and FIFO queue promotion (cli.ts
+ * onConnectionPromoted). A send failure is the caller's transport's problem;
+ * this helper only reports how many were attempted.
+ */
+
+import { createQuestion } from '@remi/shared';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
+
+export function resendPendingQuestions(
+  send: (message: ProtocolMessage) => void,
+  sessionId: UUID,
+  pendingQuestions: readonly Question[],
+  claudeSessionId?: UUID,
+): number {
+  for (const question of pendingQuestions) {
+    send(createQuestion(question, sessionId, claudeSessionId));
+  }
+  return pendingQuestions.length;
+}

--- a/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
+++ b/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
@@ -30,9 +30,7 @@ const DEFAULT_MAX_ENTRIES = 500;
 
 /** Canonical cache key for an answer payload: the raw answer string, or a
  *  stable serialization of structured AskUserQuestion selections (#627),
- *  which carry the answer in `extra.selections` instead of `answer`.
- *  Duplicate deliveries of one tap carry byte-identical payloads on every
- *  channel, so exact matching suffices (no label/value normalization). */
+ *  which carry the answer in `extra.selections` instead of `answer`. */
 export function answerCacheKey(
   answer: string,
   selections?: readonly { questionIndex: number; optionIndices: readonly number[] }[],
@@ -44,7 +42,7 @@ export function answerCacheKey(
 }
 
 export class ResolvedAnswerCache {
-  private readonly entries = new Map<string, { key: string; atMs: number }>();
+  private readonly entries = new Map<string, { keys: ReadonlySet<string>; atMs: number }>();
   private readonly ttlMs: number;
   private readonly maxEntries: number;
   private readonly nowMs: () => number;
@@ -55,21 +53,33 @@ export class ResolvedAnswerCache {
     this.nowMs = opts.nowMs ?? Date.now;
   }
 
-  /** Record a successfully-applied answer for `questionId`. */
-  record(questionId: string, key: string): void {
+  /**
+   * Record a successfully-applied answer for `questionId` under EVERY key the
+   * same logical decision can arrive as. The channels are not byte-identical:
+   * an in-app tap sends the option VALUE ("1") while a push action sends the
+   * LABEL ("Yes") — both resolve to the same option when applied
+   * (`resolveOption` matches either field), so the dedup must accept either
+   * spelling too. Callers pass the raw answer plus the resolved option's
+   * value/label (review #759 finding 1); the question is gone by the time a
+   * duplicate arrives, so the equivalence must be captured at record time.
+   */
+  record(questionId: string, keys: readonly string[]): void {
     this.prune();
+    const set = new Set(keys.filter((k) => k.length > 0));
+    if (set.size === 0) return;
     // Delete-then-set keeps insertion order meaningful for eviction even if a
     // question were somehow re-recorded.
     this.entries.delete(questionId);
-    this.entries.set(questionId, { key, atMs: this.nowMs() });
+    this.entries.set(questionId, { keys: set, atMs: this.nowMs() });
     if (this.entries.size > this.maxEntries) {
       const oldest = this.entries.keys().next().value;
       if (oldest !== undefined) this.entries.delete(oldest);
     }
   }
 
-  /** True iff `questionId` was resolved with exactly this answer key within
-   *  the TTL — i.e. the incoming answer is a duplicate delivery of a success. */
+  /** True iff `questionId` was resolved with this answer (under any recorded
+   *  spelling) within the TTL — i.e. the incoming answer is a duplicate
+   *  delivery of a success. */
   matches(questionId: string, key: string): boolean {
     const entry = this.entries.get(questionId);
     if (!entry) return false;
@@ -77,7 +87,7 @@ export class ResolvedAnswerCache {
       this.entries.delete(questionId);
       return false;
     }
-    return entry.key === key;
+    return entry.keys.has(key);
   }
 
   private prune(): void {

--- a/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
+++ b/packages/daemon/src/cli/handlers/resolved-answer-cache.ts
@@ -1,0 +1,94 @@
+/**
+ * #752: short-TTL memory of successfully-applied answers, keyed by questionId.
+ *
+ * Every lock-screen tap fires two-to-three independent deliveries of the same
+ * (sessionId, questionId, answer): the native Swift POST (RemiAnswerRelay),
+ * Capacitor's JS path (live WebSocket or `relayAnswerDirect` POST), and — for
+ * relay-connected daemons — a signaling-Worker-forwarded copy. The first copy
+ * to arrive resolves the question and synchronously removes it from the
+ * registry, so the loser deterministically saw `active === null`, got 'stale'
+ * (HTTP 409 / STALE_ANSWER), and both client layers translated that into an
+ * "Answer not delivered" notification — a false negative on essentially every
+ * tap where the app process was alive.
+ *
+ * This cache lets the answer core tell a same-value duplicate of a SUCCESSFUL
+ * answer ("report 'delivered'; the tap worked") apart from a genuinely
+ * unknown/expired/conflicting one (still 'stale'). Only successful
+ * applications are recorded — a throwing PTY submit or a cancel is not an
+ * applied answer, and a conflicting late answer (different value, e.g. "No"
+ * tapped on a second device after "Yes" already won) must keep failing loudly.
+ *
+ * TTL covers the observed redelivery window (signaling-relay copies have been
+ * seen re-forwarded on WebSocket reconnect minutes after the original); a
+ * same-value duplicate is honest to acknowledge no matter how late, so the
+ * bound exists for memory, not correctness. Insertion order doubles as the
+ * eviction order (Map preserves it; entries are never re-inserted).
+ */
+
+const DEFAULT_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_ENTRIES = 500;
+
+/** Canonical cache key for an answer payload: the raw answer string, or a
+ *  stable serialization of structured AskUserQuestion selections (#627),
+ *  which carry the answer in `extra.selections` instead of `answer`.
+ *  Duplicate deliveries of one tap carry byte-identical payloads on every
+ *  channel, so exact matching suffices (no label/value normalization). */
+export function answerCacheKey(
+  answer: string,
+  selections?: readonly { questionIndex: number; optionIndices: readonly number[] }[],
+): string {
+  if (selections && selections.length > 0) {
+    return `auq:${JSON.stringify(selections.map((s) => [s.questionIndex, [...s.optionIndices].sort((a, b) => a - b)]))}`;
+  }
+  return answer;
+}
+
+export class ResolvedAnswerCache {
+  private readonly entries = new Map<string, { key: string; atMs: number }>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly nowMs: () => number;
+
+  constructor(opts: { ttlMs?: number; maxEntries?: number; nowMs?: () => number } = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.nowMs = opts.nowMs ?? Date.now;
+  }
+
+  /** Record a successfully-applied answer for `questionId`. */
+  record(questionId: string, key: string): void {
+    this.prune();
+    // Delete-then-set keeps insertion order meaningful for eviction even if a
+    // question were somehow re-recorded.
+    this.entries.delete(questionId);
+    this.entries.set(questionId, { key, atMs: this.nowMs() });
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+  }
+
+  /** True iff `questionId` was resolved with exactly this answer key within
+   *  the TTL — i.e. the incoming answer is a duplicate delivery of a success. */
+  matches(questionId: string, key: string): boolean {
+    const entry = this.entries.get(questionId);
+    if (!entry) return false;
+    if (this.nowMs() - entry.atMs > this.ttlMs) {
+      this.entries.delete(questionId);
+      return false;
+    }
+    return entry.key === key;
+  }
+
+  private prune(): void {
+    const now = this.nowMs();
+    for (const [id, entry] of this.entries) {
+      if (now - entry.atMs > this.ttlMs) this.entries.delete(id);
+    }
+  }
+
+  /** Test-only: current entry count. */
+  sizeForTest(): number {
+    return this.entries.size;
+  }
+}

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -31,6 +31,7 @@ import type { SessionBindingStore, SessionRegistry, SessionStore } from '../../s
 import type { TranscriptDiscovery } from '../../transcript/index.ts';
 import { log, logError } from '../logger.ts';
 import { resolveDirectory } from '../path-resolver.ts';
+import { resendPendingQuestions } from './pending-question-resend.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 /**
@@ -99,6 +100,17 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
               connectionId,
               createReplayBatch(targetSessionId as UUID, result.replayMessages, true),
             );
+          }
+          // #753 (#760 review finding 2): this attach surface needs the same
+          // live re-send as the hello attach path, or a session switched-to
+          // mid-held-question shows nothing.
+          const resent = resendPendingQuestions(
+            (m) => send(connectionId, m),
+            targetSessionId as UUID,
+            result.currentQuestions,
+          );
+          if (resent > 0) {
+            log(`Re-sent ${resent} pending question(s) to resumed connection ${connectionId}`);
           }
           log(`Session ${targetSessionId} still alive; attached connection`);
           return;

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -382,6 +382,11 @@ export function setupHookBridge(
       // the hook keyed by it (#573). The bridge still does the onQuestion +
       // status side effects exactly as before.
       escalate: (i, summary) => hookBridge.handlePermissionRequest(i, summary),
+      // #751 PTY-arbiter: a subagent-tagged escalation the gate cannot decide
+      // parks its rich question (same builder as a real escalation, minus the
+      // push/registration side effects) and answers 'passthrough'; the tracker
+      // pushes it only if Claude's native prompt actually renders on the PTY.
+      parkForPTY: (i) => tracker.parkAwaitingPTY(hookBridge.buildPermissionQuestion(i)),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -137,16 +137,21 @@ export function createMessageApiForSession(
       log(`Question detected: ${question.text.substring(0, 50)}...`);
       const questionSessionId = getPrimarySessionId() ?? sessionId;
       const claudeSessionId = getClaudeSessionId?.() ?? undefined;
+      // #753: stamp held-ness onto the question itself so every downstream
+      // copy (live message, registry entry, attach-time re-send) carries it —
+      // the terminal attach client banners ONLY held questions, the one class
+      // that never renders on the PTY.
+      const stamped: Question = opts?.held === true ? { ...question, held: true } : question;
       const msg: ProtocolMessage = {
         type: 'question',
         id: generateId(),
         timestamp: now(),
-        question,
+        question: stamped,
         sessionId: questionSessionId,
         ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
-      sessionRegistry.addQuestion(questionSessionId, question);
+      sessionRegistry.addQuestion(questionSessionId, stamped);
 
       // Push: a non-held question only pushes when no client is attached (the
       // client sees it in-app). A HELD escalation (#603 Phase 3) always also
@@ -157,7 +162,7 @@ export function createMessageApiForSession(
       // pushConfig/refreshDeviceTokens contract change surfacing as an
       // unhandled rejection (matches the escalator's #672 push guard).
       void notifications
-        .maybePush(questionSessionId, question, { held: opts?.held === true })
+        .maybePush(questionSessionId, stamped, { held: opts?.held === true })
         .catch((err) => {
           logError(`[Session ${sessionId}] Question push threw:`, err);
         });

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -81,7 +81,24 @@ export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): st
     state = 'approved';
   }
 
-  const clients = status.connections > 0 ? `${status.connections} client(s)` : 'no clients';
+  // #755: label from the REAL attach state (exclusive PTY slot + FIFO queue),
+  // not the raw connection counter — `connections` also counts query-mode
+  // utility clients (remi ls / kill / phone list polls), which is how the bar
+  // used to read "1 client(s)" with nobody attached. Fall back to the old
+  // counter label only when the attach fields are absent (older writer).
+  const queued = status.queuedCount ?? 0;
+  const clients =
+    status.attached === undefined
+      ? status.connections > 0
+        ? `${status.connections} client(s)`
+        : 'no clients'
+      : status.attached
+        ? queued > 0
+          ? `attached (+${queued} waiting)`
+          : 'attached'
+        : queued > 0
+          ? `${queued} waiting`
+          : 'no clients';
   const repoBranch = status.repo ? `${status.repo}:${status.branch}` : status.branch;
   const head = repoBranch ? `remi:${status.wsPort} ${repoBranch}` : `remi:${status.wsPort}`;
   return `${head} | ${clients} | ${state}`;

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -18,34 +18,17 @@
  */
 
 import * as fs from 'node:fs';
-import type { AgentStatus, UUID } from '@remi/shared';
+import type { AgentStatus, AutoApproveState, RemiStatus } from '@remi/shared';
 
 /** Session status surfaced in the status file. `starting` now lives in the
  *  shared `AgentStatus` (#576), so this is just an alias kept for callers. */
 export type RemiSessionStatus = AgentStatus;
 
-/**
- * Auto-approve eval state surfaced in Claude's native status line (#560).
- *
- * Driven by a COUNT (inc on eval start, dec on every end path), not a boolean
- * spinner — a count cannot get "stuck" the way the old shared TerminalIndicator
- * did when concurrent evals (parallel subagents / multiple sessions) interleaved
- * its start/stop. `inFlight > 0` => a permission is being decided right now.
- * Times are epoch SECONDS so the statusline shell script can compute elapsed
- * with `date +%s` (macOS `date` has no millisecond format).
- */
-export interface AutoApproveState {
-  /** Evals in flight on this daemon. 0 = idle. */
-  inFlight: number;
-  /** Epoch seconds the current in-flight batch began (set on 0->1, cleared on
-   *  1->0). The statusline shows `evaluating <now-sinceS>s`. */
-  sinceS: number;
-  /** Last settled verdict, for a post-eval cue. */
-  lastVerdict: 'approved' | 'escalated' | 'none';
-  /** Epoch seconds of the last verdict; the statusline fades 'approved' after a
-   *  few seconds and keeps 'escalated' (needs-you) until the next eval. */
-  lastVerdictAtS: number;
-}
+/** `AutoApproveState` and `RemiStatus` moved to @remi/shared (#754) so the
+ *  daemon can broadcast the snapshot to clients (`remi_status`) and the attach
+ *  client can render the same reserved-row bar. Re-exported for existing
+ *  daemon-side importers. */
+export type { AutoApproveState, RemiStatus };
 
 export const IDLE_AUTO_APPROVE: AutoApproveState = {
   inFlight: 0,
@@ -60,32 +43,6 @@ export const IDLE_AUTO_APPROVE: AutoApproveState = {
  *  the render in statusline-installer.ts). */
 export const ESCALATE_FRESH_S = 60;
 
-export interface RemiStatus {
-  pid: number;
-  connections: number;
-  sessionStatus: RemiSessionStatus;
-  adapters: string[];
-  wsPort: number;
-  sessionId: UUID | null;
-  repo: string;
-  branch: string;
-  autoApprove: AutoApproveState;
-  /**
-   * Distinguishes a session-less hub daemon (`remi serve`, #542) from an
-   * ordinary single-session daemon/wrapper process. Optional so an older
-   * writer/reader pair (mixed-version upgrade window) degrades gracefully
-   * rather than failing a strict shape check.
-   */
-  mode?: 'hub' | 'session';
-  /**
-   * The remi binary version this process runs (#539). A daemon holds its
-   * binary for life; `remi status`/`ls` compare this against the installed
-   * binary to flag stale daemons. Optional for the same mixed-version
-   * reasons as `mode`.
-   */
-  version?: string;
-}
-
 export interface StatusWriterDeps {
   /** Returns the path to write to. Called on every flush so caller can swap files at runtime. */
   readonly getTargetFile: () => string;
@@ -95,12 +52,29 @@ export interface StatusWriterDeps {
   readonly writeLog: (msg: string) => void;
   /** Debounce window in ms. Default 300. Tests override to 0. */
   readonly debounceMs?: number;
+  /**
+   * #755: live attach state, stamped into the status on every flush so the
+   * "attached / N waiting" label tracks the session registry (the source of
+   * truth: `activeConnectionId` / `waitingConnections`) rather than the blunt
+   * `connections` counter, which also counts query-mode utility clients.
+   * Pull-based because attach transitions happen in several places (attach,
+   * disconnect, FIFO auto-promotion) that don't all flow through cli.ts.
+   * Optional: tests and the earliest boot phase run without it.
+   */
+  readonly getAttachState?: () => { attached: boolean; queuedCount: number } | null;
+  /**
+   * #754: broadcast the freshly-flushed snapshot to connected clients
+   * (`remi_status`), on the same debounce as the disk write. Optional and
+   * throw-guarded: display state must never break the writer.
+   */
+  readonly broadcast?: (status: Readonly<RemiStatus>) => void;
 }
 
 export class StatusWriter {
   private readonly status: RemiStatus;
-  private readonly deps: Required<StatusWriterDeps>;
+  private readonly deps: StatusWriterDeps & { debounceMs: number };
   private errorLogged = false;
+  private broadcastErrorLogged = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(initial: RemiStatus, deps: StatusWriterDeps) {
@@ -199,6 +173,32 @@ export class StatusWriter {
   }
 
   private write(): void {
+    // #755: refresh the attach-state fields from the registry at flush time so
+    // every scheduled write (status changes, evals, connection churn) carries
+    // current values; a pull here beats scattering updates over every attach /
+    // disconnect / auto-promotion site.
+    try {
+      const attach = this.deps.getAttachState?.();
+      if (attach) {
+        this.status.attached = attach.attached;
+        this.status.queuedCount = attach.queuedCount;
+      }
+    } catch (err) {
+      if (!this.broadcastErrorLogged) {
+        this.deps.writeLog(`[error] Status attach-state read failed: ${err}`);
+        this.broadcastErrorLogged = true;
+      }
+    }
+    // #754: clients get the same debounced snapshot the disk gets, regardless
+    // of whether the file write itself is enabled.
+    try {
+      this.deps.broadcast?.(this.status);
+    } catch (err) {
+      if (!this.broadcastErrorLogged) {
+        this.deps.writeLog(`[error] Status broadcast failed: ${err}`);
+        this.broadcastErrorLogged = true;
+      }
+    }
     if (!this.deps.isEnabled()) return;
     const targetFile = this.deps.getTargetFile();
     const tmpFile = `${targetFile}.tmp`;

--- a/packages/daemon/src/cli/statusline-installer.ts
+++ b/packages/daemon/src/cli/statusline-installer.ts
@@ -34,10 +34,20 @@ REMI=""
 # avoid duplicating the remi fields just above the bar.
 REMI_STATUS_FILE="${remiDir}/status-\$REMI_PORT.json"
 if [ "\$REMI_STATUS_BAR" != "1" ] && [ -n "\$REMI_PORT" ] && [ -f "\$REMI_STATUS_FILE" ]; then
-  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH AA_INFLIGHT AA_SINCE AA_LASTV AA_LASTAT < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // "", .autoApprove.inFlight // 0, .autoApprove.sinceS // 0, .autoApprove.lastVerdict // "none", .autoApprove.lastVerdictAtS // 0] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
+  IFS=\$'\\t' read -r S_PID S_CONNS S_STATUS S_REPO S_BRANCH AA_INFLIGHT AA_SINCE AA_LASTV AA_LASTAT S_ATTACHED S_QUEUED < <(jq -r '[.pid // 0, .connections // 0, .sessionStatus // "unknown", .repo // "", .branch // "", .autoApprove.inFlight // 0, .autoApprove.sinceS // 0, .autoApprove.lastVerdict // "none", .autoApprove.lastVerdictAtS // 0, (.attached | if . == null then "unset" else tostring end), .queuedCount // 0] | @tsv' "\$REMI_STATUS_FILE" 2>/dev/null)
   if [ -n "\$S_PID" ] && kill -0 "\$S_PID" 2>/dev/null; then
+    # #755: label from the real attach state (exclusive PTY slot + queue), not
+    # the raw connection counter (which also counts remi ls / kill / phone
+    # list polls). "unset" = status file from an older daemon -> old label.
     CLIENT_INFO="no clients"
-    [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
+    if [ "\$S_ATTACHED" = "unset" ]; then
+      [ "\$S_CONNS" != "0" ] && CLIENT_INFO="\${S_CONNS} client(s)"
+    elif [ "\$S_ATTACHED" = "true" ]; then
+      CLIENT_INFO="attached"
+      [ "\${S_QUEUED:-0}" != "0" ] && CLIENT_INFO="attached (+\${S_QUEUED} waiting)"
+    else
+      [ "\${S_QUEUED:-0}" != "0" ] && CLIENT_INFO="\${S_QUEUED} waiting"
+    fi
     # The status segment reflects auto-approve state when a permission is being
     # decided, otherwise Claude's agent status (#560). All arithmetic is guarded
     # (:-0) so a status file from an older daemon (no autoApprove key) renders

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -411,6 +411,20 @@ export class HookEventBridge {
     // prompt that does not render on the user's PTY does not push, and
     // one that does is genuinely answerable. The tracker handles both
     // cases; this method now only builds the question payload.
+    const question = this.buildPermissionQuestion(input, summary);
+    this.events.onQuestion(question);
+    this.events.onStatusChange('waiting');
+    return question.id;
+  }
+
+  /**
+   * Build the rich Question payload for a PermissionRequest WITHOUT firing the
+   * onQuestion/onStatusChange side effects. Used by `handlePermissionRequest`
+   * (escalation: push + register) and by the gate's #751 PTY-arbiter parking
+   * (`QuestionPresenceTracker.parkAwaitingPTY`), where the question must only
+   * surface if Claude's native prompt actually renders on the PTY.
+   */
+  buildPermissionQuestion(input: PermissionRequestHookInput, summary?: string): Question {
     const toolName = input.tool_name || 'unknown tool';
 
     // Question-bearing tools (AskUserQuestion, ExitPlanMode) carry the real
@@ -443,9 +457,8 @@ export class HookEventBridge {
       optionsAreFallback = built.isFallback;
     }
 
-    const questionId = generateId();
-    this.events.onQuestion({
-      id: questionId,
+    return {
+      id: generateId(),
       text: promptText,
       options,
       allowsFreeText: false,
@@ -471,9 +484,7 @@ export class HookEventBridge {
       // (e.g. "Force-push to main?"). AskUserQuestion carries authored content, so a
       // summary is only threaded for non-AUQ permission escalations.
       ...(summary ? { summary } : {}),
-    });
-    this.events.onStatusChange('waiting');
-    return questionId;
+    };
   }
 
   handlePostToolUseFailure(input: PostToolUseFailureHookInput): void {

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -865,4 +865,102 @@ describe('QuestionPresenceTracker', () => {
       expect(pushes.length).toBe(1);
     });
   });
+
+  describe('awaiting-PTY parking (#751)', () => {
+    const DEBOUNCE_MS = 20;
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    it('a parked record + rendered prompt pushes IMMEDIATELY, merged, no debounce', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('reviewer · Bash: git push'));
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+
+      // Hook + render is positive double-confirmation: no orphan debounce.
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('reviewer · Bash: git push'); // merged rich label
+      expect(tracker.hasPendingForTest()).toBe(false); // record consumed
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+    });
+
+    it('an unrelated LIVE question does not suppress a parked prompt (bypasses gate-owned check)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => true, // e.g. a held main card is open
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Edit: config.toml'),
+        agentId: 'agent-1',
+      });
+
+      // The PTY prompt does not name the agent: sole-candidate pairing applies.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to make this edit?'));
+
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('agent · Edit: config.toml');
+    });
+
+    it("status leaving 'waiting' expires a parked record (allowlist absorbed the request)", async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
+
+      tracker.onStatusChange('executing'); // Claude proceeded; prompt never rendered
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+
+      // A later prompt is a plain orphan again: debounced, pushed bare.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('unrelated later prompt'));
+      expect(pushes.length).toBe(0);
+      await wait(DEBOUNCE_MS * 2);
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('unrelated later prompt');
+    });
+
+    it('a NORMAL pending record for the prompt agent still suppresses (echo protection intact)', async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      // A normal gate escalation is mid-flight for main; a parked record
+      // exists for a different agent. The unnamed PTY prompt matches main's
+      // normal record -> gate-owned -> suppressed (not stolen by the parked one).
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Write: notes.md'),
+        agentId: 'agent-1',
+      });
+
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      await wait(DEBOUNCE_MS * 2);
+
+      expect(pushes.length).toBe(0);
+    });
+
+    it('a normal recordPendingHook for the same agent clears the parked flag', async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
+      // A real gate escalation for the same agent takes over the prompt cycle.
+      tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: ls'));
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+
+      // Its render echo is suppressed like any gate-owned cycle.
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      await wait(DEBOUNCE_MS * 2);
+      expect(pushes.length).toBe(0);
+    });
+  });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -71,6 +71,9 @@ describe('AutoApproveGate', () => {
   // resets the leaked tracker ONLY for a MAIN-tagged event, never for a
   // genuine subagent-tagged one.
   let resets: number;
+  // #751: records parkForPTY() calls (subagent escalations parked for PTY
+  // arbitration instead of held/denied).
+  let parks: PermissionRequestHookInput[];
 
   function evaluator(
     result: AutoApproveResult,
@@ -108,6 +111,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
+        parkForPTY: (i) => {
+          parks.push(i);
+        },
       },
       SID,
     );
@@ -139,6 +145,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
+        parkForPTY: (i) => {
+          parks.push(i);
+        },
         escalateModel: 'big-model',
       },
       SID,
@@ -165,6 +174,7 @@ describe('AutoApproveGate', () => {
     cancels = [];
     subagent = false;
     resets = 0;
+    parks = [];
     tracker = new QuestionPresenceTracker(() => {});
     configureLogger({ writeLog: () => {} });
   });
@@ -248,15 +258,18 @@ describe('AutoApproveGate', () => {
     expect(onEscalateCalls).toBe(1);
   });
 
-  test('escalate in subagent context default-denies via the response, no inject (#496)', async () => {
+  test('#751: subagent-tagged escalate parks for PTY arbitration (sync-Task shape, tracker true)', async () => {
     subagent = true;
-    // #710: default-deny requires a genuinely subagent-TAGGED event
-    // (agent_id present), not just isInSubagentContext() true — otherwise a
-    // leaked tracker would deny the main agent forever.
+    // A subagent-tagged escalate no longer denies (silent teammate breakage)
+    // nor holds/pushes (cards for prompts the user never saw): it parks the
+    // rich question and answers 'passthrough', so Claude's normal permission
+    // flow decides whether the prompt renders — the PTY is the arbiter.
     const d = await gateWith(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }));
-    expect(d).toBe('deny');
-    expect(submits).toHaveLength(0); // the core fix: deny without touching the PTY
-    expect(escalations).toHaveLength(0);
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0); // nothing injected
+    expect(escalations).toHaveLength(0); // no immediate push
+    expect(parks).toHaveLength(1); // parked awaiting PTY render
+    expect(parks[0]?.agent_id).toBe('agent-1');
     expect(resets).toBe(0); // a real subagent event never resets the tracker
   });
 
@@ -354,25 +367,25 @@ describe('AutoApproveGate', () => {
     expect(escalations).toHaveLength(1);
   });
 
-  test('eval rejection in subagent context default-denies via the response', async () => {
+  test('#751: eval rejection on a subagent-tagged event parks + passthrough', async () => {
     subagent = true;
-    // #710: requires agent_id (a real subagent-tagged event); see the
-    // escalate-branch test above for the rationale.
     const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(
       pr({ agent_id: 'agent-1' }),
     );
-    expect(d).toBe('deny');
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
     expect(resets).toBe(0);
   });
 
-  test('no service + subagent: default-deny via the response', async () => {
+  test('#751: no service + subagent-tagged event parks + passthrough', async () => {
     subagent = true;
     const d = await gateWith(null).resolvePermission(pr({ agent_id: 'agent-1' }));
-    expect(d).toBe('deny');
+    expect(d).toBe('passthrough');
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
     expect(resets).toBe(0);
   });
 
@@ -417,13 +430,88 @@ describe('AutoApproveGate', () => {
     expect(tracker.hasPendingForTest()).toBe(false); // pending cleared
   });
 
-  test('escalate_model is NOT consulted in a subagent context (denies via response) (#522)', async () => {
+  test('escalate_model is NOT consulted for a subagent-tagged event (parks instead) (#522/#751)', async () => {
     subagent = true;
-    // #710: a real subagent-tagged event (agent_id present).
     const d = await gateWithSecondOpinion(approve).resolvePermission(pr({ agent_id: 'agent-1' }));
-    // Subagent escalate denies directly; the second opinion (which would allow)
-    // must not run, since the user could not answer a subagent prompt anyway.
-    expect(d).toBe('deny');
+    // Subagent escalate parks + passthrough; the second opinion (which would
+    // allow) must not run — the hook answer is passthrough either way.
+    expect(d).toBe('passthrough');
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+  });
+
+  // #751 regression: routing keys on the event's own agent_id ALONE. The
+  // SubagentContextTracker only brackets SYNCHRONOUS Task/Agent spawns, so
+  // team members and async/background subagents always observe
+  // isInSubagentContext() false (the production shape of the 2026-07-08
+  // soak). AND-gating on the tracker escalated their prompts to the phone
+  // as if they were the main agent's (hold + push).
+  test('#751: subagent-tagged escalate with tracker FALSE parks + passthrough (team/async shape)', async () => {
+    subagent = false; // async/team spawn: the tracker never bracketed it
+    const d = await gateWith(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0); // never pushed as a main-agent card
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0); // no leak: nothing to reset
+  });
+
+  test('#751: subagent-tagged eval-error with tracker FALSE parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(evaluator(approve, { throws: true })).resolvePermission(
+      pr({ agent_id: 'agent-1' }),
+    );
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0);
+  });
+
+  test('#751: subagent-tagged no-service with tracker FALSE parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(null).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+    expect(resets).toBe(0);
+  });
+
+  test('#751: subagent-tagged pick forfeits the inject and parks + passthrough', async () => {
+    subagent = false;
+    const d = await gateWith(evaluator(pick(2))).resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
+    expect(submits).toHaveLength(0); // never types into the main PTY
+    expect(escalations).toHaveLength(0);
+    expect(parks).toHaveLength(1);
+  });
+
+  test('#751: a parkForPTY throw is absorbed; the passthrough still stands', async () => {
+    subagent = false;
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const g = new AutoApproveGate(
+      {
+        service: evaluator(escalate),
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: () => {
+          throw new Error('test: tracker down');
+        },
+      },
+      SID,
+    );
+    const d = await g.resolvePermission(pr({ agent_id: 'agent-1' }));
+    expect(d).toBe('passthrough');
     expect(escalations).toHaveLength(0);
   });
 
@@ -532,15 +620,16 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     expect(events).toEqual(['start', 'escalate']);
   });
 
-  test('subagent escalate->deny still fires handled (buffer + cue close), no inject', async () => {
+  test('#751: subagent escalate parks -> fires start then escalate (buffer closes), no inject', async () => {
     subagent = true;
-    // #710: default-deny requires a real subagent-tagged event (agent_id set).
     expect(await gate(evaluator(escalate)).resolvePermission(pr({ agent_id: 'agent-1' }))).toBe(
-      'deny',
+      'passthrough',
     );
-    // Subagent escalate default-denies via the RESPONSE (no inject) -> markHandled.
+    // Parking is semantically an escalation (PTY-mediated): the onEscalate cue
+    // must close the #484 buffer window opened by onEvalStart, or every later
+    // prompt in the session would buffer forever.
     expect(submits).toHaveLength(0);
-    expect(events).toEqual(['start', 'handled']);
+    expect(events).toEqual(['start', 'escalate']);
   });
 
   test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {
@@ -1069,23 +1158,16 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
     await registry.shutdown();
   });
 
-  test('(a) a SUBAGENT-tagged hold survives cancelStale(Stop, mainOnly) and stays resolvable', async () => {
+  test('(a) #751: a SUBAGENT-tagged escalate never holds -- parks + passthrough immediately', async () => {
+    // Pre-#751 this shape (agent_id present, tracker false) created a held
+    // teammate card that (#711) had to survive a mainOnly Stop. Post-#751 no
+    // subagent hold exists at all: the question parks for PTY arbitration and
+    // the hook resolves passthrough at once, so there is nothing for Stop to
+    // spare or for the user to answer until the prompt renders.
     const g = gate(evaluator(escalate));
-    const pending = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qid = lastQuestionId as UUID;
-
-    g.cancelStale('Stop', { mainOnly: true });
-
-    let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
-    await new Promise((r) => setTimeout(r, 10));
-    expect(settled).toBe(false); // still held -- mainOnly spared it
-
-    expect(g.resolveHeld(qid, 'allow')).toBe(true);
-    expect(await pending).toBe('allow');
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
+    expect(lastQuestionId).toBeUndefined(); // no escalate() call, no card
+    g.cancelStale('Stop', { mainOnly: true }); // nothing to release; must not throw
   });
 
   test('(b) a MAIN hold IS released on cancelStale(Stop, mainOnly), with notifyResolved(cancelled)', async () => {
@@ -1104,38 +1186,32 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
     expect(g.resolveHeld(qid, 'allow')).toBe(false); // the hold is gone
   });
 
-  test('(c) SessionEnd (cancelStale with no opts) releases BOTH main and subagent holds', async () => {
+  test('(c) SessionEnd (cancelStale with no opts) releases a main hold; a concurrent subagent event parked (#751)', async () => {
     const g = gate(evaluator(escalate));
     const pendingMain = g.resolvePermission(pr());
     await new Promise((r) => setTimeout(r, 20));
     const qidMain = lastQuestionId as UUID;
-    const pendingSub = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qidSub = lastQuestionId as UUID;
+    // #751: the subagent event resolves passthrough immediately (parked), so
+    // teardown only ever has the main hold to release.
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
 
     g.cancelStale('SessionEnd');
 
     expect(await pendingMain).toBe('passthrough');
-    expect(await pendingSub).toBe('passthrough');
     expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
-    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
   });
 
-  test('(e) forceRelease still releases BOTH main and subagent holds', async () => {
+  test('(e) forceRelease still releases a main hold; a concurrent subagent event parked (#751)', async () => {
     const g = gate(evaluator(escalate));
     const pendingMain = g.resolvePermission(pr());
     await new Promise((r) => setTimeout(r, 20));
     const qidMain = lastQuestionId as UUID;
-    const pendingSub = g.resolvePermission(pr(teammate));
-    await new Promise((r) => setTimeout(r, 20));
-    const qidSub = lastQuestionId as UUID;
+    expect(await g.resolvePermission(pr(teammate))).toBe('passthrough');
 
     g.forceRelease('remi unstick');
 
     expect(await pendingMain).toBe('passthrough');
-    expect(await pendingSub).toBe('passthrough');
     expect(g.resolveHeld(qidMain, 'allow')).toBe(false);
-    expect(g.resolveHeld(qidSub, 'allow')).toBe(false);
   });
 
   test('cancelStale(Stop, mainOnly) cancels only the in-flight MAIN eval; a concurrent SUBAGENT eval keeps running and its late verdict still reconciles', async () => {
@@ -1377,6 +1453,22 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
     expect(escalations).toHaveLength(1);
     g.resolveHeld(lastQuestionId as UUID, 'allow');
     expect(await pending).toBe('allow');
+  });
+
+  test('#751: a subagent-tagged slow eval never arms the early push (tracker FALSE)', async () => {
+    // The gate() harness pins isInSubagentContext() false, which is exactly
+    // the async/team-spawn shape: the tag on the event itself must veto the
+    // early USER push+hold, and the late escalate verdict then parks.
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, { pushHoldMs: 20 });
+    const pending = g.resolvePermission({ ...pr(), agent_id: 'agent-1' });
+
+    await new Promise((r) => setTimeout(r, 40)); // past the push-hold timer
+    expect(escalations).toHaveLength(0); // no early push for a subagent prompt
+
+    release(escalate);
+    expect(await pending).toBe('passthrough'); // #751 parks + passthrough, still no push
+    expect(escalations).toHaveLength(0);
   });
 });
 
@@ -1840,36 +1932,24 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
     expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(false);
   });
 
-  // #711 review follow-up: onDeliveryUnconfirmed's short-window RE-ARM rebuilds
-  // the PendingHold entry (new timer, same resolve) -- prove that rebuild
-  // preserves `isSubagent`, not just the initial `createHold` tagging.
-  test('#711 a SUBAGENT hold re-armed via onDeliveryUnconfirmed keeps isSubagent tagged (survives mainOnly Stop)', async () => {
+  // #751: a subagent-tagged escalation never enters the hold/delivery-gating
+  // machinery at all -- it parks for PTY arbitration and resolves passthrough
+  // before any delivery probe or hold timer can arm. (Pre-#751 this shape
+  // created a re-armable subagent hold whose isSubagent tag had to survive
+  // the onDeliveryUnconfirmed rebuild.)
+  test('#751 a SUBAGENT-tagged escalation bypasses delivery gating entirely (parks, no hold)', async () => {
     const gate = deliveryGate({
       delivery: Promise.resolve('failed'),
       deliveryConfirmMs: 20,
-      holdUnconfirmedMs: 500, // long enough to land cancelStale inside the re-armed window
+      holdUnconfirmedMs: 500,
       holdMs: 60_000,
     });
     const pending = gate.resolvePermission(
       pr({ agent_id: 'teammate-1', agent_type: 'general-purpose' }),
     );
-    // Past deliveryConfirmMs: onDeliveryUnconfirmed has fired and re-armed the
-    // hold via `this.pendingHolds.set(qid, { resolve: hold.resolve, timer, isSubagent: hold.isSubagent })`.
-    await new Promise((r) => setTimeout(r, 60));
-
-    // If the re-arm dropped the isSubagent tag, mainOnly would wrongly treat
-    // this as a main hold and release it here.
-    gate.cancelStale('Stop', { mainOnly: true });
-
-    let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(settled).toBe(false); // still held -- re-armed hold correctly tagged subagent
-
-    expect(gate.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
-    expect(await pending).toBe('allow');
+    expect(await pending).toBe('passthrough'); // immediate: no hold, no delivery probe
+    expect(lastQuestionId).toBeUndefined(); // no escalate() call, no pushed card
+    gate.cancelStale('Stop', { mainOnly: true }); // nothing held; must not throw
   });
 });
 

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -266,7 +266,7 @@ describe('runAttachClient', () => {
     expect(pongMsg).toBeTruthy();
   });
 
-  function makeQuestion(text: string): Question {
+  function makeQuestion(text: string, held = true): Question {
     return {
       id: generateId() as UUID,
       text,
@@ -276,13 +276,14 @@ describe('runAttachClient', () => {
       ],
       allowsFreeText: false,
       isAnswered: false,
+      ...(held ? { held: true } : {}),
     };
   }
 
   // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
   // raw PTY bytes for the prompt ever exist — the LIVE question message is
   // the only signal an attached terminal gets, and it must render.
-  test('renders a banner for a LIVE question (held prompts never paint the PTY)', async () => {
+  test('renders a banner for a LIVE held question (held prompts never paint the PTY)', async () => {
     setupOutput();
     const targetSessionId = generateId();
     const question = makeQuestion('Allow file edit?');
@@ -328,6 +329,52 @@ describe('runAttachClient', () => {
     expect(output).toContain("run 'remi unstick'");
     // Bannered exactly once despite the duplicate delivery.
     expect(output.split('pending question: Allow file edit?').length).toBe(2);
+  });
+
+  // #760 review finding 1: the daemon emits multiple `question` messages per
+  // VISIBLE prompt cycle (hook bridge + PTY parser, different ids); only held
+  // questions — which never render natively — may banner.
+  test('does NOT banner a non-held live question (its prompt renders natively in raw PTY)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow Bash: ls?', /* held */ false);
+
+    server = Bun.serve({
+      port: TEST_PORT + 8,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 8,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).not.toContain('Allow Bash: ls?');
+    expect(output).not.toContain('pending question');
   });
 
   test('suppresses questions inside a replay batch (history cannot prove pendingness)', async () => {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -8,6 +8,7 @@ import {
   createHelloAck,
   createPing,
   createQuestion,
+  createQuestionResolved,
   createReplayBatch,
   deserialize,
   generateId,
@@ -265,12 +266,10 @@ describe('runAttachClient', () => {
     expect(pongMsg).toBeTruthy();
   });
 
-  test('suppresses question messages (raw PTY provides the interactive prompt)', async () => {
-    setupOutput();
-    const targetSessionId = generateId();
-    const question: Question = {
+  function makeQuestion(text: string): Question {
+    return {
       id: generateId() as UUID,
-      text: 'Allow file edit?',
+      text,
       options: [
         { label: 'Yes', value: 'yes', isRecommended: true, isYes: true, isNo: false },
         { label: 'No', value: 'no', isRecommended: false, isYes: false, isNo: true },
@@ -278,6 +277,15 @@ describe('runAttachClient', () => {
       allowsFreeText: false,
       isAnswered: false,
     };
+  }
+
+  // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
+  // raw PTY bytes for the prompt ever exist — the LIVE question message is
+  // the only signal an attached terminal gets, and it must render.
+  test('renders a banner for a LIVE question (held prompts never paint the PTY)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow file edit?');
 
     server = Bun.serve({
       port: TEST_PORT + 4,
@@ -295,6 +303,8 @@ describe('runAttachClient', () => {
           if (msg.type === 'hello') {
             ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
             setTimeout(() => {
+              // Duplicate delivery (daemon re-send + broadcast): renders once.
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
               ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
             }, 50);
             setTimeout(() => ws.close(), 200);
@@ -313,8 +323,113 @@ describe('runAttachClient', () => {
     });
 
     const output = readOutput();
-    // Question messages are suppressed in terminal attach mode;
-    // the raw PTY output already contains the interactive prompt
-    expect(output).not.toContain('Allow file edit?');
+    expect(output).toContain('[remi] pending question: Allow file edit?');
+    expect(output).toContain('1) Yes  2) No');
+    expect(output).toContain("run 'remi unstick'");
+    // Bannered exactly once despite the duplicate delivery.
+    expect(output.split('pending question: Allow file edit?').length).toBe(2);
+  });
+
+  test('suppresses questions inside a replay batch (history cannot prove pendingness)', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Old replayed question?');
+
+    server = Bun.serve({
+      port: TEST_PORT + 5,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            ws.send(
+              serialize(
+                createReplayBatch(
+                  targetSessionId as UUID,
+                  [createQuestion(question, targetSessionId as UUID)],
+                  true,
+                ),
+              ),
+            );
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 5,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    // A replayed question may have been answered long ago (question_resolved
+    // is never recorded into history), so no banner.
+    expect(output).not.toContain('Old replayed question?');
+  });
+
+  test('acknowledges question_resolved only for questions it bannered', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const question = makeQuestion('Allow push?');
+    const unrelatedQuestionId = generateId() as UUID;
+
+    server = Bun.serve({
+      port: TEST_PORT + 6,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              // A resolved broadcast for a question never bannered: silent.
+              ws.send(
+                serialize(
+                  createQuestionResolved(targetSessionId as UUID, unrelatedQuestionId, 'answered'),
+                ),
+              );
+              ws.send(serialize(createQuestion(question, targetSessionId as UUID)));
+              ws.send(
+                serialize(createQuestionResolved(targetSessionId as UUID, question.id, 'answered')),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 250);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 6,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('[remi] pending question: Allow push?');
+    expect(output.split('[remi] question answered').length).toBe(2); // exactly once
   });
 });

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -8,6 +8,7 @@ import {
   createHelloAck,
   createPing,
   createQuestion,
+  createRemiStatus,
   createReplayBatch,
   deserialize,
   generateId,
@@ -316,5 +317,73 @@ describe('runAttachClient', () => {
     // Question messages are suppressed in terminal attach mode;
     // the raw PTY output already contains the interactive prompt
     expect(output).not.toContain('Allow file edit?');
+  });
+
+  // #754: remi_status is display state for the reserved-row bar; on a non-TTY
+  // output (piped/tests) the bar never starts and nothing is printed.
+  test('consumes remi_status without printing when stdout is not a TTY', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 7,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(targetSessionId as UUID, {
+                    pid: 1,
+                    connections: 1,
+                    sessionStatus: 'thinking',
+                    adapters: ['ws'],
+                    wsPort: 19924,
+                    sessionId: targetSessionId as UUID,
+                    repo: 'remi',
+                    branch: 'develop',
+                    autoApprove: {
+                      inFlight: 0,
+                      sinceS: 0,
+                      lastVerdict: 'none',
+                      lastVerdictAtS: 0,
+                    },
+                    attached: true,
+                    queuedCount: 0,
+                  }),
+                ),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 7,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    // No bar escapes (reverse video / DECSTBM) and no bar label leaked. (The
+    // "[attached to session ...]" header is unrelated and expected.)
+    expect(output).not.toContain('| attached');
+    expect(output).not.toContain('\x1b[7m');
+    expect(output).not.toContain('\x1b[1;');
   });
 });

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -275,6 +275,46 @@ describe('createConnectionHandlers', () => {
       expect(replay.messages?.length).toBe(2);
     });
 
+    test('#753: pending questions are re-sent as LIVE question messages after attach', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      // One question answered before this attach (must NOT be re-sent), one
+      // still pending (must arrive as a live `question` message).
+      const answeredId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: answeredId,
+        text: 'old, already answered?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      sessionRegistry.removeQuestion(sessionId, answeredId);
+      const pendingId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: pendingId,
+        text: 'Allow Bash: git push',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
+      expect(questionMsgs).toHaveLength(1);
+      const q = questionMsgs[0]?.message as { question: { id: UUID; text: string } };
+      expect(q.question.id).toBe(pendingId);
+      expect(q.question.text).toBe('Allow Bash: git push');
+      // Ordering: hello_ack first, live questions after (and after any replay).
+      expect(sendCalls[0]?.message.type).toBe('hello_ack');
+      expect(sendCalls[sendCalls.length - 1]?.message.type).toBe('question');
+    });
+
     test('second concurrent connection is queued and still receives helloAck + replay', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI(2));

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1669,6 +1669,87 @@ describe('createInputHandlers', () => {
       const other = 'cccccccc-0000-0000-0000-000000000000' as UUID;
       expect(await handlers.relayAnswer(sessionId, other, 'Yes')).toBe('stale');
     });
+
+    test('cross-surface: in-app answers with the VALUE, the push duplicate arrives as the LABEL', async () => {
+      // The in-app card sends the option value ("1"); the push action sends
+      // the label ("Yes"). Same tap, different spelling — the cache records
+      // both at application time (#759 review finding 1).
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, '1'); // in-app value
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered'); // push label
+      expect(await handlers.relayAnswer(sessionId, QID, 'No')).toBe('stale'); // conflict stays loud
+    });
+
+    test('a duplicate of a HELD-hook-resolved answer reports delivered', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const held: Array<'allow' | 'deny'> = [];
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        resolveHeldPermission: (_s, _q, d) => {
+          held.push(d);
+          return true;
+        },
+      });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(held).toEqual(['allow']); // resolved via the hook, no PTY submit
+      expect(ptyCapture.submits).toEqual([]);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered'); // duplicate
+      expect(held).toEqual(['allow']); // hook not touched again
+    });
+
+    test('a duplicate AUQ selections delivery reports delivered', async () => {
+      // Mirror the structured-AUQ harness: the PTY echoes the closure marker
+      // on ENTER so the runner treats the answer as accepted.
+      const sessionId = sessionRegistry.createSessionId();
+      const writes: string[] = [];
+      const pty = {
+        id: generateId(),
+        write: (content: string) => {
+          writes.push(content);
+          if (content === AUQ_KEYS.ENTER) {
+            appendPtyOutput(sessionId, "⏺ User answered Claude's questions:  ⎿ · Color → Red");
+          }
+        },
+        submitInput: async () => {},
+        close: async () => {},
+      } as unknown as PTYSession;
+      sessionRegistry.registerSession(sessionId, '/test/dir', pty, fakeMessageAPI(new Map()));
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Color: pick one',
+        options: [{ value: '1', label: 'Red', isRecommended: true, isYes: false, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+        kind: 'multi_question',
+        questions: [
+          {
+            header: 'Color',
+            text: 'pick one',
+            multiSelect: false,
+            options: [{ value: '1', label: 'Red', isRecommended: true, isYes: false, isNo: false }],
+          },
+        ],
+      });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const selections = [{ questionIndex: 0, optionIndices: [0] }];
+
+      await handlers.onAnswer(CID, sessionId, QID, '', undefined, { selections });
+      expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+
+      // The losing channel re-delivers the same selections (WS path; the HTTP
+      // relay never carries selections). A duplicate of an applied AUQ answer
+      // must not produce a STALE_ANSWER / AUQ error frame.
+      await handlers.onAnswer(CID, sessionId, QID, '', undefined, { selections });
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
   });
 
   describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -1566,6 +1566,111 @@ describe('createInputHandlers', () => {
     });
   });
 
+  // #752: every lock-screen tap fires two-to-three deliveries of the same
+  // answer (native POST, Capacitor JS path, signaling relay). The first copy
+  // wins; the losers must report 'delivered' — NOT 'stale' (HTTP 409), which
+  // both client layers turned into a false "Answer not delivered" notification.
+  describe('duplicate answer deliveries (#752)', () => {
+    function registerYesNo(): { sessionId: UUID; ptyCapture: { submits: string[] } } {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'Allow Bash: git push',
+        options: [
+          { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+          { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+        ],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      return { sessionId, ptyCapture };
+    }
+
+    test('a same-value relay duplicate after a relay success reports delivered, no re-submit', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      // The losing channel's copy: same tap, question already consumed.
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']); // nothing re-submitted
+    });
+
+    test('cross-channel: a WS answer then its relay duplicate reports delivered', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // in-app WS copy wins
+      expect(ptyCapture.submits).toEqual(['1']);
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('a WS duplicate sends NO STALE_ANSWER error frame', async () => {
+      const { sessionId } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // duplicate
+
+      expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+    });
+
+    test('a CONFLICTING late answer (different value) still reports stale', async () => {
+      const { sessionId, ptyCapture } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
+      // A second device answered "No" after "Yes" already won: must fail loudly.
+      expect(await handlers.relayAnswer(sessionId, QID, 'No')).toBe('stale');
+      expect(ptyCapture.submits).toEqual(['1']);
+    });
+
+    test('a duplicate of a THROWING (never-applied) submit still reports stale', async () => {
+      const ptyCapture = {
+        writes: [] as string[],
+        submits: [] as string[],
+        submitError: new Error('pty closed'),
+      };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      sessionRegistry.addQuestion(sessionId, {
+        id: QID,
+        text: 'proceed?',
+        options: [{ value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+      await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
+      // The answer was never applied, so its duplicate is NOT a success echo.
+      expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('stale');
+    });
+
+    test('an unknown question with no recorded answer still reports stale', async () => {
+      const { sessionId } = registerYesNo();
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const other = 'cccccccc-0000-0000-0000-000000000000' as UUID;
+      expect(await handlers.relayAnswer(sessionId, other, 'Yes')).toBe('stale');
+    });
+  });
+
   describe('onQuestionResolved cross-client dismissal (#585 P7)', () => {
     function registerWithQuestion(questionId: UUID): UUID {
       const ptyCapture = { writes: [] as string[], submits: [] as string[] };

--- a/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
+++ b/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ResolvedAnswerCache,
+  answerCacheKey,
+} from '../../../src/cli/handlers/resolved-answer-cache.ts';
+
+describe('ResolvedAnswerCache (#752)', () => {
+  test('a recorded answer matches the same value and rejects a different one', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', 'Yes');
+    expect(cache.matches('q1', 'Yes')).toBe(true);
+    expect(cache.matches('q1', 'No')).toBe(false); // conflicting late answer stays stale
+    expect(cache.matches('q2', 'Yes')).toBe(false); // unknown question
+  });
+
+  test('entries expire after the TTL', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ ttlMs: 100, nowMs: () => now });
+    cache.record('q1', 'Yes');
+    now += 99;
+    expect(cache.matches('q1', 'Yes')).toBe(true);
+    now += 2;
+    expect(cache.matches('q1', 'Yes')).toBe(false);
+    expect(cache.sizeForTest()).toBe(0); // expired entry dropped on read
+  });
+
+  test('the cache is bounded: the oldest entry is evicted past maxEntries', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ maxEntries: 2, nowMs: () => now });
+    cache.record('q1', 'a');
+    now += 1;
+    cache.record('q2', 'b');
+    now += 1;
+    cache.record('q3', 'c');
+    expect(cache.sizeForTest()).toBe(2);
+    expect(cache.matches('q1', 'a')).toBe(false); // evicted (oldest)
+    expect(cache.matches('q2', 'b')).toBe(true);
+    expect(cache.matches('q3', 'c')).toBe(true);
+  });
+
+  test('record prunes expired entries so dead questions never count toward the cap', () => {
+    let now = 1_000;
+    const cache = new ResolvedAnswerCache({ ttlMs: 100, maxEntries: 10, nowMs: () => now });
+    cache.record('q1', 'a');
+    now += 200; // q1 expired
+    cache.record('q2', 'b');
+    expect(cache.sizeForTest()).toBe(1);
+  });
+
+  test('answerCacheKey: plain answers pass through, AUQ selections serialize stably', () => {
+    expect(answerCacheKey('Yes')).toBe('Yes');
+    // Option order inside one selection must not matter (multi-select taps
+    // may enumerate in a different order per channel).
+    const a = answerCacheKey('', [{ questionIndex: 0, optionIndices: [2, 0] }]);
+    const b = answerCacheKey('', [{ questionIndex: 0, optionIndices: [0, 2] }]);
+    expect(a).toBe(b);
+    // Different picks are different keys.
+    const c = answerCacheKey('', [{ questionIndex: 0, optionIndices: [1] }]);
+    expect(c).not.toBe(a);
+    // Selections win over the answer string (AUQ answers carry an empty/dummy answer).
+    expect(answerCacheKey('ignored', [{ questionIndex: 1, optionIndices: [0] }])).toContain('auq:');
+  });
+});

--- a/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
+++ b/packages/daemon/tests/cli/handlers/resolved-answer-cache.test.ts
@@ -7,16 +7,31 @@ import {
 describe('ResolvedAnswerCache (#752)', () => {
   test('a recorded answer matches the same value and rejects a different one', () => {
     const cache = new ResolvedAnswerCache();
-    cache.record('q1', 'Yes');
+    cache.record('q1', ['Yes']);
     expect(cache.matches('q1', 'Yes')).toBe(true);
     expect(cache.matches('q1', 'No')).toBe(false); // conflicting late answer stays stale
     expect(cache.matches('q2', 'Yes')).toBe(false); // unknown question
   });
 
+  test('multiple keys record every spelling of one decision (value vs label)', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', ['Yes', '1']);
+    expect(cache.matches('q1', 'Yes')).toBe(true); // push-action label
+    expect(cache.matches('q1', '1')).toBe(true); // in-app value
+    expect(cache.matches('q1', 'No')).toBe(false);
+  });
+
+  test('empty key lists record nothing', () => {
+    const cache = new ResolvedAnswerCache();
+    cache.record('q1', ['']);
+    expect(cache.sizeForTest()).toBe(0);
+    expect(cache.matches('q1', '')).toBe(false);
+  });
+
   test('entries expire after the TTL', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ ttlMs: 100, nowMs: () => now });
-    cache.record('q1', 'Yes');
+    cache.record('q1', ['Yes']);
     now += 99;
     expect(cache.matches('q1', 'Yes')).toBe(true);
     now += 2;
@@ -27,11 +42,11 @@ describe('ResolvedAnswerCache (#752)', () => {
   test('the cache is bounded: the oldest entry is evicted past maxEntries', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ maxEntries: 2, nowMs: () => now });
-    cache.record('q1', 'a');
+    cache.record('q1', ['a']);
     now += 1;
-    cache.record('q2', 'b');
+    cache.record('q2', ['b']);
     now += 1;
-    cache.record('q3', 'c');
+    cache.record('q3', ['c']);
     expect(cache.sizeForTest()).toBe(2);
     expect(cache.matches('q1', 'a')).toBe(false); // evicted (oldest)
     expect(cache.matches('q2', 'b')).toBe(true);
@@ -41,9 +56,9 @@ describe('ResolvedAnswerCache (#752)', () => {
   test('record prunes expired entries so dead questions never count toward the cap', () => {
     let now = 1_000;
     const cache = new ResolvedAnswerCache({ ttlMs: 100, maxEntries: 10, nowMs: () => now });
-    cache.record('q1', 'a');
+    cache.record('q1', ['a']);
     now += 200; // q1 expired
-    cache.record('q2', 'b');
+    cache.record('q2', ['b']);
     expect(cache.sizeForTest()).toBe(1);
   });
 

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -103,6 +103,29 @@ describe('createResumeSessionHandlers', () => {
     expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
   });
 
+  test('#753: re-sends pending questions as live messages on the still-alive attach path', async () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+    const pendingId = 'aaaaaaaa-1111-2222-3333-444444444444' as UUID;
+    sessionRegistry.addQuestion(sessionId, {
+      id: pendingId,
+      text: 'Allow Bash: git push',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      held: true,
+    });
+
+    const handlers = makeHandlers();
+    await handlers.onResumeSessionRequest(CID, sessionId, REQ);
+
+    const questionMsgs = sendCalls.filter((c) => c.message.type === 'question');
+    expect(questionMsgs).toHaveLength(1);
+    const q = questionMsgs[0]?.message as { question: { id: UUID; held?: boolean } };
+    expect(q.question.id).toBe(pendingId);
+    expect(q.question.held).toBe(true); // held flag survives the re-send
+  });
+
   test('rejects when another session is active and the target does not match', async () => {
     const activeId = sessionRegistry.createSessionId();
     sessionRegistry.registerSession(activeId, '/other/dir', fakePTY(), fakeMessageAPI());

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1920,9 +1920,12 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.questionCalls).toBe(1); // escalated to the user, not silently denied
   });
 
-  test('#710: a genuinely subagent-TAGGED PermissionRequest (agent_id set) during an active Task context still default-denies', async () => {
-    // The still-valid case: agent_id present proves this really is a subagent
-    // prompt (not a leak), so it must keep default-denying via the response.
+  test('#751: a genuinely subagent-TAGGED PermissionRequest (agent_id set) during an active Task context parks + passthrough', async () => {
+    // agent_id present proves this really is a subagent prompt (not a leak).
+    // #751 PTY-arbiter: instead of the old default-deny (silent teammate
+    // breakage), the gate parks the rich question and answers 'passthrough' --
+    // no PTY inject, no immediate push/registration; the question surfaces
+    // only if Claude's native prompt renders on the PTY.
     build({ autoApprove: true, autoApproveDecision: 'escalate' });
 
     hookServer.fire('SessionStart', {
@@ -1950,9 +1953,14 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
     });
 
-    expect(decision).toBe('deny');
+    expect(decision).toBe('passthrough');
     expect(ptySubmits).toEqual([]);
-    expect(messageApiLog.questionCalls).toBe(0);
+    // The park routes through recordPendingHook, which this harness's
+    // PassthroughTracker collapses into an immediate PTY-visible push — i.e.
+    // the simulated terminal rendered the prompt, so the parked question
+    // surfaced. True park-until-render semantics are covered in
+    // tests/api/question-presence-tracker.test.ts ("awaiting-PTY parking").
+    expect(messageApiLog.questionCalls).toBe(1);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -51,9 +51,38 @@ describe('formatStatusBar', () => {
     expect(out).toBe('remi:19924 remi:develop | no clients | thinking');
   });
 
-  test('client count pluralizes', () => {
+  test('client count pluralizes (legacy fallback: no attach fields on the status)', () => {
     expect(formatStatusBar(mkStatus({ connections: 2 }), NOW_MS)).toContain('| 2 client(s) |');
     expect(formatStatusBar(mkStatus({ connections: 0 }), NOW_MS)).toContain('| no clients |');
+  });
+
+  // #755: with attach fields present, the label reads the REAL attach state
+  // (exclusive PTY slot + FIFO queue), never the raw connection counter,
+  // which also counts query-mode utility clients (remi ls / kill / polls).
+  test('attached session reads "attached", not a connection count', () => {
+    const out = formatStatusBar(
+      mkStatus({ connections: 3, attached: true, queuedCount: 0 }),
+      NOW_MS,
+    );
+    expect(out).toContain('| attached |');
+    expect(out).not.toContain('client(s)');
+  });
+
+  test('attached with queued viewers reads "attached (+N waiting)"', () => {
+    expect(
+      formatStatusBar(mkStatus({ connections: 3, attached: true, queuedCount: 2 }), NOW_MS),
+    ).toContain('| attached (+2 waiting) |');
+  });
+
+  test('not attached: queued-only shows "N waiting"; none shows "no clients" even with query connections', () => {
+    expect(
+      formatStatusBar(mkStatus({ connections: 2, attached: false, queuedCount: 1 }), NOW_MS),
+    ).toContain('| 1 waiting |');
+    // A `remi ls` poll bumped connections but nothing is attached or queued:
+    // the pre-#755 bar showed "1 client(s)" here.
+    expect(
+      formatStatusBar(mkStatus({ connections: 1, attached: false, queuedCount: 0 }), NOW_MS),
+    ).toContain('| no clients |');
   });
 
   test('in-flight eval shows evaluating with elapsed seconds', () => {

--- a/packages/daemon/tests/cli/status-writer.test.ts
+++ b/packages/daemon/tests/cli/status-writer.test.ts
@@ -257,4 +257,79 @@ describe('StatusWriter', () => {
     expect(w.state.autoApprove.inFlight).toBe(0); // back to idle, not stuck
     expect(w.state.autoApprove.sinceS).toBe(0);
   });
+
+  // #754/#755: every flush stamps live attach state and broadcasts the
+  // snapshot to clients on the same debounce as the disk write.
+  describe('broadcast + attach-state stamping (#754/#755)', () => {
+    test('flush stamps getAttachState fields and fires broadcast with them', () => {
+      const broadcasts: Array<{
+        attached: boolean | undefined;
+        queuedCount: number | undefined;
+      }> = [];
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        getAttachState: () => ({ attached: true, queuedCount: 2 }),
+        broadcast: (s) => broadcasts.push({ attached: s.attached, queuedCount: s.queuedCount }),
+      });
+      writer.flush();
+      expect(broadcasts).toEqual([{ attached: true, queuedCount: 2 }]);
+      const onDisk = JSON.parse(fs.readFileSync(target, 'utf-8'));
+      expect(onDisk.attached).toBe(true);
+      expect(onDisk.queuedCount).toBe(2);
+    });
+
+    test('broadcast fires even when the file write is disabled', () => {
+      let broadcastCount = 0;
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => false,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        broadcast: () => {
+          broadcastCount += 1;
+        },
+      });
+      writer.flush();
+      expect(broadcastCount).toBe(1);
+      expect(fs.existsSync(target)).toBe(false);
+    });
+
+    test('a throwing broadcast is logged once and never breaks the file write', () => {
+      const writer = new StatusWriter(baseStatus({ connections: 1 }), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        broadcast: () => {
+          throw new Error('registry down');
+        },
+      });
+      writer.flush();
+      writer.flush();
+      const onDisk = JSON.parse(fs.readFileSync(target, 'utf-8'));
+      expect(onDisk.connections).toBe(1); // file write survived
+      expect(logs.filter((l) => l.includes('Status broadcast failed'))).toHaveLength(1);
+    });
+
+    test('debounce collapses bursts into a single broadcast', async () => {
+      let broadcastCount = 0;
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 10,
+        broadcast: () => {
+          broadcastCount += 1;
+        },
+      });
+      writer.update({ connections: 1 });
+      writer.update({ connections: 2 });
+      writer.update({ connections: 3 });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(broadcastCount).toBe(1);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/statusline-installer.test.ts
+++ b/packages/daemon/tests/cli/statusline-installer.test.ts
@@ -42,6 +42,17 @@ describe('buildStatuslineScript', () => {
     expect(script).toContain('STATE="evaluating');
     expect(script).toContain('STATE="needs you"');
   });
+
+  test('labels the real attach state, keeping the counter label as legacy fallback (#755)', () => {
+    const script = buildStatuslineScript('/x');
+    // reads the attach fields; "unset" marks an older daemon's status file
+    expect(script).toContain('.attached');
+    expect(script).toContain('.queuedCount');
+    expect(script).toContain('CLIENT_INFO="attached"');
+    expect(script).toContain('waiting');
+    // legacy fallback stays for pre-#755 status files
+    expect(script).toContain('client(s)');
+  });
 });
 
 describe('installStatusLine', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,8 @@ export type {
   MessageState,
   MessageSender,
   AgentStatus,
+  AutoApproveState,
+  RemiStatus,
   Message,
   BulletType,
   Bullet,
@@ -97,6 +99,7 @@ export type {
   SessionViewsMessage,
   SessionViewMeta,
   QuestionResolvedMessage,
+  RemiStatusMessage,
   CreateHelloAckOptions,
   CreateHelloOptions,
 } from './protocol.ts';
@@ -151,6 +154,7 @@ export {
   createSessionRotated,
   createSessionViews,
   createQuestionResolved,
+  createRemiStatus,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -16,6 +16,7 @@ import type {
   DiscoverableSession,
   Message,
   Question,
+  RemiStatus,
   Session,
   StructuredMessage,
   Timestamp,
@@ -104,7 +105,8 @@ export type ProtocolMessage =
   | HubStatusMessage
   | SessionRotatedMessage
   | SessionViewsMessage
-  | QuestionResolvedMessage;
+  | QuestionResolvedMessage
+  | RemiStatusMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -334,6 +336,22 @@ export interface QuestionResolvedMessage {
   readonly questionId: UUID;
   /** Why it resolved, for diagnostics + client UX (all dismiss the card the same). */
   readonly reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
+}
+
+/**
+ * Daemon status snapshot broadcast (#754). Fired on the StatusWriter's
+ * debounced flush (and once to each newly attached connection), never
+ * recorded into replay history — it is ephemeral display state. The terminal
+ * attach client renders it on the same reserved-row status bar the wrapper
+ * draws; other clients may ignore it.
+ */
+export interface RemiStatusMessage {
+  readonly type: 'remi_status';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** The daemon's primary session the snapshot describes. */
+  readonly sessionId: UUID;
+  readonly status: RemiStatus;
 }
 
 /** Session state update */
@@ -909,6 +927,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'session_rotated',
     'session_views',
     'question_resolved',
+    'remi_status',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1217,6 +1236,22 @@ export function createQuestionResolved(
     sessionId,
     questionId,
     reason,
+  };
+}
+
+/**
+ * Create a daemon status snapshot broadcast (#754). The status object is
+ * copied shallowly (plus autoApprove one level deep) so a later in-place
+ * mutation of the daemon's live status cannot retroactively change a message
+ * already queued for serialization.
+ */
+export function createRemiStatus(sessionId: UUID, status: RemiStatus): RemiStatusMessage {
+  return {
+    type: 'remi_status',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    status: { ...status, autoApprove: { ...status.autoApprove } },
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -229,6 +229,18 @@ export interface Question {
    * plain-string suggestion path.
    */
   readonly optionsAreFallback?: boolean | undefined;
+
+  /**
+   * #753: true when the auto-approve gate is HOLDING this question's
+   * PermissionRequest hook (Model B) — Claude is blocked inside the hook call
+   * and never renders the prompt, so no PTY bytes for it exist. The terminal
+   * attach client banners exactly these (they are otherwise invisible in a
+   * terminal); non-held questions render natively and need no banner.
+   * Stamped once at question emission (message-api-setup) from the push
+   * options, so live messages, registry entries, and attach-time re-sends all
+   * carry it.
+   */
+  readonly held?: boolean | undefined;
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -435,3 +435,69 @@ export interface DiscoverableSession {
   /** Hostname of the daemon hosting this session */
   readonly daemonHost?: string;
 }
+
+/**
+ * Auto-approve eval state surfaced in status displays (#560). Driven by a
+ * COUNT (inc on eval start, dec on every end path), not a boolean spinner —
+ * a count cannot get "stuck" when concurrent evals interleave start/stop.
+ * Times are epoch SECONDS so the statusline shell script can compute elapsed
+ * with `date +%s`.
+ *
+ * Lives in shared (#754) because the daemon broadcasts the full status
+ * snapshot to clients (`remi_status`), and the terminal attach client renders
+ * the same reserved-row bar the wrapper does.
+ */
+export interface AutoApproveState {
+  /** Evals in flight on this daemon. 0 = idle. */
+  inFlight: number;
+  /** Epoch seconds the current in-flight batch began (set on 0->1, cleared on
+   *  1->0). Status displays show `evaluating <now-sinceS>s`. */
+  sinceS: number;
+  /** Last settled verdict, for a post-eval cue. */
+  lastVerdict: 'approved' | 'escalated' | 'none';
+  /** Epoch seconds of the last verdict; displays fade 'approved' after a few
+   *  seconds and keep 'escalated' (needs-you) until the next eval. */
+  lastVerdictAtS: number;
+}
+
+/**
+ * The daemon's status snapshot: written (debounced) to the per-port status
+ * file the Claude statusline script reads, rendered on the wrapper's
+ * reserved-row status bar, and broadcast to clients as `remi_status` (#754)
+ * so an attach client can render the same bar.
+ */
+export interface RemiStatus {
+  pid: number;
+  connections: number;
+  sessionStatus: AgentStatus;
+  adapters: string[];
+  wsPort: number;
+  sessionId: UUID | null;
+  repo: string;
+  branch: string;
+  autoApprove: AutoApproveState;
+  /**
+   * #755: true when a client holds the session's exclusive PTY slot
+   * (`activeConnectionId !== null`) — the status label reads "attached".
+   * Unlike `connections`, this never counts query-mode utility clients
+   * (`remi ls` / `remi kill` / phone session-list polls). Optional so an
+   * older writer/reader pair degrades gracefully.
+   */
+  attached?: boolean;
+  /** #755: clients queued behind the active one (read-only viewers). */
+  queuedCount?: number;
+  /**
+   * Distinguishes a session-less hub daemon (`remi serve`, #542) from an
+   * ordinary single-session daemon/wrapper process. Optional so an older
+   * writer/reader pair (mixed-version upgrade window) degrades gracefully
+   * rather than failing a strict shape check.
+   */
+  mode?: 'hub' | 'session';
+  /**
+   * The remi binary version this process runs (#539). A daemon holds its
+   * binary for life; `remi status`/`ls` compare this against the installed
+   * binary to flag stale daemons. Optional for the same mixed-version
+   * reasons as `mode`.
+   */
+  version?: string;
+}

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -21,6 +21,7 @@ import {
   createPong,
   createQuestion,
   createQuestionResolved,
+  createRemiStatus,
   createReplayBatch,
   createResumeSessionRequest,
   createResumeSessionResponse,
@@ -406,6 +407,47 @@ describe('createQuestionResolved() (#585 P7)', () => {
         expect(parsed.reason).toBe(reason);
       }
     }
+  });
+});
+
+describe('createRemiStatus() (#754)', () => {
+  function mkRemiStatus() {
+    return {
+      pid: 1,
+      connections: 2,
+      sessionStatus: 'thinking' as const,
+      adapters: ['ws'],
+      wsPort: 19924,
+      sessionId: null,
+      repo: 'remi',
+      branch: 'develop',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'none' as const, lastVerdictAtS: 0 },
+      attached: true,
+      queuedCount: 1,
+    };
+  }
+
+  test('builds a well-formed remi_status message that round-trips', () => {
+    const sessionId = generateId();
+    const msg = createRemiStatus(sessionId, mkRemiStatus());
+    expect(msg.type).toBe('remi_status');
+    expect(msg.sessionId).toBe(sessionId);
+    const parsed = deserialize(serialize(msg));
+    expect(parsed?.type).toBe('remi_status');
+    if (parsed?.type === 'remi_status') {
+      expect(parsed.status.attached).toBe(true);
+      expect(parsed.status.queuedCount).toBe(1);
+      expect(parsed.status.autoApprove.lastVerdict).toBe('none');
+    }
+  });
+
+  test('snapshots the status: later mutation of the source does not leak into the message', () => {
+    const status = mkRemiStatus();
+    const msg = createRemiStatus(generateId(), status);
+    status.attached = false;
+    status.autoApprove.inFlight = 5;
+    expect(msg.status.attached).toBe(true);
+    expect(msg.status.autoApprove.inFlight).toBe(0);
   });
 });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1484,6 +1484,12 @@ function App() {
         break;
       }
 
+      case 'remi_status':
+        // #754: terminal status-bar snapshot; the web app renders session
+        // state from session_update/transcript flows instead. Explicitly
+        // ignored so the debounced broadcast doesn't spam the debug log.
+        break;
+
       default:
         console.debug(`[App] Unhandled message type: ${(message as { type: string }).type}`);
         break;


### PR DESCRIPTION
Epic #757. Closes #751, closes #752, closes #753, closes #754, closes #755.

Four user-visible failures from the 2026-07-08 live soak, root-caused and fixed. Each landed on the epic branch via a reviewed PR (pr-review-toolkit findings addressed in follow-up commits):

## #751 — PTY-arbiter routing for subagent permissions (PR #758)

Subagent-tagged PermissionRequests the auto-approve gate cannot decide (escalate verdict, eval error, forfeited pick, no service) previously either silently denied (sync-Task shape) or held+pushed as main-agent phone cards (team/async shape, the AND-gate bug). Now they park their rich question in QuestionPresenceTracker and answer 'passthrough': Claude runs its normal permission flow, the allowlist may absorb the request, or the native prompt renders in the terminal and the tracker pushes the merged card immediately (no orphan debounce, exempt from gate-owned suppression). LLM approve/deny verdicts still resolve silently. Direction verified against Claude Code docs: no lead auto-approval exists for tool permissions; teammate prompts bubble to the lead session; team teammates fire no hooks (#23983) and stay on the orphan-PTY path. Subagent holds no longer exist; Part B early-push and the escalate_model second opinion are skipped for subagent events.

## #752 — answer delivery dedup (PR #759)

Every lock-screen tap fires two-to-three deliveries (native POST, Capacitor JS, signaling relay); the losers got HTTP 409 stale and surfaced a false "Answer not delivered" notification. New ResolvedAnswerCache records each successfully-applied answer under every spelling of the decision (raw answer + option value + label — surfaces disagree: in-app sends the value, push sends the label); same-decision duplicates now report delivered. Conflicting late answers, unknown questions, and never-applied (throwing) submits still report stale.

## #753 — pending questions visible on attach (PR #760)

Held hooks (Model B) never paint the PTY, and attach clients discarded question messages entirely. The daemon now re-sends the authoritative pending set (attachConnection's currentQuestions) as live messages after the replay batch, on ALL attach surfaces (hello attach, resume-request attach, FIFO promotion). Questions carry a `held` flag stamped at emission; `remi attach` banners exactly the held ones (cyan text + options + unstick hint) — non-held prompts render natively and are not double-printed.

## #754/#755 — status bar on attach + honest label (PR #761)

RemiStatus moved to @remi/shared; new `remi_status` broadcast on the StatusWriter's debounced flush. `remi attach` renders the same reserved-row StatusBar the wrapper draws (row reserved via rows-1 resize, bar starts on first snapshot so older daemons waste no row, cleared on detach). The label now reads real attach state pulled from the session registry at flush time: `attached` / `attached (+N waiting)` / `N waiting` / `no clients` — query-mode utility connections (remi ls/kill, phone polls) no longer count as clients. Mirrored in the bash statusline script; old counter label kept as fallback for older status files.

## Testing

Full suite run locally on the merged branch (plus per-PR suites during development). Companion design issue #756 (audit surface for silently-handled subagent decisions, subagent_policy config) stays open.