### PR TITLE
Scope eval buffer to main-context evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ lock-screen answer notices, and what a terminal attach can see.
   racing the hub for the shared file.
 
 ### Fixed
+- **Orphan prompt routing survives subagent eval streams** (#767): the
+  eval-in-flight buffer (#484) treated ANY auto-approve eval as owning the
+  prompt cycle, so on sessions with back-to-back subagent evals every
+  hook-less rendered prompt (agent-team teammate permissions, MCP dialogs,
+  #751 parked renders) was captured and silently discarded by the next
+  unrelated approve — questions never reached the phone. The buffer window is
+  now opened only by main-context evals (counted, so concurrent evals cannot
+  close each other's window), parked renders are matched before any buffering,
+  and the previously invisible park/buffer/expiry decisions are logged.
 - **Subagent permission questions are PTY-arbitered** (#751, #763): the
   auto-approve gate no longer holds-and-pushes subagent-tagged escalations
   blindly — it parks the question and passes the hook through, and the push

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -136,14 +136,23 @@ export class QuestionPresenceTracker {
    *  dropped instead of typing into the main agent's input. */
   private ptyShowingQuestion = false;
 
-  /** True while the auto-approve LLM is deciding a permission. A PTY prompt
-   *  that appears during this window is BUFFERED (not pushed): if the verdict
-   *  is approve/deny/pick the prompt is auto-handled and must never reach the
+  /** Count of MAIN-context auto-approve evals in flight. A PTY prompt that
+   *  appears while this is > 0 is BUFFERED (not pushed): if the verdict is
+   *  approve/deny/pick the prompt is auto-handled and must never reach the
    *  user; only an escalate verdict releases the buffered prompt. This is the
    *  fix for "every auto-approved permission still pushed APNS" (#484) — and it
    *  must buffer (not suppress-and-replay) because the rising-edge PTY emit
-   *  (#486) fires only once, so a suppressed prompt would never re-emit. */
-  private autoApproveInFlight = false;
+   *  (#486) fires only once, so a suppressed prompt would never re-emit.
+   *
+   *  SUBAGENT evals never open this window (#767): a held subagent hook blocks
+   *  only that subagent, so a render arriving during its eval is some OTHER
+   *  prompt (an agent-team teammate permission, an MCP dialog, a #751 parked
+   *  render) — buffering it pairs the render with an unrelated verdict, and
+   *  the next unrelated approve discards a real question. On sessions with a
+   *  continuous subagent eval stream that ate every orphan render. A COUNTER
+   *  (not the old boolean) because concurrent evals exist; the first verdict
+   *  must not close a window another main eval still owns. */
+  private mainEvalsInFlight = 0;
   /** The PTY prompt held while an auto-approve eval is in flight. Released by
    *  `onAutoApproveEscalate` (verdict = escalate), discarded by the
    *  status/clearPending resets (verdict = handled, or the prompt is gone). */
@@ -240,6 +249,9 @@ export class QuestionPresenceTracker {
     // this one; the parked flag applies to whatever record now owns the key
     // (both are hook-derived for the same agent's prompt cycle).
     this.awaitingPTY.set(agentKey(question), this.deps.nowMs?.() ?? Date.now());
+    console.debug(
+      `[QuestionPresenceTracker] Parked question awaiting PTY render (agent "${agentKey(question)}"): "${question.text.slice(0, 60)}"`,
+    );
   }
 
   /**
@@ -254,6 +266,9 @@ export class QuestionPresenceTracker {
     if (agentId === undefined) return;
     if (this.awaitingPTY.delete(agentId)) {
       this.pending.delete(agentId);
+      console.debug(
+        `[QuestionPresenceTracker] Parked question expired (agent "${agentId}" advanced without a render)`,
+      );
     }
   }
 
@@ -338,21 +353,34 @@ export class QuestionPresenceTracker {
    * numbered options), which beats crashing on a network blip during APNS.
    */
   onPTYPromptVisible(ptyQuestion: Question): void {
-    if (this.autoApproveInFlight) {
-      // A permission eval owns this prompt: buffer it, do not push yet. The
-      // verdict decides — onAutoApproveEscalate releases it; a status-leaves-
-      // waiting / clearPending reset (auto-handled, or prompt gone) discards it.
+    if (this.mainEvalsInFlight > 0) {
+      // A MAIN permission eval owns this prompt: buffer it, do not push yet.
+      // The verdict decides — onAutoApproveEscalate releases it; a status-
+      // leaves-waiting / clearPending reset (auto-handled, or prompt gone)
+      // discards it.
       //
-      // DORMANT under synchronous decisions (#496): Claude now BLOCKS on the
-      // hook response and does not render the permission prompt during the eval,
-      // so this branch is effectively never taken (the verdict is returned before
-      // any prompt renders; escalate clears the flag before the passthrough
-      // prompt appears). Retained as defense-in-depth — it is the #484
-      // APNS-flood guard for any future async/parallel eval path, and removing it
-      // buys nothing while risking the flood it prevents.
+      // Near-dormant under synchronous MAIN decisions (#496): Claude BLOCKS on
+      // the hook response and does not render that permission's prompt during
+      // the eval — the #484 APNS-flood guard for any async/parallel eval path.
+      // Scoped to MAIN evals only (#767): a subagent eval blocks only its own
+      // subagent, so renders arriving during one are other prompts entirely
+      // and must flow, not buffer.
+      console.debug(
+        `[QuestionPresenceTracker] Buffering PTY prompt during main eval: "${ptyQuestion.text.slice(0, 60)}"`,
+      );
       this.bufferedDuringEval = ptyQuestion;
       return;
     }
+    this.pairAndPush(ptyQuestion);
+  }
+
+  /**
+   * Pair-and-push core shared by every push trigger (#767): the buffer-window
+   * check lives only in `onPTYPromptVisible`; the #751 parked-render path and
+   * the escalate-release path call this directly so an in-flight eval cannot
+   * re-capture a prompt that has already won its arbitration.
+   */
+  private pairAndPush(ptyQuestion: Question): void {
     const key = agentKey(ptyQuestion);
     let recordKey: string | undefined = this.pending.has(key) ? key : undefined;
     if (recordKey === undefined && this.pending.size === 1) {
@@ -453,20 +481,30 @@ export class QuestionPresenceTracker {
    * `onPTYPromptVisible` merge/push path.
    */
   onOrphanPTYPrompt(ptyQuestion: Question): void {
-    if (this.autoApproveInFlight) {
-      // Same #484 semantics as onPTYPromptVisible: the eval owns this prompt
-      // cycle; only its own escalate verdict may release it.
-      this.bufferedDuringEval = ptyQuestion;
-      return;
-    }
     // #751 PTY-arbiter: a parked subagent escalation whose prompt has now
-    // rendered. Merge + push IMMEDIATELY through the normal pair path — no
-    // orphan debounce (hook + render is positive double-confirmation) and no
-    // gate-owned / live-question suppression (an unrelated live card must not
-    // eat the one prompt class this parking exists to surface).
+    // rendered. Merge + push IMMEDIATELY through the pair core — no orphan
+    // debounce (hook + render is positive double-confirmation), no gate-owned
+    // / live-question suppression (an unrelated live card must not eat the one
+    // prompt class this parking exists to surface), and CHECKED BEFORE the
+    // eval buffer (#767): the parked record's own eval already settled, so an
+    // in-flight eval here is some other agent's and must not capture — let
+    // alone discard — a prompt that already won its arbitration.
     const parkedKey = this.matchAwaitingPTYKey(ptyQuestion);
     if (parkedKey !== undefined) {
-      this.onPTYPromptVisible(ptyQuestion);
+      console.debug(
+        `[QuestionPresenceTracker] Parked question's prompt rendered; pushing (agent "${parkedKey}"): "${ptyQuestion.text.slice(0, 60)}"`,
+      );
+      this.pairAndPush(ptyQuestion);
+      return;
+    }
+    if (this.mainEvalsInFlight > 0) {
+      // Same #484 semantics as onPTYPromptVisible: a MAIN eval owns this
+      // prompt cycle; only its own escalate verdict may release it. Subagent
+      // evals never open this window (#767).
+      console.debug(
+        `[QuestionPresenceTracker] Buffering orphan PTY prompt during main eval: "${ptyQuestion.text.slice(0, 60)}"`,
+      );
+      this.bufferedDuringEval = ptyQuestion;
       return;
     }
     if (this.isGateOwnedCycle(ptyQuestion)) {
@@ -518,10 +556,13 @@ export class QuestionPresenceTracker {
       const armed = this.armedOrphanQuestion;
       this.armedOrphanQuestion = null;
       if (armed === null) return;
-      // Re-check ownership: an eval could have started, or the gate could
+      // Re-check ownership: a main eval could have started, or the gate could
       // have taken the prompt (registered / stashed a same-agent hook
       // record), during the debounce window.
-      if (this.autoApproveInFlight) {
+      if (this.mainEvalsInFlight > 0) {
+        console.debug(
+          `[QuestionPresenceTracker] Buffering orphan PTY prompt at debounce fire (main eval started): "${armed.text.slice(0, 60)}"`,
+        );
         this.bufferedDuringEval = armed;
         return;
       }
@@ -531,14 +572,15 @@ export class QuestionPresenceTracker {
         );
         return;
       }
-      // Still orphaned: push through the SAME merge/push path a non-orphan
-      // PTY prompt uses, per spec, rather than a bespoke bare push — that
-      // keeps ptyShowingQuestion / pairing semantics identical. A pending
-      // record for a DIFFERENT agent (already ruled out as THIS agent's
-      // owner above) can still attach via onPTYPromptVisible's own sole-
-      // candidate heuristic (#483); that is pre-existing, general-purpose
-      // pairing behavior, not something this fallback adds.
-      this.onPTYPromptVisible(armed);
+      // Still orphaned: push through the SAME pair core a non-orphan PTY
+      // prompt uses, per spec, rather than a bespoke bare push — that keeps
+      // ptyShowingQuestion / pairing semantics identical (the buffer re-check
+      // just ran above, so the core is called directly). A pending record for
+      // a DIFFERENT agent (already ruled out as THIS agent's owner above) can
+      // still attach via the core's own sole-candidate heuristic (#483); that
+      // is pre-existing, general-purpose pairing behavior, not something this
+      // fallback adds.
+      this.pairAndPush(armed);
     }, ms);
     // Never let an armed 1.5s debounce block a graceful daemon shutdown
     // (mirrors the sibling hold/delivery timers in auto-approve-gate.ts).
@@ -563,13 +605,18 @@ export class QuestionPresenceTracker {
       for (const key of [...this.pending.keys()]) {
         const parkedAt = this.awaitingPTY.get(key);
         if (parkedAt !== undefined && now - parkedAt <= PARKED_RECORD_TTL_MS) continue;
+        if (parkedAt !== undefined) {
+          console.debug(
+            `[QuestionPresenceTracker] Parked question expired (agent "${key}", TTL ${PARKED_RECORD_TTL_MS}ms elapsed without a render)`,
+          );
+        }
         this.pending.delete(key);
         this.awaitingPTY.delete(key);
       }
       this.ptyShowingQuestion = false;
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
-      this.autoApproveInFlight = false;
+      this.mainEvalsInFlight = 0;
       this.bufferedDuringEval = null;
       // New prompt cycle starts fresh: a held push from the prior cycle must not
       // suppress an identical id in a future one (ids are unique, so this is
@@ -583,40 +630,57 @@ export class QuestionPresenceTracker {
   }
 
   /**
-   * An auto-approve LLM eval has STARTED for a permission. Until it resolves,
-   * a PTY prompt for it is buffered, not pushed (so a silently auto-approved
-   * permission never reaches the user). Paired with `onAutoApproveEscalate`
-   * (release) and the status/clearPending resets (discard).
+   * An auto-approve LLM eval has STARTED for a permission. Until a MAIN-context
+   * eval resolves, a PTY prompt is buffered, not pushed (so a silently
+   * auto-approved permission never reaches the user). Paired with
+   * `onAutoApproveEscalate` (release) and the status/clearPending resets
+   * (discard). A SUBAGENT eval (#767) never opens the buffer window: its held
+   * hook blocks only that subagent, so it cannot be the prompt now rendering —
+   * see `mainEvalsInFlight`.
    */
-  onAutoApproveStart(): void {
-    this.autoApproveInFlight = true;
+  onAutoApproveStart(isSubagent = false): void {
+    if (isSubagent) return;
+    this.mainEvalsInFlight += 1;
   }
 
   /**
    * The auto-approve verdict was ESCALATE: the user must answer. End the buffer
-   * window and release the held PTY prompt (re-running the normal pair+push
-   * path, which now finds the hook record the escalation just stashed). If no
-   * prompt was buffered yet, the next `onPTYPromptVisible` pushes normally.
+   * window and release the held PTY prompt (re-running the pair+push core,
+   * which now finds the hook record the escalation just stashed — NOT the
+   * buffer-checking entry point, since a sibling main eval may still be in
+   * flight and the escalate verdict owns the release). If no prompt was
+   * buffered yet, the next `onPTYPromptVisible` pushes normally. A subagent
+   * verdict (#767, the #751 park path) never opened the window, so it must not
+   * release or discard another eval's buffered prompt.
    */
-  onAutoApproveEscalate(): void {
-    this.autoApproveInFlight = false;
+  onAutoApproveEscalate(isSubagent = false): void {
+    if (isSubagent) return;
+    this.mainEvalsInFlight = Math.max(0, this.mainEvalsInFlight - 1);
     const buffered = this.bufferedDuringEval;
     this.bufferedDuringEval = null;
     if (buffered !== null) {
-      this.onPTYPromptVisible(buffered);
+      this.pairAndPush(buffered);
     }
   }
 
   /**
    * The auto-approve verdict was HANDLED automatically (approve/deny/pick
-   * injected, or a subagent default-deny): the user must NOT see this prompt.
-   * Close the buffer window and discard any buffered prompt. Surgical (does not
-   * touch pending hook records of OTHER agents). EVERY `onAutoApproveStart` must
-   * be matched by exactly one of escalate / handled / a status-or-clear reset,
-   * or the buffer would stick true and silently drop later prompts.
+   * injected): the user must NOT see this prompt. Close the buffer window and
+   * discard any buffered prompt. Surgical (does not touch pending hook records
+   * of OTHER agents). EVERY main `onAutoApproveStart` must be matched by
+   * exactly one of escalate / handled / a status-or-clear reset, or the buffer
+   * would stick open and silently drop later prompts. A subagent verdict
+   * (#767) is a no-op here: discarding on it was exactly how an unrelated
+   * subagent approve destroyed a buffered teammate/parked prompt.
    */
-  onAutoApproveHandled(): void {
-    this.autoApproveInFlight = false;
+  onAutoApproveHandled(isSubagent = false): void {
+    if (isSubagent) return;
+    this.mainEvalsInFlight = Math.max(0, this.mainEvalsInFlight - 1);
+    if (this.bufferedDuringEval !== null) {
+      console.debug(
+        `[QuestionPresenceTracker] Discarding buffered PTY prompt (main eval auto-handled): "${this.bufferedDuringEval.text.slice(0, 60)}"`,
+      );
+    }
     this.bufferedDuringEval = null;
   }
 
@@ -630,7 +694,7 @@ export class QuestionPresenceTracker {
     this.pending.clear();
     this.awaitingPTY.clear();
     this.ptyShowingQuestion = false;
-    this.autoApproveInFlight = false;
+    this.mainEvalsInFlight = 0;
     this.bufferedDuringEval = null;
     this.pushedHeldIds.clear();
     // #712: the prompt was answered in-terminal or the session is rotating —

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -204,8 +204,11 @@ export interface AutoApproveGateDeps {
    *  broadcast for it (the #484 buffering itself is unaffected). */
   onEvalStart?: (ctx: { isSubagent: boolean }) => void;
   /** Called when the verdict is escalate (the user must answer), so the tracker
-   *  releases the buffered PTY prompt. #484. */
-  onEscalate?: () => void;
+   *  releases the buffered PTY prompt. #484. `ctx.isSubagent` (#767): a
+   *  subagent verdict (the #751 park path) never opened the tracker's buffer
+   *  window, so the setup layer must not let it release — or discard — a
+   *  prompt buffered by a MAIN eval still in flight. */
+  onEscalate?: (ctx: { isSubagent: boolean }) => void;
   /** The gate's push trigger: called with a `Question.id` so the tracker pushes
    *  that question IMMEDIATELY (-> sessionRegistry.addQuestion + APNS), making it
    *  answerable. Called for BOTH escalation shapes (#625):
@@ -1338,7 +1341,7 @@ export class AutoApproveGate {
    * user never saw asked -- the tracker + terminal cue still fire either way.
    */
   private markHandled(isSubagent: boolean): void {
-    this.deps.tracker.onAutoApproveHandled();
+    this.deps.tracker.onAutoApproveHandled(isSubagent);
     this.safeCueWithArg('onHandled', this.deps.onHandled, { isSubagent });
   }
 
@@ -1368,7 +1371,7 @@ export class AutoApproveGate {
         err,
       );
     }
-    this.safeCue('onEscalate', this.deps.onEscalate);
+    this.safeCueWithArg('onEscalate', this.deps.onEscalate, { isSubagent: true });
   }
 
   /**
@@ -1498,7 +1501,9 @@ export class AutoApproveGate {
       // locked, or every later prompt in this session would buffer forever. #484.
       // safeCue: the wired callback releases the buffer (critical) then fires the
       // terminal cue (#513, cosmetic); a cue throw must not break the finally.
-      this.safeCue('onEscalate', this.deps.onEscalate);
+      this.safeCueWithArg('onEscalate', this.deps.onEscalate, {
+        isSubagent: this.isSubagentEvent(input),
+      });
     }
     if (questionId) {
       const observed: ObservedToolCall = {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -394,7 +394,11 @@ export function setupHookBridge(
       // status line via the StatusWriter. A COUNT (start/end) replaces the old
       // shared title spinner, which raced under concurrent evals.
       onEvalStart: (ctx) => {
-        tracker.onAutoApproveStart();
+        // #767: only a MAIN-context eval opens the tracker's #484 buffer
+        // window. A subagent eval holds only its own subagent's hook, so a
+        // prompt rendering during it is some OTHER question (teammate
+        // permission, parked #751 render) that must flow, not buffer.
+        tracker.onAutoApproveStart(ctx.isSubagent);
         deps.statusWriter?.autoApproveStart(Date.now());
         // #576: surface the in-flight eval on the client pill ('working').
         // #711: skip the CLIENT broadcast for a subagent/team-member eval --
@@ -403,8 +407,10 @@ export function setupHookBridge(
         // StatusWriter terminal cue above still fire unconditionally.
         if (!ctx.isSubagent) broadcastAutoApproveStatus('evaluating');
       },
-      onEscalate: () => {
-        tracker.onAutoApproveEscalate();
+      onEscalate: (ctx) => {
+        // #767: a subagent escalate (the #751 park path) never opened the
+        // buffer window; it must not release/discard a MAIN eval's buffer.
+        tracker.onAutoApproveEscalate(ctx.isSubagent);
         deps.statusWriter?.autoApproveEnd('escalated', Date.now());
         // No status broadcast here: a MAIN escalate routes through
         // handlePermissionRequest -> onStatusChange('waiting'), which broadcasts

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -653,6 +653,110 @@ describe('QuestionPresenceTracker', () => {
     });
   });
 
+  describe('buffer window is main-eval-scoped (#767)', () => {
+    const DEBOUNCE_MS = 20;
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    it('a subagent eval does not open the buffer window — renders flow during it', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart(true); // subagent WebFetch eval in flight
+      tracker.onPTYPromptVisible(makePTYQuestion('Teammate permission prompt'));
+      expect(pushes.length).toBe(1); // NOT buffered
+    });
+
+    it('orphan render routes during a continuous subagent eval stream (2026-07-09 soak)', async () => {
+      // The live failure: back-to-back subagent evals kept the old boolean
+      // window open, every hook-less teammate prompt was buffered, and each
+      // unrelated approve discarded it — questions never routed at all.
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      });
+      tracker.onAutoApproveStart(true);
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Agent-team permission prompt'));
+      tracker.onAutoApproveHandled(true); // unrelated approve lands
+      tracker.onAutoApproveStart(true); // next eval begins immediately
+      await wait(DEBOUNCE_MS + 10);
+      expect(pushes.length).toBe(1);
+    });
+
+    it('a subagent approve does not discard a MAIN-buffered prompt', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart(); // main eval opens the window
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0);
+      tracker.onAutoApproveHandled(true); // unrelated subagent approve — no-op
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate(); // the main verdict still owns the release
+      expect(pushes.length).toBe(1);
+      expect(pushes[0]?.options.map((o) => o.label)).toEqual(['Yes', 'Yes, always', 'No']);
+    });
+
+    it('a subagent escalate (park path) does not release a MAIN-buffered prompt early', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate(true); // a teammate's park fires the cue
+      expect(pushes.length).toBe(0); // still buffered: the main eval owns it
+      tracker.onAutoApproveHandled(); // main verdict: auto-handled -> discard
+      expect(pushes.length).toBe(0);
+    });
+
+    it('a parked render pushes immediately while an unrelated subagent eval is in flight', () => {
+      // The #751 push trigger must survive the eval storm: park -> render ->
+      // push, regardless of whichever other agent is being evaluated.
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('researcher · WebFetch: example.com'),
+        agentId: 'subagent-A',
+      });
+      tracker.onAutoApproveStart(true); // another agent's eval running
+      tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
+      expect(pushes.length).toBe(1); // immediate, merged, not buffered
+      expect(pushes[0]?.text).toBe('researcher · WebFetch: example.com');
+    });
+
+    it('a parked render wins over the main-eval buffer (parked check runs first)', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
+        hasLiveQuestions: () => false,
+      });
+      tracker.parkAwaitingPTY({
+        ...makePermissionRequestHook('researcher · Edit: notes.md'),
+        agentId: 'subagent-A',
+      });
+      tracker.onAutoApproveStart(); // a MAIN eval is in flight
+      tracker.onOrphanPTYPrompt({
+        ...makePTYQuestion('Do you want to make this edit?'),
+        agentId: 'subagent-A',
+      });
+      expect(pushes.length).toBe(1); // pushed, not captured by the buffer
+      // The buffer stays empty: the main verdict has nothing to discard.
+      tracker.onAutoApproveHandled();
+      expect(pushes.length).toBe(1);
+    });
+
+    it('concurrent main evals: the first verdict does not close the window the second owns', () => {
+      const pushes: Question[] = [];
+      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      tracker.onAutoApproveStart();
+      tracker.onAutoApproveStart();
+      tracker.onAutoApproveHandled(); // first settles; window must stay open
+      tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
+      expect(pushes.length).toBe(0); // still buffered under the second eval
+      tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
+      tracker.onAutoApproveEscalate();
+      expect(pushes.length).toBe(1);
+    });
+  });
+
   describe('orphan PTY prompt fallback (#712)', () => {
     // Short real timer (no fake-timer precedent in this suite) — see
     // auto-approve-gate.test.ts's `holdMs: 30` pattern.

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -570,7 +570,9 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
         isInSubagentContext: () => subagent,
         escalate: () => undefined,
         onEvalStart: () => events.push('start'),
-        onEscalate: () => events.push('escalate'),
+        // #767: the cue carries whose verdict this is, so the setup layer can
+        // keep a subagent park from touching the main-eval buffer window.
+        onEscalate: (ctx) => events.push(ctx.isSubagent ? 'escalate:subagent' : 'escalate'),
         onHandled: () => events.push('handled'),
         onCancelled: () => events.push('cancelled'),
       },
@@ -639,10 +641,11 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
       'passthrough',
     );
     // Parking is semantically an escalation (PTY-mediated): the onEscalate cue
-    // must close the #484 buffer window opened by onEvalStart, or every later
-    // prompt in the session would buffer forever.
+    // still fires for the statusline, but tagged subagent (#767) — a subagent
+    // eval never opens the #484 buffer window, so its cue must not release or
+    // discard a prompt buffered by a concurrent MAIN eval.
     expect(submits).toHaveLength(0);
-    expect(events).toEqual(['start', 'escalate']);
+    expect(events).toEqual(['start', 'escalate:subagent']);
   });
 
   test('a throwing cue callback is absorbed: decision not re-run, no re-escalation', async () => {


### PR DESCRIPTION
Fixes #767.

Live soak on 0.6.19-dev.11 (port 18766, agent-team session with a continuous subagent WebFetch eval stream): rendered permission prompts never routed to the phone at all. Root cause: the #484 eval-in-flight buffer treated ANY eval as owning the prompt cycle. Every orphan PTY render was captured into the single-slot buffer, and the next unrelated subagent approve discarded it silently. The #751 parked-render trigger was eaten the same way (parked-match ran AFTER the buffer check, and its push routed back through the buffering entry point).

Changes:

- `QuestionPresenceTracker`: the buffer window is now opened only by MAIN-context evals, counted (`mainEvalsInFlight`) instead of a boolean so concurrent evals cannot close each other's window. `onAutoApproveStart/Escalate/Handled` take `isSubagent` (default false; existing callers unchanged); subagent verdicts are no-ops on the buffer.
- Pair+push core extracted out of `onPTYPromptVisible` (`pairAndPush`); the parked-render path and the escalate-release path call it directly so an in-flight eval cannot re-capture a prompt that already won arbitration.
- `onOrphanPTYPrompt` checks the parked match FIRST: a parked record's own eval already settled, so hook + render double-confirmation beats any other in-flight eval.
- The invisible decision points now log: park, parked-render push, buffer stash, buffer discard, own-agent-advance expiry, TTL expiry (feeds the #756 audit-surface design).
- Gate: `onEscalate` cue now carries `{isSubagent}` (both call sites); `markHandled` forwards the flag to the tracker.

Not addressed here (follow-up per #767): `isGateOwnedCycle`'s any-live-question suppression granularity — needs the new logs against real soak data first.

Tests: 7 new tracker cases (subagent-eval storm, subagent approve/escalate vs main buffer, parked-first ordering under both eval kinds, concurrent main evals) + gate cue-tagging assertion. typecheck green; tracker/gate/bridge-setup/input-events suites 300 pass.