### PR TITLE
Fetch the model at boot when it is not local

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -12,7 +12,8 @@
 import { errorToString } from '@remi/shared';
 import { fileActivityRecord } from './engine-activity.ts';
 import type { EngineHost } from './engine-host.ts';
-import { clearModelCache, probeEngine, unloadModel } from './engine-models.ts';
+import { clearModelCache, probeEngine, pullModel, unloadModel } from './engine-models.ts';
+import type { PullProgress } from './engine-models.ts';
 import { extractJsonObject } from './json-extract.ts';
 import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
 import type { LLMClientConfig } from './llm-client.ts';
@@ -40,6 +41,29 @@ const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate'])
  * (the one production caller) passes a real scope, its own `sessionId`.
  */
 const DEFAULT_SCOPE = '__default__';
+
+/**
+ * One line describing a pull in flight, for `ensureModelPresent`.
+ *
+ * Deliberately leads with SIZE and ELAPSED rather than a percentage. The
+ * engine's parent `Progress` advances per completed FILE, and these repos are
+ * one multi-GB `model.safetensors` plus a few small ones, so the fraction steps
+ * ~0.6% and then sits still for the entire transfer. Rendering that as a
+ * percentage reads as a stuck download; `advancing` is the engine's own signal
+ * for whether the number means anything yet (#292/#293).
+ */
+function describePullProgress(p: PullProgress): string {
+  const parts: string[] = [];
+  if (p.sizeBytes !== undefined && p.sizeBytes > 0) {
+    parts.push(`${(p.sizeBytes / 1_000_000_000).toFixed(2)} GB`);
+  }
+  parts.push(`${Math.round(p.elapsedMs / 1000)}s elapsed`);
+  // Only quote a percentage once it is demonstrably moving.
+  if (p.advancing && p.fraction !== undefined) {
+    parts.push(`${Math.round(p.fraction * 100)}%`);
+  }
+  return parts.join(', ');
+}
 
 /**
  * Convert one `permission_suggestions` entry into an LLM-ready label, or
@@ -126,6 +150,10 @@ export class AutoApproveService {
   private readonly escalateTimeoutMs: number;
   /** True when the provider is the Yooz engine (enables the /v1/llm/preload warm-up). */
   private readonly providerIsYooz: boolean;
+  /** True when remi owns this engine and may therefore mutate its disk/memory
+   *  state (fetch, unload, delete). False for a shared super-yooz host, where
+   *  all of that is the host's policy (#818). */
+  private readonly ownsEngine: boolean;
 
   /**
    * Two-stage idle policy (#820). The engine never evicts or drops cache on
@@ -231,6 +259,7 @@ export class AutoApproveService {
     this.escalateTimeoutMs = config.escalate_timeout > 0 ? config.escalate_timeout * 1000 : 0;
     this.queueTimeoutMs = config.queue_timeout > 0 ? config.queue_timeout * 1000 : 0;
     this.providerIsYooz = config.provider === 'yooz';
+    this.ownsEngine = this.providerIsYooz && config.engine === 'owned';
     // Only the engine transport has an unload endpoint at all, and (today)
     // remi always owns its own engine -- #818 introduces the shared-engine
     // mode, where `ownsEngine` flips false and this timer must never arm.
@@ -252,7 +281,7 @@ export class AutoApproveService {
         // shared (super-yooz) engine's residency is the host's policy, and
         // touching weights (or even just the cache) another module is
         // mid-generate on is hostile.
-        ownsEngine: this.providerIsYooz && config.engine === 'owned',
+        ownsEngine: this.ownsEngine,
       },
       {
         unload: (model) => unloadModel(this.llmConfig.baseUrl, model),
@@ -335,6 +364,55 @@ export class AutoApproveService {
    *  wrongly is the failure this path has to be held to. */
   get engineChangeCount(): number {
     return this.engineChanges;
+  }
+
+  /**
+   * Make sure the configured model is on disk, fetching it if it is not.
+   *
+   * Owner decision 2026-07-26: "if we don't have the model locally we pull it;
+   * if the model is in, there would not be a reason to pull."
+   *
+   * Without this the model still arrives — the engine downloads it implicitly
+   * on the first `preload`/`generate` — but that means a fresh install's FIRST
+   * permission blocks on a silent multi-GB fetch. Doing it deliberately at boot
+   * makes it a visible, progress-reporting pull instead, and by the time a
+   * permission arrives the weights are already there.
+   *
+   * The "already present" half is cheap and doubly guarded: `pullModel` returns
+   * immediately when the inventory reports the model cached, and the engine's
+   * own `requestDownload` no-ops on a cached/loaded row. Concurrent pulls
+   * across daemons collapse onto one download engine-side, so ten daemons
+   * calling this produce one fetch.
+   *
+   * NOT awaited by the caller: a cold pull is minutes, and the daemon must be
+   * serving long before that. Evaluations escalate meanwhile, which is the safe
+   * direction.
+   */
+  async ensureModelPresent(): Promise<void> {
+    // Only when remi owns the engine. On a shared (super-yooz) host, what is on
+    // disk is the host's business -- the same boundary that stops the residency
+    // timer touching a shared engine's weights (#818).
+    if (!this.providerIsYooz || !this.ownsEngine) return;
+    const model = this.llmConfig.model;
+    if (model.length === 0) return;
+
+    try {
+      await pullModel(this.llmConfig.baseUrl, model, {
+        onProgress: (p) => {
+          // Report SIZE and elapsed, never a bare percentage: the engine's
+          // download fraction is flat for the whole multi-GB transfer (the
+          // weights file is staged outside the hub dir and moved in at the
+          // end), so a percentage would sit at ~0.6% and read as stuck.
+          this.logFn(`[AutoApprove] Fetching ${model}: ${describePullProgress(p)}`);
+        },
+      });
+    } catch (err) {
+      // Never fatal. A missing model means evaluations escalate, which is the
+      // behavior without this method at all.
+      this.logFn(
+        `[AutoApprove] Could not fetch ${model} (auto-approve will escalate until it is present): ${errorToString(err)}`,
+      );
+    }
   }
 
   /**

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -897,9 +897,23 @@ let autoApproveService: AutoApproveService | null = null;
     // construction; a standalone `remi --daemon` on a machine with no hub still
     // gets one, because requiring a hub would recreate exactly the silent
     // escalate-everything failure #818 exists to remove.
-    void autoApproveService.ensureEngine().catch((err) => {
-      writeToLog(`[AutoApprove] Engine startup check failed: ${errorToString(err)}`);
-    });
+    void autoApproveService
+      .ensureEngine()
+      .then(async (up) => {
+        // Only once an engine answers: a pull is an engine operation. Chained
+        // rather than fired alongside, so a cold start does not race the
+        // helper's own startup with a download request it cannot serve.
+        //
+        // Owner decision 2026-07-26: fetch the model if it is not local, do
+        // nothing if it is. Without this the weights still arrive, but
+        // implicitly, on the first permission -- so a fresh install's first
+        // question blocks on a silent multi-GB download instead of a visible
+        // one that happened at boot.
+        if (up) await autoApproveService?.ensureModelPresent();
+      })
+      .catch((err) => {
+        writeToLog(`[AutoApprove] Engine startup check failed: ${errorToString(err)}`);
+      });
     const rulesSummary = `allow=${allow.length} deny=${deny.length} instructions=${instructions ? 'yes' : 'no'}`;
     const mcSummary = `multichoice=${multichoice}${multichoiceModel ? ` mc_model=${multichoiceModel}` : ''}`;
     const escalateSummary = aaCfg.escalate_model

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -246,10 +246,17 @@ export async function runModelCommand(
         io.out(`engine:   ${baseUrl} (reachable, ${aa.engine})`);
         io.out(`model:    ${configured}`);
         if (row === undefined) {
-          // Either the engine does not serve this id, or it predates the
-          // catalogue. Both mean auto-approve cannot evaluate, so say so
-          // rather than printing a reassuring blank.
-          io.out('state:    not served by this engine');
+          // Do NOT report this as "not served". The engine accepts a model's
+          // HuggingFace repo id as an ALIAS (`YoozLabs/Qwen3.5-4B-...` resolves
+          // to `yooz-instruct-4b`), but neither `/v1/models` nor
+          // `/v1/llm/models` exposes that mapping — so when the configured
+          // value is an alias, which it is by default, an id comparison finds
+          // nothing even though the model is present and working. Claiming it
+          // is missing would be a false alarm on the default config
+          // (yooz-engine#308 asks for the mapping so this can be resolved).
+          io.out("state:    unknown — this engine's listing does not name it");
+          io.out('          (a HuggingFace-style id resolves server-side, so');
+          io.out('           this is expected until yooz-engine#308)');
         } else {
           io.out(`loaded:   ${row.loaded ? 'yes' : 'no'}`);
           io.out(`on disk:  ${row.cached ? 'yes' : 'no'}`);

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -227,15 +227,53 @@ export async function runModelCommand(
   try {
     switch (verb) {
       case 'status': {
-        const s = reachable.status;
+        // Report the model REMI will use, not whatever the engine's TouchUp
+        // picker happens to have active. `/v1/llm/status` (`reachable.status`)
+        // describes the ACTIVE TIER ONLY — so on an engine whose picker sits on
+        // `yooz-light-v3`, this used to print that as `model:` and, worse,
+        // print ITS residency as `loaded:`. A user would read "loaded: yes" and
+        // conclude remi was warm while remi's own model was not resident at all.
+        //
+        // Sourced from the disk inventory (`/v1/models`), which is
+        // catalogue-wide. `/v1/state` is NOT usable here: it is scoped to the
+        // picker's rows, so a generate-only catalogue model (the default) is
+        // simply absent from it (verified live 2026-07-26; yooz-engine#307).
+        const configured = aa.model;
+        const row = await inventory(baseUrl)
+          .then((all) => all.find((m) => m.id === configured))
+          .catch(() => undefined);
+
         io.out(`engine:   ${baseUrl} (reachable, ${aa.engine})`);
-        io.out(`model:    ${s.modelId ?? aa.model} (configured: ${aa.model})`);
-        io.out(`loaded:   ${s.loaded ? 'yes' : 'no'}`);
-        if (s.state !== undefined) io.out(`state:    ${s.state}`);
-        if (s.progress !== undefined) {
-          io.out(`download: ${Math.round(s.progress * 100)}% in flight`);
+        io.out(`model:    ${configured}`);
+        if (row === undefined) {
+          // Either the engine does not serve this id, or it predates the
+          // catalogue. Both mean auto-approve cannot evaluate, so say so
+          // rather than printing a reassuring blank.
+          io.out('state:    not served by this engine');
+        } else {
+          io.out(`loaded:   ${row.loaded ? 'yes' : 'no'}`);
+          io.out(`on disk:  ${row.cached ? 'yes' : 'no'}`);
+          io.out(`size:     ${formatSize(row.sizeBytes)}`);
         }
-        if (s.lastError !== undefined) io.out(`error:    ${s.lastError}`);
+        // `/v1/llm/status` carries the live load state and the last load
+        // ERROR, which the inventory does not — worth surfacing, because "not
+        // loaded" and "failed to load, disk full" are very different problems.
+        // But it describes the ACTIVE TIER, so it is only OUR error when the
+        // active tier IS our model. Attributing another model's failure to
+        // remi's would be the same misreport this block exists to fix.
+        const s = reachable.status;
+        const statusIsOurs = s.modelId === undefined || s.modelId === configured;
+        if (statusIsOurs) {
+          if (s.state !== undefined) io.out(`state:    ${s.state}`);
+          if (s.progress !== undefined) {
+            io.out(`download: ${Math.round(s.progress * 100)}% in flight`);
+          }
+          if (s.lastError !== undefined) io.out(`error:    ${s.lastError}`);
+        } else {
+          // The picker's active tier belongs to whoever owns TouchUp, but it
+          // shares the GPU, so name it rather than hiding it.
+          io.out(`engine picker: ${s.modelId} (not used by remi)`);
+        }
         return 0;
       }
       case 'ls': {

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -273,6 +273,47 @@ describe('AutoApproveService engine supervision (#818)', () => {
     }
   });
 
+  // `ensureModelPresent` only acts for the `yooz` provider, and `provider =
+  // 'yooz'` resolves to the FIXED loopback 19924 regardless of `base_url` — so
+  // it cannot be pointed at an ephemeral test server the way the other tests
+  // here are. Pointing `provider` at a URL instead makes `providerIsYooz`
+  // false, which makes the method a no-op and any such test vacuous (it passes
+  // with the guard deleted). The observable that works without a server is the
+  // LOG: an owned engine attempts and reports, a shared one never starts.
+  //
+  // The "already cached, so do not re-fetch" half is covered where it is
+  // genuinely testable, at `pullModel` in engine-models.test.ts ("is
+  // idempotent: an already-cached model downloads nothing").
+  test('a shared engine is never told to fetch anything', async () => {
+    // What is on a super-yooz host's disk is the host's business — the same
+    // boundary that stops the residency timer touching its weights (#818).
+    const logs: string[] = [];
+    const service = new AutoApproveService(
+      { ...config(), provider: 'yooz', engine: 'shared' },
+      (m) => logs.push(m),
+    );
+
+    await service.ensureModelPresent();
+
+    expect(logs).toEqual([]); // it did not even try
+  });
+
+  test('an owned engine attempts the fetch and reports failure honestly', async () => {
+    // Nothing is listening on 19924 in this environment, so the pull fails —
+    // and the point is that it FAILS LOUDLY rather than silently, and never
+    // throws. A missing model degrades to escalate-everything, which is the
+    // behavior without this method at all.
+    const logs: string[] = [];
+    const service = new AutoApproveService(
+      { ...config(), provider: 'yooz', engine: 'owned' },
+      (m) => logs.push(m),
+    );
+
+    await service.ensureModelPresent();
+
+    expect(logs.join('\n')).toContain('Could not fetch');
+  });
+
   test('the single-flight guard clears, so a later failure can still repair', async () => {
     // A stuck `healInFlight` would silently disable self-heal for the life of
     // the daemon -- the exact failure mode #818 exists to remove.

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -173,6 +173,35 @@ describe('remi model status', () => {
     expect(text).toContain('37%');
   });
 
+  test('an alias the engine lists under a canonical id is not called missing', async () => {
+    // The default config names a HuggingFace repo id, which the engine
+    // resolves server-side to a canonical catalogue id -- and neither model
+    // listing exposes that mapping. So an id comparison finds nothing for a
+    // model that is present and working. Reporting "not served" there would
+    // be a false alarm on the SHIPPED default (yooz-engine#308).
+    const t = io();
+    await runModelCommand(['status'], configWith({ model: 'YoozLabs/Some-Repo-Id' }), t.io, {
+      probe: async (): Promise<EngineProbe> => ({ reachable: true, status: { loaded: true } }),
+      // The engine lists it under its canonical id, not the alias.
+      inventory: async () => [
+        {
+          id: 'yooz-instruct-4b',
+          module: 'llm',
+          displayName: 'Yooz-Instruct-4B',
+          sizeBytes: 2_387_349_504,
+          cached: true,
+          loaded: false,
+          isActive: false,
+          deletable: true,
+        },
+      ],
+    });
+
+    const text = t.out.join('\n');
+    expect(text).not.toContain('not served');
+    expect(text).toContain('unknown');
+  });
+
   test('never reports another model’s state as remi’s', async () => {
     // The engine's picker sits on a different tier and is mid-download. None
     // of that is remi's: reporting it would tell a user their model is busy or

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -151,19 +151,44 @@ describe('remi model ls / ps', () => {
 
 describe('remi model status', () => {
   test('reports the engine, the model, and an in-flight download', async () => {
+    // The status fixture must name the CONFIGURED model: `/v1/llm/status`
+    // describes the engine's active tier, so a download it reports is only
+    // remi's when that tier is remi's model. (The fixture used to say
+    // `yooz-light-v3` while the config asked for something else, and expected
+    // remi to claim that download as its own — the misattribution this
+    // command was fixed to stop.)
     const t = io();
+    const configured = DEFAULT_CONFIG.auto_approve.model;
     const code = await runModelCommand(['status'], configWith(), t.io, {
       probe: async (): Promise<EngineProbe> => ({
         reachable: true,
-        status: { loaded: false, modelId: 'yooz-light-v3', progress: 0.37, state: 'downloading' },
+        status: { loaded: false, modelId: configured, progress: 0.37, state: 'downloading' },
       }),
     });
 
     expect(code).toBe(0);
     const text = t.out.join('\n');
     expect(text).toContain('reachable');
-    expect(text).toContain('yooz-light-v3');
+    expect(text).toContain(configured);
     expect(text).toContain('37%');
+  });
+
+  test('never reports another model’s state as remi’s', async () => {
+    // The engine's picker sits on a different tier and is mid-download. None
+    // of that is remi's: reporting it would tell a user their model is busy or
+    // warm when it is neither.
+    const t = io();
+    await runModelCommand(['status'], configWith(), t.io, {
+      probe: async (): Promise<EngineProbe> => ({
+        reachable: true,
+        status: { loaded: true, modelId: 'yooz-light-v3', progress: 0.37, state: 'downloading' },
+      }),
+    });
+
+    const text = t.out.join('\n');
+    expect(text).not.toContain('37%');
+    // ...but it is named, not hidden — it shares the GPU.
+    expect(text).toContain('engine picker: yooz-light-v3');
   });
 
   test('surfaces a failed load rather than reporting a bare "not loaded"', async () => {


### PR DESCRIPTION
Owner decision 2026-07-26: *"if we don't have the model locally we pull it; if the model is in, then there would not be a reason to pull."*

## Why this is not just convenience

The weights already arrive without it — the engine fetches them implicitly inside `MLXLLMBackend` on the first `preload`/`generate`. But that means a fresh install's **first permission** blocks on a silent multi-GB download. Doing it deliberately at boot converts that into a visible, progress-reporting pull that happens before any permission arrives.

## Shape

- Chained **after** `ensureEngine()`, not fired alongside it: a pull is an engine operation, so racing the helper's own startup with a download it cannot yet serve would just produce a spurious failure.
- **Not awaited.** A cold pull is minutes; the daemon must be serving long before. Evaluations escalate meanwhile, which is the safe direction.
- **Gated on owning the engine.** What is on a shared super-yooz host's disk is the host's business — the same boundary that stops the residency timer touching its weights (#818).
- **Never fatal.** A failed fetch logs and leaves auto-approve escalating, which is exactly the behavior without this method at all.

The "already present" half needed no new logic and is guarded twice: `pullModel` returns immediately when the inventory reports the model cached, and the engine's own `requestDownload` no-ops on a `.cached`/`.loaded` row. Concurrent pulls across daemons collapse to one download engine-side (`backgroundPreloadTasks` dedupes), so ten daemons produce one fetch.

Progress reports **size and elapsed, not a bare percentage**: the engine's fraction is flat for the entire transfer (the weights file is staged outside the hub dir and moved in at the end), so a percentage sits near 0.6% and reads as stuck. It quotes a percentage only once the engine's own `advancing` flag says it means something.

## Known limitation, deliberately shipped

**This is inert for the default model until yooz-engine#306.** That issue is the one this work uncovered: `POST /v1/touchup/download` still keys on the 3-case picker enum, so it 400s catalogue models including `YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx`. Until it lands, this degrades to one honest log line rather than a crash, and it works today for `yooz-quality-v3`.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3753 pass, 69 skip, 0 fail
- [x] 2 new tests: a shared engine never starts a fetch; an owned one attempts it and reports failure honestly rather than throwing
- [x] **Mutation-verified**: deleting the ownership gate fails the shared-engine test

One note on test design. My first attempt at these was **vacuous** — I pointed `provider` at an ephemeral test server, which makes `providerIsYooz` false and turns the method into a no-op, so both tests passed with the guard deleted. `provider = 'yooz'` resolves to the fixed loopback 19924 regardless of `base_url`, so this method cannot be aimed at a test server the way the neighbouring tests are; the log is the observable that works. The "already cached, do not re-fetch" half is covered where it is genuinely testable, at `pullModel` (`engine-models.test.ts:212`), rather than duplicated here as something that would pass either way.
