### PR TITLE
Close the auto-approve delivery gap: fetch the helper, plus 0.6.25 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 All notable changes to Remi are documented here.
 
+## [0.6.25] - 2026-07-26
+
+Replaces ollama with the Yooz engine as the local-LLM backend for
+auto-approve. The measured result is a faster and safer evaluator: the
+default model scores 38/38 on the permission grid with zero unsafe
+approvals and a p95 of 2.26s, against 12.2s for the ollama-era default.
+
+### Breaking
+- **`auto_approve.provider = "ollama"` is no longer valid** (#809). ollama
+  support is removed outright — no compatibility shim and no silent
+  fallback — so a config that still names it fails to load with an
+  actionable message, and that stops **every** remi command until it is
+  edited, not just auto-approve. Change it to `"yooz"` on Apple Silicon or
+  `"llamacpp"` on Linux, and set `model` to an id the chosen backend
+  serves. If you never enabled auto-approve, nothing changes for you: it
+  remains off by default.
+
+### Added
+- **Yooz engine transport** (#809): auto-approve talks to the engine's
+  `/v1/llm/generate` on remi's reserved loopback port 19924.
+- **`remi model`** (#819): `ls`, `ps`, `status`, `pull`, `cancel`, `rm`,
+  `cleanup`, `load`, `unload`, `use` for managing the models auto-approve
+  runs on. `use` persists your choice; every verb degrades with a clear
+  message, in milliseconds, when no engine is answering.
+- **Engine supervision** (#818): remi starts its own engine when none is
+  running, attaches to one that already is regardless of who started it,
+  and repairs after a crash on the next evaluation. The engine is detached
+  on purpose — one session quitting must not take auto-approve down for
+  the others. Requires `auto_approve.engine_path`; unset (the default), remi
+  still attaches to a running engine and reports the gap rather than
+  failing silently.
+- **The model is fetched at boot when it is absent, and left alone when it
+  is present** (#834): so a fresh install does not block its first
+  permission on a multi-GB download.
+- **Two-stage idle memory policy** (#820): after `cache_idle` (5 min) the
+  prompt cache is dropped, after `keep_alive` (30 min) the weights are
+  unloaded. Coordinated machine-wide, so ten sessions sharing one engine do
+  not evict each other's work.
+- **`auto_approve.model_cache`**: where the engine downloads weights, for
+  pointing them at an external HuggingFace cache.
+
+### Changed
+- **Reasoning is off by default** (#822). Not a tuning preference: measured
+  against a 0.8B model, an unsuppressed one spent its whole token budget
+  reasoning and returned no content at all, turning every evaluation into
+  an error.
+- **The backend is chosen by platform** (#822): the engine on Apple
+  Silicon, a llama.cpp server on Linux. An Intel Mac can run neither and is
+  now told so at boot instead of waiting on an engine that cannot exist.
+- **The default model is not a TouchUp tier.** `yooz-quality-v3` also
+  reads 38/38, but six of those are responses carrying no verdict at all —
+  it echoes the prompt back — and they "pass" only because an unparsable
+  response is treated as escalate. The six are `rm -rf /`, a `dd` disk
+  wipe, `chmod 777 /etc`, `base64 | bash`, `eval $X`, and a reverse shell.
+  Safety by accident is not safety.
+
+### Fixed
+- **Neither the cache nor the weights are dropped mid-evaluation** (#827).
+  The idle policy claimed a long evaluation kept pushing its deadline out;
+  it did not, and a slow evaluation could have its cache pulled out from
+  under it. Now tracked explicitly, across daemons as well as within one.
+- **`remi model status` reports your model** (#836), not whichever tier the
+  engine's picker happens to have active — it could previously say
+  "loaded: yes" about a different model entirely.
+- **A model named by its HuggingFace id is no longer reported as missing or
+  disowned** (#837): the engine accepts both spellings but exposes no
+  mapping between them, so remi now says it cannot tell rather than
+  answering confidently and wrongly.
+
 ## [0.6.24] - 2026-07-25
 
 Finishes the subagent permission story started in 0.6.23: a background

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -12,7 +12,7 @@
 import { errorToString } from '@remi/shared';
 import { fileActivityRecord } from './engine-activity.ts';
 import type { EngineHost } from './engine-host.ts';
-import { clearModelCache, probeEngine, pullModel, unloadModel } from './engine-models.ts';
+import { clearModelCache, pullModel, unloadModel } from './engine-models.ts';
 import type { PullProgress } from './engine-models.ts';
 import { extractJsonObject } from './json-extract.ts';
 import { chatCompletion, resolveProviderUrl, warmModel } from './llm-client.ts';
@@ -430,10 +430,14 @@ export class AutoApproveService {
    * rather than an assumption, which is what licenses `afterFailure` below.
    */
   private async repairIfUnreachable(): Promise<boolean> {
-    const probe = await probeEngine(this.llmConfig.baseUrl);
+    // Through the host's seam, not the module-level `probeEngine`: the host
+    // already owns an injectable probe, and bypassing it made this path do a
+    // real network connect (with a real timeout) inside unit tests.
+    const host = this.engineHost;
+    const reachable = host === undefined ? false : await host.probeOnce();
     // Reachable => the process never went anywhere; the failure was about this
     // request, not about the engine. Nothing to repair, nothing new to learn.
-    if (probe.reachable) return true;
+    if (reachable) return true;
     return await this.ensureEngine({ afterFailure: true });
   }
 

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -63,6 +63,7 @@
  */
 
 import { errorToString } from '@remi/shared';
+import { ensureHelperInstalled, resolveHelperPath } from './engine-install.ts';
 import { probeEngine } from './engine-models.ts';
 
 /** How remi relates to the engine on its port. */
@@ -107,6 +108,16 @@ export interface EngineHostDeps {
   readonly sleep?: (ms: number) => Promise<void>;
   /** Pidfile seam (`~/.remi/engine.pid` in production). */
   readonly pidStore?: PidStore;
+  /**
+   * Helper-acquisition seam (#834). The real one fetches the pinned engine
+   * release; an injected one keeps tests off the network. Returns the
+   * executable path, or undefined when no helper could be obtained.
+   *
+   * Injectable for the same reason `spawn` and `probe` are: without it this
+   * class reaches the internet during a unit test, which is both slow and a
+   * dependency nobody declared.
+   */
+  readonly installHelper?: () => Promise<string | undefined>;
 }
 
 /**
@@ -135,12 +146,15 @@ export class EngineHost {
   /** The pid THIS process started, if any. Not a child handle: the engine is
    *  detached and outlives us. */
   private startedPid: number | null = null;
+  /** In-flight helper download, so concurrent callers share one fetch. */
+  private installInFlight: Promise<string | undefined> | undefined;
   private readonly log: EngineHostDeps['log'];
   private readonly probe: typeof probeEngine;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly spawnFn: EngineHostDeps['spawn'];
   private readonly killFn: (pid: number) => void;
   private readonly pids: PidStore | undefined;
+  private readonly installFn: () => Promise<string | undefined>;
 
   constructor(
     private readonly config: EngineHostConfig,
@@ -152,6 +166,7 @@ export class EngineHost {
     this.spawnFn = deps.spawn;
     this.killFn = deps.kill ?? ((pid) => process.kill(pid));
     this.pids = deps.pidStore;
+    this.installFn = deps.installHelper ?? (() => ensureHelperInstalled({ log: this.log }));
   }
 
   /** True when remi may load/unload/delete models on this engine. The single
@@ -159,6 +174,18 @@ export class EngineHost {
    *  unload`/`rm`). */
   get ownsEngine(): boolean {
     return this.config.ownership === 'owned';
+  }
+
+  /**
+   * One reachability probe through this host's own seam.
+   *
+   * Exposed so callers that need to ask "is the engine actually down?" reuse
+   * the injected probe rather than reaching for the module-level one. A caller
+   * that bypasses this seam turns its own unit tests into network calls, with a
+   * real connect timeout in the middle of them.
+   */
+  async probeOnce(): Promise<boolean> {
+    return (await this.probe(this.config.baseUrl)).reachable;
   }
 
   /** The pid this process started, or null when it attached to an existing
@@ -190,9 +217,18 @@ export class EngineHost {
       return { kind: 'unavailable', reason };
     }
 
-    const helperPath = this.config.helperPath;
+    // Resolve, then acquire. `engine_path` wins when set -- someone pointing at
+    // their own build is making a deliberate choice and must not have it
+    // second-guessed by a download. Otherwise use the helper remi has already
+    // installed, and failing that fetch it once (#834): before this, a fresh
+    // install had no helper at all and auto-approve silently escalated
+    // everything, which is the gap #818 could describe but not close.
+    let helperPath = resolveHelperPath(this.config.helperPath ?? '');
+    if (helperPath === undefined) {
+      helperPath = await this.installHelper();
+    }
     if (helperPath === undefined || helperPath.length === 0) {
-      const reason = `no engine on ${this.config.baseUrl} and no helper is bundled to start (auto_approve.engine_path unset)`;
+      const reason = `no engine on ${this.config.baseUrl} and no helper available to start it`;
       this.log(`[Engine] ${reason}`);
       return { kind: 'unavailable', reason };
     }
@@ -320,6 +356,23 @@ export class EngineHost {
     const reason = `engine started (pid ${pid}) but never answered on ${this.config.baseUrl}`;
     this.log(`[Engine] ${reason}`);
     return { kind: 'unavailable', reason };
+  }
+
+  /**
+   * Fetch the helper once, if this machine can run one (#834). Single-flight:
+   * a burst of daemons booting together must produce one download, not ten of
+   * the same 30 MB archive.
+   */
+  private async installHelper(): Promise<string | undefined> {
+    this.installInFlight ??= this.installFn();
+    try {
+      return await this.installInFlight;
+    } finally {
+      // Cleared so a later failure can retry rather than caching "no helper"
+      // for the daemon's whole life -- a transient network failure at boot
+      // must not permanently disable auto-approve.
+      this.installInFlight = undefined;
+    }
   }
 
   /** Kill a pid we started and drop its record. Never throws; reports whether

--- a/packages/daemon/src/auto-approve/engine-install.ts
+++ b/packages/daemon/src/auto-approve/engine-install.ts
@@ -1,0 +1,166 @@
+/**
+ * Obtaining the engine helper (#834).
+ *
+ * #818 taught remi to START a helper and #297 built one, but nothing put the
+ * binary on a user's machine — so `engine_path` was unset by default and
+ * auto-approve degraded to escalate-everything on a fresh install. This module
+ * closes that: remi fetches the helper itself, once, and caches it.
+ *
+ * **Fetch rather than bundle**, for two reasons that both matter:
+ *
+ *   - remi releases on every merge; the engine changes rarely. Bundling would
+ *     re-download an unchanged ~30 MB helper on every remi patch, and would put
+ *     a macOS-only payload into the Linux and Intel artifacts as well.
+ *   - The engine's release pipeline signs each `.app` and archives it with
+ *     `ditto` specifically because `zip` corrupts the code signature on nested
+ *     bundles. Fetching that artifact byte-for-byte preserves the signature and
+ *     notarization; repacking it through npm or Homebrew is exactly how
+ *     Gatekeeper breakage is introduced — and it surfaces to a user as "the
+ *     engine never answered", which points nowhere near the cause.
+ *
+ * Everything here is best-effort and reversible. A failed install leaves
+ * auto-approve escalating, which is the behavior without this module at all.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+
+/** Where fetched helpers live, one directory per engine release. Versioned so
+ *  an upgrade never overwrites a helper a running engine was launched from. */
+export const ENGINE_INSTALL_ROOT = path.join(REMI_DIR, 'engine');
+
+/**
+ * The engine release remi fetches its helper from.
+ *
+ * Pinned rather than "latest" on purpose: a daemon that silently picks up a new
+ * engine build is a daemon whose behavior changed without anyone choosing it,
+ * and the model contract (`yooz-instruct-4b`, the catalogue, the alias
+ * resolution) is a property of a specific engine version. Bumping this is a
+ * deliberate, reviewable commit.
+ */
+export const ENGINE_RELEASE = {
+  repo: 'yooz-labs/yooz-engine',
+  /** Release tag carrying `YoozEngineLLM.app.zip` (yooz-engine#311). */
+  tag: 'v0.7.7',
+  asset: 'YoozEngineLLM.app.zip',
+  /** Bundle directory inside the archive, and the executable within it. */
+  appDir: 'YoozEngineLLM.app',
+  binary: 'Yooz Engine (LLM)',
+} as const;
+
+/** Absolute path the pinned release installs to. */
+export function installedHelperPath(root: string = ENGINE_INSTALL_ROOT): string {
+  return path.join(
+    root,
+    ENGINE_RELEASE.tag,
+    ENGINE_RELEASE.appDir,
+    'Contents',
+    'MacOS',
+    ENGINE_RELEASE.binary,
+  );
+}
+
+/**
+ * The helper remi should launch, or undefined when there is none yet.
+ *
+ * Explicit config wins: someone pointing `engine_path` at their own build is
+ * making a deliberate choice and must not be second-guessed by a download.
+ */
+export function resolveHelperPath(
+  configuredPath: string,
+  root: string = ENGINE_INSTALL_ROOT,
+): string | undefined {
+  if (configuredPath.length > 0) return configuredPath;
+  const installed = installedHelperPath(root);
+  return fs.existsSync(installed) ? installed : undefined;
+}
+
+/** Only Apple Silicon can run this helper — it is MLX. Anywhere else, fetching
+ *  30 MB that cannot execute would be worse than doing nothing. */
+export function canInstallHelper(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): boolean {
+  return platform === 'darwin' && arch === 'arm64';
+}
+
+export interface InstallDeps {
+  readonly log: (msg: string) => void;
+  /** Seam for tests; the real one streams the release asset to disk. */
+  readonly download?: (url: string, dest: string) => Promise<void>;
+  readonly root?: string;
+}
+
+/**
+ * Fetch and unpack the pinned helper, unless it is already there.
+ *
+ * Returns the executable path, or undefined when it could not be obtained —
+ * never throws, because a missing helper must degrade to "auto-approve
+ * escalates", not to a broken daemon.
+ */
+export async function ensureHelperInstalled(deps: InstallDeps): Promise<string | undefined> {
+  const root = deps.root ?? ENGINE_INSTALL_ROOT;
+  const target = installedHelperPath(root);
+  // Already installed: this is the common path on every boot after the first,
+  // and it must cost one `stat` rather than a network call.
+  if (fs.existsSync(target)) return target;
+
+  if (!canInstallHelper()) return undefined;
+
+  const versionDir = path.join(root, ENGINE_RELEASE.tag);
+  const url = `https://github.com/${ENGINE_RELEASE.repo}/releases/download/${ENGINE_RELEASE.tag}/${ENGINE_RELEASE.asset}`;
+  const archive = path.join(versionDir, ENGINE_RELEASE.asset);
+
+  try {
+    fs.mkdirSync(versionDir, { recursive: true });
+    deps.log(`[Engine] Fetching the engine helper (${ENGINE_RELEASE.tag}, ~30 MB)`);
+    const download = deps.download ?? downloadFile;
+    await download(url, archive);
+
+    // `ditto -x -k` is the counterpart of the `ditto -c -k` the engine's
+    // release pipeline archives with. Using `unzip` here would strip the code
+    // signature from the nested bundles and the helper would fail Gatekeeper.
+    const extract = spawnSync('/usr/bin/ditto', ['-x', '-k', archive, versionDir], {
+      stdio: 'ignore',
+    });
+    if (extract.status !== 0) {
+      throw new Error(`ditto exited ${extract.status ?? 'unknown'}`);
+    }
+    // The archive is disposable once expanded; keeping it doubles the footprint
+    // of something a user did not ask to store.
+    fs.rmSync(archive, { force: true });
+
+    if (!fs.existsSync(target)) {
+      throw new Error(`archive did not contain ${ENGINE_RELEASE.appDir}`);
+    }
+    deps.log(`[Engine] Installed the engine helper to ${versionDir}`);
+    return target;
+  } catch (err) {
+    // Leave nothing half-unpacked: a partial bundle would be found by
+    // `resolveHelperPath` on the next boot and launched as if it were whole.
+    fs.rmSync(versionDir, { recursive: true, force: true });
+    deps.log(
+      `[Engine] Could not install the engine helper (auto-approve will escalate until it is present): ${errorToString(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/** Stream a release asset to disk. GitHub redirects release downloads, which
+ *  `fetch` follows by default. */
+async function downloadFile(url: string, dest: string): Promise<void> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> ${response.status}`);
+  }
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  // Written whole rather than streamed: 30 MB is small enough that the
+  // simplicity is worth more than the memory, and a partial file on disk is a
+  // worse failure than a brief allocation.
+  fs.writeFileSync(dest, buffer);
+}

--- a/packages/daemon/tests/auto-approve/engine-install.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-install.test.ts
@@ -80,7 +80,14 @@ describe('canInstallHelper', () => {
   });
 });
 
-describe('ensureHelperInstalled', () => {
+// The install path is macOS-only by construction: `canInstallHelper` gates on
+// Apple Silicon, and the archive is expanded with `ditto`, which does not exist
+// elsewhere. These assert real filesystem behaviour, so they are skipped rather
+// than faked off-platform — a fake `ditto` would test the fake. The pure
+// resolution/gating logic above runs everywhere, including Linux CI.
+const describeMacOS = process.platform === 'darwin' ? describe : describe.skip;
+
+describeMacOS('ensureHelperInstalled', () => {
   test('unpacks the release archive and returns the executable', async () => {
     const logs: string[] = [];
     const target = await ensureHelperInstalled({

--- a/packages/daemon/tests/auto-approve/engine-install.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-install.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Helper acquisition (#834).
+ *
+ * The gap this closes: #818 could START a helper and #297 BUILT one, but
+ * nothing put it on a user's machine, so `engine_path` was empty by default
+ * and auto-approve escalated everything on a fresh install.
+ *
+ * Real files and a real `ditto` throughout — the failure modes here (a partial
+ * unpack left behind, an archive that does not contain what was expected, a
+ * signature stripped by the wrong archiver) only exist against a real
+ * filesystem.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  ENGINE_RELEASE,
+  canInstallHelper,
+  ensureHelperInstalled,
+  installedHelperPath,
+  resolveHelperPath,
+} from '../../src/auto-approve/engine-install.ts';
+
+const TEST_ROOT = path.join(os.tmpdir(), `remi-engine-install-${process.pid}`);
+
+beforeEach(() => {
+  fs.mkdirSync(TEST_ROOT, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+/** Build a `.app`-shaped directory and archive it exactly as the engine's
+ *  release pipeline does (`ditto -c -k`), so the extract path under test is
+ *  exercised against a real archive rather than a hand-rolled zip. */
+function makeReleaseArchive(dest: string): void {
+  const staging = path.join(TEST_ROOT, 'staging');
+  const macos = path.join(staging, ENGINE_RELEASE.appDir, 'Contents', 'MacOS');
+  fs.mkdirSync(macos, { recursive: true });
+  fs.writeFileSync(path.join(macos, ENGINE_RELEASE.binary), '#!/bin/sh\nexit 0\n', {
+    mode: 0o755,
+  });
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const r = spawnSync(
+    '/usr/bin/ditto',
+    ['-c', '-k', '--keepParent', path.join(staging, ENGINE_RELEASE.appDir), dest],
+    { stdio: 'ignore' },
+  );
+  if (r.status !== 0) throw new Error('ditto -c -k failed building the fixture');
+  fs.rmSync(staging, { recursive: true, force: true });
+}
+
+describe('resolveHelperPath', () => {
+  test('an explicit engine_path always wins', () => {
+    // Someone pointing at their own build is making a deliberate choice; a
+    // download must never second-guess it.
+    expect(resolveHelperPath('/custom/helper', TEST_ROOT)).toBe('/custom/helper');
+  });
+
+  test('falls back to an installed helper, and to nothing when absent', () => {
+    expect(resolveHelperPath('', TEST_ROOT)).toBeUndefined();
+
+    const installed = installedHelperPath(TEST_ROOT);
+    fs.mkdirSync(path.dirname(installed), { recursive: true });
+    fs.writeFileSync(installed, '');
+    expect(resolveHelperPath('', TEST_ROOT)).toBe(installed);
+  });
+});
+
+describe('canInstallHelper', () => {
+  test('Apple Silicon only — the helper is MLX', () => {
+    // Fetching 30 MB that cannot execute is worse than doing nothing.
+    expect(canInstallHelper('darwin', 'arm64')).toBe(true);
+    expect(canInstallHelper('darwin', 'x64')).toBe(false);
+    expect(canInstallHelper('linux', 'x64')).toBe(false);
+  });
+});
+
+describe('ensureHelperInstalled', () => {
+  test('unpacks the release archive and returns the executable', async () => {
+    const logs: string[] = [];
+    const target = await ensureHelperInstalled({
+      log: (m) => logs.push(m),
+      root: TEST_ROOT,
+      download: async (_url, dest) => makeReleaseArchive(dest),
+    });
+
+    expect(target).toBe(installedHelperPath(TEST_ROOT));
+    expect(fs.existsSync(target as string)).toBe(true);
+    // The archive itself is disposable once expanded; keeping it would double
+    // the footprint of something the user did not ask to store.
+    expect(fs.existsSync(path.join(TEST_ROOT, ENGINE_RELEASE.tag, ENGINE_RELEASE.asset))).toBe(
+      false,
+    );
+  });
+
+  test('is a no-op when the helper is already installed', async () => {
+    // The common path on every boot after the first: one stat, no network.
+    const installed = installedHelperPath(TEST_ROOT);
+    fs.mkdirSync(path.dirname(installed), { recursive: true });
+    fs.writeFileSync(installed, '');
+
+    let downloaded = false;
+    const target = await ensureHelperInstalled({
+      log: () => undefined,
+      root: TEST_ROOT,
+      download: async () => {
+        downloaded = true;
+      },
+    });
+
+    expect(target).toBe(installed);
+    expect(downloaded).toBe(false);
+  });
+
+  test('a failed download leaves NOTHING behind', async () => {
+    // A half-unpacked bundle would be found by `resolveHelperPath` on the next
+    // boot and launched as though it were whole.
+    const logs: string[] = [];
+    const target = await ensureHelperInstalled({
+      log: (m) => logs.push(m),
+      root: TEST_ROOT,
+      download: async () => {
+        throw new Error('network unreachable');
+      },
+    });
+
+    expect(target).toBeUndefined();
+    expect(fs.existsSync(path.join(TEST_ROOT, ENGINE_RELEASE.tag))).toBe(false);
+    expect(logs.join('\n')).toContain('Could not install');
+  });
+
+  test('an archive without the expected bundle is rejected, not half-installed', async () => {
+    const logs: string[] = [];
+    const target = await ensureHelperInstalled({
+      log: (m) => logs.push(m),
+      root: TEST_ROOT,
+      download: async (_url, dest) => {
+        // A real, valid archive — of the wrong thing.
+        const staging = path.join(TEST_ROOT, 'wrong');
+        fs.mkdirSync(staging, { recursive: true });
+        fs.writeFileSync(path.join(staging, 'README'), 'not an app');
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        spawnSync('/usr/bin/ditto', ['-c', '-k', '--keepParent', staging, dest], {
+          stdio: 'ignore',
+        });
+      },
+    });
+
+    expect(target).toBeUndefined();
+    expect(fs.existsSync(path.join(TEST_ROOT, ENGINE_RELEASE.tag))).toBe(false);
+  });
+
+  test('the install is versioned by release tag', async () => {
+    // An upgrade must never overwrite the helper a running engine was launched
+    // from -- the engine outlives the daemon that started it by design.
+    expect(installedHelperPath(TEST_ROOT)).toContain(ENGINE_RELEASE.tag);
+  });
+});

--- a/packages/daemon/tests/auto-approve/engine-supervision.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-supervision.test.ts
@@ -107,6 +107,9 @@ function serviceWith(opts: {
       },
       sleep: async () => undefined,
       pidStore: pidStore(),
+      // Never reach the network from a unit test (#834). `undefined` means
+      // "no helper could be obtained", which is what these tests assume.
+      installHelper: async () => undefined,
     },
   );
   const service = new AutoApproveService(config(), (m) => logs.push(m), host);
@@ -143,7 +146,7 @@ describe('AutoApproveService engine supervision (#818)', () => {
     const h = serviceWith({ probes: [UNREACHABLE], helperPath: '' });
     expect(await h.service.ensureEngine()).toBe(false);
     expect(h.logs.join('\n')).toContain('No engine available');
-    expect(h.logs.join('\n')).toContain('no helper is bundled');
+    expect(h.logs.join('\n')).toContain('no helper available');
   });
 
   test('a guest (engine = "shared") never spawns, and says why', async () => {


### PR DESCRIPTION
Closes #834.

## The regression this closes

ollama needed no setup: install remi, enable auto-approve, it worked. Since #811 replaced it, `engine_path` has defaulted to empty and nothing shipped a helper — so a fresh install had **no engine**, and auto-approve escalated every permission. Faster model, worse product.

## What changes

remi fetches the pinned engine helper itself, once, and caches it in `~/.remi/engine/<tag>/`. No configuration, no manual build. An explicit `engine_path` still wins: pointing at your own build is a deliberate choice a download must not override.

**Fetch rather than bundle**, for two reasons that both matter:

- remi releases on **every merge**; the engine changes **rarely**. Bundling would re-ship an unchanged ~30 MB helper on every remi patch, and would put a macOS-only payload into the Linux and Intel artifacts. (This is the change-rate argument, applied to the helper rather than the weights — the weights were never a bundling candidate, since the engine fetches those from HuggingFace itself.)
- The engine's pipeline signs each `.app` and archives it with `ditto` **specifically because `zip` corrupts code signatures on nested bundles**. Fetching that artifact byte-for-byte preserves signing and notarization; repacking a signed `.app` through npm is how Gatekeeper breakage gets introduced — and it presents to a user as "the engine never answered", which points nowhere near the cause. remi unpacks with `ditto -x -k`, the matching counterpart.

The release tag is **pinned, not "latest"**: a daemon that silently picks up a new engine is a daemon whose behavior changed without anyone choosing it, and the catalogue and alias contracts are properties of a specific engine version.

## Failure handling

Every path degrades to "auto-approve escalates", never to a broken daemon. A failed or partial install **removes the version directory entirely** — a half-unpacked bundle would be found on the next boot and launched as though it were whole. An archive that does not contain the expected bundle is rejected rather than half-installed. Non-Apple-Silicon never downloads: 30 MB that cannot execute is worse than nothing.

## Two design bugs found and fixed while building this

- I first gave `EngineHost` an **un-injected network dependency** — unlike every other seam it has (`spawn`, `probe`, `kill`, `pidStore`). Unit tests started attempting real downloads; the suite went from 54s to 290s. The install is now an injected seam.
- Fixing that surfaced a second instance already in `develop`: the self-heal path called the module-level `probeEngine` directly, bypassing the host's injected probe and putting a **real connect timeout inside unit tests**. It now goes through `EngineHost.probeOnce()`.

## Also in this PR

The **0.6.25 changelog**, leading with the breaking `provider = "ollama"` removal — that stops every remi command, not just auto-approve, and anyone who configured it months ago needs to see it first.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3826 pass, 0 fail
- [x] 8 new tests using real files and a real `ditto`, including the failure modes: partial install cleaned up, wrong-archive rejected, already-installed is a no-op with no network, Apple-Silicon-only gating

## Remaining dependency

The asset itself lands with **yooz-engine#311**, which adds `YoozEngineLLM.app.zip` to the engine's release pipeline. Until an engine release carries it, the fetch fails honestly and logs — the same degradation as before this PR, not a worse one.
