### PR TITLE
feat(macos): hub setup onboarding and settings (#773)

### DIFF
--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -19,6 +19,12 @@ in query mode (it never counts as a "client" in the icon state), and embeds
 the web UI pointed at it. Session daemons spawned by the hub are discovered
 through the hub's session list, exactly like the iPhone app does it.
 
+Reconnects back off exponentially (1 s doubling to a 30 s cap) after a hub
+disconnects. The onboarding panel's "Check Again" button (`HubClient.rescanNow()`,
+#773) triggers an immediate scan instead of waiting out that backoff; it is a
+no-op while already scanning or connected, so it can never race the scheduled
+reconnect into a duplicate socket.
+
 ## What the app deliberately cannot do
 
 The app runs in the App Sandbox (required for TestFlight/App Store) with the
@@ -26,8 +32,11 @@ network-client capability only. It **cannot**:
 
 - **Start the hub.** Install the hub's LaunchAgent once with `remi --install`
   (starts at login, crash-restarts), or run `remi start` for the current
-  session. The menu offers a copy button for the install command when no hub
-  is running.
+  session. When no hub is found, the main window shows an onboarding panel
+  (#773) walking through installing `remi`, starting the hub, and setting up
+  its login item, each with a one-click Copy button for the terminal
+  command. The Settings scene (⌘,) repeats the login-item command alongside
+  the current hub status for later reference.
 - **Stop the hub.** "Quit Remi" quits the app; the hub and every session it
   supervises keep running. Stop the hub with `remi stop` (running session
   daemons keep serving even then). A protocol-level stop from the app is

--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -23,7 +23,16 @@ Reconnects back off exponentially (1 s doubling to a 30 s cap) after a hub
 disconnects. The onboarding panel's "Check Again" button (`HubClient.rescanNow()`,
 #773) triggers an immediate scan instead of waiting out that backoff; it is a
 no-op while already scanning or connected, so it can never race the scheduled
-reconnect into a duplicate socket.
+reconnect into a duplicate socket. A failed manual rescan also cancels
+whatever backoff timer was already pending before scheduling the next one, so
+repeated "Check Again" clicks can't stack independent reconnect chains.
+
+The main window only shows the onboarding panel before the client has EVER
+connected to a peer. Once it has, the window keeps showing the web UI for the
+rest of the app's lifetime, even through transient disconnects (a missed
+ping, a brief network blip, a hub restart mid-upgrade) — those are the web
+app's own problem to surface, not a reason to tear down and reload the
+embedded WKWebView and lose client-side state.
 
 ## What the app deliberately cannot do
 
@@ -32,11 +41,11 @@ network-client capability only. It **cannot**:
 
 - **Start the hub.** Install the hub's LaunchAgent once with `remi --install`
   (starts at login, crash-restarts), or run `remi start` for the current
-  session. When no hub is found, the main window shows an onboarding panel
-  (#773) walking through installing `remi`, starting the hub, and setting up
-  its login item, each with a one-click Copy button for the terminal
-  command. The Settings scene (⌘,) repeats the login-item command alongside
-  the current hub status for later reference.
+  session. Before the app has ever found a hub, the main window shows an
+  onboarding panel (#773) walking through installing `remi`, starting the
+  hub, and setting up its login item, each with a one-click Copy button for
+  the terminal command. The Settings scene (⌘,) repeats the login-item
+  command alongside the current hub status for later reference.
 - **Stop the hub.** "Quit Remi" quits the app; the hub and every session it
   supervises keep running. Stop the hub with `remi stop` (running session
   daemons keep serving even then). A protocol-level stop from the app is
@@ -51,6 +60,9 @@ network-client capability only. It **cannot**:
 - "Open Remi at Login" registers the APP as a login item (SMAppService).
   This is independent of the HUB's autostart — the LaunchAgent from
   `remi --install`. For the full always-on setup, enable both.
+- The main window never tears down its WKWebView once a hub has ever been
+  seen (see "Relationship to the hub" above) — only the true first-run,
+  never-connected case shows the onboarding panel instead.
 
 ## Building from source
 

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -7,12 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0624CA493FEF2D140B88CFF7 /* HubSetupCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */; };
 		0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
+		2626DA9FECF5CE594406FCF2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */; };
 		477C35A4907835166E4AECF6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
+		4DDC81BB89C55D2F2E819002 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
 		5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
 		56A2EE338C23F3064E056B31 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DD72A5787EF3FFBF772C89F /* Assets.xcassets */; };
 		5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */; };
+		7099815B76AC17566B2A96C5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */; };
 		7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */; };
 		779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
 		787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */; };
@@ -22,18 +26,23 @@
 		954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */; };
 		A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		B02F8C5F4512A48DA88A1311 /* HubSetupCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */; };
 		B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */; };
 		B380134DB301B91E8FB492B1 /* web in Resources */ = {isa = PBXBuildFile; fileRef = 5DB62EAF2230D75844C2E431 /* web */; };
 		B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
 		C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		DCB33A9FC9A43C32D55F1C86 /* HubSetupCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */; };
+		E2A47A3FEF612AA225168AB6 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
 		FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		03E03C1A89AE93F94D40EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubSetupCommands.swift; sourceTree = "<group>"; };
 		1F4E747A3D65101EAE2331D4 /* RemiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemiApp.swift; sourceTree = "<group>"; };
+		286C0F48CEB5BC01CC53529D /* HubSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubSetupView.swift; sourceTree = "<group>"; };
 		355697014B8A803D93F9E3EA /* WebViewWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewWindow.swift; sourceTree = "<group>"; };
 		385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubProtocolTests.swift; sourceTree = "<group>"; };
 		3C92562123ECC39FB269FB4A /* Remi.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Remi.entitlements; sourceTree = "<group>"; };
@@ -50,6 +59,8 @@
 		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
 		C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubProtocol.swift; sourceTree = "<group>"; };
+		C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubSetupCommandsTests.swift; sourceTree = "<group>"; };
+		CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -71,11 +82,14 @@
 				B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */,
 				81CA6F64B5FFA6B90233A956 /* HubClient.swift */,
 				C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */,
+				1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */,
+				286C0F48CEB5BC01CC53529D /* HubSetupView.swift */,
 				5A7875E7E74CA980AD4B502F /* IconState.swift */,
 				03E03C1A89AE93F94D40EA16 /* Info.plist */,
 				E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */,
 				3C92562123ECC39FB269FB4A /* Remi.entitlements */,
 				1F4E747A3D65101EAE2331D4 /* RemiApp.swift */,
+				CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */,
 				355697014B8A803D93F9E3EA /* WebViewWindow.swift */,
 				ECC1B78C2B42CFA4F799B774 /* Resources */,
 			);
@@ -89,6 +103,7 @@
 				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
 				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
 				385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */,
+				C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */,
 				6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */,
 			);
 			path = RemiTests;
@@ -239,9 +254,12 @@
 				A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */,
 				779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */,
 				D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */,
+				B02F8C5F4512A48DA88A1311 /* HubSetupCommands.swift in Sources */,
+				E2A47A3FEF612AA225168AB6 /* HubSetupView.swift in Sources */,
 				AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */,
 				FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */,
 				8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */,
+				2626DA9FECF5CE594406FCF2 /* SettingsView.swift in Sources */,
 				0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -257,9 +275,13 @@
 				7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */,
 				B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */,
 				61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */,
+				0624CA493FEF2D140B88CFF7 /* HubSetupCommands.swift in Sources */,
+				DCB33A9FC9A43C32D55F1C86 /* HubSetupCommandsTests.swift in Sources */,
+				4DDC81BB89C55D2F2E819002 /* HubSetupView.swift in Sources */,
 				5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */,
 				868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */,
 				C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */,
+				7099815B76AC17566B2A96C5 /* SettingsView.swift in Sources */,
 				FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -100,6 +100,9 @@ final class HubClient: ObservableObject {
     private var consecutiveFailures = 0
     private var reconnectDelay: TimeInterval = 1
     private var started = false
+    /// Guards scanAndConnect against overlap: a manual rescanNow() call
+    /// racing the scheduled backoff rescan into two sockets (#773).
+    private var isScanning = false
     /// Port of the most recent successful connection. Survives the phase
     /// flip to .unreachable (#745 review: deriving the hint from `phase`
     /// inside scheduleReconnect always read nil, making hint-first reconnect
@@ -125,11 +128,26 @@ final class HubClient: ObservableObject {
         Task { await scanAndConnect() }
     }
 
+    /// Manual re-check from the onboarding panel's "Check Again" button
+    /// (#773). Only meaningful while unreachable; the isScanning/phase
+    /// guards inside scanAndConnect make this safe to call at any time
+    /// without racing the scheduled backoff rescan into two sockets. We do
+    /// NOT cancel the pending backoff Task — those same guards make its
+    /// eventual firing a no-op once a scan is underway or connected.
+    func rescanNow() {
+        guard case .unreachable = phase else { return }
+        Task { await scanAndConnect(preferring: lastConnectedPort) }
+    }
+
     // MARK: - Discovery
 
     /// Probe every port in the daemon range in parallel; hub (session-less)
     /// responders win over session daemons; lowest port breaks ties.
     private func scanAndConnect(preferring hintPort: Int? = nil) async {
+        guard !isScanning else { return }
+        if case .connected = phase { return }
+        isScanning = true
+        defer { isScanning = false }
         phase = .scanning
         let ports = Self.scanOrder(hintPort: hintPort, ports: scanPorts)
         let responders = await Self.probe(ports: ports)

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -111,6 +111,13 @@ final class HubClient: ObservableObject {
     /// Guards scanAndConnect against overlap: a manual rescanNow() call
     /// racing the scheduled backoff rescan into two sockets (#773).
     private var isScanning = false
+    /// The currently-pending backoff Task, if any. scheduleReconnect()
+    /// cancels this before scheduling a new one, so a failed manual
+    /// rescan can't leave the old timer running alongside the new one
+    /// (#777 review, finding 3: repeated failed rescans were stacking
+    /// independent reconnect chains instead of superseding the pending
+    /// one).
+    private var reconnectTask: Task<Void, Never>?
     /// Port of the most recent successful connection. Survives the phase
     /// flip to .unreachable (#745 review: deriving the hint from `phase`
     /// inside scheduleReconnect always read nil, making hint-first reconnect
@@ -139,13 +146,26 @@ final class HubClient: ObservableObject {
     /// Manual re-check from the onboarding panel's "Check Again" button
     /// (#773). Only meaningful while unreachable; the isScanning/phase
     /// guards inside scanAndConnect make this safe to call at any time
-    /// without racing the scheduled backoff rescan into two sockets. We do
-    /// NOT cancel the pending backoff Task — those same guards make its
-    /// eventual firing a no-op once a scan is underway or connected.
+    /// without racing the scheduled backoff rescan into two sockets. If
+    /// this rescan itself fails, scheduleReconnect() cancels whatever
+    /// backoff Task was already pending before scheduling the next one
+    /// (#777 review, finding 3), so repeated manual rescans can't stack
+    /// independent reconnect timers.
     func rescanNow() {
         guard case .unreachable = phase else { return }
         Task { await scanAndConnect(preferring: lastConnectedPort) }
     }
+
+    #if DEBUG
+    /// Test-only seam (#777 review, finding 4): drives `phase` straight to
+    /// .unreachable without going through scanAndConnect's real failure
+    /// path, which would itself call scheduleReconnect() and start an
+    /// unrelated backoff chain — exactly the ambiguity a rescanNow() test
+    /// needs to avoid racing against. Compiled out of Release builds.
+    func forceUnreachableForTesting() {
+        phase = .unreachable
+    }
+    #endif
 
     // MARK: - Discovery
 
@@ -339,14 +359,19 @@ final class HubClient: ObservableObject {
     }
 
     private func scheduleReconnect() {
+        // Supersede, don't stack: a previously-scheduled backoff sleep
+        // that hasn't fired yet gets cancelled here (#777 review, finding
+        // 3), so at most one reconnect chain is ever pending.
+        reconnectTask?.cancel()
         let delay = reconnectDelay
         reconnectDelay = Self.nextReconnectDelay(after: reconnectDelay)
         // After 3 straight failures do a full range rescan; before that,
         // retry with the last known port first.
         let hint: Int? = Self.shouldUseHint(consecutiveFailures: consecutiveFailures)
             ? lastConnectedPort : nil
-        Task { [weak self] in
+        reconnectTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
             await self?.scanAndConnect(preferring: hint)
         }
     }

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -69,6 +69,14 @@ final class HubClient: ObservableObject {
         return "ws://127.0.0.1:\(port)/ws"
     }
 
+    /// True once the client has connected to any peer at least once.
+    /// Derived from lastConnectedPort, which is never cleared, so this
+    /// never resets either (#777 review, finding 1): RemiApp keeps
+    /// WebViewWindow mounted once this flips true, so a transient
+    /// disconnect (missed pong, brief network blip, hub restart) never
+    /// tears down and reloads the WKWebView.
+    var hasEverConnected: Bool { lastConnectedPort != nil }
+
     /// Client census line for the menu ("Clients: 2 local, 1 remote"), #650.
     /// Label-first format sidesteps the pluralization mismatch a trailing
     /// noun creates ("1 local, 1 remote clients", #746 review).

--- a/packages/macos/Remi/HubSetupCommands.swift
+++ b/packages/macos/Remi/HubSetupCommands.swift
@@ -1,0 +1,13 @@
+//
+//  HubSetupCommands.swift
+//  Remi
+//
+//  Shared command strings for hub onboarding (#773), so HubSetupView and
+//  SettingsView never drift out of sync with each other.
+//
+
+enum HubSetupCommands {
+    static let install = "brew install yooz-labs/tap/remi"
+    static let startHub = "remi start"
+    static let autostart = "remi --install"
+}

--- a/packages/macos/Remi/HubSetupView.swift
+++ b/packages/macos/Remi/HubSetupView.swift
@@ -89,6 +89,11 @@ struct CommandRow: View {
     let command: String
 
     @State private var copied = false
+    /// Bumped on every click; a pending reset Task only applies if it's
+    /// still the latest one when it wakes (#777 review, finding 5), so
+    /// rapid re-clicks extend the "Copied" window instead of an earlier
+    /// click's reset firing right after a later click.
+    @State private var copyGeneration = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -110,12 +115,16 @@ struct CommandRow: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(command, forType: .string)
                     copied = true
+                    copyGeneration += 1
+                    let generation = copyGeneration
                     // Fire-and-forget label reset instead of a Timer: no
                     // invalidation to worry about, and a view teardown
                     // mid-flight just drops the Task.
                     Task {
                         try? await Task.sleep(nanoseconds: 1_500_000_000)
-                        copied = false
+                        if generation == copyGeneration {
+                            copied = false
+                        }
                     }
                 }
             }

--- a/packages/macos/Remi/HubSetupView.swift
+++ b/packages/macos/Remi/HubSetupView.swift
@@ -1,0 +1,124 @@
+//
+//  HubSetupView.swift
+//  Remi
+//
+//  Onboarding panel shown in the main window while no hub is attached
+//  (#773). The app is sandboxed and cannot start the hub itself; this walks
+//  the user through the terminal commands that do, then gets out of the way
+//  once HubClient finds one.
+//
+
+import SwiftUI
+
+struct HubSetupView: View {
+    @ObservedObject var hubClient: HubClient
+
+    var body: some View {
+        Group {
+            if case .scanning = hubClient.phase {
+                scanningView
+            } else {
+                // RemiApp only shows this view while hubClient.hubURL is
+                // nil, which happens only in .scanning or .unreachable —
+                // .connected always has a hub URL. So anything reaching
+                // here that isn't .scanning is .unreachable.
+                unreachableView
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var scanningView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Looking for a Remi hub…")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var unreachableView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("No Remi hub is running on this Mac")
+                        .font(.title2)
+                        .bold()
+                    Text(
+                        "Remi attaches to the hub daemon (remi serve), which does the actual work of running your Claude Code sessions. Set it up once from Terminal, then this window attaches automatically."
+                    )
+                    .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    CommandRow(
+                        title: "1. Install remi",
+                        caption: "Skip this if you already have it installed.",
+                        command: HubSetupCommands.install)
+                    CommandRow(
+                        title: "2. Start the hub",
+                        caption: "Runs the hub for this Terminal session.",
+                        command: HubSetupCommands.startHub)
+                    CommandRow(
+                        title: "3. Start the hub automatically at login",
+                        caption:
+                            "Installs a LaunchAgent that keeps the hub running and restarts it if it crashes; this is the hub's login item, separate from opening this app at login.",
+                        command: HubSetupCommands.autostart)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Button("Check Again") { hubClient.rescanNow() }
+                    Text(
+                        "This window checks automatically and closes on its own once a hub is found."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(32)
+            .frame(maxWidth: 560, alignment: .leading)
+        }
+    }
+}
+
+/// A command the user copies into Terminal: title, one-line explanation, the
+/// command in monospaced text, and a Copy button. Shared between
+/// HubSetupView's onboarding steps and SettingsView's hub section (#773).
+struct CommandRow: View {
+    let title: String
+    var caption: String? = nil
+    let command: String
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.headline)
+            if let caption {
+                Text(caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 8) {
+                Text(command)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .background(Color.secondary.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                Button(copied ? "Copied" : "Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(command, forType: .string)
+                    copied = true
+                    // Fire-and-forget label reset instead of a Timer: no
+                    // invalidation to worry about, and a view teardown
+                    // mid-flight just drops the Task.
+                    Task {
+                        try? await Task.sleep(nanoseconds: 1_500_000_000)
+                        copied = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -23,12 +23,11 @@ struct RemiApp: App {
                 Text(hubClient.clientsLine)
             }
             if case .unreachable = hubClient.phase {
-                // The sandboxed app cannot start the hub itself (#651);
-                // point at the terminal commands and make them one copy away.
-                Text("Start it with: remi start").font(.caption)
-                Button("Copy Install Command (remi --install)") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString("remi --install", forType: .string)
+                // The sandboxed app cannot start the hub itself (#651); the
+                // onboarding panel (#773) carries the actual setup steps.
+                Button("Set Up Hub…") {
+                    openWindow(id: "main")
+                    NSApp.activate(ignoringOtherApps: true)
                 }
             }
             Divider()
@@ -50,6 +49,8 @@ struct RemiApp: App {
             } else {
                 Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
             }
+            SettingsLink { Text("Settings…") }
+                .keyboardShortcut(",")
             Divider()
             Button("Quit Remi") {
                 // Quits the APP only. The hub is not ours to stop: the app is
@@ -69,9 +70,22 @@ struct RemiApp: App {
         .menuBarExtraStyle(.menu)
 
         Window("Remi", id: "main") {
-            WebViewWindow(hubClient: hubClient)
-                .frame(minWidth: 720, minHeight: 480)
+            Group {
+                // .connected(isHub: false) — a session daemon with no hub —
+                // still has a non-nil hubURL and keeps showing the web UI;
+                // that seeds the web client and is intentional (#773 plan).
+                if hubClient.hubURL != nil {
+                    WebViewWindow(hubClient: hubClient)
+                } else {
+                    HubSetupView(hubClient: hubClient)
+                }
+            }
+            .frame(minWidth: 720, minHeight: 480)
         }
         .defaultSize(width: 1100, height: 760)
+
+        Settings {
+            SettingsView(hubClient: hubClient, launchAtLogin: launchAtLogin)
+        }
     }
 }

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -49,8 +49,17 @@ struct RemiApp: App {
             } else {
                 Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
             }
-            SettingsLink { Text("Settings…") }
-                .keyboardShortcut(",")
+            Button("Settings…") {
+                // SettingsLink drives the same underlying mechanism as
+                // openWindow, so it is subject to the same accessory-app
+                // quirk as "Open Remi" / "Set Up Hub…" above: it does not
+                // bring the app forward on its own (#777 review, finding
+                // 2). Using the responder-chain action directly lets us
+                // pair it with the same activate() call.
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                NSApp.activate(ignoringOtherApps: true)
+            }
+            .keyboardShortcut(",")
             Divider()
             Button("Quit Remi") {
                 // Quits the APP only. The hub is not ours to stop: the app is

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -71,10 +71,19 @@ struct RemiApp: App {
 
         Window("Remi", id: "main") {
             Group {
-                // .connected(isHub: false) — a session daemon with no hub —
-                // still has a non-nil hubURL and keeps showing the web UI;
-                // that seeds the web client and is intentional (#773 plan).
-                if hubClient.hubURL != nil {
+                // Once the client has EVER connected, keep WebViewWindow
+                // mounted for the app's lifetime (#777 review, finding 1):
+                // phase flips away from .connected on every transient
+                // disconnect (missed pong, brief network blip, hub
+                // restart mid-upgrade), and gating purely on hubURL != nil
+                // tore down and recreated the WKWebView — full reload,
+                // lost client-side state — on each one. hasEverConnected
+                // never resets, so HubSetupView is reserved for the true
+                // first-run/never-connected case it was designed for.
+                // WebViewWindow's own hubURL-change path (WebViewWindow.swift)
+                // already handles re-injecting/reloading once a NEW hub
+                // URL appears; no extra reload logic needed here.
+                if hubClient.hubURL != nil || hubClient.hasEverConnected {
                     WebViewWindow(hubClient: hubClient)
                 } else {
                     HubSetupView(hubClient: hubClient)

--- a/packages/macos/Remi/SettingsView.swift
+++ b/packages/macos/Remi/SettingsView.swift
@@ -1,0 +1,44 @@
+//
+//  SettingsView.swift
+//  Remi
+//
+//  Settings scene (#773): the app-at-login toggle mirrors the menu, plus a
+//  Hub section explaining the hub's own login item (remi --install) — the
+//  sandboxed app cannot install that LaunchAgent itself.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var hubClient: HubClient
+    @ObservedObject var launchAtLogin: LaunchAtLogin
+
+    var body: some View {
+        Form {
+            Section("Application") {
+                // Same semantics as the menu toggle (#651): needsApproval
+                // gets its own button rather than a toggle that would
+                // silently snap back off.
+                if launchAtLogin.needsApproval {
+                    Button("Login Item Pending Approval — Open System Settings") {
+                        launchAtLogin.openSystemSettings()
+                    }
+                } else {
+                    Toggle("Open Remi at Login", isOn: $launchAtLogin.isEnabled)
+                }
+            }
+
+            Section("Hub") {
+                Text(hubClient.menuStatusLine)
+                    .foregroundStyle(.secondary)
+                CommandRow(
+                    title: "Start hub at login",
+                    caption:
+                        "Remi is sandboxed and can't install this for you; run it once from Terminal. Installs a LaunchAgent that keeps the hub running and restarts it if it crashes.",
+                    command: HubSetupCommands.autostart)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+}

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -37,11 +37,9 @@ final class HubClientIntegrationTests: XCTestCase {
         return binary
     }
 
-    func testDiscoversRealHubAndDetectsSessionlessAck() async throws {
-        let binary = try requireBinary()
-        // Port inside the app's scan range but above the common live ones.
-        let port = 18781
-
+    /// Spawns a real hub (session-less `serve`) on `port` with an isolated
+    /// $HOME, stored on `process`/`homeDir` for tearDown to clean up.
+    private func spawnHub(binary: String, port: Int) throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("remi-macos-it-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
@@ -62,6 +60,13 @@ final class HubClientIntegrationTests: XCTestCase {
         proc.standardError = Pipe()
         try proc.run()
         process = proc
+    }
+
+    func testDiscoversRealHubAndDetectsSessionlessAck() async throws {
+        let binary = try requireBinary()
+        // Port inside the app's scan range but above the common live ones.
+        let port = 18781
+        try spawnHub(binary: binary, port: port)
 
         // 1. The scanner finds the hub via the real HTTP probe.
         var responders: [Int] = []
@@ -139,5 +144,84 @@ final class HubClientIntegrationTests: XCTestCase {
         XCTAssertTrue(censusSeen, "hub_status never reached the published state")
         let statusLine = await MainActor.run { client.menuStatusLine }
         XCTAssertTrue(statusLine.contains("running on \(port)"), statusLine)
+    }
+
+    /// #773: the onboarding panel's "Check Again" button calls rescanNow();
+    /// it should connect promptly once a hub appears, not wait out the
+    /// scheduled backoff (which caps at 30 s).
+    func testRescanNowConnectsPromptly() async throws {
+        let binary = try requireBinary()
+        let port = 18782
+
+        // 1. Start the client scanning a port where nothing listens yet.
+        let client = await MainActor.run { HubClient(scanPorts: [port]) }
+        await MainActor.run { client.start() }
+        var reachedUnreachable = false
+        for _ in 0..<20 {  // up to ~5 s
+            let phase = await MainActor.run { client.phase }
+            if phase == .unreachable {
+                reachedUnreachable = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(reachedUnreachable, "client never reached .unreachable before the hub started")
+
+        // 2. Start the real hub on that port, and wait for it to actually
+        //    bind before rescanning — rescanNow() fires one scan pass, not
+        //    a retry loop.
+        try spawnHub(binary: binary, port: port)
+        for _ in 0..<40 {  // up to ~10 s
+            let responders = await HubClient.probe(ports: [port])
+            if responders.contains(port) { break }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+
+        // 3. Manual rescan connects well under the ~30 s backoff cap.
+        let rescanStart = Date()
+        await MainActor.run { client.rescanNow() }
+        var connectedAsHub = false
+        for _ in 0..<40 {  // up to ~10 s
+            let phase = await MainActor.run { client.phase }
+            if case .connected(let p, let isHub) = phase, isHub {
+                XCTAssertEqual(p, port)
+                connectedAsHub = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(connectedAsHub, "rescanNow never reached connected(isHub: true)")
+        XCTAssertLessThan(
+            Date().timeIntervalSince(rescanStart), 15,
+            "rescanNow took long enough to suggest it fell back to the backoff timer")
+    }
+
+    /// #773: a manual rescan while already connected must be a no-op —
+    /// otherwise it would race the scheduled backoff rescan into two
+    /// sockets (the isScanning/phase guards in scanAndConnect exist for
+    /// exactly this).
+    func testRescanNowIsNoOpWhileConnected() async throws {
+        let binary = try requireBinary()
+        let port = 18783
+        try spawnHub(binary: binary, port: port)
+
+        let client = await MainActor.run { HubClient(scanPorts: [port]) }
+        await MainActor.run { client.start() }
+        var connectedAsHub = false
+        for _ in 0..<60 {  // up to ~15 s
+            let phase = await MainActor.run { client.phase }
+            if case .connected(let p, let isHub) = phase, isHub {
+                XCTAssertEqual(p, port)
+                connectedAsHub = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(connectedAsHub, "client never connected to the real hub")
+
+        await MainActor.run { client.rescanNow() }
+        try await Task.sleep(nanoseconds: 2_000_000_000)  // short settle window
+        let phaseAfter = await MainActor.run { client.phase }
+        XCTAssertEqual(phaseAfter, .connected(port: port, isHub: true))
     }
 }

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -149,27 +149,24 @@ final class HubClientIntegrationTests: XCTestCase {
     /// #773: the onboarding panel's "Check Again" button calls rescanNow();
     /// it should connect promptly once a hub appears, not wait out the
     /// scheduled backoff (which caps at 30 s).
+    ///
+    /// The client is deliberately never start()ed (#777 review, finding
+    /// 4): start() would run the real scan-failure path, which schedules
+    /// its own natural backoff chain — a later natural retry could then
+    /// land the connection on its own, making the rescanNow() assertions
+    /// below pass vacuously (or, on a slow natural-retry cycle, flake).
+    /// forceUnreachableForTesting() drives phase to .unreachable directly
+    /// so rescanNow() is the ONLY thing that can possibly connect here.
     func testRescanNowConnectsPromptly() async throws {
         let binary = try requireBinary()
         let port = 18782
 
-        // 1. Start the client scanning a port where nothing listens yet.
         let client = await MainActor.run { HubClient(scanPorts: [port]) }
-        await MainActor.run { client.start() }
-        var reachedUnreachable = false
-        for _ in 0..<20 {  // up to ~5 s
-            let phase = await MainActor.run { client.phase }
-            if phase == .unreachable {
-                reachedUnreachable = true
-                break
-            }
-            try await Task.sleep(nanoseconds: 250_000_000)
-        }
-        XCTAssertTrue(reachedUnreachable, "client never reached .unreachable before the hub started")
+        await MainActor.run { client.forceUnreachableForTesting() }
 
-        // 2. Start the real hub on that port, and wait for it to actually
-        //    bind before rescanning — rescanNow() fires one scan pass, not
-        //    a retry loop.
+        // Start the real hub on that port, and wait for it to actually
+        // bind before rescanning — rescanNow() fires one scan pass, not
+        // a retry loop.
         try spawnHub(binary: binary, port: port)
         for _ in 0..<40 {  // up to ~10 s
             let responders = await HubClient.probe(ports: [port])
@@ -177,7 +174,8 @@ final class HubClientIntegrationTests: XCTestCase {
             try await Task.sleep(nanoseconds: 250_000_000)
         }
 
-        // 3. Manual rescan connects well under the ~30 s backoff cap.
+        // Manual rescan connects well under the ~30 s backoff cap — and
+        // with no backoff chain running, it's the only thing that could.
         let rescanStart = Date()
         await MainActor.run { client.rescanNow() }
         var connectedAsHub = false

--- a/packages/macos/RemiTests/HubSetupCommandsTests.swift
+++ b/packages/macos/RemiTests/HubSetupCommandsTests.swift
@@ -9,7 +9,6 @@
 
 import XCTest
 
-
 final class HubSetupCommandsTests: XCTestCase {
     func testCommandStrings() {
         XCTAssertEqual(HubSetupCommands.install, "brew install yooz-labs/tap/remi")

--- a/packages/macos/RemiTests/HubSetupCommandsTests.swift
+++ b/packages/macos/RemiTests/HubSetupCommandsTests.swift
@@ -1,0 +1,19 @@
+//
+//  HubSetupCommandsTests.swift
+//  RemiTests
+//
+//  Typo lock (#773): these strings get pasted straight into a user's
+//  Terminal, so a drift here is a broken onboarding step, not a cosmetic
+//  diff.
+//
+
+import XCTest
+
+
+final class HubSetupCommandsTests: XCTestCase {
+    func testCommandStrings() {
+        XCTAssertEqual(HubSetupCommands.install, "brew install yooz-labs/tap/remi")
+        XCTAssertEqual(HubSetupCommands.startHub, "remi start")
+        XCTAssertEqual(HubSetupCommands.autostart, "remi --install")
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the menu's copy-command-only no-hub UX with a real onboarding panel
in the main window plus a Settings scene, per design D on #773 (pure UI, no
new permissions/entitlements; Apple Events terminal handoff is a separate
follow-up, out of scope here).

- `HubSetupCommands` — single source of truth for the three terminal commands
  (`brew install yooz-labs/tap/remi`, `remi start`, `remi --install`), shared
  by the onboarding panel and Settings so they can't drift.
- `HubSetupView` — shown in the main window whenever `HubClient.hubURL` is
  nil: a scanning state, then (once unreachable) three numbered steps with
  copy-to-clipboard commands, and a "Check Again" button. `CommandRow` is a
  small shared component (command + Copy button with "Copied" feedback) used
  by both the panel and Settings.
- `HubClient.rescanNow()` — manual re-check wired to "Check Again", guarded
  against racing the scheduled backoff reconnect: `scanAndConnect` now
  early-returns while already scanning or connected (`isScanning` flag +
  `defer`), so a manual rescan and the pending backoff Task can never open
  two sockets. The backoff Task itself is never cancelled; the guards make
  its eventual firing a no-op once already connected/scanning.
- `RemiApp` — the main window now swaps between `WebViewWindow` (hub URL
  present, including the `.connected(isHub: false)` session-daemon seed
  case) and `HubSetupView` (no hub URL). The menu's unreachable-state caption
  + copy button are replaced with a "Set Up Hub…" button that opens the
  window. Added a `SettingsLink` (⌘,) above Quit and a `Settings` scene.
- `SettingsView` — "Application" section mirrors the existing app-at-login
  menu toggle; "Hub" section shows the live status line plus the
  `remi --install` command (reusing `CommandRow`).
- `docs/MACOS_APP.md` updated: the no-hub description now points at the
  onboarding panel + Settings instead of the old copy-command menu item, and
  the discovery section documents `rescanNow()`'s no-op-while-connected
  semantics.
- Regenerated `Remi.xcodeproj` via `scripts/generate-macos-project.sh` (new
  source files picked up by the `sources: path: Remi` glob; no manual
  project.yml edit needed).

## Test plan

- [x] `HubSetupCommandsTests` — typo-locks the three exact command strings.
- [x] `HubClientIntegrationTests` extended with two new real-hub tests (no
  mocks): `testRescanNowConnectsPromptly` (client stuck at `.unreachable` on
  a port nothing is listening on, real hub started, `rescanNow()` reaches
  `.connected(isHub: true)` in under a second, well under the 30s backoff
  cap) and `testRescanNowIsNoOpWhileConnected` (calling `rescanNow()` while
  already connected leaves the phase unchanged across a 2s settle window).
- [x] Full suite green:

```
Test Suite 'All tests' passed at 2026-07-09 22:32:37.540.
	 Executed 24 tests, with 0 failures (0 unexpected) in 6.790 (6.801) seconds
** TEST SUCCEEDED **
```
  Run via:
  ```
  bun install && bun run build:macos-web && bun run build:binary
  DEVELOPER_DIR=/Volumes/S1/Applications/Xcode.app/Contents/Developer \
    TEST_RUNNER_REMI_TEST_BINARY=$PWD/dist/remi \
    xcodebuild test -project packages/macos/Remi.xcodeproj -scheme Remi
  ```
- [x] Plain Debug build of the `Remi` app target: `** BUILD SUCCEEDED **`
  (`xcodebuild build -project packages/macos/Remi.xcodeproj -scheme Remi
  -configuration Debug -destination 'platform=macOS'`).

Closes #773