### PR TITLE
Fix phantom question cards: replay gate + live snapshot reconciliation

### DIFF
--- a/packages/daemon/src/adapters/telegram-adapter.ts
+++ b/packages/daemon/src/adapters/telegram-adapter.ts
@@ -540,9 +540,10 @@ export class TelegramAdapter implements ConnectionAdapter {
 
       // Messages that don't need Telegram rendering.
       // N/A on Telegram: no PTY/attach/wire-auth; content surfaces via other branches.
-      // hub_status / remi_status are display-state broadcasts (menu-bar icon,
-      // attach status bar) fired on every census change / status flush — without
-      // an explicit no-op they would console.warn continuously (#766 review).
+      // hub_status / remi_status / question_snapshot are display-state broadcasts
+      // (menu-bar icon, attach status bar, web reconciliation) fired on every
+      // census change / status flush / question add-remove-clear — without an
+      // explicit no-op they would console.warn continuously (#766 review, #798).
       case 'create_session_response':
       case 'ping':
       case 'pong':
@@ -554,6 +555,7 @@ export class TelegramAdapter implements ConnectionAdapter {
       case 'auth_result':
       case 'hub_status':
       case 'remi_status':
+      case 'question_snapshot':
         return true;
 
       default:

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -112,6 +112,7 @@ loadDotenvFile();
 import {
   createDaemonUpdateAvailable,
   createQuestionResolved,
+  createQuestionSnapshot,
   createRemiStatus,
   createSessionUpdate,
 } from '@remi/shared';
@@ -1024,6 +1025,21 @@ const sessionRegistry = new SessionRegistry(
         );
       } catch (err) {
         logError(`[live-sessions] setPendingQuestions failed: ${errorToString(err)}`);
+      }
+      // #798: broadcast the authoritative live-question-id set to every
+      // connected client (same fan-out as question_resolved/remi_status).
+      // Backstops the client-side replay gate -- a client that reconnects
+      // into a quiet session gets no new question/resolve event to re-sync
+      // it, so this snapshot is what actually clears a phantom card there.
+      try {
+        registry.broadcast(
+          createQuestionSnapshot(
+            sessionId,
+            questions.map((q) => q.id),
+          ),
+        );
+      } catch (err) {
+        logError(`[QuestionSnapshot] broadcast failed for ${sessionId}: ${errorToString(err)}`);
       }
     },
   },

--- a/packages/daemon/tests/question-snapshot-broadcast.test.ts
+++ b/packages/daemon/tests/question-snapshot-broadcast.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the question_snapshot broadcast (#798 part 2).
+ *
+ * Reproduces the exact glue cli.ts wires into `SessionRegistry`'s
+ * `onQuestionsChanged` (fired on every add/remove/clear -- shared with the
+ * #786/#787 live-sessions mirror): broadcast a `createQuestionSnapshot` of the
+ * live question-id set to every connected client. cli.ts itself is a CLI
+ * composition root (parses argv, spins up the whole daemon) and is not
+ * unit-testable directly, so this test exercises the same two collaborators
+ * (`SessionRegistry` + `WebSocketServer`) it wires together, over a REAL
+ * WebSocket connection -- no mocks of the thing under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  type ProtocolMessage,
+  type QuestionSnapshotMessage,
+  createHello,
+  createQuestionSnapshot,
+  generateId,
+  serialize,
+} from '@remi/shared';
+import type { MessageAPI } from '../src/api/message-api.ts';
+import type { PTYSession } from '../src/pty/pty-session.ts';
+import { WebSocketServer } from '../src/server/websocket-server.ts';
+import { SessionRegistry } from '../src/session/session-registry.ts';
+
+function createMockPTY(): PTYSession {
+  return {
+    id: generateId(),
+    close: mock(() => Promise.resolve()),
+  } as unknown as PTYSession;
+}
+
+function createMockMessageAPI(): MessageAPI {
+  return {
+    bulletCount: 0,
+    handleMessage: mock(() => {}),
+    handleMessageUpdate: mock(() => {}),
+    reset: mock(() => {}),
+  } as unknown as MessageAPI;
+}
+
+function mkQuestion(id: string, agentId?: string) {
+  return {
+    id: id as ReturnType<typeof generateId>,
+    text: `${id}?`,
+    options: [],
+    allowsFreeText: true,
+    isAnswered: false,
+    ...(agentId !== undefined && { agentId }),
+  };
+}
+
+/** Waits for the next `question_snapshot` broadcast on `ws`. */
+function nextSnapshot(ws: WebSocket): Promise<QuestionSnapshotMessage> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Timed out waiting for snapshot')), 5000);
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data.toString()) as ProtocolMessage;
+      if (data.type === 'question_snapshot') {
+        clearTimeout(timeout);
+        resolve(data);
+      }
+    };
+  });
+}
+
+describe('question_snapshot broadcast (#798)', () => {
+  let server: WebSocketServer;
+  let registry: SessionRegistry;
+  const testPort = 9950;
+
+  beforeEach(() => {
+    server = new WebSocketServer({ port: testPort });
+    // Mirrors cli.ts's onQuestionsChanged wiring exactly: broadcast the live
+    // question-id set to every connected client on every add/remove/clear.
+    registry = new SessionRegistry(
+      { orphanTimeoutMs: 60_000 },
+      {
+        onQuestionsChanged: (sessionId, questions) => {
+          server.broadcast(
+            createQuestionSnapshot(
+              sessionId,
+              questions.map((q) => q.id),
+            ),
+          );
+        },
+      },
+    );
+  });
+
+  afterEach(async () => {
+    await registry.shutdown();
+    if (server.running) {
+      await server.stop();
+    }
+  });
+
+  async function connectClient(): Promise<WebSocket> {
+    await server.start();
+    const ws = new WebSocket(`ws://localhost:${testPort}/ws`);
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => ws.send(serialize(createHello('test-client', '1.0.0')));
+      ws.onmessage = (event) => {
+        const data = JSON.parse(event.data.toString());
+        if (data.type === 'hello_ack') resolve();
+      };
+      ws.onerror = () => reject(new Error('WebSocket error'));
+      setTimeout(() => reject(new Error('Connection timeout')), 5000);
+    });
+    return ws;
+  }
+
+  test('addQuestion broadcasts a snapshot with the full live id set', async () => {
+    const ws = await connectClient();
+    const sid = generateId();
+    registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+    const q1 = generateId();
+    const snapshotPromise = nextSnapshot(ws);
+    registry.addQuestion(sid, mkQuestion(q1));
+    const snapshot = await snapshotPromise;
+
+    expect(snapshot.sessionId).toBe(sid);
+    expect(snapshot.questionIds).toEqual([q1]);
+
+    ws.close();
+  });
+
+  test('a second addQuestion broadcasts BOTH ids (main + subagent)', async () => {
+    const ws = await connectClient();
+    const sid = generateId();
+    registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+    const q1 = generateId();
+    const q2 = generateId();
+    registry.addQuestion(sid, mkQuestion(q1));
+    await nextSnapshot(ws);
+
+    const snapshotPromise = nextSnapshot(ws);
+    registry.addQuestion(sid, mkQuestion(q2, 'sub-7'));
+    const snapshot = await snapshotPromise;
+
+    expect(snapshot.sessionId).toBe(sid);
+    expect(new Set(snapshot.questionIds)).toEqual(new Set([q1, q2]));
+
+    ws.close();
+  });
+
+  test('removeQuestion broadcasts the reduced set', async () => {
+    const ws = await connectClient();
+    const sid = generateId();
+    registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+    const q1 = generateId();
+    const q2 = generateId();
+    registry.addQuestion(sid, mkQuestion(q1));
+    await nextSnapshot(ws);
+    registry.addQuestion(sid, mkQuestion(q2));
+    await nextSnapshot(ws);
+
+    const snapshotPromise = nextSnapshot(ws);
+    registry.removeQuestion(sid, q1);
+    const snapshot = await snapshotPromise;
+
+    expect(snapshot.sessionId).toBe(sid);
+    expect(snapshot.questionIds).toEqual([q2]);
+
+    ws.close();
+  });
+
+  test('clearQuestions broadcasts an empty set', async () => {
+    const ws = await connectClient();
+    const sid = generateId();
+    registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+    registry.addQuestion(sid, mkQuestion(generateId()));
+    await nextSnapshot(ws);
+
+    const snapshotPromise = nextSnapshot(ws);
+    registry.clearQuestions(sid);
+    const snapshot = await snapshotPromise;
+
+    expect(snapshot.sessionId).toBe(sid);
+    expect(snapshot.questionIds).toEqual([]);
+
+    ws.close();
+  });
+
+  test('a connected client with no onQuestionsChanged consumer receives nothing (sanity: unrelated events do not broadcast)', async () => {
+    const ws = await connectClient();
+    const sid = generateId();
+    registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+
+    let received = false;
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data.toString());
+      if (data.type === 'question_snapshot') received = true;
+    };
+
+    // registerSession alone (no question activity) must not fire a snapshot.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(received).toBe(false);
+
+    ws.close();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -102,6 +102,7 @@ export type {
   SessionViewMeta,
   QuestionResolvedMessage,
   RemiStatusMessage,
+  QuestionSnapshotMessage,
   CreateHelloAckOptions,
   CreateHelloOptions,
 } from './protocol.ts';
@@ -157,6 +158,7 @@ export {
   createSessionViews,
   createQuestionResolved,
   createRemiStatus,
+  createQuestionSnapshot,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -106,7 +106,8 @@ export type ProtocolMessage =
   | SessionRotatedMessage
   | SessionViewsMessage
   | QuestionResolvedMessage
-  | RemiStatusMessage;
+  | RemiStatusMessage
+  | QuestionSnapshotMessage;
 
 /** Client hello - initiates connection */
 export interface HelloMessage {
@@ -339,6 +340,38 @@ export interface QuestionResolvedMessage {
   readonly questionId: UUID;
   /** Why it resolved, for diagnostics + client UX (all dismiss the card the same). */
   readonly reason: 'answered' | 'auto_approved' | 'auto_denied' | 'cancelled';
+}
+
+/**
+ * Daemon -> client broadcast: the authoritative set of question ids currently
+ * pending for a session (#798). Fired from the SAME `SessionRegistry.onQuestionsChanged`
+ * wiring that already mirrors the live set into the live-sessions registry file on
+ * every add/remove/clear (#786/#787) — this is the WebSocket counterpart, sent to
+ * ALL connected clients (never recorded into replay history; a reconnecting client
+ * gets a fresh one on the next add/remove/clear, not a stale replayed copy).
+ *
+ * Backstops the replay-gate fix (#798 part 1): a `question` message replayed from
+ * history is not trustworthy for pendingness (`question_resolved` is broadcast-only
+ * and never recorded), so a client that reconnects into a quiet session — no new
+ * question/resolve event to re-sync it — would otherwise keep a phantom card
+ * forever. On receipt, a client drops any displayed card for `sessionId` whose id
+ * is not in `questionIds`, while preserving cards in a locally-submitting or
+ * already-resolved/answered-trace state (#652/#653 invariants) since those own
+ * their own removal timer and a snapshot racing ahead of the resolve broadcast must
+ * not rip them out early.
+ *
+ * Old clients ignore the unknown message type (`isValidMessage` drops it); a new
+ * client against an old daemon simply never receives one — no behavior change, the
+ * replay gate alone still fixes the reconnect-into-quiet-session case there.
+ */
+export interface QuestionSnapshotMessage {
+  readonly type: 'question_snapshot';
+  readonly id: UUID;
+  readonly timestamp: Timestamp;
+  /** Remi session the snapshot describes. */
+  readonly sessionId: UUID;
+  /** Every question id currently pending for this session (may be empty). */
+  readonly questionIds: readonly UUID[];
 }
 
 /**
@@ -982,6 +1015,7 @@ function isValidMessage(value: unknown): value is ProtocolMessage {
     'session_views',
     'question_resolved',
     'remi_status',
+    'question_snapshot',
   ];
 
   return validTypes.includes(obj['type'] as string);
@@ -1290,6 +1324,24 @@ export function createQuestionResolved(
     sessionId,
     questionId,
     reason,
+  };
+}
+
+/**
+ * Create a question-snapshot broadcast (#798). `questionIds` is copied into a
+ * new array so a later in-place mutation of the caller's live set cannot
+ * retroactively change a message already queued for serialization.
+ */
+export function createQuestionSnapshot(
+  sessionId: UUID,
+  questionIds: readonly UUID[],
+): QuestionSnapshotMessage {
+  return {
+    type: 'question_snapshot',
+    id: generateId(),
+    timestamp: now(),
+    sessionId,
+    questionIds: [...questionIds],
   };
 }
 

--- a/packages/shared/tests/protocol.test.ts
+++ b/packages/shared/tests/protocol.test.ts
@@ -22,6 +22,7 @@ import {
   createPong,
   createQuestion,
   createQuestionResolved,
+  createQuestionSnapshot,
   createRemiStatus,
   createReplayBatch,
   createResumeSessionRequest,
@@ -408,6 +409,39 @@ describe('createQuestionResolved() (#585 P7)', () => {
         expect(parsed.reason).toBe(reason);
       }
     }
+  });
+});
+
+describe('createQuestionSnapshot() (#798)', () => {
+  test('builds a well-formed question_snapshot message', () => {
+    const sessionId = generateId();
+    const q1 = generateId();
+    const q2 = generateId();
+    const msg = createQuestionSnapshot(sessionId, [q1, q2]);
+    expect(msg.type).toBe('question_snapshot');
+    expect(msg.sessionId).toBe(sessionId);
+    expect(msg.questionIds).toEqual([q1, q2]);
+    expect(typeof msg.id).toBe('string');
+    expect(typeof msg.timestamp).toBe('string');
+  });
+
+  test('round-trips through serialize/deserialize, including an empty set', () => {
+    const sessionId = generateId();
+    const original = createQuestionSnapshot(sessionId, []);
+    const parsed = deserialize(serialize(original));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe('question_snapshot');
+    if (parsed?.type === 'question_snapshot') {
+      expect(parsed.sessionId).toBe(sessionId);
+      expect(parsed.questionIds).toEqual([]);
+    }
+  });
+
+  test('copies questionIds: later mutation of the source array does not leak into the message', () => {
+    const ids = [generateId(), generateId()];
+    const msg = createQuestionSnapshot(generateId(), ids);
+    ids.push(generateId());
+    expect(msg.questionIds).toHaveLength(2);
   });
 });
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -480,14 +480,11 @@ function App() {
       requestTranscriptLoadRef.current?.(connId, sid);
     };
 
-    // Reconcile a session's cards against an authoritative live-question-id
-    // set (#798 parts 2/3), shared by the `question_snapshot` broadcast and a
-    // `STALE_ANSWER` error's `pendingQuestionIds` -- both carry the same
-    // shape. Reads/writes questionsRef the same way the question_resolved
-    // handler does (#585, P7 FIX 3) so concurrent reconciliations never race
-    // each other into a stale `questionPending` badge.
-    const reconcileLiveQuestions = (sid: string, liveQuestionIds: readonly string[]) => {
-      const nextQuestions = pruneQuestionsNotLive(questionsRef.current, sid, liveQuestionIds);
+    // Commit a recomputed questions map if it actually changed, recomputing
+    // `sid`'s `questionPending` badge from the SAME committed map (#585, P7
+    // FIX 3) so concurrent reconciliations never race each other into a stale
+    // badge. Shared by every pure question-map reducer below.
+    const commitQuestionsIfChanged = (nextQuestions: Map<string, UIQuestion>, sid: string) => {
       if (nextQuestions === questionsRef.current) return;
       const stillPending = getSessionQuestions(nextQuestions, sid).some(isQuestionPending);
       questionsRef.current = nextQuestions;
@@ -495,6 +492,13 @@ function App() {
       setSessions((prev) =>
         prev.map((s) => (s.id === sid ? { ...s, questionPending: stillPending } : s)),
       );
+    };
+
+    // Reconcile a session's cards against an authoritative live-question-id
+    // set (#798 parts 2/3), shared by the `question_snapshot` broadcast and a
+    // `STALE_ANSWER` error's `pendingQuestionIds` -- both carry the same shape.
+    const reconcileLiveQuestions = (sid: string, liveQuestionIds: readonly string[]) => {
+      commitQuestionsIfChanged(pruneQuestionsNotLive(questionsRef.current, sid, liveQuestionIds), sid);
     };
 
     switch (message.type) {
@@ -1539,7 +1543,25 @@ function App() {
         if (errorCode === 'STALE_ANSWER') {
           const details = (message as { details?: Record<string, unknown> }).details;
           const staleSessionId = asNonEmptyString(details?.['sessionId']);
+          const staleQuestionId = asNonEmptyString(details?.['questionId']);
           const pendingQuestionIds = asStringArray(details?.['pendingQuestionIds']);
+          // The named question is precisely the one the user just answered,
+          // so its card is very likely `submitting: true` -- which
+          // pruneQuestionsNotLive deliberately PROTECTS from the
+          // reconciliation below (#652/#653). /clear, /resume, and a
+          // MAX_PENDING_QUESTIONS eviction all reach STALE_ANSWER without ever
+          // firing question_resolved for the dead id, and AUQ_AUTOANSWER_FAILED
+          // (above) only clears `submitting` for a different failure path --
+          // so without this, the card this error names would stick at
+          // "Answering..." forever (#800 review). Force-remove it outright by
+          // id first, mirroring resolveQuestionCard's submitting-card branch
+          // for question_resolved: no trace, no protection.
+          if (staleSessionId && staleQuestionId) {
+            commitQuestionsIfChanged(
+              removeQuestionById(questionsRef.current, staleSessionId, staleQuestionId),
+              staleSessionId,
+            );
+          }
           if (staleSessionId && pendingQuestionIds) {
             reconcileLiveQuestions(staleSessionId, pendingQuestionIds);
           }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -33,10 +33,12 @@ import { relayAnswerDirect } from '@/lib/push-answer-relay';
 import { resolvePushAnswerTarget } from '@/lib/push-answer-resolver';
 import {
   RESOLVED_TRACE_LINGER_MS,
+  applyIncomingQuestion,
   clearMainQuestionOnStatus,
   clearSessionQuestions,
   getSessionQuestions,
   isQuestionPending,
+  pruneQuestionsNotLive,
   questionKey,
   removeQuestionById,
   removeQuestionByKeyIfId,
@@ -44,7 +46,6 @@ import {
 } from '@/lib/question-collection';
 import { dismissDeliveredNotification } from '@/lib/notifications';
 import { mapQuestionToUIQuestion } from '@/lib/question-mapping';
-import { shouldKeepExisting } from '@/lib/question-merge';
 import { bindingRotated } from '@/lib/session-binding';
 import { shouldEvictCachedSession } from '@/lib/session-eviction';
 import { autoSelectIfNone, evictIfActive, evictManyIfActive } from '@/lib/session-selection';
@@ -107,6 +108,14 @@ const RESYNC_MAX_STASH_AGE_MS = 10000;
  */
 function asNonEmptyString(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Validates an unknown JSON value as a string array (an empty array is a
+ *  valid result -- e.g. `pendingQuestionIds` when a session has no pending
+ *  questions left -- so this must not be confused with `asNonEmptyString`'s
+ *  "absent" semantics). Returns undefined only when malformed. */
+function asStringArray(v: unknown): string[] | undefined {
+  return Array.isArray(v) && v.every((item) => typeof item === 'string') ? v : undefined;
 }
 
 function rememberSessionDaemon(sessionId: string, url: string): void {
@@ -272,7 +281,6 @@ function App() {
   // review). Without this, every reply set/clear in any session would
   // re-create handleSend and bust InputArea memoization.
   const replyContextsRef = useRef<Map<UUID, ReplyContext>>(replyContexts);
-  const isReplayingRef = useRef(false);
   const requestSessionListRef = useRef<typeof requestSessionList | null>(null);
   const connectionsRef = useRef<readonly ConnectionState[]>([]);
   // Outstanding user_input sends awaiting their `ack`, keyed by message id
@@ -355,7 +363,11 @@ function App() {
   }, []);
 
   // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
-  const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage) => {
+  // `inReplay` (#798, mirrors the terminal client's #753 fix) is true only for
+  // messages recursively dispatched from the `replay_batch` case below; every
+  // external caller (the connection manager's onMessage) always passes a LIVE
+  // message and relies on the default.
+  const handleMessage = useCallback((connectionId: ConnectionId, message: ProtocolMessage, inReplay = false) => {
     // Cancel and forget both resync timers for `sid`, if any -- shared by
     // flushResyncSurvivors (a trigger just fired) and discardResyncStash (the
     // session is gone, no trigger will ever fire).
@@ -466,6 +478,23 @@ function App() {
       }
       loadedTranscriptsRef.current.add(sid);
       requestTranscriptLoadRef.current?.(connId, sid);
+    };
+
+    // Reconcile a session's cards against an authoritative live-question-id
+    // set (#798 parts 2/3), shared by the `question_snapshot` broadcast and a
+    // `STALE_ANSWER` error's `pendingQuestionIds` -- both carry the same
+    // shape. Reads/writes questionsRef the same way the question_resolved
+    // handler does (#585, P7 FIX 3) so concurrent reconciliations never race
+    // each other into a stale `questionPending` badge.
+    const reconcileLiveQuestions = (sid: string, liveQuestionIds: readonly string[]) => {
+      const nextQuestions = pruneQuestionsNotLive(questionsRef.current, sid, liveQuestionIds);
+      if (nextQuestions === questionsRef.current) return;
+      const stillPending = getSessionQuestions(nextQuestions, sid).some(isQuestionPending);
+      questionsRef.current = nextQuestions;
+      setQuestions(nextQuestions);
+      setSessions((prev) =>
+        prev.map((s) => (s.id === sid ? { ...s, questionPending: stillPending } : s)),
+      );
     };
 
     switch (message.type) {
@@ -805,6 +834,15 @@ function App() {
       }
 
       case 'question': {
+        // #798 (mirrors the terminal client's #753 fix): replayed history is
+        // not trustworthy for pendingness -- `question_resolved` is
+        // broadcast-only and never recorded, so an already-answered question
+        // replays indistinguishably from a pending one. Skip BEFORE touching
+        // lastQuestionIdRef too: poisoning it with a replayed id would dedupe
+        // away the daemon's live resend of the SAME id that immediately
+        // follows the replay batch (pending-question-resend.ts), leaving no
+        // card at all for a genuinely still-pending question.
+        if (inReplay) break;
         const q = message.question;
         // Dedup: skip if we already have this question (can arrive from multiple connections or hook+PTY)
         if (q.id === lastQuestionIdRef.current) {
@@ -821,25 +859,19 @@ function App() {
           break;
         }
         // Map daemon Question to UIQuestion (pure function, unit-tested in
-        // lib/question-mapping.test.ts).
-        const uiQuestion = mapQuestionToUIQuestion(q, questionSessionId);
-        const questionAgentId = q.agentId;
-        const key = questionKey(questionSessionId, questionAgentId);
-        setQuestions((prev) => {
-          // Richer-wins guard (#396), scoped to this agent's slot. The daemon
-          // emits two questions for one prompt cycle (HookEventBridge default
-          // 3-set + PTY-parsed multi-choice with full sentences); their ids
-          // differ so a same-key second arrival would otherwise overwrite the
-          // first regardless of richness. A DIFFERENT agent's prompt has a
-          // different key and so coexists rather than clobbering (#419/#425).
-          const existing = prev.get(key);
-          if (existing && shouldKeepExisting(existing, uiQuestion)) {
-            return prev;
-          }
-          const next = new Map(prev);
-          next.set(key, uiQuestion);
-          return next;
-        });
+        // lib/question-mapping.test.ts). #798 part 4: prefer the wire
+        // message's own timestamp over local receipt time.
+        const uiQuestion = mapQuestionToUIQuestion(q, questionSessionId, message.timestamp);
+        // Insert at the composite key (scoped by agent, #419/#425), deferring
+        // to the richer-wins guard (#396) when a card is already in that slot
+        // -- the daemon emits two questions per prompt cycle (HookEventBridge
+        // default 3-set + PTY-parsed multi-choice with full sentences) with
+        // different ids, so a same-key second arrival would otherwise
+        // overwrite the first regardless of richness. `inReplay` is always
+        // false here (the case already broke above otherwise); threaded
+        // through so applyIncomingQuestion stays self-contained (#798 part 1,
+        // unit-tested in question-collection.test.ts).
+        setQuestions((prev) => applyIncomingQuestion(prev, uiQuestion, inReplay));
 
         // Mark session as having a pending question
         setSessions((prev) =>
@@ -895,14 +927,24 @@ function App() {
         break;
       }
 
+      case 'question_snapshot': {
+        // #798 parts 2/3: the daemon's authoritative live-question-id set for
+        // this session, fired from SessionRegistry.onQuestionsChanged on every
+        // add/remove/clear. Backstops the replay gate above -- a reconnect into
+        // a QUIET session gets no new question/resolve event to re-sync it, so
+        // this snapshot is what actually clears a phantom card there.
+        reconcileLiveQuestions(message.sessionId, message.questionIds);
+        break;
+      }
+
       case 'replay_batch': {
-        // Replay batches arrive on connect/reconnect. Suppress notifications during replay
-        // to prevent spamming the user with old events.
-        isReplayingRef.current = true;
+        // Replay batches arrive on connect/reconnect. Each replayed message is
+        // dispatched with inReplay=true (#798) so replay-sensitive cases (currently
+        // just 'question', mirroring the terminal client's #753 fix) can skip
+        // state mutations that assume LIVE pendingness.
         for (const replayMsg of message.messages) {
-          handleMessage(connectionId, replayMsg);
+          handleMessage(connectionId, replayMsg, true);
         }
-        isReplayingRef.current = false;
         break;
       }
 
@@ -1486,6 +1528,21 @@ function App() {
             details,
           );
           // Fall through so the user sees the error in chat.
+        }
+        // STALE_ANSWER (#798 part 3): the daemon already rejected the answer
+        // (input-events.ts) because the question is no longer pending, and it
+        // attaches the full live-question-id set it rejected against --
+        // reconcile through the same pruning path as a `question_snapshot`
+        // broadcast so any other phantom card for this session (not just the
+        // one this answer targeted) clears too. Falls through unchanged so the
+        // user still sees the rejection in chat.
+        if (errorCode === 'STALE_ANSWER') {
+          const details = (message as { details?: Record<string, unknown> }).details;
+          const staleSessionId = asNonEmptyString(details?.['sessionId']);
+          const pendingQuestionIds = asStringArray(details?.['pendingQuestionIds']);
+          if (staleSessionId && pendingQuestionIds) {
+            reconcileLiveQuestions(staleSessionId, pendingQuestionIds);
+          }
         }
         // Clear loading state for any session awaiting transcript load, and allow retry.
         // The daemon does not echo sessionId in error responses, so we clear all loading sessions.

--- a/packages/web/src/lib/question-collection.ts
+++ b/packages/web/src/lib/question-collection.ts
@@ -9,6 +9,7 @@
 
 import { MAIN_AGENT_ID } from '@remi/shared';
 import type { AgentStatus, UIQuestion, UIQuestionResolvedReason } from '@/types';
+import { shouldKeepExisting } from './question-merge';
 
 /**
  * How long an answered/resolved card lingers (collapsed) before it is removed
@@ -34,6 +35,41 @@ export interface StatusClearOptions {
 /** Composite map key: a session's prompt, scoped to its agent (main default). */
 export function questionKey(sessionId: string, agentId?: string | undefined): string {
   return `${sessionId}#${agentId ?? MAIN_AGENT_ID}`;
+}
+
+/**
+ * Apply an incoming `question` message to the collection the way `App.tsx`'s
+ * `case 'question'` handler does: insert at the composite key, deferring to
+ * `shouldKeepExisting`'s richer-wins guard (#396) when a card is already
+ * there. A REPLAYED message (`inReplay=true`) is a pure no-op (#798 part 1,
+ * mirrors the terminal client's #753 fix): replayed history is not
+ * trustworthy for pendingness -- `question_resolved` is broadcast-only and
+ * never recorded, so an already-answered question replays indistinguishably
+ * from a pending one, and the daemon re-sends the authoritative live set as
+ * LIVE messages right after the replay batch (pending-question-resend.ts).
+ *
+ * Extracted as the exact insertion logic App.tsx composes at the call site
+ * (rather than only inline there) so the #798 fix is unit-testable
+ * independent of the WebSocket/React plumbing (mirrors the #718 review
+ * precedent for `mapQuestionToUIQuestion`). App.tsx additionally short-
+ * circuits BEFORE calling this on `inReplay`, so a replayed message never
+ * touches its `lastQuestionIdRef` dedup ref either -- poisoning that ref
+ * with a replayed id would dedupe away the live resend of the SAME id that
+ * immediately follows the replay batch. Returns the SAME reference when the
+ * message is skipped (replay) or a richer existing card wins.
+ */
+export function applyIncomingQuestion(
+  questions: Map<string, UIQuestion>,
+  uiQuestion: UIQuestion,
+  inReplay: boolean,
+): Map<string, UIQuestion> {
+  if (inReplay) return questions;
+  const key = questionKey(uiQuestion.sessionId, uiQuestion.agentId);
+  const existing = questions.get(key);
+  if (existing && shouldKeepExisting(existing, uiQuestion)) return questions;
+  const next = new Map(questions);
+  next.set(key, uiQuestion);
+  return next;
 }
 
 /** All pending questions belonging to a session, in insertion order. */
@@ -224,4 +260,44 @@ export function resolveQuestionCard(
 /** Whether a card is still awaiting the user (drives the session's pending badge). */
 export function isQuestionPending(q: UIQuestion): boolean {
   return q.answeredWith == null && q.resolvedReason == null;
+}
+
+/**
+ * Whether a card must be PROTECTED from live-question-snapshot pruning (#798
+ * parts 2/3) even though its id is absent from the snapshot. Mirrors the
+ * #652/#653 invariants `resolveQuestionCard` already applies to a
+ * `question_resolved` broadcast: a card the user is actively submitting (#627
+ * AUQ/cancel in flight) or one already flipped to a resolved/answered trace
+ * owns its own removal timer, so a snapshot racing ahead of the matching
+ * resolve broadcast must not rip it out early.
+ */
+function isProtectedFromPruning(q: UIQuestion): boolean {
+  return q.submitting === true || q.answeredWith != null || q.resolvedReason != null;
+}
+
+/**
+ * Reconcile a session's cards against the daemon's authoritative live-question
+ * id set (#798 parts 2/3, the replay-gate backstop): drop any unprotected card
+ * for `sessionId` whose id is not in `liveQuestionIds` (see
+ * `isProtectedFromPruning`). Sourced from either the `question_snapshot`
+ * broadcast (fired on every `SessionRegistry.onQuestionsChanged` add/remove/
+ * clear) or a `STALE_ANSWER` error's `pendingQuestionIds` — both carry the same
+ * shape (the full live id set for a session), so one function serves both call
+ * sites. Returns the SAME reference when nothing was pruned (no-op update).
+ */
+export function pruneQuestionsNotLive(
+  questions: Map<string, UIQuestion>,
+  sessionId: string,
+  liveQuestionIds: readonly string[],
+): Map<string, UIQuestion> {
+  const liveIds = new Set(liveQuestionIds);
+  let next: Map<string, UIQuestion> | undefined;
+  for (const [key, q] of questions) {
+    if (q.sessionId !== sessionId) continue;
+    if (liveIds.has(q.id)) continue;
+    if (isProtectedFromPruning(q)) continue;
+    if (!next) next = new Map(questions);
+    next.delete(key);
+  }
+  return next ?? questions;
 }

--- a/packages/web/src/lib/question-mapping.ts
+++ b/packages/web/src/lib/question-mapping.ts
@@ -7,7 +7,7 @@
  * no side effects.
  */
 
-import type { Question, UUID } from '@remi/shared';
+import type { Question, Timestamp, UUID } from '@remi/shared';
 import type { UIQuestion, UIQuestionOption } from '@/types';
 
 /**
@@ -45,8 +45,18 @@ function toUIQuestionOption(o: Question['options'][number]): UIQuestionOption {
  * responsible for the "sessionId is mandatory" guard (#437) before calling
  * this — a malformed message with no sessionId is dropped upstream, never
  * reaching this pure mapping.
+ *
+ * `wireTimestamp` (#798 part 4) should be the enclosing `QuestionMessage`'s own
+ * `timestamp` when the caller has one — preferred over local receipt time so a
+ * card born from a delayed/replayed message shows its true age instead of
+ * always reading "Just now". Falls back to the current time when omitted or
+ * malformed (e.g. a caller with no wire message to hand, or a bad timestamp).
  */
-export function mapQuestionToUIQuestion(q: Question, sessionId: UUID): UIQuestion {
+export function mapQuestionToUIQuestion(
+  q: Question,
+  sessionId: UUID,
+  wireTimestamp?: Timestamp,
+): UIQuestion {
   const structuredOptions = q.options.map(toUIQuestionOption);
 
   // #626: carry the full AskUserQuestion structure (headers, per-option
@@ -58,6 +68,11 @@ export function mapQuestionToUIQuestion(q: Question, sessionId: UUID): UIQuestio
     options: step.options.map(toUIQuestionOption),
   }));
 
+  const timestamp =
+    wireTimestamp !== undefined && Number.isFinite(Date.parse(wireTimestamp))
+      ? wireTimestamp
+      : new Date().toISOString();
+
   return {
     id: q.id,
     sessionId,
@@ -65,7 +80,7 @@ export function mapQuestionToUIQuestion(q: Question, sessionId: UUID): UIQuestio
     prompt: q.text,
     options: q.options.length > 0 ? q.options.map((o) => o.label) : undefined,
     structuredOptions: structuredOptions.length > 0 ? structuredOptions : undefined,
-    timestamp: new Date().toISOString(),
+    timestamp,
     agentId: q.agentId,
     ...(q.kind ? { kind: q.kind } : {}),
     ...(uiQuestions && uiQuestions.length > 0 ? { questions: uiQuestions } : {}),

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -6,11 +6,13 @@
 import { describe, expect, test } from 'bun:test';
 import {
   STATUS_CLEAR_FRESHNESS_MS,
+  applyIncomingQuestion,
   clearMainQuestionOnStatus,
   clearSessionQuestions,
   getSessionQuestions,
   hasSessionQuestion,
   isQuestionPending,
+  pruneQuestionsNotLive,
   questionKey,
   removeQuestionById,
   removeQuestionByKeyIfId,
@@ -274,5 +276,149 @@ describe('isQuestionPending (#652)', () => {
     expect(isQuestionPending(qWith(q('s1', undefined, 'a'), { resolvedReason: 'answered' }))).toBe(
       false,
     );
+  });
+});
+
+describe('applyIncomingQuestion (#798 part 1 -- the replay gate)', () => {
+  test('a LIVE question message creates a card', () => {
+    const empty = new Map<string, UIQuestion>();
+    const incoming = q('s1', undefined, 'a');
+    const next = applyIncomingQuestion(empty, incoming, false);
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('a REPLAYED question message creates NO card (the #798 bug fix, mirrors terminal #753)', () => {
+    const empty = new Map<string, UIQuestion>();
+    const incoming = q('s1', undefined, 'a');
+    const next = applyIncomingQuestion(empty, incoming, true);
+    expect(next).toBe(empty);
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('replaying several stale questions in a batch resurrects NOTHING (the reported bug)', () => {
+    // Regression for #798: a reconnect replayed a full history batch containing
+    // several long-answered questions still inside the replay window. None of
+    // them may create a phantom "Just now" card.
+    let map = new Map<string, UIQuestion>();
+    for (const [sid, id] of [
+      ['s1', 'a'],
+      ['s1', 'b'],
+      ['s2', 'c'],
+    ] as const) {
+      map = applyIncomingQuestion(map, q(sid, undefined, id), true);
+    }
+    expect(map.size).toBe(0);
+  });
+
+  test('a LIVE resend of the SAME id right after replay still creates the card', () => {
+    // The daemon re-sends the authoritative pending set as LIVE messages
+    // immediately after the replay batch (pending-question-resend.ts) -- the
+    // fix must not treat that id as "already seen" just because a replayed
+    // copy of it passed through moments earlier.
+    let map = new Map<string, UIQuestion>();
+    map = applyIncomingQuestion(map, q('s1', undefined, 'a'), true); // replayed: no-op
+    map = applyIncomingQuestion(map, q('s1', undefined, 'a'), false); // live resend
+    expect(getSessionQuestions(map, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('defers to the richer-wins guard for a live second arrival in the same slot', () => {
+    // shouldKeepExisting's freshness window is measured against the REAL clock
+    // (applyIncomingQuestion passes no `now` override), so both cards need a
+    // current, not fixed-fixture, timestamp -- otherwise the guard falls
+    // through its "stale" branch and replaces regardless of richness.
+    const now = new Date().toISOString();
+    const richer = qWith(q('s1', undefined, 'a'), {
+      timestamp: now,
+      structuredOptions: [
+        { label: 'Yes', value: 'y' },
+        { label: 'No', value: 'n' },
+        { label: 'Always', value: 'a' },
+      ],
+    });
+    const poorer = qWith(q('s1', undefined, 'b'), {
+      timestamp: now,
+      structuredOptions: [
+        { label: 'Yes', value: 'y' },
+        { label: 'No', value: 'n' },
+      ],
+    });
+    let map = new Map<string, UIQuestion>();
+    map = applyIncomingQuestion(map, richer, false);
+    map = applyIncomingQuestion(map, poorer, false);
+    // The poorer arrival is dropped; the richer card (id 'a') stays.
+    expect(getSessionQuestions(map, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('a different agent gets its own coexisting slot (#419/#425)', () => {
+    let map = new Map<string, UIQuestion>();
+    map = applyIncomingQuestion(map, q('s1', undefined, 'main-q'), false);
+    map = applyIncomingQuestion(map, q('s1', 'sub-7', 'sub-q'), false);
+    expect(getSessionQuestions(map, 's1').map((x) => x.id).sort()).toEqual(['main-q', 'sub-q']);
+  });
+});
+
+describe('pruneQuestionsNotLive (#798 parts 2/3)', () => {
+  test('drops a card whose id is missing from the live set', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('keeps a card whose id IS in the live set', () => {
+    const map = build(q('s1', undefined, 'a'));
+    const next = pruneQuestionsNotLive(map, 's1', ['a']);
+    expect(next).toBe(map);
+  });
+
+  test('prunes only the missing card, keeps a live sibling (main + subagent)', () => {
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-7', 'b'));
+    const next = pruneQuestionsNotLive(map, 's1', ['b']);
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['b']);
+  });
+
+  test('never touches a different session, even with an empty live set', () => {
+    const map = build(q('s1', undefined, 'a'), q('s2', undefined, 'c'));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['c']);
+  });
+
+  test('returns the SAME reference when nothing was pruned (no-op update)', () => {
+    const map = build(q('s1', undefined, 'a'));
+    expect(pruneQuestionsNotLive(map, 's2', [])).toBe(map);
+  });
+
+  test('PRESERVES a submitting card even though its id is missing (#627 AUQ in flight)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { submitting: true }));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(next).toBe(map);
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('PRESERVES a locally-answered card even though its id is missing (#652 own removal timer)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { answeredWith: '1' }));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(next).toBe(map);
+  });
+
+  test('PRESERVES a resolved-elsewhere trace card even though its id is missing (#652)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { resolvedReason: 'answered' }));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(next).toBe(map);
+  });
+
+  test('a same-id card in ANOTHER session is unaffected by this session live set', () => {
+    const map = build(q('s1', undefined, 'dup'), q('s2', undefined, 'dup'));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+    expect(getSessionQuestions(next, 's2').map((x) => x.id)).toEqual(['dup']);
+  });
+
+  test('reconciles a whole phantom set at once (the reported bug: multiple stale cards, no pending question)', () => {
+    // Regression for #798: a reconnect-into-quiet-session replayed several
+    // stale question cards. The live snapshot says NONE are pending anymore.
+    const map = build(q('s1', undefined, 'a'), q('s1', 'sub-1', 'b'), q('s1', 'sub-2', 'c'));
+    const next = pruneQuestionsNotLive(map, 's1', []);
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
   });
 });

--- a/packages/web/tests/lib/question-collection.test.ts
+++ b/packages/web/tests/lib/question-collection.test.ts
@@ -422,3 +422,37 @@ describe('pruneQuestionsNotLive (#798 parts 2/3)', () => {
     expect(getSessionQuestions(next, 's1')).toEqual([]);
   });
 });
+
+describe('STALE_ANSWER force-clear (#800 review, MEDIUM finding)', () => {
+  // pruneQuestionsNotLive protects a submitting card (above), which means the
+  // exact card a STALE_ANSWER names -- the one the user just answered, still
+  // `submitting: true` -- can never clear through reconciliation alone. /clear,
+  // /resume, and a MAX_PENDING_QUESTIONS eviction all reach STALE_ANSWER without
+  // ever firing question_resolved for the dead id, so App.tsx force-removes the
+  // named id by id (removeQuestionById, unconditional) BEFORE reconciling the
+  // rest of the session against the live snapshot.
+
+  test('removeQuestionById force-clears a submitting card unconditionally (no protection)', () => {
+    const map = build(qWith(q('s1', undefined, 'a'), { submitting: true }));
+    const next = removeQuestionById(map, 's1', 'a');
+    expect(getSessionQuestions(next, 's1')).toEqual([]);
+  });
+
+  test('the App.tsx STALE_ANSWER flow: force-remove the named id, then prune the rest against the live snapshot', () => {
+    // Two submitting cards in the same session: 'a' is the one a STALE_ANSWER
+    // names (the daemon rejected it -- /clear, /resume, or an eviction), 'b' is
+    // a genuinely different in-flight submit the error says nothing about.
+    const map = build(
+      qWith(q('s1', undefined, 'a'), { submitting: true }),
+      qWith(q('s1', 'sub-7', 'b'), { submitting: true }),
+    );
+    // Step 1 (the fix): force-remove the exact id STALE_ANSWER names.
+    let next = removeQuestionById(map, 's1', 'a');
+    // Step 2: reconcile the rest against the live snapshot (empty here too).
+    next = pruneQuestionsNotLive(next, 's1', []);
+    // 'a' is gone (force-cleared, no longer stuck at "Answering..."); 'b'
+    // SURVIVES -- still submitting and never named by this error, so pruning
+    // alone must not touch it even though it's also missing from the live set.
+    expect(getSessionQuestions(next, 's1').map((x) => x.id)).toEqual(['b']);
+  });
+});

--- a/packages/web/tests/lib/question-mapping.test.ts
+++ b/packages/web/tests/lib/question-mapping.test.ts
@@ -139,4 +139,30 @@ describe('mapQuestionToUIQuestion', () => {
     expect(ui.questions).toBeUndefined();
     expect(ui.submitLabel).toBeUndefined();
   });
+
+  describe('timestamp (#798 part 4)', () => {
+    test('prefers the wire message timestamp over local receipt time', () => {
+      const wireTs = '2026-01-01T00:00:00.000Z';
+      const ui = mapQuestionToUIQuestion(question(), SID, wireTs);
+      expect(ui.timestamp).toBe(wireTs);
+    });
+
+    test('falls back to the current time when no wire timestamp is given', () => {
+      const before = Date.now();
+      const ui = mapQuestionToUIQuestion(question(), SID);
+      const after = Date.now();
+      const parsed = Date.parse(ui.timestamp);
+      expect(parsed).toBeGreaterThanOrEqual(before);
+      expect(parsed).toBeLessThanOrEqual(after);
+    });
+
+    test('falls back to the current time for a malformed wire timestamp', () => {
+      const before = Date.now();
+      const ui = mapQuestionToUIQuestion(question(), SID, 'not-a-date');
+      const after = Date.now();
+      const parsed = Date.parse(ui.timestamp);
+      expect(parsed).toBeGreaterThanOrEqual(before);
+      expect(parsed).toBeLessThanOrEqual(after);
+    });
+  });
 });


### PR DESCRIPTION
## Root cause

On every WS reconnect (`attachConnection` -> `replay_batch`), the web
client replayed history with no gating: `App.tsx`'s `handleMessage`
recursively re-dispatched every replayed message, `isReplayingRef` was
set but never read (dead code), and `case 'question'` inserted a
replayed question identically to a live one. `question_resolved` is
deliberately broadcast-only and never recorded into history, so a
question answered long ago but still inside the replay window
resurrected on every reconnect, timestamped "Just now" because
`mapQuestionToUIQuestion` stamped `new Date()` instead of the wire
timestamp.

The terminal client already fixed exactly this in #753
(`attach-client.ts`'s `inReplay` flag); the web client never got the
parity fix.

## Fix

1. **Replay gate (parity with #753).** `handleMessage` now takes an
   `inReplay` parameter; `replay_batch` dispatches replayed messages
   with `inReplay=true`. `case 'question'` skips before touching
   `lastQuestionIdRef` too -- poisoning that ref with a replayed id
   would dedupe away the daemon's live resend of the same id that
   immediately follows the replay batch. Removed the dead
   `isReplayingRef`.

2. **New `question_snapshot` protocol message + client reconciliation
   (the backstop).** `SessionRegistry.onQuestionsChanged` already
   fires with the full live question-id set on every add/remove/clear
   (the #786/#787 live-sessions mirror wiring in `cli.ts`); this adds
   a broadcast of the same set as a new daemon->client message,
   mirroring `question_resolved`/`remi_status` wiring exactly
   (broadcast to all clients, never recorded into replay history). The
   client drops any displayed card whose id is missing from the
   snapshot, while preserving cards in a locally-submitting or
   already-resolved/answered-trace state (the #652/#653 invariants).
   This covers the case a quiet-session reconnect leaves phantoms with
   no new question/resolve event to clear them.

3. **`STALE_ANSWER.pendingQuestionIds` + `questionId`.** The daemon
   already returns the full live id set on every stale-answer
   rejection (`input-events.ts`); the client reconciles through the
   same pruning path. Review follow-up (MEDIUM): the pruning path
   deliberately PROTECTS a `submitting` card, which is exactly the
   state of the card the STALE_ANSWER names -- the one the user just
   answered. `/clear`, `/resume`, and a `MAX_PENDING_QUESTIONS`
   eviction all reach `STALE_ANSWER` without ever firing
   `question_resolved` for the dead id, so that specific card could
   get stuck at "Answering..." forever. Fixed by force-removing the
   named `questionId` outright (`removeQuestionById`, unconditional)
   before reconciling the rest of the session against
   `pendingQuestionIds` -- mirrors `resolveQuestionCard`'s
   submitting-card branch for `question_resolved` (no trace, no
   protection).

4. **Wire timestamp.** `mapQuestionToUIQuestion` now prefers the
   `QuestionMessage`'s own timestamp over local receipt time, so any
   future stale card shows its true age.

Version skew: an old client drops the unknown `question_snapshot` type
via `isValidMessage` -- no behavior change. A new client against an
old daemon never receives one -- the replay gate alone still fixes the
reconnect case there.

## New protocol message checklist (10-step)

- `QuestionSnapshotMessage` interface + `createQuestionSnapshot` factory
  in `packages/shared/src/protocol.ts`
- Added to the `ProtocolMessage` union and `isValidMessage`'s `validTypes`
- Exported (type + factory) from `packages/shared/src/index.ts`
- Steps 4-8 (connection.ts / connection-adapter.ts / websocket-server.ts /
  websocket-adapter.ts bridges) verified N/A: this is a daemon->client
  broadcast, same shape as `question_resolved`/`remi_status`, which use
  the generic `AdapterRegistry.broadcast()` fan-out with no
  connection-event wiring of their own
- No `sharedEvents` entry needed (same reasoning -- outbound only)
- `case 'question_snapshot'` added to `App.tsx`'s `handleMessage` switch
- Telegram adapter: added to the `hub_status`/`remi_status`-style
  display-state no-op list so it doesn't spam `console.warn`

## Tests

- `packages/shared/tests/protocol.test.ts`: `createQuestionSnapshot`
  round-trip, empty-set, and defensive-copy tests
- `packages/daemon/tests/question-snapshot-broadcast.test.ts` (new):
  real `WebSocketServer` + `SessionRegistry`, reproducing the broadcast
  half of cli.ts's `onQuestionsChanged` glue (not the try/catch wrapping
  or the parallel `liveSessionsRegistry.setPendingQuestions` mirror,
  which are cli.ts-only and untested here) -- add/remove/clear each
  broadcast a correct snapshot to a connected client over a real WS
  connection
- `packages/web/tests/lib/question-collection.test.ts`: `pruneQuestionsNotLive`
  (drops missing ids, preserves submitting/answered/resolved cards, a
  multi-card phantom-set regression test), `applyIncomingQuestion`
  (the replay-gate proof: a replayed message creates no card, a live
  resend of the same id right after still does, richer-wins guard
  still applies to live arrivals), and the STALE_ANSWER force-clear
  scenario (a named submitting card is force-removed while a
  different, un-named submitting card survives pruning)
- `packages/web/tests/lib/question-mapping.test.ts`: wire-timestamp
  preference, fallback on absent/malformed timestamp

All run: `bun run typecheck`, `bunx biome check` (touched daemon/shared
files), `bun test packages/shared` (246 pass), `bun test packages/daemon`
excluding `auto-approve/` (2329 pass -- one pre-existing intermittent
flake in `live-sessions-watcher.test.ts` unrelated to this change,
passes reliably in isolation, not touched by this PR), `bun test
packages/web` (412 pass), `cd packages/web && bun run build` (succeeds).
`packages/web` is ESLint-gated, not biome (pre-existing repo setup);
`bun run lint` there shows only the two pre-existing unrelated errors
already on develop.

## Deviations from the issue's literal wording

- Extracted `applyIncomingQuestion` (the insertion + replay-gate logic)
  and `pruneQuestionsNotLive`/`isProtectedFromPruning` into
  `question-collection.ts` rather than inlining everything in `App.tsx`,
  mirroring the existing `mapQuestionToUIQuestion` (#718) and
  `shouldKeepExisting`/`resolveQuestionCard` extraction precedent in
  this same file -- there is no React component-test harness in this
  repo (`packages/web` has none), so this is what makes the replay-gate
  fix itself unit-testable rather than only exercised via manual/Chrome
  MCP verification.

## Needs on-device / manual verification

- The actual browser-level reconnect flow (kill a WS connection mid-
  session with a pending question already answered, force a
  `replay_batch`, confirm no phantom card appears and a live snapshot
  clears any that do) is not covered by an automated end-to-end test
  since there's no component-test harness for `App.tsx` in this repo.
  The pure-function tests above prove the fix logic directly; a live
  Chrome MCP / device pass would give full confidence the wiring is
  exercised correctly.

Closes #798
