### PR TITLE
fix: release-review daemon findings

### DIFF
--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -540,6 +540,9 @@ export class TelegramAdapter implements ConnectionAdapter {
 
       // Messages that don't need Telegram rendering.
       // N/A on Telegram: no PTY/attach/wire-auth; content surfaces via other branches.
+      // hub_status / remi_status are display-state broadcasts (menu-bar icon,
+      // attach status bar) fired on every census change / status flush — without
+      // an explicit no-op they would console.warn continuously (#766 review).
       case 'create_session_response':
       case 'ping':
       case 'pong':
@@ -549,6 +552,8 @@ export class TelegramAdapter implements ConnectionAdapter {
       case 'raw_pty_output':
       case 'auth_challenge':
       case 'auth_result':
+      case 'hub_status':
+      case 'remi_status':
         return true;
 
       default:

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -13,6 +13,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
 import { rotateIfNeeded } from './log-rotation.ts';
+import { formatVersionDrift } from './version-drift.ts';
+
+// Re-exported for existing importers/tests; the definition moved to
+// version-drift.ts so `remi ls` shares the exact wording (#766 review).
+export { formatVersionDrift };
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
 export const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
@@ -304,21 +309,6 @@ export function stopDaemon(): void {
   console.log('Daemon killed.');
 }
 
-/**
- * One-line drift note when a running daemon's binary version differs from
- * the installed binary (#539: a daemon holds its binary for life; upgrades
- * only affect newly started daemons). Null when either side is unknown or
- * they match. Exported for tests and shared by `remi status`/`remi ls`.
- */
-export function formatVersionDrift(
-  runningVersion: string | undefined,
-  installedVersion: string | undefined,
-): string | null {
-  if (!runningVersion || !installedVersion) return null;
-  if (runningVersion === installedVersion) return null;
-  return `running remi ${runningVersion}; installed binary is ${installedVersion} — restart to apply`;
-}
-
 export function showDaemonStatus(installedVersion?: string): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
   if (!pid) {
@@ -344,7 +334,7 @@ export function showDaemonStatus(installedVersion?: string): void {
       console.log(`  Version: ${version}`);
       const drift = formatVersionDrift(version, installedVersion);
       if (drift) {
-        console.log(`  WARNING: ${drift}`);
+        console.log(`  WARNING: daemon ${drift}`);
       }
     }
   } else {

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -21,6 +21,7 @@ import {
   discoverNetworkDaemons,
   queryMultiplePorts,
 } from './session-resolver.ts';
+import { formatVersionDrift } from './version-drift.ts';
 
 /** Return the terminal width, defaulting to 100 when stdout is not a TTY (e.g. piped). */
 function getTerminalWidth(): number {
@@ -648,13 +649,11 @@ export function formatVersionDriftWarnings(
   entries: ReadonlyArray<{ name: string; wsPort: number; version?: string | undefined }>,
   installedVersion: string | undefined,
 ): string[] {
-  if (!installedVersion) return [];
   const lines: string[] = [];
   for (const entry of entries) {
-    if (entry.version && entry.version !== installedVersion) {
-      lines.push(
-        `  ! ${entry.name} (port ${entry.wsPort}) runs remi ${entry.version}; installed binary is ${installedVersion} — restart to apply`,
-      );
+    const drift = formatVersionDrift(entry.version, installedVersion);
+    if (drift) {
+      lines.push(`  ! ${entry.name} (port ${entry.wsPort}) ${drift}`);
     }
   }
   return lines;

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -74,6 +74,10 @@ export class StatusWriter {
   private readonly status: RemiStatus;
   private readonly deps: StatusWriterDeps & { debounceMs: number };
   private errorLogged = false;
+  // Separate once-per-streak flags per failure source: a latched attach-state
+  // read failure must not mute the first report of a broken remi_status
+  // broadcast (which the #754 attach status bar depends on), or vice versa.
+  private attachStateErrorLogged = false;
   private broadcastErrorLogged = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -184,9 +188,9 @@ export class StatusWriter {
         this.status.queuedCount = attach.queuedCount;
       }
     } catch (err) {
-      if (!this.broadcastErrorLogged) {
+      if (!this.attachStateErrorLogged) {
         this.deps.writeLog(`[error] Status attach-state read failed: ${err}`);
-        this.broadcastErrorLogged = true;
+        this.attachStateErrorLogged = true;
       }
     }
     // #754: clients get the same debounced snapshot the disk gets, regardless

--- a/packages/daemon/src/cli/version-drift.ts
+++ b/packages/daemon/src/cli/version-drift.ts
@@ -1,0 +1,18 @@
+/**
+ * One-line drift phrase for a daemon whose recorded binary version differs
+ * from the installed binary (#539: a daemon holds its binary for life;
+ * upgrades only affect newly started daemons). Null when either side is
+ * unknown or they match.
+ *
+ * The single source of the wording shared by `remi status` (daemon-manager)
+ * and `remi ls` (ls-client), so the two commands' warnings cannot silently
+ * drift apart (#766 release review).
+ */
+export function formatVersionDrift(
+  runningVersion: string | undefined,
+  installedVersion: string | undefined,
+): string | null {
+  if (!runningVersion || !installedVersion) return null;
+  if (runningVersion === installedVersion) return null;
+  return `runs remi ${runningVersion}; installed binary is ${installedVersion} — restart to apply`;
+}

--- a/packages/daemon/tests/cli/handlers/pending-question-resend.test.ts
+++ b/packages/daemon/tests/cli/handlers/pending-question-resend.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import type { ProtocolMessage, Question, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import { resendPendingQuestions } from '../../../src/cli/handlers/pending-question-resend.ts';
+
+function makeQuestion(text: string): Question {
+  return {
+    id: generateId(),
+    text,
+    options: [
+      { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+      { label: 'No', value: '2', isRecommended: false, isYes: false, isNo: true },
+    ],
+    allowsFreeText: false,
+    isAnswered: false,
+  };
+}
+
+describe('resendPendingQuestions (#753)', () => {
+  const sessionId = generateId() as UUID;
+  const claudeSessionId = generateId() as UUID;
+
+  it('sends one live question message per pending question, preserving order', () => {
+    const sent: ProtocolMessage[] = [];
+    const pending = [makeQuestion('Allow Bash?'), makeQuestion('Allow Edit?')];
+
+    const count = resendPendingQuestions((m) => sent.push(m), sessionId, pending, claudeSessionId);
+
+    expect(count).toBe(2);
+    expect(sent).toHaveLength(2);
+    for (const [i, msg] of sent.entries()) {
+      expect(msg.type).toBe('question');
+      if (msg.type !== 'question') continue;
+      expect(msg.question).toBe(pending[i] as Question);
+      expect(msg.sessionId).toBe(sessionId);
+      expect(msg.claudeSessionId).toBe(claudeSessionId);
+    }
+  });
+
+  it('omits claudeSessionId from the wire message when not provided', () => {
+    const sent: ProtocolMessage[] = [];
+    resendPendingQuestions((m) => sent.push(m), sessionId, [makeQuestion('Allow Bash?')]);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).not.toHaveProperty('claudeSessionId');
+  });
+
+  it('no pending questions -> sends nothing and reports 0', () => {
+    const sent: ProtocolMessage[] = [];
+    expect(resendPendingQuestions((m) => sent.push(m), sessionId, [])).toBe(0);
+    expect(sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Addresses the daemon-scope findings from the PR #766 release review comment.

- Important 1: `hub_status` / `remi_status` added to TelegramAdapter's explicit no-op list — they are display-state broadcasts fired on every census change / status flush and were falling to the default `console.warn`, spamming continuously for Telegram-enabled daemons.
- Suggestion 1: `StatusWriter` now uses separate once-per-streak error flags for the attach-state read vs the `remi_status` broadcast, so one failure source can no longer permanently mute the other's first report. (Also closes the identical nitpick from the late #761 review.)
- Suggestion 2: the version-drift wording moved to a single `cli/version-drift.ts` shared by `remi status` and `remi ls` (`formatVersionDrift` re-exported from daemon-manager for existing importers). `remi ls` output is byte-identical; `remi status` now says "WARNING: daemon runs remi X; installed binary is Y — restart to apply".
- Suggestion 4: direct unit test for `pending-question-resend.ts` (order, claudeSessionId omission, empty set).

Suggestion 3 (Swift client must model `hello_ack.sessionId` as optional) is being verified in the macOS fix PR, where `HelloAckFrame` decoding is wired in with a null-sessionId test.

Tests: telegram-adapter (31), ls-client + daemon-manager + status-writer + new resend suite (81) all pass; typecheck clean.