### PR TITLE
fix(web): follow system theme changes (#778)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -27,6 +27,7 @@ import { deduplicateMessage } from '@/lib/message-dedup';
 import { cleanPreviewText, stripProtocolTags } from '@/lib/message-filter';
 import { mergeResyncSurvivors, selectResyncSurvivors } from '@/lib/message-resync';
 import { clearNativeRoute, setNativeRoute, syncNativeIdentity } from '@/lib/native-bridge';
+import { syncNativeStatusBarTheme } from '@/lib/native-theme';
 import { setSoundEnabled } from '@/lib/notifications';
 import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
@@ -49,6 +50,7 @@ import { shouldEvictCachedSession } from '@/lib/session-eviction';
 import { autoSelectIfNone, evictIfActive, evictManyIfActive } from '@/lib/session-selection';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
+import { resolveEffectiveTheme } from '@/lib/theme';
 import type {
   AppSettings,
   ConnectionId,
@@ -163,13 +165,8 @@ function loadSettings(): AppSettings {
 }
 
 function applyTheme(theme: AppSettings['theme']) {
-  const root = document.documentElement;
-  if (theme === 'system') {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-  } else {
-    root.setAttribute('data-theme', theme);
-  }
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  document.documentElement.setAttribute('data-theme', resolveEffectiveTheme(theme, prefersDark));
 }
 
 /** Convert shared Bullet[] to UIBullet[] */
@@ -313,6 +310,7 @@ function App() {
 
   useEffect(() => {
     applyTheme(settings.theme);
+    syncNativeStatusBarTheme();
 
     const fontSizeMap = { small: '14px', medium: '16px', large: '18px' } as const;
     document.documentElement.style.setProperty(
@@ -324,6 +322,23 @@ function App() {
 
     localStorage.setItem(LOCALSTORAGE_SETTINGS_KEY, JSON.stringify(settings));
   }, [settings]);
+
+  // Follow OS theme changes while the user has picked 'system' (#778):
+  // applyTheme('system') otherwise only samples matchMedia once, at the
+  // point settings.theme last changed, so a running app never notices an
+  // OS light/dark flip. Separate from the effect above (keyed on the whole
+  // settings object) so this listener isn't torn down/rebuilt on unrelated
+  // settings changes (font size, sound, etc).
+  useEffect(() => {
+    if (settings.theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => {
+      applyTheme('system');
+      syncNativeStatusBarTheme();
+    };
+    mq.addEventListener('change', handleChange);
+    return () => mq.removeEventListener('change', handleChange);
+  }, [settings.theme]);
 
   const handleSettingsChange = useCallback((newSettings: AppSettings) => {
     setSettings(newSettings);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -320,7 +320,7 @@ function App() {
 
   useEffect(() => {
     applyTheme(settings.theme);
-    syncNativeStatusBarTheme();
+    void syncNativeStatusBarTheme();
 
     const fontSizeMap = { small: '14px', medium: '16px', large: '18px' } as const;
     document.documentElement.style.setProperty(
@@ -333,18 +333,18 @@ function App() {
     localStorage.setItem(LOCALSTORAGE_SETTINGS_KEY, JSON.stringify(settings));
   }, [settings]);
 
-  // Follow OS theme changes while the user has picked 'system' (#778):
-  // applyTheme('system') otherwise only samples matchMedia once, at the
-  // point settings.theme last changed, so a running app never notices an
-  // OS light/dark flip. Separate from the effect above (keyed on the whole
-  // settings object) so this listener isn't torn down/rebuilt on unrelated
-  // settings changes (font size, sound, etc).
+  // Follow OS theme changes while the user has picked 'system' (#778): the
+  // effect above only resamples matchMedia when the SETTINGS change (font
+  // size, sound, an explicit theme pick, ...), not on an actual OS-level
+  // light/dark flip, so a running app never notices one on its own. Kept
+  // as its own effect (rather than folded into the one above) so this
+  // listener isn't torn down/rebuilt on those unrelated settings changes.
   useEffect(() => {
     if (settings.theme !== 'system') return;
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
       applyTheme('system');
-      syncNativeStatusBarTheme();
+      void syncNativeStatusBarTheme();
     };
     mq.addEventListener('change', handleChange);
     return () => mq.removeEventListener('change', handleChange);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -50,7 +50,7 @@ import { shouldEvictCachedSession } from '@/lib/session-eviction';
 import { autoSelectIfNone, evictIfActive, evictManyIfActive } from '@/lib/session-selection';
 import { dedupSessions } from '@/lib/session-dedup';
 import { type ReplyContext, formatReplyMessage } from '@/lib/reply-format';
-import { resolveEffectiveTheme } from '@/lib/theme';
+import { parseThemeSetting, resolveEffectiveTheme } from '@/lib/theme';
 import type {
   AppSettings,
   ConnectionId,
@@ -157,7 +157,17 @@ function forgetEvictedSessions(evictedIds: readonly string[]): void {
 function loadSettings(): AppSettings {
   try {
     const stored = localStorage.getItem(LOCALSTORAGE_SETTINGS_KEY);
-    if (stored) return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // theme flows into resolveEffectiveTheme's AppSettings['theme'] param, so a
+      // hand-edited/corrupted stored value must be rejected here rather than
+      // trusted through (#778 review).
+      return {
+        ...DEFAULT_SETTINGS,
+        ...parsed,
+        theme: parseThemeSetting(parsed?.theme) ?? DEFAULT_SETTINGS.theme,
+      };
+    }
   } catch (err) {
     console.warn('Failed to load settings, using defaults:', err);
   }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -247,7 +247,10 @@
   }
 }
 
-/* Light mode -- warm paper whites, same lime accent */
+/* Light mode -- warm paper whites, same lime accent.
+   data-theme is stamped by applyTheme() in App.tsx from the values of
+   EffectiveTheme (src/lib/theme.ts) -- keep this selector's value in sync
+   with that type if it ever changes. */
 html[data-theme="light"] {
   --color-primary: #c9eb4a;
   --color-primary-dark: #b9db3a;

--- a/packages/web/src/lib/native-theme.ts
+++ b/packages/web/src/lib/native-theme.ts
@@ -2,11 +2,10 @@
  * Native (Capacitor) status-bar theme syncing (#778). Reads the CURRENT
  * effective theme from the `data-theme` attribute App.tsx's theme effect
  * stamps on <html> -- that attribute is the source of truth for "what
- * theme is showing right now" once applyTheme() has run, so this never
- * needs its own matchMedia sample. Falls back to matchMedia only for the
- * narrow startup window before React's first effect flush has landed
- * (initNative() runs synchronously right after createRoot().render(),
- * ahead of passive effects).
+ * theme is showing right now" once applyTheme() has run. Falls back to its
+ * own matchMedia sample only for the narrow startup window before React's
+ * first effect flush has landed (initNative() runs synchronously right
+ * after createRoot().render(), ahead of passive effects).
  *
  * No-op on web (guarded by isNative()); never throws (matches the rest of
  * initNative()'s try/warn/continue pattern).

--- a/packages/web/src/lib/native-theme.ts
+++ b/packages/web/src/lib/native-theme.ts
@@ -14,19 +14,20 @@
 
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { isNative } from './platform';
+import { type EffectiveTheme, parseEffectiveTheme } from './theme';
 
-function currentEffectiveThemeIsDark(): boolean {
-  const stamped = document.documentElement.getAttribute('data-theme');
-  if (stamped === 'dark') return true;
-  if (stamped === 'light') return false;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+function readCurrentEffectiveTheme(): EffectiveTheme {
+  const stamped = parseEffectiveTheme(document.documentElement.getAttribute('data-theme'));
+  if (stamped) return stamped;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 /** Sync the native status bar style to the root element's current effective theme. */
 export async function syncNativeStatusBarTheme(): Promise<void> {
   if (!isNative()) return;
   try {
-    await StatusBar.setStyle({ style: currentEffectiveThemeIsDark() ? Style.Dark : Style.Light });
+    const style = readCurrentEffectiveTheme() === 'dark' ? Style.Dark : Style.Light;
+    await StatusBar.setStyle({ style });
   } catch (err) {
     console.warn('[syncNativeStatusBarTheme] StatusBar setStyle failed:', err);
   }

--- a/packages/web/src/lib/native-theme.ts
+++ b/packages/web/src/lib/native-theme.ts
@@ -1,0 +1,33 @@
+/**
+ * Native (Capacitor) status-bar theme syncing (#778). Reads the CURRENT
+ * effective theme from the `data-theme` attribute App.tsx's theme effect
+ * stamps on <html> -- that attribute is the source of truth for "what
+ * theme is showing right now" once applyTheme() has run, so this never
+ * needs its own matchMedia sample. Falls back to matchMedia only for the
+ * narrow startup window before React's first effect flush has landed
+ * (initNative() runs synchronously right after createRoot().render(),
+ * ahead of passive effects).
+ *
+ * No-op on web (guarded by isNative()); never throws (matches the rest of
+ * initNative()'s try/warn/continue pattern).
+ */
+
+import { StatusBar, Style } from '@capacitor/status-bar';
+import { isNative } from './platform';
+
+function currentEffectiveThemeIsDark(): boolean {
+  const stamped = document.documentElement.getAttribute('data-theme');
+  if (stamped === 'dark') return true;
+  if (stamped === 'light') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+/** Sync the native status bar style to the root element's current effective theme. */
+export async function syncNativeStatusBarTheme(): Promise<void> {
+  if (!isNative()) return;
+  try {
+    await StatusBar.setStyle({ style: currentEffectiveThemeIsDark() ? Style.Dark : Style.Light });
+  } catch (err) {
+    console.warn('[syncNativeStatusBarTheme] StatusBar setStyle failed:', err);
+  }
+}

--- a/packages/web/src/lib/theme.ts
+++ b/packages/web/src/lib/theme.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure theme-resolution helper, extracted so the system-theme-follow logic
+ * (#778) is unit-testable without a DOM or MediaQueryList. The DOM/Capacitor
+ * side (reading matchMedia, stamping data-theme, syncing the native status
+ * bar) lives in App.tsx / main.tsx and calls this for the actual decision.
+ */
+
+import type { AppSettings } from '../types';
+
+export type EffectiveTheme = 'light' | 'dark';
+
+/** Resolve the concrete light/dark theme for a setting + current OS preference.
+ *  'system' samples prefersDark; explicit 'light'/'dark' ignore it. */
+export function resolveEffectiveTheme(
+  theme: AppSettings['theme'],
+  prefersDark: boolean,
+): EffectiveTheme {
+  return theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme;
+}

--- a/packages/web/src/lib/theme.ts
+++ b/packages/web/src/lib/theme.ts
@@ -1,8 +1,10 @@
 /**
- * Pure theme-resolution helper, extracted so the system-theme-follow logic
- * (#778) is unit-testable without a DOM or MediaQueryList. The DOM/Capacitor
- * side (reading matchMedia, stamping data-theme, syncing the native status
- * bar) lives in App.tsx / main.tsx and calls this for the actual decision.
+ * Pure theme value-resolution/narrowing helpers (#778), extracted so this
+ * logic is unit-testable without a DOM or MediaQueryList. Consumed by
+ * App.tsx's applyTheme()/loadSettings() (resolveEffectiveTheme,
+ * parseThemeSetting) and by native-theme.ts's status-bar sync
+ * (parseEffectiveTheme); the matchMedia sampling and data-theme
+ * reading/writing themselves stay in those callers, not here.
  */
 
 import type { AppSettings } from '../types';

--- a/packages/web/src/lib/theme.ts
+++ b/packages/web/src/lib/theme.ts
@@ -9,6 +9,24 @@ import type { AppSettings } from '../types';
 
 export type EffectiveTheme = 'light' | 'dark';
 
+const THEME_SETTINGS: ReadonlySet<AppSettings['theme']> = new Set(['light', 'dark', 'system']);
+
+/** Narrow an arbitrary value to a valid `AppSettings['theme']`, or `null` if it
+ *  isn't one. Used at the localStorage JSON.parse boundary in loadSettings()
+ *  so a corrupted/hand-edited stored value can't smuggle garbage through
+ *  resolveEffectiveTheme (#778 review). */
+export function parseThemeSetting(value: unknown): AppSettings['theme'] | null {
+  return typeof value === 'string' && THEME_SETTINGS.has(value as AppSettings['theme'])
+    ? (value as AppSettings['theme'])
+    : null;
+}
+
+/** Narrow an arbitrary value (e.g. a DOM `data-theme` attribute read, which is
+ *  typed `string | null`) to an `EffectiveTheme`, or `null` if it isn't one. */
+export function parseEffectiveTheme(value: string | null): EffectiveTheme | null {
+  return value === 'light' || value === 'dark' ? value : null;
+}
+
 /** Resolve the concrete light/dark theme for a setting + current OS preference.
  *  'system' samples prefersDark; explicit 'light'/'dark' ignore it. */
 export function resolveEffectiveTheme(

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -20,6 +20,9 @@ async function initNative(): Promise<void> {
   try {
     // #778: shared with the theme-change listener in App.tsx so the status
     // bar stays in sync after startup too, not just at this one-shot sample.
+    // App.tsx's settings effect calls this again on mount, ahead of or behind
+    // this one depending on effect-flush timing -- harmless (idempotent,
+    // no-op on web), not worth ordering around.
     await syncNativeStatusBarTheme();
     await StatusBar.setOverlaysWebView({ overlay: true });
   } catch (err) {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,6 @@
 import { App as CapApp } from '@capacitor/app';
 import { Network } from '@capacitor/network';
-import { StatusBar, Style } from '@capacitor/status-bar';
+import { StatusBar } from '@capacitor/status-bar';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 // Bundled variable fonts (offline-first; no CDN). Inter Tight for UI/display,
@@ -9,6 +9,7 @@ import '@fontsource-variable/inter-tight';
 import '@fontsource-variable/jetbrains-mono';
 import './index.css';
 import App from './App.tsx';
+import { syncNativeStatusBarTheme } from './lib/native-theme';
 import { initNotifications } from './lib/notifications';
 import { isNative } from './lib/platform';
 
@@ -17,10 +18,9 @@ async function initNative(): Promise<void> {
   if (!isNative()) return;
 
   try {
-    const prefersDark =
-      document.documentElement.getAttribute('data-theme') === 'dark' ||
-      window.matchMedia('(prefers-color-scheme: dark)').matches;
-    await StatusBar.setStyle({ style: prefersDark ? Style.Dark : Style.Light });
+    // #778: shared with the theme-change listener in App.tsx so the status
+    // bar stays in sync after startup too, not just at this one-shot sample.
+    await syncNativeStatusBarTheme();
     await StatusBar.setOverlaysWebView({ overlay: true });
   } catch (err) {
     console.warn('[initNative] StatusBar setup failed:', err);

--- a/packages/web/tests/lib/theme.test.ts
+++ b/packages/web/tests/lib/theme.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the theme-resolution helper (#778). Pure function; no mocks --
+ * Tests for the theme-resolution helpers (#778). Pure functions; no mocks --
  * the DOM/matchMedia/Capacitor side of the fix (App.tsx's system-theme
  * listener, native-theme.ts's status bar sync) isn't testable in this
  * package's DOM-less bun:test setup, so the extracted decision logic is
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { resolveEffectiveTheme } from '../../src/lib/theme';
+import { parseEffectiveTheme, parseThemeSetting, resolveEffectiveTheme } from '../../src/lib/theme';
 
 describe('resolveEffectiveTheme', () => {
   test('system theme resolves to dark when the OS prefers dark', () => {
@@ -24,5 +24,37 @@ describe('resolveEffectiveTheme', () => {
 
   test('explicit light ignores the OS preference', () => {
     expect(resolveEffectiveTheme('light', true)).toBe('light');
+  });
+});
+
+describe('parseThemeSetting', () => {
+  test('accepts light, dark, and system', () => {
+    expect(parseThemeSetting('light')).toBe('light');
+    expect(parseThemeSetting('dark')).toBe('dark');
+    expect(parseThemeSetting('system')).toBe('system');
+  });
+
+  test('rejects a corrupted string value', () => {
+    expect(parseThemeSetting('solarized')).toBeNull();
+  });
+
+  test('rejects non-string values from a malformed JSON.parse result', () => {
+    expect(parseThemeSetting(null)).toBeNull();
+    expect(parseThemeSetting(undefined)).toBeNull();
+    expect(parseThemeSetting(42)).toBeNull();
+    expect(parseThemeSetting({ theme: 'dark' })).toBeNull();
+  });
+});
+
+describe('parseEffectiveTheme', () => {
+  test('accepts light and dark', () => {
+    expect(parseEffectiveTheme('light')).toBe('light');
+    expect(parseEffectiveTheme('dark')).toBe('dark');
+  });
+
+  test('rejects system, null, and arbitrary strings', () => {
+    expect(parseEffectiveTheme('system')).toBeNull();
+    expect(parseEffectiveTheme(null)).toBeNull();
+    expect(parseEffectiveTheme('')).toBeNull();
   });
 });

--- a/packages/web/tests/lib/theme.test.ts
+++ b/packages/web/tests/lib/theme.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for the theme-resolution helper (#778). Pure function; no mocks --
+ * the DOM/matchMedia/Capacitor side of the fix (App.tsx's system-theme
+ * listener, native-theme.ts's status bar sync) isn't testable in this
+ * package's DOM-less bun:test setup, so the extracted decision logic is
+ * what's covered here.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveEffectiveTheme } from '../../src/lib/theme';
+
+describe('resolveEffectiveTheme', () => {
+  test('system theme resolves to dark when the OS prefers dark', () => {
+    expect(resolveEffectiveTheme('system', true)).toBe('dark');
+  });
+
+  test('system theme resolves to light when the OS prefers light', () => {
+    expect(resolveEffectiveTheme('system', false)).toBe('light');
+  });
+
+  test('explicit dark ignores the OS preference', () => {
+    expect(resolveEffectiveTheme('dark', false)).toBe('dark');
+  });
+
+  test('explicit light ignores the OS preference', () => {
+    expect(resolveEffectiveTheme('light', true)).toBe('light');
+  });
+});


### PR DESCRIPTION
## Summary

- `applyTheme('system')` sampled `matchMedia('(prefers-color-scheme: dark)')` once, only when `settings` changed, so a running app never noticed the OS flipping between light/dark (e.g. automatic dark mode at sunset). Most visible in the native shells (macOS menu-bar app, iOS), which stay open for days; browser tabs mostly hid it via frequent reloads.
- `initNative()` in `main.tsx` set the Capacitor status-bar style from the same one-shot sample at startup, so it also went stale.

## Changes

- `packages/web/src/lib/theme.ts` (new): pure `resolveEffectiveTheme(theme, prefersDark)` plus two narrowing helpers added during review -- `parseThemeSetting(value: unknown)` (validates a loaded `AppSettings['theme']`) and `parseEffectiveTheme(value: string | null)` (validates a raw `data-theme` DOM read). Extracted so the decision logic is unit-testable without a DOM/MediaQueryList.
- `packages/web/src/lib/native-theme.ts` (new): `syncNativeStatusBarTheme()` -- reads the effective theme from the `data-theme` attribute App.tsx's theme effect stamps on `<html>` via `parseEffectiveTheme` (falling back to its own `matchMedia` sample only for the narrow startup window before React's first effect flush), and syncs `StatusBar.setStyle`. No-op on web, never throws.
- `packages/web/src/App.tsx`:
  - `applyTheme()` now delegates to `resolveEffectiveTheme()`.
  - `loadSettings()` validates the stored `theme` field via `parseThemeSetting()` so a corrupted/hand-edited localStorage value can't smuggle garbage through `resolveEffectiveTheme`.
  - New dedicated `useEffect` keyed on `settings.theme`: while `theme === 'system'`, registers a `change` listener on `matchMedia('(prefers-color-scheme: dark)')` that re-applies the theme and re-syncs the native status bar; torn down on cleanup or when the user picks an explicit theme. Kept separate from the existing multi-concern settings effect so it isn't rebuilt on unrelated settings changes (font size, sound, etc).
  - The existing settings effect now also calls `syncNativeStatusBarTheme()` (as `void syncNativeStatusBarTheme()`, matching the codebase's fire-and-forget convention) so explicit theme switches sync the status bar too, not just the system-follow path.
- `packages/web/src/main.tsx`: `initNative()`'s status-bar setup now calls the shared `syncNativeStatusBarTheme()` helper instead of duplicating the sampling logic; a comment notes the intentional (harmless, idempotent) double sync with App.tsx's mount-time call.
- `packages/web/src/index.css`: cross-reference comment on the `data-theme` selector pointing back to `EffectiveTheme`.
- `packages/web/tests/lib/theme.test.ts` (new): unit tests for `resolveEffectiveTheme`, `parseThemeSetting`, and `parseEffectiveTheme` (9 test cases total). No mocks, matches this package's existing pure-logic test pattern (DOM/matchMedia/Capacitor side isn't unit-testable in this DOM-less `bun:test` setup, same rationale as `useEdgeSwipeBack.test.ts`).

Closes #778

## Test plan

- [x] `bun test packages/web/tests/lib/theme.test.ts` -- 9 pass
- [x] `bun test packages/web/tests` -- 393 pass, 0 fail (27 files, includes new/expanded test)
- [x] `cd packages/web && bun run build` (`tsc -b && vite build`) -- succeeds; pre-existing >500kB chunk-size warning only, unrelated to this change
- [x] `cd packages/web && bunx eslint src/App.tsx src/main.tsx src/lib/theme.ts src/lib/native-theme.ts src/index.css tests/lib/theme.test.ts` -- clean, no new lint errors. (Full `bun run lint` still reports 2 pre-existing errors in untouched files `InputArea.tsx` and `message-filter.ts`, matching AGENTS.md's note about pre-existing ESLint issues in this package.)

Reviewed by two independent passes (own 5-agent pr-review-toolkit sweep + a second reviewer's PR comment below); all findings addressed: `parseEffectiveTheme`/`parseThemeSetting` narrowing helpers, `EffectiveTheme`-typed native read path, localStorage validation, `void`-prefixed fire-and-forget syncs, and three comment-accuracy fixes (theme.ts module doc overstated its callers; native-theme.ts's doc self-contradicted about needing its own matchMedia sample; App.tsx's listener comment understated the settings effect's resample scope).

Not yet re-verified live on the macOS/iOS native shells (issue notes item 3, WKWebView appearance inheritance, should need no Swift-side change once the listener is in place, but wasn't independently re-checked here).