### PR TITLE
Harden engine supervision after review (#818 follow-up)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -12,7 +12,7 @@
 import { errorToString } from '@remi/shared';
 import { fileActivityRecord } from './engine-activity.ts';
 import type { EngineHost } from './engine-host.ts';
-import { clearModelCache, unloadModel } from './engine-models.ts';
+import { clearModelCache, probeEngine, unloadModel } from './engine-models.ts';
 import { extractJsonObject } from './json-extract.ts';
 import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
@@ -144,6 +144,10 @@ export class AutoApproveService {
   private readonly engineHost: EngineHost | undefined;
   /** In-flight self-heal, so a burst of failed evals triggers one repair. */
   private healInFlight: Promise<void> | null = null;
+  /** How many times we concluded a DIFFERENT engine is now serving (#826).
+   *  Diagnostic: the decision is otherwise invisible, and treating a healthy
+   *  engine as replaced silently re-arms a degrade that exists to stay off. */
+  private engineChanges = 0;
   /** Max ms a permission eval may wait in the serialization queue before it
    *  escalates gracefully (#551); 0 = no bound. */
   private readonly queueTimeoutMs: number;
@@ -294,20 +298,53 @@ export class AutoApproveService {
     // discarded whenever a different one is now serving (#826). Two cases:
     //
     //   - `spawned`: unambiguously a new process.
-    //   - `attached` AFTER a failure: we only got here because an evaluation
-    //     failed against the engine, so something answering now is very likely
-    //     a replacement -- a restarted or upgraded helper, or another daemon's
-    //     engine that won the race to replace the dead one. Without this, a
-    //     `shared` guest could NEVER clear the flag (it can never spawn), and
-    //     the loser of a heal race would keep a stale flag learned from an
-    //     engine that no longer exists.
+    //   - `attached` after a repair that only ran BECAUSE the engine was
+    //     unreachable (`repairIfUnreachable` establishes that precondition):
+    //     the engine went away and something answers now, so it is a different
+    //     process. Without this a `shared` guest could NEVER clear the flag --
+    //     it can never spawn -- and the loser of a heal race would keep a flag
+    //     learned from an engine that no longer exists.
     //
-    // A boot-time `attached` is deliberately NOT treated as a change: that is
-    // the ordinary "an engine was already up" path, with nothing learned yet.
+    // The down-then-up transition is the ONLY evidence of a new process we
+    // have: `EngineProbe` carries `loaded`/`modelId`/`progress`/`state` but no
+    // pid and no start time, so a bare `attached` cannot distinguish "a
+    // replacement" from "the same engine, still alive, that merely failed one
+    // request". A boot-time `attached` is likewise not a change: nothing has
+    // been learned about that engine yet.
     if (state.kind === 'spawned' || (opts?.afterFailure === true && state.kind === 'attached')) {
+      this.engineChanges += 1;
       this.residency.noteEngineChanged();
     }
     return true;
+  }
+
+  /** Times a new engine has been detected (#826). Exposed because "we decided
+   *  the engine was replaced" is otherwise unobservable, and deciding it
+   *  wrongly is the failure this path has to be held to. */
+  get engineChangeCount(): number {
+    return this.engineChanges;
+  }
+
+  /**
+   * Repair, but ONLY when the engine is genuinely unreachable.
+   *
+   * `evaluate()`'s catch wraps the whole evaluation, including response
+   * parsing — so an unparsable reply from a perfectly healthy engine reaches
+   * the heal path exactly like a dead socket does. Without this probe, one bad
+   * LLM response would be treated as "a new engine appeared" and would clear
+   * `cacheUnsupported` against the very same process that already told us its
+   * clear-cache route is missing, re-arming the doomed request and the log line
+   * the degrade exists to stop.
+   *
+   * Probing first also makes the down-then-up transition a real precondition
+   * rather than an assumption, which is what licenses `afterFailure` below.
+   */
+  private async repairIfUnreachable(): Promise<boolean> {
+    const probe = await probeEngine(this.llmConfig.baseUrl);
+    // Reachable => the process never went anywhere; the failure was about this
+    // request, not about the engine. Nothing to repair, nothing new to learn.
+    if (probe.reachable) return true;
+    return await this.ensureEngine({ afterFailure: true });
   }
 
   /**
@@ -319,7 +356,7 @@ export class AutoApproveService {
    */
   private healEngine(): void {
     if (this.engineHost === undefined || this.healInFlight !== null) return;
-    this.healInFlight = this.ensureEngine({ afterFailure: true })
+    this.healInFlight = this.repairIfUnreachable()
       .catch((err) => {
         this.logFn(`[AutoApprove] Engine self-heal failed: ${errorToString(err)}`);
         return false;

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -45,10 +45,21 @@
  * process plus aggressive weight eviction is the right shape; reaping the
  * process itself is not worth the coordination.
  *
- * The pidfile doubles as the start race guard: it is created O_EXCL, so of two
- * daemons booting simultaneously exactly one spawns and the other waits and
- * attaches. (The port would arbitrate anyway — the loser's engine would fail
- * to bind — but losing that race noisily is worse than not entering it.)
+ * The pidfile is a BEST-EFFORT start-race guard, not the guarantee: created
+ * O_EXCL, so of two daemons booting simultaneously one normally spawns and the
+ * other waits and attaches. It is not an exclusive lock — see
+ * `engine-process.ts` for the window that survives, which Node cannot close
+ * without an OS advisory lock.
+ *
+ * **The port is the guarantee.** 19924 admits one listener, so a claimant that
+ * slips through the pidfile still fails to bind, and `startEngine` stops a
+ * helper that turns out to be redundant. The pidfile exists to keep that case
+ * rare and quiet — losing the race noisily is worse than not entering it.
+ *
+ * That cleanup is deliberately ordered: a redundant helper is stopped only
+ * AFTER something else is confirmed to be answering. Killing on the strength of
+ * the pidfile alone would bet a running engine against a competitor that has
+ * not started one yet, which can leave the machine with none.
  */
 
 import { errorToString } from '@remi/shared';
@@ -270,30 +281,41 @@ export class EngineHost {
     // claiming inside it would leave the pidfile naming someone else's engine
     // while we believe we own it -- so the reclaim is checked, not assumed.
     this.pids?.release(process.pid);
-    if (this.pids !== undefined && !this.pids.claim(pid)) {
-      // Somebody else's engine now owns the record, so ours is redundant: it
-      // will either lose the port bind or, worse, sit wedged forever. Logging
-      // and carrying on would leak a multi-GB process nothing tracks -- the
-      // pidfile would name their engine while we believed we owned ours.
-      this.log(
-        `[Engine] Started engine pid ${pid} but another process claimed the record first; stopping ours and attaching to theirs`,
-      );
-      this.killStarted(pid);
-      if (await this.waitForReady()) {
-        return { kind: 'attached', ownership: this.config.ownership };
-      }
-      const reason = `stopped our redundant engine (pid ${pid}) but the winner never answered on ${this.config.baseUrl}`;
-      this.log(`[Engine] ${reason}`);
-      return { kind: 'unavailable', reason };
+    const lostRecord = this.pids !== undefined && !this.pids.claim(pid);
+    if (lostRecord) {
+      this.log(`[Engine] Started engine pid ${pid} but another process claimed the record first`);
     }
     this.startedPid = pid;
     this.log(`[Engine] Started detached engine pid ${pid} (${helperPath})`);
 
-    if (await this.waitForReady()) return { kind: 'spawned', pid };
+    if (await this.waitForReady()) {
+      if (!lostRecord) return { kind: 'spawned', pid };
 
-    // Started but never bound. Kill it rather than leaving a wedged headless
-    // process behind: we cannot assume the helper exits on its own when it
-    // cannot take the port.
+      // Something is serving and the record says it is not ours to track, so
+      // ours is probably redundant -- but killing it BEFORE confirming that is
+      // a bad bet. The process that took the record has not necessarily started
+      // anything yet; it may only just have decided to. Killing on that basis
+      // can leave the machine with NO engine while a competitor is still
+      // downloading multi-GB weights.
+      //
+      // So: only now, with the port confirmed answering, stop ours -- then
+      // re-probe. The probe carries no pid, so "someone answers" cannot tell us
+      // WHO; if the port goes dark once ours is gone, ours was the one serving
+      // and we must report that rather than claim a healthy attach.
+      this.killStarted(pid);
+      const after = await this.probe(this.config.baseUrl);
+      if (after.reachable) {
+        this.log(`[Engine] Stopped our redundant engine (pid ${pid}); attached to theirs`);
+        return { kind: 'attached', ownership: this.config.ownership };
+      }
+      const reason = `stopped our engine (pid ${pid}) after another process claimed the record, but ${this.config.baseUrl} then went dark`;
+      this.log(`[Engine] ${reason}`);
+      return { kind: 'unavailable', reason };
+    }
+
+    // Started but never bound, and nothing else answered either. Kill it rather
+    // than leaving a wedged headless process behind: we cannot assume the
+    // helper exits on its own when it cannot take the port.
     this.killStarted(pid);
     const reason = `engine started (pid ${pid}) but never answered on ${this.config.baseUrl}`;
     this.log(`[Engine] ${reason}`);

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -31,6 +31,30 @@ export const ENGINE_LOG_FILE = path.join(REMI_DIR, 'engine.log');
 /** Is this pid a live process? Signal 0 tests existence without delivering
  *  anything. EPERM means alive but owned by another user, which still counts —
  *  something holds the record and we must not claim it. */
+/**
+ * Delete `file` only if it still records exactly `expected`.
+ *
+ * Every delete on these paths must be compare-then-delete. A blind `unlink`
+ * removes whatever is at the path *now*, which is not necessarily what the
+ * caller observed a moment ago — that is precisely how two claimants both end
+ * up believing they hold an exclusive record.
+ *
+ * Still a check-then-act at the syscall level, so it narrows the window rather
+ * than eliminating it; see the class doc for why that is acceptable here.
+ * Returns false when the content had changed (someone else owns it now) or the
+ * delete failed.
+ */
+function unlinkIfMatches(file: string, expected: number): boolean {
+  try {
+    const current = Number.parseInt(fs.readFileSync(file, 'utf8').trim(), 10);
+    if (current !== expected) return false;
+    fs.unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -61,13 +85,22 @@ function isAlive(pid: number): boolean {
  * So displacement happens under a separate `wx` mutex, with the record
  * RE-CHECKED inside it: whoever takes the mutex is the only process that may
  * delete the stale file, and anyone who took it after a live record appeared
- * backs off instead. The mutex is held for a few synchronous syscalls, and a
- * dead mutex holder is itself displaced, so it cannot wedge anything either.
+ * backs off instead. Every delete is compare-then-delete (`unlinkIfMatches`) so
+ * no process can blindly remove a record or mutex it did not observe.
  *
- * The residual window is a process dying between taking the mutex and writing
- * the record; the next claim clears it. Note also that the pidfile is the
- * SECOND line of defence, not the only one — the port is the real singleton
- * (see `engine-host.ts`), so a loser that slips through still fails to bind.
+ * **This is best-effort, not an exclusive lock, and the distinction matters.**
+ * Node has no `flock`, and "atomically replace this file only if its owner is
+ * dead" is not expressible with create/rename/unlink alone. A narrow window
+ * survives: if a process dies mid-displacement it leaves BOTH the record and
+ * the mutex stale, and two claimants recovering from that state can each
+ * conclude they hold the mutex. Compare-then-delete shrinks that window; it
+ * does not close it. Closing it properly needs an OS advisory lock.
+ *
+ * That is acceptable only because the pidfile is the SECOND line of defence.
+ * **The port is the real singleton** (see `engine-host.ts`): 19924 admits one
+ * listener, so a claimant that slips through still fails to bind, and
+ * `startEngine` cleans up a helper that turns out to be redundant. The pidfile
+ * exists to keep that case rare and quiet, not to be the guarantee.
  */
 export class FileEnginePidStore implements PidStore {
   constructor(private readonly file: string = ENGINE_PID_FILE) {}
@@ -102,12 +135,12 @@ export class FileEnginePidStore implements PidStore {
     try {
       // RE-CHECK inside the mutex: between our check above and taking it, the
       // holder may have displaced the stale record and be live now.
-      if (this.read() !== null) return false;
-      try {
-        fs.unlinkSync(this.file);
-      } catch {
-        // Already gone -- the create below still decides the winner.
-      }
+      const stale = this.rawPid(this.file);
+      if (stale === null || isAlive(stale)) return false;
+      // Compare-then-delete: only remove the exact stale record we just read.
+      // A blind unlink here would destroy a LIVE record written by a process
+      // that displaced this one in between -- the same bug one level down.
+      if (!unlinkIfMatches(this.file, stale)) return false;
       return this.tryCreate(this.file, pid);
     } finally {
       this.releaseMutex(mutex, pid);
@@ -119,49 +152,42 @@ export class FileEnginePidStore implements PidStore {
    *  permanently — the same staleness rule as the record it guards. */
   private acquireMutex(mutex: string, pid: number): boolean {
     if (this.tryCreate(mutex, pid)) return true;
-    let holder: number;
-    try {
-      holder = Number.parseInt(fs.readFileSync(mutex, 'utf8').trim(), 10);
-    } catch {
-      // Vanished between the failed create and the read: retry once.
-      return this.tryCreate(mutex, pid);
-    }
-    if (Number.isInteger(holder) && holder > 0 && isAlive(holder)) return false;
-    try {
-      fs.unlinkSync(mutex);
-    } catch {
-      // Someone else cleared it; the create below settles who wins.
-    }
+    const holder = this.rawPid(mutex);
+    // Vanished between the failed create and the read: retry once.
+    if (holder === null) return this.tryCreate(mutex, pid);
+    if (isAlive(holder)) return false;
+    // Compare-then-delete, for the same reason as the record itself: a blind
+    // unlink would remove a mutex another process legitimately took while we
+    // were deciding.
+    if (!unlinkIfMatches(mutex, holder)) return false;
     return this.tryCreate(mutex, pid);
   }
 
   private releaseMutex(mutex: string, pid: number): void {
+    unlinkIfMatches(mutex, pid);
+  }
+
+  /** The pid recorded in `file` regardless of liveness, or null when absent or
+   *  malformed. `read()` deliberately conflates "dead holder" with "no record";
+   *  the displacement paths need to tell those apart. */
+  private rawPid(file: string): number | null {
+    let raw: string;
     try {
-      if (Number.parseInt(fs.readFileSync(mutex, 'utf8').trim(), 10) !== pid) return;
-      fs.unlinkSync(mutex);
+      raw = fs.readFileSync(file, 'utf8');
     } catch {
-      // Already gone, or never ours to remove.
+      return null;
     }
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
   }
 
   release(pid: number): void {
-    // Read the raw file rather than `read()`: release must work for a pid that
-    // has already exited (the normal case when clearing our own record), and
-    // `read()` deliberately reports a dead holder as absent.
-    let raw: string;
-    try {
-      raw = fs.readFileSync(this.file, 'utf8');
-    } catch {
-      return;
-    }
-    // Only ever remove OUR record. Releasing unconditionally would let a late
+    // Compare-then-delete against the RAW content, not `read()`: release must
+    // work for a pid that has already exited (the normal case when clearing our
+    // own record), and `read()` deliberately reports a dead holder as absent.
+    // Only ever remove OUR record -- releasing unconditionally would let a late
     // cleanup delete the record of an engine somebody else has since started.
-    if (Number.parseInt(raw.trim(), 10) !== pid) return;
-    try {
-      fs.unlinkSync(this.file);
-    } catch {
-      // Already gone: the post-condition holds either way.
-    }
+    unlinkIfMatches(this.file, pid);
   }
 
   /** Atomic create-or-fail. `wx` is the whole point — an exists-then-write

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -210,7 +210,58 @@ describe('EngineHost — the start race', () => {
     expect(spawnCalls).toHaveLength(1);
     expect(killed).toEqual([777]); // ours was stopped, not left running
     expect(h.startedByUs).toBeNull();
-    expect(logs.join('\n')).toContain('stopping ours');
+    expect(logs.join('\n')).toContain('Stopped our redundant engine');
+  });
+
+  test('losing the reclaim does NOT kill ours while nothing else is answering', async () => {
+    // The availability trap. Whoever took the record has not necessarily
+    // started anything yet -- it may only just have decided to, and may still
+    // be downloading multi-GB weights. Killing our already-running engine on
+    // that basis alone can leave the machine with NO engine at all, converting
+    // a cosmetic pidfile mismatch into a real outage, in exactly the
+    // multi-daemon boot this feature is built around.
+    let claims = 0;
+    const pids: PidStore = {
+      read: () => 999,
+      claim: () => ++claims === 1,
+      release: () => {},
+    };
+    const { h, killed, logs } = host(
+      // Nothing ever answers: the "winner" never produced a working engine.
+      {},
+      { probes: [UNREACHABLE], pids, spawnPid: 777 },
+    );
+
+    const state = await h.ensureRunning();
+
+    // Never reported as a healthy attach to an engine that does not exist.
+    expect(state.kind).toBe('unavailable');
+    expect(logs.join('\n')).not.toContain('Stopped our redundant engine');
+    // It is still cleaned up at the end -- but as "started and never bound",
+    // not as "redundant", and only after nothing answered.
+    expect(killed).toEqual([777]);
+    expect(logs.join('\n')).toContain('never answered');
+  });
+
+  test('if the port goes dark once ours is stopped, that is reported, not hidden', async () => {
+    // The probe carries no pid, so "someone answers" cannot tell us WHO. If we
+    // stop ours and the port dies with it, ours WAS the one serving -- and
+    // claiming `attached` there would report a healthy engine that is gone.
+    let claims = 0;
+    const pids: PidStore = {
+      read: () => 999,
+      claim: () => ++claims === 1,
+      release: () => {},
+    };
+    const { h, logs } = host(
+      {},
+      { probes: [UNREACHABLE, REACHABLE, UNREACHABLE], pids, spawnPid: 777 },
+    );
+
+    const state = await h.ensureRunning();
+
+    expect(state.kind).toBe('unavailable');
+    expect(logs.join('\n')).toContain('went dark');
   });
 });
 

--- a/packages/daemon/tests/auto-approve/engine-process.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-process.test.ts
@@ -126,6 +126,31 @@ describe('FileEnginePidStore', () => {
     expect(new FileEnginePidStore(PID_FILE).read()).toBe(process.pid);
   });
 
+  test('a claimant does not delete a record it did not observe as stale', () => {
+    // Compare-then-delete. The joint precondition a single crash mid-swap
+    // leaves behind: BOTH the record and the mutex stale. A claimant recovering
+    // from that must never blindly unlink -- if another process displaced the
+    // record and is LIVE, deleting it would let two processes each believe they
+    // hold an exclusive claim, which is the original bug one level down.
+    fs.writeFileSync(`${PID_FILE}.claim`, `${DEAD_PID}\n`); // stale mutex
+    fs.writeFileSync(PID_FILE, `${process.pid}\n`); // ...but a LIVE record
+
+    // The live record must win regardless of the stale mutex beside it.
+    expect(new FileEnginePidStore(PID_FILE).claim(process.pid + 1)).toBe(false);
+    expect(fs.readFileSync(PID_FILE, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  test('a stale mutex holder cannot be displaced by someone who misread it', () => {
+    // `unlinkIfMatches` on the mutex: a claimant that observed holder X must not
+    // remove a mutex now held by Y.
+    fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);
+    fs.writeFileSync(`${PID_FILE}.claim`, `${process.pid}\n`); // live holder
+
+    expect(new FileEnginePidStore(PID_FILE).claim(process.pid + 1)).toBe(false);
+    // The live mutex survives the failed claim.
+    expect(fs.readFileSync(`${PID_FILE}.claim`, 'utf8').trim()).toBe(String(process.pid));
+  });
+
   test('the displacement mutex is released once the claim settles', () => {
     // A leaked mutex would block the NEXT displacement until its holder died.
     fs.writeFileSync(PID_FILE, `${DEAD_PID}\n`);

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -189,6 +189,65 @@ describe('AutoApproveService engine supervision (#818)', () => {
     await new Promise((r) => setTimeout(r, 20));
   });
 
+  test('a reachable engine is not "repaired" just because one eval failed', async () => {
+    // `evaluate()`'s catch wraps the WHOLE evaluation, including response
+    // parsing -- so an unparsable reply from a perfectly healthy engine reaches
+    // the heal path exactly like a dead socket does. Repairing there would
+    // clear `cacheUnsupported` against the very same process that already told
+    // us its clear-cache route is missing, re-arming the doomed request and the
+    // log line the degrade exists to suppress (#826).
+    //
+    // A real HTTP server stands in for the healthy engine, so the reachability
+    // probe is a genuine round trip rather than an assumption.
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ loaded: true }),
+    });
+    try {
+      const logs: string[] = [];
+      const spawns: string[] = [];
+      const base = `http://127.0.0.1:${server.port}`;
+      const engineHost = new EngineHost(
+        { baseUrl: base, ownership: 'owned', helperPath: '/bin/sleep' },
+        {
+          log: (m) => logs.push(m),
+          spawn: (p) => {
+            spawns.push(p);
+            return 4242;
+          },
+          pidStore: pidStore(),
+        },
+      );
+      // `provider` must carry the URL: `resolveProviderUrl('yooz', ...)` returns
+      // the fixed loopback 19924 and IGNORES `base_url`, so overriding
+      // `base_url` alone would silently point the probe at a different host
+      // than the engine under test. A full URL passes through unchanged.
+      //
+      // The server answers every path, so the ENGINE is healthy; the eval still
+      // fails because the generate response carries no `text` field. That is
+      // exactly the shape of "healthy engine, unusable reply".
+      const service = new AutoApproveService(
+        { ...config(), provider: base, base_url: base },
+        (m) => logs.push(m),
+        engineHost,
+      );
+
+      const result = await service.evaluate('Bash', { command: 'echo 1' });
+      expect(result.decision).toBe('escalate');
+      await new Promise((r) => setTimeout(r, 60));
+
+      // Nothing started: the engine never went anywhere.
+      expect(spawns).toEqual([]);
+      // And crucially, it was NOT recorded as a new engine. This is the
+      // assertion that matters: both the correct and the broken version reach
+      // "attached, no spawn", so only the engine-change decision distinguishes
+      // them -- and it is the decision that resets `cacheUnsupported`.
+      expect(service.engineChangeCount).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  });
+
   test('the single-flight guard clears, so a later failure can still repair', async () => {
     // A stuck `healInFlight` would silently disable self-heal for the life of
     // the daemon -- the exact failure mode #818 exists to remove.


### PR DESCRIPTION
Follow-up to #828 (merged). Three findings from its review, all reproduced or traced before fixing.

## 1. The displacement mutex had the same shape as the bug it fixed

`acquireMutex`'s stale-displacement branch was check-then-blind-`unlink` — structurally identical to the `claim()` race #828 closed, just one level down. The joint precondition a single crash mid-swap leaves behind is **both** the record and the mutex stale, and two claimants recovering from that could each conclude they held the mutex, then both blindly unlink the record.

Every delete on these paths is now **compare-then-delete** (`unlinkIfMatches`): no process removes a record or mutex it did not observe.

**This narrows the window; it does not close it**, and the docs now say so. Node has no `flock`, and "atomically replace this file only if its owner is dead" is not expressible with create/rename/unlink alone. The previous comments claimed unqualified exclusivity, which is how someone later builds something load-bearing on top of it. They now state the real guarantee: **the port is the singleton**, the pidfile exists to keep double-spawns rare and quiet.

## 2. Kill-on-lost-reclaim was an availability regression

#828 killed our just-spawned engine as soon as the reclaim was lost. But the "winner" is only whichever process's `claim` landed in the release/reclaim gap — it **has not started an engine yet**, and may still be fetching multi-GB weights. So we bet a running engine against a competitor that may never bind, converting a cosmetic pidfile mismatch into a real outage, precisely in the multi-daemon boot this feature targets.

Now: ours is stopped **only after something else is confirmed answering**. And because the probe carries no pid (see below), a re-probe afterwards catches the case where ours *was* the one serving and the port goes dark with it — reported honestly instead of as a healthy `attached`.

## 3. `cacheUnsupported` was cleared against engines that never went away

`evaluate()`'s catch wraps the whole evaluation **including response parsing**, so one unparsable reply from a perfectly healthy engine reached the heal path exactly like a dead socket. With `afterFailure` set, that reset `cacheUnsupported` against the very same process that had already reported its clear-cache route missing — re-arming the doomed request and log line the degrade exists to suppress (#826).

`EngineProbe` carries `loaded`/`modelId`/`progress`/`state` — **no pid, no start time** — so a bare `attached` genuinely cannot distinguish a replacement from the same engine. Repair now probes first and does nothing when the engine is reachable, which makes down-then-up a real precondition rather than an assumption.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3741 pass, 69 skip, 0 fail
- [x] New: both-artifacts-stale and live-mutex cases for compare-then-delete
- [x] New: winner-never-answers (ours is not killed) and port-goes-dark-after-kill
- [x] New: a reachable engine is not treated as replaced after a failed eval
- [x] **Mutation-verified** each new guard

One note on method: my first version of the reachable-engine test passed with the guard disabled, because both paths reach "attached, no spawn" — the difference is only whether the engine-change decision fires. It now asserts on `engineChangeCount`, added because that decision is otherwise unobservable, and deciding it wrongly is exactly what this path must be held to.