### PR TITLE
fix(#799): purge subagent/rejected questions on advance

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -45,6 +45,18 @@
  * a foreign session's PermissionRequest never creates an entry here in the
  * first place (post-#672 that stays entirely with ForeignSessionEscalator's
  * informational-only push), so there is nothing for this gate to cancel for it.
+ *
+ * #799: `parkSubagentForPTY` registers a signature too (tagged `isSubagent`
+ * + the event's own `agent_id`), closing the gap where a subagent/teammate
+ * permission answered in the terminal had NO removal path at all (only
+ * `escalateToUser`, main-context-only, ever populated the map pre-#799).
+ * Subagent PreToolUse/PostToolUse in `hook-bridge-setup.ts` now also call
+ * `cancelExternallyResolved` (with the event's own `agent_id`, scoped so it
+ * can never cross-resolve a different agent's or main's still-open
+ * escalation) before their early return — the same signature match main
+ * gets, so a subagent permission answered directly in the terminal (the
+ * matching tool then runs) is resolved through the normal `removeQuestion`
+ * + `onResolved` funnel instead of leaking forever.
  */
 
 import type { UUID } from '@remi/shared';
@@ -68,6 +80,12 @@ interface ToolSignature {
    *  only main-tagged entries here, so a teammate's still-open escalation is
    *  not wiped out just because the lead agent idled. */
   readonly isSubagent: boolean;
+  /** #799: the escalating event's own `input.agent_id` (undefined for a MAIN
+   *  event). Lets `findOpenQuestionMatching` scope a match to the EXACT
+   *  agent that opened it -- without this, two different agents (or a
+   *  subagent and main) issuing an identical (tool_name, tool_input) could
+   *  cross-resolve each other's unrelated escalation. */
+  readonly agentId: string | undefined;
 }
 
 /** An observed tool call to correlate against `openQuestionSignatures`. Same
@@ -77,6 +95,10 @@ export interface ObservedToolCall {
   readonly toolName: string;
   readonly toolInput: Record<string, unknown>;
   readonly toolUseId?: string | undefined;
+  /** #799: the observing event's own `input.agent_id` (undefined for a MAIN
+   *  PreToolUse/PostToolUse). Must match the tracked signature's `agentId`
+   *  exactly -- see `ToolSignature.agentId`. */
+  readonly agentId?: string | undefined;
 }
 
 /**
@@ -187,8 +209,15 @@ export interface AutoApproveGateDeps {
    * question only surfaces if Claude's native prompt actually renders on the
    * PTY. Optional so tests that don't wire it degrade to a plain passthrough
    * (the rendered prompt then pushes bare via the #712 orphan path).
+   *
+   * Returns the parked `Question.id` (#799) so `parkSubagentForPTY` can
+   * register it in `openQuestionSignatures` the same way `escalateToUser`
+   * does for a main escalation -- without an id there is nothing for a later
+   * matching subagent tool event or `SubagentStop` to resolve, which was the
+   * root cause of #799 (a subagent question answered in the terminal never
+   * left the pending store). `undefined` when the dep is unwired or throws.
    */
-  parkForPTY?: (input: PermissionRequestHookInput, summary?: string) => void;
+  parkForPTY?: (input: PermissionRequestHookInput, summary?: string) => UUID | undefined;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -361,11 +390,12 @@ export class AutoApproveGate {
   private readonly evalIsSubagentById = new Map<number, boolean>();
 
   /**
-   * Every OPEN escalation this gate has created (held OR passthrough), keyed
-   * by `Question.id`, by its (tool_name, tool_input) signature (#673). Entry
-   * lifecycle: created in `escalateToUser` on a successful escalation; removed
-   * by exactly TWO owners, unconditionally (regardless of whether a hold
-   * existed), so no exit path can leak an entry:
+   * Every OPEN escalation this gate has created (held OR passthrough, MAIN or
+   * subagent), keyed by `Question.id`, by its (tool_name, tool_input, agentId)
+   * signature (#673, #799). Entry lifecycle: created in `escalateToUser` on a
+   * successful MAIN escalation, or in `parkSubagentForPTY` (#799) on a parked
+   * subagent one; removed by exactly TWO owners, unconditionally (regardless
+   * of whether a hold existed), so no exit path can leak an entry:
    *   - the public `resolveHeld` (a separate, non-delegating path — it owns
    *     its own delete);
    *   - the private `releaseHeld`, which EVERY other resolution path funnels
@@ -1361,15 +1391,46 @@ export class AutoApproveGate {
    * A parkForPTY throw is absorbed: the passthrough still stands, and the
    * rendered prompt degrades to a bare #712 orphan push instead of a merged
    * one.
+   *
+   * #799: also registers the parked question's signature in
+   * `openQuestionSignatures`, tagged `isSubagent: true` + this event's own
+   * `agent_id` -- the SAME bookkeeping `escalateToUser` does for a main
+   * escalation. Without this, a subagent permission answered directly in the
+   * terminal (approved -> the matching tool runs, or the allowlist absorbs
+   * it) had no way to ever leave `sessionRegistry.currentQuestions`: neither
+   * `cancelExternallyResolved` (no signature to match) nor `cancelStale`
+   * (subagent holds never exist) could reach it. A later matching subagent
+   * PreToolUse/PostToolUse (`cancelExternallyResolved`, wired in
+   * `hook-bridge-setup.ts`) can now find and resolve it through the normal
+   * `removeQuestion` + `onResolved` funnel. Mirrors `escalateToUser`'s own
+   * duplicate-re-request cleanup: a re-park for the identical signature (the
+   * SAME agent re-asking) proves the earlier parked/pushed record is dead.
    */
   private parkSubagentForPTY(input: PermissionRequestHookInput, summary?: string): void {
+    let questionId: UUID | undefined;
     try {
-      this.deps.parkForPTY?.(input, summary);
+      questionId = this.deps.parkForPTY?.(input, summary);
     } catch (err) {
       logError(
         `[AutoApprove ${this.sessionTag}] parkForPTY threw (prompt will fall to the orphan push path):`,
         err,
       );
+    }
+    if (questionId) {
+      const observed: ObservedToolCall = {
+        toolName: input.tool_name,
+        toolInput: input.tool_input,
+        toolUseId: input.tool_use_id,
+        agentId: input.agent_id,
+      };
+      this.cancelExternallyResolved(observed, 'duplicate-re-park-subagent');
+      this.openQuestionSignatures.set(questionId, {
+        toolName: observed.toolName,
+        toolInputKey: stableToolInputKey(observed.toolInput),
+        toolUseId: observed.toolUseId,
+        isSubagent: true,
+        agentId: observed.agentId,
+      });
     }
     this.safeCueWithArg('onEscalate', this.deps.onEscalate, { isSubagent: true });
   }
@@ -1510,6 +1571,7 @@ export class AutoApproveGate {
         toolName: input.tool_name,
         toolInput: input.tool_input,
         toolUseId: input.tool_use_id,
+        agentId: input.agent_id,
       };
       // #673 duplicate re-request: Claude re-issuing the IDENTICAL
       // PermissionRequest (same tool signature) proves any earlier OPEN
@@ -1534,6 +1596,10 @@ export class AutoApproveGate {
         // #711: tags this OPEN escalation main vs subagent/team-member, so a
         // mainOnly Stop (cancelStale) clears only main-tagged entries here.
         isSubagent: this.isSubagentEvent(input),
+        // #799: always undefined here -- escalateToUser is main-context only
+        // (see the class doc); kept for ToolSignature's shape symmetry with
+        // parkSubagentForPTY's own registration.
+        agentId: observed.agentId,
       });
     }
     return questionId;
@@ -1572,6 +1638,12 @@ export class AutoApproveGate {
     const observedKey = stableToolInputKey(observed.toolInput);
     for (const [qid, sig] of this.openQuestionSignatures) {
       if (sig.toolName !== observed.toolName || sig.toolInputKey !== observedKey) continue;
+      // #799: never cross agents. A MAIN observation (agentId undefined) can
+      // only match a MAIN-registered signature, and a subagent observation
+      // only its OWN agent's signature -- otherwise two different agents (or
+      // a subagent and main) issuing the identical (tool_name, tool_input)
+      // could resolve each other's unrelated escalation.
+      if (sig.agentId !== observed.agentId) continue;
       // Signature agrees. Two DIFFERENT tool calls can legitimately share an
       // identical (tool_name, tool_input) (e.g. two `ls` calls in a row) --
       // if BOTH sides carry a tool_use_id, it must ALSO agree, or this is a

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -57,6 +57,19 @@
  * gets, so a subagent permission answered directly in the terminal (the
  * matching tool then runs) is resolved through the normal `removeQuestion`
  * + `onResolved` funnel instead of leaking forever.
+ *
+ * A tool-signature match cannot cover a permission REJECTED in the terminal
+ * ("No" / "keep planning" — a deny produces no tool call at all). Two more
+ * triggers close that gap, both routing through the SAME funnel instead of a
+ * silent bookkeeping-only delete:
+ *   - `cancelStale('Stop', {mainOnly:true})`: Claude cannot fire `Stop`
+ *     ("finished responding") while still genuinely blocked rendering its
+ *     own native passthrough prompt (design/multi-choice, e.g. ExitPlanMode),
+ *     so a MAIN-tagged signature still open at Stop proves it was resolved
+ *     without a matching tool call ever firing.
+ *   - `cancelStaleForAgent`, called from `SubagentStop`: that agent's own
+ *     turn is over, so anything still open for it cannot still be blocking —
+ *     the single-agent mirror of the Stop reasoning above.
  */
 
 import type { UUID } from '@remi/shared';
@@ -81,9 +94,10 @@ interface ToolSignature {
    *  not wiped out just because the lead agent idled. */
   readonly isSubagent: boolean;
   /** #799: the escalating event's own `input.agent_id` (undefined for a MAIN
-   *  event). Lets `findOpenQuestionMatching` scope a match to the EXACT
-   *  agent that opened it -- without this, two different agents (or a
-   *  subagent and main) issuing an identical (tool_name, tool_input) could
+   *  event). Lets `findOpenQuestionMatching` and `cancelStaleForAgent` scope
+   *  a match to the EXACT agent that opened it -- without this, two
+   *  different agents (or a subagent and main) issuing an identical
+   *  (tool_name, tool_input) could
    *  cross-resolve each other's unrelated escalation. */
   readonly agentId: string | undefined;
 }
@@ -403,15 +417,18 @@ export class AutoApproveGate {
    *     (hold-timeout / undelivered-notification fail-open),
    *     `reconcileLateVerdict`'s cancelled branch (Part B), and
    *     `resolveSupersededQuestion` (#673's own external-resolution / stale
-   *     -duplicate cleanup).
-   * `cancelStale` and `forceRelease` additionally wholesale-clear the whole
-   * map (session end / force-release — nothing tracked is relevant after
-   * either). A stale entry is harmless (a signature match just triggers a
-   * redundant, idempotent cleanup), but MUST NOT be able to accumulate
-   * indefinitely: an un-deleted entry from a timed-out/cancelled hold would
-   * sit for the rest of the process lifetime and could fire a spurious
-   * `notifyResolved` for a question dead for hours on a much-later,
-   * unrelated duplicate of the same command.
+   *     -duplicate cleanup, also the funnel `cancelStaleForAgent` (#799) and
+   *     `cancelStale`'s mainOnly Stop sweep (#799) use).
+   * `releaseAllHolds` ALSO deletes an entry it just released (#799 — so the
+   * mainOnly Stop sweep below never double-resolves it), and `cancelStale`
+   * (non-mainOnly) / `forceRelease` wholesale-clear the whole map (session
+   * end / force-release — nothing tracked is relevant after either). A stale
+   * entry is harmless (a signature match just triggers a redundant, idempotent
+   * cleanup), but MUST NOT be able to accumulate indefinitely: an un-deleted
+   * entry from a timed-out/cancelled hold would sit for the rest of the
+   * process lifetime and could fire a spurious `notifyResolved` for a
+   * question dead for hours on a much-later, unrelated duplicate of the same
+   * command.
    */
   private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
 
@@ -462,8 +479,22 @@ export class AutoApproveGate {
     // moot; a teammate's is not (its hold, if any, was just spared above, and
     // its signature must stay trackable for external-resolution cancellation).
     if (mainOnly) {
-      for (const [qid, sig] of this.openQuestionSignatures) {
-        if (!sig.isSubagent) this.openQuestionSignatures.delete(qid);
+      // #799: a MAIN-tagged signature STILL open here was never held (a held
+      // one was already released + unregistered by releaseAllHolds above) --
+      // it is a PASSTHROUGH escalation (multi-choice / design, e.g.
+      // ExitPlanMode) Claude rendered natively and is still tracking. Claude
+      // cannot fire `Stop` ("finished responding") while genuinely blocked
+      // rendering that native prompt, so a MAIN Stop observing it still open
+      // proves it was resolved WITHOUT a matching tool call ever firing --
+      // most commonly a rejection ("No" / "keep planning") answered directly
+      // in the terminal, the one #799 gap `cancelExternallyResolved` can
+      // never catch (a deny produces no PreToolUse to match against). Route
+      // each survivor through the SAME funnel a tool-signature match uses
+      // (not a silent bookkeeping-only delete), so question_resolved + APNS
+      // dismiss + the live-sessions mirror all fire for it too.
+      for (const [qid, sig] of [...this.openQuestionSignatures]) {
+        if (sig.isSubagent) continue;
+        this.resolveSupersededQuestion(qid, reason);
       }
     } else {
       this.openQuestionSignatures.clear();
@@ -503,6 +534,35 @@ export class AutoApproveGate {
     }
     if (cancelledCount > 0) {
       log(`[AutoApprove] Cancelled ${cancelledCount} stale MAIN-context LLM eval(s): ${reason}`);
+    }
+  }
+
+  /**
+   * #799: resolve every OPEN escalation this gate still tracks for ONE exact
+   * subagent/team-member `agent_id` -- the single-agent mirror of
+   * `cancelStale('Stop', {mainOnly:true})`'s reasoning above. Called from
+   * `SubagentStop`: that event fires only once THAT agent's own turn is
+   * fully over, so any escalation still open for it (whether its rich
+   * question was ever pushed to a client, or only parked awaiting a PTY
+   * render that never came) can no longer be "about to run a tool" for that
+   * agent. This is the one unambiguous signal for a subagent permission
+   * REJECTED in the terminal (or silently absorbed by the allowlist without
+   * a render): a deny produces no tool call, so the #799 tool-signature
+   * match (`cancelExternallyResolved`, wired on subagent PreToolUse/
+   * PostToolUse) can never catch it.
+   *
+   * Scoped strictly to `agentId`: a DIFFERENT agent's still-open escalation
+   * (including main's, whose signatures never carry an agentId) is left
+   * completely untouched, so one teammate finishing can never phantom-
+   * resolve another teammate's -- or the lead's -- still-pending prompt.
+   * Each match funnels through `resolveSupersededQuestion`, so
+   * `removeQuestion` + `onResolved` (question_resolved broadcast + APNS
+   * dismiss) fire exactly as a matching tool call would.
+   */
+  cancelStaleForAgent(agentId: string, reason: string): void {
+    for (const [qid, sig] of [...this.openQuestionSignatures]) {
+      if (sig.agentId !== agentId) continue;
+      this.resolveSupersededQuestion(qid, reason);
     }
   }
 
@@ -649,6 +709,12 @@ export class AutoApproveGate {
       // gone (#585, P7), and drop the registry entry so no ghost card replays.
       this.notifyResolved(qid, 'cancelled');
       this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
+      // #799: mirror releaseHeld's own openQuestionSignatures/confirmedDeliveries
+      // cleanup so this qid reads as ALREADY resolved. Without this, cancelStale's
+      // mainOnly sweep over the surviving signatures (below) would find this
+      // just-released entry too and fire a second, spurious notifyResolved for it.
+      this.openQuestionSignatures.delete(qid);
+      this.confirmedDeliveries.delete(qid);
       hold.resolve(decision);
       this.pendingHolds.delete(qid);
     }
@@ -1401,7 +1467,8 @@ export class AutoApproveGate {
    * `cancelExternallyResolved` (no signature to match) nor `cancelStale`
    * (subagent holds never exist) could reach it. A later matching subagent
    * PreToolUse/PostToolUse (`cancelExternallyResolved`, wired in
-   * `hook-bridge-setup.ts`) can now find and resolve it through the normal
+   * `hook-bridge-setup.ts`) or that agent's own `SubagentStop`
+   * (`cancelStaleForAgent`) can now find and resolve it through the normal
    * `removeQuestion` + `onResolved` funnel. Mirrors `escalateToUser`'s own
    * duplicate-re-request cleanup: a re-park for the identical signature (the
    * SAME agent re-asking) proves the earlier parked/pushed record is dead.

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -415,20 +415,20 @@ export class AutoApproveGate {
    *   - the private `releaseHeld`, which EVERY other resolution path funnels
    *     through: `releaseHeldAsPassthrough` (normal answer), `failOpenHeld`
    *     (hold-timeout / undelivered-notification fail-open),
-   *     `reconcileLateVerdict`'s cancelled branch (Part B), and
+   *     `reconcileLateVerdict`'s cancelled branch (Part B),
    *     `resolveSupersededQuestion` (#673's own external-resolution / stale
    *     -duplicate cleanup, also the funnel `cancelStaleForAgent` (#799) and
-   *     `cancelStale`'s mainOnly Stop sweep (#799) use).
-   * `releaseAllHolds` ALSO deletes an entry it just released (#799 — so the
-   * mainOnly Stop sweep below never double-resolves it), and `cancelStale`
-   * (non-mainOnly) / `forceRelease` wholesale-clear the whole map (session
-   * end / force-release — nothing tracked is relevant after either). A stale
-   * entry is harmless (a signature match just triggers a redundant, idempotent
-   * cleanup), but MUST NOT be able to accumulate indefinitely: an un-deleted
-   * entry from a timed-out/cancelled hold would sit for the rest of the
-   * process lifetime and could fire a spurious `notifyResolved` for a
-   * question dead for hours on a much-later, unrelated duplicate of the same
-   * command.
+   *     `cancelStale`'s mainOnly Stop sweep (#799) use), and `releaseAllHolds`
+   *     (#799 -- so the mainOnly Stop sweep below never re-finds and double
+   *     -resolves a qid it just released via a held hook).
+   * `cancelStale` (non-mainOnly) / `forceRelease` wholesale-clear the whole
+   * map (session end / force-release — nothing tracked is relevant after
+   * either). A stale entry is harmless (a signature match just triggers a
+   * redundant, idempotent cleanup), but MUST NOT be able to accumulate
+   * indefinitely: an un-deleted entry from a timed-out/cancelled hold would
+   * sit for the rest of the process lifetime and could fire a spurious
+   * `notifyResolved` for a question dead for hours on a much-later,
+   * unrelated duplicate of the same command.
    */
   private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
 
@@ -689,11 +689,16 @@ export class AutoApproveGate {
     return this.releaseHeld(questionId, 'passthrough');
   }
 
-  /** Resolve pending holds with one decision + reason, clearing timers and
-   *  removing each released entry. Used by `cancelStale` (session teardown, or
-   *  a mainOnly-scoped Stop, #711) -- `mainOnly` releases only holds NOT
-   *  tagged subagent, leaving a teammate's hold (and its timer) intact so it
-   *  stays answerable via `resolveHeld`. */
+  /** Resolve pending holds with one decision + reason. Used by `cancelStale`
+   *  (session teardown, or a mainOnly-scoped Stop, #711) -- `mainOnly`
+   *  releases only holds NOT tagged subagent, leaving a teammate's hold (and
+   *  its timer) intact so it stays answerable via `resolveHeld`. Delegates
+   *  the per-hold teardown entirely to `releaseHeld` (its single owner, see
+   *  that method's docstring) so the timer/registry/signature/delivery
+   *  cleanup is never duplicated here -- #799's mainOnly Stop sweep in
+   *  `cancelStale` depends on `releaseHeld` having already dropped this qid's
+   *  `openQuestionSignatures` entry, or it would re-find it and double-fire
+   *  `notifyResolved`. */
   private releaseAllHolds(decision: PermissionDecision, reason: string, mainOnly = false): void {
     const targets = mainOnly
       ? [...this.pendingHolds].filter(([, hold]) => !hold.isSubagent)
@@ -702,21 +707,13 @@ export class AutoApproveGate {
     log(
       `[AutoApprove ${this.sessionTag}] Releasing ${targets.length} held hook(s) as ${decision} (${reason}${mainOnly ? ', main-only' : ''})`,
     );
-    for (const [qid, hold] of targets) {
-      clearTimeout(hold.timer);
+    for (const [qid] of targets) {
       // The session is going away (Stop/SessionEnd); dismiss the pushed card on
       // every client BEFORE resolving so it does not linger after the prompt is
-      // gone (#585, P7), and drop the registry entry so no ghost card replays.
+      // gone (#585, P7). `releaseHeld` then clears the timer, drops the registry
+      // + signature/delivery bookkeeping, and resolves the hook.
       this.notifyResolved(qid, 'cancelled');
-      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
-      // #799: mirror releaseHeld's own openQuestionSignatures/confirmedDeliveries
-      // cleanup so this qid reads as ALREADY resolved. Without this, cancelStale's
-      // mainOnly sweep over the surviving signatures (below) would find this
-      // just-released entry too and fire a second, spurious notifyResolved for it.
-      this.openQuestionSignatures.delete(qid);
-      this.confirmedDeliveries.delete(qid);
-      hold.resolve(decision);
-      this.pendingHolds.delete(qid);
+      this.releaseHeld(qid, decision);
     }
   }
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -813,7 +813,15 @@ export function setupHookBridge(
     // the terminal (or an unrelated allowlist absorption left no render), so
     // no PreToolUse/PostToolUse ever fires for it. Scoped to this exact
     // agent_id, so a sibling teammate's still-open escalation is untouched.
+    //
+    // Also expire this agent's PARKED tracker record (#763), pairing with
+    // cancelStaleForAgent the same way the PreToolUse-subagent branch pairs
+    // noteAgentAdvanced with cancelExternallyResolved above. Without this, a
+    // resolved-but-still-parked record can survive up to PARKED_RECORD_TTL_MS
+    // (120s) and pair with a delayed PTY render for this agent key, re-pushing
+    // a phantom card for a question that is already gone from sessionRegistry.
     if (input.agent_id) {
+      tracker.noteAgentAdvanced(input.agent_id);
       autoApproveGate.cancelStaleForAgent(input.agent_id, 'SubagentStop');
     }
   });

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -767,7 +767,21 @@ export function setupHookBridge(
     if (!binder.admits(input)) return;
     // Status event: a subagent's tool failure must not flip MAIN's status, so
     // drop on agent_id — the same split policy as Pre/PostToolUse (#419).
-    if (isSubagentEvent(input)) return;
+    if (isSubagentEvent(input)) {
+      // #799: a tool call that FAILED still proves the gating permission was
+      // granted (the tool actually ran) — at least as strong a signal as a
+      // successful PostToolUse. Same agent-scoped external-resolution cancel
+      // as the PreToolUse/PostToolUse subagent branches above.
+      autoApproveGate.cancelExternallyResolved(
+        {
+          toolName: input.tool_name,
+          toolInput: input.tool_input,
+          agentId: input.agent_id,
+        },
+        'PostToolUseFailure-subagent',
+      );
+      return;
+    }
     handlers.onPostToolUseFailure?.(input);
   });
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -386,8 +386,15 @@ export function setupHookBridge(
       // parks its rich question (same builder as a real escalation, minus the
       // push/registration side effects) and answers 'passthrough'; the tracker
       // pushes it only if Claude's native prompt actually renders on the PTY.
-      parkForPTY: (i, summary) =>
-        tracker.parkAwaitingPTY(hookBridge.buildPermissionQuestion(i, summary)),
+      // #799: return the parked question's id so the gate can register its
+      // signature in `openQuestionSignatures` -- without it, a subagent
+      // permission answered in the terminal has no removal path at all (see
+      // the PreToolUse/PostToolUse/SubagentStop wiring below).
+      parkForPTY: (i, summary) => {
+        const question = hookBridge.buildPermissionQuestion(i, summary);
+        tracker.parkAwaitingPTY(question);
+        return question.id;
+      },
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native
@@ -470,9 +477,14 @@ export function setupHookBridge(
   // transcript, so session-id filtering cannot distinguish them.
   //
   // Split policy:
-  //   - `PreToolUse` / `PostToolUse` / `SessionStart`: dropped here so
-  //     status updates and Task-tool tracking stay scoped to the main
-  //     interactive session.
+  //   - `PreToolUse` / `PostToolUse` / `SessionStart`: STATUS updates and
+  //     Task-tool tracking are dropped here so they stay scoped to the main
+  //     interactive session. #799: Pre/PostToolUse additionally call
+  //     `autoApproveGate.cancelExternallyResolved` (agent-scoped) before
+  //     returning — a tool call now running for this exact agent proves any
+  //     permission the gate parked/pushed for it was answered outside Remi's
+  //     own path, so its card must still be resolved even though the rest of
+  //     the event is dropped.
   //   - `PermissionRequest` / `Notification(permission_prompt)`: forwarded
   //     (phase 4, #419). Push is gated by PTY presence in the tracker,
   //     not by agent_id. A hot-switched subagent view that renders a
@@ -568,6 +580,21 @@ export function setupHookBridge(
       // out-of-band) — expire its parked record so it cannot stale-merge
       // onto a later unrelated prompt.
       tracker.noteAgentAdvanced(input.agent_id);
+      // #799: mirrors the main-context external-resolution cancel below —
+      // this agent's tool is now running, so any parked/pushed permission
+      // question the gate is still tracking FOR THIS AGENT with a matching
+      // (tool_name, tool_input) signature was answered outside Remi's own
+      // path (most commonly directly in the terminal). Funnel it through the
+      // same removeQuestion + question_resolved cleanup a main match uses.
+      autoApproveGate.cancelExternallyResolved(
+        {
+          toolName: input.tool_name,
+          toolInput: input.tool_input,
+          toolUseId: input.tool_use_id,
+          agentId: input.agent_id,
+        },
+        'PreToolUse-subagent',
+      );
       return;
     }
     // NB: do NOT cancel the in-flight auto-approve eval here (#537). Under
@@ -616,6 +643,18 @@ export function setupHookBridge(
       // in hook-event-bridge.ts and by the gate's #710 leak-recovery
       // escalate (reset + escalate as main instead of denying).
       hookBridge.noteSubagentToolEnd(input.tool_name, input.tool_use_id);
+      // #799: same external-resolution cancel as the PreToolUse branch above
+      // — a tool that has already FINISHED is at least as strong a signal
+      // that its permission was resolved elsewhere as one that just started.
+      autoApproveGate.cancelExternallyResolved(
+        {
+          toolName: input.tool_name,
+          toolInput: input.tool_input,
+          toolUseId: input.tool_use_id,
+          agentId: input.agent_id,
+        },
+        'PostToolUse-subagent',
+      );
       return;
     }
     // See the PreToolUse note above: no cancelStale here (#537). The previous

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -29,6 +29,10 @@
  * while agent-team teammates keep working, so it releases/cancels only
  * MAIN-context holds and evals, sparing a teammate's still-open escalation.
  * SessionEnd is real teardown and stays unscoped (releases/cancels everything).
+ * #799: `SubagentStop` calls `gate.cancelStaleForAgent(agent_id)`, the
+ * single-agent mirror of Stop's mainOnly sweep — resolves any permission
+ * still open for THAT agent (the terminal-rejection case a matching tool
+ * call can never signal, since a deny produces no tool call at all).
  *
  * This listener block IS the per-session hook router (admit-then-fan-out); a
  * formal HookRouter class is deferred to a later refactor (#470). The function
@@ -800,6 +804,17 @@ export function setupHookBridge(
       handlers.onSubagentStop?.(input);
     } catch (err) {
       logError(`[Hooks] SubagentStop view-tracking failed for ${sessionId}: ${errorToString(err)}`);
+    }
+    // #799: this agent's turn is fully over, so any permission escalation the
+    // gate still tracks for it (parked-then-pushed, or parked-and-never-
+    // rendered) can no longer be "about to run a tool" — resolve it through
+    // the same funnel a matching tool call uses. Covers the one case a tool
+    // signature match never can: the subagent's permission was REJECTED in
+    // the terminal (or an unrelated allowlist absorption left no render), so
+    // no PreToolUse/PostToolUse ever fires for it. Scoped to this exact
+    // agent_id, so a sibling teammate's still-open escalation is untouched.
+    if (input.agent_id) {
+      autoApproveGate.cancelStaleForAgent(input.agent_id, 'SubagentStop');
     }
   });
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -759,6 +759,10 @@ export function setupHookBridge(
     // the bridge emits a "Retry?" card via onQuestion. Like PermissionRequest it
     // is NOT agent_id-dropped — PTY-presence gating happens downstream in the
     // tracker (#419).
+    //
+    // #799 deliberately does NOT clear open escalations here: an unknown-state
+    // agent is exactly the ambiguous signal #799 avoids clearing on (unlike a
+    // clean Stop/SubagentStop). Known residual leak, tracked as #802.
     handlers.onStopFailure?.(input);
   });
 

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -2586,3 +2586,266 @@ describe('AutoApproveGate subagent external-resolution (#799)', () => {
     expect(resolvedLog).toEqual([{ qid: firstQid, reason: 'cancelled' }]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #799 part 2: a question REJECTED in the terminal never produces a matching
+// tool call, so the signature-match funnel above can never catch it. Stop
+// cannot fire ("Claude finished responding") while genuinely blocked
+// rendering its own native passthrough prompt, so a MAIN-tagged signature
+// still open when Stop(mainOnly) fires is resolved through the same funnel
+// instead of a silent bookkeeping-only delete.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate Stop resolves a still-open MAIN passthrough question (#799 part 2)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+  let parkedIds: UUID[];
+
+  function gate(
+    opts: {
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service: null,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        parkForPTY: () => {
+          const id = generateId() as UUID;
+          parkedIds.push(id);
+          return id;
+        },
+        holdMs: 60_000, // holding is on, but ExitPlanMode is always multi-choice -> passthrough
+        alwaysEscalateTools: new Set(),
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  /** ExitPlanMode is ALWAYS multi-choice (`ALWAYS_MULTI_CHOICE_TOOLS`), so
+   *  this escalates as a PASSTHROUGH -- never held -- exactly the
+   *  "No, keep planning" shape #799 targets. */
+  function planModePr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'plan',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'ExitPlanMode',
+      tool_input: {},
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    lastQuestionId = undefined;
+    parkedIds = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('fires: Stop(mainOnly) resolves a still-open MAIN passthrough question ("keep planning" answered in the terminal)', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(planModePr())).toBe('passthrough');
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'Accept plan?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    g.cancelStale('Stop', { mainOnly: true });
+
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+
+  test('never fires ambiguously: Stop(mainOnly) does not touch a still-open SUBAGENT question', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    // A still-open SUBAGENT escalation (#799: now also signature-registered,
+    // tagged isSubagent -- this is exactly the entry Stop(mainOnly) must spare).
+    const subagentPr: PermissionRequestHookInput = {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      agent_id: 'agent-1',
+      agent_type: 'general-purpose',
+    };
+    expect(await g.resolvePermission(subagentPr)).toBe('passthrough');
+    const subagentQid = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: subagentQid,
+      text: 'ls?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+
+    // A genuinely open MAIN question too, so the test proves Stop(mainOnly)
+    // resolves ITS OWN kind while sparing the subagent's.
+    expect(await g.resolvePermission(planModePr())).toBe('passthrough');
+    const mainQid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: mainQid,
+      text: 'Accept plan?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    g.cancelStale('Stop', { mainOnly: true });
+
+    expect(registry.getQuestion(SID, mainQid)).toBeNull(); // MAIN: resolved
+    expect(registry.getQuestion(SID, subagentQid)).not.toBeNull(); // subagent: untouched
+    expect(resolvedLog).toEqual([{ qid: mainQid, reason: 'cancelled' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #799 part 2, subagent mirror: cancelStaleForAgent, wired from SubagentStop.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate cancelStaleForAgent (#799 part 2, subagent)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let parkedIds: UUID[];
+
+  function gate(
+    opts: {
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service: null,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        // Unused by these subagent-only tests (no main escalation is ever
+        // driven), but AutoApproveGateDeps requires it.
+        escalate: () => generateId(),
+        parkForPTY: () => {
+          const id = generateId() as UUID;
+          parkedIds.push(id);
+          return id;
+        },
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  function pr(agentId: string, command: string): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command },
+      agent_id: agentId,
+      agent_type: 'general-purpose',
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    parkedIds = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test("fires: SubagentStop resolves that agent's still-open question (denied in the terminal, no tool call ever followed)", async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr('agent-1', 'rm -rf /tmp/x'))).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    g.cancelStaleForAgent('agent-1', 'SubagentStop');
+
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+
+  test("never fires ambiguously: a DIFFERENT agent's SubagentStop does not resolve this agent's still-open question", async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr('agent-1', 'ls'))).toBe('passthrough');
+    const qid1 = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: qid1,
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+    expect(await g.resolvePermission(pr('agent-2', 'ls'))).toBe('passthrough');
+    const qid2 = parkedIds[1] as UUID;
+    registry.addQuestion(SID, {
+      id: qid2,
+      text: 'proceed?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-2',
+    });
+
+    g.cancelStaleForAgent('agent-1', 'SubagentStop');
+
+    expect(registry.getQuestion(SID, qid1)).toBeNull(); // agent-1's is resolved
+    expect(registry.getQuestion(SID, qid2)).not.toBeNull(); // agent-2's is untouched
+    expect(resolvedLog).toEqual([{ qid: qid1, reason: 'cancelled' }]);
+  });
+});

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -115,6 +115,7 @@ describe('AutoApproveGate', () => {
         parkForPTY: (i, summary) => {
           parks.push(i);
           parkSummaries.push(summary);
+          return undefined; // these tests don't exercise #799 signature registration
         },
       },
       SID,
@@ -150,6 +151,7 @@ describe('AutoApproveGate', () => {
         parkForPTY: (i, summary) => {
           parks.push(i);
           parkSummaries.push(summary);
+          return undefined; // these tests don't exercise #799 signature registration
         },
         escalateModel: 'big-model',
       },
@@ -2401,5 +2403,186 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
     expect(() =>
       g.cancelExternallyResolved({ toolName: 'Bash', toolInput: { command: 'ls' } }, 'PreToolUse'),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #799: a subagent/teammate permission question answered IN THE TERMINAL had
+// NO removal path from sessionRegistry.currentQuestions -- parkSubagentForPTY
+// never registered an openQuestionSignatures entry (only main-context
+// escalateToUser did), so a matching subagent PreToolUse/PostToolUse could
+// never find it to clean up. These tests exercise the fix: parkSubagentForPTY
+// now registers an agent-scoped signature too.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate subagent external-resolution (#799)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let parkedIds: UUID[];
+
+  function gate(
+    opts: {
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        // No service configured: a subagent-tagged event parks synchronously
+        // (deterministic, no eval timing to await).
+        service: null,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => {}),
+        isInSubagentContext: () => false,
+        // Unused by these subagent-only tests (no main escalation is ever
+        // driven), but AutoApproveGateDeps requires it.
+        escalate: () => generateId(),
+        parkForPTY: () => {
+          const id = generateId() as UUID;
+          parkedIds.push(id);
+          return id;
+        },
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      agent_id: 'agent-1',
+      agent_type: 'general-purpose',
+      ...over,
+    };
+  }
+
+  function stashQuestion(id: UUID, agentId: string): void {
+    registry.addQuestion(SID, {
+      id,
+      text: 'proceed?',
+      options: [{ value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false }],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId,
+    });
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    parkedIds = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('(a) a matching subagent tool signature resolves the parked/pushed question', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    stashQuestion(qid, 'agent-1');
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+
+    // The user answered directly in the terminal: Claude now runs the tool.
+    g.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-1' },
+      'PreToolUse-subagent',
+    );
+
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+
+  test('(a) the same signature match also works from the PostToolUse side', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    stashQuestion(qid, 'agent-1');
+
+    g.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-1' },
+      'PostToolUse-subagent',
+    );
+
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+
+  test('(b) a non-matching tool_input for the SAME agent leaves the parked question open', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    stashQuestion(qid, 'agent-1');
+
+    g.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'rm -rf /' }, agentId: 'agent-1' },
+      'PreToolUse-subagent',
+    );
+
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+    expect(resolvedLog).toHaveLength(0);
+  });
+
+  test('(b) a matching signature from a DIFFERENT agent does not resolve this one', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr({ agent_id: 'agent-1' }))).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    stashQuestion(qid, 'agent-1');
+
+    g.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-OTHER' },
+      'PreToolUse-subagent',
+    );
+
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+    expect(resolvedLog).toHaveLength(0);
+  });
+
+  test('(b) a MAIN tool event (no agentId) never resolves a subagent-parked question with an identical signature', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const qid = parkedIds[0] as UUID;
+    stashQuestion(qid, 'agent-1');
+
+    g.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'git push' } }, // no agentId -> main
+      'PreToolUse',
+    );
+
+    expect(registry.getQuestion(SID, qid)).not.toBeNull();
+    expect(resolvedLog).toHaveLength(0);
+  });
+
+  test('a duplicate park for the SAME agent + signature cancels the stale earlier parked record', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const firstQid = parkedIds[0] as UUID;
+    // Claude re-issues the IDENTICAL PermissionRequest for the same agent.
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const secondQid = parkedIds[1] as UUID;
+    expect(secondQid).not.toBe(firstQid);
+
+    expect(resolvedLog).toEqual([{ qid: firstQid, reason: 'cancelled' }]);
   });
 });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2256,7 +2256,11 @@ describe('setupHookBridge', () => {
 
     test("SubagentStop resolves that agent's still-open permission (denied in the terminal, no tool call ever followed)", async () => {
       const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
-      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      const { tracker } = build({
+        autoApprove: true,
+        autoApproveDecision: 'escalate',
+        broadcastResolvedLog,
+      });
       lock('claude-799-stop');
 
       await hookServer.firePermission({
@@ -2268,6 +2272,8 @@ describe('setupHookBridge', () => {
         tool_input: { command: 'rm important-file' },
       });
       expect(broadcastResolvedLog).toHaveLength(0); // still open: no tool call ever fired (denied)
+      // The park left a parked-awaiting-PTY tracker record for this agent.
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
 
       hookServer.fire('SubagentStop', {
         session_id: 'claude-799-stop',
@@ -2277,6 +2283,12 @@ describe('setupHookBridge', () => {
 
       expect(broadcastResolvedLog).toHaveLength(1);
       expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+      // #799 review fix: SubagentStop must ALSO expire the tracker's parked
+      // record (mirrors the PreToolUse-subagent branch's noteAgentAdvanced
+      // pairing) -- otherwise it survives up to PARKED_RECORD_TTL_MS and can
+      // pair with a later, unrelated PTY render for this agent key and
+      // re-push a phantom card for a question already gone from the registry.
+      expect(tracker.awaitingPTYCountForTest()).toBe(0);
     });
 
     test("never fires ambiguously: SubagentStop for one agent does not resolve a DIFFERENT agent's still-open permission", async () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2150,6 +2150,111 @@ describe('setupHookBridge', () => {
     expect(messageApiLog.questionCalls).toBe(0); // no escalate
   });
 
+  // ---------------------------------------------------------------------------
+  // #799: a subagent/teammate permission question answered IN THE TERMINAL had
+  // no removal path from sessionRegistry.currentQuestions. Fix: the gate now
+  // registers a signature for a parked subagent escalation too, and the
+  // subagent branches of PreToolUse/PostToolUse (which used to early-return
+  // before ever reaching the gate) now call cancelExternallyResolved; a
+  // SubagentStop resolves anything still open for that agent (the
+  // rejected-in-the-terminal case no tool call ever announces).
+  // ---------------------------------------------------------------------------
+  describe('#799: subagent question purge', () => {
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('a matching subagent PreToolUse resolves a parked permission (question_resolved fires)', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-pre');
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-799-pre',
+        agent_id: 'agent-799-1',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+      expect(decision).toBe('passthrough');
+      expect(broadcastResolvedLog).toHaveLength(0); // parked, not resolved yet
+
+      // The user answered directly in the terminal: Claude now runs the tool.
+      hookServer.fire('PreToolUse', {
+        session_id: 'claude-799-pre',
+        agent_id: 'agent-799-1',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('a matching subagent PostToolUse also resolves it', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-post');
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-799-post',
+        agent_id: 'agent-799-2',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls -la' },
+      });
+      expect(decision).toBe('passthrough');
+      expect(broadcastResolvedLog).toHaveLength(0);
+
+      hookServer.fire('PostToolUse', {
+        session_id: 'claude-799-post',
+        agent_id: 'agent-799-2',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls -la' },
+        tool_response: 'ok',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('(b) a non-matching subagent PreToolUse leaves the parked permission open', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-nomatch');
+
+      await hookServer.firePermission({
+        session_id: 'claude-799-nomatch',
+        agent_id: 'agent-799-3',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+
+      hookServer.fire('PreToolUse', {
+        session_id: 'claude-799-nomatch',
+        agent_id: 'agent-799-3',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/x' }, // different command -> no signature match
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(0);
+    });
+  });
+
   describe('session_rotated emission on rotation (#430 #438)', () => {
     /**
      * Set up a hook bridge that captures every protocol message it tries

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2253,6 +2253,66 @@ describe('setupHookBridge', () => {
 
       expect(broadcastResolvedLog).toHaveLength(0);
     });
+
+    test("SubagentStop resolves that agent's still-open permission (denied in the terminal, no tool call ever followed)", async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-stop');
+
+      await hookServer.firePermission({
+        session_id: 'claude-799-stop',
+        agent_id: 'agent-799-4',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm important-file' },
+      });
+      expect(broadcastResolvedLog).toHaveLength(0); // still open: no tool call ever fired (denied)
+
+      hookServer.fire('SubagentStop', {
+        session_id: 'claude-799-stop',
+        agent_id: 'agent-799-4',
+        agent_type: 'general-purpose',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test("never fires ambiguously: SubagentStop for one agent does not resolve a DIFFERENT agent's still-open permission", async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-ambig');
+
+      await hookServer.firePermission({
+        session_id: 'claude-799-ambig',
+        agent_id: 'agent-799-A',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo A' },
+      });
+      await hookServer.firePermission({
+        session_id: 'claude-799-ambig',
+        agent_id: 'agent-799-B',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo B' },
+      });
+      expect(broadcastResolvedLog).toHaveLength(0);
+
+      // Only agent-A finished.
+      hookServer.fire('SubagentStop', {
+        session_id: 'claude-799-ambig',
+        agent_id: 'agent-799-A',
+        agent_type: 'general-purpose',
+      });
+
+      // Exactly ONE resolution -- agent-B's still-open permission is untouched.
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
   });
 
   describe('session_rotated emission on rotation (#430 #438)', () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2325,6 +2325,62 @@ describe('setupHookBridge', () => {
       expect(broadcastResolvedLog).toHaveLength(1);
       expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
     });
+
+    test('a matching subagent PostToolUseFailure resolves it (a failed tool still proves the permission was granted)', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-failure');
+
+      await hookServer.firePermission({
+        session_id: 'claude-799-failure',
+        agent_id: 'agent-799-5',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf build/' },
+      });
+      expect(broadcastResolvedLog).toHaveLength(0);
+
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-799-failure',
+        agent_id: 'agent-799-5',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PostToolUseFailure',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf build/' },
+        error: 'exit 1',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('a non-matching subagent PostToolUseFailure leaves the parked permission open', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-799-failure-nomatch');
+
+      await hookServer.firePermission({
+        session_id: 'claude-799-failure-nomatch',
+        agent_id: 'agent-799-6',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf build/' },
+      });
+
+      hookServer.fire('PostToolUseFailure', {
+        session_id: 'claude-799-failure-nomatch',
+        agent_id: 'agent-799-6',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PostToolUseFailure',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf dist/' }, // different command -> no signature match
+        error: 'exit 1',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(0);
+    });
   });
 
   describe('session_rotated emission on rotation (#430 #438)', () => {


### PR DESCRIPTION
## Root cause

A subagent/teammate permission question answered IN THE TERMINAL had no removal path from `sessionRegistry.currentQuestions`:

- The only external-resolution mechanism, `AutoApproveGate.cancelExternallyResolved` (`auto-approve-gate.ts`), is driven by `PreToolUse`/`PostToolUse` signature matches against `openQuestionSignatures`.
- `openQuestionSignatures` was populated only by the MAIN-context `escalateToUser`. Subagent escalations go through `parkSubagentForPTY`, which never registered a signature.
- `hook-bridge-setup.ts`'s `PreToolUse`/`PostToolUse` listeners early-return for `isSubagentEvent(input)` before ever reaching the gate's external-resolution cancel.
- The one terminal-closure detector, `detectAuqTerminalAnswers` (`pty-session-setup.ts`), is deliberately `kind === 'multi_question'`-only (AUQ), so it never covers a plain permission question either.

Net effect: a parked subagent permission (any tool) pushed to clients then answered in the terminal sat in the store until rotation/`/clear`, the `MAX_PENDING_QUESTIONS` LRU eviction, or a client answer — leaking a phantom card to every surface (in-app, menu-bar, lock screen).

Also affected (same root cause, main context): a question REJECTED in the terminal ("No" / "keep planning", e.g. `ExitPlanMode`) never produces a matching tool call, so signature-matching can never clear it either.

## Fix

**Part 1 — subagent tool advancement (commit `834de0a`)**

`parkSubagentForPTY` now registers a signature in `openQuestionSignatures` too, tagged `isSubagent: true` plus the event's own `agent_id` (`ToolSignature`/`ObservedToolCall` gained an `agentId` field so a match can never cross agents or leak into main). The subagent branches of `PreToolUse`/`PostToolUse` in `hook-bridge-setup.ts` now call `cancelExternallyResolved` (agent-scoped) before their early return, so a matching tool call now running for that agent resolves the question through the normal `removeQuestion` + `onResolved` funnel — the same `question_resolved` broadcast + APNS dismiss a main-context match gets.

**Part 2 — rejection-in-terminal (commit `1ea65a8`)**

Investigated the candidate signals named in the issue (`QuestionPresenceTracker` prompt-disappearance, Stop/agent-advance events) against the hard constraint from #668/#652: never clear on an ambiguous signal.

- `QuestionPresenceTracker` prompt-disappearance was ruled out: it only tracks NOT-YET-PUSHED hook records (`pending`/`awaitingPTY`), not the pushed/registered `sessionRegistry` question this bug is about, and its resets are driven by generic status churn that already caused cross-agent leaks pre-#763.
- Chosen signal: `Stop` (main) / `SubagentStop` (subagent), justified by verified hook semantics already documented elsewhere in this file — Claude Code cannot fire `Stop` ("finished responding") while still genuinely blocked rendering its own native passthrough prompt or waiting on a held hook response. A signature still open in `openQuestionSignatures` when `Stop`/`SubagentStop` fires therefore proves the underlying prompt already resolved without ever producing a matching tool call — the exact shape a deny/"keep planning" answer takes.
- `cancelStale('Stop', {mainOnly:true})`'s existing mainOnly sweep now routes each surviving MAIN-tagged signature through `resolveSupersededQuestion` (full funnel) instead of a silent bookkeeping-only delete.
- New `cancelStaleForAgent(agentId, reason)`, wired from `SubagentStop`, is the single-agent mirror: resolves only escalations open for that EXACT `agent_id`, so a sibling teammate's (or main's) still-open escalation is never touched — the ambiguity guard.
- `releaseAllHolds` now also drops its own `openQuestionSignatures`/`confirmedDeliveries` entries when it releases a hold, so the `Stop` mainOnly sweep can never double-fire `notifyResolved` for the same question.

This does **not** touch `detectAuqTerminalAnswers` or weaken its AUQ-only scope/test (`pty-session-setup.test.ts:312`) — it is a separate, independent signal.

## Tests

- `packages/daemon/tests/auto-approve/auto-approve-gate.test.ts`: signature registration/matching for a parked subagent question (own agent match, wrong agent no-op, main-vs-subagent cross-check, duplicate re-park cleanup); `cancelStale('Stop', {mainOnly:true})` resolving a still-open MAIN passthrough question while sparing a subagent's; `cancelStaleForAgent` resolving only its own agent's question.
- `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts`: end-to-end wiring — a matching subagent `PreToolUse`/`PostToolUse` resolves a parked permission (`question_resolved` observed via `broadcastQuestionResolved`); a non-matching tool leaves it open; `SubagentStop` resolves its own agent's still-open permission and never a different agent's.
- No live model required — `service: null` / a deterministic evaluator drives every new test; verified they pass without Ollama running.

`bunx biome check`, `bun run typecheck`, and `bun test packages/daemon/tests` (2833 tests, 2764 pass, 69 skip — the Ollama-gated LLM tests self-skip without a live model) all green.

## Deviations from the issue text

None in approach. One addition beyond the issue's literal wording: an `agentId` field was added to `ToolSignature`/`ObservedToolCall` (not explicitly named in the issue) to make cross-agent signature collisions impossible now that subagent signatures are registered too — without it, two different agents (or a subagent and main) issuing an identical `(tool_name, tool_input)` could otherwise resolve each other's unrelated escalation.

## Needs on-device verification

The core claim behind Part 2 (Claude Code cannot fire `Stop`/`SubagentStop` while a native passthrough prompt is still genuinely unanswered) is based on documented hook semantics and existing in-code assumptions (e.g. the file's own `#537`/`#711` comments), not a fresh live capture. Recommend a real soak: park a subagent permission, deny it in the terminal, confirm the phone card clears within seconds and a `question_resolved` is observed on the wire; same for a MAIN `ExitPlanMode` "keep planning" answer.

Closes #799
Refs #538
