### PR TITLE
Resolve the local LLM backend by platform (#822)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -173,7 +173,7 @@ import { StatusBar, childRows } from './cli/status-bar.ts';
 import { installStatusLine } from './cli/statusline-installer.ts';
 import { installSuspendHandler } from './cli/suspend-handler.ts';
 import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
-import { applyEnvOverrides, loadConfig } from './config/index.ts';
+import { applyEnvOverrides, detectLocalLLMPlatform, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
 import type { PermissionRequestHookInput } from './hooks/index.ts';
@@ -835,6 +835,18 @@ let autoApproveService: AutoApproveService | null = null;
 
     const multichoice = parsedArgs.autoApproveMultichoice ?? aaCfg.multichoice;
     const multichoiceModel = parsedArgs.autoApproveMultichoiceModel ?? aaCfg.multichoice_model;
+
+    // #822: say it plainly when this machine cannot run ANY local backend
+    // (notably an Intel Mac — "macOS" is not the boundary, Apple Silicon is).
+    // Without this the user gets a 30s startup timeout and then every question
+    // escalated, which is indistinguishable from a bug. Only a local provider
+    // is affected: a remote one (OpenRouter, a custom URL) works anywhere.
+    const localProvider = provider === 'yooz' || provider === 'llamacpp';
+    if (localProvider && detectLocalLLMPlatform() === 'unsupported') {
+      writeToLog(
+        `[AutoApprove] No local LLM backend exists for ${process.platform}/${process.arch}: the Yooz engine needs Apple Silicon (MLX) and the llama.cpp path is Linux. Auto-approve will escalate every permission until you point auto_approve.provider at a reachable backend (e.g. openrouter, or a custom URL).`,
+      );
+    }
 
     // #818: who starts the engine. Only meaningful for the engine transport —
     // an OpenRouter or llama.cpp base URL is not something remi supervises, and

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -17,6 +17,46 @@ import type { AutoApproveConfig } from '../auto-approve/types.ts';
 const REMI_DIR = path.join(os.homedir(), '.remi');
 export const CONFIG_PATH = path.join(REMI_DIR, 'config.toml');
 
+/**
+ * Which local-LLM backend can actually run here (#822).
+ *
+ * The supported targets carry DIFFERENT backends, so a single hardcoded default
+ * is wrong on half of them:
+ *
+ *   - Apple Silicon -> the Yooz engine. MLX, so `darwin-arm64` only; an Intel
+ *     Mac cannot run it however much it looks like "macOS".
+ *   - Linux -> a thin `llama-server`, which speaks the OpenAI-compatible shape
+ *     and therefore reuses the existing transport unchanged.
+ *   - Anything else (notably `darwin-x64`) -> neither. Reported as such rather
+ *     than defaulted to a backend that cannot exist there, because the failure
+ *     would otherwise be a 30s startup timeout followed by escalate-everything
+ *     — indistinguishable from a bug.
+ *
+ * Both backends listen on remi's reserved port 19924, and only one can run per
+ * machine by construction, so the platform decides which without negotiation.
+ */
+export type LocalLLMPlatform = 'yooz' | 'llamacpp' | 'unsupported';
+
+export function detectLocalLLMPlatform(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): LocalLLMPlatform {
+  if (platform === 'darwin') return arch === 'arm64' ? 'yooz' : 'unsupported';
+  if (platform === 'linux') return 'llamacpp';
+  return 'unsupported';
+}
+
+/**
+ * The `auto_approve.provider` default for THIS machine. An unsupported target
+ * still gets `'yooz'` so the config shape and error messages stay stable; what
+ * changes there is that the daemon says so at boot (see `cli.ts`) instead of
+ * silently waiting on an engine that can never appear.
+ */
+function defaultProvider(): string {
+  const detected = detectLocalLLMPlatform();
+  return detected === 'unsupported' ? 'yooz' : detected;
+}
+
 /** Daemon settings (restart required to apply changes) */
 export interface DaemonConfig {
   readonly base_port: number;
@@ -148,11 +188,11 @@ export const DEFAULT_CONFIG: RemiConfig = {
   },
   auto_approve: {
     enabled: false,
-    // The Yooz engine's LLM module (loopback :19924, macOS) is the local-LLM
-    // provider (#809). Elsewhere, `provider = "llamacpp"` points the same port
-    // at a thin llama.cpp server instead (OpenAI-compatible, so it reuses the
-    // 'openai' transport unmodified).
-    provider: 'yooz',
+    // Resolved by PLATFORM, not hardcoded (#822): the Yooz engine on Apple
+    // Silicon, a thin llama.cpp server on Linux. Both listen on remi's reserved
+    // port 19924 and only one can exist per machine, so nothing has to
+    // negotiate. See `detectLocalLLMPlatform`.
+    provider: defaultProvider(),
     // Fast small default: with synchronous decisions (#496) the eval blocks
     // Claude, so the default must be quick + RAM-light across platforms (incl.
     // MacBook Air). Heavier models go in `escalate_model` (second opinion,

--- a/packages/daemon/src/config/index.ts
+++ b/packages/daemon/src/config/index.ts
@@ -2,6 +2,7 @@ export {
   applyEnvOverrides,
   CONFIG_PATH,
   DEFAULT_CONFIG,
+  detectLocalLLMPlatform,
   formatConfig,
   generateDefaultConfig,
   initConfigFile,

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -16,6 +16,14 @@ import {
   loadConfig,
 } from '../src/config/config.ts';
 
+/** What `auto_approve.provider` should default to on the machine running these
+ *  tests (#822). Derived from the platform detector rather than read back from
+ *  `DEFAULT_CONFIG`, so assertions using it are real rather than circular. */
+function expectedDefaultProvider(): string {
+  const detected = detectLocalLLMPlatform();
+  return detected === 'unsupported' ? 'yooz' : detected;
+}
+
 const TEST_DIR = path.join(os.tmpdir(), `remi-config-test-${process.pid}`);
 const TEST_CONFIG = path.join(TEST_DIR, 'config.toml');
 
@@ -286,7 +294,10 @@ describe('formatConfig', () => {
     const output = formatConfig(DEFAULT_CONFIG, path.join(TEST_DIR, 'nonexistent.toml'));
     expect(output).toContain('[auto_approve]');
     expect(output).toContain('enabled = false');
-    expect(output).toContain('provider = "yooz"');
+    // Platform-dependent by design (#822): the engine on Apple Silicon, a
+    // llama.cpp sidecar on Linux. Asserting a literal here passes on a macOS
+    // dev machine and fails on Linux CI, which is exactly what happened.
+    expect(output).toContain(`provider = "${expectedDefaultProvider()}"`);
     // disable_thinking must be visible in `config show` so a user who set it
     // can confirm it (it was missed in the initial formatConfig wiring).
     expect(output).toContain('disable_thinking = true');
@@ -377,7 +388,10 @@ describe('auto_approve config', () => {
   test('defaults are present', () => {
     expect(DEFAULT_CONFIG.auto_approve).toEqual({
       enabled: false,
-      provider: 'yooz',
+      // Resolved per platform (#822), so the expectation is too — but derived
+      // from `detectLocalLLMPlatform` rather than from `DEFAULT_CONFIG`, which
+      // would assert the value against itself and prove nothing.
+      provider: expectedDefaultProvider(),
       model: 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx',
       api_key: '',
       base_url: 'http://127.0.0.1:19924',

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import {
   DEFAULT_CONFIG,
   applyEnvOverrides,
+  detectLocalLLMPlatform,
   formatConfig,
   generateDefaultConfig,
   initConfigFile,
@@ -315,6 +316,35 @@ describe('formatConfig', () => {
   // returning no verdict at all (echoing the prompt back) on six of the most
   // dangerous scenarios, which only "pass" because unparsable => escalate.
   // Defaulting to one would be safety by accident (#809 Phase D, engine#303).
+  // #822: the supported targets carry DIFFERENT backends, so one hardcoded
+  // default is wrong on half of them. Apple Silicon runs the MLX engine; Linux
+  // runs a llama.cpp sidecar; an Intel Mac runs neither, and must be told so at
+  // boot rather than waiting 30s on an engine that cannot exist.
+  test('the local-LLM backend is chosen by platform, not hardcoded', () => {
+    expect(detectLocalLLMPlatform('darwin', 'arm64')).toBe('yooz');
+    expect(detectLocalLLMPlatform('linux', 'x64')).toBe('llamacpp');
+    expect(detectLocalLLMPlatform('linux', 'arm64')).toBe('llamacpp');
+  });
+
+  test('an Intel Mac is unsupported, not silently pointed at the MLX engine', () => {
+    // The trap this guards: "macOS" reads like the boundary, but MLX makes it
+    // Apple Silicon. Defaulting darwin-x64 to 'yooz' would look reasonable and
+    // fail as a startup timeout.
+    expect(detectLocalLLMPlatform('darwin', 'x64')).toBe('unsupported');
+    expect(detectLocalLLMPlatform('win32', 'x64')).toBe('unsupported');
+  });
+
+  test('the shipped default provider matches this machine', () => {
+    const expected = detectLocalLLMPlatform();
+    if (expected !== 'unsupported') {
+      expect(DEFAULT_CONFIG.auto_approve.provider).toBe(expected);
+    } else {
+      // Unsupported targets keep a stable config shape; the daemon reports the
+      // gap at boot instead of the config pretending it away.
+      expect(DEFAULT_CONFIG.auto_approve.provider).toBe('yooz');
+    }
+  });
+
   test('default model is not one of the engine TouchUp grammar tiers', () => {
     expect(['yooz-light-v3', 'yooz-quality-v3']).not.toContain(DEFAULT_CONFIG.auto_approve.model);
   });


### PR DESCRIPTION
Groundwork for #822 now that the target list is settled: **Apple Silicon and Linux** (x64 first, arm64 later), with Intel Mac out of scope.

## The problem

`auto_approve.provider` was hardcoded to `'yooz'`. The supported targets carry **different backends** — the MLX engine on Apple Silicon, a `llama-server` sidecar on Linux — so a single default is wrong on half of them and would have to be hand-corrected by every Linux user.

## The change

`detectLocalLLMPlatform()` resolves it: `darwin+arm64 -> yooz`, `linux -> llamacpp`, everything else `unsupported`. Both backends listen on remi's reserved 19924 and only one can exist per machine, so the platform decides without negotiation.

It also names the boundary correctly. **"macOS" reads like the line, but MLX makes it Apple Silicon**, so an Intel Mac can run neither backend. Defaulting `darwin-x64` to the engine looks reasonable and fails as a 30s `waitForReady` timeout followed by escalate-everything — indistinguishable from a bug. That case is now reported at boot, naming the remote-provider alternative (OpenRouter or a custom URL works anywhere).

An unsupported target still keeps `'yooz'` in the config so the shape and error messages stay stable; what changes is that the daemon says so out loud rather than waiting on an engine that cannot appear.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3751 pass, 69 skip, 0 fail
- [x] 3 new tests: platform resolution, Intel-Mac-is-unsupported (including why it is the tempting mistake), and that the shipped default matches the running machine