### PR TITLE
macos: surface and guarantee hub daemon autostart

### DIFF
--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -44,14 +44,16 @@ network-client capability only. It **cannot**:
   session. Before the app has ever found a hub, the main window shows an
   onboarding panel (#773) walking through installing `remi`, starting the
   hub, and setting up its login item, each with a one-click Copy button for
-  the terminal command. The Settings scene (⌘,) repeats the login-item
-  command alongside the current hub status for later reference.
+  the terminal command.
 - **Stop the hub.** "Quit Remi" quits the app; the hub and every session it
   supervises keep running. Stop the hub with `remi stop` (running session
   daemons keep serving even then). A protocol-level stop from the app is
   tracked in #747, blocked on #535.
 - Read `~/.remi` or signal processes. Everything it knows arrives over the
-  loopback WebSocket.
+  loopback WebSocket — including, since #788, whether `remi --install`'s
+  LaunchAgent is actually on disk: the hub self-reports its own autostart
+  state (`"installed"` / `"none"`) as an optional field on the `hub_status`
+  census, because the sandboxed app has no other way to know.
 
 ## Lifecycle (#651)
 
@@ -60,6 +62,13 @@ network-client capability only. It **cannot**:
 - "Open Remi at Login" registers the APP as a login item (SMAppService).
   This is independent of the HUB's autostart — the LaunchAgent from
   `remi --install`. For the full always-on setup, enable both.
+- The Settings scene's Hub section is state-aware on the hub's reported
+  autostart (#788): `"installed"` shows a plain confirmation line (no
+  command needed); `"none"` shows a warning that remote access won't
+  survive a logout/reboot, plus the `remi --install` command row to fix it;
+  a hub too old to report the field (nil) falls back to today's neutral
+  command row. The menu-bar dropdown adds a "Hub autostart not set up…"
+  item — opening Settings — whenever a connected hub confirms `"none"`.
 - The main window never tears down its WKWebView once a hub has ever been
   seen (see "Relationship to the hub" above) — only the true first-run,
   never-connected case shows the onboarding panel instead.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -349,13 +349,12 @@ if (cliInstall || cliUninstall) {
   const binaryPath = pathResolved ?? process.execPath;
 
   if (platform === 'darwin') {
-    const { launchAgentPath } = await import('./cli/service-templates.ts');
+    // Template rationale (serve-not-daemon, KeepAlive semantics) lives with
+    // the builder in service-templates.ts.
+    const { launchAgentPath, buildLaunchAgentPlist } = await import('./cli/service-templates.ts');
     const dest = launchAgentPath(home);
 
     if (cliInstall) {
-      // Template rationale (serve-not-daemon, KeepAlive semantics) lives with
-      // the builder in service-templates.ts.
-      const { buildLaunchAgentPlist } = await import('./cli/service-templates.ts');
       const content = buildLaunchAgentPlist(binaryPath, home);
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.mkdirSync(path.join(home, '.remi'), { recursive: true });
@@ -406,12 +405,11 @@ if (cliInstall || cliUninstall) {
       }
     }
   } else if (platform === 'linux') {
-    const { systemdUnitPath } = await import('./cli/service-templates.ts');
+    const { systemdUnitPath, buildSystemdUnit } = await import('./cli/service-templates.ts');
     const dest = systemdUnitPath(home);
     const serviceDir = path.dirname(dest);
 
     if (cliInstall) {
-      const { buildSystemdUnit } = await import('./cli/service-templates.ts');
       fs.mkdirSync(serviceDir, { recursive: true });
       fs.writeFileSync(dest, buildSystemdUnit(binaryPath));
       Bun.spawnSync(['systemctl', '--user', 'daemon-reload']);

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -125,6 +125,7 @@ import { QuestionPresenceTracker } from './api/question-presence-tracker.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import { AutoApproveService, resolveProviderUrl } from './auto-approve/index.ts';
+import { detectAutostartState } from './cli/autostart-state.ts';
 import { resolveClaudeBinding } from './cli/claude-binding.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
 import { runReloadCommand } from './cli/cmd-reload.ts';
@@ -348,8 +349,8 @@ if (cliInstall || cliUninstall) {
   const binaryPath = pathResolved ?? process.execPath;
 
   if (platform === 'darwin') {
-    const plistName = 'com.yooz.remi.plist';
-    const dest = path.join(home, 'Library', 'LaunchAgents', plistName);
+    const { launchAgentPath } = await import('./cli/service-templates.ts');
+    const dest = launchAgentPath(home);
 
     if (cliInstall) {
       // Template rationale (serve-not-daemon, KeepAlive semantics) lives with
@@ -405,8 +406,9 @@ if (cliInstall || cliUninstall) {
       }
     }
   } else if (platform === 'linux') {
-    const serviceDir = path.join(home, '.config', 'systemd', 'user');
-    const dest = path.join(serviceDir, 'remi.service');
+    const { systemdUnitPath } = await import('./cli/service-templates.ts');
+    const dest = systemdUnitPath(home);
+    const serviceDir = path.dirname(dest);
 
     if (cliInstall) {
       const { buildSystemdUnit } = await import('./cli/service-templates.ts');
@@ -1673,6 +1675,9 @@ const hubClientTracker: HubClientTracker | null = serveMode
       },
       broadcast: (message) => registry.broadcast(message),
       getSessions: () => liveSessionsRegistry.listLive().length,
+      // Re-checked on every census build/change-check (#788): a cheap fs
+      // stat, cheap enough to not bother caching across calls.
+      getAutostartState: () => detectAutostartState(process.platform, os.homedir()),
       hubVersion: REMI_VERSION,
     })
   : null;

--- a/packages/daemon/src/cli/autostart-state.ts
+++ b/packages/daemon/src/cli/autostart-state.ts
@@ -1,0 +1,35 @@
+/**
+ * Autostart-state detection for the `hub_status` census (#788).
+ *
+ * The macOS menu-bar app is sandboxed and cannot read `~/Library/LaunchAgents`
+ * or `~/.remi` directly, so the hub must self-report whether `remi --install`
+ * has been run. This is a cheap fs existence check against the exact artifact
+ * `--install` writes (see `launchAgentPath`/`systemdUnitPath` in
+ * service-templates.ts, the single source of truth for those paths) — no
+ * launchctl/systemctl calls, just a stat.
+ *
+ * Pure function of (platform, home) so it is testable against a temp
+ * directory standing in for HOME, without touching the real filesystem
+ * outside the sandbox the test runs in.
+ */
+
+import fs from 'node:fs';
+import type { HubAutostartState } from '@remi/shared';
+import { launchAgentPath, systemdUnitPath } from './service-templates.ts';
+
+/**
+ * `'installed'` when the login-service artifact `remi --install` writes is
+ * present, `'none'` otherwise (never installed, removed via `--uninstall`,
+ * or a platform `--install` refuses to run on — there is no artifact that
+ * could exist there).
+ */
+export function detectAutostartState(platform: NodeJS.Platform, home: string): HubAutostartState {
+  switch (platform) {
+    case 'darwin':
+      return fs.existsSync(launchAgentPath(home)) ? 'installed' : 'none';
+    case 'linux':
+      return fs.existsSync(systemdUnitPath(home)) ? 'installed' : 'none';
+    default:
+      return 'none';
+  }
+}

--- a/packages/daemon/src/cli/hub-client-tracker.ts
+++ b/packages/daemon/src/cli/hub-client-tracker.ts
@@ -9,7 +9,7 @@
  */
 
 import { createHubStatus } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { HubAutostartState, ProtocolMessage, UUID } from '@remi/shared';
 import type { AdapterMetadata } from '../adapters/index.ts';
 import { isLoopbackAddress } from '../server/peer-helpers.ts';
 
@@ -57,6 +57,13 @@ export interface HubClientTrackerDeps {
   readonly broadcast: (message: ProtocolMessage) => void;
   /** Live child session daemon count (live-sessions registry census). */
   readonly getSessions: () => number;
+  /**
+   * Cheap fs existence check for the `remi --install` login-service artifact
+   * (#788). Called fresh on every census build/change-check so installing or
+   * uninstalling while the hub is running is picked up on the next
+   * broadcast, without a restart.
+   */
+  readonly getAutostartState: () => HubAutostartState;
   /** REMI_VERSION of the hub process. */
   readonly hubVersion: string;
 }
@@ -65,16 +72,26 @@ export class HubClientTracker {
   private readonly clients = new Map<UUID, PeerClass>();
   private readonly deps: HubClientTrackerDeps;
   /**
-   * Last counts broadcast, for change detection (sessions included). Seeded
-   * with the real census at construction — a null sentinel would force a
-   * spurious broadcast on the first connect even when nothing changed
-   * (#744 review).
+   * Last counts broadcast, for change detection (sessions + autostart
+   * included). Seeded with the real census at construction — a null
+   * sentinel would force a spurious broadcast on the first connect even
+   * when nothing changed (#744 review).
    */
-  private lastEmitted: { local: number; remote: number; sessions: number };
+  private lastEmitted: {
+    local: number;
+    remote: number;
+    sessions: number;
+    autostart: HubAutostartState;
+  };
 
   constructor(deps: HubClientTrackerDeps) {
     this.deps = deps;
-    this.lastEmitted = { local: 0, remote: 0, sessions: deps.getSessions() };
+    this.lastEmitted = {
+      local: 0,
+      remote: 0,
+      sessions: deps.getSessions(),
+      autostart: deps.getAutostartState(),
+    };
   }
 
   counts(): { localClients: number; remoteClients: number; sessions: number } {
@@ -116,21 +133,27 @@ export class HubClientTracker {
   }
 
   private statusMessage(): ProtocolMessage {
-    return createHubStatus({ ...this.counts(), hubVersion: this.deps.hubVersion });
+    return createHubStatus({
+      ...this.counts(),
+      hubVersion: this.deps.hubVersion,
+      autostart: this.deps.getAutostartState(),
+    });
   }
 
   /** Returns true when a broadcast actually went out. */
   private broadcastIfChanged(): boolean {
     const { localClients, remoteClients, sessions } = this.counts();
+    const autostart = this.deps.getAutostartState();
     const prev = this.lastEmitted;
     if (
       prev.local === localClients &&
       prev.remote === remoteClients &&
-      prev.sessions === sessions
+      prev.sessions === sessions &&
+      prev.autostart === autostart
     ) {
       return false;
     }
-    this.lastEmitted = { local: localClients, remote: remoteClients, sessions };
+    this.lastEmitted = { local: localClients, remote: remoteClients, sessions, autostart };
     this.deps.broadcast(this.statusMessage());
     return true;
   }

--- a/packages/daemon/src/cli/hub-client-tracker.ts
+++ b/packages/daemon/src/cli/hub-client-tracker.ts
@@ -105,6 +105,22 @@ export class HubClientTracker {
   }
 
   /**
+   * Full census for one broadcast cycle: client counts plus a single fresh
+   * getAutostartState() fs check. Callers thread the result through
+   * statusMessage()/broadcastIfChanged() instead of each re-reading deps,
+   * so one onConnect/onDisconnect/refresh() call does exactly one
+   * getAutostartState() (and one counts()) rather than two (#788 review).
+   */
+  private snapshot(): {
+    localClients: number;
+    remoteClients: number;
+    sessions: number;
+    autostart: HubAutostartState;
+  } {
+    return { ...this.counts(), autostart: this.deps.getAutostartState() };
+  }
+
+  /**
    * Track a newly connected client. Every client receives the census exactly
    * ONCE per connect (#744 review): by the time this runs (post-hello_ack),
    * the new connection is already reachable by `broadcast` on every
@@ -115,35 +131,31 @@ export class HubClientTracker {
    */
   onConnect(connectionId: UUID, metadata: AdapterMetadata): void {
     this.clients.set(connectionId, classifyClient(metadata));
-    if (!this.broadcastIfChanged()) {
-      this.deps.send(connectionId, this.statusMessage());
+    const snapshot = this.snapshot();
+    if (!this.broadcastIfChanged(snapshot)) {
+      this.deps.send(connectionId, this.statusMessage(snapshot));
     }
   }
 
   onDisconnect(connectionId: UUID): void {
     if (this.clients.delete(connectionId)) {
-      this.broadcastIfChanged();
+      this.broadcastIfChanged(this.snapshot());
     }
   }
 
   /** Re-check the census after an external change (child session
    *  registered/removed via the live-sessions watcher). */
   refresh(): void {
-    this.broadcastIfChanged();
+    this.broadcastIfChanged(this.snapshot());
   }
 
-  private statusMessage(): ProtocolMessage {
-    return createHubStatus({
-      ...this.counts(),
-      hubVersion: this.deps.hubVersion,
-      autostart: this.deps.getAutostartState(),
-    });
+  private statusMessage(snapshot: ReturnType<HubClientTracker['snapshot']>): ProtocolMessage {
+    return createHubStatus({ ...snapshot, hubVersion: this.deps.hubVersion });
   }
 
   /** Returns true when a broadcast actually went out. */
-  private broadcastIfChanged(): boolean {
-    const { localClients, remoteClients, sessions } = this.counts();
-    const autostart = this.deps.getAutostartState();
+  private broadcastIfChanged(snapshot: ReturnType<HubClientTracker['snapshot']>): boolean {
+    const { localClients, remoteClients, sessions, autostart } = snapshot;
     const prev = this.lastEmitted;
     if (
       prev.local === localClients &&
@@ -154,7 +166,7 @@ export class HubClientTracker {
       return false;
     }
     this.lastEmitted = { local: localClients, remote: remoteClients, sessions, autostart };
-    this.deps.broadcast(this.statusMessage());
+    this.deps.broadcast(this.statusMessage(snapshot));
     return true;
   }
 }

--- a/packages/daemon/src/cli/service-templates.ts
+++ b/packages/daemon/src/cli/service-templates.ts
@@ -6,6 +6,25 @@
  * touching launchctl/systemctl (#542 review).
  */
 
+import path from 'node:path';
+
+/**
+ * Where `remi --install` writes the LaunchAgent plist, and where the
+ * autostart-state detector (#788) checks for it. Single source of truth so
+ * the two never drift.
+ */
+export function launchAgentPath(home: string): string {
+  return path.join(home, 'Library', 'LaunchAgents', 'com.yooz.remi.plist');
+}
+
+/**
+ * Where `remi --install` writes the systemd user unit, and where the
+ * autostart-state detector (#788) checks for it.
+ */
+export function systemdUnitPath(home: string): string {
+  return path.join(home, '.config', 'systemd', 'user', 'remi.service');
+}
+
 /**
  * LaunchAgent plist running the session-less hub.
  *

--- a/packages/daemon/tests/cli/autostart-state.test.ts
+++ b/packages/daemon/tests/cli/autostart-state.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Real-fs tests for autostart-state detection (#788): the hub reports
+ * whether `remi --install`'s login-service artifact is on disk so the
+ * sandboxed macOS app (which cannot read `~/Library/LaunchAgents` itself)
+ * can surface it. Uses a temp dir as a fake HOME, injected directly — no
+ * mocking of `fs` or `os`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { detectAutostartState } from '../../src/cli/autostart-state.ts';
+import { launchAgentPath, systemdUnitPath } from '../../src/cli/service-templates.ts';
+
+describe('detectAutostartState (#788)', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-autostart-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test('darwin: none when no LaunchAgent plist exists', () => {
+    expect(detectAutostartState('darwin', home)).toBe('none');
+  });
+
+  test('darwin: installed once the LaunchAgent plist exists', () => {
+    const plist = launchAgentPath(home);
+    fs.mkdirSync(path.dirname(plist), { recursive: true });
+    fs.writeFileSync(plist, '<plist/>');
+    expect(detectAutostartState('darwin', home)).toBe('installed');
+  });
+
+  test('darwin: back to none after the plist is removed (uninstall)', () => {
+    const plist = launchAgentPath(home);
+    fs.mkdirSync(path.dirname(plist), { recursive: true });
+    fs.writeFileSync(plist, '<plist/>');
+    expect(detectAutostartState('darwin', home)).toBe('installed');
+
+    fs.unlinkSync(plist);
+    expect(detectAutostartState('darwin', home)).toBe('none');
+  });
+
+  test('darwin: an unrelated file under LaunchAgents does not count', () => {
+    const plistDir = path.dirname(launchAgentPath(home));
+    fs.mkdirSync(plistDir, { recursive: true });
+    fs.writeFileSync(path.join(plistDir, 'com.other.app.plist'), '<plist/>');
+    expect(detectAutostartState('darwin', home)).toBe('none');
+  });
+
+  test('linux: none when no systemd unit exists', () => {
+    expect(detectAutostartState('linux', home)).toBe('none');
+  });
+
+  test('linux: installed once the systemd user unit exists', () => {
+    const unit = systemdUnitPath(home);
+    fs.mkdirSync(path.dirname(unit), { recursive: true });
+    fs.writeFileSync(unit, '[Unit]\n');
+    expect(detectAutostartState('linux', home)).toBe('installed');
+  });
+
+  test('linux: darwin artifacts under the same fake HOME do not leak across platforms', () => {
+    const plist = launchAgentPath(home);
+    fs.mkdirSync(path.dirname(plist), { recursive: true });
+    fs.writeFileSync(plist, '<plist/>');
+    expect(detectAutostartState('linux', home)).toBe('none');
+  });
+
+  test('unsupported platforms (e.g. win32) always report none', () => {
+    expect(detectAutostartState('win32', home)).toBe('none');
+  });
+});

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -592,6 +592,7 @@ describe('onPeerConnect/onPeerDisconnect feed the hub census (#650)', () => {
         },
         broadcast: (message) => broadcasts.push(message),
         getSessions: () => 0,
+        getAutostartState: () => 'none',
         hubVersion: '9.9.9-test',
       });
       const handlers = createConnectionHandlers({

--- a/packages/daemon/tests/cli/hub-client-tracker.test.ts
+++ b/packages/daemon/tests/cli/hub-client-tracker.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { HubStatusMessage, ProtocolMessage, UUID } from '@remi/shared';
+import type { HubAutostartState, HubStatusMessage, ProtocolMessage, UUID } from '@remi/shared';
 import type { AdapterMetadata } from '../../src/adapters/index.ts';
 import { HubClientTracker, classifyClient } from '../../src/cli/hub-client-tracker.ts';
 
@@ -49,20 +49,25 @@ describe('classifyClient (#650)', () => {
 });
 
 describe('HubClientTracker (#650)', () => {
-  function makeTracker(initialSessions = 0) {
+  function makeTracker(initialSessions = 0, initialAutostart: HubAutostartState = 'none') {
     const sent: Array<{ connectionId: UUID; message: ProtocolMessage }> = [];
     const broadcasts: ProtocolMessage[] = [];
     let sessions = initialSessions;
+    let autostart = initialAutostart;
     const tracker = new HubClientTracker({
       send: (connectionId, message) => sent.push({ connectionId, message }),
       broadcast: (message) => broadcasts.push(message),
       getSessions: () => sessions,
+      getAutostartState: () => autostart,
       hubVersion: '9.9.9-test',
     });
     const setSessions = (n: number): void => {
       sessions = n;
     };
-    return { tracker, sent, broadcasts, setSessions };
+    const setAutostart = (s: HubAutostartState): void => {
+      autostart = s;
+    };
+    return { tracker, sent, broadcasts, setSessions, setAutostart };
   }
 
   const asStatus = (m: ProtocolMessage): HubStatusMessage => m as HubStatusMessage;
@@ -145,5 +150,33 @@ describe('HubClientTracker (#650)', () => {
     tracker.refresh();
     expect(broadcasts).toHaveLength(1);
     expect(asStatus(broadcasts[0]!).sessions).toBe(2);
+  });
+
+  test('status frames carry the current autostart state (#788)', () => {
+    const { tracker, sent } = makeTracker(0, 'installed');
+    tracker.onConnect('q1' as UUID, wsMeta('127.0.0.1', 'query'));
+    expect(asStatus(sent[0]!.message).autostart).toBe('installed');
+  });
+
+  test('refresh broadcasts when autostart install/uninstall is detected (#788)', () => {
+    const { tracker, broadcasts, setAutostart } = makeTracker(0, 'none');
+    tracker.onConnect('c1' as UUID, wsMeta('127.0.0.1'));
+    broadcasts.length = 0;
+
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(0); // nothing changed
+
+    // `remi --install` ran while the hub was up; next census build picks it
+    // up without a restart.
+    setAutostart('installed');
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(1);
+    expect(asStatus(broadcasts[0]!).autostart).toBe('installed');
+
+    broadcasts.length = 0;
+    setAutostart('none');
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(1);
+    expect(asStatus(broadcasts[0]!).autostart).toBe('none');
   });
 });

--- a/packages/daemon/tests/cli/service-templates.test.ts
+++ b/packages/daemon/tests/cli/service-templates.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { buildLaunchAgentPlist, buildSystemdUnit } from '../../src/cli/service-templates.ts';
+import {
+  buildLaunchAgentPlist,
+  buildSystemdUnit,
+  launchAgentPath,
+  systemdUnitPath,
+} from '../../src/cli/service-templates.ts';
 
 describe('buildLaunchAgentPlist', () => {
   const binary = '/opt/homebrew/bin/remi';
@@ -46,5 +51,19 @@ describe('buildSystemdUnit', () => {
     expect(unit).not.toContain('--daemon');
     expect(unit).toContain('Restart=on-failure');
     expect(unit).toContain('WantedBy=default.target');
+  });
+});
+
+// Single source of truth for the paths --install writes and the
+// autostart-state detector (#788) reads, so they can never drift apart.
+describe('launchAgentPath / systemdUnitPath (#788)', () => {
+  const home = '/Users/testuser';
+
+  test('launchAgentPath matches the plist --install writes', () => {
+    expect(launchAgentPath(home)).toBe(`${home}/Library/LaunchAgents/com.yooz.remi.plist`);
+  });
+
+  test('systemdUnitPath matches the unit --install writes', () => {
+    expect(systemdUnitPath(home)).toBe(`${home}/.config/systemd/user/remi.service`);
   });
 });

--- a/packages/daemon/tests/integration/hub-status.test.ts
+++ b/packages/daemon/tests/integration/hub-status.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createHello, deserialize, serialize } from '@remi/shared/protocol.ts';
 import type { HubStatusMessage, ProtocolMessage } from '@remi/shared/protocol.ts';
+import { launchAgentPath, systemdUnitPath } from '../../src/cli/service-templates.ts';
 import { type HubHandle, cleanupHub, pollUntil, spawnHub } from './hub-test-utils.ts';
 
 const hubs: HubHandle[] = [];
@@ -171,6 +172,38 @@ describe('hub_status census (integration, #650)', () => {
       'sessions census after removal',
     );
 
+    monitor.ws.close();
+  }, 30000);
+
+  test('reports autostart state, re-checked on the next census build (#788)', async () => {
+    const hub = await spawnHub();
+    hubs.push(hub);
+
+    const monitor = await connect(hub.port, 'query');
+    await pollUntil(() => lastStatus(monitor) !== undefined, 5000, 'initial hub_status');
+    // Real subprocess, real HOME (isolated temp dir): nothing was ever
+    // installed there, so the hub reports 'none'.
+    expect(lastStatus(monitor)?.autostart).toBe('none');
+
+    // Write the exact artifact `remi --install` would write (no
+    // launchctl/systemctl involved) for whatever platform this test runs
+    // on — matches what the spawned hub subprocess checks for.
+    const artifact =
+      process.platform === 'darwin' ? launchAgentPath(hub.home) : systemdUnitPath(hub.home);
+    fs.mkdirSync(path.dirname(artifact), { recursive: true });
+    fs.writeFileSync(artifact, 'placeholder');
+
+    // No watcher on the autostart artifact by design (#788): it is only
+    // re-checked when the next census build fires for another reason. A
+    // second client connecting is exactly such a trigger.
+    const user = await connect(hub.port);
+    await pollUntil(
+      () => lastStatus(monitor)?.autostart === 'installed',
+      5000,
+      'autostart flips to installed on the next broadcast',
+    );
+
+    user.ws.close();
     monitor.ws.close();
   }, 30000);
 });

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -49,6 +49,10 @@ final class HubClient: ObservableObject {
     @Published private(set) var remoteClients = 0
     @Published private(set) var sessions = 0
     @Published private(set) var hubVersion: String?
+    /// Autostart state reported by the hub (#788): `"installed"`, `"none"`,
+    /// or nil (either not yet received, or a pre-#788 hub that never sends
+    /// the field). Settings/menu treat nil as "unknown", not "none".
+    @Published private(set) var autostart: String?
 
     var iconState: IconState {
         switch phase {
@@ -86,6 +90,15 @@ final class HubClient: ObservableObject {
         if localClients > 0 { parts.append("\(localClients) local") }
         if remoteClients > 0 { parts.append("\(remoteClients) remote") }
         return "Clients: \(parts.joined(separator: ", "))"
+    }
+
+    /// True only once a real hub has explicitly confirmed no autostart
+    /// artifact exists (#788). nil (not yet received, or a pre-#788 hub
+    /// that never sends the field) reads false — a warning only fires on a
+    /// confirmed "none", never on "we don't know yet".
+    var autostartMissing: Bool {
+        guard case .connected(_, isHub: true) = phase else { return false }
+        return autostart == "none"
     }
 
     var menuStatusLine: String {
@@ -306,6 +319,7 @@ final class HubClient: ObservableObject {
                 remoteClients = status.remoteClients
                 sessions = status.sessions
                 hubVersion = status.hubVersion
+                autostart = status.autostart
             }
         case "pong":
             missedPongs = 0
@@ -353,6 +367,7 @@ final class HubClient: ObservableObject {
         remoteClients = 0
         sessions = 0
         hubVersion = nil
+        autostart = nil
         phase = .unreachable
         consecutiveFailures += 1
         scheduleReconnect()

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -91,4 +91,11 @@ struct HubStatusFrame: Decodable {
     let remoteClients: Int
     let sessions: Int
     let hubVersion: String
+    /// Whether `remi --install`'s login-service artifact exists on this
+    /// Mac (#788): `"installed"` or `"none"`. The sandboxed app cannot
+    /// read `~/Library/LaunchAgents` itself, so the hub self-reports this.
+    /// Optional/nil on a pre-#788 hub — that must read as "unknown", not
+    /// "none", so the UI keeps today's neutral copy instead of a false
+    /// warning.
+    let autostart: String?
 }

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -30,6 +30,17 @@ struct RemiApp: App {
                     NSApp.activate(ignoringOtherApps: true)
                 }
             }
+            // The hub confirmed no LaunchAgent is installed (#788): remote
+            // access silently stops working after the next logout/reboot.
+            // Routes to Settings, the same place the fix lives, via the
+            // same responder-chain action + activate() pairing used by the
+            // "Settings…" item below.
+            if hubClient.autostartMissing {
+                Button("Hub autostart not set up…") {
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+            }
             Divider()
             Button("Open Remi") {
                 openWindow(id: "main")

--- a/packages/macos/Remi/SettingsView.swift
+++ b/packages/macos/Remi/SettingsView.swift
@@ -8,8 +8,9 @@
 //
 //  The Hub section is state-aware on `hubClient.autostart` (#788), the
 //  field the hub self-reports in `hub_status` since the app cannot read
-//  ~/Library/LaunchAgents itself: "installed" confirms the LaunchAgent is
-//  in place and drops the command row entirely; "none" warns that remote
+//  ~/Library/LaunchAgents itself: "installed" confirms the LaunchAgent FILE
+//  is in place (presence-only — see the job-health caveat at its use site
+//  and #791) and drops the command row entirely; "none" warns that remote
 //  access won't survive a logout/reboot and keeps the command row so the
 //  user can fix it; nil (older hub, field absent) falls back to today's
 //  neutral copy since the app genuinely doesn't know either way.
@@ -50,8 +51,20 @@ struct SettingsView: View {
     private var hubAutostartContent: some View {
         switch hubClient.autostart {
         case "installed":
-            Text("Hub starts at login (LaunchAgent installed)")
-                .foregroundStyle(.secondary)
+            // Wording asserts only what detectAutostartState actually
+            // verifies: the plist FILE exists, not that the launchd job is
+            // healthy (a stale baked binary path after a `brew upgrade`, or
+            // an uninstall that failed to bootout, can leave the file
+            // present but the job broken/unloaded). Tracked in #791 — once
+            // that lands a job-health check, this copy can go back to
+            // asserting "starts at login" once it's actually verified.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Hub LaunchAgent installed")
+                    .foregroundStyle(.secondary)
+                Text("Starts the hub automatically at login.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         case "none":
             Text("Hub runs only until you log out — remote access will be down after a reboot.")
                 .foregroundStyle(.orange)

--- a/packages/macos/Remi/SettingsView.swift
+++ b/packages/macos/Remi/SettingsView.swift
@@ -6,6 +6,14 @@
 //  Hub section explaining the hub's own login item (remi --install) — the
 //  sandboxed app cannot install that LaunchAgent itself.
 //
+//  The Hub section is state-aware on `hubClient.autostart` (#788), the
+//  field the hub self-reports in `hub_status` since the app cannot read
+//  ~/Library/LaunchAgents itself: "installed" confirms the LaunchAgent is
+//  in place and drops the command row entirely; "none" warns that remote
+//  access won't survive a logout/reboot and keeps the command row so the
+//  user can fix it; nil (older hub, field absent) falls back to today's
+//  neutral copy since the app genuinely doesn't know either way.
+//
 
 import SwiftUI
 
@@ -31,14 +39,36 @@ struct SettingsView: View {
             Section("Hub") {
                 Text(hubClient.menuStatusLine)
                     .foregroundStyle(.secondary)
-                CommandRow(
-                    title: "Start hub at login",
-                    caption:
-                        "Remi is sandboxed and can't install this for you; run it once from Terminal. Installs a LaunchAgent that keeps the hub running and restarts it if it crashes.",
-                    command: HubSetupCommands.autostart)
+                hubAutostartContent
             }
         }
         .padding(20)
         .frame(width: 420)
+    }
+
+    @ViewBuilder
+    private var hubAutostartContent: some View {
+        switch hubClient.autostart {
+        case "installed":
+            Text("Hub starts at login (LaunchAgent installed)")
+                .foregroundStyle(.secondary)
+        case "none":
+            Text("Hub runs only until you log out — remote access will be down after a reboot.")
+                .foregroundStyle(.orange)
+            autostartCommandRow
+        default:
+            // nil: either not connected yet, or a pre-#788 hub that never
+            // sends the field — the app genuinely doesn't know, so it
+            // keeps today's neutral copy rather than guessing.
+            autostartCommandRow
+        }
+    }
+
+    private var autostartCommandRow: some View {
+        CommandRow(
+            title: "Start hub at login",
+            caption:
+                "Remi is sandboxed and can't install this for you; run it once from Terminal. Installs a LaunchAgent that keeps the hub running and restarts it if it crashes.",
+            command: HubSetupCommands.autostart)
     }
 }

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -38,12 +38,23 @@ final class HubClientIntegrationTests: XCTestCase {
     }
 
     /// Spawns a real hub (session-less `serve`) on `port` with an isolated
-    /// $HOME, stored on `process`/`homeDir` for tearDown to clean up.
-    private func spawnHub(binary: String, port: Int) throws {
+    /// $HOME, stored on `process`/`homeDir` for tearDown to clean up. When
+    /// `withAutostartInstalled` is set, pre-creates the exact LaunchAgent
+    /// artifact `remi --install` would have written (#788) — no
+    /// launchctl/systemctl involved, just the fs marker the hub checks for.
+    private func spawnHub(binary: String, port: Int, withAutostartInstalled: Bool = false) throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("remi-macos-it-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         homeDir = home
+
+        if withAutostartInstalled {
+            let launchAgentsDir = home.appendingPathComponent("Library/LaunchAgents")
+            try FileManager.default.createDirectory(
+                at: launchAgentsDir, withIntermediateDirectories: true)
+            let plist = launchAgentsDir.appendingPathComponent("com.yooz.remi.plist")
+            try "<plist/>".write(to: plist, atomically: true, encoding: .utf8)
+        }
 
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: binary)
@@ -101,6 +112,9 @@ final class HubClientIntegrationTests: XCTestCase {
             if envelope.type == "hub_status" {
                 let status = try JSONDecoder().decode(HubStatusFrame.self, from: data)
                 XCTAssertEqual(status.localClients, 0)  // query client never counts
+                // #788: the isolated $HOME this test spawns the hub with
+                // never had `remi --install` run against it.
+                XCTAssertEqual(status.autostart, "none")
                 sawHubStatus = true
             }
             if sawHubAck && sawHubStatus { break }
@@ -130,20 +144,45 @@ final class HubClientIntegrationTests: XCTestCase {
         // query-mode client never counts itself.
         var censusSeen = false
         for _ in 0..<20 {
-            let (sessions, local, version) = await MainActor.run {
-                (client.sessions, client.localClients, client.hubVersion)
+            let (sessions, local, version, autostart) = await MainActor.run {
+                (client.sessions, client.localClients, client.hubVersion, client.autostart)
             }
             if version != nil {
                 XCTAssertEqual(sessions, 0)
                 XCTAssertEqual(local, 0)
+                // #788: fresh isolated $HOME, never `remi --install`ed.
+                XCTAssertEqual(autostart, "none")
                 censusSeen = true
                 break
             }
             try await Task.sleep(nanoseconds: 250_000_000)
         }
         XCTAssertTrue(censusSeen, "hub_status never reached the published state")
+        let autostartMissing = await MainActor.run { client.autostartMissing }
+        XCTAssertTrue(autostartMissing, "autostartMissing should be true for an uninstalled hub")
         let statusLine = await MainActor.run { client.menuStatusLine }
         XCTAssertTrue(statusLine.contains("running on \(port)"), statusLine)
+    }
+
+    /// #788: a hub whose $HOME already carries the LaunchAgent artifact
+    /// (as if `remi --install` had run) reports "installed", and
+    /// autostartMissing reads false — no false warning.
+    func testHubWithAutostartInstalledReportsInstalled() async throws {
+        let binary = try requireBinary()
+        let port = 18784
+        try spawnHub(binary: binary, port: port, withAutostartInstalled: true)
+
+        let client = await MainActor.run { HubClient(scanPorts: [port]) }
+        await MainActor.run { client.start() }
+        var autostart: String?
+        for _ in 0..<60 {  // up to ~15 s
+            autostart = await MainActor.run { client.autostart }
+            if autostart != nil { break }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertEqual(autostart, "installed")
+        let autostartMissing = await MainActor.run { client.autostartMissing }
+        XCTAssertFalse(autostartMissing, "autostartMissing must be false once installed")
     }
 
     /// #773: the onboarding panel's "Check Again" button calls rescanNow();

--- a/packages/macos/RemiTests/HubProtocolTests.swift
+++ b/packages/macos/RemiTests/HubProtocolTests.swift
@@ -18,6 +18,10 @@ final class HubProtocolTests: XCTestCase {
     private let hubStatusFixture = """
         {"type":"hub_status","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-08T01:29:44.322Z","localClients":0,"remoteClients":0,"sessions":0,"hubVersion":"0.6.19-dev.4"}
         """
+    /// #788: a hub new enough to report autostart state.
+    private let hubStatusWithAutostartFixture = """
+        {"type":"hub_status","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-08T01:29:44.322Z","localClients":0,"remoteClients":0,"sessions":0,"hubVersion":"0.6.22-dev.1","autostart":"installed"}
+        """
     /// A message-delivery ack (#663) arrives BEFORE hello_ack on a real
     /// connection; the client must skip unknown types without failing.
     private let ackFixture = """
@@ -58,6 +62,21 @@ final class HubProtocolTests: XCTestCase {
         XCTAssertEqual(status.remoteClients, 0)
         XCTAssertEqual(status.sessions, 0)
         XCTAssertEqual(status.hubVersion, "0.6.19-dev.4")
+    }
+
+    /// #788: a pre-#788 hub omits `autostart` entirely — must decode
+    /// cleanly to nil (unknown), not fail the whole frame.
+    func testHubStatusWithoutAutostartDecodesToNil() throws {
+        let status = try JSONDecoder().decode(
+            HubStatusFrame.self, from: Data(hubStatusFixture.utf8))
+        XCTAssertNil(status.autostart)
+    }
+
+    /// #788: a hub that HAS installed its LaunchAgent reports it.
+    func testDecodesHubStatusWithAutostartInstalled() throws {
+        let status = try JSONDecoder().decode(
+            HubStatusFrame.self, from: Data(hubStatusWithAutostartFixture.utf8))
+        XCTAssertEqual(status.autostart, "installed")
     }
 
     func testUnknownFrameTypeOnlyNeedsTheEnvelope() throws {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -95,6 +95,7 @@ export type {
   UnregisterDeviceTokenMessage,
   DaemonUpdateAvailableMessage,
   HubStatusMessage,
+  HubAutostartState,
   SessionRotatedMessage,
   SessionViewsMessage,
   SessionViewMeta,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -792,12 +792,22 @@ export interface DaemonUpdateAvailableMessage {
 }
 
 /**
+ * Whether the hub's login-service artifact (`remi --install`'s LaunchAgent
+ * plist on macOS, systemd user unit on Linux) exists on disk (#788).
+ * `'installed'` means the hub restarts automatically after logout/reboot;
+ * `'none'` means it runs only for the lifetime of the process that started
+ * it. Omitted entirely on platforms `--install` does not support.
+ */
+export type HubAutostartState = 'installed' | 'none';
+
+/**
  * Hub connection/session census (#650, epic #648): the daemon half of the
  * menu-bar icon state. Sent by HUB-MODE daemons only — to a connection right
  * after its hello_ack, and broadcast to all connections whenever the counts
- * change (client connect/disconnect, child session registered/removed).
- * Query-mode clients (remi ls, the menu-bar app itself) receive it but are
- * never counted. Pre-#650 clients drop it via isValidMessage.
+ * change (client connect/disconnect, child session registered/removed,
+ * autostart install/uninstall). Query-mode clients (remi ls, the menu-bar
+ * app itself) receive it but are never counted. Pre-#650 clients drop it via
+ * isValidMessage.
  */
 export interface HubStatusMessage {
   readonly type: 'hub_status';
@@ -811,6 +821,12 @@ export interface HubStatusMessage {
   readonly sessions: number;
   /** REMI_VERSION of the hub process. */
   readonly hubVersion: string;
+  /**
+   * Autostart state (#788), OPTIONAL so older hubs (pre-#788) still decode
+   * cleanly on newer clients. Absent means "unknown", not "none" — clients
+   * should treat it the same as a hub too old to report it.
+   */
+  readonly autostart?: HubAutostartState;
 }
 
 /** A recent project directory aggregated from session history */
@@ -1714,6 +1730,7 @@ export function createHubStatus(counts: {
   remoteClients: number;
   sessions: number;
   hubVersion: string;
+  autostart?: HubAutostartState;
 }): HubStatusMessage {
   return {
     type: 'hub_status',
@@ -1723,6 +1740,7 @@ export function createHubStatus(counts: {
     remoteClients: counts.remoteClients,
     sessions: counts.sessions,
     hubVersion: counts.hubVersion,
+    ...(counts.autostart !== undefined && { autostart: counts.autostart }),
   };
 }
 


### PR DESCRIPTION
## Summary

The macOS menu-bar app is sandboxed and cannot read `~/Library/LaunchAgents`
or `~/.remi`, so it had no way to tell the user whether the hub's autostart
(`remi --install`) was actually set up. This PR has the hub self-report that
state over the wire, and surfaces it in the app.

### Daemon side

- `packages/daemon/src/cli/autostart-state.ts` (new): `detectAutostartState(platform, home)`,
  a pure/cheap `fs.existsSync` check against the exact LaunchAgent plist /
  systemd unit path `remi --install` writes.
- `packages/daemon/src/cli/service-templates.ts`: extracted `launchAgentPath(home)` /
  `systemdUnitPath(home)` as the single source of truth for those paths,
  reused by both `--install`/`--uninstall` in `cli.ts` and the new detector
  (previously the path was duplicated inline in `cli.ts`).
- `packages/daemon/src/cli/hub-client-tracker.ts`: `HubClientTrackerDeps` gains
  `getAutostartState: () => HubAutostartState`, called fresh on every
  `statusMessage()` build and folded into `broadcastIfChanged()`'s
  change-detection tuple, so running `remi --install`/`--uninstall` while the
  hub is up is picked up on the next broadcast (no restart needed).
- `packages/daemon/src/cli.ts`: wires `detectAutostartState(process.platform, os.homedir())`
  into the tracker.

### Shared protocol

- `packages/shared/src/protocol.ts`: new `HubAutostartState = 'installed' | 'none'`
  type; `HubStatusMessage` and `createHubStatus` gain an OPTIONAL `autostart`
  field (no new message type, additive only — older clients/hubs are
  unaffected). Exported from `packages/shared/src/index.ts`.

### macOS app (Swift)

- `HubProtocol.swift`: `HubStatusFrame.autostart: String?`.
- `HubClient.swift`: publishes `autostart`, resets it on disconnect, and adds
  `autostartMissing` (true only once a real hub confirms `"none"`).
- `SettingsView.swift`: Hub section is now state-aware —
  `"installed"` shows a plain confirmation line (no command needed);
  `"none"` shows a warning plus the `remi --install` command row;
  `nil` (older hub) keeps today's neutral command row.
- `RemiApp.swift`: menu dropdown adds a "Hub autostart not set up…" item
  (opens Settings) whenever a connected hub confirms `"none"`.
- `docs/MACOS_APP.md`: documents the new self-reported field and the
  resulting UI behavior.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on all touched TS files — clean (pre-existing
      `noNonNullAssertion` warnings in `hub-client-tracker.test.ts` predate
      this change and don't fail the gate)
- [x] `bun test packages/shared` + all `packages/daemon/tests/*` except
      `auto-approve/` (per repo convention — needs a live LLM endpoint) —
      **1112 pass, 0 fail**
- [x] New daemon tests: `packages/daemon/tests/cli/autostart-state.test.ts`
      (real-fs, temp dir as fake HOME, no mocks), path-helper tests in
      `service-templates.test.ts`, change-detection tests in
      `hub-client-tracker.test.ts`, and a real-hub integration test in
      `packages/daemon/tests/integration/hub-status.test.ts` (spawns a real
      `remi serve` subprocess, writes the artifact mid-run, confirms the
      broadcast flips on the next census change)
- [x] `xcodebuild test -project packages/macos/Remi.xcodeproj -scheme Remi`
      with `TEST_RUNNER_REMI_TEST_BINARY` pointing at a freshly built
      `dist/remi` — **27/27 tests pass**, including two real-hub
      integration tests added for this change (fresh-HOME "none" case,
      pre-seeded-LaunchAgent "installed" case)

## Deviations from the issue sketch

None — implementation matches the agreed design exactly (optional field only,
no new message type, hub self-reports via cheap fs check re-evaluated per
census build).

## Coordination note

Kept additive/optional only, per the note that a sibling branch is adding
different optional fields (`pendingQuestions`/`questions`) to the same
`hub_status`/`HubStatusFrame` types — merge conflict should be trivial.

Closes #788
