### PR TITLE
Put the model commands where models are managed

### DIFF
--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -319,6 +319,14 @@ export function formatHelp(version: string): string {
     entry('remi attach [name]', 'Attach to a session (Ctrl+B d to detach)'),
     '',
     bold('Auto-Approve (LLM):'),
+    // The model commands live here, not under Configuration, because the
+    // models exist only to serve this evaluator -- and commands come before
+    // flags because `remi model` is a ten-verb subsystem, not a setting. It
+    // spent 0.7.0-0.7.1 as one line at the bottom of Configuration, where a
+    // user read the whole help output and did not find it (#850).
+    entry('remi model ls', "What's downloaded, and which model is active"),
+    entry('remi model use <id>', 'Switch the model auto-approve runs on'),
+    entry('remi model --help', 'All model commands (pull, rm, ps, ...)'),
     entry('--auto-approve', 'Enable LLM auto-approve for permissions'),
     entry('--no-auto-approve', 'Disable auto-approve (overrides config)'),
     entry('--auto-approve-model M', 'LLM model (default: the engine 4B qat-lean)'),
@@ -355,7 +363,6 @@ export function formatHelp(version: string): string {
     entry('remi config', 'Show effective configuration'),
     entry('remi config init', 'Create default config file'),
     entry('remi reload', 'Hot-reload config on running daemons'),
-    entry('remi model', 'Manage the auto-approve LLM (see "remi model --help")'),
     '',
     bold('Service:'),
     entry('remi start', 'Start the hub in the background'),

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -322,9 +322,15 @@ export function formatHelp(version: string): string {
     // The model commands live here, not under Configuration, because the
     // models exist only to serve this evaluator -- and commands come before
     // flags because `remi model` is a ten-verb subsystem, not a setting. It
-    // spent 0.7.0-0.7.1 as one line at the bottom of Configuration, where a
-    // user read the whole help output and did not find it (#850).
-    entry('remi model ls', "What's downloaded, and which model is active"),
+    // shipped in 0.7.0 listed nowhere at all (#843), then spent 0.7.1 as one
+    // line at the bottom of Configuration, where a user read the whole help
+    // output and still did not find it (#850).
+    //
+    // "which one remi uses", not "active": `ls` marks remi's CONFIGURED model
+    // with `*`, while a possibly different row is labelled `engine active` for
+    // the engine picker's resident tier. Calling the first one "active" is the
+    // same conflation `remi model rm` used to make.
+    entry('remi model ls', "What's downloaded, and which one remi uses"),
     entry('remi model use <id>', 'Switch the model auto-approve runs on'),
     entry('remi model --help', 'All model commands (pull, rm, ps, ...)'),
     entry('--auto-approve', 'Enable LLM auto-approve for permissions'),

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -148,16 +148,32 @@ describe('formatCommandHelp', () => {
 });
 
 describe('help formatting', () => {
-  /** The lines under `heading`, up to the next blank line. */
+  /**
+   * The lines under `heading`, up to the next heading.
+   *
+   * Delimiting on the next HEADING rather than the next blank line matters:
+   * `Options:` already contains an internal blank line, so a blank-line rule
+   * would silently return a truncated section and let an assertion about a
+   * dropped entry pass green. Headings are unindented; entries are not.
+   */
   function sectionOf(text: string, heading: string): string {
     const plain = text.replace(/\x1b\[[0-9]+m/g, '');
     const lines = plain.split('\n');
     const start = lines.findIndex((l) => l.trim() === heading);
     if (start === -1) throw new Error(`no "${heading}" section in help output`);
     const rest = lines.slice(start + 1);
-    const end = rest.findIndex((l) => l.trim() === '');
+    const end = rest.findIndex((l) => /^\S/.test(l));
     return (end === -1 ? rest : rest.slice(0, end)).join('\n');
   }
+
+  test('sectionOf spans a section that contains a blank line', () => {
+    // Guards the helper itself: `Options:` has a blank line in the middle, and
+    // a blank-line-delimited reader drops everything after it while still
+    // looking like it worked.
+    const options = sectionOf(formatHelp('0.0.0-test'), 'Options:');
+    expect(options).toContain('--port PORT');
+    expect(options).toContain('--force'); // after the internal blank line
+  });
 
   test('the model commands sit in the Auto-Approve section, not Configuration', () => {
     // 0.7.0 shipped `remi model` with per-command help but no entry in the

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -150,7 +150,6 @@ describe('formatCommandHelp', () => {
 describe('help formatting', () => {
   /** The lines under `heading`, up to the next blank line. */
   function sectionOf(text: string, heading: string): string {
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI is the point
     const plain = text.replace(/\x1b\[[0-9]+m/g, '');
     const lines = plain.split('\n');
     const start = lines.findIndex((l) => l.trim() === heading);

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -148,10 +148,33 @@ describe('formatCommandHelp', () => {
 });
 
 describe('help formatting', () => {
-  test('the global list mentions "remi model" so it is discoverable', () => {
-    // It shipped in 0.7.0 with per-command help but no entry in the command
-    // list, so the only way to find it was to already know it existed (#843).
-    expect(formatHelp('0.0.0-test')).toContain('remi model');
+  /** The lines under `heading`, up to the next blank line. */
+  function sectionOf(text: string, heading: string): string {
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI is the point
+    const plain = text.replace(/\x1b\[[0-9]+m/g, '');
+    const lines = plain.split('\n');
+    const start = lines.findIndex((l) => l.trim() === heading);
+    if (start === -1) throw new Error(`no "${heading}" section in help output`);
+    const rest = lines.slice(start + 1);
+    const end = rest.findIndex((l) => l.trim() === '');
+    return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+  }
+
+  test('the model commands sit in the Auto-Approve section, not Configuration', () => {
+    // 0.7.0 shipped `remi model` with per-command help but no entry in the
+    // global list (#843). The fix put one line at the BOTTOM of Configuration,
+    // where a user read the whole output and still did not find it (#850) --
+    // so asserting mere presence is not enough to call it discoverable.
+    const text = formatHelp('0.0.0-test');
+    expect(sectionOf(text, 'Auto-Approve (LLM):')).toContain('remi model');
+    expect(sectionOf(text, 'Configuration:')).not.toContain('remi model');
+  });
+
+  test('the model commands come before the auto-approve flags', () => {
+    // `remi model` is a ten-verb subsystem, not a setting; listing it after the
+    // flags would read as an afterthought of them.
+    const section = sectionOf(formatHelp('0.0.0-test'), 'Auto-Approve (LLM):');
+    expect(section.indexOf('remi model')).toBeLessThan(section.indexOf('--auto-approve'));
   });
 
   test('a term wider than the column still has a space before its description', () => {


### PR DESCRIPTION
Closes #850.

`remi --help` did list `remi model` (#843), but as the last line of **Configuration**, after `remi config` / `remi reload`. A user read the whole output and did not find it, then found `remi model --help` worked fine. That is the right verdict: technically present, practically undiscoverable.

Two things made it easy to miss. **Wrong section** -- "Configuration" is where you look for config files and reload, not a model manager; the natural home is **Auto-Approve (LLM)**, since the models exist only to serve that evaluator, and that section listed *flags only*. **Wrong weight** -- one line implies one command, but `remi model` has ten verbs.

Now section 2 of 8, right under Quick Start, commands before flags:

```
Auto-Approve (LLM):
  remi model ls                 What's downloaded, and which model is active
  remi model use <id>           Switch the model auto-approve runs on
  remi model --help             All model commands (pull, rm, ps, ...)
  --auto-approve                Enable LLM auto-approve for permissions
  ...
```

Three lines rather than ten: enough to show it is a subsystem and to cover the two verbs most people want, with a pointer to the rest. The buried Configuration line is gone.

## Testing

The existing test asserted only `formatHelp(...).toContain('remi model')` -- which **passed the entire time the line was buried**. Presence is not discoverability, so that test could never have caught this. Replaced with two that assert placement, via a helper that extracts a named section from the rendered output:

- the model commands appear under `Auto-Approve (LLM):` and *not* under `Configuration:`
- they precede the `--auto-approve` flags

Both verified to discriminate by mutation:

| Mutation | Result |
|---|---|
| revert to the buried Configuration line (0.7.1 behavior) | placement test fails |
| keep in Auto-Approve but move after the flags | ordering test fails |
| unmutated | 20 pass |

`bun test packages/daemon/tests/cli/` -- 955 pass, 0 fail. Biome and `tsc --noEmit` clean. Rendered output checked against a compiled binary.