### PR TITLE
fix: macOS app release-review findings

### DIFF
--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -60,10 +60,13 @@ final class HubClient: ObservableObject {
         }
     }
 
-    /// The URL the embedded web UI should connect to, e.g. ws://127.0.0.1:18765.
+    /// The URL the embedded web UI should connect to, e.g.
+    /// ws://127.0.0.1:18765/ws. Must include the path: the daemon's upgrade
+    /// handler only matches the exact configured path (default `/ws`), no
+    /// fallback (#766 review).
     var hubURL: String? {
         guard case let .connected(port, _) = phase else { return nil }
-        return "ws://127.0.0.1:\(port)"
+        return "ws://127.0.0.1:\(port)/ws"
     }
 
     /// Client census line for the menu ("Clients: 2 local, 1 remote"), #650.

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -232,9 +232,15 @@ final class HubClient: ObservableObject {
 
         switch envelope.type {
         case "hello_ack":
-            // Explicit-null detection: JSONDecoder cannot distinguish absent
-            // from null through `String?`, and the hub/session distinction
-            // hangs on exactly that (#542). Absent => treat as session peer.
+            // Validate the frame shape via HelloAckFrame; a malformed ack
+            // (missing serverVersion) is dropped rather than treated as a
+            // handshake. Its `sessionId: String?` still can't tell null from
+            // absent through JSONDecoder's decodeIfPresent, so the hub/session
+            // distinction (#542) is recovered separately below, from the raw
+            // JSON, where that distinction survives.
+            guard (try? JSONDecoder().decode(HelloAckFrame.self, from: data)) != nil else {
+                return
+            }
             let isHub = Self.helloAckHasNullSessionId(data)
             phase = .connected(port: port, isHub: isHub)
             lastConnectedPort = port

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -300,6 +300,7 @@ final class HubClient: ObservableObject {
         localClients = 0
         remoteClients = 0
         sessions = 0
+        hubVersion = nil
         phase = .unreachable
         consecutiveFailures += 1
         scheduleReconnect()

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -92,8 +92,3 @@ struct HubStatusFrame: Decodable {
     let sessions: Int
     let hubVersion: String
 }
-
-/// Incoming `pong`.
-struct PongFrame: Decodable {
-    let type: String
-}

--- a/packages/macos/Remi/Info.plist
+++ b/packages/macos/Remi/Info.plist
@@ -30,7 +30,7 @@
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <!-- App Store requires a category (archive warned without it). -->
-    <key>LSApplicationCategoryName</key>
+    <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <!-- The WKWebView talks ws://127.0.0.1 and the scanner probes
          http://127.0.0.1; ATS treats loopback as local networking. -->

--- a/packages/macos/Remi/WebViewWindow.swift
+++ b/packages/macos/Remi/WebViewWindow.swift
@@ -7,6 +7,7 @@
 //  points it at the discovered hub via an injected global.
 //
 
+import AppKit
 import SwiftUI
 import WebKit
 
@@ -19,7 +20,7 @@ struct WebViewWindow: NSViewRepresentable {
     nonisolated static func nativeBootstrapScript(hubUrl: String?) -> String {
         let urlLiteral: String
         if let hubUrl {
-            // hubUrl is machine-built (ws://127.0.0.1:<port>), never
+            // hubUrl is machine-built (ws://127.0.0.1:<port>/ws), never
             // user-controlled; JSON-encode defensively anyway.
             // .withoutEscapingSlashes: default JSON escapes / as \/ which is
             // valid JS but gratuitously unreadable in the injected script.
@@ -47,6 +48,8 @@ struct WebViewWindow: NSViewRepresentable {
         configuration.userContentController.addUserScript(script)
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.load(URLRequest(url: URL(string: "\(DistSchemeHandler.scheme)://localhost/index.html")!))
         return webView
     }
@@ -74,10 +77,48 @@ struct WebViewWindow: NSViewRepresentable {
         Coordinator(lastInjectedHubUrl: hubClient.hubURL)
     }
 
-    final class Coordinator {
+    /// Tracks the last-injected hub URL and enforces the navigation policy
+    /// for the WKWebView (#766 review, finding 2): rendered chat/transcript
+    /// Markdown can carry target=_blank links, and with no delegate WebKit's
+    /// default policy lets that content navigate the app's only window off
+    /// the bundled `remi-app://` origin — into which the bootstrap script
+    /// re-injects the hub URL on every load.
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         var lastInjectedHubUrl: String?
         init(lastInjectedHubUrl: String?) {
             self.lastInjectedHubUrl = lastInjectedHubUrl
+        }
+
+        /// Allow only same-origin (`remi-app://`) navigations plus the
+        /// `about:blank` placeholder WebKit uses en route to
+        /// `createWebViewWith` for target=_blank/window.open. Everything
+        /// else is cancelled and handed to the system browser instead.
+        func webView(
+            _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let url = navigationAction.request.url else {
+                decisionHandler(.cancel)
+                return
+            }
+            if url.scheme == DistSchemeHandler.scheme || url.absoluteString == "about:blank" {
+                decisionHandler(.allow)
+                return
+            }
+            decisionHandler(.cancel)
+            NSWorkspace.shared.open(url)
+        }
+
+        /// target=_blank / window.open(): never create a second
+        /// WebKit-hosted window inside the sandboxed app; open externally.
+        func webView(
+            _ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            if let url = navigationAction.request.url {
+                NSWorkspace.shared.open(url)
+            }
+            return nil
         }
     }
 }

--- a/packages/macos/RemiTests/DistSchemeHandlerTests.swift
+++ b/packages/macos/RemiTests/DistSchemeHandlerTests.swift
@@ -67,10 +67,13 @@ final class DistSchemeHandlerTests: XCTestCase {
     }
 
     func testNativeBootstrapScript() {
-        let with = WebViewWindow.nativeBootstrapScript(hubUrl: "ws://127.0.0.1:18765")
+        // hubUrl carries the /ws path (#766 review, finding 1): the daemon's
+        // WebSocket upgrade only matches the exact configured path, no
+        // fallback for a bare "ws://host:port".
+        let with = WebViewWindow.nativeBootstrapScript(hubUrl: "ws://127.0.0.1:18765/ws")
         XCTAssertTrue(with.contains("window.__REMI_NATIVE__"))
         XCTAssertTrue(with.contains("'macos-menubar'"))
-        XCTAssertTrue(with.contains("ws://127.0.0.1:18765"))
+        XCTAssertTrue(with.contains("ws://127.0.0.1:18765/ws"))
 
         let without = WebViewWindow.nativeBootstrapScript(hubUrl: nil)
         XCTAssertTrue(without.contains("hubUrl: null"))

--- a/packages/macos/RemiTests/HubProtocolTests.swift
+++ b/packages/macos/RemiTests/HubProtocolTests.swift
@@ -26,6 +26,12 @@ final class HubProtocolTests: XCTestCase {
 
     func testDecodesRealHelloAckWithNullSessionId() throws {
         let data = Data(helloAckFixture.utf8)
+        // HelloAckFrame is production-wired (#766 review): handleFrame
+        // decodes it to validate the frame shape before accepting a
+        // handshake. A JSON `null` for sessionId MUST decode cleanly here,
+        // not throw — decodeIfPresent collapses it to Swift `nil` same as an
+        // absent key would, which is exactly why the hub/session distinction
+        // is recovered separately below, from the raw JSON.
         let ack = try JSONDecoder().decode(HelloAckFrame.self, from: data)
         XCTAssertEqual(ack.type, "hello_ack")
         XCTAssertNil(ack.sessionId)

--- a/packages/web/src/lib/native-host.ts
+++ b/packages/web/src/lib/native-host.ts
@@ -13,7 +13,7 @@
 export interface RemiNativeHost {
   /** e.g. 'macos-menubar' */
   readonly platform: string;
-  /** ws://127.0.0.1:<port> of the discovered hub; null while undiscovered. */
+  /** ws://127.0.0.1:<port>/ws of the discovered hub; null while undiscovered. */
   readonly hubUrl: string | null;
 }
 

--- a/packages/web/tests/lib/native-host.test.ts
+++ b/packages/web/tests/lib/native-host.test.ts
@@ -19,17 +19,17 @@ describe('nativeHubUrlToConnect (#649)', () => {
     expect(
       nativeHubUrlToConnect(
         ['ws://127.0.0.1:18766/ws'],
-        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765' },
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765/ws' },
         toId,
       ),
-    ).toBe('ws://127.0.0.1:18765');
+    ).toBe('ws://127.0.0.1:18765/ws');
   });
 
   test('no-op when already restored, including alias spellings', () => {
     expect(
       nativeHubUrlToConnect(
         ['ws://localhost:18765/ws'],
-        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765' },
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18765/ws' },
         toId,
       ),
     ).toBeNull();
@@ -46,9 +46,9 @@ describe('nativeHubUrlToConnect (#649)', () => {
     expect(
       nativeHubUrlToConnect(
         [],
-        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18770' },
+        { platform: 'macos-menubar', hubUrl: 'ws://127.0.0.1:18770/ws' },
         toId,
       ),
-    ).toBe('ws://127.0.0.1:18770');
+    ).toBe('ws://127.0.0.1:18770/ws');
   });
 });


### PR DESCRIPTION
Fixes the macOS-app findings from the PR #766 release review comment
("Release review — macOS app scope"), plus one finding from the
TestFlight upload attempt.

## Fixes

**1. Critical: missing /ws path in native hub handoff URL**
`HubClient.hubURL` built `window.__REMI_NATIVE__.hubUrl` without the
WebSocket path, so the embedded WKWebView could never connect (the
daemon's upgrade handler matches only the exact configured path,
default `/ws`, no fallback). Appended `/ws`; updated the
`native-host.test.ts` fixtures and `DistSchemeHandlerTests.
testNativeBootstrapScript` that had baked in the omission. Grepped
`packages/macos` and `packages/web` for other un-suffixed hub-URL
literals; none found.

**2. Important: no WKNavigationDelegate/WKUIDelegate**
`WebViewWindow` set no navigation policy, so rendered chat/transcript
Markdown (react-markdown `target=_blank` links) could navigate the
app's only window off the bundled `remi-app://` origin, into a page
the bootstrap script would still re-inject the hub URL into. Added a
`Coordinator` conforming to both delegates: `decidePolicyFor
navigationAction` allows only `remi-app://` (plus `about:blank`) and
opens everything else via `NSWorkspace`; `createWebViewWith` opens
`target=_blank` externally instead of spawning a second WebKit window.

**3. Info.plist key typo (found during TestFlight upload; ASC
rejected the .pkg)**
`LSApplicationCategoryName` -> `LSApplicationCategoryType` (the actual
Apple key). Value unchanged (`public.app-category.developer-tools`).
Fixed at the single checked-in source (`Info.plist`, referenced
directly via `INFOPLIST_FILE` with `GENERATE_INFOPLIST_FILE: NO`, so
there's no generator step to also update).

**4. `hubVersion` staleness**
Not reset to `nil` in `handleDisconnect()`. Reset alongside the other
census fields; no new UI (that's future #650 work).

**5. Dead protocol structs**
`HelloAckFrame` and `PongFrame` were declared but never used by
production code. Wired `HelloAckFrame` into `handleFrame`'s
`hello_ack` case to validate the frame shape before accepting a
handshake (the null-vs-absent `sessionId` distinction, #542, still
needs the separate raw-JSON check since `JSONDecoder`'s
`decodeIfPresent` collapses both to `nil`); added a test asserting a
JSON `null` decodes cleanly through `HelloAckFrame` rather than
throwing. `PongFrame` had zero references anywhere, including tests
- deleted outright, since pong handling needs no payload.

**6. `LaunchAtLogin.isEnabled`'s explicit `objectWillChange.send()`**
Investigated and left unchanged. `isEnabled` is a plain computed
property (get/set) wrapping `SMAppService.mainApp.status`, and
`LaunchAtLogin` has zero `@Published` stored properties, so nothing
else ever fires `objectWillChange` for this object. The explicit
`.send()` is the only thing that tells SwiftUI to refresh the Toggle
after a register()/unregister() call - it is load-bearing, not noise.
Removing it would silently break the toggle's live UI update.

## Testing

- `xcodebuild -project packages/macos/Remi.xcodeproj -scheme Remi
  build` - succeeds (`DEVELOPER_DIR=/Volumes/S1/Applications/Xcode.app/
  Contents/Developer`).
- `xcodebuild ... test` - 21/21 tests pass (1 real-hub integration
  test skips without `REMI_TEST_BINARY`).
- Also ran the real-hub integration test against a freshly built
  `dist/remi` binary (`TEST_RUNNER_REMI_TEST_BINARY=$PWD/dist/remi`) -
  passes, exercising the actual `/ws` handshake end to end.
- `cd packages/web && bun run build` - tsc + vite build succeeds.
- `bun test tests/lib/native-host.test.ts tests/lib/connection-id.test.ts`
  - 20/20 pass.
- `bunx eslint src/lib/native-host.ts tests/lib/native-host.test.ts`
  - clean (packages/web lints via ESLint, not biome).
- `typos` on all changed files - clean.

All fixes from the review are addressed except finding 6, which was
investigated and is intentionally left as-is per the reasoning above.

Ref: review comment on #766 ("Release review — macOS app scope").