### PR TITLE
fix: pin npm 11 in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,11 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: |
           npm install -g promise-retry
-          npm install -g npm@latest
+          # Pin the npm 11 line: OIDC trusted publishing needs >=11.5, but
+          # npm@latest resolved to 12.0.0 on 2026-07-09, which ships without
+          # sigstore in its tree -> MODULE_NOT_FOUND in libnpmpublish
+          # provenance at publish time (broke the v0.6.19 publish twice).
+          npm install -g npm@11
           echo "npm version: $(npm --version)"
 
       - name: Download all artifacts


### PR DESCRIPTION
The v0.6.19 npm publish failed twice with `Cannot find module 'sigstore'` from `libnpmpublish/lib/provenance.js`. Root cause: the publish job's `npm install -g npm@latest` now resolves to npm 12.0.0 (released 2026-07-09), whose global install ends up without `sigstore` — required unconditionally by libnpmpublish for the OIDC trusted-publishing provenance path. Deterministic, not a flaky runner (reproduced on two fresh runners; upgrade log shows "removed 71 packages", npm version: 12.0.0).

Fix: pin the npm 11 line (`npm@11`), which is what this flow was validated on (OIDC needs >=11.5).

Recovery plan after merge: re-point the v0.6.19 tag at the fixed main commit (product code identical; only this workflow file differs) to re-trigger release.yml — the GitHub release updates idempotently via softprops/action-gh-release, publish-npm skips already-published packages (none), then update-homebrew runs. A twin PR lands the same pin on develop.