### PR TITLE
Wire engine supervision into the daemon (#818, #826)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -281,7 +281,7 @@ export class AutoApproveService {
    * safe direction — but it must never be silent, which is what #818 was filed
    * for in the first place.
    */
-  async ensureEngine(): Promise<boolean> {
+  async ensureEngine(opts?: { readonly afterFailure?: boolean }): Promise<boolean> {
     const host = this.engineHost;
     if (host === undefined) return false;
     const state = await host.ensureRunning();
@@ -289,10 +289,24 @@ export class AutoApproveService {
       this.logFn(`[AutoApprove] No engine available: ${state.reason}`);
       return false;
     }
-    // A newly started engine is a DIFFERENT process, so any capability we
-    // learned about the previous one (notably "this build has no clear-cache
-    // route") no longer applies (#826).
-    if (state.kind === 'spawned') this.residency.noteEngineChanged();
+    // Any capability we learned about the previous engine (notably "this build
+    // has no clear-cache route") is a fact about a PROCESS, so it must be
+    // discarded whenever a different one is now serving (#826). Two cases:
+    //
+    //   - `spawned`: unambiguously a new process.
+    //   - `attached` AFTER a failure: we only got here because an evaluation
+    //     failed against the engine, so something answering now is very likely
+    //     a replacement -- a restarted or upgraded helper, or another daemon's
+    //     engine that won the race to replace the dead one. Without this, a
+    //     `shared` guest could NEVER clear the flag (it can never spawn), and
+    //     the loser of a heal race would keep a stale flag learned from an
+    //     engine that no longer exists.
+    //
+    // A boot-time `attached` is deliberately NOT treated as a change: that is
+    // the ordinary "an engine was already up" path, with nothing learned yet.
+    if (state.kind === 'spawned' || (opts?.afterFailure === true && state.kind === 'attached')) {
+      this.residency.noteEngineChanged();
+    }
     return true;
   }
 
@@ -305,7 +319,7 @@ export class AutoApproveService {
    */
   private healEngine(): void {
     if (this.engineHost === undefined || this.healInFlight !== null) return;
-    this.healInFlight = this.ensureEngine()
+    this.healInFlight = this.ensureEngine({ afterFailure: true })
       .catch((err) => {
         this.logFn(`[AutoApprove] Engine self-heal failed: ${errorToString(err)}`);
         return false;

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -11,6 +11,7 @@
 
 import { errorToString } from '@remi/shared';
 import { fileActivityRecord } from './engine-activity.ts';
+import type { EngineHost } from './engine-host.ts';
 import { clearModelCache, unloadModel } from './engine-models.ts';
 import { extractJsonObject } from './json-extract.ts';
 import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
@@ -134,6 +135,15 @@ export class AutoApproveService {
    * the weights entirely.
    */
   private readonly residency: ModelResidency;
+  /**
+   * Who starts the engine (#818). Absent when remi has no business supervising
+   * one — a non-engine provider (OpenRouter, llama.cpp), or a caller that did
+   * not supply it (tests). Absent means the old behavior: attach to whatever is
+   * on the port, or escalate.
+   */
+  private readonly engineHost: EngineHost | undefined;
+  /** In-flight self-heal, so a burst of failed evals triggers one repair. */
+  private healInFlight: Promise<void> | null = null;
   /** Max ms a permission eval may wait in the serialization queue before it
    *  escalates gracefully (#551); 0 = no bound. */
   private readonly queueTimeoutMs: number;
@@ -184,7 +194,8 @@ export class AutoApproveService {
    *  (Claude advanced past the prompt) from a timeout abort. */
   private cancelReason: string | null = null;
 
-  constructor(config: AutoApproveConfig, logFn: (msg: string) => void) {
+  constructor(config: AutoApproveConfig, logFn: (msg: string) => void, engineHost?: EngineHost) {
+    this.engineHost = engineHost;
     this.llmConfig = {
       baseUrl: resolveProviderUrl(config.provider, config.base_url),
       apiKey: config.api_key,
@@ -194,10 +205,12 @@ export class AutoApproveService {
       // OpenAI-compatible (a thin llama.cpp server, OpenRouter, and any custom
       // URL all speak /v1/chat/completions already).
       kind: config.provider === 'yooz' ? 'yooz' : 'openai',
-      // 'yooz' only: prefix the engine's `/no_think` convention to disable
-      // reasoning. Faster, but lowers decision quality (the chain-of-thought is
-      // load-bearing for following broad user instructions), so default OFF.
-      // No effect on the 'openai' kind (no equivalent knob there).
+      // Suppress the model's chain-of-thought. Defaults ON, and applies to BOTH
+      // transports -- `/no_think` is a chat-template convention the Qwen3 family
+      // itself recognizes, so it is a property of the model, not the server, and
+      // the openai kind additionally sends `chat_template_kwargs`. Not a tuning
+      // knob: unsuppressed, the QAT-lean 0.8B spent its whole token budget
+      // reasoning and returned NO content, so every eval became an error (#822).
       disableThinking: config.disable_thinking,
     };
     this.logFn = logFn;
@@ -255,6 +268,51 @@ export class AutoApproveService {
    *  may still be using the model or its cache (#820). */
   stopResidencyTimer(): void {
     this.residency.stop();
+  }
+
+  /**
+   * Make sure an engine is answering, starting one if this remi owns the engine
+   * (#818). Safe to call repeatedly: `EngineHost.ensureRunning` attaches to an
+   * existing engine before considering a spawn, and claims the pidfile before
+   * spawning, so concurrent callers across daemons cannot start two.
+   *
+   * Returns whether an engine is now reachable, so a caller at boot can report
+   * the gap. A missing engine is NOT fatal — evaluation escalates, which is the
+   * safe direction — but it must never be silent, which is what #818 was filed
+   * for in the first place.
+   */
+  async ensureEngine(): Promise<boolean> {
+    const host = this.engineHost;
+    if (host === undefined) return false;
+    const state = await host.ensureRunning();
+    if (state.kind === 'unavailable') {
+      this.logFn(`[AutoApprove] No engine available: ${state.reason}`);
+      return false;
+    }
+    // A newly started engine is a DIFFERENT process, so any capability we
+    // learned about the previous one (notably "this build has no clear-cache
+    // route") no longer applies (#826).
+    if (state.kind === 'spawned') this.residency.noteEngineChanged();
+    return true;
+  }
+
+  /**
+   * Fire-and-forget repair after a failed evaluation. Single-flight: a burst of
+   * failures (every queued permission failing against the same dead engine)
+   * must produce ONE repair attempt, not one per question — `ensureRunning`
+   * waits up to 30s for a spawned helper to bind, so an unguarded call per
+   * failure would pile up dozens of overlapping waits.
+   */
+  private healEngine(): void {
+    if (this.engineHost === undefined || this.healInFlight !== null) return;
+    this.healInFlight = this.ensureEngine()
+      .catch((err) => {
+        this.logFn(`[AutoApprove] Engine self-heal failed: ${errorToString(err)}`);
+        return false;
+      })
+      .then(() => {
+        this.healInFlight = null;
+      });
   }
 
   /**
@@ -702,6 +760,14 @@ export class AutoApproveService {
       const reasoning = isAbort ? `LLM timeout after ${durationMs}ms` : `Error: ${errorMsg}`;
       // Always log errors regardless of logDecisions setting
       this.logFn(`${prefix} ERROR ${toolName}: ${reasoning} (${durationMs}ms)`);
+
+      // #818 self-heal, LAZY by design. A daemon started at 09:00 must survive
+      // the engine dying at 14:00, and boot-time-only supervision cannot do
+      // that. A timeout is excluded: the engine answered, it was just slow, and
+      // treating "slow" as "dead" would try to start a second engine against a
+      // busy one. Deliberately NOT awaited -- this eval has already escalated,
+      // so the repair is for the NEXT one and must not add latency here.
+      if (!isAbort) this.healEngine();
 
       return {
         decision: 'escalate',

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -271,9 +271,20 @@ export class EngineHost {
     // while we believe we own it -- so the reclaim is checked, not assumed.
     this.pids?.release(process.pid);
     if (this.pids !== undefined && !this.pids.claim(pid)) {
+      // Somebody else's engine now owns the record, so ours is redundant: it
+      // will either lose the port bind or, worse, sit wedged forever. Logging
+      // and carrying on would leak a multi-GB process nothing tracks -- the
+      // pidfile would name their engine while we believed we owned ours.
       this.log(
-        `[Engine] Started engine pid ${pid} but another process claimed the record first; not recording ours`,
+        `[Engine] Started engine pid ${pid} but another process claimed the record first; stopping ours and attaching to theirs`,
       );
+      this.killStarted(pid);
+      if (await this.waitForReady()) {
+        return { kind: 'attached', ownership: this.config.ownership };
+      }
+      const reason = `stopped our redundant engine (pid ${pid}) but the winner never answered on ${this.config.baseUrl}`;
+      this.log(`[Engine] ${reason}`);
+      return { kind: 'unavailable', reason };
     }
     this.startedPid = pid;
     this.log(`[Engine] Started detached engine pid ${pid} (${helperPath})`);

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -45,13 +45,29 @@ function isAlive(pid: number): boolean {
  *
  * The exclusivity is what makes it a start-race guard rather than a note: two
  * daemons booting together must not both spawn a multi-GB helper. `wx` gives
- * that atomically — the loser's create fails, it waits, and attaches to the
- * winner's engine.
+ * that atomically for the common case — the loser's create fails, it waits, and
+ * attaches to the winner's engine.
  *
  * A STALE record (the recorded process is gone, e.g. the machine lost power
- * mid-download) must not wedge the feature forever, so a dead holder is cleared
- * and the claim retried once. The retry is bounded at one: if a live process
- * takes the record in between, it genuinely owns it and we lose fairly.
+ * mid-download) must not wedge the feature forever, so a dead holder is
+ * displaced. That displacement is the subtle part, and a naive
+ * check-then-unlink-then-create is WRONG: two processes that both observe the
+ * same stale record can both proceed, and the second one's `unlink` deletes the
+ * first one's freshly written LIVE record before recreating under its own pid.
+ * Both callers then believe they hold an exclusive claim, and both spawn an
+ * engine — precisely the crash-then-reboot case (stale record + hub and session
+ * daemon booting together) this class exists to prevent.
+ *
+ * So displacement happens under a separate `wx` mutex, with the record
+ * RE-CHECKED inside it: whoever takes the mutex is the only process that may
+ * delete the stale file, and anyone who took it after a live record appeared
+ * backs off instead. The mutex is held for a few synchronous syscalls, and a
+ * dead mutex holder is itself displaced, so it cannot wedge anything either.
+ *
+ * The residual window is a process dying between taking the mutex and writing
+ * the record; the next claim clears it. Note also that the pidfile is the
+ * SECOND line of defence, not the only one — the port is the real singleton
+ * (see `engine-host.ts`), so a loser that slips through still fails to bind.
  */
 export class FileEnginePidStore implements PidStore {
   constructor(private readonly file: string = ENGINE_PID_FILE) {}
@@ -73,16 +89,59 @@ export class FileEnginePidStore implements PidStore {
 
   claim(pid: number): boolean {
     fs.mkdirSync(path.dirname(this.file), { recursive: true });
-    if (this.tryCreate(pid)) return true;
+    if (this.tryCreate(this.file, pid)) return true;
 
     // Create failed, so a record exists. Only a DEAD holder may be displaced.
     if (this.read() !== null) return false;
+
+    // Serialize displacement. Without this, two processes that both saw the
+    // stale record race, and the second's unlink destroys the first's LIVE
+    // record -- both then return true and both spawn an engine.
+    const mutex = `${this.file}.claim`;
+    if (!this.acquireMutex(mutex, pid)) return false;
     try {
-      fs.unlinkSync(this.file);
-    } catch {
-      // Someone else cleared it first; the retry below settles who wins.
+      // RE-CHECK inside the mutex: between our check above and taking it, the
+      // holder may have displaced the stale record and be live now.
+      if (this.read() !== null) return false;
+      try {
+        fs.unlinkSync(this.file);
+      } catch {
+        // Already gone -- the create below still decides the winner.
+      }
+      return this.tryCreate(this.file, pid);
+    } finally {
+      this.releaseMutex(mutex, pid);
     }
-    return this.tryCreate(pid);
+  }
+
+  /** Take the displacement mutex. A mutex left behind by a process that died
+   *  mid-displacement is itself displaced, so a crash cannot wedge claiming
+   *  permanently — the same staleness rule as the record it guards. */
+  private acquireMutex(mutex: string, pid: number): boolean {
+    if (this.tryCreate(mutex, pid)) return true;
+    let holder: number;
+    try {
+      holder = Number.parseInt(fs.readFileSync(mutex, 'utf8').trim(), 10);
+    } catch {
+      // Vanished between the failed create and the read: retry once.
+      return this.tryCreate(mutex, pid);
+    }
+    if (Number.isInteger(holder) && holder > 0 && isAlive(holder)) return false;
+    try {
+      fs.unlinkSync(mutex);
+    } catch {
+      // Someone else cleared it; the create below settles who wins.
+    }
+    return this.tryCreate(mutex, pid);
+  }
+
+  private releaseMutex(mutex: string, pid: number): void {
+    try {
+      if (Number.parseInt(fs.readFileSync(mutex, 'utf8').trim(), 10) !== pid) return;
+      fs.unlinkSync(mutex);
+    } catch {
+      // Already gone, or never ours to remove.
+    }
   }
 
   release(pid: number): void {
@@ -107,9 +166,9 @@ export class FileEnginePidStore implements PidStore {
 
   /** Atomic create-or-fail. `wx` is the whole point — an exists-then-write
    *  would reintroduce the race this class exists to close. */
-  private tryCreate(pid: number): boolean {
+  private tryCreate(file: string, pid: number): boolean {
     try {
-      fs.writeFileSync(this.file, `${pid}\n`, { flag: 'wx' });
+      fs.writeFileSync(file, `${pid}\n`, { flag: 'wx' });
       return true;
     } catch {
       return false;

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -1,0 +1,175 @@
+/**
+ * Production seams for `EngineHost` (#818): the `~/.remi/engine.pid` record and
+ * the detached spawn.
+ *
+ * `engine-host.ts` holds the POLICY (attach first, claim before spawning, never
+ * reap on exit) and takes both of these as injectable deps so it stays testable
+ * without touching the filesystem or starting processes. This module is the
+ * other half: the real implementations, which are the parts that can only be
+ * verified against a real OS.
+ */
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+import type { PidStore } from './engine-host.ts';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+
+/** The engine start record. Sibling of `daemon.pid` (the hub's), deliberately
+ *  separate: the engine is a peer of the hub, not a child of it, and outlives
+ *  whichever process started it. */
+export const ENGINE_PID_FILE = path.join(REMI_DIR, 'engine.pid');
+
+/** Where a remi-started engine's stdout/stderr go. Without this the helper's
+ *  own diagnostics vanish, and "the engine did not come up" is exactly the
+ *  case where you need them. */
+export const ENGINE_LOG_FILE = path.join(REMI_DIR, 'engine.log');
+
+/** Is this pid a live process? Signal 0 tests existence without delivering
+ *  anything. EPERM means alive but owned by another user, which still counts —
+ *  something holds the record and we must not claim it. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * `~/.remi/engine.pid`, claimed exclusively.
+ *
+ * The exclusivity is what makes it a start-race guard rather than a note: two
+ * daemons booting together must not both spawn a multi-GB helper. `wx` gives
+ * that atomically — the loser's create fails, it waits, and attaches to the
+ * winner's engine.
+ *
+ * A STALE record (the recorded process is gone, e.g. the machine lost power
+ * mid-download) must not wedge the feature forever, so a dead holder is cleared
+ * and the claim retried once. The retry is bounded at one: if a live process
+ * takes the record in between, it genuinely owns it and we lose fairly.
+ */
+export class FileEnginePidStore implements PidStore {
+  constructor(private readonly file: string = ENGINE_PID_FILE) {}
+
+  read(): number | null {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.file, 'utf8');
+    } catch {
+      return null;
+    }
+    const pid = Number.parseInt(raw.trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 0) return null;
+    // A record naming a dead process is not a record. Reporting null here is
+    // what lets `claim` clear it and what stops `remi engine stop` from
+    // signalling a pid that has since been recycled by an unrelated process.
+    return isAlive(pid) ? pid : null;
+  }
+
+  claim(pid: number): boolean {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    if (this.tryCreate(pid)) return true;
+
+    // Create failed, so a record exists. Only a DEAD holder may be displaced.
+    if (this.read() !== null) return false;
+    try {
+      fs.unlinkSync(this.file);
+    } catch {
+      // Someone else cleared it first; the retry below settles who wins.
+    }
+    return this.tryCreate(pid);
+  }
+
+  release(pid: number): void {
+    // Read the raw file rather than `read()`: release must work for a pid that
+    // has already exited (the normal case when clearing our own record), and
+    // `read()` deliberately reports a dead holder as absent.
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.file, 'utf8');
+    } catch {
+      return;
+    }
+    // Only ever remove OUR record. Releasing unconditionally would let a late
+    // cleanup delete the record of an engine somebody else has since started.
+    if (Number.parseInt(raw.trim(), 10) !== pid) return;
+    try {
+      fs.unlinkSync(this.file);
+    } catch {
+      // Already gone: the post-condition holds either way.
+    }
+  }
+
+  /** Atomic create-or-fail. `wx` is the whole point — an exists-then-write
+   *  would reintroduce the race this class exists to close. */
+  private tryCreate(pid: number): boolean {
+    try {
+      fs.writeFileSync(this.file, `${pid}\n`, { flag: 'wx' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Start the engine helper DETACHED, mirroring how `daemon-manager.ts` launches
+ * the hub: `detached: true` + `unref()`, output to a log file, no handle kept.
+ *
+ * Detached is not an optimization here, it is the contract. The engine is a
+ * machine-wide singleton shared by every session daemon; a session that spawned
+ * it and then quit must not take auto-approve down for the others (#818).
+ *
+ * Returns the child's pid. Throws when the spawn itself fails (bad path,
+ * missing execute bit) so `EngineHost` can release its claim and report the
+ * reason rather than leaving a record for a process that never existed.
+ */
+export function spawnDetachedEngine(
+  helperPath: string,
+  env: Record<string, string>,
+  logFile: string = ENGINE_LOG_FILE,
+): number {
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  const logFd = fs.openSync(logFile, 'a');
+  try {
+    fs.writeSync(logFd, `\n--- Engine starting at ${new Date().toISOString()} ---\n`);
+    const child = spawn(helperPath, [], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: { ...process.env, ...env },
+    });
+    // A spawn failure surfaces TWICE: synchronously on some runtimes, and as an
+    // asynchronous 'error' event on all of them. An unhandled 'error' event on
+    // a ChildProcess is thrown as an uncaught exception, which on a detached
+    // helper would take the whole daemon down over a missing engine binary --
+    // the opposite of the "no engine is not fatal" contract. Absorb it here;
+    // `EngineHost.waitForReady` already treats never-answering as unavailable.
+    child.on('error', (err) => {
+      try {
+        fs.appendFileSync(logFile, `Engine spawn failed: ${errorToString(err)}\n`);
+      } catch {
+        // The log is best-effort; never let diagnostics become the failure.
+      }
+    });
+    const pid = child.pid;
+    if (pid === undefined) {
+      throw new Error('spawn returned no pid');
+    }
+    child.unref();
+    // The child holds its own duplicate of the descriptor, so closing ours does
+    // not cut off its logging -- and NOT closing it leaks an fd per attempt.
+    return pid;
+  } finally {
+    try {
+      fs.closeSync(logFd);
+    } catch (err) {
+      // Nothing actionable: the spawn already succeeded or already threw.
+      void errorToString(err);
+    }
+  }
+}

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -149,7 +149,10 @@ export function spawnDetachedEngine(
     // helper would take the whole daemon down over a missing engine binary --
     // the opposite of the "no engine is not fatal" contract. Absorb it here;
     // `EngineHost.waitForReady` already treats never-answering as unavailable.
-    child.on('error', (err) => {
+    // Cast per the existing idiom in `live-sessions-watcher.ts`: the bundled
+    // `ChildProcess` type does not surface the EventEmitter surface it has at
+    // runtime, and CI resolves a stricter view of it than a local install.
+    (child as unknown as import('node:events').EventEmitter).on('error', (err: unknown) => {
       try {
         fs.appendFileSync(logFile, `Engine spawn failed: ${errorToString(err)}\n`);
       } catch {

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -1,6 +1,14 @@
 export { AutoApproveService, parseDecision } from './auto-approve-service.ts';
 export { AutoApproveGate } from './auto-approve-gate.ts';
 export type { AutoApproveEvaluator, AutoApproveGateDeps } from './auto-approve-gate.ts';
+export { EngineHost } from './engine-host.ts';
+export type { EngineHostState, EngineOwnership, PidStore } from './engine-host.ts';
+export {
+  ENGINE_LOG_FILE,
+  ENGINE_PID_FILE,
+  FileEnginePidStore,
+  spawnDetachedEngine,
+} from './engine-process.ts';
 export { resolveProviderUrl } from './llm-client.ts';
 export { alertBody, alertTitle, SubagentAlerter } from './subagent-alert.ts';
 export type { SubagentAlert } from './subagent-alert.ts';

--- a/packages/daemon/src/auto-approve/model-residency.ts
+++ b/packages/daemon/src/auto-approve/model-residency.ts
@@ -159,6 +159,29 @@ export class ModelResidency {
     this.clearTimerFn = deps.clearTimer ?? ((h) => clearTimeout(h));
   }
 
+  /**
+   * A DIFFERENT engine process now answers on the port (#826): remi started
+   * one, or re-attached after a failure.
+   *
+   * `cacheUnsupported` is a fact about an engine PROCESS ("this build has no
+   * clear-cache route"), but it is stored on a daemon that outlives it. Once
+   * `EngineHost` can start and restart engines during a daemon's life, a user
+   * upgrading the engine underneath a long-running daemon is ordinary — and
+   * without this, stage 1 would stay disabled until the DAEMON restarted,
+   * leaving ~1.5 GB of prompt KV resident that could have been reclaimed.
+   *
+   * The retry flags go too: they are per-idle-window judgments about a
+   * specific engine, and a new one deserves a clean attempt.
+   */
+  noteEngineChanged(): void {
+    if (this.cacheUnsupported) {
+      this.deps.log('[Residency] New engine detected; re-enabling the prompt-cache stage');
+    }
+    this.cacheUnsupported = false;
+    this.cacheRetried = false;
+    this.unloadRetried = false;
+  }
+
   /** True when this instance will ever unload anything (stage 2). Predates
    *  stage 1 and is kept with this exact meaning for existing callers/tests. */
   get enabled(): boolean {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -124,10 +124,13 @@ import { Authenticator } from './auth/authenticator.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import {
   AutoApproveService,
+  EngineHost,
+  FileEnginePidStore,
   SubagentAlerter,
   alertBody,
   alertTitle,
   resolveProviderUrl,
+  spawnDetachedEngine,
 } from './auto-approve/index.ts';
 import { detectAutostartState } from './cli/autostart-state.ts';
 import { resolveClaudeBinding } from './cli/claude-binding.ts';
@@ -833,6 +836,27 @@ let autoApproveService: AutoApproveService | null = null;
     const multichoice = parsedArgs.autoApproveMultichoice ?? aaCfg.multichoice;
     const multichoiceModel = parsedArgs.autoApproveMultichoiceModel ?? aaCfg.multichoice_model;
 
+    // #818: who starts the engine. Only meaningful for the engine transport —
+    // an OpenRouter or llama.cpp base URL is not something remi supervises, and
+    // handing those an EngineHost would mean spawning a Yooz helper for a
+    // provider that never talks to one.
+    const engineHost =
+      provider === 'yooz'
+        ? new EngineHost(
+            {
+              baseUrl,
+              ownership: aaCfg.engine,
+              helperPath: aaCfg.engine_path,
+              modelCache: aaCfg.model_cache,
+            },
+            {
+              log: writeToLog,
+              spawn: spawnDetachedEngine,
+              pidStore: new FileEnginePidStore(),
+            },
+          )
+        : undefined;
+
     autoApproveService = new AutoApproveService(
       {
         ...aaCfg,
@@ -848,7 +872,22 @@ let autoApproveService: AutoApproveService | null = null;
         multichoice_model: multichoiceModel,
       },
       writeToLog,
+      engineHost,
     );
+
+    // Start (or attach to) the engine at boot, but do NOT block the daemon on
+    // it: a cold helper can take tens of seconds to bind, and remi must be
+    // answering its own port long before then. Evaluation escalates while the
+    // engine is coming up, which is the safe direction, and `ensureEngine`
+    // reports the outcome either way so "no engine" is never silent.
+    //
+    // On a hub machine the hub reaches here first and wins the pidfile race by
+    // construction; a standalone `remi --daemon` on a machine with no hub still
+    // gets one, because requiring a hub would recreate exactly the silent
+    // escalate-everything failure #818 exists to remove.
+    void autoApproveService.ensureEngine().catch((err) => {
+      writeToLog(`[AutoApprove] Engine startup check failed: ${errorToString(err)}`);
+    });
     const rulesSummary = `allow=${allow.length} deny=${deny.length} instructions=${instructions ? 'yes' : 'no'}`;
     const mcSummary = `multichoice=${multichoice}${multichoiceModel ? ` mc_model=${multichoiceModel}` : ''}`;
     const escalateSummary = aaCfg.escalate_model

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -186,6 +186,32 @@ describe('EngineHost — the start race', () => {
     expect(await h.ensureRunning()).toEqual({ kind: 'attached', ownership: 'owned' });
     expect(spawnCalls).toHaveLength(0); // nothing was ever started
   });
+
+  test('losing the reclaim STOPS our redundant engine instead of leaking it', async () => {
+    // The claim is released and retaken under the child's pid once we have it.
+    // A third process can take the record inside that window -- and then our
+    // helper is redundant: the pidfile names THEIR engine while ours keeps
+    // running, untracked, holding multi-GB of weights nothing will ever free.
+    let claims = 0;
+    const pids: PidStore = {
+      read: () => 999,
+      // First claim (under our own pid, before spawning) succeeds; the reclaim
+      // under the child's pid loses to a third process.
+      claim: () => ++claims === 1,
+      release: () => {},
+    };
+    const { h, spawnCalls, killed, logs } = host(
+      {},
+      { probes: [UNREACHABLE, REACHABLE], pids, spawnPid: 777 },
+    );
+
+    // We attach to the winner's engine rather than reporting our own.
+    expect(await h.ensureRunning()).toEqual({ kind: 'attached', ownership: 'owned' });
+    expect(spawnCalls).toHaveLength(1);
+    expect(killed).toEqual([777]); // ours was stopped, not left running
+    expect(h.startedByUs).toBeNull();
+    expect(logs.join('\n')).toContain('stopping ours');
+  });
 });
 
 describe('EngineHost — lifetime independence', () => {

--- a/packages/daemon/tests/auto-approve/engine-process.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-process.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Production seams for engine supervision (#818): the real `~/.remi/engine.pid`
+ * store and the real detached spawn.
+ *
+ * `engine-host.test.ts` covers the POLICY against an in-memory PidStore. This
+ * file covers the two things that policy cannot: whether the on-disk claim is
+ * actually exclusive, and whether the spawn actually detaches. Both use real
+ * files and real processes — the failure modes here (a non-atomic claim, an
+ * fd leak, a child that dies with its parent) only exist against a real OS.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { FileEnginePidStore, spawnDetachedEngine } from '../../src/auto-approve/engine-process.ts';
+
+const TEST_DIR = path.join(os.tmpdir(), `remi-engine-pid-${process.pid}`);
+const PID_FILE = path.join(TEST_DIR, 'engine.pid');
+const LOG_FILE = path.join(TEST_DIR, 'engine.log');
+
+/** A pid that is certainly dead. Very large values are above the wrap range on
+ *  both macOS and Linux, so nothing can be recycled onto them mid-test. */
+const DEAD_PID = 999_999_998;
+
+beforeEach(() => {
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('FileEnginePidStore', () => {
+  test('claims an unheld record and reports it back', () => {
+    const store = new FileEnginePidStore(PID_FILE);
+    expect(store.claim(process.pid)).toBe(true);
+    expect(store.read()).toBe(process.pid);
+  });
+
+  test('a second claim against a LIVE holder fails', () => {
+    // The start-race guard: of two daemons booting together exactly one may
+    // spawn a multi-GB helper. If this ever returns true for both, #818's
+    // "one engine per machine" invariant is gone.
+    const first = new FileEnginePidStore(PID_FILE);
+    const second = new FileEnginePidStore(PID_FILE);
+    expect(first.claim(process.pid)).toBe(true);
+    expect(second.claim(process.pid + 1)).toBe(false);
+    expect(second.read()).toBe(process.pid);
+  });
+
+  test('a STALE record is displaced, not obeyed forever', () => {
+    // A machine that lost power mid-download must not need manual cleanup.
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    const store = new FileEnginePidStore(PID_FILE);
+    expect(store.claim(process.pid)).toBe(true);
+    expect(store.read()).toBe(process.pid);
+  });
+
+  test('read() reports a dead holder as absent', () => {
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    expect(new FileEnginePidStore(PID_FILE).read()).toBeNull();
+  });
+
+  test('read() reports a missing or malformed file as absent', () => {
+    const store = new FileEnginePidStore(PID_FILE);
+    expect(store.read()).toBeNull();
+    fs.writeFileSync(PID_FILE, 'not-a-pid\n');
+    expect(store.read()).toBeNull();
+    fs.writeFileSync(PID_FILE, '-4\n');
+    expect(store.read()).toBeNull();
+  });
+
+  test('release only removes OUR record', () => {
+    // A late cleanup must not delete the record of an engine somebody else
+    // started in the meantime.
+    const store = new FileEnginePidStore(PID_FILE);
+    store.claim(process.pid);
+    store.release(process.pid + 1);
+    expect(store.read()).toBe(process.pid);
+    store.release(process.pid);
+    expect(store.read()).toBeNull();
+  });
+
+  test('release works for an already-dead pid', () => {
+    // The normal cleanup case: the engine we recorded has exited, and the
+    // record must still be removable even though read() calls it absent.
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    new FileEnginePidStore(PID_FILE).release(DEAD_PID);
+    expect(fs.existsSync(PID_FILE)).toBe(false);
+  });
+
+  test('claim after release succeeds', () => {
+    const store = new FileEnginePidStore(PID_FILE);
+    expect(store.claim(process.pid)).toBe(true);
+    store.release(process.pid);
+    expect(store.claim(process.pid)).toBe(true);
+  });
+
+  test('creates the containing directory', () => {
+    const nested = path.join(TEST_DIR, 'deep', 'engine.pid');
+    expect(new FileEnginePidStore(nested).claim(process.pid)).toBe(true);
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+});
+
+describe('spawnDetachedEngine', () => {
+  /** A real, harmless long-running binary standing in for the helper. */
+  const SLEEP = '/bin/sleep';
+
+  test('starts a real process and returns its pid', () => {
+    const pid = spawnDetachedEngine(SLEEP, { YOOZ_ENGINE_PORT: '19924' }, LOG_FILE);
+    try {
+      expect(pid).toBeGreaterThan(0);
+      // Signal 0: alive without delivering anything.
+      expect(() => process.kill(pid, 0)).not.toThrow();
+    } finally {
+      try {
+        process.kill(pid);
+      } catch {
+        // Already gone; the assertion above is what matters.
+      }
+    }
+  });
+
+  test('throws on a helper path that cannot be executed', () => {
+    // EngineHost relies on this throwing so it can release its pidfile claim.
+    // A silent failure would leave a record for a process that never existed,
+    // blocking every later attempt.
+    const missing = path.join(TEST_DIR, 'no-such-helper');
+    expect(() => spawnDetachedEngine(missing, {}, LOG_FILE)).toThrow();
+  });
+
+  test('writes a start banner to the log file', () => {
+    // The helper's own diagnostics are the only evidence available when it
+    // starts but never binds, so the log has to exist and be appended to.
+    const pid = spawnDetachedEngine(SLEEP, {}, LOG_FILE);
+    try {
+      expect(fs.readFileSync(LOG_FILE, 'utf8')).toContain('Engine starting at');
+    } finally {
+      try {
+        process.kill(pid);
+      } catch {
+        // Cleanup only.
+      }
+    }
+  });
+
+  test('repeated spawns do not leak descriptors', () => {
+    // The log fd is opened per attempt; without the close in the finally block
+    // a daemon retrying a failing helper would exhaust its fd budget.
+    const before = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
+    const pids: number[] = [];
+    try {
+      for (let i = 0; i < 12; i++) pids.push(spawnDetachedEngine(SLEEP, {}, LOG_FILE));
+      const after = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
+      const beforeCount = before?.openFileDescriptors?.length;
+      const afterCount = after?.openFileDescriptors?.length;
+      // Only assert when the runtime actually reports descriptors; the leak
+      // this guards is a hard +1 per call, so a small allowance is ample.
+      if (typeof beforeCount === 'number' && typeof afterCount === 'number') {
+        expect(afterCount - beforeCount).toBeLessThan(6);
+      }
+    } finally {
+      for (const pid of pids) {
+        try {
+          process.kill(pid);
+        } catch {
+          // Cleanup only.
+        }
+      }
+    }
+  });
+});

--- a/packages/daemon/tests/auto-approve/engine-process.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-process.test.ts
@@ -97,6 +97,42 @@ describe('FileEnginePidStore', () => {
     expect(store.claim(process.pid)).toBe(true);
   });
 
+  // Displacing a stale record is the one path where two processes can both
+  // believe they won: without serialization, the second claimant's `unlink`
+  // deletes the first's freshly written LIVE record and both return true, so
+  // both spawn a multi-GB helper. That is the crash-then-reboot case (stale
+  // record + hub and session daemon booting together).
+  //
+  // These drive the mutex directly rather than racing real processes: a real
+  // race only hits the window occasionally, so a timing-based test passes just
+  // as happily against the broken implementation and proves nothing.
+  test('a claimant backs off while another process is mid-displacement', () => {
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    // A LIVE process (this one) holds the displacement mutex.
+    fs.writeFileSync(`${PID_FILE}.claim`, `${process.pid}\n`);
+
+    expect(new FileEnginePidStore(PID_FILE).claim(process.pid + 1)).toBe(false);
+    // The stale record is untouched: displacing it is the mutex holder's job.
+    expect(fs.readFileSync(PID_FILE, 'utf8').trim()).toBe(String(DEAD_PID));
+  });
+
+  test('a mutex left behind by a dead process does not wedge claiming', () => {
+    // The mutex must not become a new way to jam the feature permanently --
+    // that would trade one wedge for another.
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    fs.writeFileSync(`${PID_FILE}.claim`, `${DEAD_PID}\n`);
+
+    expect(new FileEnginePidStore(PID_FILE).claim(process.pid)).toBe(true);
+    expect(new FileEnginePidStore(PID_FILE).read()).toBe(process.pid);
+  });
+
+  test('the displacement mutex is released once the claim settles', () => {
+    // A leaked mutex would block the NEXT displacement until its holder died.
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    expect(new FileEnginePidStore(PID_FILE).claim(process.pid)).toBe(true);
+    expect(fs.existsSync(`${PID_FILE}.claim`)).toBe(false);
+  });
+
   test('creates the containing directory', () => {
     const nested = path.join(TEST_DIR, 'deep', 'engine.pid');
     expect(new FileEnginePidStore(nested).claim(process.pid)).toBe(true);

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -73,10 +73,18 @@ function serviceWith(opts: {
   probes: EngineProbe[];
   ownership?: 'owned' | 'shared';
   helperPath?: string;
+  /** Block every probe until the returned gate is opened, so callers can hold
+   *  a repair in flight and observe what concurrent callers do. */
+  gated?: boolean;
 }) {
   const logs: string[] = [];
   const spawns: string[] = [];
   let probeIndex = 0;
+  let probeCalls = 0;
+  let openGate: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    openGate = resolve;
+  });
   const host = new EngineHost(
     {
       baseUrl: 'http://127.0.0.1:19929',
@@ -92,13 +100,25 @@ function serviceWith(opts: {
         return 4242;
       },
       kill: () => undefined,
-      probe: async () => opts.probes[Math.min(probeIndex++, opts.probes.length - 1)] ?? UNREACHABLE,
+      probe: async () => {
+        probeCalls += 1;
+        if (opts.gated === true) await gate;
+        return opts.probes[Math.min(probeIndex++, opts.probes.length - 1)] ?? UNREACHABLE;
+      },
       sleep: async () => undefined,
       pidStore: pidStore(),
     },
   );
   const service = new AutoApproveService(config(), (m) => logs.push(m), host);
-  return { service, logs, spawns };
+  return {
+    service,
+    logs,
+    spawns,
+    /** Every `ensureRunning` begins with exactly one attach-probe, so this
+     *  counts repair ATTEMPTS regardless of what each one concluded. */
+    probeCount: () => probeCalls,
+    openGate: () => openGate?.(),
+  };
 }
 
 describe('AutoApproveService engine supervision (#818)', () => {
@@ -145,7 +165,12 @@ describe('AutoApproveService engine supervision (#818)', () => {
     // `ensureRunning` waits for a spawned helper to bind, so an unguarded call
     // per failure would pile up overlapping waits -- and on a real machine,
     // every queued permission fails at once against the same dead engine.
-    const h = serviceWith({ probes: [UNREACHABLE, REACHABLE] });
+    //
+    // The probe is GATED so the first repair is provably still in flight when
+    // the later evaluations fail. Without that, evals serialize on the single
+    // eval slot, each repair finishes before the next failure, and the test
+    // passes whether or not the single-flight guard exists at all.
+    const h = serviceWith({ probes: [REACHABLE], gated: true });
     const results = await Promise.all([
       h.service.evaluate('Bash', { command: 'echo 1' }),
       h.service.evaluate('Bash', { command: 'echo 2' }),
@@ -154,10 +179,26 @@ describe('AutoApproveService engine supervision (#818)', () => {
 
     // Every one escalates: a dead engine must never approve anything.
     for (const r of results) expect(r.decision).toBe('escalate');
-    // Let the fire-and-forget repair settle.
-    await new Promise((r) => setTimeout(r, 50));
-    // Exactly one: >1 means the single-flight guard is gone, 0 means the repair
-    // never fired and the daemon would stay broken until restart.
-    expect(h.spawns).toEqual(['/bin/sleep']);
+    // Exactly one repair attempt is outstanding for three failures. Counting
+    // probes rather than spawns is deliberate: the pidfile would collapse
+    // concurrent SPAWNS on its own, so a spawn count cannot distinguish the
+    // guard working from the pidfile covering for its absence.
+    expect(h.probeCount()).toBe(1);
+
+    h.openGate();
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  test('the single-flight guard clears, so a later failure can still repair', async () => {
+    // A stuck `healInFlight` would silently disable self-heal for the life of
+    // the daemon -- the exact failure mode #818 exists to remove.
+    const h = serviceWith({ probes: [REACHABLE] });
+    await h.service.evaluate('Bash', { command: 'echo 1' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(h.probeCount()).toBe(1);
+
+    await h.service.evaluate('Bash', { command: 'echo 2' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(h.probeCount()).toBe(2);
   });
 });

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -1,0 +1,163 @@
+/**
+ * `AutoApproveService` <-> `EngineHost` wiring (#818).
+ *
+ * `engine-host.test.ts` covers the host's policy in isolation and
+ * `engine-process.test.ts` covers the real pidfile/spawn. What is left, and
+ * what this file pins, is the part that only exists once they are connected:
+ * the service reports a missing engine instead of failing silently, and a burst
+ * of failed evaluations triggers ONE repair rather than one per question.
+ *
+ * No mocks: the service and the host are the real classes, driven through the
+ * seams they already expose for exactly this (probe/spawn/pidStore).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import { EngineHost, type PidStore } from '../../src/auto-approve/engine-host.ts';
+import type { EngineProbe } from '../../src/auto-approve/engine-models.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+
+const UNREACHABLE: EngineProbe = { reachable: false, reason: 'ECONNREFUSED' };
+const REACHABLE: EngineProbe = { reachable: true, status: { loaded: true } };
+
+/** In-memory pid record with the production semantics. */
+function pidStore(): PidStore {
+  let current: number | null = null;
+  return {
+    read: () => current,
+    claim: (pid) => {
+      if (current !== null) return false;
+      current = pid;
+      return true;
+    },
+    release: (pid) => {
+      if (current === pid) current = null;
+    },
+  };
+}
+
+function config(over?: Partial<AutoApproveConfig>): AutoApproveConfig {
+  return {
+    enabled: true,
+    provider: 'yooz',
+    model: 'test-model',
+    api_key: '',
+    // A port nothing listens on: every LLM call fails fast, which is the
+    // precondition for the self-heal tests below.
+    base_url: 'http://127.0.0.1:19929',
+    timeout: 2,
+    log_decisions: false,
+    allow: [],
+    deny: [],
+    subagent_alert: [],
+    approve_groups: [],
+    deny_groups: [],
+    instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
+    escalate_model: '',
+    escalate_timeout: 0,
+    queue_timeout: 240,
+    cache_idle: 0,
+    keep_alive: 0,
+    engine: 'owned',
+    engine_path: '/bin/sleep',
+    model_cache: '',
+    disable_thinking: true,
+    always_escalate_tools: [],
+    ...over,
+  } as AutoApproveConfig;
+}
+
+function serviceWith(opts: {
+  probes: EngineProbe[];
+  ownership?: 'owned' | 'shared';
+  helperPath?: string;
+}) {
+  const logs: string[] = [];
+  const spawns: string[] = [];
+  let probeIndex = 0;
+  const host = new EngineHost(
+    {
+      baseUrl: 'http://127.0.0.1:19929',
+      ownership: opts.ownership ?? 'owned',
+      helperPath: opts.helperPath ?? '/bin/sleep',
+      startupTimeoutMs: 200,
+      probeIntervalMs: 20,
+    },
+    {
+      log: (m) => logs.push(m),
+      spawn: (p) => {
+        spawns.push(p);
+        return 4242;
+      },
+      kill: () => undefined,
+      probe: async () => opts.probes[Math.min(probeIndex++, opts.probes.length - 1)] ?? UNREACHABLE,
+      sleep: async () => undefined,
+      pidStore: pidStore(),
+    },
+  );
+  const service = new AutoApproveService(config(), (m) => logs.push(m), host);
+  return { service, logs, spawns };
+}
+
+describe('AutoApproveService engine supervision (#818)', () => {
+  test('attaches to an engine that is already answering, and does not spawn', async () => {
+    // The core ownership rule: it does not matter who started the engine, only
+    // that one is up. Spawning a second would load a second multi-GB copy of
+    // the same weights and lose the port race anyway.
+    const h = serviceWith({ probes: [REACHABLE] });
+    expect(await h.service.ensureEngine()).toBe(true);
+    expect(h.spawns).toEqual([]);
+  });
+
+  test('starts one when nothing is answering', async () => {
+    const h = serviceWith({ probes: [UNREACHABLE, REACHABLE] });
+    expect(await h.service.ensureEngine()).toBe(true);
+    expect(h.spawns).toEqual(['/bin/sleep']);
+  });
+
+  test('reports the gap instead of failing silently when it cannot start one', async () => {
+    // This is the whole point of #818: before it, a machine with no engine
+    // degraded to escalating every permission with no explanation anywhere.
+    const h = serviceWith({ probes: [UNREACHABLE], helperPath: '' });
+    expect(await h.service.ensureEngine()).toBe(false);
+    expect(h.logs.join('\n')).toContain('No engine available');
+    expect(h.logs.join('\n')).toContain('no helper is bundled');
+  });
+
+  test('a guest (engine = "shared") never spawns, and says why', async () => {
+    // A super-yooz host owns its engine; starting a second one on remi's port
+    // would be remi claiming a process it has no right to supervise.
+    const h = serviceWith({ probes: [UNREACHABLE], ownership: 'shared' });
+    expect(await h.service.ensureEngine()).toBe(false);
+    expect(h.spawns).toEqual([]);
+    expect(h.logs.join('\n')).toContain('guest');
+  });
+
+  test('a service with no host reports no engine rather than throwing', async () => {
+    // Non-engine providers (OpenRouter, llama.cpp) get no EngineHost at all.
+    const service = new AutoApproveService(config({ provider: 'openrouter' }), () => undefined);
+    expect(await service.ensureEngine()).toBe(false);
+  });
+
+  test('a burst of failed evaluations triggers ONE repair, not one per question', async () => {
+    // `ensureRunning` waits for a spawned helper to bind, so an unguarded call
+    // per failure would pile up overlapping waits -- and on a real machine,
+    // every queued permission fails at once against the same dead engine.
+    const h = serviceWith({ probes: [UNREACHABLE, REACHABLE] });
+    const results = await Promise.all([
+      h.service.evaluate('Bash', { command: 'echo 1' }),
+      h.service.evaluate('Bash', { command: 'echo 2' }),
+      h.service.evaluate('Bash', { command: 'echo 3' }),
+    ]);
+
+    // Every one escalates: a dead engine must never approve anything.
+    for (const r of results) expect(r.decision).toBe('escalate');
+    // Let the fire-and-forget repair settle.
+    await new Promise((r) => setTimeout(r, 50));
+    // Exactly one: >1 means the single-flight guard is gone, 0 means the repair
+    // never fired and the daemon would stay broken until restart.
+    expect(h.spawns).toEqual(['/bin/sleep']);
+  });
+});

--- a/packages/daemon/tests/auto-approve/model-residency.test.ts
+++ b/packages/daemon/tests/auto-approve/model-residency.test.ts
@@ -377,6 +377,36 @@ describe('ModelResidency stage 1 (cache-drop, #820)', () => {
     expect(h.logs.filter((l) => l.includes('does not support cache-clear'))).toHaveLength(1);
   });
 
+  test('noteEngineChanged re-enables stage 1 after an engine upgrade (#826)', async () => {
+    // `cacheUnsupported` is a fact about an engine PROCESS, stored on a daemon
+    // that outlives it. Once EngineHost can start engines mid-life, a user
+    // upgrading the engine under a long-running daemon is ordinary, and without
+    // this the daemon would keep ~1.5 GB of prompt KV resident until restart.
+    const h = harness(
+      { cacheIdleMs: 500 },
+      { clearCacheThrows: new ClearCacheUnsupportedError('/v1/llm/clear-cache failed 404: nope') },
+    );
+    h.residency.noteActivity();
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.residency.cacheStageEnabled).toBe(false);
+
+    h.residency.noteEngineChanged();
+
+    expect(h.residency.cacheStageEnabled).toBe(true);
+    expect(h.logs.join('\n')).toContain('New engine detected');
+  });
+
+  test('noteEngineChanged is silent when stage 1 was never degraded', async () => {
+    // It runs on every spawn, including the ordinary first one at boot, so it
+    // must not narrate a recovery that did not happen.
+    const h = harness({ cacheIdleMs: 500 });
+    h.residency.noteEngineChanged();
+    expect(h.residency.cacheStageEnabled).toBe(true);
+    expect(h.logs.join('\n')).not.toContain('New engine detected');
+  });
+
   test('a transient clear-cache failure is logged and never thrown out of the timer callback', async () => {
     const h = harness({ cacheIdleMs: 500 }, { clearCacheThrows: new Error('engine restarted') });
     h.residency.noteActivity();


### PR DESCRIPTION
Closes #818. Closes #826.

## The gap

`EngineHost` landed in #811 with tests, but `grep` found zero importers in
`packages/daemon/src/` — `cli.ts` never mentioned it. So production never
started an engine, and a machine with none (the normal state today) degraded
to escalating every permission with no explanation anywhere. That silent
degradation is what #818 was filed to remove.

## What this adds

**The two production seams** (`auto-approve/engine-process.ts`). `EngineHost`
takes both as injectable deps so its policy stays testable without touching
the filesystem or starting processes; this is the other half.

- `FileEnginePidStore` over `~/.remi/engine.pid`, claimed with `wx`. The
  atomicity is the point: it is a start-race guard, not a note, so of two
  daemons booting together exactly one spawns a multi-GB helper. A **stale**
  record (recorded process gone — power loss mid-download) is displaced and
  the claim retried once, so no manual cleanup is ever needed. `release` only
  ever removes OUR record, so a late cleanup cannot delete the record of an
  engine somebody else has since started.
- `spawnDetachedEngine`, mirroring how `daemon-manager.ts` launches the hub:
  `detached: true` + `unref()`, output to `~/.remi/engine.log`. Detached is
  the contract, not an optimization — a session that spawned the engine and
  then quit must not take auto-approve down for the other nine.

**The call sites** (`cli.ts`). `ensureEngine()` runs at boot but is *not*
awaited: a cold helper can take tens of seconds to bind and remi must answer
its own port long before then. Evaluation escalates meanwhile, which is the
safe direction. On a hub machine the hub reaches it first and wins the pidfile
race by construction; a standalone `remi --daemon` on a machine with no hub
still gets an engine, because requiring a hub would recreate the exact silent
failure this issue removes.

**Lazy self-heal** (`auto-approve-service.ts`). A daemon started at 09:00 must
survive the engine dying at 14:00, which boot-time-only supervision cannot do.
A failed evaluation kicks a repair, single-flight so a burst of failures
(every queued permission failing against the same dead engine) produces ONE
attempt rather than dozens of overlapping 30s waits. Not awaited — that eval
has already escalated, so the repair is for the next one. **Timeouts are
excluded**: the engine answered, it was just slow, and treating slow as dead
would try to start a second engine against a busy one.

**#826**, which by design lands with this wiring. `cacheUnsupported` is a fact
about an engine PROCESS stored on a daemon that outlives it. Now that remi can
start engines mid-life, a user upgrading the engine underneath a long-running
daemon is ordinary, so `noteEngineChanged()` clears it on every spawn.
Previously stage 1 would have stayed disabled until the daemon restarted,
holding ~1.5 GB of prompt KV it could have reclaimed.

## A real bug found while testing

A failed spawn surfaces twice: synchronously on some runtimes, and as an
asynchronous `'error'` event on all of them. An unhandled `'error'` on a
`ChildProcess` is rethrown as an uncaught exception — so a missing engine
binary would have taken the **whole daemon** down, the exact opposite of the
"no engine is not fatal" contract. Caught by `engine-process.test.ts`
before it could ship. Now absorbed and logged.

## Not in scope

- The helper binary itself: yooz-engine#297. `engine_path` unset means remi
  still ATTACHES to an engine already on the port and otherwise reports the
  gap — it does not pretend to have started one.
- `remi model pull` on a machine with no engine still reports "unreachable"
  rather than starting one. Clear, but a dead end; worth a follow-up.
- #827 (`cache_idle` can fire mid-eval) is untouched.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3731 pass, 69 skip, 0 fail
- [x] New: `engine-process.test.ts` (13) covers the real pidfile and real
      spawned processes — claim exclusivity, stale displacement,
      release-only-own, fd non-leak across repeated spawns
- [x] New: `engine-supervision.test.ts` (6) covers the wiring — attach without
      spawning, spawn when absent, report the gap, a `shared` guest never
      spawns, and a burst of failures produces exactly one repair
- [x] New: two `model-residency` tests for `noteEngineChanged`
- [ ] On-device: engine actually starts from a daemon on a machine with a
      helper installed (needs yooz-engine#297)
