### PR TITLE
Send question_snapshot on every attach

### DIFF
--- a/packages/daemon/src/cli/handlers/pending-question-resend.ts
+++ b/packages/daemon/src/cli/handlers/pending-question-resend.ts
@@ -15,9 +15,34 @@
  * path (connection-events) and the resume-request attach path
  * (resume-session-events). A send failure is the caller's transport's
  * problem; this helper only reports how many were attempted.
+ *
+ * #808: the re-send above is purely ADDITIVE — it says what IS live and can
+ * never retract a card the client is already showing. The negative half is a
+ * `question_snapshot` carrying the same authoritative id set, sent here so
+ * both attach surfaces get it.
+ *
+ * This closes a hole in #798. That change broadcasts `question_snapshot` from
+ * `onQuestionsChanged` and its comment says the point is to resync "a client
+ * that reconnects into a quiet session" — but a quiet session is precisely one
+ * where nothing changes, so no broadcast ever fires and the client's
+ * `reconcileLiveQuestions` never runs. A phantom card therefore survived
+ * reconnect indefinitely (issue #808 shapes 2 and 3): `question_resolved` is
+ * broadcast-only and never replayed, so a resolve missed while disconnected is
+ * lost forever, with nothing afterwards to correct the client.
+ *
+ * The EMPTY case is the one that matters most and the one the additive path
+ * structurally cannot express: zero pending questions sends a snapshot with an
+ * empty id set, which is exactly what tells a client holding a stale card to
+ * drop it. So the snapshot is sent unconditionally, not only when there is
+ * something to list.
+ *
+ * Safe against the "never clear on an ambiguous signal" invariant (#668/#652):
+ * this is not an inference from a status change or a screen scrape. It is the
+ * registry's own `currentQuestions`, read at attach time and shipped verbatim
+ * — the most authoritative statement of pendingness the daemon can make.
  */
 
-import { createQuestion } from '@remi/shared';
+import { createQuestion, createQuestionSnapshot } from '@remi/shared';
 import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 
 export function resendPendingQuestions(
@@ -29,5 +54,13 @@ export function resendPendingQuestions(
   for (const question of pendingQuestions) {
     send(createQuestion(question, sessionId, claudeSessionId));
   }
+  // Sent AFTER the live questions so the client has already registered them
+  // and cannot prune one it is about to be told about in the same batch.
+  send(
+    createQuestionSnapshot(
+      sessionId,
+      pendingQuestions.map((q) => q.id),
+    ),
+  );
   return pendingQuestions.length;
 }

--- a/packages/daemon/tests/cli/handlers/connection-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/connection-events.test.ts
@@ -35,6 +35,18 @@ const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
 describe('createConnectionHandlers', () => {
   let sessionRegistry: SessionRegistry;
   let sendCalls: Array<{ connectionId: UUID; message: ProtocolMessage }>;
+
+  /**
+   * #808: every successful attach now ends with a `question_snapshot` carrying
+   * the authoritative live-question-id set (see `pending-question-resend.ts`).
+   * The tests below assert attach MECHANICS — ack shape, replay ordering — so
+   * they filter it out rather than re-indexing around it. The snapshot's own
+   * contract (contents, position, and the load-bearing empty case) is covered
+   * by `pending-question-resend.test.ts` plus the dedicated test at the end of
+   * this describe.
+   */
+  const attachMessages = (): Array<{ connectionId: UUID; message: ProtocolMessage }> =>
+    sendCalls.filter((c) => c.message.type !== 'question_snapshot');
   let trackedConnections: Array<{ id: UUID; type: string }>;
   let untrackedConnections: UUID[];
   let connectionAddedCount: number;
@@ -121,7 +133,7 @@ describe('createConnectionHandlers', () => {
         platformData: { kind: 'websocket' },
       });
 
-      expect(sendCalls).toHaveLength(1);
+      expect(attachMessages()).toHaveLength(1);
       const msg = sendCalls[0]?.message as {
         type: string;
         sessionId?: unknown;
@@ -144,7 +156,7 @@ describe('createConnectionHandlers', () => {
         platformData: { kind: 'websocket' },
       });
 
-      expect(sendCalls).toHaveLength(1);
+      expect(attachMessages()).toHaveLength(1);
       const msg = sendCalls[0]?.message as { type: string };
       expect(msg.type).toBe('hello_ack');
       expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
@@ -227,7 +239,7 @@ describe('createConnectionHandlers', () => {
       });
 
       // No error; helloAck sent and attach succeeded.
-      expect(sendCalls).toHaveLength(1);
+      expect(attachMessages()).toHaveLength(1);
       const msg = sendCalls[0]?.message as { type: string; sessionId?: UUID };
       expect(msg.type).toBe('hello_ack');
       expect(msg.sessionId).toBe(sessionId);
@@ -255,7 +267,7 @@ describe('createConnectionHandlers', () => {
         platformData: { kind: 'websocket' },
       });
 
-      expect(sendCalls).toHaveLength(2);
+      expect(attachMessages()).toHaveLength(2);
       const ack = sendCalls[0]?.message as {
         type: string;
         isResume?: boolean;
@@ -312,7 +324,62 @@ describe('createConnectionHandlers', () => {
       expect(q.question.text).toBe('Allow Bash: git push');
       // Ordering: hello_ack first, live questions after (and after any replay).
       expect(sendCalls[0]?.message.type).toBe('hello_ack');
-      expect(sendCalls[sendCalls.length - 1]?.message.type).toBe('question');
+      expect(attachMessages().at(-1)?.message.type).toBe('question');
+    });
+
+    test('#808: attach ends with a question_snapshot naming exactly the live ids', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      // One answered, one still pending: the snapshot must name ONLY the live
+      // one, so a client still showing the answered card learns to drop it.
+      const answeredId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: answeredId,
+        text: 'already answered?',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+      sessionRegistry.removeQuestion(sessionId, answeredId);
+      const pendingId = generateId();
+      sessionRegistry.addQuestion(sessionId, {
+        id: pendingId,
+        text: 'Allow Bash: git push',
+        options: [],
+        allowsFreeText: false,
+        isAnswered: false,
+      });
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      const snapshot = sendCalls.at(-1)?.message;
+      if (snapshot?.type !== 'question_snapshot') throw new Error('expected a trailing snapshot');
+      expect(snapshot.sessionId).toBe(sessionId);
+      expect([...snapshot.questionIds]).toEqual([pendingId]);
+    });
+
+    test('#808: attaching into a session with NO pending questions still sends an empty snapshot', async () => {
+      const sessionId = sessionRegistry.createSessionId();
+      sessionRegistry.registerSession(sessionId, '/test/dir', fakePTY(), fakeMessageAPI());
+      setPrimarySessionId(sessionId);
+
+      await makeHandlers().onConnect(CID, {
+        adapterType: 'websocket',
+        platformData: { kind: 'websocket' },
+      });
+
+      // The regression that #808 is actually about: pre-fix this attach sent
+      // hello_ack and nothing else, so a client holding a phantom card from a
+      // resolve it missed while disconnected was never corrected. The empty
+      // snapshot is the correction, and it only exists on this quiet path.
+      const snapshot = sendCalls.at(-1)?.message;
+      if (snapshot?.type !== 'question_snapshot') throw new Error('expected a trailing snapshot');
+      expect([...snapshot.questionIds]).toEqual([]);
     });
 
     test('second concurrent connection also attaches (not queued) and receives helloAck + replay (#795)', async () => {
@@ -342,7 +409,7 @@ describe('createConnectionHandlers', () => {
 
       // The second connection still gets helloAck + replay so it can render
       // history, exactly as before -- only the write-exclusivity is gone.
-      expect(sendCalls).toHaveLength(2);
+      expect(attachMessages()).toHaveLength(2);
       const ack = sendCalls[0]?.message as {
         type: string;
         isResume?: boolean;
@@ -398,7 +465,7 @@ describe('createConnectionHandlers', () => {
 
       await makeHandlers().onConnect(CID, { adapterType: 'websocket' });
 
-      expect(sendCalls).toHaveLength(1);
+      expect(attachMessages()).toHaveLength(1);
       expect((sendCalls[0]?.message as { type: string }).type).toBe('hello_ack');
       expect(sessionRegistry.getSession(sessionId)?.attachedConnections.has(CID)).toBe(true);
     });

--- a/packages/daemon/tests/cli/handlers/pending-question-resend.test.ts
+++ b/packages/daemon/tests/cli/handlers/pending-question-resend.test.ts
@@ -27,9 +27,9 @@ describe('resendPendingQuestions (#753)', () => {
     const count = resendPendingQuestions((m) => sent.push(m), sessionId, pending, claudeSessionId);
 
     expect(count).toBe(2);
-    expect(sent).toHaveLength(2);
-    for (const [i, msg] of sent.entries()) {
-      expect(msg.type).toBe('question');
+    const questions = sent.filter((m) => m.type === 'question');
+    expect(questions).toHaveLength(2);
+    for (const [i, msg] of questions.entries()) {
       if (msg.type !== 'question') continue;
       expect(msg.question).toBe(pending[i] as Question);
       expect(msg.sessionId).toBe(sessionId);
@@ -40,13 +40,44 @@ describe('resendPendingQuestions (#753)', () => {
   it('omits claudeSessionId from the wire message when not provided', () => {
     const sent: ProtocolMessage[] = [];
     resendPendingQuestions((m) => sent.push(m), sessionId, [makeQuestion('Allow Bash?')]);
-    expect(sent).toHaveLength(1);
-    expect(sent[0]).not.toHaveProperty('claudeSessionId');
+    const question = sent.find((m) => m.type === 'question');
+    expect(question).toBeDefined();
+    expect(question).not.toHaveProperty('claudeSessionId');
+  });
+});
+
+describe('resendPendingQuestions attach snapshot (#808)', () => {
+  const sessionId = generateId() as UUID;
+
+  it('sends a question_snapshot carrying exactly the live ids, AFTER the questions', () => {
+    const sent: ProtocolMessage[] = [];
+    const pending = [makeQuestion('Allow Bash?'), makeQuestion('Allow Edit?')];
+
+    resendPendingQuestions((m) => sent.push(m), sessionId, pending);
+
+    // Ordering is load-bearing: a snapshot arriving BEFORE the questions it
+    // lists would have the client prune cards it is about to be told about.
+    expect(sent.map((m) => m.type)).toEqual(['question', 'question', 'question_snapshot']);
+    const snapshot = sent.at(-1);
+    if (snapshot?.type !== 'question_snapshot') throw new Error('expected a snapshot');
+    expect(snapshot.sessionId).toBe(sessionId);
+    expect([...snapshot.questionIds]).toEqual(pending.map((q) => q.id));
   });
 
-  it('no pending questions -> sends nothing and reports 0', () => {
+  it('no pending questions -> STILL sends an empty snapshot (the phantom-clearing case)', () => {
     const sent: ProtocolMessage[] = [];
+
+    // This is the case the additive re-send structurally cannot express, and
+    // the one that matters most: a client reconnecting into a quiet session
+    // holding a stale card gets no `question` and (pre-#808) no snapshot
+    // either, so nothing ever told it to drop the card. The empty id set is
+    // that instruction.
     expect(resendPendingQuestions((m) => sent.push(m), sessionId, [])).toBe(0);
-    expect(sent).toHaveLength(0);
+
+    expect(sent).toHaveLength(1);
+    const snapshot = sent[0];
+    if (snapshot?.type !== 'question_snapshot') throw new Error('expected a snapshot');
+    expect(snapshot.sessionId).toBe(sessionId);
+    expect([...snapshot.questionIds]).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes the structural root of #808 shapes 2 (card reappears on reconnect) and a large slice of 3 (card never clears). Complements #812, which adds the lifecycle tracer and the diagnosis this came from.

## The hole

#798 broadcasts `question_snapshot` from `onQuestionsChanged` (`cli.ts:1036-1050`). Its own comment states the intent:

> Backstops the client-side replay gate -- a client that reconnects into a quiet session gets no new question/resolve event to re-sync it, so this snapshot is what actually clears a phantom card there.

That intent is not achieved. The snapshot fires **only when questions change**, and a quiet session is precisely one where nothing changes - so no broadcast fires, and the client's `reconcileLiveQuestions` never runs. Combined with `question_resolved` being broadcast-only and never replayed (`pending-question-resend.ts`), a resolve missed while the client was disconnected is lost permanently, with nothing afterwards able to correct the client. The card sits there forever.

## The fix

`resendPendingQuestions` was already the shared helper for both attach surfaces (hello attach in `connection-events.ts`, resume attach in `resume-session-events.ts`), and it already receives the authoritative `pendingQuestions` from `attachConnection`. But it is purely **additive**: it can say what IS live and can never retract a card the client is already showing.

It now sends the negative half too - a `question_snapshot` with the same authoritative id set. One edit, both attach paths, no new call sites.

Two details that carry the fix:

- **The empty case is the point.** Zero pending questions sends a snapshot with an empty id set, which is exactly the instruction a client holding a stale card needs. This is the case the additive re-send structurally cannot express, and pre-fix that attach sent `hello_ack` and nothing else. So the snapshot is unconditional, not "only when there is something to list."
- **Ordering.** Sent after the live `question` messages, so the client has registered them and cannot prune one it is about to be told about in the same batch.

## Invariant check

This does not weaken "never clear a question on an ambiguous signal" (#668/#652). It is not inferred from a status transition or a screen scrape - it is the registry's own `currentQuestions`, read at attach time and shipped verbatim. That is the most authoritative statement of pendingness the daemon can make, and the client already handles the message (`App.tsx:934`, `reconcileLiveQuestions`).

## Tests

4 new. Two at the helper level (contents + position; the empty case) and two at the attach level (`question_snapshot` names exactly the live ids with an answered one excluded; a session with no pending questions still gets an empty snapshot).

Seven existing `connection-events` tests asserted exact attach message counts and now see one more message. Rather than bumping each count - brittle, and it obscures what they are actually testing - they route through a new `attachMessages()` helper that filters the snapshot out, since those tests are about ack shape and replay ordering. The snapshot's own contract is asserted by the dedicated tests instead.

```
bun run typecheck                                  clean
bunx biome check <changed files>                    clean
bun test daemon cli/ api/ session/ + shared   1290 pass  0 fail
```

## Not addressed here

The other paths from the #812 diagnosis, deliberately left separate:
- **Shape 1** (survives a terminal answer): no safe immediate signal exists for a terminal denial with no matching tool call; today it clears only on the owning agent's next Stop/SubagentStop, so it persists while the agent keeps working. Needs on-device trace data on real latency before changing anything.
- **Submitting-lock**: a card stuck `submitting` is exempt from pruning indefinitely (`question-collection.ts:274-276`); wants a bounded client-side timeout.
- **#802 StopFailure**: unchanged, still deliberately conservative.
- **LRU eviction** (`session-registry.ts:441`): deletes directly rather than through `removeQuestion`, so it fires no `question_resolved` and no APNS dismiss. Low severity (cap is 8, a hit signals a runaway loop) but a real funnel bypass, found by the #812 audit.