### PR TITLE
macOS app: native notifications + needs-attention icon for pending questions

### DIFF
--- a/docs/MACOS_APP.md
+++ b/docs/MACOS_APP.md
@@ -8,8 +8,15 @@ connections, and a window hosting the full Remi web UI. Part of epic #648.
 menu bar:  [r]  idle (thin outline)      no clients connected
            [r]  bold "r"                 local client attached
            [■]  filled, "r" knocked out  remote client(s) connected
+           [■]  filled, "r" knocked out  a question is pending (needs you!)
            [r]  dimmed                   hub not running
 ```
+
+The needs-attention state (#786/#787) reuses the remote-connected glyph —
+"the icon just inverts" — and takes precedence over every other reachable
+state: a pending question on ANY session outranks remote/local client
+presence, second only to the hub being unreachable at all (see
+"Notifications" below).
 
 ## Relationship to the hub
 
@@ -52,6 +59,33 @@ network-client capability only. It **cannot**:
   tracked in #747, blocked on #535.
 - Read `~/.remi` or signal processes. Everything it knows arrives over the
   loopback WebSocket.
+
+## Notifications (#786)
+
+When a question is pending on any session, the app posts a native macOS
+notification ("Claude needs you") — the same "push" experience iOS gets via
+APNS, delivered locally with no relay. Both the notification and the
+needs-attention icon state read the same data source: the hub's
+`hub_status.questions` census, which the daemon builds by mirroring each
+session's pending questions into its `~/.remi/live-sessions/<id>.json` entry
+(so the hub never has to talk to a session daemon's own connection).
+
+- `NotificationManager` (`Remi/NotificationManager.swift`) requests
+  `UNUserNotificationCenter` authorization lazily, the first time a question
+  actually needs posting — not at launch.
+- Notifications are keyed by question id: a reconnect or a repeated
+  `hub_status` broadcast for a still-pending question never re-alerts.
+- Answered anywhere (terminal, phone, web) clears it: the next census drops
+  the id, and the app withdraws that notification (delivered or still
+  pending).
+- A transient hub disconnect does NOT clear notifications or the menu's
+  "N questions waiting" line — those only refresh from a real `hub_status`
+  frame after reconnecting, so a missed pong or a brief network blip can't
+  make a still-pending question look resolved.
+- Clicking a notification activates the app and opens the main window, same
+  as the "Open Remi" menu item.
+- The pure new-vs-seen diff (`NotificationDiff.diff`) is unit-tested without
+  touching `UNUserNotificationCenter` at all (`RemiTests/NotificationDiffTests.swift`).
 
 ## Lifecycle (#651)
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -151,6 +151,7 @@ import {
 } from './cli/handlers/transcript-events.ts';
 import { type TrivialHandlers, createTrivialHandlers } from './cli/handlers/trivial-events.ts';
 import { HubClientTracker } from './cli/hub-client-tracker.ts';
+import { buildHubQuestionCensus } from './cli/hub-question-census.ts';
 import type { LiveSessionsCollectResult } from './cli/live-sessions-watcher.ts';
 import { startLiveSessionsWatcher } from './cli/live-sessions-watcher.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
@@ -173,6 +174,7 @@ import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
   DEFAULT_BASE_PORT,
   DEFAULT_PORT_RANGE,
+  PendingQuestionCreatedAtTracker,
   SessionBindingStore,
   SessionRegistry,
   SessionRegistryFile,
@@ -963,6 +965,10 @@ const orphanTimeoutMs =
 // registry below is constructed before `sessionHandlers` exists, so onSessionClosed
 // reaches the resolver through this holder, assigned once the handlers are wired.
 let resolveStopOnClose: ((sessionId: UUID) => void) | null = null;
+// Mirrors the session's pending questions into the live-sessions registry
+// file (#786/#787), keyed by question id so `createdAt` stays stable across
+// the repeated onQuestionsChanged calls a single question's lifecycle fires.
+const pendingQuestionCreatedAt = new PendingQuestionCreatedAtTracker();
 const sessionRegistry = new SessionRegistry(
   {
     orphanTimeoutMs,
@@ -1009,6 +1015,19 @@ const sessionRegistry = new SessionRegistry(
     },
     onSessionResumed: (sessionId, connectionId) => {
       log(`Session resumed: ${sessionId} by connection ${connectionId}`);
+    },
+    onQuestionsChanged: (sessionId, questions) => {
+      // Best-effort: a registry-file hiccup here must never take down the
+      // question pipeline itself (the live WS `question`/`question_resolved`
+      // broadcasts already happened before this fires).
+      try {
+        liveSessionsRegistry.setPendingQuestions(
+          sessionId,
+          pendingQuestionCreatedAt.sync(questions),
+        );
+      } catch (err) {
+        logError(`[live-sessions] setPendingQuestions failed: ${errorToString(err)}`);
+      }
     },
     onConnectionReclaimed: (sessionId, staleConnectionId, newConnectionId) => {
       // Same device reconnected while its own previous connection still held
@@ -1672,7 +1691,9 @@ const hubClientTracker: HubClientTracker | null = serveMode
         sendToConnection(connectionId, message);
       },
       broadcast: (message) => registry.broadcast(message),
-      getSessions: () => liveSessionsRegistry.listLive().length,
+      // #786/#787: the same listLive() read the plain session count used,
+      // now also flattened into the pending-question census.
+      getCensus: () => buildHubQuestionCensus(liveSessionsRegistry.listLive()),
       hubVersion: REMI_VERSION,
     })
   : null;

--- a/packages/daemon/src/cli/hub-client-tracker.ts
+++ b/packages/daemon/src/cli/hub-client-tracker.ts
@@ -9,9 +9,10 @@
  */
 
 import { createHubStatus } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { HubPendingQuestion, ProtocolMessage, UUID } from '@remi/shared';
 import type { AdapterMetadata } from '../adapters/index.ts';
 import { isLoopbackAddress } from '../server/peer-helpers.ts';
+import type { HubQuestionCensus } from './hub-question-census.ts';
 
 /**
  * How a connection counts toward the icon state:
@@ -55,36 +56,71 @@ export interface HubClientTrackerDeps {
   readonly send: (connectionId: UUID, message: ProtocolMessage) => void;
   /** Broadcast a message to all connections (count changes). */
   readonly broadcast: (message: ProtocolMessage) => void;
-  /** Live child session daemon count (live-sessions registry census). */
-  readonly getSessions: () => number;
+  /**
+   * Live child session daemon count + pending-question census
+   * (live-sessions registry, #786/#787). Reads the same registry entries
+   * the plain session count used to.
+   */
+  readonly getCensus: () => HubQuestionCensus;
   /** REMI_VERSION of the hub process. */
   readonly hubVersion: string;
+}
+
+/** Stable, order-independent key for a question-id set, so change detection
+ *  (`broadcastIfChanged`) treats "same ids, different array order" as
+ *  unchanged but any add/remove as a change. */
+function questionIdsKey(questions: readonly HubPendingQuestion[]): string {
+  return questions
+    .map((q) => q.id)
+    .sort()
+    .join(',');
 }
 
 export class HubClientTracker {
   private readonly clients = new Map<UUID, PeerClass>();
   private readonly deps: HubClientTrackerDeps;
   /**
-   * Last counts broadcast, for change detection (sessions included). Seeded
-   * with the real census at construction — a null sentinel would force a
-   * spurious broadcast on the first connect even when nothing changed
-   * (#744 review).
+   * Last counts broadcast, for change detection (sessions + the pending-
+   * question id set included, #786/#787 — two different question sets of
+   * equal SIZE, e.g. one answered while another arrived in the same beat,
+   * must still count as a change). Seeded with the real census at
+   * construction — a null sentinel would force a spurious broadcast on the
+   * first connect even when nothing changed (#744 review).
    */
-  private lastEmitted: { local: number; remote: number; sessions: number };
+  private lastEmitted: { local: number; remote: number; sessions: number; questionIds: string };
 
   constructor(deps: HubClientTrackerDeps) {
     this.deps = deps;
-    this.lastEmitted = { local: 0, remote: 0, sessions: deps.getSessions() };
+    const census = deps.getCensus();
+    this.lastEmitted = {
+      local: 0,
+      remote: 0,
+      sessions: census.sessions,
+      questionIds: questionIdsKey(census.questions),
+    };
   }
 
-  counts(): { localClients: number; remoteClients: number; sessions: number } {
+  counts(): {
+    localClients: number;
+    remoteClients: number;
+    sessions: number;
+    pendingQuestions: number;
+    questions: readonly HubPendingQuestion[];
+  } {
     let local = 0;
     let remote = 0;
     for (const cls of this.clients.values()) {
       if (cls === 'local') local++;
       else if (cls === 'remote') remote++;
     }
-    return { localClients: local, remoteClients: remote, sessions: this.deps.getSessions() };
+    const census = this.deps.getCensus();
+    return {
+      localClients: local,
+      remoteClients: remote,
+      sessions: census.sessions,
+      pendingQuestions: census.questions.length,
+      questions: census.questions,
+    };
   }
 
   /**
@@ -110,7 +146,8 @@ export class HubClientTracker {
   }
 
   /** Re-check the census after an external change (child session
-   *  registered/removed via the live-sessions watcher). */
+   *  registered/removed, or a session's pendingQuestions changed, via the
+   *  live-sessions watcher, #786/#787). */
   refresh(): void {
     this.broadcastIfChanged();
   }
@@ -121,16 +158,18 @@ export class HubClientTracker {
 
   /** Returns true when a broadcast actually went out. */
   private broadcastIfChanged(): boolean {
-    const { localClients, remoteClients, sessions } = this.counts();
+    const { localClients, remoteClients, sessions, questions } = this.counts();
+    const questionIds = questionIdsKey(questions);
     const prev = this.lastEmitted;
     if (
       prev.local === localClients &&
       prev.remote === remoteClients &&
-      prev.sessions === sessions
+      prev.sessions === sessions &&
+      prev.questionIds === questionIds
     ) {
       return false;
     }
-    this.lastEmitted = { local: localClients, remote: remoteClients, sessions };
+    this.lastEmitted = { local: localClients, remote: remoteClients, sessions, questionIds };
     this.deps.broadcast(this.statusMessage());
     return true;
   }

--- a/packages/daemon/src/cli/hub-question-census.ts
+++ b/packages/daemon/src/cli/hub-question-census.ts
@@ -1,0 +1,33 @@
+/**
+ * Aggregates live-sessions registry entries into the hub's pending-question
+ * census (#786/#787): the data behind `HubStatusMessage.pendingQuestions` /
+ * `.questions`. Pure over the entries `SessionRegistryFile#listLive()`
+ * already returns for the plain session count — no extra fs reads.
+ */
+
+import type { HubPendingQuestion } from '@remi/shared';
+import type { LiveSessionEntry } from '../session/session-registry-file.ts';
+
+export interface HubQuestionCensus {
+  /** Live child session daemon count (same value `getSessions` used to return). */
+  readonly sessions: number;
+  /** Every pending question across every live session, flattened. */
+  readonly questions: readonly HubPendingQuestion[];
+}
+
+/** Flatten each entry's `pendingQuestions` into the wire-shaped census list. */
+export function buildHubQuestionCensus(entries: readonly LiveSessionEntry[]): HubQuestionCensus {
+  const questions: HubPendingQuestion[] = [];
+  for (const entry of entries) {
+    for (const q of entry.pendingQuestions ?? []) {
+      questions.push({
+        id: q.id,
+        sessionId: entry.sessionId,
+        sessionName: entry.name,
+        label: q.label,
+        createdAt: q.createdAt,
+      });
+    }
+  }
+  return { sessions: entries.length, questions };
+}

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -20,7 +20,15 @@ export { TranscriptIndex, type TranscriptIndexEntry } from './transcript-index.t
 export {
   SessionRegistryFile,
   type LiveSessionEntry,
+  type PendingQuestionEntry,
   claudeChildLooksAlive,
   DEFAULT_BASE_PORT,
   DEFAULT_PORT_RANGE,
 } from './session-registry-file.ts';
+
+export {
+  buildPendingQuestionLabel,
+  PENDING_QUESTION_LABEL_MAX,
+} from './pending-question-label.ts';
+
+export { PendingQuestionCreatedAtTracker } from './pending-question-created-at-tracker.ts';

--- a/packages/daemon/src/session/pending-question-created-at-tracker.ts
+++ b/packages/daemon/src/session/pending-question-created-at-tracker.ts
@@ -1,0 +1,47 @@
+/**
+ * Tracks first-seen timestamps for a session's pending questions (#786/#787).
+ *
+ * `SessionRegistry`'s `onQuestionsChanged` event fires with the FULL current
+ * question set every time ANY question is added, answered, or cleared —
+ * and `Question` itself carries no timestamp. Stamping every still-pending
+ * question with "now" on every event would misreport how long a question
+ * has actually been waiting (every OTHER pending question would appear to
+ * have just arrived). This tracker memoizes each question id's first-seen
+ * time so the `LiveSessionEntry.pendingQuestions` mirror reports a stable
+ * `createdAt`, and prunes ids that are no longer pending so the map cannot
+ * grow unbounded across a long session's lifetime.
+ *
+ * One instance per daemon (one session per daemon), constructed once in
+ * cli.ts alongside the SessionRegistry it observes.
+ */
+
+import type { Question, UUID } from '@remi/shared';
+import { buildPendingQuestionLabel } from './pending-question-label.ts';
+import type { PendingQuestionEntry } from './session-registry-file.ts';
+
+export class PendingQuestionCreatedAtTracker {
+  private readonly firstSeen = new Map<UUID, string>();
+
+  /** Injectable clock so tests can assert exact `createdAt` values. */
+  constructor(private readonly nowIso: () => string = () => new Date().toISOString()) {}
+
+  /**
+   * Recompute the registry-file entries for the current question set.
+   * Prunes ids no longer present in `questions` and assigns a fresh
+   * `createdAt` only to ids seen for the first time.
+   */
+  sync(questions: readonly Question[]): PendingQuestionEntry[] {
+    const liveIds = new Set(questions.map((q) => q.id));
+    for (const id of this.firstSeen.keys()) {
+      if (!liveIds.has(id)) this.firstSeen.delete(id);
+    }
+    return questions.map((q) => {
+      let createdAt = this.firstSeen.get(q.id);
+      if (createdAt === undefined) {
+        createdAt = this.nowIso();
+        this.firstSeen.set(q.id, createdAt);
+      }
+      return { id: q.id, label: buildPendingQuestionLabel(q), createdAt };
+    });
+  }
+}

--- a/packages/daemon/src/session/pending-question-label.ts
+++ b/packages/daemon/src/session/pending-question-label.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure label builder for the live-sessions registry's `pendingQuestions`
+ * mirror (#786/#787). Produces a short, human-readable string for a pending
+ * `Question` — used by the macOS menu-bar app's native notifications and
+ * the hub census, neither of which has the full Question payload (only the
+ * registry file's flat `{id, label, createdAt}` entries).
+ *
+ * Not the same string as `notifications/notification-dispatcher.ts`'s
+ * `buildPushText`: that one builds a lock-screen title+body pair (session
+ * name prefixed, full option list). This one is a single short phrase
+ * suitable for a menu-bar list row or a notification body line.
+ */
+
+import type { Question } from '@remi/shared';
+
+/** Cap for a generic (non-permission) label — a truncated question/summary
+ *  text is still readable at this length in a notification body or list row. */
+export const PENDING_QUESTION_LABEL_MAX = 140;
+
+/** Truncate to `max` characters, appending an ellipsis when cut. */
+function truncateLabel(text: string, max: number): string {
+  const trimmed = text.replace(/\s+/g, ' ').trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+/**
+ * Extract the tool name from a permission-request question's generated
+ * text. `HookEventBridge.buildPermissionQuestion` (hook-event-bridge.ts)
+ * produces exactly two shapes for the non-AskUserQuestion/ExitPlanMode
+ * branch:
+ *   - no subagent: "Allow Bash: git push origin main" or "Allow Bash"
+ *   - subagent:    "code-reviewer · Bash: git push origin main" or
+ *                   "code-reviewer · Bash"
+ * Returns null for any other shape (notably the toolQuestion branch, which
+ * is already phrased as a natural question with no "Allow " prefix) so the
+ * caller falls back to the generic text-based label instead of extracting
+ * garbage.
+ */
+function extractPermissionToolName(text: string): string | null {
+  let rest: string;
+  const agentSepIdx = text.indexOf(' · ');
+  if (agentSepIdx >= 0) {
+    rest = text.slice(agentSepIdx + 3);
+  } else if (text.startsWith('Allow ')) {
+    rest = text.slice('Allow '.length);
+  } else {
+    return null;
+  }
+  const colonIdx = rest.indexOf(':');
+  const toolName = (colonIdx >= 0 ? rest.slice(0, colonIdx) : rest).trim();
+  return toolName.length > 0 ? toolName : null;
+}
+
+/**
+ * Build a short label for a pending question (#786/#787):
+ *   - a multi-question AskUserQuestion form: the topics (header, or text)
+ *     of every sub-question, comma-joined
+ *   - a permission-request question shaped like "Allow <tool>: <command>"
+ *     (or its subagent-prefixed variant): "Permission: <tool>"
+ *   - everything else (AskUserQuestion/ExitPlanMode toolQuestion prompts,
+ *     StopFailure, PTY-parsed fallback prompts): the summary or question
+ *     text, truncated to `PENDING_QUESTION_LABEL_MAX` characters
+ */
+export function buildPendingQuestionLabel(question: Question): string {
+  if (question.kind === 'multi_question' && question.questions && question.questions.length > 0) {
+    const topics = question.questions.map((s) => s.header || s.text).join(', ');
+    return truncateLabel(topics, PENDING_QUESTION_LABEL_MAX);
+  }
+  if (question.source === 'permission_request') {
+    const toolName = extractPermissionToolName(question.text);
+    if (toolName) return `Permission: ${toolName}`;
+  }
+  return truncateLabel(question.summary || question.text, PENDING_QUESTION_LABEL_MAX);
+}

--- a/packages/daemon/src/session/session-registry-file.ts
+++ b/packages/daemon/src/session/session-registry-file.ts
@@ -19,6 +19,19 @@ import { isProcessAlive } from './process-alive.ts';
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const LIVE_SESSIONS_DIR = path.join(REMI_DIR, 'live-sessions');
 
+/**
+ * One unanswered question surfaced in the live-sessions registry mirror
+ * (#786/#787): the hub census reads this straight off disk to build the
+ * `hub_status.questions` list, without needing to talk to the owning session
+ * daemon. `label` is a short human string, e.g. "Permission: Bash" or a
+ * truncated free-text question (see `buildPendingQuestionLabel`).
+ */
+export interface PendingQuestionEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly createdAt: string;
+}
+
 /** A live session entry written by each remi wrapper process. */
 export interface LiveSessionEntry {
   readonly sessionId: string;
@@ -48,6 +61,16 @@ export interface LiveSessionEntry {
    * installed binary to flag stale daemons.
    */
   readonly version?: string;
+  /**
+   * Unanswered questions currently pending on this session (#786/#787),
+   * mirroring `SessionRegistry`'s in-memory `currentQuestions` so the hub
+   * (which never talks to a session daemon's own connection) can build its
+   * `hub_status` census straight off the registry file. Kept in sync by
+   * `setPendingQuestions` on every add/resolve/clear via `SessionRegistry`'s
+   * `onQuestionsChanged` event. Absent on legacy entries and pre-#786
+   * daemons; both cases mean "unknown", not "definitely none".
+   */
+  readonly pendingQuestions?: readonly PendingQuestionEntry[];
 }
 
 /**
@@ -68,6 +91,18 @@ export function claudeChildLooksAlive(entry: LiveSessionEntry): boolean {
 export const DEFAULT_BASE_PORT = DAEMON_BASE_PORT;
 export const DEFAULT_PORT_RANGE = DAEMON_PORT_RANGE;
 
+/** Type guard for a single `PendingQuestionEntry` after JSON.parse. */
+function isValidPendingQuestionEntry(data: unknown): data is PendingQuestionEntry {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj['id'] === 'string' &&
+    obj['id'].length > 0 &&
+    typeof obj['label'] === 'string' &&
+    typeof obj['createdAt'] === 'string'
+  );
+}
+
 /** Type guard for LiveSessionEntry after JSON.parse. */
 function isValidEntry(data: unknown): data is LiveSessionEntry {
   if (typeof data !== 'object' || data === null) return false;
@@ -78,6 +113,10 @@ function isValidEntry(data: unknown): data is LiveSessionEntry {
     (typeof childPid === 'number' && Number.isInteger(childPid) && childPid > 0);
   const childExited = obj['claudeChildExited'];
   const childExitedOk = childExited === undefined || typeof childExited === 'boolean';
+  const pendingQuestions = obj['pendingQuestions'];
+  const pendingQuestionsOk =
+    pendingQuestions === undefined ||
+    (Array.isArray(pendingQuestions) && pendingQuestions.every(isValidPendingQuestionEntry));
   return (
     typeof obj['sessionId'] === 'string' &&
     obj['sessionId'].length > 0 &&
@@ -87,7 +126,8 @@ function isValidEntry(data: unknown): data is LiveSessionEntry {
     obj['wsPort'] > 0 &&
     obj['wsPort'] <= 65535 &&
     childPidOk &&
-    childExitedOk
+    childExitedOk &&
+    pendingQuestionsOk
   );
 }
 
@@ -184,6 +224,18 @@ export class SessionRegistryFile {
    */
   markClaudeChildExited(sessionId: string): void {
     this.patchEntry(sessionId, { claudeChildExited: true });
+  }
+
+  /**
+   * Replace the pending-questions mirror for a session (#786/#787). Called
+   * from the daemon's `SessionRegistry.onQuestionsChanged` event, which
+   * fires with the FULL current question set on every add/resolve/clear —
+   * so this always overwrites rather than merges, keeping the file an exact
+   * mirror of `SessionRegistry`'s in-memory `currentQuestions` regardless of
+   * which lifecycle path (hook, PTY-parsed, terminal, push, web) changed it.
+   */
+  setPendingQuestions(sessionId: string, pendingQuestions: readonly PendingQuestionEntry[]): void {
+    this.patchEntry(sessionId, { pendingQuestions });
   }
 
   /**

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -106,6 +106,15 @@ export interface SessionRegistryEvents {
    * transport — the registry has no transport handle to do that itself.
    */
   onConnectionReclaimed?: (sessionId: UUID, staleConnectionId: UUID, newConnectionId: UUID) => void;
+  /**
+   * The session's pending-question set changed: one was added, one was
+   * resolved (from any surface — terminal, push, web), or all were cleared
+   * (#786/#787). Fires with the FULL current set (not a delta) from
+   * `addQuestion`/`removeQuestion`/`clearQuestions`, so a caller mirroring
+   * this into another store (the live-sessions registry file, for the hub
+   * census) can always overwrite rather than merge.
+   */
+  onQuestionsChanged?: (sessionId: UUID, questions: readonly Question[]) => void;
 }
 
 /** A managed session with all its runtime state */
@@ -664,6 +673,7 @@ export class SessionRegistry {
       );
     }
     this.session.lastActivityAt = now();
+    this.events.onQuestionsChanged?.(sessionId, [...map.values()]);
   }
 
   /** Remove one answered/resolved question by id. */
@@ -671,6 +681,7 @@ export class SessionRegistry {
     if (this.session !== null && this.session.sessionId === sessionId) {
       this.session.currentQuestions.delete(questionId);
       this.session.lastActivityAt = now();
+      this.events.onQuestionsChanged?.(sessionId, [...this.session.currentQuestions.values()]);
     }
   }
 
@@ -682,6 +693,7 @@ export class SessionRegistry {
     if (this.session !== null && this.session.sessionId === sessionId) {
       this.session.currentQuestions.clear();
       this.session.lastActivityAt = now();
+      this.events.onQuestionsChanged?.(sessionId, []);
     }
   }
 

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -591,7 +591,7 @@ describe('onPeerConnect/onPeerDisconnect feed the hub census (#650)', () => {
           sent.push({ connectionId, message });
         },
         broadcast: (message) => broadcasts.push(message),
-        getSessions: () => 0,
+        getCensus: () => ({ sessions: 0, questions: [] }),
         hubVersion: '9.9.9-test',
       });
       const handlers = createConnectionHandlers({

--- a/packages/daemon/tests/cli/hub-client-tracker.test.ts
+++ b/packages/daemon/tests/cli/hub-client-tracker.test.ts
@@ -5,9 +5,10 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { HubStatusMessage, ProtocolMessage, UUID } from '@remi/shared';
+import type { HubPendingQuestion, HubStatusMessage, ProtocolMessage, UUID } from '@remi/shared';
 import type { AdapterMetadata } from '../../src/adapters/index.ts';
 import { HubClientTracker, classifyClient } from '../../src/cli/hub-client-tracker.ts';
+import type { HubQuestionCensus } from '../../src/cli/hub-question-census.ts';
 
 function wsMeta(peerAddress: string | null, mode?: 'query' | 'attach'): AdapterMetadata {
   return {
@@ -48,21 +49,35 @@ describe('classifyClient (#650)', () => {
   });
 });
 
-describe('HubClientTracker (#650)', () => {
-  function makeTracker(initialSessions = 0) {
+function makeQuestion(overrides: Partial<HubPendingQuestion> = {}): HubPendingQuestion {
+  return {
+    id: 'q-1',
+    sessionId: 's-1',
+    sessionName: 'host:project/main',
+    label: 'Permission: Bash',
+    createdAt: '2026-07-17T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('HubClientTracker (#650, #786/#787)', () => {
+  function makeTracker(initialSessions = 0, initialQuestions: HubPendingQuestion[] = []) {
     const sent: Array<{ connectionId: UUID; message: ProtocolMessage }> = [];
     const broadcasts: ProtocolMessage[] = [];
-    let sessions = initialSessions;
+    let census: HubQuestionCensus = { sessions: initialSessions, questions: initialQuestions };
     const tracker = new HubClientTracker({
       send: (connectionId, message) => sent.push({ connectionId, message }),
       broadcast: (message) => broadcasts.push(message),
-      getSessions: () => sessions,
+      getCensus: () => census,
       hubVersion: '9.9.9-test',
     });
     const setSessions = (n: number): void => {
-      sessions = n;
+      census = { ...census, sessions: n };
     };
-    return { tracker, sent, broadcasts, setSessions };
+    const setQuestions = (questions: HubPendingQuestion[]): void => {
+      census = { ...census, questions };
+    };
+    return { tracker, sent, broadcasts, setSessions, setQuestions };
   }
 
   const asStatus = (m: ProtocolMessage): HubStatusMessage => m as HubStatusMessage;
@@ -124,13 +139,25 @@ describe('HubClientTracker (#650)', () => {
     tracker.onConnect('r1' as UUID, wsMeta('192.168.1.20'));
     tracker.onConnect('q1' as UUID, wsMeta('127.0.0.1', 'query'));
 
-    expect(tracker.counts()).toEqual({ localClients: 2, remoteClients: 1, sessions: 0 });
+    expect(tracker.counts()).toEqual({
+      localClients: 2,
+      remoteClients: 1,
+      sessions: 0,
+      pendingQuestions: 0,
+      questions: [],
+    });
     const last = asStatus(broadcasts.at(-1) as ProtocolMessage);
     expect(last.localClients).toBe(2);
     expect(last.remoteClients).toBe(1);
 
     tracker.onDisconnect('l1' as UUID);
-    expect(tracker.counts()).toEqual({ localClients: 1, remoteClients: 1, sessions: 0 });
+    expect(tracker.counts()).toEqual({
+      localClients: 1,
+      remoteClients: 1,
+      sessions: 0,
+      pendingQuestions: 0,
+      questions: [],
+    });
   });
 
   test('refresh broadcasts only when the session census changed', () => {
@@ -145,5 +172,65 @@ describe('HubClientTracker (#650)', () => {
     tracker.refresh();
     expect(broadcasts).toHaveLength(1);
     expect(asStatus(broadcasts[0]!).sessions).toBe(2);
+  });
+
+  test('cold start seeds the pending-question census too (no spurious first broadcast)', () => {
+    const q = makeQuestion();
+    const { tracker, broadcasts, sent } = makeTracker(1, [q]);
+    tracker.onConnect('q1' as UUID, wsMeta('127.0.0.1', 'query'));
+    expect(broadcasts).toHaveLength(0);
+    const frame = asStatus(sent[0]!.message);
+    expect(frame.pendingQuestions).toBe(1);
+    expect(frame.questions).toEqual([q]);
+  });
+
+  test('refresh broadcasts a NEW question even when counts are unchanged', () => {
+    const { tracker, broadcasts, setQuestions } = makeTracker(1, []);
+    tracker.onConnect('c1' as UUID, wsMeta('127.0.0.1'));
+    broadcasts.length = 0;
+
+    setQuestions([makeQuestion({ id: 'q-new' })]);
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(1);
+    const frame = asStatus(broadcasts[0]!);
+    expect(frame.pendingQuestions).toBe(1);
+    expect(frame.questions).toEqual([makeQuestion({ id: 'q-new' })]);
+  });
+
+  test('refresh broadcasts when a question is answered (count drops to 0)', () => {
+    const q = makeQuestion();
+    const { tracker, broadcasts, setQuestions } = makeTracker(1, [q]);
+    tracker.onConnect('c1' as UUID, wsMeta('127.0.0.1'));
+    broadcasts.length = 0;
+
+    setQuestions([]);
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(1);
+    expect(asStatus(broadcasts[0]!).pendingQuestions).toBe(0);
+  });
+
+  test('refresh broadcasts when the SET changes but the SIZE does not', () => {
+    // One answered, a different one arrives in the same beat: pure count
+    // comparison would miss this (both censuses have length 1).
+    const { tracker, broadcasts, setQuestions } = makeTracker(1, [makeQuestion({ id: 'q-old' })]);
+    tracker.onConnect('c1' as UUID, wsMeta('127.0.0.1'));
+    broadcasts.length = 0;
+
+    setQuestions([makeQuestion({ id: 'q-different' })]);
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(1);
+    expect(asStatus(broadcasts[0]!).questions?.[0]?.id).toBe('q-different');
+  });
+
+  test('refresh does NOT broadcast when the question set is unchanged, just reordered', () => {
+    const a = makeQuestion({ id: 'q-a' });
+    const b = makeQuestion({ id: 'q-b' });
+    const { tracker, broadcasts, setQuestions } = makeTracker(1, [a, b]);
+    tracker.onConnect('c1' as UUID, wsMeta('127.0.0.1'));
+    broadcasts.length = 0;
+
+    setQuestions([b, a]); // same ids, different order
+    tracker.refresh();
+    expect(broadcasts).toHaveLength(0);
   });
 });

--- a/packages/daemon/tests/cli/hub-question-census.test.ts
+++ b/packages/daemon/tests/cli/hub-question-census.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Real-fs test for the hub census aggregation (#786/#787): writes
+ * LiveSessionEntry files to a real temp directory through SessionRegistryFile
+ * (same path the daemon uses), then verifies buildHubQuestionCensus flattens
+ * them into the wire-shaped HubPendingQuestion list. No mocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { buildHubQuestionCensus } from '../../src/cli/hub-question-census.ts';
+import {
+  DEFAULT_BASE_PORT,
+  type LiveSessionEntry,
+  SessionRegistryFile,
+} from '../../src/session/session-registry-file.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-hub-census-test-'));
+}
+
+function makeEntry(overrides: Partial<LiveSessionEntry> = {}): LiveSessionEntry {
+  return {
+    sessionId: `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    pid: process.pid,
+    wsPort: DEFAULT_BASE_PORT,
+    hookPort: DEFAULT_BASE_PORT + 100,
+    projectPath: '/tmp/test-project',
+    name: 'test:project/main',
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('buildHubQuestionCensus (#786/#787, real fs)', () => {
+  let tmpDir: string;
+  let registry: SessionRegistryFile;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    registry = new SessionRegistryFile(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('empty registry census is zero sessions, zero questions', () => {
+    const census = buildHubQuestionCensus(registry.listLive());
+    expect(census).toEqual({ sessions: 0, questions: [] });
+  });
+
+  test('sessions with no pending questions count toward `sessions` but contribute nothing to `questions`', () => {
+    registry.register(makeEntry({ sessionId: 'a', wsPort: DEFAULT_BASE_PORT }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: DEFAULT_BASE_PORT + 1 }));
+
+    const census = buildHubQuestionCensus(registry.listLive());
+    expect(census.sessions).toBe(2);
+    expect(census.questions).toEqual([]);
+  });
+
+  test('flattens each session pendingQuestions entry, carrying sessionId + sessionName', () => {
+    registry.register(
+      makeEntry({ sessionId: 'a', name: 'host:project-a/main', wsPort: DEFAULT_BASE_PORT }),
+    );
+    registry.register(
+      makeEntry({ sessionId: 'b', name: 'host:project-b/dev', wsPort: DEFAULT_BASE_PORT + 1 }),
+    );
+    registry.setPendingQuestions('a', [
+      { id: 'qa1', label: 'Permission: Bash', createdAt: '2026-07-17T00:00:00.000Z' },
+      { id: 'qa2', label: 'Allow this action?', createdAt: '2026-07-17T00:00:01.000Z' },
+    ]);
+    registry.setPendingQuestions('b', [
+      { id: 'qb1', label: 'Permission: Write', createdAt: '2026-07-17T00:00:02.000Z' },
+    ]);
+
+    const census = buildHubQuestionCensus(registry.listLive());
+    expect(census.sessions).toBe(2);
+    expect(census.questions).toHaveLength(3);
+
+    const byId = new Map(census.questions.map((q) => [q.id, q]));
+    expect(byId.get('qa1')).toEqual({
+      id: 'qa1',
+      sessionId: 'a',
+      sessionName: 'host:project-a/main',
+      label: 'Permission: Bash',
+      createdAt: '2026-07-17T00:00:00.000Z',
+    });
+    expect(byId.get('qb1')).toEqual({
+      id: 'qb1',
+      sessionId: 'b',
+      sessionName: 'host:project-b/dev',
+      label: 'Permission: Write',
+      createdAt: '2026-07-17T00:00:02.000Z',
+    });
+  });
+
+  test('answering a question (setPendingQuestions with a smaller set) drops it from the next census', () => {
+    registry.register(makeEntry({ sessionId: 'a' }));
+    registry.setPendingQuestions('a', [
+      { id: 'q1', label: 'x', createdAt: 't1' },
+      { id: 'q2', label: 'y', createdAt: 't2' },
+    ]);
+    registry.setPendingQuestions('a', [{ id: 'q2', label: 'y', createdAt: 't2' }]);
+
+    const census = buildHubQuestionCensus(registry.listLive());
+    expect(census.questions.map((q) => q.id)).toEqual(['q2']);
+  });
+
+  test('a stale (dead-pid) session is dropped by listLive before it reaches the census', () => {
+    registry.register(makeEntry({ sessionId: 'dead', pid: 999999 }));
+    registry.setPendingQuestions('dead', [{ id: 'q1', label: 'x', createdAt: 't' }]);
+
+    // listLive() itself reaps the dead entry (pre-existing behavior); the
+    // census must reflect that, not resurrect a question for a gone daemon.
+    const census = buildHubQuestionCensus(registry.listLive());
+    expect(census.sessions).toBe(0);
+    expect(census.questions).toEqual([]);
+  });
+});

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -433,4 +433,68 @@ describe('SessionRegistryFile', () => {
       ).toBe(false);
     });
   });
+
+  // ---- pending questions mirror (#786/#787) -------------------------------
+
+  describe('pending questions', () => {
+    test('setPendingQuestions round-trips and preserves other fields (notably startedAt)', () => {
+      const entry = makeEntry({ sessionId: 's', wsPort: 18767 });
+      registry.register(entry);
+      registry.setPendingQuestions('s', [
+        { id: 'q1', label: 'Permission: Bash', createdAt: '2026-07-17T00:00:00.000Z' },
+      ]);
+
+      const live = registry.listLive();
+      expect(live).toHaveLength(1);
+      expect(live[0]!.pendingQuestions).toEqual([
+        { id: 'q1', label: 'Permission: Bash', createdAt: '2026-07-17T00:00:00.000Z' },
+      ]);
+      expect(live[0]!.startedAt).toBe(entry.startedAt);
+      expect(live[0]!.wsPort).toBe(18767);
+    });
+
+    test('setPendingQuestions with an empty array clears the mirror', () => {
+      registry.register(makeEntry({ sessionId: 's' }));
+      registry.setPendingQuestions('s', [{ id: 'q1', label: 'x', createdAt: 'now' }]);
+      registry.setPendingQuestions('s', []);
+
+      const live = registry.listLive();
+      expect(live[0]!.pendingQuestions).toEqual([]);
+    });
+
+    test('legacy entry without pendingQuestions parses with the field absent', () => {
+      registry.register(makeEntry({ sessionId: 'legacy' }));
+      const live = registry.listLive();
+      expect(live[0]!.pendingQuestions).toBeUndefined();
+    });
+
+    test('setPendingQuestions is a no-op for a missing entry', () => {
+      registry.setPendingQuestions('ghost', [{ id: 'q1', label: 'x', createdAt: 'now' }]);
+      expect(registry.listLive()).toHaveLength(0);
+    });
+
+    test('an entry with a malformed pendingQuestions array is rejected by listLive', () => {
+      const filePath = path.join(tmpDir, 'bad-pq.json');
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          ...makeEntry({ sessionId: 'bad-pq' }),
+          pendingQuestions: [{ id: 'q1' /* missing label/createdAt */ }],
+        }),
+      );
+      expect(registry.listLive()).toHaveLength(0);
+    });
+
+    test('multiple sessions each keep their own independent pendingQuestions', () => {
+      registry.register(makeEntry({ sessionId: 'a' }));
+      registry.register(makeEntry({ sessionId: 'b' }));
+      registry.setPendingQuestions('a', [{ id: 'qa', label: 'A', createdAt: 't' }]);
+
+      const live = registry.listLive();
+      const a = live.find((e) => e.sessionId === 'a');
+      const b = live.find((e) => e.sessionId === 'b');
+      expect(a!.pendingQuestions).toEqual([{ id: 'qa', label: 'A', createdAt: 't' }]);
+      expect(b!.pendingQuestions).toBeUndefined();
+    });
+  });
 });

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -35,6 +35,7 @@ describe('SessionRegistry', () => {
     onSessionResumed: ReturnType<typeof mock>;
     onConnectionPromoted: ReturnType<typeof mock>;
     onConnectionReclaimed: ReturnType<typeof mock>;
+    onQuestionsChanged: ReturnType<typeof mock>;
   };
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('SessionRegistry', () => {
       onSessionResumed: mock(() => {}),
       onConnectionPromoted: mock(() => {}),
       onConnectionReclaimed: mock(() => {}),
+      onQuestionsChanged: mock(() => {}),
     };
 
     registry = new SessionRegistry(
@@ -155,6 +157,59 @@ describe('SessionRegistry', () => {
 
       const result = registry.attachConnection(sid, generateId());
       expect(result.currentQuestions.map((q) => q.id)).toEqual([q1, q2]);
+    });
+
+    describe('onQuestionsChanged (#786/#787)', () => {
+      test('fires with the full current set on addQuestion', () => {
+        const sid = generateId();
+        registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+        const q1 = generateId();
+        registry.addQuestion(sid, mkQuestion(q1));
+        expect(events.onQuestionsChanged).toHaveBeenLastCalledWith(sid, [mkQuestion(q1)]);
+
+        const q2 = generateId();
+        registry.addQuestion(sid, mkQuestion(q2, 'sub-7'));
+        expect(events.onQuestionsChanged).toHaveBeenLastCalledWith(sid, [
+          mkQuestion(q1),
+          mkQuestion(q2, 'sub-7'),
+        ]);
+      });
+
+      test('fires with the reduced set on removeQuestion', () => {
+        const sid = generateId();
+        registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+        const q1 = generateId();
+        const q2 = generateId();
+        registry.addQuestion(sid, mkQuestion(q1));
+        registry.addQuestion(sid, mkQuestion(q2));
+        events.onQuestionsChanged.mockClear();
+
+        registry.removeQuestion(sid, q1);
+        expect(events.onQuestionsChanged).toHaveBeenCalledTimes(1);
+        expect(events.onQuestionsChanged).toHaveBeenCalledWith(sid, [mkQuestion(q2)]);
+      });
+
+      test('fires with an empty array on clearQuestions', () => {
+        const sid = generateId();
+        registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+        registry.addQuestion(sid, mkQuestion(generateId()));
+        events.onQuestionsChanged.mockClear();
+
+        registry.clearQuestions(sid);
+        expect(events.onQuestionsChanged).toHaveBeenCalledWith(sid, []);
+      });
+
+      test('does not fire for a sessionId that does not match the registered session', () => {
+        const sid = generateId();
+        registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+        registry.addQuestion(
+          'unknown-session' as ReturnType<typeof generateId>,
+          mkQuestion(generateId()),
+        );
+        registry.removeQuestion('unknown-session' as ReturnType<typeof generateId>, generateId());
+        registry.clearQuestions('unknown-session' as ReturnType<typeof generateId>);
+        expect(events.onQuestionsChanged).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/daemon/tests/session/pending-question-created-at-tracker.test.ts
+++ b/packages/daemon/tests/session/pending-question-created-at-tracker.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for PendingQuestionCreatedAtTracker (#786/#787): a question's
+ * createdAt must stay stable across repeated sync() calls (the
+ * onQuestionsChanged event fires with the FULL current set on every
+ * add/remove), and must be pruned once the question is no longer pending.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question } from '@remi/shared';
+import { PendingQuestionCreatedAtTracker } from '../../src/session/pending-question-created-at-tracker.ts';
+
+function mkQuestion(id: string, overrides: Partial<Question> = {}): Question {
+  return {
+    id,
+    text: `${id}?`,
+    options: [],
+    allowsFreeText: false,
+    isAnswered: false,
+    ...overrides,
+  };
+}
+
+describe('PendingQuestionCreatedAtTracker (#786/#787)', () => {
+  test('assigns createdAt on first sight and keeps it stable across later syncs', () => {
+    let clock = 0;
+    const tracker = new PendingQuestionCreatedAtTracker(() => `t${clock++}`);
+
+    const first = tracker.sync([mkQuestion('q1')]);
+    expect(first).toEqual([{ id: 'q1', label: 'q1?', createdAt: 't0' }]);
+
+    // A SECOND question arrives; q1 must keep its original createdAt even
+    // though this is a new sync() call driven by a fresh onQuestionsChanged.
+    const second = tracker.sync([mkQuestion('q1'), mkQuestion('q2')]);
+    expect(second).toEqual([
+      { id: 'q1', label: 'q1?', createdAt: 't0' },
+      { id: 'q2', label: 'q2?', createdAt: 't1' },
+    ]);
+  });
+
+  test('prunes an id once it is no longer in the live set, so it re-stamps if it ever returns', () => {
+    let clock = 0;
+    const tracker = new PendingQuestionCreatedAtTracker(() => `t${clock++}`);
+
+    tracker.sync([mkQuestion('q1')]);
+    tracker.sync([]); // q1 answered/resolved
+
+    // A brand-new question that happens to reuse the id 'q1' (unrealistic in
+    // practice -- UUIDs -- but the tracker has no way to know that, and the
+    // point is: gone-then-back gets a FRESH timestamp, not the stale one).
+    const resynced = tracker.sync([mkQuestion('q1')]);
+    expect(resynced).toEqual([{ id: 'q1', label: 'q1?', createdAt: 't1' }]);
+  });
+
+  test('empty sync clears everything and returns an empty array', () => {
+    const tracker = new PendingQuestionCreatedAtTracker(() => 'now');
+    tracker.sync([mkQuestion('q1'), mkQuestion('q2')]);
+    expect(tracker.sync([])).toEqual([]);
+  });
+
+  test('uses buildPendingQuestionLabel for the label field', () => {
+    const tracker = new PendingQuestionCreatedAtTracker(() => 'now');
+    const [entry] = tracker.sync([
+      mkQuestion('q1', { text: 'Allow Bash: ls', source: 'permission_request' }),
+    ]);
+    expect(entry?.label).toBe('Permission: Bash');
+  });
+
+  test('defaults to a real ISO clock when none is injected', () => {
+    const tracker = new PendingQuestionCreatedAtTracker();
+    const [entry] = tracker.sync([mkQuestion('q1')]);
+    expect(entry?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+});

--- a/packages/daemon/tests/session/pending-question-label.test.ts
+++ b/packages/daemon/tests/session/pending-question-label.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the pending-question label builder (#786/#787): pure function,
+ * no fs/network involved.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question } from '@remi/shared';
+import {
+  PENDING_QUESTION_LABEL_MAX,
+  buildPendingQuestionLabel,
+} from '../../src/session/pending-question-label.ts';
+
+function mkQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'q-1',
+    text: 'Allow this action?',
+    options: [],
+    allowsFreeText: false,
+    isAnswered: false,
+    ...overrides,
+  };
+}
+
+describe('buildPendingQuestionLabel (#786/#787)', () => {
+  test('a plain permission-request question becomes "Permission: <tool>"', () => {
+    const q = mkQuestion({
+      text: 'Allow Bash: git push origin main',
+      source: 'permission_request',
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Permission: Bash');
+  });
+
+  test('a tool with no command summary still extracts cleanly', () => {
+    const q = mkQuestion({ text: 'Allow Write', source: 'permission_request' });
+    expect(buildPendingQuestionLabel(q)).toBe('Permission: Write');
+  });
+
+  test('a subagent-prefixed permission-request question extracts the tool, not the agent', () => {
+    const q = mkQuestion({
+      text: 'code-reviewer · Bash: git push origin main',
+      source: 'permission_request',
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Permission: Bash');
+  });
+
+  test('a subagent-prefixed permission-request question with no command', () => {
+    const q = mkQuestion({ text: 'code-reviewer · Bash', source: 'permission_request' });
+    expect(buildPendingQuestionLabel(q)).toBe('Permission: Bash');
+  });
+
+  test('an AskUserQuestion/ExitPlanMode-style permission_request (already phrased as a question) falls back to text', () => {
+    // toolQuestion branch of buildPermissionQuestion: no "Allow " prefix, no
+    // agent separator either (main agent) -- extractPermissionToolName must
+    // return null and NOT fabricate a "Permission: " label.
+    const q = mkQuestion({
+      text: 'Exit plan mode and start implementing?',
+      source: 'permission_request',
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Exit plan mode and start implementing?');
+  });
+
+  test('a StopFailure question (no source) uses the text verbatim', () => {
+    const q = mkQuestion({ text: 'Session stop failed (timeout). Retry?' });
+    expect(buildPendingQuestionLabel(q)).toBe('Session stop failed (timeout). Retry?');
+  });
+
+  test('a PTY-fallback question (source pty) uses the text verbatim', () => {
+    const q = mkQuestion({ text: 'Overwrite existing file?', source: 'pty' });
+    expect(buildPendingQuestionLabel(q)).toBe('Overwrite existing file?');
+  });
+
+  test('a summary, when present, is preferred over text for non-permission questions', () => {
+    const q = mkQuestion({
+      text: 'Allow Bash: git push --force origin main',
+      summary: 'Force-push to main?',
+      source: 'pty',
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Force-push to main?');
+  });
+
+  test('a multi_question AskUserQuestion joins sub-question headers', () => {
+    const q = mkQuestion({
+      kind: 'multi_question',
+      questions: [
+        { header: 'Framework', text: 'Which framework?', multiSelect: false, options: [] },
+        { header: 'Language', text: 'Which language?', multiSelect: false, options: [] },
+      ],
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Framework, Language');
+  });
+
+  test('a multi_question sub-question with no header falls back to its text', () => {
+    const q = mkQuestion({
+      kind: 'multi_question',
+      questions: [{ header: '', text: 'Pick an option', multiSelect: false, options: [] }],
+    });
+    expect(buildPendingQuestionLabel(q)).toBe('Pick an option');
+  });
+
+  test('long free text is truncated to PENDING_QUESTION_LABEL_MAX with an ellipsis', () => {
+    const longText = `A${'b'.repeat(200)}?`;
+    const q = mkQuestion({ text: longText, source: 'pty' });
+    const label = buildPendingQuestionLabel(q);
+    expect(label.length).toBe(PENDING_QUESTION_LABEL_MAX);
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  test('whitespace runs (PTY column-aligned garble) collapse to single spaces', () => {
+    const q = mkQuestion({ text: 'Do   you\n\nwant   to proceed?', source: 'pty' });
+    expect(buildPendingQuestionLabel(q)).toBe('Do you want to proceed?');
+  });
+});

--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		56A2EE338C23F3064E056B31 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DD72A5787EF3FFBF772C89F /* Assets.xcassets */; };
 		5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */; };
+		6769D18A40238978D0A1A802 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */; };
 		7099815B76AC17566B2A96C5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */; };
 		7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */; };
 		779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
@@ -32,8 +33,10 @@
 		B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
 		C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */; };
+		D914DD758D12BA0F2F2192AA /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */; };
 		DCB33A9FC9A43C32D55F1C86 /* HubSetupCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */; };
 		E2A47A3FEF612AA225168AB6 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
+		F1F060E53A0E11347B560DD6 /* NotificationDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEF3BCD8B2F7017165A715A /* NotificationDiffTests.swift */; };
 		FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
 /* End PBXBuildFile section */
@@ -52,8 +55,10 @@
 		5A7875E7E74CA980AD4B502F /* IconState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconState.swift; sourceTree = "<group>"; };
 		5DB62EAF2230D75844C2E431 /* web */ = {isa = PBXFileReference; lastKnownFileType = folder; name = web; path = Remi/Resources/web; sourceTree = SOURCE_ROOT; };
 		69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClientIntegrationTests.swift; sourceTree = "<group>"; };
+		6AEF3BCD8B2F7017165A715A /* NotificationDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDiffTests.swift; sourceTree = "<group>"; };
 		6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStateTests.swift; sourceTree = "<group>"; };
 		734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandlerServingTests.swift; sourceTree = "<group>"; };
 		81CA6F64B5FFA6B90233A956 /* HubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClient.swift; sourceTree = "<group>"; };
 		B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandler.swift; sourceTree = "<group>"; };
@@ -87,6 +92,7 @@
 				5A7875E7E74CA980AD4B502F /* IconState.swift */,
 				03E03C1A89AE93F94D40EA16 /* Info.plist */,
 				E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */,
+				7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */,
 				3C92562123ECC39FB269FB4A /* Remi.entitlements */,
 				1F4E747A3D65101EAE2331D4 /* RemiApp.swift */,
 				CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */,
@@ -105,6 +111,7 @@
 				385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */,
 				C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */,
 				6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */,
+				6AEF3BCD8B2F7017165A715A /* NotificationDiffTests.swift */,
 			);
 			path = RemiTests;
 			sourceTree = "<group>";
@@ -258,6 +265,7 @@
 				E2A47A3FEF612AA225168AB6 /* HubSetupView.swift in Sources */,
 				AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */,
 				FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */,
+				6769D18A40238978D0A1A802 /* NotificationManager.swift in Sources */,
 				8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */,
 				2626DA9FECF5CE594406FCF2 /* SettingsView.swift in Sources */,
 				0C46ABF54A97FA1F17BE04B0 /* WebViewWindow.swift in Sources */,
@@ -281,6 +289,8 @@
 				5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */,
 				868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */,
 				C06956DFD17992CEB0E8F1F7 /* LaunchAtLogin.swift in Sources */,
+				F1F060E53A0E11347B560DD6 /* NotificationDiffTests.swift in Sources */,
+				D914DD758D12BA0F2F2192AA /* NotificationManager.swift in Sources */,
 				7099815B76AC17566B2A96C5 /* SettingsView.swift in Sources */,
 				FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */,
 			);

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -49,15 +49,36 @@ final class HubClient: ObservableObject {
     @Published private(set) var remoteClients = 0
     @Published private(set) var sessions = 0
     @Published private(set) var hubVersion: String?
+    /// Pending-question census (#786/#787), from the same `hub_status` frame
+    /// as the client counts. `pendingQuestions` is the total; `questions` is
+    /// the full list (session-qualified) for the menu-bar notification diff.
+    @Published private(set) var pendingQuestions = 0
+    @Published private(set) var questions: [HubPendingQuestionFrame] = []
+
+    /// Owns UNUserNotificationCenter (#786). Driven directly from
+    /// `handleFrame`'s hub_status case below, since that is where the fresh
+    /// question list already lands -- no separate SwiftUI observation needed.
+    /// RemiApp sets `onNotificationActivated` once at startup.
+    let notificationManager = NotificationManager()
 
     var iconState: IconState {
         switch phase {
         case .connected(_, isHub: true):
             return IconState.derive(
-                reachable: true, localClients: localClients, remoteClients: remoteClients)
+                reachable: true, localClients: localClients, remoteClients: remoteClients,
+                pendingQuestions: pendingQuestions)
         default:
             return .unreachable
         }
+    }
+
+    /// Pending-question summary line for the menu ("1 question waiting" /
+    /// "N questions waiting"), #786/#787. nil when nothing is pending so
+    /// RemiApp can skip the row entirely instead of showing a "0 questions"
+    /// line.
+    var questionsLine: String? {
+        guard pendingQuestions > 0 else { return nil }
+        return pendingQuestions == 1 ? "1 question waiting" : "\(pendingQuestions) questions waiting"
     }
 
     /// The URL the embedded web UI should connect to, e.g.
@@ -306,6 +327,13 @@ final class HubClient: ObservableObject {
                 remoteClients = status.remoteClients
                 sessions = status.sessions
                 hubVersion = status.hubVersion
+                pendingQuestions = status.pendingQuestions ?? 0
+                questions = status.questions ?? []
+                notificationManager.sync(
+                    current: questions.map {
+                        PendingQuestionNotice(
+                            id: $0.id, sessionName: $0.sessionName, label: $0.label)
+                    })
             }
         case "pong":
             missedPongs = 0
@@ -353,6 +381,14 @@ final class HubClient: ObservableObject {
         remoteClients = 0
         sessions = 0
         hubVersion = nil
+        // pendingQuestions/questions and the notificationManager's seen-ids
+        // are DELIBERATELY left alone here (#786/#787): a transient
+        // disconnect (missed pong, network blip, hub restart) does not mean
+        // the questions went away, just that we can't see the hub for a
+        // moment. Clearing them would withdraw live notifications for
+        // still-pending questions and re-alert on every reconnect. The next
+        // hub_status frame after reconnecting re-syncs both from the real
+        // census.
         phase = .unreachable
         consecutiveFailures += 1
         scheduleReconnect()

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -84,6 +84,16 @@ struct HelloAckFrame: Decodable {
     let daemonVersion: String?
 }
 
+/// One pending question in the hub census (#786/#787): mirrors
+/// `HubPendingQuestion` in packages/shared/src/protocol.ts.
+struct HubPendingQuestionFrame: Decodable, Equatable {
+    let id: String
+    let sessionId: String
+    let sessionName: String
+    let label: String
+    let createdAt: String
+}
+
 /// Incoming `hub_status` census (#650): the icon-state data source.
 struct HubStatusFrame: Decodable {
     let type: String
@@ -91,4 +101,8 @@ struct HubStatusFrame: Decodable {
     let remoteClients: Int
     let sessions: Int
     let hubVersion: String
+    /// #786/#787: absent on a hub build predating these fields (older
+    /// daemon than the app, or the field was never populated yet).
+    let pendingQuestions: Int?
+    let questions: [HubPendingQuestionFrame]?
 }

--- a/packages/macos/Remi/IconState.swift
+++ b/packages/macos/Remi/IconState.swift
@@ -2,10 +2,15 @@
 //  IconState.swift
 //  Remi
 //
-//  Pure reducer for the menu-bar icon (#650): (reachable, localClients,
-//  remoteClients) -> which glyph renders and how. Precedence, per the icon
-//  spec: unreachable (dimmed idle) > remote (filled, knocked-out "r") >
-//  local (hollow "r" stroke) > idle (plain outline).
+//  Pure reducer for the menu-bar icon (#650, #786/#787): (reachable,
+//  localClients, remoteClients, pendingQuestions) -> which glyph renders and
+//  how. Precedence, per the icon spec: unreachable (dimmed idle) >
+//  needsAttention (a question is pending on ANY session) > remote (filled,
+//  knocked-out "r") > local (hollow "r" stroke) > idle (plain outline).
+//  needsAttention outranks remote/local: "my agent needs me" is the one
+//  moment the icon must grab attention regardless of who else is connected.
+//  unreachable still wins over needsAttention -- with no hub connection
+//  there is no question data to trust either way.
 //
 //  Phase B ships SF-Symbol placeholders; Phase C swaps in the custom
 //  rounded-square "r" template assets without touching this reducer.
@@ -18,9 +23,13 @@ enum IconState: Equatable {
     case idle
     case localAttached
     case remoteConnected
+    case needsAttention
 
-    static func derive(reachable: Bool, localClients: Int, remoteClients: Int) -> IconState {
+    static func derive(
+        reachable: Bool, localClients: Int, remoteClients: Int, pendingQuestions: Int
+    ) -> IconState {
         if !reachable { return .unreachable }
+        if pendingQuestions > 0 { return .needsAttention }
         if remoteClients > 0 { return .remoteConnected }
         if localClients > 0 { return .localAttached }
         return .idle
@@ -36,6 +45,14 @@ enum IconState: Equatable {
         case .localAttached:
             return "menubar-local"
         case .remoteConnected:
+            return "menubar-remote"
+        case .needsAttention:
+            // #787: deliberately reuses the remoteConnected asset (filled
+            // square, knocked-out "r") rather than a new glyph. The user's
+            // spec was "the icon just inverts relative to its normal look" --
+            // the inverted look IS the remote glyph. A distinct attention
+            // treatment (e.g. a badge dot) was noted as a future option in
+            // #787, not required for this precedence change.
             return "menubar-remote"
         }
     }

--- a/packages/macos/Remi/NotificationManager.swift
+++ b/packages/macos/Remi/NotificationManager.swift
@@ -108,19 +108,36 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     /// not app launch) per the issue's implementation sketch. Safe to call
     /// repeatedly: `getNotificationSettings` reflects the real OS state, so
     /// an already-decided user is never re-prompted.
+    ///
+    /// `getNotificationSettings`/`requestAuthorization`'s completion handlers
+    /// are `@Sendable` and run on an arbitrary background queue, not
+    /// MainActor -- so every hop back into MainActor-isolated state (the
+    /// `center` property itself, and `completion`'s body, which in `sync()`
+    /// calls the MainActor-isolated `post(_:)`) must go through
+    /// `Task { @MainActor in ... }`, same pattern as the delegate callback
+    /// below.
     private func requestAuthorizationIfNeeded(_ completion: @escaping (Bool) -> Void) {
-        center.getNotificationSettings { settings in
-            switch settings.authorizationStatus {
-            case .authorized, .provisional:
-                completion(true)
-            case .notDetermined:
-                self.center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
-                    completion(granted)
+        center.getNotificationSettings { [weak self] settings in
+            Task { @MainActor [weak self] in
+                switch settings.authorizationStatus {
+                case .authorized, .provisional:
+                    completion(true)
+                case .notDetermined:
+                    self?.center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                        Task { @MainActor in
+                            completion(granted)
+                        }
+                    }
+                case .denied, .ephemeral:
+                    // Silently drops the push: the icon state (#787) and the
+                    // "N questions waiting" menu line still work (they read
+                    // hub_status directly, independent of OS authorization),
+                    // but nothing tells the user THIS is why they stopped
+                    // getting banners. Tracked in #793.
+                    completion(false)
+                @unknown default:
+                    completion(false)
                 }
-            case .denied, .ephemeral:
-                completion(false)
-            @unknown default:
-                completion(false)
             }
         }
     }

--- a/packages/macos/Remi/NotificationManager.swift
+++ b/packages/macos/Remi/NotificationManager.swift
@@ -51,7 +51,24 @@ enum NotificationDiff {
 
 @MainActor
 final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
-    private let center: UNUserNotificationCenter
+    /// LAZY, not constructed in `init()`: `UNUserNotificationCenter.current()`
+    /// requires a real app-bundle context and crashes
+    /// (`bundleProxyForCurrentProcess is nil`) when called from a process
+    /// without one -- notably `RemiTests.xctest`, which is UN-hosted by
+    /// design (project.yml) so it never runs inside `Remi.app`.
+    /// `HubClientIntegrationTests` constructs real `HubClient` instances
+    /// (and therefore a real `NotificationManager` via `HubClient`'s stored
+    /// property), so an eager `.current()` in `init()` crashed EVERY test
+    /// that merely creates a `HubClient`, not just notification-specific
+    /// ones (#786 CI failure). Deferring until the first actual post/
+    /// withdraw means a `sync()` call with nothing to report -- the common
+    /// case for those tests, which never have a pending question -- never
+    /// touches it at all.
+    private lazy var center: UNUserNotificationCenter = {
+        let c = UNUserNotificationCenter.current()
+        c.delegate = self
+        return c
+    }()
     /// Question ids from the most recent `sync()` call, so the next call can
     /// diff against it. Not persisted across launches: a question still
     /// pending after a relaunch is, correctly, treated as new again (there is
@@ -63,12 +80,6 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     /// the "Open Remi" menu item (RemiApp.swift) -- this class has no
     /// `openWindow` environment action of its own to call directly.
     var onNotificationActivated: (() -> Void)?
-
-    init(center: UNUserNotificationCenter = .current()) {
-        self.center = center
-        super.init()
-        center.delegate = self
-    }
 
     /// Called on every `hub_status` frame (#786/#787): diffs the current
     /// pending-question set against what was last synced, posts one

--- a/packages/macos/Remi/NotificationManager.swift
+++ b/packages/macos/Remi/NotificationManager.swift
@@ -1,0 +1,159 @@
+//
+//  NotificationManager.swift
+//  Remi
+//
+//  Native macOS notifications for pending Claude Code questions (#786).
+//  Same data source as the needs-attention icon state (#787): the hub_status
+//  census's `questions` list. The app is a query-mode client with no other
+//  way to learn a question is pending — this is the "push" experience iOS
+//  already has (APNS), delivered locally with no relay.
+//
+//  Authorization is requested lazily, the first time a question actually
+//  needs posting (not at launch) -- matching the issue's implementation
+//  sketch and avoiding a permission prompt for a user who never uses a
+//  session that asks questions.
+//
+
+import Foundation
+import UserNotifications
+
+/// Minimal shape NotificationManager needs from a pending question --
+/// decoupled from `HubPendingQuestionFrame` (HubProtocol.swift) so the pure
+/// diff logic below has no Codable/networking dependency and is trivially
+/// constructible from a test.
+struct PendingQuestionNotice: Equatable {
+    let id: String
+    let sessionName: String
+    let label: String
+}
+
+/// Pure diff between the previously-seen and newly-received pending-question
+/// id sets (#786). Exported as a standalone, side-effect-free function so it
+/// can be unit-tested without touching UNUserNotificationCenter at all.
+enum NotificationDiff {
+    struct Result: Equatable {
+        /// Questions whose id was NOT in the previous set -- post one
+        /// notification per entry.
+        let newQuestions: [PendingQuestionNotice]
+        /// Ids that WERE in the previous set but are absent now -- the
+        /// question was answered (from any surface) or pruned; withdraw its
+        /// notification. Sorted for deterministic test assertions.
+        let resolvedIds: [String]
+    }
+
+    static func diff(previousIds: Set<String>, current: [PendingQuestionNotice]) -> Result {
+        let currentIds = Set(current.map(\.id))
+        let newQuestions = current.filter { !previousIds.contains($0.id) }
+        let resolvedIds = previousIds.subtracting(currentIds).sorted()
+        return Result(newQuestions: newQuestions, resolvedIds: resolvedIds)
+    }
+}
+
+@MainActor
+final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
+    private let center: UNUserNotificationCenter
+    /// Question ids from the most recent `sync()` call, so the next call can
+    /// diff against it. Not persisted across launches: a question still
+    /// pending after a relaunch is, correctly, treated as new again (there is
+    /// no prior in-process notification to reconcile against).
+    private var seenIds: Set<String> = []
+
+    /// Fired when the user clicks/activates a delivered notification (#786).
+    /// Set by RemiApp to open the main window + activate the app, mirroring
+    /// the "Open Remi" menu item (RemiApp.swift) -- this class has no
+    /// `openWindow` environment action of its own to call directly.
+    var onNotificationActivated: (() -> Void)?
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+        super.init()
+        center.delegate = self
+    }
+
+    /// Called on every `hub_status` frame (#786/#787): diffs the current
+    /// pending-question set against what was last synced, posts one
+    /// notification per newly-seen id, and withdraws (both delivered and
+    /// still-pending) notifications for ids that disappeared -- answered from
+    /// the terminal, the phone, or the web UI, all indistinguishable here and
+    /// all correctly handled the same way ("answered-anywhere-clears").
+    func sync(current: [PendingQuestionNotice]) {
+        let diff = NotificationDiff.diff(previousIds: seenIds, current: current)
+        seenIds = Set(current.map(\.id))
+
+        if !diff.resolvedIds.isEmpty {
+            center.removeDeliveredNotifications(withIdentifiers: diff.resolvedIds)
+            center.removePendingNotificationRequests(withIdentifiers: diff.resolvedIds)
+        }
+        guard !diff.newQuestions.isEmpty else { return }
+        requestAuthorizationIfNeeded { [weak self] granted in
+            guard granted else { return }
+            for question in diff.newQuestions {
+                self?.post(question)
+            }
+        }
+    }
+
+    /// Authorization is requested LAZILY (first question that needs posting,
+    /// not app launch) per the issue's implementation sketch. Safe to call
+    /// repeatedly: `getNotificationSettings` reflects the real OS state, so
+    /// an already-decided user is never re-prompted.
+    private func requestAuthorizationIfNeeded(_ completion: @escaping (Bool) -> Void) {
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .authorized, .provisional:
+                completion(true)
+            case .notDetermined:
+                self.center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                    completion(granted)
+                }
+            case .denied, .ephemeral:
+                completion(false)
+            @unknown default:
+                completion(false)
+            }
+        }
+    }
+
+    private func post(_ question: PendingQuestionNotice) {
+        let content = UNMutableNotificationContent()
+        content.title = "Claude needs you"
+        content.body = "\(question.label) — \(question.sessionName)"
+        content.sound = .default
+        // Identifier = question id (#786): lets sync() withdraw this exact
+        // notification later via removeDeliveredNotifications/
+        // removePendingNotificationRequests, and lets a reconnect/re-broadcast
+        // of the same still-pending question dedupe by id instead of
+        // re-alerting (the diff above never re-posts an id already in
+        // seenIds).
+        let request = UNNotificationRequest(
+            identifier: question.id, content: content, trigger: nil)
+        center.add(request)
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Without this, UNUserNotificationCenter suppresses the banner/sound for
+    /// a notification posted while the app is foreground -- wrong here since
+    /// the menu-bar app has no "foreground" the user perceives the way a
+    /// normal app window does; they need the banner regardless.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter, willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) ->
+            Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    /// Clicking the notification activates the app and opens the main window
+    /// (#786), same pattern as the "Open Remi" menu item.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        Task { @MainActor [weak self] in
+            self?.onNotificationActivated?()
+        }
+        completionHandler()
+    }
+}

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -21,6 +21,11 @@ struct RemiApp: App {
             Text(hubClient.menuStatusLine)
             if case .connected(_, isHub: true) = hubClient.phase {
                 Text(hubClient.clientsLine)
+                // #786/#787: "1 question waiting" / "N questions waiting",
+                // the same census driving the notifications + icon state.
+                if let questionsLine = hubClient.questionsLine {
+                    Text(questionsLine)
+                }
             }
             if case .unreachable = hubClient.phase {
                 // The sandboxed app cannot start the hub itself (#651); the
@@ -74,7 +79,17 @@ struct RemiApp: App {
             // accessory app with no initial window.
             Image(hubClient.iconState.assetName)
                 .opacity(hubClient.iconState.opacity)
-                .task { hubClient.start() }
+                .task {
+                    hubClient.start()
+                    // #786: clicking a delivered notification activates the
+                    // app and opens the main window, same as "Open Remi"
+                    // below. NotificationManager has no `openWindow`
+                    // environment action of its own to call.
+                    hubClient.notificationManager.onNotificationActivated = {
+                        openWindow(id: "main")
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                }
         }
         .menuBarExtraStyle(.menu)
 

--- a/packages/macos/RemiTests/HubProtocolTests.swift
+++ b/packages/macos/RemiTests/HubProtocolTests.swift
@@ -58,6 +58,29 @@ final class HubProtocolTests: XCTestCase {
         XCTAssertEqual(status.remoteClients, 0)
         XCTAssertEqual(status.sessions, 0)
         XCTAssertEqual(status.hubVersion, "0.6.19-dev.4")
+        // Pre-#786 fixture: the new fields are genuinely absent, not
+        // present-but-null -- decodeIfPresent-style optionals collapse both
+        // to nil, which is exactly the "older hub" case this must handle.
+        XCTAssertNil(status.pendingQuestions)
+        XCTAssertNil(status.questions)
+    }
+
+    /// #786/#787: a hub_status frame carrying the pending-question census.
+    /// Shape matches packages/shared/src/protocol.ts's HubPendingQuestion /
+    /// createHubStatus.
+    private let hubStatusWithQuestionsFixture = """
+        {"type":"hub_status","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-17T01:29:44.322Z","localClients":1,"remoteClients":0,"sessions":1,"hubVersion":"0.6.22-dev.1","pendingQuestions":1,"questions":[{"id":"9f717fd0-b097-4457-9f3b-42cc40c9d3c2","sessionId":"b165ec10-6d38-4fc1-b733-fcabd58d1430","sessionName":"host:project/main","label":"Permission: Bash","createdAt":"2026-07-17T01:29:40.000Z"}]}
+        """
+
+    func testDecodesHubStatusWithPendingQuestions() throws {
+        let status = try JSONDecoder().decode(
+            HubStatusFrame.self, from: Data(hubStatusWithQuestionsFixture.utf8))
+        XCTAssertEqual(status.pendingQuestions, 1)
+        let questions = try XCTUnwrap(status.questions)
+        XCTAssertEqual(questions.count, 1)
+        XCTAssertEqual(questions[0].id, "9f717fd0-b097-4457-9f3b-42cc40c9d3c2")
+        XCTAssertEqual(questions[0].sessionName, "host:project/main")
+        XCTAssertEqual(questions[0].label, "Permission: Bash")
     }
 
     func testUnknownFrameTypeOnlyNeedsTheEnvelope() throws {

--- a/packages/macos/RemiTests/IconStateTests.swift
+++ b/packages/macos/RemiTests/IconStateTests.swift
@@ -2,8 +2,8 @@
 //  IconStateTests.swift
 //  RemiTests
 //
-//  Table test for the icon-state reducer (#650 precedence:
-//  unreachable > remote > local > idle).
+//  Table test for the icon-state reducer (#650, #786/#787 precedence:
+//  unreachable > needsAttention > remote > local > idle).
 //
 
 import XCTest
@@ -11,21 +11,26 @@ import XCTest
 
 final class IconStateTests: XCTestCase {
     func testPrecedenceTable() {
-        let cases: [(reachable: Bool, local: Int, remote: Int, expected: IconState)] = [
-            (false, 0, 0, .unreachable),
-            (false, 3, 2, .unreachable),  // unreachable wins over everything
-            (true, 0, 0, .idle),
-            (true, 1, 0, .localAttached),
-            (true, 5, 0, .localAttached),
-            (true, 0, 1, .remoteConnected),
-            (true, 2, 1, .remoteConnected),  // remote wins over local
+        let cases: [(reachable: Bool, local: Int, remote: Int, pending: Int, expected: IconState)] = [
+            (false, 0, 0, 0, .unreachable),
+            (false, 3, 2, 0, .unreachable),  // unreachable wins over everything
+            (false, 0, 0, 5, .unreachable),  // unreachable wins over needsAttention too
+            (true, 0, 0, 0, .idle),
+            (true, 1, 0, 0, .localAttached),
+            (true, 5, 0, 0, .localAttached),
+            (true, 0, 1, 0, .remoteConnected),
+            (true, 2, 1, 0, .remoteConnected),  // remote wins over local
+            (true, 0, 0, 1, .needsAttention),
+            (true, 2, 1, 1, .needsAttention),  // needsAttention wins over remote
+            (true, 1, 0, 3, .needsAttention),  // needsAttention wins over local
         ]
         for c in cases {
             XCTAssertEqual(
                 IconState.derive(
-                    reachable: c.reachable, localClients: c.local, remoteClients: c.remote),
+                    reachable: c.reachable, localClients: c.local, remoteClients: c.remote,
+                    pendingQuestions: c.pending),
                 c.expected,
-                "reachable=\(c.reachable) local=\(c.local) remote=\(c.remote)")
+                "reachable=\(c.reachable) local=\(c.local) remote=\(c.remote) pending=\(c.pending)")
         }
     }
 
@@ -33,6 +38,7 @@ final class IconStateTests: XCTestCase {
         XCTAssertEqual(IconState.unreachable.opacity, 0.4)
         XCTAssertEqual(IconState.idle.opacity, 1.0)
         XCTAssertEqual(IconState.remoteConnected.opacity, 1.0)
+        XCTAssertEqual(IconState.needsAttention.opacity, 1.0)
     }
 
     func testAssetNamesMapToCatalogEntries() throws {
@@ -50,7 +56,9 @@ final class IconStateTests: XCTestCase {
                 .filter { $0.hasSuffix(".imageset") }
                 .map { $0.replacingOccurrences(of: ".imageset", with: "") })
 
-        let states: [IconState] = [.idle, .unreachable, .localAttached, .remoteConnected]
+        let states: [IconState] = [
+            .idle, .unreachable, .localAttached, .remoteConnected, .needsAttention,
+        ]
         for state in states {
             XCTAssertTrue(
                 imagesets.contains(state.assetName),
@@ -58,5 +66,8 @@ final class IconStateTests: XCTestCase {
         }
         // The unreachable state reuses the idle glyph, dimmed.
         XCTAssertEqual(IconState.unreachable.assetName, IconState.idle.assetName)
+        // #787: needsAttention deliberately reuses the remoteConnected glyph
+        // (see IconState.assetName doc comment).
+        XCTAssertEqual(IconState.needsAttention.assetName, IconState.remoteConnected.assetName)
     }
 }

--- a/packages/macos/RemiTests/NotificationDiffTests.swift
+++ b/packages/macos/RemiTests/NotificationDiffTests.swift
@@ -1,0 +1,79 @@
+//
+//  NotificationDiffTests.swift
+//  RemiTests
+//
+//  Tests for the pure new-vs-seen diff behind native notifications (#786):
+//  no UNUserNotificationCenter involved, just NotificationDiff.diff().
+//
+
+import XCTest
+
+
+final class NotificationDiffTests: XCTestCase {
+    private func notice(_ id: String, session: String = "host:project/main", label: String = "Permission: Bash")
+        -> PendingQuestionNotice
+    {
+        PendingQuestionNotice(id: id, sessionName: session, label: label)
+    }
+
+    func testEmptyPreviousAndCurrentIsANoOp() {
+        let result = NotificationDiff.diff(previousIds: [], current: [])
+        XCTAssertEqual(result.newQuestions, [])
+        XCTAssertEqual(result.resolvedIds, [])
+    }
+
+    func testFirstSeenQuestionsAreAllNew() {
+        let result = NotificationDiff.diff(previousIds: [], current: [notice("q1"), notice("q2")])
+        XCTAssertEqual(result.newQuestions, [notice("q1"), notice("q2")])
+        XCTAssertEqual(result.resolvedIds, [])
+    }
+
+    func testAQuestionThatDisappearsIsResolved() {
+        let result = NotificationDiff.diff(previousIds: ["q1"], current: [])
+        XCTAssertEqual(result.newQuestions, [])
+        XCTAssertEqual(result.resolvedIds, ["q1"])
+    }
+
+    func testAStillPendingQuestionIsNeitherNewNorResolved() {
+        let result = NotificationDiff.diff(previousIds: ["q1"], current: [notice("q1")])
+        XCTAssertEqual(result.newQuestions, [])
+        XCTAssertEqual(result.resolvedIds, [])
+    }
+
+    func testOneResolvedAndOneNewInTheSameBeat() {
+        // The exact case a naive count-only comparison would miss: same
+        // SIZE (1 in, 1 out) but a genuinely different question.
+        let result = NotificationDiff.diff(previousIds: ["q-old"], current: [notice("q-new")])
+        XCTAssertEqual(result.newQuestions, [notice("q-new")])
+        XCTAssertEqual(result.resolvedIds, ["q-old"])
+    }
+
+    func testMixedSetOfNewStillPendingAndResolved() {
+        let result = NotificationDiff.diff(
+            previousIds: ["q1", "q2", "q3"],
+            current: [notice("q2"), notice("q4")])
+        XCTAssertEqual(result.newQuestions, [notice("q4")])
+        XCTAssertEqual(result.resolvedIds, ["q1", "q3"])
+    }
+
+    func testResolvedIdsAreSortedForDeterministicOrdering() {
+        let result = NotificationDiff.diff(previousIds: ["qc", "qa", "qb"], current: [])
+        XCTAssertEqual(result.resolvedIds, ["qa", "qb", "qc"])
+    }
+
+    func testReconnectReplayOfAnAlreadySeenQuestionDoesNotReAlert() {
+        // A reconnect/re-broadcast of the SAME still-pending question must
+        // not re-notify -- exactly what keying by id (not counting) buys.
+        let previous: Set<String> = ["q1"]
+        let result = NotificationDiff.diff(previousIds: previous, current: [notice("q1")])
+        XCTAssertTrue(result.newQuestions.isEmpty)
+    }
+
+    func testEquatableNoticeCarriesSessionAndLabel() {
+        let a = notice("q1", session: "host:a/main", label: "Permission: Bash")
+        let b = notice("q1", session: "host:a/main", label: "Permission: Bash")
+        let c = notice("q1", session: "host:b/main", label: "Permission: Bash")
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -95,6 +95,7 @@ export type {
   UnregisterDeviceTokenMessage,
   DaemonUpdateAvailableMessage,
   HubStatusMessage,
+  HubPendingQuestion,
   SessionRotatedMessage,
   SessionViewsMessage,
   SessionViewMeta,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -792,6 +792,29 @@ export interface DaemonUpdateAvailableMessage {
 }
 
 /**
+ * One unanswered question surfaced in the hub census (#786/#787): one entry
+ * per pending question across every live child session daemon, sourced from
+ * each session's live-sessions registry entry (`LiveSessionEntry.pendingQuestions`,
+ * packages/daemon/src/session/session-registry-file.ts). Drives the macOS
+ * menu-bar app's native notifications (#786) and needs-attention icon state
+ * (#787) — the app is a query-mode client with no other way to learn a
+ * question is pending.
+ */
+export interface HubPendingQuestion {
+  /** Question id, matching the owning session's `Question.id`. */
+  readonly id: UUID;
+  /** Session the question belongs to. */
+  readonly sessionId: UUID;
+  /** The owning session's human-readable name (registry entry's `name`). */
+  readonly sessionName: string;
+  /** Short human label, e.g. "Permission: Bash" or a truncated question text
+   *  (see `buildPendingQuestionLabel` in the daemon package). */
+  readonly label: string;
+  /** When the question first became pending (ISO8601). */
+  readonly createdAt: Timestamp;
+}
+
+/**
  * Hub connection/session census (#650, epic #648): the daemon half of the
  * menu-bar icon state. Sent by HUB-MODE daemons only — to a connection right
  * after its hello_ack, and broadcast to all connections whenever the counts
@@ -811,6 +834,18 @@ export interface HubStatusMessage {
   readonly sessions: number;
   /** REMI_VERSION of the hub process. */
   readonly hubVersion: string;
+  /**
+   * Total pending questions across every live child session (#786/#787).
+   * Optional: absent on a hub predating this field, and safely ignored by a
+   * pre-#786 client (isValidMessage only checks `type`).
+   */
+  readonly pendingQuestions?: number;
+  /**
+   * The pending questions themselves (#786/#787). #787's icon state only
+   * needs `pendingQuestions`' count; #786's native notifications need this
+   * list to diff by id (new question -> post, disappeared id -> withdraw).
+   */
+  readonly questions?: readonly HubPendingQuestion[];
 }
 
 /** A recent project directory aggregated from session history */
@@ -1714,6 +1749,8 @@ export function createHubStatus(counts: {
   remoteClients: number;
   sessions: number;
   hubVersion: string;
+  pendingQuestions?: number;
+  questions?: readonly HubPendingQuestion[];
 }): HubStatusMessage {
   return {
     type: 'hub_status',
@@ -1723,6 +1760,8 @@ export function createHubStatus(counts: {
     remoteClients: counts.remoteClients,
     sessions: counts.sessions,
     hubVersion: counts.hubVersion,
+    ...(counts.pendingQuestions !== undefined && { pendingQuestions: counts.pendingQuestions }),
+    ...(counts.questions !== undefined && { questions: counts.questions }),
   };
 }
 

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -17,6 +17,7 @@ import {
   createError,
   createHello,
   createHelloAck,
+  createHubStatus,
   createPing,
   createPong,
   createQuestion,
@@ -39,7 +40,7 @@ import {
   now,
   serialize,
 } from '../src/protocol.ts';
-import type { AgentOutputMessage, HelloMessage } from '../src/protocol.ts';
+import type { AgentOutputMessage, HelloMessage, HubStatusMessage } from '../src/protocol.ts';
 import type { Acknowledgment, Message, Question, StructuredMessage } from '../src/types.ts';
 
 describe('generateId()', () => {
@@ -448,6 +449,68 @@ describe('createRemiStatus() (#754)', () => {
     status.autoApprove.inFlight = 5;
     expect(msg.status.attached).toBe(true);
     expect(msg.status.autoApprove.inFlight).toBe(0);
+  });
+});
+
+describe('createHubStatus() (#650, #786/#787)', () => {
+  test('builds a well-formed hub_status message with the base counts only', () => {
+    const msg = createHubStatus({
+      localClients: 1,
+      remoteClients: 2,
+      sessions: 3,
+      hubVersion: '9.9.9-test',
+    });
+    expect(msg.type).toBe('hub_status');
+    expect(msg.localClients).toBe(1);
+    expect(msg.remoteClients).toBe(2);
+    expect(msg.sessions).toBe(3);
+    expect(msg.hubVersion).toBe('9.9.9-test');
+    // Optional fields are genuinely absent, not present-but-undefined, so a
+    // pre-#786 client's isValidMessage (type-only check) sees a frame that
+    // looks exactly like it always has.
+    expect('pendingQuestions' in msg).toBe(false);
+    expect('questions' in msg).toBe(false);
+  });
+
+  test('carries pendingQuestions + questions when provided, and round-trips', () => {
+    const questions = [
+      {
+        id: generateId(),
+        sessionId: generateId(),
+        sessionName: 'host:project/main',
+        label: 'Permission: Bash',
+        createdAt: now(),
+      },
+    ];
+    const msg = createHubStatus({
+      localClients: 0,
+      remoteClients: 0,
+      sessions: 1,
+      hubVersion: '9.9.9-test',
+      pendingQuestions: 1,
+      questions,
+    });
+    expect(msg.pendingQuestions).toBe(1);
+    expect(msg.questions).toEqual(questions);
+
+    const parsed = deserialize(serialize(msg));
+    expect(parsed?.type).toBe('hub_status');
+    const status = parsed as HubStatusMessage;
+    expect(status.pendingQuestions).toBe(1);
+    expect(status.questions).toEqual(questions);
+  });
+
+  test('pendingQuestions: 0 is preserved, not dropped as falsy', () => {
+    const msg = createHubStatus({
+      localClients: 0,
+      remoteClients: 0,
+      sessions: 0,
+      hubVersion: '9.9.9-test',
+      pendingQuestions: 0,
+      questions: [],
+    });
+    expect(msg.pendingQuestions).toBe(0);
+    expect(msg.questions).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements #786 (native macOS notifications) and #787 (needs-attention menu-bar icon) together — they share one data source, so one PR.

### Design: registry file -> hub census -> hub_status -> app

1. **Daemon, per-session daemon**: `SessionRegistry` gains an `onQuestionsChanged` event, firing with the FULL current pending-question set on every `addQuestion`/`removeQuestion`/`clearQuestions` call — covering every lifecycle path that already exists (HookEventBridge, OutputProcessor/PTY-fallback, auto-approve-gate, terminal-answer detection, push/web answers via `input-events.ts`) without touching any of those call sites individually. `cli.ts` wires this event to `SessionRegistryFile#setPendingQuestions`, which persists `[{id, label, createdAt}]` into the session's `~/.remi/live-sessions/<id>.json` entry. `buildPendingQuestionLabel` builds the short label ("Permission: Bash" for a plain permission-request question, a truncated question/summary text otherwise). `PendingQuestionCreatedAtTracker` memoizes each question's first-seen timestamp (`Question` itself carries none, and the event fires with the full set every time).

2. **Daemon, hub**: `buildHubQuestionCensus` flattens every live session's `pendingQuestions` into the wire-shaped `HubPendingQuestion` list (`{id, sessionId, sessionName, label, createdAt}`), reusing the same `listLive()` read the plain session count already did. `HubClientTracker`'s `getSessions` dep becomes `getCensus`; broadcast change-detection now considers the pending-question **id set**, not just counts (two different questions of equal count in the same beat still broadcasts).

3. **Shared protocol**: `HubStatusMessage`/`createHubStatus` gain two OPTIONAL fields — `pendingQuestions: number` and `questions: HubPendingQuestion[]`. No new message type; additive and optional so it merges cleanly with the sibling `autostart` field being added on another branch.

4. **macOS app**: `HubClient` publishes `pendingQuestions`/`questions` from every `hub_status` frame and drives `NotificationManager` directly (no extra SwiftUI observation). `NotificationManager` wraps `UNUserNotificationCenter`: lazy authorization on the first question that needs posting, one notification per newly-seen question id, withdrawal (delivered + pending) when a question disappears from the census (answered anywhere — terminal, phone, web). The new-vs-seen diff is a pure function (`NotificationDiff.diff`), unit-tested without touching `UNUserNotificationCenter`. Clicking a notification activates the app and opens the main window (same pattern as "Open Remi"). A transient hub disconnect deliberately does NOT clear questions/notifications — only a real `hub_status` frame after reconnecting does.

   `IconState` gains `.needsAttention`, top precedence above `.remoteConnected` (still below `.unreachable`), deliberately reusing the `remoteConnected` asset (filled square, knocked-out "r") per the user's "icon just inverts" spec — noted in a comment referencing #787.

   `RemiApp`'s menu shows "N questions waiting" when any are pending.

### What was tested

**TypeScript** (`bun run typecheck`, `bunx biome check .` both clean):
- `packages/shared/tests/protocol.test.ts` — `createHubStatus` new-field tests (absent-by-default, round-trip, `pendingQuestions: 0` not dropped as falsy)
- `packages/daemon/tests/session-registry.test.ts` — `onQuestionsChanged` fires with correct payload on add/remove/clear, and not for a mismatched sessionId
- `packages/daemon/tests/session-registry-file.test.ts` — `setPendingQuestions` round-trip, empty-array clear, legacy-entry-absent, malformed-entry rejection, per-session independence
- `packages/daemon/tests/session/pending-question-label.test.ts` — pure label builder (permission/subagent-prefixed/toolQuestion/StopFailure/PTY/multi-question/truncation/whitespace cases)
- `packages/daemon/tests/session/pending-question-created-at-tracker.test.ts` — stable createdAt across repeated syncs, pruning, re-stamping
- `packages/daemon/tests/cli/hub-question-census.test.ts` — REAL fs (temp dir via `SessionRegistryFile`), flattening, stale-session exclusion
- `packages/daemon/tests/cli/hub-client-tracker.test.ts` — census in `counts()`/broadcast, change detection on the question id SET (new/resolved/reordered/same-size-different-set cases)
- `packages/daemon/tests/cli/handlers/connection-events.test.ts` — updated for the `getCensus` dep rename

  Full relevant suite (`packages/shared` + all `packages/daemon/tests` except `auto-approve/`): 1918 tests, repeatedly green. One intermittent `port-utils.test.ts` `EADDRINUSE` flake observed (a file this PR never touches; pre-existing test-parallelism port contention, not from this change).

  Also manually verified the daemon-side wiring end-to-end: spawned a real `remi serve` hub, wrote a fake `~/.remi/live-sessions/<id>.json` entry with `pendingQuestions` directly, and confirmed a real query-mode WebSocket client received `hub_status` with the correct `pendingQuestions`/`questions` census.

**Swift** (`xcodebuild test -project packages/macos/Remi.xcodeproj -scheme Remi`): 38 tests, 3 skipped (real-hub integration tests — `REMI_TEST_BINARY` not set locally; CI's `macos-app.yml` does set it, but those tests only cover discovery/handshake, not the new pending-question flow specifically — driving a real end-to-end PermissionRequest through a live Claude Code session was out of scope here). All others pass, including the new `NotificationDiffTests` (pure diff, no `UNUserNotificationCenter` involved) and the extended `IconStateTests`/`HubProtocolTests`.

Regenerated `Remi.xcodeproj` via `scripts/generate-macos-project.sh` for the two new Swift files.

### Deviations / notes

- The label format ("Permission: Bash") is derived by pattern-matching `HookEventBridge`'s two known text shapes ("Allow X: Y" / "agent · X: Y") rather than adding a new field to the wire `Question` type — kept additive/local to the daemon package.
- Needs on-machine human verification: live notification banner + click-through (opens window, activates app), and the icon glyph flip in a real running menu-bar app — none of that is exercisable from this sandboxed environment.
- Merged latest `develop` into this branch after the sibling Dock-presence PR (#789) landed mid-task; no conflicts with this PR's actual logic (only the generated `project.pbxproj` and a doc heading needed manual resolution, both re-verified after).

### Design note: question content on the wire (review question)

`hub_status.questions` broadcasts each pending question's `label` and `sessionName` to every connected query-mode client (the menu-bar app; potentially other future hub monitors). This is intentional, not a leak: remi's threat model is single-user, multi-device — the same person's Mac, phone, and any other client attached to their own hub. Session names and project paths are already visible to any connected client via the existing `session_list_response`/discovery messages (`packages/daemon/src/cli/live-sessions-watcher.ts`), and full question content (including the actual PTY prompt text) is already broadcast in-app to attached clients and pushed via APNS to the phone. `hub_status.questions`'s short label is strictly less sensitive than what already crosses the wire elsewhere in the same trust boundary. There is no cross-user or cross-hub exposure: a query-mode client only ever sees its own hub's own sessions.

### Post-review fixes (this branch)

- **Concurrency fix**: `NotificationManager.requestAuthorizationIfNeeded` called into `UNUserNotificationCenter`'s `@Sendable` completion handlers (`getNotificationSettings`/`requestAuthorization`, which run on an arbitrary background queue) and touched the MainActor-isolated `center` property / transitively called the MainActor-isolated `post(_:)` without hopping actors first. Fixed by wrapping both completion bodies in `Task { @MainActor [weak self] in ... }`, matching the existing pattern in the `UNUserNotificationCenterDelegate` callback. Confirmed via a full `xcodebuild test` run (with `REMI_TEST_BINARY` set, matching CI) that the "Main actor-isolated property 'center'" warning is gone from the build output entirely (zero matches for "isolat" in the full log).
- **Follow-up issue filed**: #793 tracks surfacing OS notification-authorization-denied state in Settings (today it's silently dropped — the icon/menu line still work since they read `hub_status` directly, independent of notification permission).

Closes #786. Closes #787.
