### PR TITLE
feat(macos): Dock presence while window open

### DIFF
--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -58,12 +58,13 @@ network-client capability only. It **cannot**:
 - Closing the window hides the UI; the menu-bar item and your hub stay up.
 - The app launches as an accessory (no Dock icon, no Cmd-Tab entry) and
   stays that way whenever no app window is open — the menu-bar "r" is the
-  app. The moment a window (the main web-UI window or Settings) is open,
-  the app promotes itself to a regular app so it shows in the Dock and
-  Cmd-Tab like anything else; when the last such window closes, it drops
-  back to accessory. `ActivationPolicy.derive` is the pure window-count ->
-  policy decision (`ActivationPolicy.swift`); `AppDelegate` wires
-  `NSWindow.didBecomeKeyNotification`/`willCloseNotification` to it.
+  app. When a window (the main web-UI window or Settings) becomes key, the
+  app promotes itself to a regular app so it shows in the Dock and Cmd-Tab
+  like anything else; when the last such window closes, it drops back to
+  accessory. `ActivationPolicy.derive` is the pure window-count -> policy
+  decision (`ActivationPolicy.swift`); `AppDelegate` wires
+  `NSWindow.didBecomeKeyNotification`/`willCloseNotification` to it, plus
+  one manual sync right after registering (launch-ordering race).
 - "Open Remi at Login" registers the APP as a login item (SMAppService).
   This is independent of the HUB's autostart — the LaunchAgent from
   `remi --install`. For the full always-on setup, enable both.

--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -53,10 +53,17 @@ network-client capability only. It **cannot**:
 - Read `~/.remi` or signal processes. Everything it knows arrives over the
   loopback WebSocket.
 
-## Lifecycle (#651)
+## Lifecycle (#651, Dock presence #785)
 
 - Closing the window hides the UI; the menu-bar item and your hub stay up.
-- There is no Dock icon (accessory app); the menu-bar "r" is the app.
+- The app launches as an accessory (no Dock icon, no Cmd-Tab entry) and
+  stays that way whenever no app window is open — the menu-bar "r" is the
+  app. The moment a window (the main web-UI window or Settings) is open,
+  the app promotes itself to a regular app so it shows in the Dock and
+  Cmd-Tab like anything else; when the last such window closes, it drops
+  back to accessory. `ActivationPolicy.derive` is the pure window-count ->
+  policy decision (`ActivationPolicy.swift`); `AppDelegate` wires
+  `NSWindow.didBecomeKeyNotification`/`willCloseNotification` to it.
 - "Open Remi at Login" registers the APP as a login item (SMAppService).
   This is independent of the HUB's autostart — the LaunchAgent from
   `remi --install`. For the full always-on setup, enable both.

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -7,9 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0282FAB49B260E7A3ABC043A /* ActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5E9CBEBA9AB7A3E199177A /* ActivationPolicyTests.swift */; };
 		0624CA493FEF2D140B88CFF7 /* HubSetupCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */; };
 		0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
 		2626DA9FECF5CE594406FCF2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */; };
+		2FB66887F1ABC6C53CA40C06 /* ActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */; };
+		465626B53BA0E06EC5B555C0 /* ActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */; };
 		477C35A4907835166E4AECF6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
 		4DDC81BB89C55D2F2E819002 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
 		5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
@@ -54,6 +57,8 @@
 		69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClientIntegrationTests.swift; sourceTree = "<group>"; };
 		6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStateTests.swift; sourceTree = "<group>"; };
 		734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
+		7A5E9CBEBA9AB7A3E199177A /* ActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyTests.swift; sourceTree = "<group>"; };
 		7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandlerServingTests.swift; sourceTree = "<group>"; };
 		81CA6F64B5FFA6B90233A956 /* HubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClient.swift; sourceTree = "<group>"; };
 		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
@@ -77,6 +82,7 @@
 		AB3D9F531B6A4A622EDC05D1 /* Remi */ = {
 			isa = PBXGroup;
 			children = (
+				76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */,
 				C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */,
 				4DD72A5787EF3FFBF772C89F /* Assets.xcassets */,
 				B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */,
@@ -99,6 +105,7 @@
 		C7F38A4D8AF6DC703EE13673 /* RemiTests */ = {
 			isa = PBXGroup;
 			children = (
+				7A5E9CBEBA9AB7A3E199177A /* ActivationPolicyTests.swift */,
 				7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */,
 				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
 				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
@@ -250,6 +257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				465626B53BA0E06EC5B555C0 /* ActivationPolicy.swift in Sources */,
 				954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */,
 				A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */,
 				779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */,
@@ -268,6 +276,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FB66887F1ABC6C53CA40C06 /* ActivationPolicy.swift in Sources */,
+				0282FAB49B260E7A3ABC043A /* ActivationPolicyTests.swift in Sources */,
 				5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */,
 				B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */,
 				787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */,

--- a/packages/macos/Remi/ActivationPolicy.swift
+++ b/packages/macos/Remi/ActivationPolicy.swift
@@ -1,0 +1,23 @@
+//
+//  ActivationPolicy.swift
+//  Remi
+//
+//  Pure reducer for the Dock/Cmd-Tab activation policy (#785): the app
+//  launches and lives as an accessory (menu-bar only, #651) but promotes
+//  itself to a regular app — Dock icon + Cmd-Tab entry — whenever a real
+//  window (the main web-UI window, or Settings) is on screen, and drops
+//  back to accessory the moment none are. AppDelegate owns the AppKit side
+//  (window-notification wiring, NSApp.setActivationPolicy); this file only
+//  answers "given N visible windows, which policy applies."
+//
+
+import Foundation
+
+enum ActivationPolicy: Equatable {
+    case regular
+    case accessory
+
+    static func derive(visibleWindowCount: Int) -> ActivationPolicy {
+        visibleWindowCount > 0 ? .regular : .accessory
+    }
+}

--- a/packages/macos/Remi/AppDelegate.swift
+++ b/packages/macos/Remi/AppDelegate.swift
@@ -6,19 +6,79 @@
 //  closing the web-UI window must never terminate anything, and the app
 //  never owns the hub daemon (it is an attach-only sandboxed client).
 //
+//  Dock/Cmd-Tab presence (#785): a permanent accessory app has no way to
+//  switch back to it once another app takes focus, other than the menu-bar
+//  item. While a real window (main or Settings) is open we promote to
+//  .regular so the user can Cmd-Tab/Dock-click back; the moment the last
+//  one closes we drop back to .accessory. ActivationPolicy.derive is the
+//  pure decision; this file only wires window notifications to it.
+//
 
 import AppKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var windowObservers: [NSObjectProtocol] = []
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // LSUIElement in Info.plist already makes this an accessory app
         // (no Dock icon); set explicitly so the policy survives plist edits.
         NSApp.setActivationPolicy(.accessory)
+
+        let center = NotificationCenter.default
+        windowObservers = [
+            // A window becoming key is our "opened" signal — SwiftUI's
+            // openWindow()/showSettingsWindow: are always paired with an
+            // explicit NSApp.activate() call site-side (RemiApp.swift), so
+            // the new window reliably takes key status right after showing.
+            center.addObserver(
+                forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.refreshActivationPolicy()
+            },
+            // willClose (not didClose — AppKit has no such notification):
+            // the closing window is still in NSApp.windows/isVisible at
+            // this point, so it must be excluded explicitly rather than
+            // relying on a post-close recount.
+            center.addObserver(
+                forName: NSWindow.willCloseNotification, object: nil, queue: .main
+            ) { [weak self] notification in
+                self?.refreshActivationPolicy(closing: notification.object as? NSWindow)
+            },
+        ]
     }
 
     /// Window close dismisses UI only (#651 hard requirement). Accessory
     /// apps default to this, but pin it explicitly.
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
+    }
+
+    /// Windows that count toward Dock/Cmd-Tab presence: titled, on-screen
+    /// windows only. Excludes the MenuBarExtra's own borderless status-item
+    /// window and any other chrome-only window AppKit may create — those
+    /// are never `.titled`.
+    private func isPresenceWindow(_ window: NSWindow) -> Bool {
+        window.styleMask.contains(.titled)
+    }
+
+    private func refreshActivationPolicy(closing: NSWindow? = nil) {
+        let visibleCount = NSApp.windows.filter {
+            $0 !== closing && $0.isVisible && isPresenceWindow($0)
+        }.count
+        apply(ActivationPolicy.derive(visibleWindowCount: visibleCount))
+    }
+
+    private func apply(_ policy: ActivationPolicy) {
+        let target: NSApplication.ActivationPolicy = policy == .regular ? .regular : .accessory
+        guard NSApp.activationPolicy() != target else { return }
+        if target == .accessory {
+            // Known AppKit quirk: flipping .regular -> .accessory while
+            // still frontmost leaves the previous menu bar (Apple menu,
+            // app menu, ...) stale on screen until some other app
+            // activates. Yield activation first so the transition is
+            // clean (#785).
+            NSApp.deactivate()
+        }
+        NSApp.setActivationPolicy(target)
     }
 }

--- a/packages/macos/Remi/AppDelegate.swift
+++ b/packages/macos/Remi/AppDelegate.swift
@@ -45,6 +45,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.refreshActivationPolicy(closing: notification.object as? NSWindow)
             },
         ]
+
+        // Ordering race (#789 review): SwiftUI can present/key the launch
+        // window before this callback runs, so the very first
+        // didBecomeKeyNotification can fire ahead of the observers above
+        // and get missed — leaving the app stuck on .accessory with a
+        // visible window. Do one manual sync against whatever window state
+        // already exists so the policy converges regardless of ordering.
+        refreshActivationPolicy()
     }
 
     /// Window close dismisses UI only (#651 hard requirement). Accessory

--- a/packages/macos/RemiTests/ActivationPolicyTests.swift
+++ b/packages/macos/RemiTests/ActivationPolicyTests.swift
@@ -1,0 +1,48 @@
+//
+//  ActivationPolicyTests.swift
+//  RemiTests
+//
+//  Table test for the Dock/Cmd-Tab activation-policy reducer (#785):
+//  any visible presence window -> .regular, none -> .accessory.
+//
+
+import XCTest
+
+final class ActivationPolicyTests: XCTestCase {
+    func testNoWindowsIsAccessory() {
+        XCTAssertEqual(ActivationPolicy.derive(visibleWindowCount: 0), .accessory)
+    }
+
+    func testAnyVisibleWindowIsRegular() {
+        let cases = [1, 2, 3, 10]
+        for count in cases {
+            XCTAssertEqual(
+                ActivationPolicy.derive(visibleWindowCount: count), .regular,
+                "visibleWindowCount=\(count)")
+        }
+    }
+
+    func testNegativeCountTreatedAsNone() {
+        // Defensive: a miscount should never fail open into .regular.
+        XCTAssertEqual(ActivationPolicy.derive(visibleWindowCount: -1), .accessory)
+    }
+
+    func testTransitionTable() {
+        // Main window opens (1 -> .regular), Settings also opens (2, stays
+        // .regular), main closes but Settings remains (1, stays .regular),
+        // Settings closes too (0 -> .accessory).
+        let sequence: [(visibleWindowCount: Int, expected: ActivationPolicy)] = [
+            (0, .accessory),
+            (1, .regular),
+            (2, .regular),
+            (1, .regular),
+            (0, .accessory),
+        ]
+        for step in sequence {
+            XCTAssertEqual(
+                ActivationPolicy.derive(visibleWindowCount: step.visibleWindowCount),
+                step.expected,
+                "visibleWindowCount=\(step.visibleWindowCount)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The macOS menu-bar app is a permanent accessory app (`LSUIElement=true`,
`.accessory` pinned in `AppDelegate.swift`): even with the main window
open, it never appears in the Dock or Cmd-Tab, so there is no way to
switch back to it once another app takes focus.

This adds the standard hybrid menu-bar-app pattern:

- While any real app window (the main web-UI window or Settings) is
  key, promote to `NSApplicationActivationPolicy.regular` so the app
  shows in the Dock and Cmd-Tab.
- The moment the last such window closes, revert to `.accessory`
  (menu-bar only). Closing the window still never quits the app or the
  hub — `applicationShouldTerminateAfterLastWindowClosed` stays `false`
  and `LSUIElement` stays `true` (#651 unchanged). Cold launch itself
  stays Dock-free too — verified live, see "Live verification" below;
  the `Window("Remi", id: "main")` scene does not auto-present at
  launch in this app (it's opened explicitly via the menu's "Open Remi"
  / "Set Up Hub…", or Settings via ⌘, / the menu item).
- Handles the known AppKit quirk where flipping back to `.accessory`
  while frontmost leaves the previous menu bar stale: `NSApp.deactivate()`
  is called first to yield activation before the policy switch.

## Design

- `packages/macos/Remi/ActivationPolicy.swift` — a pure reducer
  (`ActivationPolicy.derive(visibleWindowCount:)`), mirroring
  `IconState.swift`'s pattern of keeping the decision logic
  AppKit-free and independently testable.
- `packages/macos/Remi/AppDelegate.swift` — wires
  `NSWindow.didBecomeKeyNotification` (window becomes key) and
  `NSWindow.willCloseNotification` (window about to close) to recompute
  the visible "presence window" count (titled windows only, which
  excludes the `MenuBarExtra` status-item window) and apply the derived
  policy.
- `packages/macos/RemiTests/ActivationPolicyTests.swift` — table tests
  for the reducer (no windows -> accessory, any visible window ->
  regular, a multi-window open/close transition sequence). No mocks.
- `docs/MACOS_APP.md` — "Lifecycle" section amended to describe the new
  hybrid behavior instead of the old "there is no Dock icon" statement.

## Review round 2

- **Fix (observer-ordering race):** the window observers were registered
  in `applicationDidFinishLaunching`, but if SwiftUI presents/keys a
  window before that callback runs, the first
  `didBecomeKeyNotification` is missed and the app is stuck on
  `.accessory` with a visible window. `applicationDidFinishLaunching`
  now does one manual `refreshActivationPolicy()` call right after
  registering the observers, so the policy always converges against
  whatever window state already exists regardless of ordering
  (`packages/macos/Remi/AppDelegate.swift`).
- **Doc nit:** `docs/MACOS_APP.md` reworded — promotion is keyed off a
  window becoming *key*, not merely "being open."
- **Live verification (cold launch):** built Debug via `xcodebuild
  -derivedDataPath ... build`, launched the built `Remi.app` directly
  (`open`), waited ~3s. Confirmed via `lsappinfo list` (`type="UIElement"`,
  which is `.accessory` — compared against a known `.regular` app in the
  same listing, `type="Foreground"`) and a `CGWindowListCopyWindowInfo`
  query scoped to the process's pid (0 windows owned) that the app
  launches accessory with **no window auto-presented**, matching the
  "launch is Dock-free" claim above. Quit the verified test instance
  cleanly afterward (`osascript ... quit`); no other Remi.app instance
  was running before or after.

## Test plan

- [x] `xcodebuild test -project packages/macos/Remi.xcodeproj -scheme Remi`
      — 28 tests executed, 0 failures, 3 skipped (the real-hub
      `HubClientIntegrationTests` cases, which need
      `TEST_RUNNER_REMI_TEST_BINARY` pointing at a `remi` binary; not
      available in this environment, unrelated to this change). Re-run
      after the review-round-2 fix, same result:

  ```
  Test Suite 'All tests' passed at 2026-07-17 23:55:24.165.
   Executed 28 tests, with 3 tests skipped and 0 failures (0 unexpected) in 1.026 (1.032) seconds
  ```

- [x] Full app target build (`xcodebuild build ... -scheme Remi`) —
      `** BUILD SUCCEEDED **`, confirming `AppDelegate.swift` (excluded
      from the unit-test target) also compiles cleanly.
- [x] Live cold-launch Dock/accessory behavior — verified directly (see
      "Review round 2" above): app launches `.accessory`, no window
      auto-presents.
- [ ] Live window-open -> `.regular` -> window-close -> `.accessory`
      transition, and the menu-bar-not-going-stale behavior, still need
      a human click-through in the actual running app (not automatable
      headlessly here — no accessibility/UI-scripting access in this
      environment). The reducer + wiring are covered by unit tests and
      code review; this is the remaining manual-QA gap.

Closes #785
