### PR TITLE
Stop disowning our own model when it is named by alias

### DIFF
--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -89,6 +89,22 @@ function isVerb(s: string | undefined): s is Verb {
  *  rows whose on-disk footprint it cannot measure (observed on swept hub
  *  directories), and "0 MB" reads as "this is empty" rather than "we don't
  *  know". */
+/**
+ * Does this look like a HuggingFace repo id rather than a canonical engine id?
+ *
+ * The engine accepts both — `YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx` resolves to
+ * `yooz-instruct-4b` — but exposes the mapping nowhere (yooz-engine#308), so
+ * remi cannot resolve one to the other. The `owner/name` slash is the only
+ * available signal, and it is enough for the one thing it is used for: knowing
+ * when an id comparison CANNOT be trusted to mean two different models.
+ *
+ * Deliberately conservative. A false positive costs an honest "cannot tell";
+ * a false negative costs a confident wrong answer.
+ */
+function looksLikeAlias(id: string): boolean {
+  return id.includes('/');
+}
+
 function formatSize(bytes: number | undefined): string {
   if (bytes === undefined || bytes === 0) return '-';
   const gb = bytes / 1e9;
@@ -269,6 +285,11 @@ export async function runModelCommand(
         // active tier IS our model. Attributing another model's failure to
         // remi's would be the same misreport this block exists to fix.
         const s = reachable.status;
+        // `modelId` is absent only from a malformed response in practice — the
+        // engine populates it unconditionally from a non-optional enum that
+        // always has a value, and `engineRequest` throws on an unparsable body
+        // before we get here. It is typed optional defensively, so treat an
+        // absent one as ours: there would be no other model it could describe.
         const statusIsOurs = s.modelId === undefined || s.modelId === configured;
         if (statusIsOurs) {
           if (s.state !== undefined) io.out(`state:    ${s.state}`);
@@ -276,9 +297,20 @@ export async function runModelCommand(
             io.out(`download: ${Math.round(s.progress * 100)}% in flight`);
           }
           if (s.lastError !== undefined) io.out(`error:    ${s.lastError}`);
+        } else if (looksLikeAlias(configured)) {
+          // A MISMATCH IS NOT A DIFFERENCE when our id is an alias. `modelId`
+          // is always canonical, `configured` may be a HuggingFace repo id, and
+          // nothing exposes the mapping (yooz-engine#308) -- so these two can
+          // name the SAME model and still compare unequal. Claiming "not used
+          // by remi" here is a live false negative: configure the picker tier
+          // by its HF id and remi disowns its own model.
+          io.out(`engine picker: ${s.modelId}`);
+          io.out('          (cannot tell whether this is your model: it is named');
+          io.out('           canonically and yours is an alias — yooz-engine#308)');
         } else {
-          // The picker's active tier belongs to whoever owns TouchUp, but it
-          // shares the GPU, so name it rather than hiding it.
+          // Both canonical, genuinely different. The picker's active tier
+          // belongs to whoever owns TouchUp, but it shares the GPU, so name it
+          // rather than hiding it.
           io.out(`engine picker: ${s.modelId} (not used by remi)`);
         }
         return 0;

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -202,6 +202,35 @@ describe('remi model status', () => {
     expect(text).toContain('unknown');
   });
 
+  test('does not disown remi’s own model when it is configured by alias', async () => {
+    // Live repro: configure a TouchUp tier by its HuggingFace id. `modelId` is
+    // always canonical (`yooz-light-v3`), `configured` is the alias, and
+    // nothing exposes the mapping — so the ids compare unequal for the SAME
+    // model, and the old code concluded "not used by remi" about remi's own
+    // model. Two spellings of one model gave two different answers, one wrong.
+    //
+    // The default config hides this: `yooz-instruct-4b` can never be a picker
+    // `modelId` (it is not a TouchUpModelSelection case), so every mismatch
+    // there is a real one by coincidence.
+    const t = io();
+    await runModelCommand(
+      ['status'],
+      configWith({ model: 'YoozLabs/Yooz-Light-v3-Qwen3.5-0.8B' }),
+      t.io,
+      {
+        probe: async (): Promise<EngineProbe> => ({
+          reachable: true,
+          status: { loaded: true, modelId: 'yooz-light-v3', state: 'idle' },
+        }),
+        inventory: async () => [],
+      },
+    );
+
+    const text = t.out.join('\n');
+    expect(text).not.toContain('not used by remi');
+    expect(text).toContain('cannot tell');
+  });
+
   test('never reports another model’s state as remi’s', async () => {
     // The engine's picker sits on a different tier and is mid-download. None
     // of that is remi's: reporting it would tell a user their model is busy or


### PR DESCRIPTION
Follow-up to #836, found in review of it. Same root cause as the bug fixed there, second instance, a few lines below — I fixed one and left the other.

## The bug

```ts
const statusIsOurs = s.modelId === undefined || s.modelId === configured;
```

`s.modelId` (from `/v1/llm/status`) is **always a canonical picker id**. `configured` may be a **HuggingFace repo id**, because the engine accepts both and that is a perfectly ordinary way to write the config — it is how the shipped default is written. Nothing exposes the mapping (yooz-engine#308), so the two can name the **same model** and still compare unequal.

The old code read that mismatch as "different model" and printed `engine picker: yooz-light-v3 (not used by remi)` — about remi's own model.

## Why it was invisible

The default config cannot trigger it. `yooz-instruct-4b` is not a `TouchUpModelSelection` case, so it can never be the picker's `modelId`; every mismatch under the default is a genuine one, by coincidence rather than by logic.

It needs a **TouchUp tier configured by its alias** — equally legitimate, since alias resolution exists precisely to support both spellings. Live repro from the review, one engine, one model, two spellings:

```
$ REMI_AUTO_APPROVE_MODEL="YoozLabs/Yooz-Light-v3-Qwen3.5-0.8B" remi model status
engine picker: yooz-light-v3 (not used by remi)     <-- WRONG, this IS remi's model

$ REMI_AUTO_APPROVE_MODEL="yooz-light-v3" remi model status
loaded:   yes / on disk: yes / state: idle          <-- correct
```

## The fix

A mismatch is reported as a different model **only when both ids are canonical**. When ours is an alias, remi cannot know, and says so — the same honesty the inventory lookup got in #836 rather than a confident wrong answer.

`looksLikeAlias` is a slash check. Deliberately conservative: a false positive costs an honest "cannot tell", a false negative costs a confident wrong answer.

Also records, in a comment, why an absent `modelId` is treated as ours — the engine populates it unconditionally from a non-optional enum with a default, so it is defensive typing rather than a reachable case. That assumption was true by inspection and unwritten; now it is written.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3756 pass, 69 skip, 0 fail
- [x] New test uses the reviewer's exact repro (TouchUp tier by alias), which is the only combination that can collide
- [x] **Mutation-verified**: disabling the alias branch fails it

The real fix is yooz-engine#308 — expose the alias mapping so remi can resolve rather than guess. Until then, honest uncertainty beats a confident wrong answer.
