### PR TITLE
Never drop cache or weights mid-evaluation (#827)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -651,6 +651,13 @@ export class AutoApproveService {
       // and aborts a healthy call (currentAbortController is shared instance
       // state).
       let raceTimer: ReturnType<typeof setTimeout> | null = null;
+      // #827: the evaluation is now genuinely in flight on the engine. Marking
+      // it HERE rather than at `evaluate()` entry also takes the queue wait out
+      // of the idle arithmetic -- the window now measures from when the LLM
+      // actually started, not from when we joined the queue. Paired with
+      // `endEval()` in the `finally` immediately below; nothing runs between
+      // this statement and the `try`, so the pairing cannot be skipped.
+      this.residency.beginEval();
       try {
         // Multi-choice + evaluate mode: dedicated prompt, optional alt model.
         // Otherwise the binary approve/deny prompt.
@@ -745,8 +752,9 @@ export class AutoApproveService {
         this.currentEvalId = null;
         this.releaseSlot();
         // #820: re-arm from the END of the eval, so the idle window measures
-        // silence rather than "time since we started thinking".
-        this.residency.noteActivity();
+        // silence rather than "time since we started thinking". #827: also
+        // drops the in-flight count, releasing both stages to act again.
+        this.residency.endEval();
       }
     } catch (err) {
       const durationMs = Date.now() - start;

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -271,6 +271,18 @@ export class AutoApproveService {
   }
 
   /**
+   * Evaluations this service currently has in flight on the engine (#827).
+   *
+   * Exposed because the `beginEval`/`endEval` pairing is the one thing that can
+   * silently disable BOTH eviction stages for the rest of the daemon's life if
+   * it ever leaks — a failure strictly worse than the bug the counter fixes,
+   * and otherwise unobservable from outside this class.
+   */
+  get evalsInFlight(): number {
+    return this.residency.inFlightCount;
+  }
+
+  /**
    * Make sure an engine is answering, starting one if this remi owns the engine
    * (#818). Safe to call repeatedly: `EngineHost.ensureRunning` attaches to an
    * existing engine before considering a spawn, and claims the pidfile before
@@ -455,6 +467,14 @@ export class AutoApproveService {
    */
   async warmEscalateModel(): Promise<void> {
     if (!this.escalateModel || !this.providerIsYooz) return;
+    // Counted as in-flight work (#827) even though it is not an evaluation: on
+    // a cold machine this is a multi-GB HuggingFace pull, and a ~20 GB model on
+    // a slow link can outlast `cache_idle` (300s) or even `keep_alive` (1800s).
+    // Uncounted, the idle timer would then call `unload` on a model that is
+    // still downloading. First-boot-only and low probability, but the counter
+    // already expresses exactly this rule, so there is no reason to leave it
+    // outside.
+    this.residency.beginEval();
     try {
       await warmModel(this.llmConfig.baseUrl, this.escalateModel);
       this.logFn(`[AutoApprove] Warmed escalate_model ${this.escalateModel} (preloaded)`);
@@ -462,6 +482,8 @@ export class AutoApproveService {
       this.logFn(
         `[AutoApprove] escalate_model warm-up failed (will load on first consult): ${errorToString(err)}`,
       );
+    } finally {
+      this.residency.endEval();
     }
   }
 

--- a/packages/daemon/src/auto-approve/model-residency.ts
+++ b/packages/daemon/src/auto-approve/model-residency.ts
@@ -42,10 +42,23 @@
  *      because this is a correctness boundary and not a preference (#818).
  *      A cache clear is less destructive than an unload, but it still steals
  *      another module's warm-prefix latency, so it gets no separate carve-out.
- *   2. **Never act mid-eval.** `noteActivity` is called when an eval starts
- *      AND when it settles, so a long-running evaluation keeps pushing both
- *      deadlines out rather than having its cache or weights pulled out from
- *      under it.
+ *   2. **Never act mid-eval.** An IN-FLIGHT COUNTER (`beginEval`/`endEval`)
+ *      holds this, not timestamps: while any evaluation is running on the
+ *      engine, both stages defer and re-arm instead of acting.
+ *
+ *      Timestamps alone did NOT hold it (#827). `noteActivity` fires at two
+ *      instants — start and settle — with nothing in between, so an evaluation
+ *      whose wall time exceeded the window had its cache dropped underneath it.
+ *      Stage 2 had enormous margin so this stayed theoretical; stage 1 did not:
+ *      `queue_timeout` (240s) + `escalate_timeout` raised to 90s, which this
+ *      project's own tuning advice suggests for a large cold escalate model,
+ *      already exceeds the 300s `cache_idle` default. Following the documented
+ *      advice for one knob silently eroded a different timer's safety margin.
+ *
+ *      The counter starts when the eval acquires its GPU slot, not at
+ *      `evaluate()` entry, which also removes the queue wait from the
+ *      arithmetic entirely: the window measures from when the LLM actually
+ *      started rather than from when the request joined the queue.
  *   3. **Degrade silently when the engine lacks stage 1.** The clear-cache
  *      endpoint may ship after this code does (#820 was split across two
  *      repos in flight). An engine that 404s/501s on it must not break
@@ -150,6 +163,10 @@ export class ModelResidency {
    * life of this process, and stage 1 goes quiet. Stage 2 is untouched.
    */
   private cacheUnsupported = false;
+  /** Evaluations currently running on the engine (#827). While non-zero,
+   *  neither stage may act: dropping the cache or the weights under a live
+   *  evaluation is exactly what rule 2 forbids. */
+  private inFlight = 0;
 
   constructor(
     private readonly config: ModelResidencyConfig,
@@ -206,6 +223,39 @@ export class ModelResidency {
    * An evaluation happened (started, or settled). Pushes BOTH idle deadlines
    * out. Cheap enough to call on every eval — it replaces at most two timers.
    */
+  /**
+   * An evaluation is now IN FLIGHT on the engine (#827).
+   *
+   * `noteActivity` alone cannot uphold rule 2. It is called at two instants —
+   * eval start and eval end — and nothing re-arms in between, so an evaluation
+   * whose total wall time exceeds the idle window has the cache dropped (or the
+   * weights unloaded) underneath it while it is genuinely still running. That
+   * is not hypothetical for stage 1: `queue_timeout` (240s) + `escalate_timeout`
+   * raised to 90s per this project's own tuning advice already exceeds the 300s
+   * `cache_idle` default.
+   *
+   * A counter states the rule directly instead of approximating it with
+   * timestamps, and it also covers an evaluation that never settles at all.
+   * MUST be paired with `endEval` in a `finally`.
+   */
+  beginEval(): void {
+    this.inFlight += 1;
+    this.noteActivity();
+  }
+
+  /** An evaluation finished (any outcome). Clamped at zero so an unpaired call
+   *  can never drive the counter negative and permanently re-enable eviction
+   *  mid-eval — the failure direction that would reintroduce #827. */
+  endEval(): void {
+    if (this.inFlight > 0) this.inFlight -= 1;
+    this.noteActivity();
+  }
+
+  /** In-flight evaluations, for tests and diagnostics. */
+  get inFlightCount(): number {
+    return this.inFlight;
+  }
+
   noteActivity(): void {
     const keepAlive = this.keepAliveEnabled;
     const cache = this.cacheStageEnabled;
@@ -235,6 +285,25 @@ export class ModelResidency {
     }
   }
 
+  /**
+   * Rule 2, enforced (#827): a stage that fires while an evaluation is still
+   * running on the engine defers instead of acting, and re-arms for a full
+   * window. Returns true when the caller must stop.
+   *
+   * Deferral is LOGGED because the counter is the one piece of state that
+   * could, if a caller ever failed to pair `beginEval`/`endEval`, disable
+   * eviction for the life of the daemon. A silent defer would make that leak
+   * invisible; a log line makes it diagnosable from `remi.log` alone.
+   */
+  private deferWhileInFlight(stage: string, rearm: () => void): boolean {
+    if (this.inFlight === 0) return false;
+    this.deps.log(
+      `[AutoApprove] ${stage} deferred: ${this.inFlight} evaluation(s) still in flight`,
+    );
+    rearm();
+    return true;
+  }
+
   private armUnload(): void {
     if (this.unloadTimer !== null) this.clearTimerFn(this.unloadTimer);
     this.unloadTimer = this.setTimer(() => {
@@ -260,6 +329,7 @@ export class ModelResidency {
    */
   private async unloadIdle(): Promise<void> {
     if (this.unloaded) return;
+    if (this.deferWhileInFlight('keep_alive unload', () => this.armUnload())) return;
 
     // Another daemon on this machine may have evaluated during OUR idle
     // window. Unloading now would cold-load that session's next permission.
@@ -316,6 +386,7 @@ export class ModelResidency {
     // Nothing resident to clear either because we already cleared it this
     // window, or because stage 2 already unloaded everything outright.
     if (this.cacheCleared || this.unloaded) return;
+    if (this.deferWhileInFlight('cache_idle clear', () => this.armCache())) return;
 
     // Same machine-wide coordination as stage 2: another daemon's session
     // may be relying on this cache RIGHT NOW for its own warm-prefix hit.

--- a/packages/daemon/src/auto-approve/model-residency.ts
+++ b/packages/daemon/src/auto-approve/model-residency.ts
@@ -79,6 +79,16 @@
  * daemon re-arms instead of acting. One `utimes` per eval, one `stat` per
  * fire, no locks and no IPC. Anything heavier belongs with #620's GPU
  * admission work.
+ *
+ * Rule 2 applies across daemons too, and needs one addition to get there. The
+ * in-flight counter is per-instance and private, so a sibling daemon cannot see
+ * that WE are mid-eval; all it sees is the shared mtime, touched at the same
+ * two instants that proved insufficient locally. An eval that outlasts the
+ * sibling's window would therefore have its cache dropped by that sibling. So
+ * while `inFlight > 0` this daemon RE-TOUCHES the shared record on a heartbeat
+ * (a quarter of the shortest window, capped at 30s), which keeps every sibling
+ * deferring for as long as the work actually lasts — using the mechanism that
+ * is already there rather than introducing a second one.
  */
 
 import { ClearCacheUnsupportedError } from './engine-models.ts';
@@ -167,6 +177,10 @@ export class ModelResidency {
    *  neither stage may act: dropping the cache or the weights under a live
    *  evaluation is exactly what rule 2 forbids. */
   private inFlight = 0;
+  /** Refreshes the SHARED activity record while `inFlight > 0`, so a sibling
+   *  daemon on the same engine keeps seeing machine activity for the whole
+   *  duration of our eval rather than only at its two endpoints (#827). */
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly config: ModelResidencyConfig,
@@ -241,6 +255,7 @@ export class ModelResidency {
   beginEval(): void {
     this.inFlight += 1;
     this.noteActivity();
+    this.startHeartbeat();
   }
 
   /** An evaluation finished (any outcome). Clamped at zero so an unpaired call
@@ -248,6 +263,7 @@ export class ModelResidency {
    *  mid-eval — the failure direction that would reintroduce #827. */
   endEval(): void {
     if (this.inFlight > 0) this.inFlight -= 1;
+    if (this.inFlight === 0) this.stopHeartbeat();
     this.noteActivity();
   }
 
@@ -283,6 +299,56 @@ export class ModelResidency {
       this.clearTimerFn(this.cacheTimer);
       this.cacheTimer = null;
     }
+    this.stopHeartbeat();
+  }
+
+  /**
+   * Keep the SHARED activity record fresh while this daemon has work in flight
+   * (#827, cross-daemon half).
+   *
+   * The in-flight counter is per-instance and private, so it protects only THIS
+   * daemon's evals. A sibling daemon sharing the engine sees nothing but the
+   * `engine-activity` mtime — and that mtime is touched at exactly two instants,
+   * eval start and settle, which is the same "nothing in between" shape that
+   * failed locally. Once our eval outlasts the sibling's window, its
+   * `sinceLastMs() < window` check goes false and it drops the cache or unloads
+   * the weights out from under us. The module treats ten daemons on one engine
+   * as the common case, so this is not an exotic path.
+   *
+   * A heartbeat closes it with the mechanism already in place: while work is in
+   * flight we re-touch the shared record, so every sibling keeps seeing recent
+   * machine activity and keeps deferring. No locks, no IPC, nothing to keep in
+   * sync — the same reasons `engine-activity.ts` chose an mtime in the first
+   * place. The interval is a quarter of the shortest window (capped at 30s) so
+   * a sibling cannot observe a gap wider than its own threshold.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer !== null || this.deps.activity === undefined) return;
+    const windows = [this.config.cacheIdleMs, this.config.keepAliveMs].filter((w) => w > 0);
+    if (windows.length === 0) return;
+    // A quarter of the SHORTEST window, so a sibling can never observe a gap
+    // as wide as its own threshold. Capped at 30s (a longer window does not
+    // need a faster beat) and floored at 50ms purely so a pathologically small
+    // configured window cannot turn this into a busy loop. The floor must never
+    // exceed the window itself, which is why it is not the round 1s it looks
+    // like it should be.
+    const interval = Math.max(50, Math.min(30_000, Math.floor(Math.min(...windows) / 4)));
+    const tick = (): void => {
+      this.heartbeatTimer = null;
+      // Settled while the timer was pending: nothing to advertise.
+      if (this.inFlight === 0) return;
+      this.deps.activity?.touch();
+      this.heartbeatTimer = this.setTimer(tick, interval);
+      this.heartbeatTimer.unref?.();
+    };
+    this.heartbeatTimer = this.setTimer(tick, interval);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer === null) return;
+    this.clearTimerFn(this.heartbeatTimer);
+    this.heartbeatTimer = null;
   }
 
   /**

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -189,6 +189,31 @@ describe('AutoApproveService engine supervision (#818)', () => {
     await new Promise((r) => setTimeout(r, 20));
   });
 
+  test('evaluate() pairs beginEval/endEval on every exit (#827)', async () => {
+    // The counter's own semantics are covered in model-residency.test.ts, but
+    // the bug #827 describes was a CALLING-PATTERN bug, and nothing exercised
+    // the actual call site: deleting `endEval()` from evaluate()'s finally
+    // passed the entire suite. A leak there permanently disables BOTH eviction
+    // stages after the first evaluation — worse than the bug being fixed.
+    const h = serviceWith({ probes: [REACHABLE] });
+    expect(h.service.evalsInFlight).toBe(0);
+
+    // Failure path: the LLM call throws (nothing on the port).
+    await h.service.evaluate('Bash', { command: 'echo 1' });
+    expect(h.service.evalsInFlight).toBe(0);
+
+    // Fast path: returns before ever acquiring a slot, so it must not have
+    // incremented in the first place.
+    await h.service.evaluate('Read', { file_path: '/tmp/x' });
+    expect(h.service.evalsInFlight).toBe(0);
+
+    // Cancellation: aborts through the same try/finally.
+    const pending = h.service.evaluate('Bash', { command: 'echo 2' });
+    h.service.cancel('test cancel');
+    await pending;
+    expect(h.service.evalsInFlight).toBe(0);
+  });
+
   test('the single-flight guard clears, so a later failure can still repair', async () => {
     // A stuck `healInFlight` would silently disable self-heal for the life of
     // the daemon -- the exact failure mode #818 exists to remove.

--- a/packages/daemon/tests/auto-approve/model-residency.test.ts
+++ b/packages/daemon/tests/auto-approve/model-residency.test.ts
@@ -63,6 +63,92 @@ function harness(
   };
 }
 
+describe('ModelResidency rule 2 — never act mid-eval (#827)', () => {
+  // The case the timestamp approach got wrong: one evaluation whose wall time
+  // exceeds the idle window. `noteActivity` fires only at start and settle, so
+  // nothing re-armed in between and the timer fired with the eval still live on
+  // the engine. Reachable with shipped defaults: queue_timeout 240s +
+  // escalate_timeout 90s (this project's own advice for a cold escalate model)
+  // > cache_idle 300s.
+  test('stage 1 defers while an evaluation is still running', async () => {
+    const h = harness({ cacheIdleMs: 500 });
+    h.residency.beginEval();
+
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.cacheCleared).toEqual([]); // the cache survived the eval
+    expect(h.logs.join('\n')).toContain('deferred');
+    expect(h.residency.cacheStageEnabled).toBe(true); // deferral is not degradation
+  });
+
+  test('stage 2 defers while an evaluation is still running', async () => {
+    const h = harness();
+    h.residency.beginEval();
+
+    h.fireUnloadTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.unloaded).toEqual([]);
+    expect(h.logs.join('\n')).toContain('deferred');
+  });
+
+  test('both stages act again once the evaluation settles', async () => {
+    // The deferral must be temporary; a permanent one is just a memory leak.
+    const h = harness({ cacheIdleMs: 500 });
+    h.residency.beginEval();
+    h.fireCacheTimer();
+    await Promise.resolve();
+    expect(h.cacheCleared).toEqual([]);
+
+    h.residency.endEval();
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.cacheCleared).toHaveLength(1);
+  });
+
+  test('concurrent evaluations all have to settle before a stage acts', async () => {
+    // Parallel subagents produce overlapping evals; the LAST one to finish is
+    // what releases the stages, not the first.
+    const h = harness({ cacheIdleMs: 500 });
+    h.residency.beginEval();
+    h.residency.beginEval();
+    h.residency.endEval();
+
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.cacheCleared).toEqual([]);
+    expect(h.residency.inFlightCount).toBe(1);
+
+    h.residency.endEval();
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.cacheCleared).toHaveLength(1);
+  });
+
+  test('an unpaired endEval cannot drive the counter negative', async () => {
+    // A negative counter would read as "nothing in flight" forever after,
+    // silently restoring the very bug this counter fixes.
+    const h = harness({ cacheIdleMs: 500 });
+    h.residency.endEval();
+    h.residency.endEval();
+    expect(h.residency.inFlightCount).toBe(0);
+
+    h.residency.beginEval();
+    expect(h.residency.inFlightCount).toBe(1);
+    h.fireCacheTimer();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.cacheCleared).toEqual([]); // still correctly deferred
+  });
+});
+
 describe('ModelResidency stage 2 (unload, #820)', () => {
   test('unloads every model remi loaded once the idle window elapses', async () => {
     const h = harness({ models: ['model-a', 'escalate-b'] });

--- a/packages/daemon/tests/auto-approve/model-residency.test.ts
+++ b/packages/daemon/tests/auto-approve/model-residency.test.ts
@@ -67,9 +67,11 @@ describe('ModelResidency rule 2 — never act mid-eval (#827)', () => {
   // The case the timestamp approach got wrong: one evaluation whose wall time
   // exceeds the idle window. `noteActivity` fires only at start and settle, so
   // nothing re-armed in between and the timer fired with the eval still live on
-  // the engine. Reachable with shipped defaults: queue_timeout 240s +
-  // escalate_timeout 90s (this project's own advice for a cold escalate model)
-  // > cache_idle 300s.
+  // the engine. Reachable in a realistic configuration: queue_timeout 240s (a
+  // shipped default) plus escalate_timeout raised to 90s -- NOT a default
+  // (escalate_timeout ships as 0, meaning "reuse the 30s base timeout") but
+  // what config.ts's own tuning advice suggests for a large, often-cold
+  // escalate model. 240 + 90 exceeds cache_idle's 300s default.
   test('stage 1 defers while an evaluation is still running', async () => {
     const h = harness({ cacheIdleMs: 500 });
     h.residency.beginEval();
@@ -130,6 +132,50 @@ describe('ModelResidency rule 2 — never act mid-eval (#827)', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(h.cacheCleared).toHaveLength(1);
+  });
+
+  test('a heartbeat keeps the SHARED record fresh for a sibling daemon', async () => {
+    // The cross-daemon half. `inFlight` is private and per-instance, so a
+    // sibling sharing the engine sees only the `engine-activity` mtime -- which
+    // was touched at eval start and settle and nothing in between, the same
+    // shape that failed locally. Once our eval outlasts the sibling's window,
+    // its `sinceLastMs() < window` check goes false and it drops the cache out
+    // from under us.
+    const touches: number[] = [];
+    let heartbeatFire: (() => void) | undefined;
+    const residency = new ModelResidency(
+      { keepAliveMs: 0, cacheIdleMs: 400, models: ['shared'], ownsEngine: true },
+      {
+        unload: async () => {},
+        clearCache: async () => [],
+        log: () => {},
+        activity: {
+          touch: () => touches.push(1),
+          sinceLastMs: () => 0,
+        },
+        // The heartbeat is the only timer at a quarter of the window (100ms).
+        setTimer: (fn, ms) => {
+          if (ms === 100) heartbeatFire = fn;
+          return 1 as unknown as ReturnType<typeof setTimeout>;
+        },
+        clearTimer: () => {},
+      },
+    );
+
+    residency.beginEval();
+    const afterBegin = touches.length;
+    // A long eval: the heartbeat fires while nothing else happens.
+    heartbeatFire?.();
+    heartbeatFire?.();
+
+    // Each beat re-advertises machine activity, so a sibling keeps deferring.
+    expect(touches.length).toBeGreaterThan(afterBegin);
+
+    // ...and it stops once the work settles, so eviction is not pinned forever.
+    residency.endEval();
+    const afterEnd = touches.length;
+    heartbeatFire?.();
+    expect(touches.length).toBe(afterEnd);
   });
 
   test('an unpaired endEval cannot drive the counter negative', async () => {


### PR DESCRIPTION
Closes #827.

## The gap

`ModelResidency`'s module doc states rule 2 as "a long-running evaluation keeps pushing the deadline out rather than being cut out from under." It does not. `noteActivity()` fires at exactly two instants — eval start and settle — and nothing re-arms in between, so an evaluation whose total wall time exceeds the idle window has the timer fire while it is genuinely still running on the engine.

Stage 2 (`keep_alive`, 1800s) has enormous margin, so this was theoretical. **Stage 1 does not**: `queue_timeout` (240s) + `escalate_timeout` raised to 90s — which `config.ts`'s own guidance suggests for a large, often-cold escalate model — is 330s against a 300s `cache_idle` default. Following the documented tuning advice for one knob silently erodes a different, cross-cutting timer's safety margin, and each knob is validated independently with nothing checking the relationship.

## The fix

Both halves the issue asked for:

- **In-flight counter** (`beginEval`/`endEval`). While any evaluation is running, both stages **defer and re-arm** instead of acting. This states rule 2 directly rather than approximating it with timestamps, and it also covers an evaluation that never settles.
- **Counted from GPU-slot acquisition**, not `evaluate()` entry, which removes the queue wait from the arithmetic entirely: the window now measures from when the LLM actually started rather than from when the request joined the queue.

Pairing is structural — `beginEval()` sits immediately before the `try` whose `finally` calls `endEval()`, with nothing in between, and the queue-timeout path returns *before* either. The `escalate_model` second opinion routes through `service.evaluate()` (`auto-approve-gate.ts:1891`), so it is counted too.

Two safety properties, because this counter is the one piece of state that could disable eviction for a daemon's whole life if it ever leaked:
- `endEval` **clamps at zero**, so an unpaired call cannot drive it negative and silently restore the bug.
- Every deferral is **logged**, so a leak is diagnosable from `remi.log` alone rather than presenting as "eviction just stopped working".

The module doc now describes what the code does, including why the timestamp approach failed.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3741 pass, 69 skip, 0 fail
- [x] 5 new tests covering the case the issue notes was uncovered: stage 1 defers mid-eval, stage 2 defers mid-eval, both act again once it settles, concurrent evals all must settle (parallel subagents), and an unpaired `endEval` cannot go negative
- [x] **Mutation-verified**: disabling the guard fails all 5