### PR TITLE
Release 0.7.1: remi model UX, and fix the dev-line bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-07-27
+
+Makes `remi model` usable on a fresh install and names models the way you
+would actually look them up.
+
+### Changed
+- **The engine helper is pinned to yooz-engine 0.7.8** (#843), up from 0.7.7.
+  0.7.8 is the first release whose model listings report each model's
+  registered HuggingFace repo id, which is what lets remi correlate the id in
+  your config to a row in the engine's catalogue. The pin is deliberate rather
+  than "latest": a daemon that silently picks up a new engine is a daemon whose
+  behavior changed without anyone choosing it.
+
 ### Fixed
 - **`remi model` no longer needs a daemon to exist first** (#843). Every verb
   used to probe the port and give up when nothing answered, and nothing in the
@@ -35,6 +48,13 @@ All notable changes to Remi are documented here.
   (#843), instead of reporting a present, working model as unknown.
 - **`remi --help` lists `remi model`** (#843), which was otherwise
   undiscoverable.
+- **`bump-version.sh` starts a dev line from any branch but `main`.** It decided
+  "is this the dev line?" by testing whether the current branch was literally
+  named `develop` — but the workflow forbids committing to `develop` directly,
+  so every real bump happens on a feature branch and silently produced a
+  *stable* version instead. That is how 0.7.0 shipped with no `-dev` suffix,
+  which left `auto-bump-dev` with no counter to increment and `auto-release`
+  with nothing to release: a release pipeline that fails by doing nothing.
 
 ## [0.7.0] - 2026-07-26
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.0",
+  "version": "0.7.1-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.0'; // REMI_COMPILED_VERSION
+      return '0.7.1-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.0'; // REMI_COMPILED_VERSION
+    return '0.7.1-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,17 +2,17 @@
 # bump-version.sh - Bump version, commit, tag, and optionally push to trigger release
 #
 # Versioning rules:
-#   - develop branch always has -dev.N versions (never stable)
+#   - every branch except main is on the dev line: -dev.N versions, never stable
 #   - main branch has stable versions (CI auto-strips dev suffix on merge)
-#   - patch/minor/major on develop: bump + reset to -dev.1
-#   - dev on develop: increment dev counter (dev.1 -> dev.2)
+#   - patch/minor/major off main: bump + reset to -dev.1
+#   - dev off main: increment dev counter (dev.1 -> dev.2)
 #   - stable: only allowed on main (CI use) or with --force
 #
 # Usage:
 #   ./scripts/bump-version.sh dev            # 0.4.9-dev.1 -> 0.4.9-dev.2
-#   ./scripts/bump-version.sh patch          # 0.4.9-dev.3 -> 0.4.10-dev.1 (on develop)
-#   ./scripts/bump-version.sh minor          # 0.4.9-dev.3 -> 0.5.0-dev.1  (on develop)
-#   ./scripts/bump-version.sh major          # 0.4.9-dev.3 -> 1.0.0-dev.1  (on develop)
+#   ./scripts/bump-version.sh patch          # 0.4.9-dev.3 -> 0.4.10-dev.1 (off main)
+#   ./scripts/bump-version.sh minor          # 0.4.9-dev.3 -> 0.5.0-dev.1  (off main)
+#   ./scripts/bump-version.sh major          # 0.4.9-dev.3 -> 1.0.0-dev.1  (off main)
 #   ./scripts/bump-version.sh stable         # 0.4.10-dev.1 -> 0.4.10 (main/CI only)
 #   ./scripts/bump-version.sh set 1.0.0      # Set specific version
 #   ./scripts/bump-version.sh --push patch   # Bump and push (triggers release)
@@ -45,10 +45,23 @@ if [[ -z "$BUMP_TYPE" ]]; then
   exit 1
 fi
 
-# Detect current branch
+# Which version line is this bump destined for?
+#
+# What decides the answer is where the commit is HEADED, not the branch it is
+# authored on. Only main carries stable versions, and only CI puts them there;
+# everything else -- develop and every feature branch that merges into it -- is
+# on the dev line.
+#
+# Keying that on the literal name `develop` was wrong, because the workflow
+# forbids committing to develop directly: every real bump happens on a feature
+# branch, where the old check said "not develop" and silently produced a STABLE
+# version. That is how 0.7.0 shipped with no -dev suffix (PR #841, branch
+# `minor-bump`), which then left auto-bump-dev with no counter to increment and
+# auto-release with nothing to release -- a release that fails by doing
+# nothing, which is the hardest kind to notice.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-IS_DEVELOP=$([[ "$CURRENT_BRANCH" == "develop" ]] && echo true || echo false)
 IS_MAIN=$([[ "$CURRENT_BRANCH" == "main" ]] && echo true || echo false)
+ON_DEV_LINE=$([[ "$IS_MAIN" == false ]] && echo true || echo false)
 
 # Read current version from package.json
 CURRENT_VERSION=$(node -e "process.stdout.write(require('$PKG_JSON').version)")
@@ -66,7 +79,7 @@ case "$BUMP_TYPE" in
     MAJOR=$((MAJOR + 1))
     MINOR=0
     PATCH=0
-    if [[ "$IS_DEVELOP" == true ]]; then
+    if [[ "$ON_DEV_LINE" == true ]]; then
       NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
     else
       NEW_VERSION="$MAJOR.$MINOR.$PATCH"
@@ -75,18 +88,18 @@ case "$BUMP_TYPE" in
   minor)
     MINOR=$((MINOR + 1))
     PATCH=0
-    if [[ "$IS_DEVELOP" == true ]]; then
+    if [[ "$ON_DEV_LINE" == true ]]; then
       NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
     else
       NEW_VERSION="$MAJOR.$MINOR.$PATCH"
     fi
     ;;
   patch)
-    # On develop with a dev version: bump patch, reset to dev.1
-    # On develop with a stable version: bump patch, add dev.1
-    # On main or other: just bump patch (stable)
-    if [[ "$IS_DEVELOP" == true ]]; then
-      # 0.4.9-dev.3 -> 0.4.10-dev.1 (or 0.4.9 -> 0.4.10-dev.1 if stable on develop)
+    # Off main with a dev version: bump patch, reset to dev.1
+    # Off main with a stable version: bump patch, add dev.1
+    # On main: just bump patch (stable)
+    if [[ "$ON_DEV_LINE" == true ]]; then
+      # 0.4.9-dev.3 -> 0.4.10-dev.1 (or 0.4.9 -> 0.4.10-dev.1 from a stable base)
       PATCH=$((PATCH + 1))
       NEW_VERSION="$MAJOR.$MINOR.$PATCH-dev.1"
     else
@@ -100,8 +113,8 @@ case "$BUMP_TYPE" in
       echo "Already a stable version ($CURRENT_VERSION). Nothing to do." >&2
       exit 0
     fi
-    if [[ "$IS_DEVELOP" == true && "$FORCE" == false ]]; then
-      echo "Error: 'stable' is not allowed on the develop branch." >&2
+    if [[ "$ON_DEV_LINE" == true && "$FORCE" == false ]]; then
+      echo "Error: 'stable' is only allowed on main (branch: $CURRENT_BRANCH)." >&2
       echo "Stable versions are created by CI when develop merges into main." >&2
       echo "Use --force to override (not recommended)." >&2
       exit 1


### PR DESCRIPTION
Prepares the 0.7.1 release line and fixes the release-tooling bug that made 0.7.0 fail silently.

## The tooling bug

`bump-version.sh` decided "is this the dev line?" by testing whether the current branch was literally named `develop`:

```bash
IS_DEVELOP=$([[ "$CURRENT_BRANCH" == "develop" ]] && echo true || echo false)
```

But the workflow forbids committing to `develop` directly, so every real bump happens on a feature branch, where that check said "not develop" and produced a **stable** version instead of a `-dev.1` one.

That is exactly how 0.7.0 shipped with no `-dev` suffix (PR #841, branch `minor-bump`). The consequences were both silent:

- `auto-bump-dev` had no `-dev.N` counter to increment, so it no-op'd on every push to develop since.
- `auto-release` saw an already-stable version on main and logged "no auto-release needed" — no tag, no npm publish, no Homebrew update. The 0.7.0 tag had to be pushed by hand.

A release pipeline that fails by *doing nothing* is the hardest kind to notice, so this is worth fixing at the root rather than working around per release.

The fix follows where a commit is **headed** rather than what it is named: only `main` carries stable versions, and only CI puts them there. Everything else is on the dev line.

Verified with a mutation test over a throwaway repo — reverting to the old branch check reproduces the historical bug precisely:

| branch | verb | fixed | old check |
|---|---|---|---|
| `feature/foo` | patch | `0.7.1-dev.1` | `0.7.1` (bug) |
| `minor-bump` | minor | `0.8.0-dev.1` | `0.8.0` (bug, = the 0.7.0 failure) |
| `develop` | patch | `0.7.1-dev.1` | `0.7.1-dev.1` |
| `main` | patch | `0.7.1` | `0.7.1` |

## Release prep

- Version `0.7.0` -> `0.7.1-dev.1` (package.json + `REMI_COMPILED_VERSION`), so merging develop into main now actually triggers `auto-release`.
- CHANGELOG: `[Unreleased]` promoted to `[0.7.1] - 2026-07-27`, covering the #843 `remi model` fixes.

## Pinning

Verified for this release:

- Engine helper pinned to `v0.7.8` in `engine-install.ts`. Release is published (not draft), all four artifacts uploaded; the pinned `YoozEngineLLM.app.zip` URL serves, and the installed helper's signature verifies clean (`Developer ID Application: Yooz Labs Inc. (9DQ459HAZB)`, `codesign --verify --deep --strict` passes).
- No stale references to any older engine version remain outside tests and CHANGELOG.
- bun pinned at 1.3.11 in all three workflows (the 1.3.12 `--compile` regression).
- npm platform packages and their `optionalDependencies` are stamped from the tag by `release.yml`; Homebrew likewise. No hand-pinning needed.
- App (iOS/macOS) version is deliberately decoupled from the daemon version (#658) and is not part of this release.

## Testing

- `biome check .` on a clean worktree: exit 0, 48 warnings, 0 errors. (In a working checkout it reports errors from gitignored `packages/macos` build artifacts, which do not exist in CI.)
- `tsc --noEmit` clean.
- Full suite run locally.
