### PR TITLE
Scope parked-record expiry to the owning agent

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -69,6 +69,15 @@ function agentKey(question: Question): string {
  *  long enough to matter to the user. */
 const DEFAULT_ORPHAN_DEBOUNCE_MS = 1500;
 
+/** How long a parked awaiting-PTY record (#751) survives other agents'
+ *  status churn (#763). A prompt that will render does so within
+ *  milliseconds of the hook's passthrough answer; one that never renders is
+ *  normally expired by its own agent's next PreToolUse (`noteAgentAdvanced`).
+ *  The TTL is the backstop for an agent that stalls without either signal,
+ *  so a stale parked record cannot merge onto an unrelated prompt minutes
+ *  later. */
+const PARKED_RECORD_TTL_MS = 120_000;
+
 export interface QuestionPresenceTrackerDeps {
   /** True iff the session currently has at least one registered, unanswered
    *  question (`sessionRegistry.getSession(id)?.currentQuestions.size > 0`).
@@ -87,6 +96,8 @@ export interface QuestionPresenceTrackerDeps {
   /** Override for `DEFAULT_ORPHAN_DEBOUNCE_MS`. Exists so tests can use a
    *  short real timer instead of faking time. */
   orphanDebounceMs?: number;
+  /** Clock override for the parked-record TTL (#763). Defaults to Date.now. */
+  nowMs?: () => number;
 }
 
 export class QuestionPresenceTracker {
@@ -99,13 +110,21 @@ export class QuestionPresenceTracker {
   private pending = new Map<string, Question>();
 
   /** Keys of `pending` records PARKED by the gate awaiting PTY arbitration
-   *  (#751): a subagent-tagged escalation the gate answered 'passthrough'
-   *  instead of holding or denying. Unlike a normal pending record (an
-   *  in-flight gate escalation whose own push is imminent), a parked record
-   *  must NOT count as gate-owned in the #712 orphan check — the PTY render
-   *  IS its push trigger. Always a subset of `pending`'s keys; every
-   *  `pending` delete/clear site mirrors onto this set. */
-  private awaitingPTY = new Set<string>();
+   *  (#751), mapped to the epoch-ms they were parked. Unlike a normal pending
+   *  record (an in-flight gate escalation whose own push is imminent), a
+   *  parked record must NOT count as gate-owned in the #712 orphan check —
+   *  the PTY render IS its push trigger — and it must SURVIVE the unscoped
+   *  status-change clear (#763): in an agent-team session every other
+   *  agent's hook activity flips status constantly, and wiping a still-live
+   *  parked record loses the merged push (or the whole prompt, when an
+   *  unrelated live question makes `hasLiveQuestions` suppress the orphan).
+   *  A parked entry expires when its OWN agent advances
+   *  (`noteAgentAdvanced` — the permission was allowlist-absorbed or
+   *  answered), on consume (render pairing), on `clearPending`
+   *  (restart/rotation), or after `PARKED_RECORD_TTL_MS`. Always a subset of
+   *  `pending`'s keys; every `pending` delete/clear site mirrors onto this
+   *  map. */
+  private awaitingPTY = new Map<string, number>();
 
   /** True while a permission prompt is on the main PTY. Set by
    *  `onPTYPromptVisible`; reset by `onStatusChange` out of `'waiting'`
@@ -220,7 +239,22 @@ export class QuestionPresenceTracker {
     // recordPendingHook may have kept a richer existing record instead of
     // this one; the parked flag applies to whatever record now owns the key
     // (both are hook-derived for the same agent's prompt cycle).
-    this.awaitingPTY.add(agentKey(question));
+    this.awaitingPTY.set(agentKey(question), this.deps.nowMs?.() ?? Date.now());
+  }
+
+  /**
+   * An agent-tagged PreToolUse arrived (#763): that agent's pending
+   * permission resolved WITHOUT a PTY render for us to pair (the session
+   * allowlist absorbed it after the gate's passthrough, or it was answered
+   * out-of-band). Its parked record is dead — expire it so it cannot
+   * stale-merge onto a later unrelated prompt. Scoped strictly to that
+   * agent's key; other agents' parked records are untouched.
+   */
+  noteAgentAdvanced(agentId: string | undefined): void {
+    if (agentId === undefined) return;
+    if (this.awaitingPTY.delete(agentId)) {
+      this.pending.delete(agentId);
+    }
   }
 
   /**
@@ -519,8 +553,19 @@ export class QuestionPresenceTracker {
    */
   onStatusChange(status: AgentStatus): void {
     if (status !== 'waiting') {
-      this.pending.clear();
-      this.awaitingPTY.clear();
+      // #763: spare still-fresh PARKED records — the main status pipeline
+      // flips on every agent's hook activity, and a teammate's routine
+      // PreToolUse must not wipe another agent's parked question before its
+      // prompt had a chance to render. Parked entries have their own
+      // lifecycle (own-agent advance / render consume / TTL / clearPending);
+      // everything else clears exactly as before.
+      const now = this.deps.nowMs?.() ?? Date.now();
+      for (const key of [...this.pending.keys()]) {
+        const parkedAt = this.awaitingPTY.get(key);
+        if (parkedAt !== undefined && now - parkedAt <= PARKED_RECORD_TTL_MS) continue;
+        this.pending.delete(key);
+        this.awaitingPTY.delete(key);
+      }
       this.ptyShowingQuestion = false;
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
@@ -598,7 +643,14 @@ export class QuestionPresenceTracker {
    *  pending record and it is parked — PTY prompts rarely name their agent,
    *  mirroring `onPTYPromptVisible`'s own pairing heuristic). With 2+ pending
    *  records and no exact match, no guess is made here; the prompt falls to
-   *  the normal owned/orphan logic. */
+   *  the normal owned/orphan logic.
+   *
+   *  ACCEPTED tradeoff (#763 finding 2): the sole-candidate fallback can pair
+   *  an unrelated render (e.g. a hook-less agent-team prompt) with the single
+   *  parked record, same as the pre-existing #483/#717 pairing heuristic.
+   *  Parking's longer lifetime widens the window, but own-agent-advance
+   *  expiry (`noteAgentAdvanced`) + the TTL bound it; revisit only if soaks
+   *  show real misattribution. */
   private matchAwaitingPTYKey(ptyQuestion: Question): string | undefined {
     const key = agentKey(ptyQuestion);
     if (this.awaitingPTY.has(key) && this.pending.has(key)) return key;

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -188,7 +188,7 @@ export interface AutoApproveGateDeps {
    * PTY. Optional so tests that don't wire it degrade to a plain passthrough
    * (the rendered prompt then pushes bare via the #712 orphan path).
    */
-  parkForPTY?: (input: PermissionRequestHookInput) => void;
+  parkForPTY?: (input: PermissionRequestHookInput, summary?: string) => void;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -1081,7 +1081,7 @@ export class AutoApproveGate {
       log(
         `[AutoApprove ${this.sessionTag}] Subagent escalate; parking for PTY arbitration (agent=${input.agent_id?.slice(0, 8)})`,
       );
-      this.parkSubagentForPTY(input);
+      this.parkSubagentForPTY(input, result.summary);
       return 'passthrough';
     }
     // A MAIN-tagged event (agent_id absent) with isInSubagentContext() true is
@@ -1359,9 +1359,9 @@ export class AutoApproveGate {
    * rendered prompt degrades to a bare #712 orphan push instead of a merged
    * one.
    */
-  private parkSubagentForPTY(input: PermissionRequestHookInput): void {
+  private parkSubagentForPTY(input: PermissionRequestHookInput, summary?: string): void {
     try {
-      this.deps.parkForPTY?.(input);
+      this.deps.parkForPTY?.(input, summary);
     } catch (err) {
       logError(
         `[AutoApprove ${this.sessionTag}] parkForPTY threw (prompt will fall to the orphan push path):`,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -386,7 +386,8 @@ export function setupHookBridge(
       // parks its rich question (same builder as a real escalation, minus the
       // push/registration side effects) and answers 'passthrough'; the tracker
       // pushes it only if Claude's native prompt actually renders on the PTY.
-      parkForPTY: (i) => tracker.parkAwaitingPTY(hookBridge.buildPermissionQuestion(i)),
+      parkForPTY: (i, summary) =>
+        tracker.parkAwaitingPTY(hookBridge.buildPermissionQuestion(i, summary)),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native
@@ -405,9 +406,14 @@ export function setupHookBridge(
       onEscalate: () => {
         tracker.onAutoApproveEscalate();
         deps.statusWriter?.autoApproveEnd('escalated', Date.now());
-        // No status broadcast here: escalate already routes through
+        // No status broadcast here: a MAIN escalate routes through
         // handlePermissionRequest -> onStatusChange('waiting'), which broadcasts
-        // the 'waiting' session_update. Re-emitting would double-emit.
+        // the 'waiting' session_update; re-emitting would double-emit. A PARKED
+        // subagent escalation (#751) bypasses handlePermissionRequest, so no
+        // 'waiting' fires here either — deliberately: the prompt may never
+        // render (allowlist absorption). When it does render, the PTY parser
+        // flips the status, and the web pill prioritizes the pushed question
+        // over raw status anyway (#763 finding 3).
       },
       // #573: a binary escalation that HOLDS its hook blocks Claude's response,
       // so Claude never renders the native prompt and the tracker's PTY-render
@@ -549,7 +555,15 @@ export function setupHookBridge(
   hookServer.on('PreToolUse', (input) => {
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
-    if (isSubagentEvent(input)) return;
+    if (isSubagentEvent(input)) {
+      // #763: an agent-tagged PreToolUse means that agent's pending
+      // permission resolved without a PTY render we could pair (the
+      // allowlist absorbed it post-passthrough, or it was answered
+      // out-of-band) — expire its parked record so it cannot stale-merge
+      // onto a later unrelated prompt.
+      tracker.noteAgentAdvanced(input.agent_id);
+      return;
+    }
     // NB: do NOT cancel the in-flight auto-approve eval here (#537). Under
     // synchronous decisions (#496) Claude BLOCKS on the PermissionRequest until
     // the daemon answers, so a running eval is never stale — it is the verdict

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -906,23 +906,105 @@ describe('QuestionPresenceTracker', () => {
       expect(pushes[0]?.text).toBe('agent · Edit: config.toml');
     });
 
-    it("status leaving 'waiting' expires a parked record (allowlist absorbed the request)", async () => {
+    it("#763: a fresh parked record SURVIVES another agent's status churn and still merges on render", () => {
       const pushes: Question[] = [];
       const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
         hasLiveQuestions: () => false,
         orphanDebounceMs: DEBOUNCE_MS,
       });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Bash: ls'),
+        agentId: 'agent-A',
+      });
+
+      // Main / teammate hook activity flips status constantly in team runs;
+      // that must NOT wipe A's still-live parked record.
+      tracker.onStatusChange('executing');
+      tracker.onStatusChange('thinking');
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('agent · Bash: ls'); // merged, not bare
+    });
+
+    it("#763: noteAgentAdvanced expires exactly that agent's parked record (allowlist absorbed)", async () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('A · Bash: ls'),
+        agentId: 'agent-A',
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('B · Edit: x.md'),
+        agentId: 'agent-B',
+      });
+
+      tracker.noteAgentAdvanced('agent-A'); // A's PreToolUse: permission resolved silently
+      tracker.noteAgentAdvanced(undefined); // main-tagged: no-op
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+
+      // B's prompt renders and still pairs by exact key.
+      tracker.onOrphanPTYPrompt({ ...makePTYQuestion('proceed?'), agentId: 'agent-B' });
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.text).toBe('B · Edit: x.md');
+      // A later unnamed prompt is a plain orphan again (A's record is gone).
+      tracker.onOrphanPTYPrompt(makePTYQuestion('unrelated later prompt'));
+      expect(pushes.length).toBe(1);
+      await wait(DEBOUNCE_MS * 2);
+      expect(pushes.length).toBe(2);
+      expect(pushes[1]?.text).toBe('unrelated later prompt');
+    });
+
+    it('#763: a parked record past the TTL is dropped by the next status change', () => {
+      let now = 1_000_000;
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+        nowMs: () => now,
+      });
       tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
 
-      tracker.onStatusChange('executing'); // Claude proceeded; prompt never rendered
-      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+      now += 119_000;
+      tracker.onStatusChange('executing');
+      expect(tracker.awaitingPTYCountForTest()).toBe(1); // inside TTL: spared
 
-      // A later prompt is a plain orphan again: debounced, pushed bare.
-      tracker.onOrphanPTYPrompt(makePTYQuestion('unrelated later prompt'));
-      expect(pushes.length).toBe(0);
-      await wait(DEBOUNCE_MS * 2);
-      expect(pushes.length).toBe(1);
-      expect(pushes[0]?.text).toBe('unrelated later prompt');
+      now += 2_000; // 121s parked: past the 120s TTL
+      tracker.onStatusChange('executing');
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+      expect(tracker.hasPendingForTest()).toBe(false);
+    });
+
+    it("#763: NORMAL pending records still clear when status leaves 'waiting'", () => {
+      const tracker = new QuestionPresenceTracker(() => {}, {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?')); // not parked
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('agent · Bash: ls'),
+        agentId: 'agent-A',
+      });
+
+      tracker.onStatusChange('executing');
+
+      expect(tracker.pendingCountForTest()).toBe(1); // only the parked one survives
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+    });
+
+    it('#763: clearPending (restart/rotation) still wipes parked records', () => {
+      const tracker = new QuestionPresenceTracker(() => {}, {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
+      tracker.clearPending();
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
+      expect(tracker.hasPendingForTest()).toBe(false);
     });
 
     it('a NORMAL pending record for the prompt agent still suppresses (echo protection intact)', async () => {

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -72,8 +72,9 @@ describe('AutoApproveGate', () => {
   // genuine subagent-tagged one.
   let resets: number;
   // #751: records parkForPTY() calls (subagent escalations parked for PTY
-  // arbitration instead of held/denied).
+  // arbitration instead of held/denied). #763: the summary passed with each.
   let parks: PermissionRequestHookInput[];
+  let parkSummaries: (string | undefined)[];
 
   function evaluator(
     result: AutoApproveResult,
@@ -111,8 +112,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
-        parkForPTY: (i) => {
+        parkForPTY: (i, summary) => {
           parks.push(i);
+          parkSummaries.push(summary);
         },
       },
       SID,
@@ -145,8 +147,9 @@ describe('AutoApproveGate', () => {
           escalations.push(i);
           return generateId();
         },
-        parkForPTY: (i) => {
+        parkForPTY: (i, summary) => {
           parks.push(i);
+          parkSummaries.push(summary);
         },
         escalateModel: 'big-model',
       },
@@ -175,6 +178,7 @@ describe('AutoApproveGate', () => {
     subagent = false;
     resets = 0;
     parks = [];
+    parkSummaries = [];
     tracker = new QuestionPresenceTracker(() => {});
     configureLogger({ writeLog: () => {} });
   });
@@ -485,6 +489,15 @@ describe('AutoApproveGate', () => {
     expect(submits).toHaveLength(0); // never types into the main PTY
     expect(escalations).toHaveLength(0);
     expect(parks).toHaveLength(1);
+  });
+
+  test('#763: the escalate verdict summary is threaded into the park', async () => {
+    subagent = false;
+    const d = await gateWith(evaluator(escalateWithSummary)).resolvePermission(
+      pr({ agent_id: 'agent-1' }),
+    );
+    expect(d).toBe('passthrough');
+    expect(parkSummaries).toEqual(['Force-push to main?']);
   });
 
   test('#751: a parkForPTY throw is absorbed; the passthrough still stands', async () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1634,7 +1634,9 @@ describe('setupHookBridge', () => {
     expect(tracker.hasPendingForTest()).toBe(true);
     expect(pushed.length).toBe(0);
 
-    // Subagent finished without the user seeing the prompt (background).
+    // #763: a MAIN-tagged PostToolUse (routine status churn from another
+    // agent's work) must NOT wipe the still-live parked record — the prompt
+    // may not have had a chance to render yet.
     hookServer.fire('PostToolUse', {
       session_id: 'claude-sub-B',
       hook_event_name: 'PostToolUse',
@@ -1642,7 +1644,21 @@ describe('setupHookBridge', () => {
       tool_input: { command: 'ls' },
       tool_response: { exit_code: 0 },
     });
+    expect(tracker.hasPendingForTest()).toBe(true);
+    expect(pushed.length).toBe(0);
 
+    // The subagent's OWN next tagged PreToolUse proves its permission
+    // resolved without a render (allowlist absorbed / answered): the parked
+    // record expires so it cannot stale-merge later. No push ever fired.
+    hookServer.fire('PreToolUse', {
+      session_id: 'claude-sub-B',
+      agent_id: 'subagent-B',
+      agent_type: 'task',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      tool_use_id: 'tu_sub_b_next',
+    });
     expect(tracker.hasPendingForTest()).toBe(false);
     expect(pushed.length).toBe(0);
   });


### PR DESCRIPTION
Closes #763. Follow-up to #762: the pr-review-toolkit pass on PR #758 reported after the merge; its high-severity finding is real and fixed here.

## The bug (finding 1)

A parked awaiting-PTY record's only home was the tracker's pending/awaitingPTY maps, and `onStatusChange` cleared BOTH wholesale on any transition away from waiting. The status pipeline flips on every agent's hook activity, so in the exact multi-agent sessions #751 targets, a teammate's routine PreToolUse wiped another agent's still-live parked record before its prompt could render. The render then missed the parked match and fell to the orphan path: bare push at best, full suppression when any unrelated live question made `hasLiveQuestions` claim the cycle.

## The fix

Parked entries now carry a parked-at timestamp and survive status churn while fresh. They expire through their own lifecycle:

- own-agent advance: a subagent-tagged PreToolUse means that agent's permission resolved without a render (allowlist absorbed post-passthrough, or answered out-of-band) — `noteAgentAdvanced` drops exactly that agent's record (wired in hook-bridge-setup's existing subagent early-return);
- render consume (unchanged), `clearPending` on restart/rotation (unchanged, full wipe);
- a 120s TTL backstop so a stalled agent's record cannot stale-merge minutes later.

Normal (non-parked) pending records clear on status changes exactly as before.

Also from the same review: finding 3 (stale onEscalate comment; the parked path deliberately never fires `onStatusChange('waiting')` — documented), finding 4 (the escalate verdict's lock-screen summary now threads through `parkForPTY` into the parked question), finding 2 (sole-candidate parked pairing accepted as the precedented #483/#717 heuristic, documented in `matchAwaitingPTYKey`, bounded by own-agent expiry + TTL).

## Tests

New: parked record survives another agent's status churn and still merges on render; `noteAgentAdvanced` scoping (only the advancing agent's record, undefined is a no-op); TTL expiry with injected clock; normal pending still clears; `clearPending` full wipe; summary threading. The hook-bridge-setup Phase-4 wiring test was rewritten to the new lifecycle (main-tagged PostToolUse no longer wipes the parked record; the agent's own tagged PreToolUse does). 482 tests across the 17 affected files pass; typecheck and biome clean.