### PR TITLE
Add opt-in question-lifecycle trace (#808)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -494,7 +494,7 @@ export class AutoApproveGate {
       // dismiss + the live-sessions mirror all fire for it too.
       for (const [qid, sig] of [...this.openQuestionSignatures]) {
         if (sig.isSubagent) continue;
-        this.resolveSupersededQuestion(qid, reason);
+        this.resolveSupersededQuestion(qid, reason, sig.toolName);
       }
     } else {
       this.openQuestionSignatures.clear();
@@ -562,7 +562,7 @@ export class AutoApproveGate {
   cancelStaleForAgent(agentId: string, reason: string): void {
     for (const [qid, sig] of [...this.openQuestionSignatures]) {
       if (sig.agentId !== agentId) continue;
-      this.resolveSupersededQuestion(qid, reason);
+      this.resolveSupersededQuestion(qid, reason, sig.toolName);
     }
   }
 
@@ -651,7 +651,7 @@ export class AutoApproveGate {
     // this leaves a ghost card that replays on reconnect and lets a late
     // handleAnswer find it "live" and misroute. The user-answer path also
     // removes it in handleAnswer's finally; a double-remove is idempotent.
-    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId, `resolveHeld:${decision}`);
     this.markHandled(hold.isSubagent);
     let resolvedDecision: PermissionDecision = decision;
     let logSuffix: string = decision;
@@ -686,7 +686,7 @@ export class AutoApproveGate {
     // #673: openQuestionSignatures cleanup lives in the private releaseHeld
     // itself (the single owner every internal caller funnels through), so
     // there is nothing extra to do here.
-    return this.releaseHeld(questionId, 'passthrough');
+    return this.releaseHeld(questionId, 'passthrough', 'released-passthrough-for-pty-answer');
   }
 
   /** Resolve pending holds with one decision + reason. Used by `cancelStale`
@@ -713,7 +713,7 @@ export class AutoApproveGate {
       // gone (#585, P7). `releaseHeld` then clears the timer, drops the registry
       // + signature/delivery bookkeeping, and resolves the hook.
       this.notifyResolved(qid, 'cancelled');
-      this.releaseHeld(qid, decision);
+      this.releaseHeld(qid, decision, reason);
     }
   }
 
@@ -815,7 +815,7 @@ export class AutoApproveGate {
     // Dismiss the stale card everywhere BEFORE resolving (#585, P7); releaseHeld
     // then clears the timer, drops the registry entry, and resolves passthrough.
     this.notifyResolved(qid, 'cancelled');
-    this.releaseHeld(qid, 'passthrough');
+    this.releaseHeld(qid, 'passthrough', 'hold-fail-open');
   }
 
   /**
@@ -1388,7 +1388,7 @@ export class AutoApproveGate {
       // Claude advanced past the prompt during the slow eval; fail the hold open.
       this.deps.tracker.clearPending();
       this.notifyResolved(qid, 'cancelled');
-      this.releaseHeld(qid, 'passthrough');
+      this.releaseHeld(qid, 'passthrough', 'part-b-cancelled');
     }
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
   }
@@ -1406,8 +1406,17 @@ export class AutoApproveGate {
    * delete must be UNCONDITIONAL (not gated on `hold` existing) or every one
    * of those exit paths leaks an entry for the rest of the process lifetime.
    * (`resolveHeld` is a separate, non-delegating path and owns its own delete.)
+   *
+   * `reason` (#808) names the caller/signal for the opt-in question-lifecycle
+   * trace; `toolName`, when the caller knows it, is carried onto the same
+   * trace record.
    */
-  private releaseHeld(questionId: UUID, decision: PermissionDecision): boolean {
+  private releaseHeld(
+    questionId: UUID,
+    decision: PermissionDecision,
+    reason = 'held-released',
+    toolName?: string,
+  ): boolean {
     this.openQuestionSignatures.delete(questionId);
     // #733: unconditional for the same leak reason as the signature delete
     // above — every hold exit path funnels through here.
@@ -1419,7 +1428,7 @@ export class AutoApproveGate {
     // Drop the registry entry so no ghost card replays (#585, P7 FIX 2). The
     // user-answer path (releaseHeldAsPassthrough -> handleAnswer finally) also
     // removes it; a double-remove is idempotent.
-    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId);
+    this.deps.sessionRegistry.removeQuestion(this.sessionId, questionId, reason, toolName);
     hold.resolve(decision);
     return true;
   }
@@ -1688,7 +1697,7 @@ export class AutoApproveGate {
   cancelExternallyResolved(observed: ObservedToolCall, reason: string): void {
     const qid = this.findOpenQuestionMatching(observed);
     if (!qid) return;
-    this.resolveSupersededQuestion(qid, reason);
+    this.resolveSupersededQuestion(qid, reason, observed.toolName);
   }
 
   /** Find an open escalation matching `observed`, preferring an exact
@@ -1732,13 +1741,17 @@ export class AutoApproveGate {
    * independently try/catch'd so one failure can never skip the rest —
    * `removeQuestion` in particular must always run even if the eval was
    * already gone or the hold release throws, or the pushed card lingers.
+   *
+   * `toolName` (#808), when the caller knows it (a signature match or a
+   * tracked `ToolSignature` both carry it), is carried onto the
+   * question-lifecycle trace record for this removal.
    */
-  private resolveSupersededQuestion(qid: UUID, reason: string): void {
+  private resolveSupersededQuestion(qid: UUID, reason: string, toolName?: string): void {
     log(
       `[AutoApprove ${this.sessionTag}] Externally resolved ${qid.slice(0, 8)} (${reason}); clearing stale escalation`,
     );
     try {
-      this.releaseHeld(qid, 'passthrough');
+      this.releaseHeld(qid, 'passthrough', reason, toolName);
     } catch (err) {
       logError(
         `[AutoApprove ${this.sessionTag}] releaseHeld during external-resolve cleanup threw:`,
@@ -1754,7 +1767,7 @@ export class AutoApproveGate {
       );
     }
     try {
-      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid);
+      this.deps.sessionRegistry.removeQuestion(this.sessionId, qid, reason, toolName);
     } catch (err) {
       logError(
         `[AutoApprove ${this.sessionTag}] removeQuestion during external-resolve cleanup threw:`,

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -182,6 +182,7 @@ import {
   TranscriptIndex,
 } from './session/index.ts';
 import { findAvailableTcpPort } from './session/port-utils.ts';
+import { traceQuestionEvent } from './session/question-trace.ts';
 import { TranscriptDiscovery, type TranscriptWatcher } from './transcript/index.ts';
 
 // ---------------------------------------------------------------------------
@@ -1041,6 +1042,19 @@ const sessionRegistry = new SessionRegistry(
       } catch (err) {
         logError(`[QuestionSnapshot] broadcast failed for ${sessionId}: ${errorToString(err)}`);
       }
+      // #808: this is the ONLY signal that drives client-side reconciliation
+      // (pruneQuestionsNotLive) today, and it fires ONLY on a change -- never
+      // proactively on attach/reconnect (see connection-events.ts /
+      // resume-session-events.ts, which only resend the still-live set).
+      // Recording every broadcast lets the on-device capture correlate "the
+      // daemon told every client the live set was X" against "the client
+      // still shows a card not in X".
+      traceQuestionEvent({
+        action: 'snapshot_broadcast',
+        sessionId,
+        signal: 'onQuestionsChanged',
+        detail: { liveQuestionIds: questions.map((q) => q.id) },
+      });
     },
   },
 );

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -17,6 +17,7 @@ import { AUQ_KEYS } from '../../hooks/auq-answer.ts';
 import { type AuqRunOutcome, runAuqAnswer } from '../../hooks/auq-runner.ts';
 import { readPtyOutput, resetPtyOutput } from '../../pty/output-buffer.ts';
 import type { ManagedSession, SessionBindingStore, SessionRegistry } from '../../session/index.ts';
+import { traceQuestionEvent } from '../../session/question-trace.ts';
 import { log, logError } from '../logger.ts';
 import { ResolvedAnswerCache, answerCacheKey } from './resolved-answer-cache.ts';
 import type { SendToConnection } from './trivial-events.ts';
@@ -322,7 +323,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       try {
         cancelAutoApproveForQuestion?.(session.sessionId, questionId, 'user-answered-auq');
       } finally {
-        sessionRegistry.removeQuestion(session.sessionId, questionId);
+        sessionRegistry.removeQuestion(session.sessionId, questionId, 'user_answer:auq');
         try {
           onQuestionResolved?.(session.sessionId, questionId);
         } catch (err) {
@@ -440,7 +441,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       } catch (err) {
         logError(`[Answer] cancel: eval cancel failed: ${errorToString(err)}`);
       }
-      sessionRegistry.removeQuestion(session.sessionId, questionId);
+      sessionRegistry.removeQuestion(session.sessionId, questionId, 'user_answer:cancel');
       try {
         onQuestionResolved?.(session.sessionId, questionId);
       } catch (err) {
@@ -488,6 +489,17 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       log(
         `Ignoring stale answer: questionId ${questionId} not in pending [${pendingIds.join(', ') || 'none'}]${freedHeld ? ' (freed an orphaned held hook -> passthrough)' : ''}`,
       );
+      // #808: informational -- nothing was removed (it is already gone), but
+      // recording what WAS still pending at this moment is exactly the
+      // evidence needed to tell "client is showing a stale card" (Shape 1/2)
+      // apart from "client and daemon agree, this really is a bad answer".
+      traceQuestionEvent({
+        action: 'stale_answer',
+        sessionId: session.sessionId,
+        questionId,
+        signal: 'STALE_ANSWER',
+        detail: { pendingQuestionIds: pendingIds, freedHeld },
+      });
       if (!viaRelay) {
         send(
           connectionId,
@@ -596,7 +608,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     } finally {
       // Remove only the answered question; sibling prompts remain answerable.
       // In `finally` so a throwing submit cannot leave a zombie question.
-      sessionRegistry.removeQuestion(session.sessionId, questionId);
+      sessionRegistry.removeQuestion(session.sessionId, questionId, 'user_answer');
       // Cross-client dismissal (#585, P7): tell every client this question is
       // resolved so its card clears and the lock-screen push is dismissed.
       // Throw-safe: a broadcast/push failure must never break answer handling,

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -303,7 +303,7 @@ export function setupHookBridge(
         }
       }
     }
-    sessionRegistry.clearQuestions(sessionId);
+    sessionRegistry.clearQuestions(sessionId, 'session_restart');
   };
 
   // ---- Bridge + hook handler registration ---------------------------------

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -151,7 +151,10 @@ export function createMessageApiForSession(
         ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
-      sessionRegistry.addQuestion(questionSessionId, stamped);
+      // #808: `source` ('permission_request' | 'notification' | 'pty') is the
+      // richest "why did this appear" signal already on the Question, and
+      // free to pass through -- no extra threading needed.
+      sessionRegistry.addQuestion(questionSessionId, stamped, stamped.source ?? 'unknown');
 
       // Push: a non-held question only pushes when no client is attached (the
       // client sees it in-app). A HELD escalation (#603 Phase 3) always also

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -148,7 +148,7 @@ export function detectAuqTerminalAnswers(
     } catch (err) {
       logError(`[AUQ] terminal-answer eval cancel failed: ${errorToString(err)}`);
     }
-    sessionRegistry.removeQuestion(sessionId, q.id);
+    sessionRegistry.removeQuestion(sessionId, q.id, 'terminal_auq_closed');
     try {
       onQuestionResolved?.(sessionId, q.id);
     } catch (err) {

--- a/packages/daemon/src/session/question-trace.ts
+++ b/packages/daemon/src/session/question-trace.ts
@@ -1,0 +1,106 @@
+/**
+ * Opt-in question-lifecycle trace (#808).
+ *
+ * The #798/#799 fixes were reasoned entirely from hook semantics, never from
+ * a live capture — exactly why the residual phantom-card shapes (#808)
+ * survived them. This module is the capture tool: when
+ * `REMI_QUESTION_TRACE=1`, every mutation of `SessionRegistry.currentQuestions`
+ * (an add, or a removal via the `removeQuestion`/`clearQuestions` funnel) and
+ * a handful of adjacent diagnostic moments (a `STALE_ANSWER` rejection, a
+ * `question_snapshot` broadcast) append one JSONL record to
+ * `~/.remi/question-trace.jsonl`.
+ *
+ * Mirrors the existing `REMI_HOOK_DEBUG` diagnostic dump (see
+ * `hooks/hook-server.ts`): synchronous `fs.appendFileSync`, wrapped so a
+ * write failure can never escape into the caller, warn-once (not every call)
+ * so a broken sink is still visible without spamming the log. Disabled (the
+ * default) short-circuits before touching the filesystem at all, so this can
+ * never affect the decision path it observes.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** One question-lifecycle event. */
+export interface QuestionTraceRecord {
+  /**
+   * What happened:
+   *   - 'add'    — a question was registered (`SessionRegistry.addQuestion`).
+   *   - 'remove' — a question left the store, whether singly
+   *     (`removeQuestion`) or as part of a wholesale `clearQuestions` (one
+   *     record per cleared question).
+   *   - 'stale_answer' — a client tried to answer a question no longer in
+   *     the store; informational (nothing removed), but tells you what WAS
+   *     still pending at that moment (see `detail.pendingQuestionIds`).
+   *   - 'snapshot_broadcast' — the daemon broadcast a `question_snapshot`
+   *     (the authoritative live-id set for a session); this is the signal
+   *     that SHOULD drive client-side reconciliation (#798 parts 2/3).
+   */
+  action: 'add' | 'remove' | 'stale_answer' | 'snapshot_broadcast';
+  sessionId: string;
+  /** Absent only for a 'snapshot_broadcast' (session-scoped, not per-question). */
+  questionId?: string | undefined;
+  /** The Claude agent this question belongs to (hook `agent_id`); absent for
+   *  the main agent. */
+  agentId?: string | undefined;
+  /** Derived from `agentId` presence — kept as an explicit field so a JSONL
+   *  consumer can filter without re-deriving it. */
+  isSubagent?: boolean | undefined;
+  /** The tool this question/escalation was for, when known at the call site
+   *  (not every removal path has it — a plain user-answered question, for
+   *  instance, does not carry a tool name). */
+  toolName?: string | undefined;
+  /** The event or reason that caused this action, e.g. 'PostToolUse',
+   *  'PostToolUse-subagent', 'Stop', 'SubagentStop', 'user_answer',
+   *  'STALE_ANSWER', 'duplicate-re-park-subagent', 'session_restart'. */
+  signal: string;
+  /**
+   * For a 'remove': true iff this went through `SessionRegistry`'s own
+   * `removeQuestion`/`clearQuestions` funnel — always true for a
+   * daemon-emitted record, since the #808 audit confirmed no other code path
+   * mutates `currentQuestions` directly (grep for `.delete(`/`.clear(` on the
+   * map turns up only these two methods). Kept as an explicit field rather
+   * than assumed: a FUTURE regression that bypasses the funnel would not
+   * emit a trace record at all, so a removal a client observed (a card
+   * clearing) with NO matching 'remove' record here is itself the signal a
+   * bypass has been introduced.
+   */
+  throughFunnel?: boolean | undefined;
+  /** Free-form extra context (e.g. the live id count for a snapshot, or the
+   *  pending id list for a stale-answer rejection). Kept loose so the trace
+   *  can absorb future signal types without a schema migration. */
+  detail?: Record<string, unknown> | undefined;
+}
+
+const TRACE_FILE_NAME = 'question-trace.jsonl';
+
+let warned = false;
+
+function isEnabled(): boolean {
+  return process.env['REMI_QUESTION_TRACE'] === '1';
+}
+
+/**
+ * Append one trace record. No-op (and does not touch the filesystem) unless
+ * `REMI_QUESTION_TRACE=1`. Throw-safe: a write failure is logged once (not
+ * on every call, so a broken sink cannot spam the log) and otherwise
+ * swallowed — this function must NEVER be able to affect the question
+ * lifecycle it is only observing.
+ */
+export function traceQuestionEvent(record: QuestionTraceRecord): void {
+  if (!isEnabled()) return;
+  try {
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...record });
+    const remiDir = path.join(os.homedir(), '.remi');
+    fs.mkdirSync(remiDir, { recursive: true });
+    fs.appendFileSync(path.join(remiDir, TRACE_FILE_NAME), `${line}\n`);
+  } catch (err) {
+    if (!warned) {
+      warned = true;
+      console.warn(
+        `[QuestionTrace] REMI_QUESTION_TRACE enabled but writing failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -25,6 +25,7 @@ import type {
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
+import { traceQuestionEvent } from './question-trace.ts';
 import { generateSessionName } from './session-name.ts';
 
 /** Upper bound on concurrently-pending questions per session. Real prompts are
@@ -431,7 +432,7 @@ export class SessionRegistry {
    * Bounded by MAX_PENDING_QUESTIONS (oldest evicted first) so a runaway
    * prompt loop cannot grow the map without limit.
    */
-  addQuestion(sessionId: UUID, question: Question): void {
+  addQuestion(sessionId: UUID, question: Question, signal = 'unknown'): void {
     if (this.session === null || this.session.sessionId !== sessionId) return;
     const map = this.session.currentQuestions;
     map.delete(question.id); // re-insert so a refreshed question is "newest"
@@ -447,29 +448,76 @@ export class SessionRegistry {
       console.warn(
         `[SessionRegistry] pending-question cap (${MAX_PENDING_QUESTIONS}) exceeded; evicted oldest id=${oldest} text="${evicted?.text.slice(0, 60) ?? ''}"`,
       );
+      // #808: an LRU eviction is a removal too -- it never goes through
+      // removeQuestion (there is no single questionId call site for it), so
+      // trace it here directly rather than let it appear as a silent gap.
+      traceQuestionEvent({
+        action: 'remove',
+        sessionId,
+        questionId: oldest,
+        agentId: evicted?.agentId,
+        isSubagent: evicted?.agentId !== undefined,
+        signal: 'lru_eviction',
+        throughFunnel: true,
+      });
     }
     this.session.lastActivityAt = now();
     this.events.onQuestionsChanged?.(sessionId, [...map.values()]);
+    traceQuestionEvent({
+      action: 'add',
+      sessionId,
+      questionId: question.id,
+      agentId: question.agentId,
+      isSubagent: question.agentId !== undefined,
+      signal,
+    });
   }
 
-  /** Remove one answered/resolved question by id. */
-  removeQuestion(sessionId: UUID, questionId: UUID): void {
+  /** Remove one answered/resolved question by id. `signal` (#808) names the
+   *  event/reason that caused the removal (e.g. 'PostToolUse', 'Stop',
+   *  'user_answer') for the opt-in question-lifecycle trace; `toolName`,
+   *  when the caller knows it, is carried onto the same record. */
+  removeQuestion(sessionId: UUID, questionId: UUID, signal = 'unknown', toolName?: string): void {
     if (this.session !== null && this.session.sessionId === sessionId) {
+      const existing = this.session.currentQuestions.get(questionId);
       this.session.currentQuestions.delete(questionId);
       this.session.lastActivityAt = now();
       this.events.onQuestionsChanged?.(sessionId, [...this.session.currentQuestions.values()]);
+      traceQuestionEvent({
+        action: 'remove',
+        sessionId,
+        questionId,
+        agentId: existing?.agentId,
+        isSubagent: existing?.agentId !== undefined,
+        toolName,
+        signal,
+        throughFunnel: true,
+      });
     }
   }
 
   /** Drop all pending questions on Claude session restart (/clear, /resume).
    *  Status-leaving-'waiting' is handled by QuestionPresenceTracker and the
    *  client; this covers the restart path only, so answers to the dying
-   *  session's prompts are refused. */
-  clearQuestions(sessionId: UUID): void {
+   *  session's prompts are refused. `signal` (#808) is carried onto one trace
+   *  record per cleared question. */
+  clearQuestions(sessionId: UUID, signal = 'unknown'): void {
     if (this.session !== null && this.session.sessionId === sessionId) {
+      const cleared = [...this.session.currentQuestions.values()];
       this.session.currentQuestions.clear();
       this.session.lastActivityAt = now();
       this.events.onQuestionsChanged?.(sessionId, []);
+      for (const q of cleared) {
+        traceQuestionEvent({
+          action: 'remove',
+          sessionId,
+          questionId: q.id,
+          agentId: q.agentId,
+          isSubagent: q.agentId !== undefined,
+          signal,
+          throughFunnel: true,
+        });
+      }
     }
   }
 

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { ProtocolMessage } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../src/api/message-api.ts';
@@ -204,6 +207,102 @@ describe('SessionRegistry', () => {
         registry.removeQuestion('unknown-session' as ReturnType<typeof generateId>, generateId());
         registry.clearQuestions('unknown-session' as ReturnType<typeof generateId>);
         expect(events.onQuestionsChanged).not.toHaveBeenCalled();
+      });
+    });
+
+    // Real subprocess (like session-store-concurrency.test.ts): Bun's
+    // os.homedir() resolves once at process startup, so a fresh subprocess
+    // with HOME set in its spawn env is the only reliable way to point the
+    // trace module (session/question-trace.ts) at a throwaway directory --
+    // mutating process.env.HOME in THIS process would not be seen by it. See
+    // tests/session/question-trace.test.ts for the module's own unit tests;
+    // this suite instead proves the WIRING from SessionRegistry is correct.
+    describe('question-lifecycle trace (#808, wiring)', () => {
+      function readTraceLines(home: string): Record<string, unknown>[] {
+        const tracePath = path.join(home, '.remi', 'question-trace.jsonl');
+        if (!fs.existsSync(tracePath)) return [];
+        return fs
+          .readFileSync(tracePath, 'utf-8')
+          .split('\n')
+          .filter((l) => l.length > 0)
+          .map((l) => JSON.parse(l));
+      }
+
+      test('add/remove/clear/evict each emit the expected trace record', async () => {
+        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-registry-trace-test-'));
+        try {
+          const worker = path.join(import.meta.dir, 'session/session-registry-trace-worker.ts');
+          const proc = Bun.spawn(['bun', worker], {
+            env: { ...process.env, HOME: tmpHome, REMI_QUESTION_TRACE: '1' },
+            stdout: 'pipe',
+            stderr: 'pipe',
+          });
+          const code = await proc.exited;
+          const stdout = await new Response(proc.stdout).text();
+          if (code !== 0) {
+            throw new Error(`worker exited ${code}: ${await new Response(proc.stderr).text()}`);
+          }
+          const { q1, q2, oldestEvicted } = JSON.parse(stdout.trim()) as {
+            q1: string;
+            q2: string;
+            oldestEvicted: string;
+          };
+
+          const lines = readTraceLines(tmpHome);
+
+          const addQ1 = lines.find((l) => l['action'] === 'add' && l['questionId'] === q1);
+          expect(addQ1).toMatchObject({ signal: 'unknown', isSubagent: false });
+
+          const addQ2 = lines.find((l) => l['action'] === 'add' && l['questionId'] === q2);
+          expect(addQ2).toMatchObject({
+            signal: 'permission_request',
+            agentId: 'sub-2',
+            isSubagent: true,
+          });
+
+          const removeQ1 = lines.find((l) => l['action'] === 'remove' && l['questionId'] === q1);
+          expect(removeQ1).toMatchObject({
+            signal: 'user_answer',
+            toolName: 'Bash',
+            throughFunnel: true,
+          });
+
+          const clearQ2 = lines.find(
+            (l) =>
+              l['action'] === 'remove' &&
+              l['questionId'] === q2 &&
+              l['signal'] === 'session_restart',
+          );
+          expect(clearQ2).toMatchObject({ throughFunnel: true });
+
+          const eviction = lines.find((l) => l['signal'] === 'lru_eviction');
+          expect(eviction).toMatchObject({
+            action: 'remove',
+            questionId: oldestEvicted,
+            throughFunnel: true,
+          });
+        } finally {
+          fs.rmSync(tmpHome, { recursive: true, force: true });
+        }
+      });
+
+      test('disabled by default (no REMI_QUESTION_TRACE): no file is written', async () => {
+        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-registry-trace-test-'));
+        try {
+          const worker = path.join(import.meta.dir, 'session/session-registry-trace-worker.ts');
+          // Rebuild from scratch (rather than `delete`) so this run can never
+          // inherit REMI_QUESTION_TRACE from the parent test process's own env.
+          const { REMI_QUESTION_TRACE: _inherited, ...rest } = process.env;
+          const env = { ...rest, HOME: tmpHome };
+          const proc = Bun.spawn(['bun', worker], { env, stdout: 'pipe', stderr: 'pipe' });
+          const code = await proc.exited;
+          if (code !== 0) {
+            throw new Error(`worker exited ${code}: ${await new Response(proc.stderr).text()}`);
+          }
+          expect(fs.existsSync(path.join(tmpHome, '.remi', 'question-trace.jsonl'))).toBe(false);
+        } finally {
+          fs.rmSync(tmpHome, { recursive: true, force: true });
+        }
       });
     });
   });

--- a/packages/daemon/tests/session/question-trace-worker.ts
+++ b/packages/daemon/tests/session/question-trace-worker.ts
@@ -1,0 +1,28 @@
+/**
+ * Worker for question-trace.test.ts (#808).
+ *
+ * `os.homedir()` in Bun resolves once at process startup and does not track
+ * later mutations of `process.env.HOME` within the SAME process, so the only
+ * reliable way to point the trace module at a throwaway directory is a fresh
+ * subprocess with `HOME` set in its spawn env (see `Bun.spawn` callers
+ * below). This worker just runs a fixed, deterministic sequence of
+ * `traceQuestionEvent` calls; the parent test asserts on the resulting file.
+ */
+import { traceQuestionEvent } from '../../src/session/question-trace.ts';
+
+traceQuestionEvent({
+  action: 'add',
+  sessionId: 'session-1',
+  questionId: 'question-1',
+  signal: 'permission_request',
+});
+traceQuestionEvent({
+  action: 'remove',
+  sessionId: 'session-1',
+  questionId: 'question-1',
+  agentId: 'agent-1',
+  isSubagent: true,
+  toolName: 'Bash',
+  signal: 'PostToolUse-subagent',
+  throughFunnel: true,
+});

--- a/packages/daemon/tests/session/question-trace.test.ts
+++ b/packages/daemon/tests/session/question-trace.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the opt-in question-lifecycle trace (#808).
+ *
+ * Real filesystem I/O, no mocks, real subprocesses (mirrors the pattern in
+ * `session-store-concurrency.test.ts`): `os.homedir()` in Bun is resolved
+ * once at process startup, so pointing the trace module at a throwaway
+ * directory requires a FRESH subprocess with `HOME` set in its spawn env —
+ * mutating `process.env.HOME` inside this test process has no effect on
+ * `os.homedir()`. This also means the real behavior (HOME as set by the
+ * caller's shell/service-manager) is exactly what gets exercised.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const WORKER = path.join(import.meta.dir, 'question-trace-worker.ts');
+
+function readTraceLines(home: string): Record<string, unknown>[] {
+  const tracePath = path.join(home, '.remi', 'question-trace.jsonl');
+  if (!fs.existsSync(tracePath)) return [];
+  return fs
+    .readFileSync(tracePath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+async function runWorker(home: string, traceEnabled: boolean): Promise<number> {
+  // Rebuild from scratch (rather than `delete`) so a disabled run can never
+  // inherit REMI_QUESTION_TRACE from the parent test process's own env.
+  const { REMI_QUESTION_TRACE: _inherited, ...rest } = process.env;
+  const env = { ...rest, HOME: home, ...(traceEnabled ? { REMI_QUESTION_TRACE: '1' } : {}) };
+  const proc = Bun.spawn(['bun', WORKER], { env, stdout: 'pipe', stderr: 'pipe' });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`worker exited ${code}: ${stderr}`);
+  }
+  return code;
+}
+
+describe('traceQuestionEvent (#808)', () => {
+  function makeTmpHome(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-question-trace-test-'));
+  }
+
+  test('disabled by default: REMI_QUESTION_TRACE unset writes no file', async () => {
+    const tmpHome = makeTmpHome();
+    try {
+      await runWorker(tmpHome, false);
+      expect(fs.existsSync(path.join(tmpHome, '.remi', 'question-trace.jsonl'))).toBe(false);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  test('REMI_QUESTION_TRACE=1 appends one JSONL record per call, with the given fields', async () => {
+    const tmpHome = makeTmpHome();
+    try {
+      await runWorker(tmpHome, true);
+      const lines = readTraceLines(tmpHome);
+      expect(lines).toHaveLength(2);
+
+      const [added, removed] = lines as [Record<string, unknown>, Record<string, unknown>];
+      expect(added).toMatchObject({
+        action: 'add',
+        sessionId: 'session-1',
+        questionId: 'question-1',
+        signal: 'permission_request',
+      });
+      expect(typeof added['ts']).toBe('string');
+      expect(Number.isNaN(Date.parse(added['ts'] as string))).toBe(false);
+
+      expect(removed).toMatchObject({
+        action: 'remove',
+        sessionId: 'session-1',
+        questionId: 'question-1',
+        agentId: 'agent-1',
+        isSubagent: true,
+        toolName: 'Bash',
+        signal: 'PostToolUse-subagent',
+        throughFunnel: true,
+      });
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  test('a write failure (unwritable ~/.remi) is swallowed, never crashes the process', async () => {
+    const tmpHome = makeTmpHome();
+    try {
+      // Pre-create ~/.remi as a FILE (not a directory) so mkdirSync/appendFileSync
+      // both fail with a real filesystem error -- no mocking of fs needed.
+      fs.writeFileSync(path.join(tmpHome, '.remi'), 'not a directory');
+      const code = await runWorker(tmpHome, true);
+      expect(code).toBe(0);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/tests/session/session-registry-trace-worker.ts
+++ b/packages/daemon/tests/session/session-registry-trace-worker.ts
@@ -1,0 +1,65 @@
+/**
+ * Worker for session-registry.test.ts's "question-lifecycle trace (#808)"
+ * suite. Same rationale as question-trace-worker.ts: `os.homedir()` is
+ * resolved once at process startup in Bun, so a fresh subprocess with `HOME`
+ * set in its spawn env is the only reliable way to point the trace file at a
+ * throwaway directory. This worker builds a REAL `SessionRegistry` (PTY and
+ * MessageAPI are the two dependencies that would otherwise require spawning
+ * a real OS process / real Claude session -- substituted here exactly as
+ * `session-registry.test.ts`'s own `createMockPTY`/`createMockMessageAPI`
+ * helpers do) and drives the exact add/remove/clear/evict sequence the
+ * parent test asserts against.
+ */
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+function fakePTY(): PTYSession {
+  return { id: generateId(), close: () => Promise.resolve() } as unknown as PTYSession;
+}
+
+function fakeMessageAPI(): MessageAPI {
+  return { bulletCount: 0 } as unknown as MessageAPI;
+}
+
+function mkQuestion(id: string, agentId?: string) {
+  return {
+    id,
+    text: `${id}?`,
+    options: [],
+    allowsFreeText: true,
+    isAnswered: false,
+    ...(agentId !== undefined && { agentId }),
+  };
+}
+
+const registry = new SessionRegistry();
+const sid = generateId();
+registry.registerSession(sid, '/test/dir', fakePTY(), fakeMessageAPI());
+
+// 1. add (main) -- exercises the 'add' record + a default signal.
+const q1 = generateId();
+registry.addQuestion(sid, mkQuestion(q1));
+
+// 2. add (subagent) with an explicit signal.
+const q2 = generateId();
+registry.addQuestion(sid, mkQuestion(q2, 'sub-2'), 'permission_request');
+
+// 3. remove q1 with an explicit signal + toolName.
+registry.removeQuestion(sid, q1, 'user_answer', 'Bash');
+
+// 4. clearQuestions -- one 'remove' record for the remaining q2.
+registry.clearQuestions(sid, 'session_restart');
+
+// 5. LRU eviction: 9 adds against MAX_PENDING_QUESTIONS=8 evicts the oldest.
+const evictionIds: string[] = [];
+for (let i = 0; i < 9; i++) {
+  const id = generateId();
+  evictionIds.push(id);
+  registry.addQuestion(sid, mkQuestion(id));
+}
+
+// Print the ids the parent test needs to key its assertions (generateId() is
+// random, so they cannot be hardcoded).
+console.log(JSON.stringify({ q1, q2, oldestEvicted: evictionIds[0] }));


### PR DESCRIPTION
## Summary

Part 1 of #808 (residual phantom/stale question cards). The #798/#799 fixes
were reasoned entirely from hook semantics, never from a live capture --
this is the capture tool.

- New `packages/daemon/src/session/question-trace.ts`: opt-in
  (`REMI_QUESTION_TRACE=1`), appends JSONL to `~/.remi/question-trace.jsonl`.
  Mirrors the existing `REMI_HOOK_DEBUG` diagnostic dump (`hooks/hook-server.ts`):
  synchronous `fs.appendFileSync`, throw-safe, warn-once on a broken sink,
  disabled short-circuits before touching the filesystem at all.
- Wired into `SessionRegistry.addQuestion` / `removeQuestion` / `clearQuestions`
  (the single funnel that mutates `currentQuestions`, confirmed by grep --
  no other code path touches the map directly) plus an LRU-eviction removal
  that never went through `removeQuestion`.
- Every removal call site threads a `signal` string naming the real cause
  (`PostToolUse`, `PostToolUse-subagent`, `Stop`, `SubagentStop`,
  `user_answer`, `duplicate-re-park-subagent`, `session_restart`,
  `lru_eviction`, ...) and, where known, a `toolName`.
- Also traces `STALE_ANSWER` rejections (informational: nothing removed, but
  records what WAS still pending) and every `question_snapshot` broadcast
  (the one signal that drives client-side reconciliation today).
- `agentId`/`isSubagent` are derived from the stored `Question` at removal
  time, so every removal record carries them regardless of caller.

## Scope note (coordination with #807)

Touches `auto-approve-gate.ts` minimally and only for trace instrumentation:
threads an optional `reason`/`toolName` through `releaseHeld` and
`resolveSupersededQuestion`'s existing call chains. Does not touch
`resolvePermission` or `parkSubagentForPTY`'s decision logic.

## Test plan

- [x] `bun run typecheck` -- clean
- [x] `bunx biome check packages/daemon` -- 0 errors (48 pre-existing warnings,
      unchanged, none in touched files)
- [x] `bun test packages/daemon/tests/ --path-ignore-patterns='**/auto-approve/**'`
      -- 2341 pass, 0 fail (auto-approve LLM sweep skipped per task instructions)
- [x] New tests, no mocks: `question-trace.test.ts` (real subprocess +
      real filesystem, since Bun's `os.homedir()` resolves once at process
      startup so HOME must be set at spawn time) and a `SessionRegistry`
      wiring test in `session-registry.test.ts` using the same subprocess
      pattern as `session-store-concurrency.test.ts`.

Refs #808. This PR is capture-only -- no clearing-behavior changes.