### PR TITLE
Tell Linux users no llama.cpp backend is managed yet

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -842,9 +842,22 @@ let autoApproveService: AutoApproveService | null = null;
     // escalated, which is indistinguishable from a bug. Only a local provider
     // is affected: a remote one (OpenRouter, a custom URL) works anywhere.
     const localProvider = provider === 'yooz' || provider === 'llamacpp';
-    if (localProvider && detectLocalLLMPlatform() === 'unsupported') {
+    const detectedBackend = detectLocalLLMPlatform();
+    if (localProvider && detectedBackend === 'unsupported') {
       writeToLog(
         `[AutoApprove] No local LLM backend exists for ${process.platform}/${process.arch}: the Yooz engine needs Apple Silicon (MLX) and the llama.cpp path is Linux. Auto-approve will escalate every permission until you point auto_approve.provider at a reachable backend (e.g. openrouter, or a custom URL).`,
+      );
+    } else if (provider === 'llamacpp') {
+      // Linux resolves to `llamacpp`, but NOTHING installs or supervises a
+      // llama-server yet (#822) -- remi only supervises the engine transport.
+      // Left unsaid, a Linux user enabling auto-approve gets silence and then
+      // every permission escalated, which is precisely the unexplained
+      // degradation #818 was filed to remove, reintroduced on another platform.
+      // The macOS path fetches its own helper (#834); this one cannot yet, so
+      // the honest thing is to say so at boot rather than at the first
+      // permission.
+      writeToLog(
+        `[AutoApprove] provider = "llamacpp" is selected for ${process.platform}, but remi does not yet download or supervise a llama.cpp server (#822). Auto-approve will escalate every permission unless you run llama-server yourself on ${baseUrl}, or point auto_approve.provider at a remote backend.`,
       );
     }
 


### PR DESCRIPTION
Found while answering "how do we protect Linux users": remi currently protects them from the *wrong thing*.

## Packaging is already right — the gap is the message

The macOS helper is **never packaged**. remi fetches it at runtime (#834), gated on `canInstallHelper()` = Apple Silicon only. So:

| channel | what a Linux user receives |
|---|---|
| npm platform package | the remi binary for their arch, nothing else |
| Homebrew bottle | same |
| helper (~30 MB, macOS `.app`) | **never downloaded, never packaged** |
| model weights (2.37 GB) | fetched by the engine, so never on Linux either |

No macOS payload reaches a Linux artifact, and no per-channel special-casing is needed, because the platform-specific part is acquired at runtime by a platform-gated code path rather than baked into a package.

## What was actually broken: silence

Linux resolves `provider` to `llamacpp` (#822/#835), but **nothing installs or supervises a llama-server** — `EngineHost` is only constructed for the `yooz` transport. And `ensureEngine` returns `false` *without logging* when there is no host, while the existing boot warning only fired for platforms with no backend at all (Intel Mac).

Net effect: a Linux user enabling auto-approve saw **nothing at boot**, then every permission escalated. That is precisely the unexplained degradation #818 was filed to remove, reintroduced on another platform — and worse here, because the macOS path now self-heals while this one silently cannot.

It now says so at boot, naming both ways forward (run `llama-server` on the same port, or use a remote provider) rather than at the first permission, when the user is already blocked.

## Test plan

- [x] `bunx biome check`, `bun run typecheck` — clean
- [x] `bun test` — 3756 pass, 69 skip, 0 fail

Does not implement #822; it stops that gap from being invisible.