### PR TITLE
Remove session exclusive write lock

### DIFF
--- a/.serena/memories/session_and_connection_architecture.md
+++ b/.serena/memories/session_and_connection_architecture.md
@@ -9,9 +9,9 @@ Remi manages Claude Code sessions with a clear separation between **session life
 
 ### Key Concepts
 - **Sessions survive connection drops** via orphan timeout mechanism
-- **Orphaned state**: When a connection detaches, non-locally-owned sessions enter orphan state for 5 minutes (default), then timeout/cleanup
+- **Orphaned state**: When the LAST attached connection detaches, non-locally-owned sessions enter orphan state for 5 minutes (default), then timeout/cleanup
 - **Locally-owned sessions** (wrapper mode): Never timeout while connected or locally owned, remain alive indefinitely until PTY exits
-- **One active connection per session**: Only one client can have an attached connection at any time
+- **Any number of attached connections per session** (#795, replacing the old exclusive-lock design): every non-query connection that attaches can read AND write immediately — there is no more single "active" connection, no FIFO queue, and no same-device/fingerprint reclaim. Concurrent-write safety instead comes from a write-serialization queue inside `PTYSession` (see below), not from exclusivity.
 
 ### ManagedSession State
 ```
@@ -23,14 +23,14 @@ workingDirectory      - Working directory for Claude Code
 PTY & MessageAPI      - References to running PTY and message processor
 lastActivityAt        - Timestamp of last message/status change
 
-activeConnectionId    - Current attached connection ID (null if none)
-lastDisconnectedAt    - When last connection detached (null if connected)
+attachedConnections   - Set<UUID> of currently attached connection IDs (empty if none) (#795)
+lastDisconnectedAt    - When the session last had ZERO attached connections (null while any are attached)
 orphanTimeoutId       - Timeout handle for cleanup on orphan timeout
 
 messageHistory[]      - Messages for replay (capped at 1000)
 lastDeliveredIndex    - Index of last delivered message
 currentStatus         - Agent status (idle, running, etc.)
-currentQuestion       - Current pending question (if any)
+currentQuestions      - Map of pending questions (multiple can be in flight: main + subagent)
 
 locallyOwned          - TRUE for wrapper mode sessions (NEVER timeout)
 ```
@@ -40,27 +40,30 @@ locallyOwned          - TRUE for wrapper mode sessions (NEVER timeout)
 #### Creation
 1. `sessionRegistry.createSessionId()` generates new UUID
 2. `registerSession(sessionId, pty, messageApi, locallyOwned)` stores session with:
-   - `activeConnectionId = null` (no one attached yet)
+   - `attachedConnections = new Set()` (no one attached yet)
    - `lastDisconnectedAt = null` (not orphaned)
    - `orphanTimeoutId = null` (no timeout)
    - `locallyOwned = false` (daemon mode) or `true` (wrapper mode)
 
 #### Connection Attach
 - `attachConnection(sessionId, connectionId)` called when client connects
-- **Exclusive Lock**: Returns error if `activeConnectionId !== null` (session already has client!)
+- **No exclusivity (#795)**: always succeeds when the session exists — the connection is added to `attachedConnections`, regardless of how many others are already attached
 - On success:
-  - `activeConnectionId = connectionId`
+  - `connectionId` added to `attachedConnections`
   - `lastDisconnectedAt = null`
   - Clears orphan timeout if resuming
   - Marks all history as delivered
   - Returns `replayMessages` (history since last delivery)
+  - `isResume` is true only when the session had ZERO attached connections before this attach — a second connection joining an already-attached session is NOT a resume
 
 #### Detach (Connection closes)
 - `detachConnection(connectionId)` called when client disconnects
-- Sets `activeConnectionId = null`
-- Sets `lastDisconnectedAt = now()`
-- **For non-locally-owned sessions**: Starts orphan timeout → cleanup after 5 min
-- **For locally-owned sessions** (wrapper): No timeout, stays alive indefinitely
+- Removes `connectionId` from `attachedConnections`
+- If OTHER connections remain attached: nothing else happens — the session stays live, no orphan timeout, no `onSessionOrphaned` (#795)
+- Only once `attachedConnections` becomes EMPTY:
+  - Sets `lastDisconnectedAt = now()`
+  - **For non-locally-owned, non-persistent sessions**: Starts orphan timeout → cleanup after 5 min
+  - **For locally-owned sessions** (wrapper) or persistent/explicitly-detached sessions: No timeout, stays alive indefinitely
 
 #### Cleanup
 - `closeSession(sessionId, reason)` removes session from registry
@@ -68,18 +71,20 @@ locallyOwned          - TRUE for wrapper mode sessions (NEVER timeout)
 - Reason: 'timeout', 'pty_exit', or 'forced'
 
 ### Multi-Attach Behavior
-**Current behavior**: Session rejects second attach attempt with error "Session already has active connection"
+**Current behavior (#795)**: any number of connections can be attached to a session at once. Every attached (non-query) connection can read AND write immediately — there is no exclusive lock, no queue, and no rejection on a second/third/... attach.
 
 ```typescript
-if (session.activeConnectionId !== null) {
-  return {
-    success: false,
-    error: 'Session already has active connection',
-  };
-}
+// attachConnection always succeeds when the session exists; no capacity check.
+session.attachedConnections.add(connectionId);
 ```
 
-This enforces **exclusive connection ownership**. Second client must wait for first to detach.
+Concurrent-write safety is NOT enforced here — it comes from `PTYSession`'s own write-serialization queue (a promise chain every `write()`/`submitInput()` call enqueues onto), so two connections submitting input at the same time can never interleave each other's bytes.
+
+### PTY Write Serialization (pty-session.ts, #795)
+- `submitInput(text)` writes `text`, waits ~50ms, then writes a trailing CR — a multi-step sequence. Without serialization, two concurrent submits from different attached connections could interleave (one's text landing inside another's 50ms gap), corrupting both. This exact race is why an earlier attempt at removing the lock (`390898b`) was reverted (`588afde`).
+- Every write-ish call (`write()`, `submitInput()`) now enqueues onto a private `writeChain: Promise<void>` so only one write sequence is ever in flight per session; a failed write doesn't poison the chain for the next one.
+- `resize()` is NOT part of this queue — it is last-writer-wins: any attached connection's `terminal_resize` is applied immediately, no negotiation between attached clients' terminal sizes.
+- `raw_pty_output` fans out to every attached connection (`cli/handlers/pty-message-fanout.ts`), not just one.
 
 ---
 
@@ -214,46 +219,44 @@ if (wrapperMode && primarySessionId && !resumeSessionId) {
 
 ## 4. ATTACH FLOW (attach-client.ts)
 
-### Multi-Attach Behavior
+### Multi-Attach Behavior (#795)
 
-When a second client tries to attach:
+When a second client attaches:
 
 1. **Connection established** → sends `hello` with session ID
 2. **Daemon receives hello** → calls `onConnect` event handler
 3. **Check primary session**: `wrapperMode && primarySessionId`
-   - If primary session has `activeConnectionId !== null`: attach fails
-   - Returns "Session already has active connection" error
-4. **Result**: Client receives error and must wait for first client to detach
+   - Always attaches (non-query connections only) — no capacity check
+4. **Result**: BOTH clients are attached and can read/write immediately; `hello_ack.attachState` is `'attached'` for each of them (never `'queued'` from a current daemon — that value is only sent for interop with an OLDER daemon that still enforces exclusivity)
 
 ### Attach Sequence
 1. Client connects WebSocket
 2. Optional: auth handshake if auth enabled
 3. Client sends `hello(clientId, version, resumeSessionId)`
 4. Server:
-   - If resuming: calls `canResume(resumeSessionId)` → checks `activeConnectionId === null`
-   - If successful: calls `attachConnection()` → sets `activeConnectionId = connectionId`
+   - `attachConnection()` → adds `connectionId` to `attachedConnections` (always succeeds when the session exists)
    - Sends `hello_ack` with session ID and `replayCount`
 5. Client receives `replay_batch` with message history
 6. Client enters raw terminal mode (if CLI attach)
 7. Client sends raw PTY bytes to server
-8. Server forwards to `session.activeConnectionId`
+8. Server forwards `raw_pty_output` to EVERY connection in `session.attachedConnections`, not a single one
 
-### Session Resume After Detach
-1. Client detaches (WebSocket closes)
-2. `detachConnection(connectionId)` → `activeConnectionId = null`
+### Session Resume After Everyone Detaches
+1. Last attached client detaches (WebSocket closes) → `attachedConnections` becomes empty
+2. `lastDisconnectedAt = now()`, orphan timeout starts
 3. Client reconnects with same `resumeSessionId`
-4. `canResume(sessionId)` checks if `activeConnectionId === null` → TRUE
-5. `attachConnection(resumeSessionId, newConnectionId)` succeeds
+4. `canResume(sessionId)` just checks the session still exists → TRUE
+5. `attachConnection(resumeSessionId, newConnectionId)` succeeds, `isResume = true` (attachedConnections was empty)
 6. Replay messages sent to restore state
 
-### Example: Re-attach Same Session
+### Example: Concurrent Attach (replaces the old exclusive-lock example)
 ```
-Client 1 attaches    → Connection A, activeConnectionId = A
-Client 1 detaches    → activeConnectionId = null, orphan timeout started
-Client 1 re-attaches → canResume(sessionId) = true
-                     → attachConnection succeeds, Connection B, activeConnectionId = B
-Client 2 tries attach → canResume(sessionId) = false (because activeConnectionId = B)
-                      → attach fails with "Session already has active connection"
+Client 1 attaches    → attachedConnections = {A}, isResume = false
+Client 2 attaches    → attachedConnections = {A, B}, isResume = false (NOT a resume -- A is still here)
+Client 1 and 2 can both submit input; PTYSession's write queue serializes the actual bytes
+Client 1 detaches    → attachedConnections = {B} -- session stays live, no orphan timeout, no onSessionOrphaned
+Client 2 detaches    → attachedConnections = {} -- NOW lastDisconnectedAt is set, orphan timeout starts
+Client 3 attaches    → attachedConnections = {C}, isResume = true (was empty)
 ```
 
 ---
@@ -262,25 +265,40 @@ Client 2 tries attach → canResume(sessionId) = false (because activeConnection
 
 ```
 Created:
-  activeConnectionId = null
+  attachedConnections = {} (empty set)
   lastDisconnectedAt = null
   orphanTimeoutId = null
   
     ↓
     
-Client Attaches:
-  activeConnectionId = connectionId
+Client A Attaches:
+  attachedConnections = {A}
   lastDisconnectedAt = null
   orphanTimeoutId = null
-  (exclusive lock established)
+  (no lock -- just membership in the set)
   
     ↓
     
-Client Detaches:
-  activeConnectionId = null
+Client B Also Attaches (#795 -- this is new, not a rejection):
+  attachedConnections = {A, B}
+  Both A and B can read AND write; PTYSession's write queue
+  serializes concurrent submits so their bytes never interleave
+  
+    ↓
+    
+Client A Detaches (B still attached):
+  attachedConnections = {B}
+  Nothing else happens -- session stays live, NO orphan timeout,
+  NO onSessionOrphaned (only fires when the set becomes empty)
+  
+    ↓
+    
+Client B Detaches (now the LAST one):
+  attachedConnections = {} (empty)
   lastDisconnectedAt = now()
+  onSessionOrphaned fires
   
-  ├─ If locallyOwned: no timeout (stays alive)
+  ├─ If locallyOwned, persistent, or explicitly detached: no timeout (stays alive)
   └─ If not: orphanTimeoutId = setTimeout(5 min)
   
     ↓
@@ -297,11 +315,11 @@ If PTY Exits:
   
 OR
   
-If Client Re-attaches:
-  activeConnectionId = newConnectionId
+If A Client Re-attaches (attachedConnections was empty):
+  attachedConnections = {newConnectionId}
   lastDisconnectedAt = null
   orphanTimeoutId = null (cleared)
-  (exclusive lock re-established)
+  isResume = true (attachedConnections WAS empty before this attach)
 ```
 
 ---
@@ -310,14 +328,14 @@ If Client Re-attaches:
 
 ### Session Uniqueness
 - Session ID = Connection ID for new sessions (set in hello)
-- Same session ID can have multiple connections over time (via resume)
-- But only ONE active connection at any time (exclusive lock)
+- Same session ID can have multiple connections over time (via resume), AND multiple connections at once (#795)
+- Any number of connections can be attached simultaneously -- no exclusive lock
 
-### Multi-Attach Prevention
-- `attachConnection()` checks `activeConnectionId !== null`
-- Returns error if already attached
-- Second client must wait for first to detach
-- No queue or multi-client support
+### Multi-Attach (#795, replacing the old "Multi-Attach Prevention")
+- `attachConnection()` always succeeds when the session exists — no capacity check, no rejection
+- Every attached connection can read and write immediately, at the same time as every other one
+- No FIFO queue, no "queued/read-only" state, no same-device/fingerprint reclaim (the old #662/#671 machinery was deleted outright, not just bypassed)
+- Concurrent-write safety comes from `PTYSession`'s write-serialization queue (see PTY WRITE SERIALIZATION above), not from exclusivity
 
 ### Port Selection
 - **Wrapper mode**: Auto-selects from 18765-18774 (10 ports max)
@@ -334,7 +352,7 @@ If Client Re-attaches:
 
 ### Connection vs Session
 - **Connection**: WebSocket transport, state machine, message handling
-- **Session**: PTY process, message history, active connection tracking
-- Sessions persist after connection closes (orphan timeout)
+- **Session**: PTY process, message history, attached-connections tracking
+- Sessions persist after all connections close (orphan timeout)
 - Connections don't persist after detach
-- 1:1 mapping for active connections; many:1 for resume lifetime
+- many:1 mapping for concurrently attached connections (#795), AND many:1 for resume lifetime over time

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -111,11 +111,8 @@ loadDotenvFile();
 
 import {
   createDaemonUpdateAvailable,
-  createError,
-  createHelloAck,
   createQuestionResolved,
   createRemiStatus,
-  createReplayBatch,
   createSessionUpdate,
 } from '@remi/shared';
 import type { ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
@@ -1029,77 +1026,6 @@ const sessionRegistry = new SessionRegistry(
         logError(`[live-sessions] setPendingQuestions failed: ${errorToString(err)}`);
       }
     },
-    onConnectionReclaimed: (sessionId, staleConnectionId, newConnectionId) => {
-      // Same device reconnected while its own previous connection still held
-      // the lock (#662) — likely a dead socket the pong reaper hasn't caught
-      // yet. The registry already moved the lock to newConnectionId; force-
-      // close the stale transport so it can't linger as a second listener.
-      log(
-        `Session ${sessionId} reclaimed by same device: evicting stale connection ${staleConnectionId} for ${newConnectionId}`,
-      );
-      registry.sendRaw(
-        staleConnectionId,
-        createError(
-          'SESSION_RECLAIMED',
-          'This device reconnected from a new connection; closing this one.',
-        ),
-      );
-      registry.closeConnection(staleConnectionId, 'Reclaimed by the same device reconnecting');
-    },
-    onConnectionPromoted: (sessionId, connectionId, result) => {
-      log(`Promoted waiting connection ${connectionId} to session ${sessionId}`);
-      // NOTE: this resolves the hello_ack binding inline rather than via
-      // currentOwnedSession() because the promoted connection may be attaching
-      // to a specific `sessionId` that is not necessarily the daemon's primary.
-      // Both read the same disk-backed store, so they stay in sync (#499).
-      const stored = sessionStore.findByRemiSessionId(sessionId);
-      const claudeId = stored?.claudeSessionId ?? null;
-      const projPath = stored?.projectPath ?? null;
-      const tpath =
-        claudeId && projPath
-          ? `${transcriptDiscovery.getProjectTranscriptDir(projPath)}/${claudeId}.jsonl`
-          : null;
-      const sent = registry.sendRaw(
-        connectionId,
-        createHelloAck('1.0.0', sessionId, {
-          resumeInfo: {
-            isResume: result.replayMessages.length > 0,
-            replayCount: result.replayMessages.length,
-            nextBulletId: result.nextBulletId,
-          },
-          binding: { claudeSessionId: claudeId, transcriptPath: tpath },
-          attachState: result.attachState,
-          daemonVersion: REMI_VERSION,
-        }),
-      );
-      if (!sent) {
-        log(`Promoted connection ${connectionId} is unreachable; detaching`);
-        sessionRegistry.detachConnection(connectionId);
-        return;
-      }
-      if (result.replayMessages.length > 0) {
-        const replaySent = registry.sendRaw(
-          connectionId,
-          createReplayBatch(sessionId, result.replayMessages, true),
-        );
-        if (!replaySent) {
-          log(`Failed to send replay batch to promoted connection ${connectionId}`);
-        }
-      }
-      // #753 (#760 review finding 2): a promoted connection was queued
-      // (read-only) while live questions may have arrived — those broadcasts
-      // only reach the active connection, so re-send the pending set now.
-      const resent = resendPendingQuestions(
-        (m) => registry.sendRaw(connectionId, m),
-        sessionId,
-        result.currentQuestions,
-        claudeId ?? undefined,
-      );
-      if (resent > 0) {
-        log(`Re-sent ${resent} pending question(s) to promoted connection ${connectionId}`);
-      }
-      cancelOrphanTimeout();
-    },
   },
 );
 
@@ -1537,14 +1463,16 @@ remiStatusBroadcast = (status) => {
   registry.broadcast(createRemiStatus(primary, status as RemiStatus));
 };
 // #755: attach state pulled from the session registry at flush time — the
-// exclusive PTY slot + FIFO queue, never the blunt connection counter.
+// set of attached connections, never the blunt connection counter. #795:
+// there is no more exclusive slot or FIFO queue, so `queuedCount` is always
+// 0; kept on the wire for older readers of the status bar/file.
 remiAttachState = () => {
   const primary = getPrimarySessionId();
   if (!primary) return { attached: false, queuedCount: 0 };
   const session = sessionRegistry.getSession(primary);
   return {
-    attached: (session?.activeConnectionId ?? null) !== null,
-    queuedCount: sessionRegistry.waitingConnectionCount,
+    attached: (session?.attachedConnections.size ?? 0) > 0,
+    queuedCount: 0,
   };
 };
 
@@ -1579,12 +1507,22 @@ const onQuestionResolved = (
   }
 };
 
-import { resendPendingQuestions } from './cli/handlers/pending-question-resend.ts';
+import { createPtyMessageFanout } from './cli/handlers/pty-message-fanout.ts';
 import { getRecentDirectories } from './cli/recent-client.ts';
 
 const sendToConnection = (connectionId: UUID, message: ProtocolMessage): boolean => {
   return registry.sendRaw(connectionId, message);
 };
+
+// #795: raw_pty_output fans out to every ATTACHED connection (there is no
+// more single exclusive one); every other message type keeps broadcasting to
+// all connections as before. Shared by both daemon-mode and wrapper-mode
+// session creation below.
+const ptyMessageFanout = createPtyMessageFanout({
+  sessionRegistry,
+  sendToConnection,
+  broadcast: (message) => registry.broadcast(message),
+});
 
 const trivialHandlers: TrivialHandlers = createTrivialHandlers({
   // #603 Phase 6: registration goes through the store (rotation prune + persist).
@@ -2218,15 +2156,7 @@ if (cliDaemonMode) {
 
     // Create the PTY session
     try {
-      await createNewSession(sessionId, workingDirectory, (sid, msg) => {
-        const session = sessionRegistry.getSession(sid);
-        if (session?.activeConnectionId) {
-          sendToConnection(session.activeConnectionId, msg);
-        }
-        if (msg.type !== 'raw_pty_output') {
-          registry.broadcast(msg);
-        }
-      });
+      await createNewSession(sessionId, workingDirectory, ptyMessageFanout);
     } catch (err) {
       const msg = errorToString(err);
       console.error(`Failed to create session: ${msg}`);
@@ -2442,16 +2372,7 @@ if (cliDaemonMode) {
   const ptySession = await createNewSession(
     sessionId,
     workingDirectory,
-    (sid, msg) => {
-      const session = sessionRegistry.getSession(sid);
-      if (session?.activeConnectionId) {
-        sendToConnection(session.activeConnectionId, msg);
-      }
-      // Raw PTY output is high-volume; only send to attached CLI client, not all viewers
-      if (msg.type !== 'raw_pty_output') {
-        registry.broadcast(msg);
-      }
-    },
+    ptyMessageFanout,
     claudeArgs,
     true, // pass-through mode
     reservedRows,
@@ -2495,7 +2416,12 @@ if (cliDaemonMode) {
   function writeToPty(text: string): void {
     if (ptySession.isRunning) {
       try {
-        ptySession.write(text);
+        // write() is queued (#795); the immediate synchronous state check
+        // still throws here, but the actual byte write settles later, so
+        // catch its rejection too.
+        void ptySession.write(text).catch((err) => {
+          log(`[PTY] write failed: ${errorToString(err)}`);
+        });
       } catch (err) {
         log(`[PTY] write failed: ${errorToString(err)}`);
       }
@@ -2662,8 +2588,11 @@ if (cliDaemonMode) {
     if (isWrapperDetached()) return; // No local terminal to forward from
     if (ptySession.isRunning) {
       try {
-        // Send Ctrl+C (0x03) to the PTY
-        ptySession.write('\x03');
+        // Send Ctrl+C (0x03) to the PTY. Queued (#795); catch the deferred
+        // rejection too, not just the immediate synchronous state check.
+        void ptySession.write('\x03').catch(() => {
+          // PTY may have exited
+        });
       } catch {
         // PTY may have exited
       }

--- a/packages/daemon/src/cli/handlers/connection-events.ts
+++ b/packages/daemon/src/cli/handlers/connection-events.ts
@@ -2,7 +2,9 @@
  * sharedEvents handlers for connection lifecycle:
  *   onConnect    - tracks a new connection, sends helloAck (optionally with
  *                  replay), and auto-attaches to the primary session unless
- *                  the client declared query mode
+ *                  the client declared query mode. Any non-query connection
+ *                  that attaches can read AND write (#795) — there is no
+ *                  more exclusive write lock or FIFO queue to land in.
  *   onDisconnect - detaches from the session registry, untracks on the
  *                  AdapterRegistry, and decrements the StatusWriter
  *                  connection count. Device tokens deliberately persist:
@@ -86,23 +88,13 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       trackConnection(connectionId, metadata.adapterType);
       onConnectionAdded();
 
-      // resumeSessionId, mode, deviceId, and clientFingerprint are only
-      // carried by the websocket adapter. Telegram and relay clients have no
-      // equivalent (their adapter selects session ownership differently).
+      // resumeSessionId and mode are only carried by the websocket adapter.
+      // Telegram and relay clients have no equivalent (their adapter selects
+      // session ownership differently).
       const platformData = metadata.platformData;
       const resumeSessionId =
         platformData?.kind === 'websocket'
           ? (platformData.resumeSessionId ?? undefined)
-          : undefined;
-      const deviceId =
-        platformData?.kind === 'websocket' ? (platformData.deviceId ?? undefined) : undefined;
-      // Authenticated identity bound to deviceId (#671); undefined when this
-      // connection has no authenticated identity (auth disabled, or a
-      // loopback-exempt peer) — attachConnection then falls back to
-      // deviceId-only reclaim matching.
-      const clientFingerprint =
-        platformData?.kind === 'websocket'
-          ? (platformData.clientFingerprint ?? undefined)
           : undefined;
       const currentPrimary = getPrimarySessionId();
 
@@ -125,12 +117,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       if (currentPrimary) {
         // Only auto-attach if the client wants to attach, not a utility client like ls/kill.
         if (!isQueryMode) {
-          const result = sessionRegistry.attachConnection(
-            currentPrimary,
-            connectionId,
-            deviceId,
-            clientFingerprint,
-          );
+          const result = sessionRegistry.attachConnection(currentPrimary, connectionId);
           if (result.success) {
             send(
               connectionId,
@@ -162,16 +149,17 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
               log(`Re-sent ${resent} pending question(s) to connection ${connectionId}`);
             }
             cancelOrphanTimeout();
-            log(
-              `${result.attachState === 'queued' ? 'Queued' : 'Attached'} connection ${connectionId} ${result.attachState === 'queued' ? 'behind' : 'to'} session ${currentPrimary}`,
-            );
+            log(`Attached connection ${connectionId} to session ${currentPrimary}`);
             return;
           }
         }
 
-        // Query mode or attach failed (session busy); send hello_ack without
-        // attach so utility clients (ls, kill) can still send requests. Still
-        // carry the binding so the client follows the current session (#499).
+        // Query mode, or a race where the session closed between the
+        // currentPrimary read above and attachConnection (attach otherwise
+        // always succeeds when the session exists, #795); send hello_ack
+        // without attach so utility clients (ls, kill) can still send
+        // requests. Still carry the binding so the client follows the
+        // current session (#499).
         send(
           connectionId,
           createHelloAck('1.0.0', currentPrimary, {
@@ -181,7 +169,7 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
         );
         onPeerConnect?.(connectionId, metadata);
         log(
-          `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'session busy'})`,
+          `Connection ${connectionId} connected without attach (${isQueryMode ? 'query mode' : 'attach race'})`,
         );
         return;
       }
@@ -206,10 +194,6 @@ export function createConnectionHandlers(deps: ConnectionHandlerDeps) {
       // an explicit unregister_device_token message arrives or APNS reports
       // the token as bad. See #308 for the explicit-disconnect follow-up.
 
-      // Explicitly remove from the waiting queue, then detach if active.
-      // detachConnection also handles waiting removal, but this ensures
-      // cleanup even if detachConnection's early-return path changes.
-      sessionRegistry.removeWaitingConnection(connectionId);
       sessionRegistry.detachConnection(connectionId);
       untrackConnection(connectionId);
       onConnectionRemoved();

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -624,31 +624,37 @@ export function createInputHandlers(deps: InputHandlerDeps) {
 
       const session = sessionRegistry.getSessionForConnection(connectionId);
       if (!session) {
-        // #662: this connection does not hold the exclusive write lock —
-        // either it's read-only (queued behind the active connection: a
-        // second client, or this same client's new connection racing the
-        // pong-reaper's eviction of its own stale one) or the session no
-        // longer exists. Previously this dropped the input with only a
-        // server-side log line, so the sender's UI showed the message as
-        // "sent" while it silently vanished. Surface it as an error instead.
+        // #795: there is no more exclusive write lock, so every attached
+        // (non-query) connection already finds its session above. Landing
+        // here now only means this connectionId was never attached at all —
+        // a query-mode client (ls/kill) sending input it should not, or a
+        // connection that already explicitly detached. New daemons no longer
+        // emit NOT_ACTIVE_CONNECTION (kept only so a newer client still
+        // understands an OLDER daemon that still queues); SESSION_NOT_FOUND
+        // covers both "session missing" and "this connection isn't attached
+        // to it" since from this connection's perspective there is no
+        // session to write to either way. Previously this dropped the input
+        // with only a server-side log line, so the sender's UI showed the
+        // message as "sent" while it silently vanished; still surface an
+        // error instead.
         const sessionExists = sessionRegistry.getSession(sessionId) !== undefined;
         log(
-          `No session found for connection ${connectionId} (session ${sessionExists ? 'exists but this connection is not active' : 'not found'})`,
+          `No session found for connection ${connectionId} (session ${sessionExists ? 'exists but this connection is not attached' : 'not found'})`,
         );
         send(
           connectionId,
-          sessionExists
-            ? createError(
-                'NOT_ACTIVE_CONNECTION',
-                'This connection is read-only (another connection holds the session); input was not delivered.',
-                // #681: carry the rejected input's own message id so the client
-                // can flip that SPECIFIC bubble to 'failed' -- the daemon acks
-                // user_input unconditionally before this check runs (connection.ts
-                // handleUserInput), so the sender otherwise sees a false
-                // "delivered" with only the read-only banner as a signal.
-                { sessionId, ...(messageId !== undefined && { messageId }) },
-              )
-            : createError('SESSION_NOT_FOUND', `Session ${sessionId} not found on this daemon`),
+          createError(
+            'SESSION_NOT_FOUND',
+            sessionExists
+              ? `This connection is not attached to session ${sessionId}; input was not delivered.`
+              : `Session ${sessionId} not found on this daemon`,
+            // #681: carry the rejected input's own message id so the client
+            // can flip that SPECIFIC bubble to 'failed' -- the daemon acks
+            // user_input unconditionally before this check runs (connection.ts
+            // handleUserInput), so the sender otherwise sees a false
+            // "delivered" with only silence as a signal.
+            { sessionId, ...(messageId !== undefined && { messageId }) },
+          ),
         );
         return;
       }
@@ -658,9 +664,12 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       }
 
       if (raw) {
-        // Raw terminal input from attach client: write directly without Enter
+        // Raw terminal input from attach client: write directly without
+        // Enter. Awaited (#795) so it queues onto the same per-session write
+        // chain as submitInput() and a failure from a queued write is still
+        // caught here.
         try {
-          session.pty.write(content);
+          await session.pty.write(content);
         } catch (err) {
           log(`[PTY] raw write failed: ${errorToString(err)}`);
         }

--- a/packages/daemon/src/cli/handlers/pending-question-resend.ts
+++ b/packages/daemon/src/cli/handlers/pending-question-resend.ts
@@ -12,10 +12,9 @@
  * that never renders on the PTY).
  *
  * Shared by every attach surface (#760 review finding 2): the hello attach
- * path (connection-events), the resume-request attach path
- * (resume-session-events), and FIFO queue promotion (cli.ts
- * onConnectionPromoted). A send failure is the caller's transport's problem;
- * this helper only reports how many were attempted.
+ * path (connection-events) and the resume-request attach path
+ * (resume-session-events). A send failure is the caller's transport's
+ * problem; this helper only reports how many were attempted.
  */
 
 import { createQuestion } from '@remi/shared';

--- a/packages/daemon/src/cli/handlers/pty-message-fanout.ts
+++ b/packages/daemon/src/cli/handlers/pty-message-fanout.ts
@@ -1,0 +1,43 @@
+/**
+ * Fan-out for PTY-originated messages (#795).
+ *
+ * `createNewSession`'s `sendMessage` callback used to special-case
+ * `raw_pty_output`: send it only to the single exclusive `activeConnectionId`,
+ * then broadcast every OTHER message type to all connections. Now that any
+ * number of connections can be attached at once, `raw_pty_output` is instead
+ * sent directly to every currently ATTACHED connection (it is high-volume, so
+ * still not broadcast to query-mode utility clients); every other message
+ * type keeps going through the ordinary adapter broadcast, unchanged.
+ *
+ * Shared by both daemon-mode and wrapper-mode session creation in cli.ts so
+ * the fan-out logic (and its tests) live in one place.
+ */
+
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { SessionRegistry } from '../../session/index.ts';
+
+export interface PtyMessageFanoutDeps {
+  sessionRegistry: SessionRegistry;
+  /** Send to one connection directly (e.g. registry.sendRaw). */
+  sendToConnection: (connectionId: UUID, message: ProtocolMessage) => boolean;
+  /** Send to every connected client (e.g. registry.broadcast). */
+  broadcast: (message: ProtocolMessage) => void;
+}
+
+export type PtyMessageFanout = (sessionId: UUID, message: ProtocolMessage) => void;
+
+export function createPtyMessageFanout(deps: PtyMessageFanoutDeps): PtyMessageFanout {
+  const { sessionRegistry, sendToConnection, broadcast } = deps;
+
+  return (sessionId, message) => {
+    if (message.type === 'raw_pty_output') {
+      const session = sessionRegistry.getSession(sessionId);
+      if (!session) return;
+      for (const connectionId of session.attachedConnections) {
+        sendToConnection(connectionId, message);
+      }
+      return;
+    }
+    broadcast(message);
+  };
+}

--- a/packages/daemon/src/cli/handlers/resume-session-events.ts
+++ b/packages/daemon/src/cli/handlers/resume-session-events.ts
@@ -215,9 +215,13 @@ export function createResumeSessionHandlers(deps: ResumeSessionHandlerDeps) {
           newSessionId,
           workingDirectory,
           (sid, msg) => {
+            // #795: fan out to every attached connection, not a single
+            // exclusive one. In practice this window is before `connectionId`
+            // has attached below, so this is normally a no-op either way.
             const session = sessionRegistry.getSession(sid);
-            if (session?.activeConnectionId) {
-              send(session.activeConnectionId, msg);
+            if (!session) return;
+            for (const connId of session.attachedConnections) {
+              send(connId, msg);
             }
           },
           ['--resume', claudeSessionId],

--- a/packages/daemon/src/cli/handlers/session-events.ts
+++ b/packages/daemon/src/cli/handlers/session-events.ts
@@ -82,8 +82,9 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   interface PendingStop {
     // Mutable: a duplicate stop appends itself via waiters.push (see below).
     waiters: Array<{ connectionId: UUID; requestId: UUID }>;
-    /** Active client to notify with SESSION_ENDED, if it isn't a requester. */
-    readonly notifyConnectionId: UUID | null;
+    /** Attached clients (#795: any number, not just one) to notify with
+     *  SESSION_ENDED, excluding requesters. */
+    readonly notifyConnectionIds: readonly UUID[];
     readonly fallbackTimer: ReturnType<typeof setTimeout>;
   }
   const pendingStops = new Map<UUID, PendingStop>();
@@ -91,16 +92,16 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
   /**
    * Resolve a deferred Stop once the session has actually closed. Call from the
    * registry's onSessionClosed for every close reason; a no-op when the session
-   * ended on its own (no pending Stop). Cancels the force-fallback, notifies a
-   * third-party client, and acks every waiting requester.
+   * ended on its own (no pending Stop). Cancels the force-fallback, notifies
+   * every third-party attached client, and acks every waiting requester.
    */
   function resolveStopOnClose(sessionId: UUID): void {
     const pending = pendingStops.get(sessionId);
     if (!pending) return;
     pendingStops.delete(sessionId);
     clearTimeout(pending.fallbackTimer);
-    if (pending.notifyConnectionId) {
-      send(pending.notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
+    for (const notifyConnectionId of pending.notifyConnectionIds) {
+      send(notifyConnectionId, createError('SESSION_ENDED', 'Session ended by request'));
     }
     for (const waiter of pending.waiters) {
       send(waiter.connectionId, createKillSessionResponse(true, waiter.requestId));
@@ -214,13 +215,12 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
       // normal /exit path the PTY has already drained before the notice fires;
       // on the rare force-fallback the close races a still-resolving pty.close(),
       // so a third-party client may see a few trailing bytes after SESSION_ENDED.
-      const notifyConnectionId =
-        session.activeConnectionId && session.activeConnectionId !== connectionId
-          ? session.activeConnectionId
-          : null;
+      const notifyConnectionIds = [...session.attachedConnections].filter(
+        (id) => id !== connectionId,
+      );
       pendingStops.set(sessionId, {
         waiters: [{ connectionId, requestId }],
-        notifyConnectionId,
+        notifyConnectionIds,
         fallbackTimer,
       });
       log(`Session stop initiated: ${sessionName}`);
@@ -238,31 +238,34 @@ export function createSessionHandlers(deps: SessionHandlerDeps) {
         return;
       }
 
-      const activeConnId = session.activeConnectionId;
-      if (activeConnId === null) {
+      const attachedConnIds = [...session.attachedConnections];
+      if (attachedConnIds.length === 0) {
         send(connectionId, createDetachSessionAck(sessionId, false, 'Session is already detached'));
         return;
       }
 
-      // Send ack to the requesting connection. It may be the active client
-      // itself, or a separate query-mode client (like `remi detach <session>`).
+      // Send ack to the requesting connection. It may be one of the attached
+      // clients itself, or a separate query-mode client (like `remi detach
+      // <session>`).
       const ackSent = send(connectionId, createDetachSessionAck(sessionId, true));
       if (!ackSent) {
         log(`Warning: detach ack could not be delivered to ${connectionId}`);
       }
 
-      // Detach the ACTIVE connection (not necessarily the requesting one).
-      // Only untrack + decrement here for third-party detach
-      // (connectionId !== activeConnId). For self-detach, onDisconnect will
-      // clean up when the WebSocket actually closes.
-      sessionRegistry.detachConnection(activeConnId, true);
-      if (activeConnId !== connectionId) {
-        untrackConnection(activeConnId);
-        onConnectionRemoved();
+      // Detach EVERY attached connection (#795: there can be more than one
+      // now), not just a single active one. Only untrack + decrement for a
+      // third-party detach (attachedConnId !== connectionId). For self-detach,
+      // onDisconnect will clean up when the WebSocket actually closes.
+      for (const attachedConnId of attachedConnIds) {
+        sessionRegistry.detachConnection(attachedConnId, true);
+        if (attachedConnId !== connectionId) {
+          untrackConnection(attachedConnId);
+          onConnectionRemoved();
+        }
       }
 
       log(
-        `Session explicitly detached: ${session.name} (active connection ${activeConnId} detached)`,
+        `Session explicitly detached: ${session.name} (attached connections [${attachedConnIds.join(', ')}] detached)`,
       );
     },
 

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -72,6 +72,10 @@ export function createTrivialHandlers(deps: TrivialHandlerDeps) {
     },
 
     onTerminalResize: (connectionId: UUID, cols: number, rows: number): void => {
+      // #795: any attached connection can resize; there is no negotiation
+      // between multiple attached clients' terminal sizes, so this is
+      // last-writer-wins by design — whichever resize lands last sets the
+      // PTY's dimensions for everyone.
       const session = sessionRegistry.getSessionForConnection(connectionId);
       if (!session) {
         log(`Terminal resize ignored: no session for connection ${connectionId}`);

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -268,9 +268,11 @@ export function createPtySessionForSession(
           }
         }
 
-        // Forward raw PTY bytes to the actively attached CLI client (if any).
+        // Forward raw PTY bytes when at least one connection is attached
+        // (#795: fanned out to ALL attached connections downstream, not just
+        // a single exclusive one — see the sendMessage wiring in cli.ts).
         const session = sessionRegistry.getSession(sessionId);
-        if (session?.activeConnectionId) {
+        if (session && session.attachedConnections.size > 0) {
           const base64Data = Buffer.from(data).toString('base64');
           sendMessage(sessionId, createRawPtyOutput(base64Data, sessionId));
         }

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -81,11 +81,14 @@ export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): st
     state = 'approved';
   }
 
-  // #755: label from the REAL attach state (exclusive PTY slot + FIFO queue),
-  // not the raw connection counter — `connections` also counts query-mode
-  // utility clients (remi ls / kill / phone list polls), which is how the bar
-  // used to read "1 client(s)" with nobody attached. Fall back to the old
-  // counter label only when the attach fields are absent (older writer).
+  // #755: label from the REAL attach state (the session's attached-connections
+  // set, #795), not the raw connection counter — `connections` also counts
+  // query-mode utility clients (remi ls / kill / phone list polls), which is
+  // how the bar used to read "1 client(s)" with nobody attached. `queued` is
+  // always 0 now that there is no more exclusive lock/FIFO queue; the
+  // "+N waiting" branch below is dead code kept only for an older daemon
+  // writing this same status file. Fall back to the old counter label only
+  // when the attach fields are absent (older writer).
   const queued = status.queuedCount ?? 0;
   const clients =
     status.attached === undefined

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -54,12 +54,14 @@ export interface StatusWriterDeps {
   readonly debounceMs?: number;
   /**
    * #755: live attach state, stamped into the status on every flush so the
-   * "attached / N waiting" label tracks the session registry (the source of
-   * truth: `activeConnectionId` / `waitingConnections`) rather than the blunt
-   * `connections` counter, which also counts query-mode utility clients.
+   * "attached" label tracks the session registry (the source of truth: its
+   * attached-connections set, #795) rather than the blunt `connections`
+   * counter, which also counts query-mode utility clients. `queuedCount` is
+   * always 0 now that there is no more exclusive write lock/FIFO queue to
+   * wait behind; kept on the wire for older readers of the status file.
    * Pull-based because attach transitions happen in several places (attach,
-   * disconnect, FIFO auto-promotion) that don't all flow through cli.ts.
-   * Optional: tests and the earliest boot phase run without it.
+   * disconnect) that don't all flow through cli.ts. Optional: tests and the
+   * earliest boot phase run without it.
    */
   readonly getAttachState?: () => { attached: boolean; queuedCount: number } | null;
   /**

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -331,7 +331,7 @@ export class NotificationDispatcher {
 
     const sessionForPush = sessionRegistry.getSession(questionSessionId);
     const hasActiveClient =
-      sessionForPush !== undefined && sessionForPush.activeConnectionId !== null;
+      sessionForPush !== undefined && sessionForPush.attachedConnections.size > 0;
     // A non-held question with a client attached: it is seen in-app over the
     // WebSocket; no push (as before), and the user IS reachable -> in_app. A HELD
     // escalation does NOT short-circuit here — it also pushes to the lock screen

--- a/packages/daemon/src/pty/pty-session.ts
+++ b/packages/daemon/src/pty/pty-session.ts
@@ -172,20 +172,59 @@ export class PTYSession {
   }
 
   /**
-   * Write data to the terminal.
-   * Throws if session is not running.
+   * Per-session write serialization (#795). Every write-ish entry point
+   * (`write`, `submitInput`) chains its terminal writes onto this promise so
+   * only one write sequence is ever in flight — one submit's full multi-step
+   * sequence (text, delay, CR) always completes before the next one starts.
+   *
+   * This is the safety property that removing the exclusive session lock
+   * requires: with any attached connection now able to submit input,
+   * concurrent submits are possible where previously only one connection
+   * could ever write at all. `390898b` allowed exactly this (queued
+   * connections could send input too) without adding this serialization, and
+   * `588afde` reverted it because "queued resize/answer/input would race the
+   * active client's session" — two concurrent `submitInput()` calls could
+   * interleave their text/CR writes and corrupt each other's input. This
+   * queue is what makes removing the lock safe this time.
    */
-  write(data: string | Uint8Array): void {
+  private writeChain: Promise<void> = Promise.resolve();
+
+  /**
+   * Queue `fn` to run only after every previously-queued write has settled
+   * (whether it succeeded or failed). Returns a promise for `fn`'s own
+   * outcome so the caller can still await/catch it; a failure never poisons
+   * the chain for writes queued after it.
+   */
+  private enqueueWrite<T>(fn: () => Promise<T> | T): Promise<T> {
+    const run = this.writeChain.then(fn);
+    this.writeChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /**
+   * Write data to the terminal.
+   * Throws synchronously if the session is not currently running. The actual
+   * byte write is then queued (see `enqueueWrite`) so a single-shot write can
+   * never land in the middle of another connection's in-flight `submitInput`
+   * sequence (#795).
+   */
+  write(data: string | Uint8Array): Promise<void> {
     if (this.state !== 'running' || !this.process?.terminal) {
       throw new Error(`Cannot write to session in state: ${this.state}`);
     }
-    this.termWrite(data);
+    return this.enqueueWrite(() => {
+      this.termWrite(data);
+    });
   }
 
   /**
    * The single sink for every byte sent to the child's terminal. Routes the
    * input through the optional capture (#627) so a keystroke recording sees the
-   * exact bytes, then writes them. Callers must have already checked `running`.
+   * exact bytes, then writes them. Callers must have already checked `running`
+   * and must only call this from inside `enqueueWrite` (#795).
    */
   private termWrite(data: string | Uint8Array): void {
     ptyCapture.in(data);
@@ -196,20 +235,31 @@ export class PTYSession {
    * Write text and submit with Enter key.
    * IMPORTANT: Writes text first, then CR separately after a small delay.
    * This matches how real keyboard input works and is required for Claude Code.
+   * Queued (#795) so the text-then-CR sequence always completes atomically
+   * with respect to any other queued write (another submit, or a raw write)
+   * for this session.
    */
   async submitInput(text: string): Promise<void> {
     if (this.state !== 'running' || !this.process?.terminal) {
       throw new Error(`Cannot write to session in state: ${this.state}`);
     }
 
-    // Write the text first
-    this.termWrite(text);
+    await this.enqueueWrite(async () => {
+      // Re-check: the session may have exited while this submit was queued
+      // behind another one.
+      if (this.state !== 'running' || !this.process?.terminal) {
+        throw new Error(`Cannot write to session in state: ${this.state}`);
+      }
 
-    // Small delay to let Claude Code process the text
-    await new Promise((resolve) => setTimeout(resolve, 50));
+      // Write the text first
+      this.termWrite(text);
 
-    // Send CR (Enter key) separately
-    this.termWrite('\r');
+      // Small delay to let Claude Code process the text
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Send CR (Enter key) separately
+      this.termWrite('\r');
+    });
   }
 
   /**

--- a/packages/daemon/src/pty/pty-session.ts
+++ b/packages/daemon/src/pty/pty-session.ts
@@ -216,6 +216,11 @@ export class PTYSession {
       throw new Error(`Cannot write to session in state: ${this.state}`);
     }
     return this.enqueueWrite(() => {
+      // Re-check: the session may have exited while this write was queued
+      // behind another one (mirrors submitInput's re-check).
+      if (this.state !== 'running' || !this.process?.terminal) {
+        throw new Error(`Cannot write to session in state: ${this.state}`);
+      }
       this.termWrite(data);
     });
   }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -152,9 +152,10 @@ const SERVER_VERSION = '0.1.0';
  * Consecutive ping ticks allowed to pass with no pong before a connection is
  * force-closed as dead (#662). A transport that dies without a clean close
  * (iOS backgrounding, cellular NAT drop) never fires the WebSocket 'close'
- * event, so without this the session's exclusive write lock
- * (`activeConnectionId`) would stay held forever. At the default 30s ping
- * interval this reaps an unresponsive peer after 2-3 intervals (60-90s),
+ * event, so without this a stale connection would stay in the session's
+ * attached set forever (#795) — never freeing the orphan timeout and
+ * lingering as a phantom recipient of broadcasts/fan-out. At the default 30s
+ * ping interval this reaps an unresponsive peer after 2-3 intervals (60-90s),
  * comfortably inside the Bun-level idleTimeout backstop in websocket-server.ts.
  */
 const MAX_MISSED_PONGS = 2;

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -8,6 +8,10 @@
  * - Locally-owned sessions (wrapper mode) are exempt from orphan timeout
  * - Connections can resume the session within the timeout window
  * - Message history is tracked for replay on reconnect
+ * - Any attached (non-query) connection can read AND write (#795): there is
+ *   no more single exclusive writer, no FIFO queue, no same-device reclaim.
+ *   Concurrent-write safety instead comes from PTYSession's own write
+ *   serialization (see pty-session.ts).
  */
 
 import type {
@@ -18,7 +22,6 @@ import type {
   Timestamp,
   UUID,
 } from '@remi/shared';
-import { errorToString } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
@@ -35,24 +38,6 @@ export interface SessionRegistryConfig {
   readonly orphanTimeoutMs?: number;
   /** Maximum messages to keep for replay. Default: 1000 */
   readonly maxReplayHistory?: number;
-}
-
-/**
- * A connection waiting for the active connection to disconnect, plus the
- * deviceId (and, when authenticated, clientFingerprint) its hello carried
- * (#662, #671). Carrying these here (not just the bare connectionId) means a
- * queued connection that gets FIFO-promoted still has its identity on record
- * afterward — so if IT later goes stale, a genuine reconnect from the same
- * device can still reclaim the lock instead of falling back to queuing
- * behind a connection that's gone for good. Without this, only the
- * FIRST-ever active connection's identity got reclaim protection; every
- * promoted connection would lose it.
- */
-interface WaitingConnection {
-  readonly connectionId: UUID;
-  readonly deviceId?: string;
-  /** Authenticated identity bound to this deviceId at hello time (#671). */
-  readonly clientFingerprint?: string;
 }
 
 /** Result of attempting to attach a connection to a session */
@@ -72,10 +57,12 @@ export interface AttachResult {
   /** Error message if attachment failed */
   readonly error?: string;
   /**
-   * Whether the connection ended up holding the exclusive write lock
-   * ('attached') or is read-only, waiting for the current holder to
-   * disconnect ('queued') (#662). Undefined only on the failure path
-   * (session not found), where the distinction is moot.
+   * Always 'attached' on success now that there is no exclusive write lock to
+   * queue behind (#795) — every non-query connection that attaches can read
+   * and write immediately. Undefined only on the failure path (session not
+   * found). Kept as a union (not narrowed to the literal) so the wire type
+   * (`HelloAckMessage.attachState`) does not need to change: older clients
+   * that still branch on `'queued'` simply never see it from a new daemon.
    */
   readonly attachState?: 'attached' | 'queued';
 }
@@ -86,26 +73,19 @@ export interface SessionRegistryEvents {
   onSessionCreated?: (sessionId: UUID) => void;
   /** Session was closed (timeout or PTY exit) */
   onSessionClosed?: (sessionId: UUID, reason: 'timeout' | 'pty_exit' | 'forced') => void;
-  /** Connection detached from the session. Fires for ALL detach reasons, not
-   * only genuine orphans: a plain non-locally-owned, non-persistent session
-   * becomes orphaned (orphan timeout armed), while locally-owned, persistent,
-   * and explicitly-detached sessions stay alive with no timeout. Inspect the
-   * session flags (locallyOwned / persistent / explicitlyDetached) to tell
-   * which case fired. */
+  /** The session's last attached connection detached, leaving it with none.
+   *  Fires for ALL such detach reasons, not only genuine orphans: a plain
+   *  non-locally-owned, non-persistent session becomes orphaned (orphan
+   *  timeout armed), while locally-owned, persistent, and explicitly-detached
+   *  sessions stay alive with no timeout. Inspect the session flags
+   *  (locallyOwned / persistent / explicitlyDetached) to tell which case
+   *  fired. Does NOT fire when one of several attached connections detaches
+   *  while others remain (#795). */
   onSessionOrphaned?: (sessionId: UUID) => void;
-  /** Session was resumed (connection reattached) */
+  /** Session was resumed: a connection attached after the session had zero
+   *  attached connections (as opposed to a second connection joining one
+   *  that already has an attached connection, which is not a "resume"). */
   onSessionResumed?: (sessionId: UUID, connectionId: UUID) => void;
-  /** A waiting connection was promoted to active after the previous client disconnected */
-  onConnectionPromoted?: (sessionId: UUID, connectionId: UUID, result: AttachResult) => void;
-  /**
-   * Same device reclaimed the exclusive write lock from its own stale
-   * connection (#662): `attachConnection` was called with a `deviceId` that
-   * matches the device already holding the lock, so the stale connection was
-   * evicted from the registry's bookkeeping in favor of the new one. The
-   * caller (cli.ts) must still force-close the stale connection's actual
-   * transport — the registry has no transport handle to do that itself.
-   */
-  onConnectionReclaimed?: (sessionId: UUID, staleConnectionId: UUID, newConnectionId: UUID) => void;
   /**
    * The session's pending-question set changed: one was added, one was
    * resolved (from any surface — terminal, push, web), or all were cleared
@@ -136,28 +116,15 @@ export interface ManagedSession {
   /** When session last had activity (message, status change) */
   lastActivityAt: Timestamp;
 
-  /** Currently attached connection ID (null if no connection is attached) */
-  activeConnectionId: UUID | null;
   /**
-   * Device id the active connection's hello carried (null if unset or no
-   * active connection). Compared against an incoming hello's deviceId
-   * (#662) to distinguish "same device reconnecting after a blip" (reclaim
-   * the lock) from "a second writer" (queue behind the FIFO as before).
+   * Connections currently attached to this session (#795). Any attached
+   * (non-query) connection can read AND write — there is no more single
+   * exclusive writer, so this is a set rather than one slot. Empty means
+   * nobody is attached (orphaned/detached).
    */
-  activeDeviceId: string | null;
-  /**
-   * Authenticated client fingerprint bound to the active connection at hello
-   * time (#671), null when the connection had no authenticated identity to
-   * bind (auth disabled daemon-wide, or this peer was loopback-exempted from
-   * auth). `deviceId` alone is client-supplied and replayable, so when this
-   * is non-null a reclaim attempt must match it too, not just `deviceId` —
-   * otherwise an authenticated-but-different peer could evict the legitimate
-   * device by guessing/replaying its deviceId. When null, there is no
-   * authenticated identity to bind to, so reclaim falls back to today's
-   * deviceId-only comparison.
-   */
-  activeClientFingerprint: string | null;
-  /** When session was last disconnected (null if connected) */
+  attachedConnections: Set<UUID>;
+  /** When the session last had ZERO attached connections (null while at
+   *  least one connection is attached). */
   lastDisconnectedAt: Timestamp | null;
   /** Timeout handle for orphan cleanup */
   orphanTimeoutId: ReturnType<typeof setTimeout> | null;
@@ -202,8 +169,6 @@ export class SessionRegistry {
   private readonly events: SessionRegistryEvents;
   private readonly orphanTimeoutMs: number;
   private readonly maxReplayHistory: number;
-  /** Connections waiting for the active connection to disconnect */
-  private readonly waitingConnections: WaitingConnection[] = [];
   /** Buffer for messages received before session registration (from readExisting transcript) */
   private preRegistrationBuffer: ProtocolMessage[] = [];
 
@@ -245,9 +210,7 @@ export class SessionRegistry {
       pty,
       messageApi,
       lastActivityAt: createdAt,
-      activeConnectionId: null,
-      activeDeviceId: null,
-      activeClientFingerprint: null,
+      attachedConnections: new Set<UUID>(),
       lastDisconnectedAt: null,
       orphanTimeoutId: null,
       messageHistory: [],
@@ -295,43 +258,35 @@ export class SessionRegistry {
   }
 
   /**
-   * Get the session for a given connection — only when that connection holds
-   * the exclusive write lock. Queued connections receive replay history via
-   * attachConnection() but cannot write to the PTY: input/answer/resize from
-   * a queued client would race the active client's session. They are auto-
-   * promoted on disconnect (FIFO).
+   * Get the session for a given connection, if that connection is currently
+   * attached (#795: any attached connection, not just a single exclusive
+   * one).
    */
   getSessionForConnection(connectionId: UUID): ManagedSession | undefined {
     if (this.session === null) return undefined;
-    if (this.session.activeConnectionId === connectionId) return this.session;
+    if (this.session.attachedConnections.has(connectionId)) return this.session;
     return undefined;
   }
 
   /**
-   * Check if a session can be resumed.
-   * Returns true if session exists and has no active connection.
+   * Check whether a session can be attached/resumed. Now simply "does the
+   * session exist" (#795) — attaching a second, third, etc. connection is
+   * always allowed, so there is no more "busy" state to distinguish.
    */
   canResume(sessionId: UUID): boolean {
-    if (this.session === null || this.session.sessionId !== sessionId) {
-      return false;
-    }
-    return this.session.activeConnectionId === null;
+    return this.session !== null && this.session.sessionId === sessionId;
   }
 
   /**
-   * Attach a connection to the session. `deviceId`, when present and equal to
-   * the device already holding the exclusive write lock, reclaims that lock
-   * instead of queuing behind it (#662) — see `reclaimForSameDevice`. When
-   * the active connection has a bound `clientFingerprint` (#671), reclaim
-   * additionally requires the incoming `clientFingerprint` to match it —
-   * see `matchesActiveDevice`.
+   * Attach a connection to the session. Always succeeds when the session
+   * exists (#795) — there is no exclusive write lock to queue behind, so
+   * every non-query connection ends up attached and able to read/write
+   * immediately. `isResume` is true only when the session had ZERO attached
+   * connections before this attach (a genuine resume after everyone left),
+   * not merely because a second connection is joining an already-attached
+   * session.
    */
-  attachConnection(
-    sessionId: UUID,
-    connectionId: UUID,
-    deviceId?: string,
-    clientFingerprint?: string,
-  ): AttachResult {
+  attachConnection(sessionId: UUID, connectionId: UUID): AttachResult {
     if (this.session === null || this.session.sessionId !== sessionId) {
       return {
         success: false,
@@ -344,46 +299,8 @@ export class SessionRegistry {
       };
     }
 
-    if (this.session.activeConnectionId !== null) {
-      if (
-        deviceId !== undefined &&
-        this.matchesActiveDevice(this.session, deviceId, clientFingerprint)
-      ) {
-        return this.reclaimForSameDevice(this.session, connectionId, deviceId, clientFingerprint);
-      }
-
-      // Different (or unknown) device, or a fingerprint mismatch against an
-      // authenticated active connection (#671): provide replay history
-      // (read-only) and queue for write promotion when the active connection
-      // disconnects. Writes from queued connections are blocked at
-      // getSessionForConnection. deviceId/clientFingerprint travel with the
-      // queue entry (#662, #671) so promotion still leaves this connection
-      // reclaimable (under the same identity check) if it later goes stale
-      // itself.
-      if (!this.waitingConnections.some((w) => w.connectionId === connectionId)) {
-        this.waitingConnections.push({
-          connectionId,
-          ...(deviceId !== undefined && { deviceId }),
-          ...(clientFingerprint !== undefined && { clientFingerprint }),
-        });
-      }
-      const MAX_REPLAY_MESSAGES = 200;
-      const replayMessages =
-        this.session.messageHistory.length > MAX_REPLAY_MESSAGES
-          ? this.session.messageHistory.slice(-MAX_REPLAY_MESSAGES)
-          : [...this.session.messageHistory];
-      return {
-        success: true,
-        isResume: true,
-        replayMessages,
-        currentStatus: this.session.currentStatus,
-        currentQuestions: [...this.session.currentQuestions.values()],
-        nextBulletId: this.session.messageApi.bulletCount + 1,
-        attachState: 'queued',
-      };
-    }
-
-    const isResume = this.session.lastDisconnectedAt !== null;
+    const wasEmpty = this.session.attachedConnections.size === 0;
+    const isResume = wasEmpty && this.session.lastDisconnectedAt !== null;
 
     // Clear orphan timeout if resuming
     if (this.session.orphanTimeoutId !== null) {
@@ -391,10 +308,7 @@ export class SessionRegistry {
       this.session.orphanTimeoutId = null;
     }
 
-    // Attach connection
-    this.session.activeConnectionId = connectionId;
-    this.session.activeDeviceId = deviceId ?? null;
-    this.session.activeClientFingerprint = clientFingerprint ?? null;
+    this.session.attachedConnections.add(connectionId);
     this.session.lastDisconnectedAt = null;
     this.session.explicitlyDetached = false;
 
@@ -425,151 +339,31 @@ export class SessionRegistry {
   }
 
   /**
-   * Whether an incoming hello's `deviceId` + `clientFingerprint` match the
-   * identity already recorded for the session's active connection (#671).
+   * Detach a connection from the session. If other connections remain
+   * attached, the session stays live (#795: no more FIFO promotion — there
+   * is nothing to promote, since everyone attached could already read and
+   * write). Only when the LAST attached connection leaves does the session
+   * become orphaned and the timeout countdown start (skipped for
+   * locally-owned, persistent, and explicitly-detached sessions).
    *
-   * `deviceId` alone is a client-supplied, self-reported string (persisted in
-   * `localStorage`) with no cryptographic binding, so trusting it in
-   * isolation lets any peer that can complete a hello (a hostile local
-   * process, or an authenticated-but-different networked peer) evict the
-   * legitimate device by guessing or replaying its `deviceId`.
-   *
-   * `clientFingerprint` must match via STRICT equality, where "both null"
-   * counts as a match: `null` means "no authenticated identity" (auth
-   * disabled daemon-wide, or this peer was loopback-exempted from auth), and
-   * a loopback peer reclaiming its own loopback-held lock (both null) is the
-   * original #666 feature this must keep working. Every other combination —
-   * fingerprint-bearing peer against a fingerprint-less active connection,
-   * fingerprint-less peer against a fingerprint-bound active connection, or
-   * two different fingerprints — is a genuine identity mismatch and must
-   * queue, not reclaim. A user switching transports (e.g. network-authenticated
-   * one moment, SSH-tunnel loopback the next) is an accepted, deliberate
-   * consequence: it queues FIFO instead of reclaiming.
-   */
-  private matchesActiveDevice(
-    session: ManagedSession,
-    deviceId: string,
-    clientFingerprint?: string,
-  ): boolean {
-    if (session.activeDeviceId === null || session.activeDeviceId !== deviceId) {
-      return false;
-    }
-    return session.activeClientFingerprint === (clientFingerprint ?? null);
-  }
-
-  /**
-   * Same physical device reconnecting while its own previous connection is
-   * still marked active (#662) — a dead-socket reconnect (missed pongs, iOS
-   * background, NAT drop) rather than a second writer. Evicts the stale
-   * connection from the registry's bookkeeping and hands the lock straight
-   * to the new one, instead of FIFO-queuing behind a connection that will
-   * likely never come back. `onConnectionReclaimed` tells the caller which
-   * connection id is now stale so it can force-close the underlying
-   * transport; the registry itself has no transport handle to do that.
-   *
-   * Callers must have already verified the identity match via
-   * `matchesActiveDevice` (#671).
-   */
-  private reclaimForSameDevice(
-    session: ManagedSession,
-    connectionId: UUID,
-    deviceId: string,
-    clientFingerprint?: string,
-  ): AttachResult {
-    const staleId = session.activeConnectionId;
-    if (staleId === null) {
-      // Unreachable: attachConnection only calls this when activeConnectionId
-      // is non-null. Guarded defensively rather than asserted.
-      throw new Error('reclaimForSameDevice called without an active connection');
-    }
-
-    session.activeConnectionId = connectionId;
-    session.activeDeviceId = deviceId;
-    session.activeClientFingerprint = clientFingerprint ?? null;
-    session.lastDisconnectedAt = null;
-    session.explicitlyDetached = false;
-
-    const MAX_REPLAY_MESSAGES = 200;
-    const replayMessages =
-      session.messageHistory.length > MAX_REPLAY_MESSAGES
-        ? session.messageHistory.slice(-MAX_REPLAY_MESSAGES)
-        : [...session.messageHistory];
-    session.lastDeliveredIndex = session.messageHistory.length - 1;
-
-    this.events.onConnectionReclaimed?.(session.sessionId, staleId, connectionId);
-
-    return {
-      success: true,
-      isResume: true,
-      replayMessages,
-      currentStatus: session.currentStatus,
-      currentQuestions: [...session.currentQuestions.values()],
-      nextBulletId: session.messageApi.bulletCount + 1,
-      attachState: 'attached',
-    };
-  }
-
-  /**
-   * Detach a connection from the session.
-   * If there are waiting connections, the next one is auto-promoted.
-   * Otherwise, non-locally-owned sessions become orphaned and start the timeout countdown.
-   * Locally-owned sessions remain active without a timeout.
-   *
-   * When `explicit` is true (tmux-style detach), the orphan timeout is skipped
-   * regardless of whether the session is locally owned; the session remains
-   * discoverable and re-attachable indefinitely.
+   * When `explicit` is true (tmux-style detach), the orphan timeout is
+   * skipped regardless of whether the session is locally owned; the session
+   * remains discoverable and re-attachable indefinitely.
    */
   detachConnection(connectionId: UUID, explicit = false): void {
-    if (this.session === null || this.session.activeConnectionId !== connectionId) {
-      // Also remove from waiting list if it was queued
-      const waitIdx = this.waitingConnections.findIndex((w) => w.connectionId === connectionId);
-      if (waitIdx >= 0) {
-        this.waitingConnections.splice(waitIdx, 1);
-      }
+    if (this.session === null || !this.session.attachedConnections.has(connectionId)) {
       return;
     }
 
     const { sessionId } = this.session;
+    this.session.attachedConnections.delete(connectionId);
 
-    // Detach connection
-    this.session.activeConnectionId = null;
-    this.session.activeDeviceId = null;
-    this.session.activeClientFingerprint = null;
-    this.session.lastDisconnectedAt = now();
-
-    // Try to promote the next waiting connection (loop until one succeeds or queue exhausted)
-    while (this.waitingConnections.length > 0) {
-      const next = this.waitingConnections.shift();
-      if (!next) continue;
-      // Carrying deviceId + clientFingerprint through promotion (#662, #671)
-      // means this connection stays reclaimable (under the same identity
-      // check) by the same device if it later goes stale itself, instead of
-      // only the original active connection getting that protection.
-      const result = this.attachConnection(
-        sessionId,
-        next.connectionId,
-        next.deviceId,
-        next.clientFingerprint,
-      );
-      if (result.success) {
-        try {
-          this.events.onConnectionPromoted?.(sessionId, next.connectionId, result);
-        } catch (err) {
-          // Callback failed (e.g., promoted connection unreachable).
-          // Log the error and detach so the loop can try the next waiter.
-          const msg = errorToString(err);
-          console.error(
-            `[SessionRegistry] Promotion callback failed for ${next.connectionId}: ${msg}`,
-          );
-          this.session.activeConnectionId = null;
-          this.session.activeDeviceId = null;
-          this.session.activeClientFingerprint = null;
-          this.session.lastDisconnectedAt = now();
-          continue;
-        }
-        return;
-      }
+    // Other connections are still attached; the session is not orphaned.
+    if (this.session.attachedConnections.size > 0) {
+      return;
     }
+
+    this.session.lastDisconnectedAt = now();
 
     // Track explicit detach state for discovery status
     this.session.explicitlyDetached = explicit;
@@ -593,24 +387,6 @@ export class SessionRegistry {
   }
 
   /**
-   * Remove a connection from the waiting queue.
-   * Call this when a waiting connection disconnects before being promoted.
-   */
-  removeWaitingConnection(connectionId: UUID): void {
-    const idx = this.waitingConnections.findIndex((w) => w.connectionId === connectionId);
-    if (idx >= 0) {
-      this.waitingConnections.splice(idx, 1);
-    }
-  }
-
-  /**
-   * Get the number of connections waiting for promotion.
-   */
-  get waitingConnectionCount(): number {
-    return this.waitingConnections.length;
-  }
-
-  /**
    * Record an outgoing message for potential replay.
    * Call this for every message sent to the client.
    */
@@ -631,7 +407,7 @@ export class SessionRegistry {
     this.session.lastActivityAt = now();
 
     // If connected, mark as delivered
-    if (this.session.activeConnectionId !== null) {
+    if (this.session.attachedConnections.size > 0) {
       this.session.lastDeliveredIndex = this.session.messageHistory.length - 1;
     }
 
@@ -723,9 +499,6 @@ export class SessionRegistry {
       });
     }
 
-    // Clear waiting queue to prevent stale IDs leaking into a future session
-    this.waitingConnections.length = 0;
-
     // Clear the session
     this.session = null;
 
@@ -787,7 +560,8 @@ export class SessionRegistry {
         messageCount: this.session.messageHistory.length,
         lastMessage,
         source: 'daemon',
-        canAttach: this.session.activeConnectionId === null,
+        // Always attachable (#795): there is no exclusive slot to be full.
+        canAttach: true,
         canResume: false,
       },
     ];
@@ -796,7 +570,7 @@ export class SessionRegistry {
   private getDiscoverableStatus(
     session: ManagedSession,
   ): 'active' | 'idle' | 'orphaned' | 'detached' {
-    if (session.activeConnectionId === null) {
+    if (session.attachedConnections.size === 0) {
       if (session.locallyOwned) return 'active';
       if (session.explicitlyDetached || session.persistent) return 'detached';
       return 'orphaned';
@@ -840,7 +614,7 @@ export class SessionRegistry {
   get orphanedCount(): number {
     if (
       this.session !== null &&
-      this.session.activeConnectionId === null &&
+      this.session.attachedConnections.size === 0 &&
       !this.session.locallyOwned &&
       // Persistent (tmux-style) sessions are intentionally kept alive, not orphaned.
       !this.session.persistent
@@ -875,7 +649,6 @@ export class SessionRegistry {
       } catch (err) {
         console.error('Failed to close PTY during shutdown:', err);
       }
-      this.waitingConnections.length = 0;
       this.session = null;
     }
   }

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -131,7 +131,7 @@ describe('createConnectionHandlers', () => {
       expect(msg.sessionId).toBe(sessionId);
       // Every connection-time ack path stamps the binary version (#539).
       expect(msg.daemonVersion).toBe('9.9.9-test');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
     });
 
     test('auto-attaches and sends helloAck when a primary session exists (non-query)', async () => {
@@ -147,7 +147,7 @@ describe('createConnectionHandlers', () => {
       expect(sendCalls).toHaveLength(1);
       const msg = sendCalls[0]?.message as { type: string };
       expect(msg.type).toBe('hello_ack');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
       expect(cancelOrphanCalls).toBe(1);
     });
 
@@ -191,7 +191,7 @@ describe('createConnectionHandlers', () => {
       expect(queryAck.type).toBe('hello_ack');
       // The query-mode/no-attach ack path also stamps the version (#539).
       expect(queryAck.daemonVersion).toBe('9.9.9-test');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.size).toBe(0);
       expect(cancelOrphanCalls).toBe(0);
     });
 
@@ -213,7 +213,7 @@ describe('createConnectionHandlers', () => {
       expect(msg.type).toBe('error');
       expect(msg.code).toBe('SESSION_NOT_FOUND');
       // Attach should NOT have happened.
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.size).toBe(0);
     });
 
     test('attaches when resumeSessionId matches the primary session', async () => {
@@ -231,7 +231,7 @@ describe('createConnectionHandlers', () => {
       const msg = sendCalls[0]?.message as { type: string; sessionId?: UUID };
       expect(msg.type).toBe('hello_ack');
       expect(msg.sessionId).toBe(sessionId);
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
       expect(cancelOrphanCalls).toBe(1);
     });
 
@@ -315,36 +315,42 @@ describe('createConnectionHandlers', () => {
       expect(sendCalls[sendCalls.length - 1]?.message.type).toBe('question');
     });
 
-    test('second concurrent connection is queued and still receives helloAck + replay', async () => {
+    test('second concurrent connection also attaches (not queued) and receives helloAck + replay (#795)', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI(2));
       setPrimarySessionId(sessionId);
 
-      // First connection takes the active slot.
+      // First connection attaches.
       const firstConn = generateId();
       sessionRegistry.attachConnection(sessionId, firstConn);
       const recorded: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
       sessionRegistry.recordOutgoingMessage(sessionId, recorded);
 
-      // Second connection arrives while the first is still active.
+      // Second connection arrives while the first is still attached.
       await makeHandlers().onConnect(CID, {
         adapterType: 'websocket',
         platformData: { kind: 'websocket' },
       });
 
-      // Active connection is still the first; CID is queued.
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(firstConn);
-      expect(sessionRegistry.waitingConnectionCount).toBe(1);
+      // Both connections are attached -- no exclusivity, no queue.
+      const session = sessionRegistry.getSession(sessionId);
+      expect(session?.attachedConnections.has(firstConn)).toBe(true);
+      expect(session?.attachedConnections.has(CID)).toBe(true);
+      expect(session?.attachedConnections.size).toBe(2);
+      // CID can read AND write immediately.
+      expect(sessionRegistry.getSessionForConnection(CID)?.sessionId).toBe(sessionId);
 
-      // Queued client still gets helloAck + replay so it can render history.
+      // The second connection still gets helloAck + replay so it can render
+      // history, exactly as before -- only the write-exclusivity is gone.
       expect(sendCalls).toHaveLength(2);
       const ack = sendCalls[0]?.message as {
         type: string;
         isResume?: boolean;
         replayCount?: number;
+        attachState?: string;
       };
       expect(ack.type).toBe('hello_ack');
-      expect(ack.isResume).toBe(true);
+      expect(ack.attachState).toBe('attached');
       expect(ack.replayCount).toBe(1);
 
       const replay = sendCalls[1]?.message as {
@@ -355,7 +361,7 @@ describe('createConnectionHandlers', () => {
       expect(replay.messages?.length).toBe(1);
     });
 
-    test('query-mode connection does not displace an existing active connection', async () => {
+    test('query-mode connection does not attach at all', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
       setPrimarySessionId(sessionId);
@@ -368,10 +374,12 @@ describe('createConnectionHandlers', () => {
         platformData: { kind: 'websocket', mode: 'query' },
       });
 
-      // Active connection stays; query-mode client did not grab the slot or
-      // queue (utility clients ls/kill should not contend for write access).
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(firstConn);
-      expect(sessionRegistry.waitingConnectionCount).toBe(0);
+      // The attached connection stays; query-mode client (ls/kill) does not
+      // attach at all -- it never contends for a slot because there is none.
+      const session = sessionRegistry.getSession(sessionId);
+      expect(session?.attachedConnections.has(firstConn)).toBe(true);
+      expect(session?.attachedConnections.has(CID)).toBe(false);
+      expect(session?.attachedConnections.size).toBe(1);
       expect(sendCalls).toHaveLength(1);
       const ack = sendCalls[0]?.message as { type: string; isResume?: boolean };
       expect(ack.type).toBe('hello_ack');
@@ -392,7 +400,7 @@ describe('createConnectionHandlers', () => {
 
       expect(sendCalls).toHaveLength(1);
       expect((sendCalls[0]?.message as { type: string }).type).toBe('hello_ack');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
     });
 
     test('tracks the connection on the AdapterRegistry before any branch decision', async () => {
@@ -405,14 +413,14 @@ describe('createConnectionHandlers', () => {
       expect(connectionAddedCount).toBe(1);
     });
 
-    test('helloAck reports attachState "attached" for a fresh attach (#662)', async () => {
+    test('helloAck reports attachState "attached" for a fresh attach', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
       setPrimarySessionId(sessionId);
 
       await makeHandlers().onConnect(CID, {
         adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-A' },
+        platformData: { kind: 'websocket' },
       });
 
       const ack = sendCalls[0]?.message as { type: string; attachState?: string };
@@ -420,112 +428,25 @@ describe('createConnectionHandlers', () => {
       expect(ack.attachState).toBe('attached');
     });
 
-    test('helloAck reports attachState "queued" for a second connection without a matching deviceId (#662)', async () => {
+    test('helloAck reports attachState "attached" for a SECOND connection too (#795: no more queued state)', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
       setPrimarySessionId(sessionId);
 
       const firstConn = generateId();
-      sessionRegistry.attachConnection(sessionId, firstConn, 'device-A');
+      sessionRegistry.attachConnection(sessionId, firstConn);
 
       await makeHandlers().onConnect(CID, {
         adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-B' },
-      });
-
-      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
-      expect(ack.type).toBe('hello_ack');
-      expect(ack.attachState).toBe('queued');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(firstConn);
-    });
-
-    test('same deviceId reclaims the lock instead of queuing behind its own stale connection (#662)', async () => {
-      const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
-      setPrimarySessionId(sessionId);
-
-      // First connection from this device takes the active slot.
-      const staleConn = generateId();
-      sessionRegistry.attachConnection(sessionId, staleConn, 'device-A');
-
-      // Same device reconnects (e.g. after a dead-socket blip) as a new
-      // connection carrying the SAME deviceId.
-      await makeHandlers().onConnect(CID, {
-        adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-A' },
+        platformData: { kind: 'websocket' },
       });
 
       const ack = sendCalls[0]?.message as { type: string; attachState?: string };
       expect(ack.type).toBe('hello_ack');
       expect(ack.attachState).toBe('attached');
-      // The lock moved to the new connection; nothing is queued.
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
-      expect(sessionRegistry.waitingConnectionCount).toBe(0);
-      expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
-    });
-
-    test('same deviceId + matching clientFingerprint reclaims (#671, auth on)', async () => {
-      const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
-      setPrimarySessionId(sessionId);
-
-      const staleConn = generateId();
-      sessionRegistry.attachConnection(sessionId, staleConn, 'device-A', 'fp-alice');
-
-      await makeHandlers().onConnect(CID, {
-        adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-A', clientFingerprint: 'fp-alice' },
-      });
-
-      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
-      expect(ack.attachState).toBe('attached');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
-      expect(sessionRegistry.waitingConnectionCount).toBe(0);
-      expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
-    });
-
-    test('same deviceId + DIFFERENT clientFingerprint is refused: queues, does not evict (#671)', async () => {
-      const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
-      setPrimarySessionId(sessionId);
-
-      // Legitimate device holds the lock after authenticating.
-      const activeConn = generateId();
-      sessionRegistry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
-
-      // A different authenticated peer replays the same deviceId but cannot
-      // produce the matching fingerprint (it authenticated with its OWN key).
-      await makeHandlers().onConnect(CID, {
-        adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-A', clientFingerprint: 'fp-mallory' },
-      });
-
-      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
-      expect(ack.attachState).toBe('queued');
-      // Legitimate device keeps the lock; nothing was evicted.
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(sessionRegistry.getSessionForConnection(activeConn)?.sessionId).toBe(sessionId);
-    });
-
-    test('same deviceId with no clientFingerprint on either side still reclaims (#671, auth off)', async () => {
-      const sessionId = sessionRegistry.createSessionId();
-      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
-      setPrimarySessionId(sessionId);
-
-      // Localhost daemon / loopback-exempt peer: no authenticator, so no
-      // clientFingerprint is ever produced on either side.
-      const staleConn = generateId();
-      sessionRegistry.attachConnection(sessionId, staleConn, 'device-A');
-
-      await makeHandlers().onConnect(CID, {
-        adapterType: 'websocket',
-        platformData: { kind: 'websocket', deviceId: 'device-A' },
-      });
-
-      const ack = sendCalls[0]?.message as { type: string; attachState?: string };
-      expect(ack.attachState).toBe('attached');
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
-      expect(sessionRegistry.getSessionForConnection(staleConn)).toBeUndefined();
+      const session = sessionRegistry.getSession(sessionId);
+      expect(session?.attachedConnections.has(firstConn)).toBe(true);
+      expect(session?.attachedConnections.has(CID)).toBe(true);
     });
   });
 
@@ -539,7 +460,22 @@ describe('createConnectionHandlers', () => {
 
       expect(untrackedConnections).toEqual([CID]);
       expect(connectionRemovedCount).toBe(1);
-      expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBeNull();
+      expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(false);
+    });
+
+    test('detaching one of two attached connections leaves the other attached (#795)', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      const otherConn = generateId();
+      sessionRegistry.attachConnection(sessionId, otherConn);
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      await makeHandlers().onDisconnect(CID, 'client closed');
+
+      const session = sessionRegistry.getSession(sessionId);
+      expect(session?.attachedConnections.has(CID)).toBe(false);
+      expect(session?.attachedConnections.has(otherConn)).toBe(true);
+      expect(sessionRegistry.getSessionForConnection(otherConn)?.sessionId).toBe(sessionId);
     });
 
     test('does not reach into deviceTokens on disconnect (regression #286)', async () => {

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -147,7 +147,64 @@ describe('createInputHandlers', () => {
       expect(msg.code).toBe('SESSION_NOT_FOUND');
     });
 
-    test('sends NOT_ACTIVE_CONNECTION when the session exists but this connection is queued (#662)', async () => {
+    test('a SECOND attached connection can also submit input (#795: no exclusive lock)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      const firstConn = generateId();
+      sessionRegistry.attachConnection(sessionId, firstConn);
+      // CID is a SECOND connection attaching concurrently -- also attached,
+      // not queued behind the first.
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await handlers.onUserInput(firstConn, sessionId, 'from first', false);
+      await handlers.onUserInput(CID, sessionId, 'from second', false);
+
+      // Both submits landed -- neither connection was denied.
+      expect(ptyCapture.submits).toEqual(['from first', 'from second']);
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test('detaching one connection leaves the other still attached and able to type (#795)', async () => {
+      const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(
+        sessionId,
+        '/test/dir',
+        fakePTY(ptyCapture),
+        fakeMessageAPI(new Map()),
+      );
+      const firstConn = generateId();
+      sessionRegistry.attachConnection(sessionId, firstConn);
+      sessionRegistry.attachConnection(sessionId, CID);
+
+      // The first connection detaches (e.g. it closed its tab).
+      sessionRegistry.detachConnection(firstConn);
+
+      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      await handlers.onUserInput(CID, sessionId, 'still typing', false);
+
+      // CID's submit still lands -- it was never affected by the other
+      // connection's detach.
+      expect(ptyCapture.submits).toEqual(['still typing']);
+      expect(sendCalls).toHaveLength(0);
+
+      // The detached connection, meanwhile, can no longer submit.
+      await handlers.onUserInput(firstConn, sessionId, 'too late', false);
+      expect(ptyCapture.submits).toEqual(['still typing']);
+      expect(sendCalls).toHaveLength(1);
+      const msg = sendCalls[0]?.message as { type: string; code?: string };
+      expect(msg.type).toBe('error');
+      expect(msg.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    test('sends SESSION_NOT_FOUND for a connection that never attached (e.g. query-mode misuse)', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(
         sessionId,
@@ -155,10 +212,7 @@ describe('createInputHandlers', () => {
         fakePTY({ writes: [], submits: [] }),
         fakeMessageAPI(new Map()),
       );
-      const activeConn = generateId();
-      sessionRegistry.attachConnection(sessionId, activeConn);
-      // CID is a different connection queued behind the active one.
-      sessionRegistry.attachConnection(sessionId, CID);
+      // CID never attaches (as a query-mode connection would not).
 
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       await handlers.onUserInput(CID, sessionId, 'ignored', false);
@@ -170,13 +224,15 @@ describe('createInputHandlers', () => {
         details?: { sessionId?: string; messageId?: string };
       };
       expect(msg.type).toBe('error');
-      expect(msg.code).toBe('NOT_ACTIVE_CONNECTION');
+      // New daemons never emit NOT_ACTIVE_CONNECTION (#795); the error code is
+      // kept string-only for an older client talking to an older daemon.
+      expect(msg.code).toBe('SESSION_NOT_FOUND');
       expect(msg.details?.sessionId).toBe(sessionId);
       // No messageId was passed in -- details must not carry a stray key.
       expect(msg.details?.messageId).toBeUndefined();
     });
 
-    test('NOT_ACTIVE_CONNECTION details carry the rejected input message id (#681)', async () => {
+    test('SESSION_NOT_FOUND details carry the rejected input message id (#681) for an unattached connection', async () => {
       const sessionId = sessionRegistry.createSessionId();
       sessionRegistry.registerSession(
         sessionId,
@@ -184,10 +240,7 @@ describe('createInputHandlers', () => {
         fakePTY({ writes: [], submits: [] }),
         fakeMessageAPI(new Map()),
       );
-      const activeConn = generateId();
-      sessionRegistry.attachConnection(sessionId, activeConn);
-      // CID is a different connection queued behind the active one.
-      sessionRegistry.attachConnection(sessionId, CID);
+      // CID never attaches.
 
       const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
       const droppedMessageId = generateId();
@@ -200,10 +253,10 @@ describe('createInputHandlers', () => {
         details?: { sessionId?: string; messageId?: string };
       };
       expect(msg.type).toBe('error');
-      expect(msg.code).toBe('NOT_ACTIVE_CONNECTION');
+      expect(msg.code).toBe('SESSION_NOT_FOUND');
       expect(msg.details?.sessionId).toBe(sessionId);
       // The specific dropped message's id, so the client can flip that ONE
-      // bubble to 'failed' instead of only refreshing the read-only banner.
+      // bubble to 'failed'.
       expect(msg.details?.messageId).toBe(droppedMessageId);
     });
 

--- a/packages/daemon/tests/cli/handlers/pty-message-fanout.test.ts
+++ b/packages/daemon/tests/cli/handlers/pty-message-fanout.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import { createRawPtyOutput, generateId, now } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { createPtyMessageFanout } from '../../../src/cli/handlers/pty-message-fanout.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../src/session/session-registry.ts';
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    write: () => {},
+    submitInput: async () => {},
+    close: async () => {},
+  } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return { bulletCount: 0 } as unknown as MessageAPI;
+}
+
+describe('createPtyMessageFanout (#795)', () => {
+  let sessionRegistry: SessionRegistry;
+  let sentDirect: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+  let broadcasted: ProtocolMessage[];
+
+  beforeEach(() => {
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 1000 });
+    sentDirect = [];
+    broadcasted = [];
+  });
+
+  afterEach(async () => {
+    await sessionRegistry.shutdown();
+  });
+
+  function makeFanout() {
+    return createPtyMessageFanout({
+      sessionRegistry,
+      sendToConnection: (connectionId, message) => {
+        sentDirect.push({ connectionId, message });
+        return true;
+      },
+      broadcast: (message) => {
+        broadcasted.push(message);
+      },
+    });
+  }
+
+  test('raw_pty_output reaches every attached connection, not just one', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+    const connA = generateId();
+    const connB = generateId();
+    const connC = generateId();
+    sessionRegistry.attachConnection(sessionId, connA);
+    sessionRegistry.attachConnection(sessionId, connB);
+    sessionRegistry.attachConnection(sessionId, connC);
+
+    const fanout = makeFanout();
+    const rawMsg = createRawPtyOutput('aGVsbG8=', sessionId);
+    fanout(sessionId, rawMsg);
+
+    expect(sentDirect).toHaveLength(3);
+    const recipients = sentDirect.map((s) => s.connectionId).sort();
+    expect(recipients).toEqual([connA, connB, connC].sort());
+    for (const s of sentDirect) {
+      expect(s.message).toBe(rawMsg);
+    }
+    // raw_pty_output is high-volume and never broadcast to query-mode clients.
+    expect(broadcasted).toHaveLength(0);
+  });
+
+  test('raw_pty_output is a no-op when nobody is attached', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+    // Nobody attaches.
+
+    const fanout = makeFanout();
+    fanout(sessionId, createRawPtyOutput('aGVsbG8=', sessionId));
+
+    expect(sentDirect).toHaveLength(0);
+    expect(broadcasted).toHaveLength(0);
+  });
+
+  test('every other message type still goes through the ordinary broadcast', () => {
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+    sessionRegistry.attachConnection(sessionId, generateId());
+
+    const fanout = makeFanout();
+    const msg: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
+    fanout(sessionId, msg);
+
+    expect(broadcasted).toEqual([msg]);
+    // Not sent directly to the attached connection -- broadcast already covers it.
+    expect(sentDirect).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/resume-session-events.test.ts
@@ -100,7 +100,7 @@ describe('createResumeSessionHandlers', () => {
       daemonVersion?: unknown;
     };
     expect('daemonVersion' in resumeAck).toBe(false);
-    expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).toBe(CID);
+    expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
   });
 
   test('#753: re-sends pending questions as live messages on the still-alive attach path', async () => {
@@ -208,7 +208,7 @@ describe('createResumeSessionHandlers', () => {
     expect(types).toContain('resume_session_response');
     expect(types).toContain('hello_ack');
     const attachedId = spawnHistory[0]?.sessionId as UUID;
-    expect(sessionRegistry.getSession(attachedId)?.activeConnectionId).toBe(CID);
+    expect(sessionRegistry.getSession(attachedId)?.attachedConnections.has(CID)).toBe(true);
   });
 
   test('closes the newly-spawned session and reports failure when createNewSession throws', async () => {

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -3,8 +3,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { createTrivialHandlers } from '../../../src/cli/handlers/trivial-events.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
+import type { PTYSession } from '../../../src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../src/session/session-registry.ts';
 import { SessionStore } from '../../../src/session/session-store.ts';
 
@@ -99,6 +102,46 @@ describe('createTrivialHandlers', () => {
     handlers.onTerminalResize(CID, 80, 24);
 
     expect(logs.some((m) => m.includes('Terminal resize ignored'))).toBe(true);
+  });
+
+  test('resize is last-writer-wins across multiple attached connections (#795)', () => {
+    const resizes: Array<{ cols: number; rows: number }> = [];
+    const pty = {
+      id: generateId(),
+      resize: (size: { cols: number; rows: number }) => {
+        resizes.push(size);
+      },
+      close: async () => {},
+    } as unknown as PTYSession;
+    const messageApi = { bulletCount: 0 } as unknown as MessageAPI;
+    const sessionId = sessionRegistry.createSessionId();
+    sessionRegistry.registerSession(sessionId, '/test/dir', pty, messageApi);
+    const connA = generateId();
+    const connB = generateId();
+    sessionRegistry.attachConnection(sessionId, connA);
+    sessionRegistry.attachConnection(sessionId, connB);
+
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({
+      registerDeviceToken: () => {},
+      unregisterDeviceToken: () => {},
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: () => {} });
+
+    // Both attached connections can resize; there is no negotiation --
+    // whichever call lands LAST wins, regardless of which connection sent it.
+    handlers.onTerminalResize(connA, 80, 24);
+    handlers.onTerminalResize(connB, 120, 40);
+    handlers.onTerminalResize(connA, 100, 30);
+
+    expect(resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 120, rows: 40 },
+      { cols: 100, rows: 30 },
+    ]);
   });
 
   test('onError writes [error]-prefixed log in wrapper mode', () => {

--- a/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/message-api-setup.test.ts
@@ -171,12 +171,12 @@ describe('createMessageApiForSession', () => {
     // hasActiveClient branch were bypassed. sendPushTrigger is imported
     // statically by the production module, so tests can't observe that call
     // directly without a mock. What we CAN assert: the in-app question
-    // message still went out, and activeConnectionId is non-null (the
-    // condition guarding the push for-loop). A follow-up that injects
+    // message still went out, and the session has an attached connection
+    // (the condition guarding the push for-loop). A follow-up that injects
     // sendPushTrigger via deps would let us assert the opposite branch.
     const questions = sendCalls.filter((c) => c.message.type === 'question');
     expect(questions).toHaveLength(1);
-    expect(sessionRegistry.getSession(sessionId)?.activeConnectionId).not.toBeNull();
+    expect(sessionRegistry.getSession(sessionId)?.attachedConnections.size).toBeGreaterThan(0);
   });
 
   test('onStatusChange emits session_update and patches StatusWriter', () => {

--- a/packages/daemon/tests/pty-session-write-serialization.test.ts
+++ b/packages/daemon/tests/pty-session-write-serialization.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Real-PTY regression test for the write-serialization queue added in
+ * pty-session.ts (#795).
+ *
+ * Removing the session's exclusive write lock means any attached connection
+ * can call `submitInput()` concurrently now, not just one. `submitInput()`
+ * writes its text, waits ~50ms, then writes a trailing CR -- if two calls
+ * interleave in that gap, one connection's text can land in the middle of
+ * another's, corrupting both. This exact race (`390898b` allowed concurrent
+ * writers without a queue; `588afde` reverted it for "queued resize/answer/
+ * input would race the active client's session") is why `PTYSession` now
+ * serializes every write through a per-session queue.
+ *
+ * This spawns a REAL PTY (no mocks) and relies on the terminal's own ECHO
+ * (canonical mode, on by default) to observe the raw bytes as they actually
+ * landed: every write we make echoes back verbatim. If two concurrent
+ * `submitInput()` calls interleaved, at least one of the two full strings
+ * would no longer appear as a contiguous, uncorrupted run in the output.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { PTYSession } from '../src/pty/pty-session.ts';
+
+describe('PTYSession write serialization (#795)', () => {
+  let session: PTYSession;
+
+  afterEach(async () => {
+    try {
+      await session?.close(2000);
+    } catch {
+      // Session may have already exited
+    }
+  });
+
+  test('concurrent submitInput calls do not interleave text/CR bytes', async () => {
+    let output = '';
+    session = new PTYSession(
+      { command: '/bin/cat', args: [] },
+      {
+        onData: (data) => {
+          output += data;
+        },
+        onError: (err) => {
+          console.error('[PTY error]', err.message);
+        },
+      },
+    );
+    await session.start();
+    expect(session.isRunning).toBe(true);
+
+    // Two distinct, easily-searched-for strings, submitted CONCURRENTLY --
+    // exactly the scenario the exclusive lock used to prevent entirely.
+    const textA = 'AAAAAAAAAAAAAAAAAAAA'; // 20 chars
+    const textB = 'BBBBBBBBBBBBBBBBBBBB'; // 20 chars
+
+    await Promise.all([session.submitInput(textA), session.submitInput(textB)]);
+
+    // Let the PTY's echo (and cat's own stdin->stdout copy) settle.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // Each full string must appear intact. cat echoes/copies every write it
+    // receives, so an uncorrupted run produces the pattern twice (raw tty
+    // echo + cat's own forwarded copy); if the writes interleaved, at least
+    // one of the two full 20-char runs would be broken up by the other
+    // connection's bytes and this count would drop.
+    const countOf = (needle: string): number => output.split(needle).length - 1;
+    expect(countOf(textA)).toBeGreaterThanOrEqual(2);
+    expect(countOf(textB)).toBeGreaterThanOrEqual(2);
+
+    // And each submit's CR immediately follows its own text with nothing
+    // from the other submit spliced in between -- the direct serialization
+    // guarantee, not just "the text happened to survive".
+    expect(output).toContain(`${textA}\r`);
+    expect(output).toContain(`${textB}\r`);
+  });
+
+  test('a raw write() does not land inside an in-flight submitInput sequence', async () => {
+    let output = '';
+    session = new PTYSession(
+      { command: '/bin/cat', args: [] },
+      {
+        onData: (data) => {
+          output += data;
+        },
+      },
+    );
+    await session.start();
+
+    const text = 'SUBMITSUBMITSUBMITSU'; // 21 chars, no 'X' in it
+    await Promise.all([
+      session.submitInput(text),
+      // A concurrent single-shot write from a different connection (e.g. a
+      // raw keystroke), racing the 50ms gap between submitInput's text and
+      // its CR.
+      session.write('X'),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // The submit's text must not have an 'X' spliced into the middle of it.
+    expect(output).toContain(`${text}\r`);
+  });
+});

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -7,7 +7,6 @@ import type { ProtocolMessage } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../src/api/message-api.ts';
 import type { PTYSession } from '../src/pty/pty-session.ts';
-import type { AttachResult } from '../src/session/session-registry.ts';
 import { SessionRegistry } from '../src/session/session-registry.ts';
 
 function createMockPTY(): PTYSession {
@@ -33,8 +32,6 @@ describe('SessionRegistry', () => {
     onSessionClosed: ReturnType<typeof mock>;
     onSessionOrphaned: ReturnType<typeof mock>;
     onSessionResumed: ReturnType<typeof mock>;
-    onConnectionPromoted: ReturnType<typeof mock>;
-    onConnectionReclaimed: ReturnType<typeof mock>;
     onQuestionsChanged: ReturnType<typeof mock>;
   };
 
@@ -44,8 +41,6 @@ describe('SessionRegistry', () => {
       onSessionClosed: mock(() => {}),
       onSessionOrphaned: mock(() => {}),
       onSessionResumed: mock(() => {}),
-      onConnectionPromoted: mock(() => {}),
-      onConnectionReclaimed: mock(() => {}),
       onQuestionsChanged: mock(() => {}),
     };
 
@@ -72,12 +67,12 @@ describe('SessionRegistry', () => {
       expect(events.onSessionCreated).toHaveBeenCalledWith(sessionId);
     });
 
-    test('session starts with no connection', () => {
+    test('session starts with no attached connections', () => {
       const sessionId = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
       const session = registry.getSession(sessionId);
-      expect(session?.activeConnectionId).toBeNull();
+      expect(session?.attachedConnections.size).toBe(0);
       expect(session?.lastDisconnectedAt).toBeNull();
     });
   });
@@ -224,9 +219,10 @@ describe('SessionRegistry', () => {
       expect(result.success).toBe(true);
       expect(result.isResume).toBe(false);
       expect(result.replayMessages).toEqual([]);
+      expect(result.attachState).toBe('attached');
 
       const session = registry.getSession(sessionId);
-      expect(session?.activeConnectionId).toBe(connectionId);
+      expect(session?.attachedConnections.has(connectionId)).toBe(true);
     });
 
     test('returns error for non-existent session', () => {
@@ -234,18 +230,6 @@ describe('SessionRegistry', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Session not found');
-    });
-
-    test('queues second connection when session already has one', () => {
-      const sessionId = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-      registry.attachConnection(sessionId, generateId());
-
-      const result = registry.attachConnection(sessionId, generateId());
-
-      // Second connection is queued (read-only with replay) rather than rejected
-      expect(result.success).toBe(true);
-      expect(result.isResume).toBe(true);
     });
 
     test('getSessionForConnection works after attach', () => {
@@ -258,415 +242,131 @@ describe('SessionRegistry', () => {
       expect(session?.sessionId).toBe(sessionId);
     });
 
-    test('getSessionForConnection returns undefined for queued (read-only) connection', () => {
-      // Exclusive write lock: only the active connection sees the session via
-      // this lookup. Queued connections receive replay through attachConnection
-      // but cannot write input/answer/resize that would race the active
-      // client. Locking this contract prevents a future refactor from silently
-      // re-introducing the input-race bug.
-      const sessionId = generateId();
-      const activeConnId = generateId();
-      const queuedConnId = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-      registry.attachConnection(sessionId, activeConnId);
-
-      // Second attach: queued.
-      const queuedAttach = registry.attachConnection(sessionId, queuedConnId);
-      expect(queuedAttach.success).toBe(true);
-      expect(queuedAttach.replayMessages).toBeDefined();
-
-      // Active still owns the session for writes.
-      expect(registry.getSessionForConnection(activeConnId)?.sessionId).toBe(sessionId);
-      // Queued must NOT.
-      expect(registry.getSessionForConnection(queuedConnId)).toBeUndefined();
-    });
-
-    test('attachState is "attached" for a fresh (non-busy) attach', () => {
+    test('getSessionForConnection returns undefined for a connection that never attached', () => {
       const sessionId = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
-      const result = registry.attachConnection(sessionId, generateId());
-
-      expect(result.attachState).toBe('attached');
-    });
-
-    test('attachState is "queued" when the session already has an active connection', () => {
-      const sessionId = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-      registry.attachConnection(sessionId, generateId());
-
-      const result = registry.attachConnection(sessionId, generateId());
-
-      expect(result.attachState).toBe('queued');
+      expect(registry.getSessionForConnection(generateId())).toBeUndefined();
     });
   });
 
-  describe('same-device lock reclaim (#662)', () => {
-    test('reconnect with the SAME deviceId reclaims the lock instead of queuing', () => {
+  describe('multi-attach: any connected client can read and write (#795)', () => {
+    test('a second connection attaching does NOT displace the first — both are attached', () => {
       const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
+      const connA = generateId();
+      const connB = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      const result = registry.attachConnection(sessionId, newConn, 'device-A');
+      const resultA = registry.attachConnection(sessionId, connA);
+      const resultB = registry.attachConnection(sessionId, connB);
 
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('attached');
-      expect(registry.waitingConnectionCount).toBe(0);
+      expect(resultA.success).toBe(true);
+      expect(resultA.attachState).toBe('attached');
+      expect(resultB.success).toBe(true);
+      expect(resultB.attachState).toBe('attached');
+
+      // Both connections independently resolve to the SAME session for
+      // reads and writes -- neither is read-only.
+      expect(registry.getSessionForConnection(connA)?.sessionId).toBe(sessionId);
+      expect(registry.getSessionForConnection(connB)?.sessionId).toBe(sessionId);
 
       const session = registry.getSession(sessionId);
-      expect(session?.activeConnectionId).toBe(newConn);
-      // The new connection now holds the write lock...
-      expect(registry.getSessionForConnection(newConn)?.sessionId).toBe(sessionId);
-      // ...and the stale one no longer does (it was evicted, not queued).
-      expect(registry.getSessionForConnection(staleConn)).toBeUndefined();
+      expect(session?.attachedConnections.size).toBe(2);
+      expect(session?.attachedConnections.has(connA)).toBe(true);
+      expect(session?.attachedConnections.has(connB)).toBe(true);
     });
 
-    test('fires onConnectionReclaimed with the stale and new connection ids', () => {
+    test('a third, fourth, ... connection can all attach at once', () => {
       const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      const conns = Array.from({ length: 5 }, () => generateId());
+
+      for (const c of conns) {
+        const result = registry.attachConnection(sessionId, c);
+        expect(result.success).toBe(true);
+        expect(result.attachState).toBe('attached');
+      }
+
+      const session = registry.getSession(sessionId);
+      expect(session?.attachedConnections.size).toBe(5);
+      for (const c of conns) {
+        expect(registry.getSessionForConnection(c)?.sessionId).toBe(sessionId);
+      }
+    });
+
+    test('a second connection joining an already-attached session is NOT a "resume"', () => {
+      const sessionId = generateId();
+      const connA = generateId();
+      const connB = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
 
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      registry.attachConnection(sessionId, newConn, 'device-A');
+      registry.attachConnection(sessionId, connA);
+      const resultB = registry.attachConnection(sessionId, connB);
 
-      expect(events.onConnectionReclaimed).toHaveBeenCalledTimes(1);
-      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, staleConn, newConn);
+      // isResume is about the session having had ZERO attached connections
+      // before, not about "someone else is already here".
+      expect(resultB.isResume).toBe(false);
+      expect(events.onSessionResumed).not.toHaveBeenCalled();
     });
 
-    test('a DIFFERENT deviceId still queues behind the active connection', () => {
+    test('detaching one of several attached connections leaves the others attached', () => {
       const sessionId = generateId();
-      const activeConn = generateId();
-      const otherConn = generateId();
+      const connA = generateId();
+      const connB = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connA);
+      registry.attachConnection(sessionId, connB);
 
-      registry.attachConnection(sessionId, activeConn, 'device-A');
-      const result = registry.attachConnection(sessionId, otherConn, 'device-B');
+      registry.detachConnection(connA);
 
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('queued');
-      expect(registry.waitingConnectionCount).toBe(1);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test("an UNDEFINED deviceId keeps today's behavior: queues, never reclaims", () => {
-      const sessionId = generateId();
-      const activeConn = generateId();
-      const otherConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      // Active connection attached WITHOUT a deviceId (older client).
-      registry.attachConnection(sessionId, activeConn);
-      const result = registry.attachConnection(sessionId, otherConn);
-
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('queued');
-      expect(registry.waitingConnectionCount).toBe(1);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test('a NEW connection with a deviceId does not reclaim when the active connection has none', () => {
-      const sessionId = generateId();
-      const activeConn = generateId();
-      const otherConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      // Active connection has no deviceId (e.g. an older client); the new
-      // connection sending one must not be treated as a match against "no
-      // device on record" — queue as normal.
-      registry.attachConnection(sessionId, activeConn);
-      const result = registry.attachConnection(sessionId, otherConn, 'device-A');
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test('reclaimed session replays full history to the new connection', () => {
-      const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI(3));
-
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      const msg: ProtocolMessage = { type: 'ping', id: generateId(), timestamp: now() };
-      registry.recordOutgoingMessage(sessionId, msg);
-
-      const result = registry.attachConnection(sessionId, newConn, 'device-A');
-
-      expect(result.replayMessages).toContain(msg);
-      expect(result.nextBulletId).toBe(4);
-    });
-
-    test('after reclaim, detaching the stale connection id is a no-op (does not orphan)', () => {
-      const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      registry.attachConnection(sessionId, newConn, 'device-A');
-
-      // The stale connection's own disconnect (e.g. its socket finally
-      // errors out after being evicted) must not clobber the new connection's
-      // lock: activeConnectionId no longer equals staleConn, so this is a no-op.
-      registry.detachConnection(staleConn);
-
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
+      // B is still attached and can read/write; the session is NOT orphaned.
+      expect(registry.getSessionForConnection(connA)).toBeUndefined();
+      expect(registry.getSessionForConnection(connB)?.sessionId).toBe(sessionId);
+      expect(registry.getSession(sessionId)?.attachedConnections.size).toBe(1);
       expect(events.onSessionOrphaned).not.toHaveBeenCalled();
     });
 
-    test('after reclaim, a genuinely different device attaching later still queues', () => {
-      const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
-      const otherDeviceConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      registry.attachConnection(sessionId, newConn, 'device-A');
-
-      const result = registry.attachConnection(sessionId, otherDeviceConn, 'device-B');
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
-    });
-
-    test('a FIFO-promoted connection carries its deviceId forward as activeDeviceId', () => {
-      // Without this, only the FIRST-ever active connection's device could
-      // ever be reclaimed; a connection reached via the waiting-queue
-      // promotion path would silently lose reclaim protection.
+    test('the session only orphans once the LAST attached connection detaches', () => {
       const sessionId = generateId();
       const connA = generateId();
       const connB = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connA);
+      registry.attachConnection(sessionId, connB);
 
-      registry.attachConnection(sessionId, connA); // active, no deviceId
-      registry.attachConnection(sessionId, connB, 'device-B'); // queued, WITH deviceId
-
-      // A disconnects -> B is FIFO-promoted to active.
       registry.detachConnection(connA);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
+      expect(events.onSessionOrphaned).not.toHaveBeenCalled();
 
-      expect(events.onConnectionPromoted).toHaveBeenCalledTimes(1);
-      const call = events.onConnectionPromoted.mock.calls[0] as
-        | [string, string, AttachResult]
-        | undefined;
-      expect(call?.[2].attachState).toBe('attached');
+      registry.detachConnection(connB);
+      expect(events.onSessionOrphaned).toHaveBeenCalledTimes(1);
+      expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
+      expect(registry.getSession(sessionId)?.attachedConnections.size).toBe(0);
     });
 
-    test('a promoted-then-stale connection is still reclaimable by the same device', () => {
-      // The exact scenario the queue-deviceId fix targets: connB starts
-      // queued (not the original active connection), gets promoted when
-      // connA disconnects, and THEN itself goes stale. A genuine reconnect
-      // from device-B must still reclaim rather than queue behind connB.
+    test('detaching an already-detached connection is a no-op', () => {
+      const sessionId = generateId();
+      const connA = generateId();
+      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connA);
+      registry.detachConnection(connA);
+      events.onSessionOrphaned.mockClear();
+
+      registry.detachConnection(connA);
+      expect(events.onSessionOrphaned).not.toHaveBeenCalled();
+    });
+
+    test('a fresh attach after everyone left IS a resume', () => {
       const sessionId = generateId();
       const connA = generateId();
       const connB = generateId();
-      const connBReconnect = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
+      registry.attachConnection(sessionId, connA);
+      registry.detachConnection(connA);
 
-      registry.attachConnection(sessionId, connA, 'device-A');
-      registry.attachConnection(sessionId, connB, 'device-B'); // queued with deviceId
+      const result = registry.attachConnection(sessionId, connB);
 
-      registry.detachConnection(connA); // connB promoted to active
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
-
-      // connB goes stale (e.g. reaped by the pong timeout) and device-B
-      // reconnects as a brand new connection.
-      const result = registry.attachConnection(sessionId, connBReconnect, 'device-B');
-
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('attached');
-      expect(registry.waitingConnectionCount).toBe(0);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connBReconnect);
-      // The promoted-then-stale connection was evicted, not queued behind.
-      expect(registry.getSessionForConnection(connB)).toBeUndefined();
-      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, connB, connBReconnect);
-    });
-
-    test('a promoted connection without a deviceId still just queues on reconnect (no false reclaim)', () => {
-      const sessionId = generateId();
-      const connA = generateId();
-      const connB = generateId();
-      const connC = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, connA); // active, no deviceId
-      registry.attachConnection(sessionId, connB); // queued, no deviceId either
-
-      registry.detachConnection(connA); // connB promoted; activeDeviceId stays null
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
-
-      const result = registry.attachConnection(sessionId, connC, 'device-C');
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('fingerprint-bound reclaim (#671)', () => {
-    test('matching deviceId + matching clientFingerprint reclaims (auth on)', () => {
-      const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, staleConn, 'device-A', 'fp-alice');
-      const result = registry.attachConnection(sessionId, newConn, 'device-A', 'fp-alice');
-
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('attached');
-      expect(registry.waitingConnectionCount).toBe(0);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
-      expect(registry.getSessionForConnection(staleConn)).toBeUndefined();
-      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, staleConn, newConn);
-    });
-
-    test('matching deviceId + DIFFERENT clientFingerprint is refused: queues, no eviction', () => {
-      const sessionId = generateId();
-      const activeConn = generateId();
-      const attackerConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      // Legitimate device authenticates and holds the lock.
-      registry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
-
-      // A different authenticated peer replays/guesses the same deviceId but
-      // cannot produce the same fingerprint. Must be refused: queued, not
-      // evicted.
-      const result = registry.attachConnection(sessionId, attackerConn, 'device-A', 'fp-mallory');
-
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('queued');
-      expect(registry.waitingConnectionCount).toBe(1);
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(registry.getSessionForConnection(activeConn)?.sessionId).toBe(sessionId);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test('matching deviceId + active has a fingerprint but reconnect sends none: refused', () => {
-      // A downgrade attempt: the legitimate device authenticated once, but a
-      // later hello for the same deviceId arrives with no clientFingerprint
-      // at all (e.g. an unauthenticated connection). Must not reclaim.
-      const sessionId = generateId();
-      const activeConn = generateId();
-      const attackerConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, activeConn, 'device-A', 'fp-alice');
-      const result = registry.attachConnection(sessionId, attackerConn, 'device-A');
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test('matching deviceId + active has NO fingerprint but reconnect sends one: refused', () => {
-      // The other mismatch direction: the active connection is loopback-
-      // exempt / unauthenticated (no bound identity), and a fingerprint-
-      // bearing (authenticated, networked) peer replays/guesses its deviceId.
-      // A networked peer must not be able to reclaim a loopback-held lock
-      // with deviceId alone just because the active side has nothing to
-      // check against — strict null==null equality means "one side null,
-      // the other not" is always a mismatch, never a free pass.
-      const sessionId = generateId();
-      const activeConn = generateId();
-      const attackerConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, activeConn, 'device-A'); // loopback, no fingerprint
-      const result = registry.attachConnection(sessionId, attackerConn, 'device-A', 'fp-mallory');
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(activeConn);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-    });
-
-    test('matching deviceId with NO fingerprint on either side still reclaims (auth off)', () => {
-      // Localhost-only daemons (or loopback-exempt peers) never authenticate,
-      // so neither side ever carries a clientFingerprint. Falls back to
-      // today's deviceId-only reclaim.
-      const sessionId = generateId();
-      const staleConn = generateId();
-      const newConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, staleConn, 'device-A');
-      const result = registry.attachConnection(sessionId, newConn, 'device-A');
-
-      expect(result.success).toBe(true);
-      expect(result.attachState).toBe('attached');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(newConn);
-      expect(events.onConnectionReclaimed).toHaveBeenCalledWith(sessionId, staleConn, newConn);
-    });
-
-    test('a FIFO-promoted connection carries its clientFingerprint forward for later reclaim checks', () => {
-      // Mirrors the deviceId-through-promotion fix (#662): a connection
-      // promoted from the waiting queue must keep the SAME identity bar for
-      // a later reclaim attempt against it, not silently downgrade to
-      // deviceId-only just because it arrived via promotion.
-      const sessionId = generateId();
-      const connA = generateId();
-      const connB = generateId();
-      const attackerConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, connA); // active, no identity
-      registry.attachConnection(sessionId, connB, 'device-B', 'fp-bob'); // queued, authenticated
-
-      registry.detachConnection(connA); // connB promoted to active
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
-      expect(registry.getSession(sessionId)?.activeClientFingerprint).toBe('fp-bob');
-
-      // An attacker guesses device-B's id but cannot produce fp-bob.
-      const spoofed = registry.attachConnection(sessionId, attackerConn, 'device-B', 'fp-mallory');
-      expect(spoofed.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(connB);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
-
-      // The real device-B reconnecting with the matching fingerprint still
-      // reclaims normally.
-      const genuine = registry.attachConnection(sessionId, generateId(), 'device-B', 'fp-bob');
-      expect(genuine.attachState).toBe('attached');
-      expect(events.onConnectionReclaimed).toHaveBeenCalledTimes(1);
-    });
-
-    test('PoC: reclaim bound to the actual authenticated identity (not a forged claim) lands queued, victim untouched', () => {
-      // Mirrors connection-auth.test.ts's TOFU PoC one layer down: even if an
-      // attacker completed authentication while WIRE-claiming the victim's
-      // fingerprint, the fix means only their OWN server-derived fingerprint
-      // is ever bound to their connection (never the claim). So the value
-      // that actually reaches attachConnection for the attacker's connection
-      // is their own, genuinely different, fingerprint — the victim's lock
-      // must survive untouched.
-      const sessionId = generateId();
-      const victimConn = generateId();
-      const attackerConn = generateId();
-      registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
-
-      registry.attachConnection(sessionId, victimConn, 'victim-device', 'fp-victim-real');
-
-      // Attacker replays/guesses the victim's deviceId; even though they
-      // WIRE-claimed 'fp-victim-real' during their own auth handshake, the
-      // daemon only ever binds the derived fingerprint of the key they
-      // actually control, which differs from the victim's.
-      const result = registry.attachConnection(
-        sessionId,
-        attackerConn,
-        'victim-device',
-        'fp-attacker-derived',
-      );
-
-      expect(result.attachState).toBe('queued');
-      expect(registry.getSession(sessionId)?.activeConnectionId).toBe(victimConn);
-      expect(registry.getSessionForConnection(victimConn)?.sessionId).toBe(sessionId);
-      expect(events.onConnectionReclaimed).not.toHaveBeenCalled();
+      expect(result.isResume).toBe(true);
+      expect(events.onSessionResumed).toHaveBeenCalledWith(sessionId, connB);
     });
   });
 
@@ -680,7 +380,7 @@ describe('SessionRegistry', () => {
       registry.detachConnection(connectionId);
 
       const session = registry.getSession(sessionId);
-      expect(session?.activeConnectionId).toBeNull();
+      expect(session?.attachedConnections.size).toBe(0);
       expect(session?.lastDisconnectedAt).not.toBeNull();
       expect(events.onSessionOrphaned).toHaveBeenCalledWith(sessionId);
     });
@@ -717,12 +417,12 @@ describe('SessionRegistry', () => {
       expect(registry.canResume(generateId())).toBe(false);
     });
 
-    test('returns false for connected session', () => {
+    test('returns true for a session with an attached connection (#795: attach is always allowed)', () => {
       const sessionId = generateId();
       registry.registerSession(sessionId, '/test/dir', createMockPTY(), createMockMessageAPI());
       registry.attachConnection(sessionId, generateId());
 
-      expect(registry.canResume(sessionId)).toBe(false);
+      expect(registry.canResume(sessionId)).toBe(true);
     });
 
     test('returns true for orphaned session', () => {
@@ -1238,230 +938,6 @@ describe('SessionRegistry', () => {
     test('is safe to call with no session', async () => {
       await registry.shutdown();
       expect(registry.sessionCount).toBe(0);
-    });
-  });
-
-  describe('waiting connection promotion', () => {
-    const sessionId = generateId();
-    const connA = generateId();
-    const connB = generateId();
-    const connC = generateId();
-
-    beforeEach(() => {
-      registry.registerSession(sessionId, '/tmp/test', createMockPTY(), createMockMessageAPI());
-    });
-
-    test('queues connection when session is busy (with read-only replay)', () => {
-      registry.attachConnection(sessionId, connA);
-      const result = registry.attachConnection(sessionId, connB);
-
-      // Queued connections now succeed with read-only replay access
-      expect(result.success).toBe(true);
-      expect(result.isResume).toBe(true);
-      expect(registry.waitingConnectionCount).toBe(1);
-    });
-
-    test('does not queue same connection twice', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-      registry.attachConnection(sessionId, connB); // duplicate
-
-      expect(registry.waitingConnectionCount).toBe(1);
-    });
-
-    test('auto-promotes waiting connection when active disconnects', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB); // queued
-
-      registry.detachConnection(connA);
-
-      // connB should now be active
-      const session = registry.getSessionForConnection(connB);
-      expect(session).toBeDefined();
-      expect(session?.activeConnectionId).toBe(connB);
-      expect(registry.waitingConnectionCount).toBe(0);
-    });
-
-    test('fires onConnectionPromoted when promoting', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-
-      registry.detachConnection(connA);
-
-      expect(events.onConnectionPromoted).toHaveBeenCalledTimes(1);
-      const call = events.onConnectionPromoted.mock.calls[0] as
-        | [string, string, AttachResult]
-        | undefined;
-      expect(call).toBeDefined();
-      const [sid, cid, result] = call as [string, string, AttachResult];
-      expect(sid).toBe(sessionId);
-      expect(cid).toBe(connB);
-      expect(result.success).toBe(true);
-    });
-
-    test('does not fire onSessionOrphaned when promoting', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-
-      registry.detachConnection(connA);
-
-      // onSessionOrphaned should NOT fire because connB was promoted
-      expect(events.onSessionOrphaned).not.toHaveBeenCalled();
-    });
-
-    test('promotes in FIFO order', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-      registry.attachConnection(sessionId, connC);
-
-      expect(registry.waitingConnectionCount).toBe(2);
-
-      // A disconnects -> B promoted
-      registry.detachConnection(connA);
-      expect(registry.getSessionForConnection(connB)).toBeDefined();
-      expect(registry.waitingConnectionCount).toBe(1);
-
-      // B disconnects -> C promoted
-      registry.detachConnection(connB);
-      expect(registry.getSessionForConnection(connC)).toBeDefined();
-      expect(registry.waitingConnectionCount).toBe(0);
-    });
-
-    test('removes waiting connection on disconnect before promotion', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-      registry.attachConnection(sessionId, connC);
-
-      // B disconnects before being promoted
-      registry.removeWaitingConnection(connB);
-      expect(registry.waitingConnectionCount).toBe(1);
-
-      // A disconnects -> C promoted (B was removed)
-      registry.detachConnection(connA);
-      expect(registry.getSessionForConnection(connC)).toBeDefined();
-    });
-
-    test('detachConnection also removes from waiting queue', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-
-      // detach connB which is in waiting queue, not active
-      registry.detachConnection(connB);
-      expect(registry.waitingConnectionCount).toBe(0);
-
-      // A disconnects -> no one to promote, becomes orphaned
-      registry.detachConnection(connA);
-      expect(events.onSessionOrphaned).toHaveBeenCalled();
-    });
-
-    test('orphans session when no waiting connections remain', () => {
-      registry.attachConnection(sessionId, connA);
-
-      registry.detachConnection(connA);
-
-      // No waiting connections, should fire orphaned event
-      expect(events.onSessionOrphaned).toHaveBeenCalled();
-    });
-
-    test('promoted connection gets isResume and replay messages', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-
-      // A disconnects, making session orphaned briefly
-      registry.detachConnection(connA);
-      // B was auto-promoted via the queue
-
-      expect(events.onConnectionPromoted).toHaveBeenCalledTimes(1);
-      const call = events.onConnectionPromoted.mock.calls[0] as
-        | [string, string, AttachResult]
-        | undefined;
-      expect(call).toBeDefined();
-      const [, , result] = call as [string, string, AttachResult];
-      expect(result.success).toBe(true);
-      // isResume is true because lastDisconnectedAt was set before promotion
-      expect(result.isResume).toBe(true);
-    });
-
-    test('promoted connection receives all recent replay messages', () => {
-      registry.attachConnection(sessionId, connA);
-
-      // Record messages while A is connected
-      const msg1 = {
-        type: 'session_update',
-        id: generateId(),
-        timestamp: now(),
-      } as ProtocolMessage;
-      const msg2 = {
-        type: 'session_update',
-        id: generateId(),
-        timestamp: now(),
-      } as ProtocolMessage;
-      registry.recordOutgoingMessage(sessionId, msg1);
-      registry.recordOutgoingMessage(sessionId, msg2);
-
-      // Detach A
-      registry.detachConnection(connA);
-
-      // Record more messages while orphaned
-      const msg3 = {
-        type: 'session_update',
-        id: generateId(),
-        timestamp: now(),
-      } as ProtocolMessage;
-      registry.recordOutgoingMessage(sessionId, msg3);
-
-      // B attaches - now gets ALL recent messages (up to 200), not just undelivered
-      const result = registry.attachConnection(sessionId, connB);
-      expect(result.success).toBe(true);
-      expect(result.replayMessages.length).toBe(3);
-    });
-
-    test('onSessionResumed fires during promotion', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-
-      registry.detachConnection(connA);
-
-      expect(events.onSessionResumed).toHaveBeenCalledTimes(1);
-      expect(events.onSessionResumed).toHaveBeenCalledWith(sessionId, connB);
-    });
-
-    test('waiting queue is cleared when session is closed', () => {
-      registry.attachConnection(sessionId, connA);
-      registry.attachConnection(sessionId, connB);
-      registry.attachConnection(sessionId, connC);
-
-      expect(registry.waitingConnectionCount).toBe(2);
-
-      registry.closeSession(sessionId, 'forced');
-
-      expect(registry.waitingConnectionCount).toBe(0);
-    });
-
-    test('skips dead waiters when onConnectionPromoted callback throws', () => {
-      // Override events to throw on first promotion, succeed on second
-      let callCount = 0;
-      const throwingRegistry = new SessionRegistry(
-        { orphanTimeoutMs: 100 },
-        {
-          onConnectionPromoted: () => {
-            callCount++;
-            if (callCount === 1) throw new Error('connection dead');
-          },
-        },
-      );
-
-      const sid = generateId();
-      throwingRegistry.registerSession(sid, '/tmp/test', createMockPTY(), createMockMessageAPI());
-      throwingRegistry.attachConnection(sid, connA);
-      throwingRegistry.attachConnection(sid, connB);
-      throwingRegistry.attachConnection(sid, connC);
-
-      // A disconnects -> B promotion throws -> C gets promoted
-      throwingRegistry.detachConnection(connA);
-
-      expect(callCount).toBe(2);
-      expect(throwingRegistry.getSessionForConnection(connC)).toBeDefined();
     });
   });
 });

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -125,12 +125,12 @@ export interface HelloMessage {
   readonly mode?: 'query' | undefined;
   /**
    * Stable per-device identifier, persisted client-side across app restarts
-   * (#662). When a reconnecting hello carries the SAME deviceId as the
-   * connection currently holding the session's exclusive write lock, the
-   * daemon treats it as the same physical client reconnecting after a
-   * transport blip (dead socket, iOS background, NAT drop) and reclaims the
-   * lock instead of FIFO-queuing behind the stale connection. Omitted by
-   * older clients, which keep today's queuing behavior.
+   * (#662). Historically used by the daemon to reclaim a stale connection's
+   * exclusive write lock on reconnect from the same device instead of
+   * FIFO-queuing behind it. Any attached connection can write since #795, so
+   * there is no more lock to reclaim — current daemons ignore this field.
+   * Still sent (and still read) for interop with an OLDER daemon that still
+   * implements exclusivity and reclaim.
    */
   readonly deviceId?: string | undefined;
 }
@@ -170,12 +170,15 @@ export interface HelloAckMessage {
   /** Next bullet ID for continuation (if resume) */
   readonly nextBulletId?: number | undefined;
   /**
-   * Whether this connection holds the session's exclusive write lock
-   * ('attached') or is read-only, waiting for the current holder to
-   * disconnect ('queued') (#662). Omitted for hello_acks sent outside the
-   * attach flow (e.g. query-mode clients, NO_SESSION). Older clients that
-   * don't read this field keep behaving as if every hello_ack meant
-   * 'attached', which was the pre-#662 (buggy) assumption.
+   * A current daemon only ever reports 'attached' here (or omits the field
+   * for hello_acks sent outside the attach flow — query-mode clients,
+   * NO_SESSION): #795 removed the exclusive write lock, so every attached
+   * connection can read and write immediately and there is no more
+   * queued/read-only state. 'queued' remains a valid value on the wire
+   * purely for interop with an OLDER daemon that still enforces exclusivity
+   * (#662) and FIFO-queues a second connection behind the first. Older
+   * clients that don't read this field keep behaving as if every hello_ack
+   * meant 'attached', which was the pre-#662 (buggy) assumption.
    */
   readonly attachState?: 'attached' | 'queued' | undefined;
   /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -489,14 +489,17 @@ export interface RemiStatus {
   branch: string;
   autoApprove: AutoApproveState;
   /**
-   * #755: true when a client holds the session's exclusive PTY slot
-   * (`activeConnectionId !== null`) — the status label reads "attached".
-   * Unlike `connections`, this never counts query-mode utility clients
-   * (`remi ls` / `remi kill` / phone session-list polls). Optional so an
-   * older writer/reader pair degrades gracefully.
+   * #755: true when at least one connection is attached to the session
+   * (#795: any number can be, not just one) — the status label reads
+   * "attached". Unlike `connections`, this never counts query-mode utility
+   * clients (`remi ls` / `remi kill` / phone session-list polls). Optional so
+   * an older writer/reader pair degrades gracefully.
    */
   attached?: boolean;
-  /** #755: clients queued behind the active one (read-only viewers). */
+  /** Always 0 from a current daemon (#795: no more exclusive write lock or
+   *  FIFO queue to wait behind). Kept on the wire so a NEWER client reading
+   *  this status from an OLDER daemon still renders a sensible "+N waiting"
+   *  label. */
   queuedCount?: number;
   /**
    * Distinguishes a session-less hub daemon (`remi serve`, #542) from an

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1419,6 +1419,36 @@ function App() {
           );
           break;
         }
+        // SESSION_NOT_FOUND carrying details.messageId (#795): a current
+        // daemon no longer queues (there is no more exclusive lock), so this
+        // replaces NOT_ACTIVE_CONNECTION as the rejection for "this
+        // connection isn't attached to the session" -- e.g. it explicitly
+        // detached, or a query-mode connection tried to send input. Same
+        // immediate bubble-flip as above (#681) so the sender isn't stuck at
+        // 'delivered' until the 5s ack-timeout sweep, but WITHOUT the
+        // queued-banner side effect: a new daemon never queues, so there is
+        // no read-only state to refresh. SESSION_NOT_FOUND without a
+        // messageId (session genuinely missing, resume mismatch, etc.) falls
+        // through to the generic error-message handling below, unchanged.
+        if (errorCode === 'SESSION_NOT_FOUND') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const rejectedMessageId = asNonEmptyString(details?.['messageId']);
+          if (rejectedMessageId) {
+            // The ack for this same input usually lands first (bubble already
+            // at 'delivered') since the daemon acks unconditionally before
+            // this check runs -- this rejection is authoritative and must
+            // win over that.
+            pendingSendsRef.current = rejectSend(pendingSendsRef.current, rejectedMessageId);
+            setMessages((prev) =>
+              prev.map((m) => (m.id === rejectedMessageId ? { ...m, state: 'failed' as const } : m)),
+            );
+            console.warn(
+              '[App] SESSION_NOT_FOUND: input not delivered (connection not attached)',
+              rejectedMessageId,
+            );
+            break;
+          }
+        }
         if (errorCode === 'STALE_BINDING') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const refusedSessionId = asNonEmptyString(details?.['sessionId']) as UUID | undefined;


### PR DESCRIPTION
## Summary

Removes the session exclusive write lock (#795). Any connected non-query
client can now send input, resize, and read output for a session — no more
FIFO queue, "queued/read-only" state, or same-device/fingerprint reclaim
(#662/#671). This fixes the remote-creation race: a phone that just created a
session no longer needs to win a hello race against every other hub client
that got the same live-sessions broadcast — everyone who connects can type.

## Design

- `SessionRegistry`: `activeConnectionId`/`activeDeviceId`/`activeClientFingerprint`
  are replaced by an `attachedConnections: Set<UUID>`. `attachConnection`
  always succeeds ('attached') when the session exists; `getSessionForConnection`
  succeeds for any attached connection. `waitingConnections`, FIFO promotion,
  and the device/fingerprint reclaim machinery are deleted outright.
- `raw_pty_output` (`cli.ts`) now fans out to every attached connection
  instead of a single exclusive one, via a new shared `pty-message-fanout.ts`
  helper (used by both daemon-mode and wrapper-mode session creation, which
  previously duplicated this logic inline).
- Resize is last-writer-wins: any attached connection's `terminal_resize`
  is accepted, no negotiation.
- Kill/detach now notify/detach every attached connection, not a single one.
- Answers are unchanged — already connection-independent with dedup via
  `ResolvedAnswerCache` (#752) and staleness guards.
- `hello_ack.attachState` stays on the wire (only ever `'attached'` or
  omitted from a new daemon now); `NOT_ACTIVE_CONNECTION` is no longer
  emitted by new daemons — kept only so a newer client still understands an
  OLDER daemon that still queues.

### Why this is safe this time

`390898b` ("queued connections get replay and can send input") made this
exact change and `588afde` reverted it: *"queued resize/answer/input would
race the active client's session."* The lock was the ONLY write-serialization
for the PTY — `PTYSession.write()`/`submitInput()` had no internal locking, so
concurrent multi-step submits (`submitInput` writes text, waits ~50ms, then
writes a trailing CR) could interleave and corrupt each other's input.

This PR adds the missing safety net in the same change: `PTYSession` now
serializes every write (`write()` and `submitInput()`) through a per-session
promise-chain queue, so one write's full multi-step sequence always completes
before the next begins — regardless of which connection sent it. That's the
property that was missing last time.

## Tests

Real end-to-end verification of the queue: I temporarily reverted
`pty-session.ts` to the pre-fix (unserialized) implementation and re-ran
`pty-session-write-serialization.test.ts` against it — it failed exactly as
expected (`AAAA...BBBB...\r` merged into one corrupted line instead of two
clean ones), confirming the test actually catches the regression this PR
exists to prevent.

Deleted/reworked the ~30 lock-behavior tests: `session-registry.test.ts`
(queueing/promotion/reclaim #662/#671 blocks), `connection-events.test.ts`
(attach/queue/reclaim blocks), `input-events.test.ts` (`NOT_ACTIVE_CONNECTION`
tests, now `SESSION_NOT_FOUND` for a connection that never attached),
`resume-session-events.test.ts` (field rename only). Kept the SESSION_ENDED
kill/detach-notify tests working (generalized to loop over N attached
connections; single-connection cases still assert byte-identical behavior).

Added:
- two connections attached simultaneously can both submit input
- concurrent `submitInput` calls do not interleave (real PTY, no mocks —
  `pty-session-write-serialization.test.ts`, plus a raw-write-vs-submit race)
- `raw_pty_output` reaches every attached connection
  (`pty-message-fanout.test.ts`, new shared helper + its own tests)
- resize is last-writer-wins across multiple attached connections
- detaching one connection leaves another attached and able to type

### Results

- `bunx biome check` on touched files: clean
- `bun run typecheck` (root, covers daemon + shared + their tests): clean
- `bun test packages/shared` + full `packages/daemon/tests` excluding
  `auto-approve/` (slow LLM tests, per repo convention): **2567 pass, 0 fail**
  (2324 daemon + 243 shared), stable across repeated runs
- `cd packages/web && bun run build`: clean (web untouched — see below)

One environment-flaky pre-existing failure unrelated to this change:
`hooks/hook-server.test.ts` hardcodes port 19920 and intermittently collides
with an actually-running "Yooz Engine" process on port 19920 on this dev
machine; confirmed by `lsof`, and confirmed the test passes clean when that
port happens to be free. Not touched by this PR.

## Web

`attachState`/`NOT_ACTIVE_CONNECTION`/read-only-banner handling in
`packages/web/src` stays exactly as-is, as version-skew compat — an OLDER
daemon can still queue a new web client. Verified the status-bar "attached"
label logic (`cli/status-bar.ts`, `cli/status-writer.ts`) still reads
sensibly with several clients attached: `queuedCount` is now always 0 from a
current daemon, so the "+N waiting" branch is simply dead until an older
daemon writes that field.

One addition after review: `input-events.ts`'s not-attached rejection now
sends `SESSION_NOT_FOUND` (not `NOT_ACTIVE_CONNECTION`) but still carries
`details.messageId` (#681) for the specific rejected input. `App.tsx` had no
branch for that combination, so the message bubble would sit at 'delivered'
until the 5s ack-timeout sweep instead of flipping to 'failed' immediately.
Added a `SESSION_NOT_FOUND` + `details.messageId` branch that does the same
immediate `rejectSend`/bubble-flip as the old `NOT_ACTIVE_CONNECTION` path,
minus the queued-banner side effect (a new daemon never queues, so there's no
read-only state to refresh). `SESSION_NOT_FOUND` without a `messageId` (the
session genuinely missing, a resume mismatch, etc.) is unaffected and keeps
falling through to the existing generic error-in-chat handling.

## Known non-goals

- **No per-connection backpressure or fairness on the PTY write queue.** One
  attached client flooding input (e.g. pasting a huge blob, or a buggy/
  malicious client hammering `user_input`) can starve every other attached
  connection's writes behind it in the FIFO chain — there's no priority, no
  per-connection rate limit, no queue-depth cap. Accepted for now: every
  writer is an authenticated, attached connection (not an open door), and the
  common case is 2-3 human-driven clients, not a producer that needs
  isolation from the others. Revisit only if this actually bites in
  practice (e.g. a real report of one client's typing starving another's).

## Deviations / notes for reviewers

- `SessionRegistry.attachConnection` signature dropped the now-unused
  `deviceId`/`clientFingerprint` parameters entirely (nothing consumes them
  anymore); the wire-level `HelloMessage.deviceId` field itself is left
  alone (still sent by clients, doc comment updated to say current daemons
  ignore it — no reason to churn the protocol/web for a field that's
  harmless to keep sending).
- `onDetachSession` (`remi detach <session>`) and `onKillSessionRequest` now
  loop over every attached connection instead of a single active one.
- `PTYSession.write()` changed signature from `void` to `Promise<void>`
  (queued now); updated every caller — some just added a `.catch()` since
  they weren't already awaiting it.
- `write()`'s enqueued closure now re-checks `state !== 'running'` before
  writing (matching `submitInput()`'s existing re-check), so a raw write
  queued behind an in-flight submit can't fire after the PTY has already
  exited.
- `.serena/memories/session_and_connection_architecture.md` updated: it
  still described the exclusive-lock/FIFO-queue/reclaim design as current
  behavior; rewrote the affected sections (SessionRegistry state, attach/
  detach flow, the state diagram, key findings) to the multi-writer model,
  plus a short PTY write-serialization note so future agent sessions reading
  that memory aren't misled.

Closes #795
