### PR TITLE
Report the engine's version, and let remi replace it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`remi model restart`** (#852) — relaunch the engine on the version remi
+  pins. Pinning did not imply running: `EngineHost`'s rule is that ownership is
+  about who *starts* an engine, not who holds it, so an engine already answering
+  is attached to however old it is, and upgrading remi never upgraded the engine
+  it talks to. It refuses to kill an engine remi has no record of starting
+  (killing whatever holds the port on a guess is how you take down something
+  that mattered), refuses against a shared engine, and reports failure rather
+  than success if the relaunched engine is still older than the pin.
+
+### Fixed
+- **`remi model status` reports the engine's version** (#852). remi never read
+  it: it pinned which helper to *install* and inferred "old engine" from a
+  missing field, so it could not tell you what you actually had. It now shows
+  the running version next to the pinned one, and when the engine is older it
+  names `remi model restart` instead of saying "upgrade the engine to 0.7.8+" —
+  advice whose only implementation was a function with no callers.
+- **`remi --help` shows the model commands under Auto-Approve** (#850), at the
+  top of the section, rather than as the last line of Configuration where a
+  user read the whole output and did not find them.
+
 ## [0.7.1] - 2026-07-27
 
 Makes `remi model` usable on a fresh install and names models the way you

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -268,7 +268,18 @@ export class EngineHost {
   static stopRecordedEngine(pids: PidStore, kill: (pid: number) => void): number | null {
     const pid = pids.read();
     if (pid === null) return null;
-    kill(pid);
+    // `read()` already drops a pid whose process is gone, but there is a real
+    // window between that check and this signal in which the engine can exit on
+    // its own — and `process.kill` throws synchronously for ESRCH (and EPERM).
+    // Letting that escape would abort the caller before the record is cleared,
+    // leaving a pidfile naming a dead process AND surfacing as a raw stack
+    // trace from a user-invoked command. Either way the record is now stale, so
+    // release it unconditionally — the same shape `killStarted` already uses.
+    try {
+      kill(pid);
+    } catch {
+      // Already gone, or not ours to signal. Both mean "stop looking here".
+    }
     pids.release(pid);
     return pid;
   }

--- a/packages/daemon/src/auto-approve/engine-install.ts
+++ b/packages/daemon/src/auto-approve/engine-install.ts
@@ -57,6 +57,40 @@ export const ENGINE_RELEASE = {
   binary: 'Yooz Engine (LLM)',
 } as const;
 
+/** The pinned engine version, without the tag's leading `v`. */
+export const PINNED_ENGINE_VERSION = ENGINE_RELEASE.tag.replace(/^v/, '');
+
+/** `[major, minor, patch]`, or undefined when the string is not a semver core.
+ *  Any prerelease suffix is dropped: `0.7.8-dev.1` compares as `0.7.8`, which
+ *  is what "does this build have the 0.7.8 features?" actually asks. */
+function semverParts(version: string): [number, number, number] | undefined {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version.replace(/^v/, ''));
+  if (m === null) return undefined;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * Is `version` older than the helper remi pins?
+ *
+ * Three-way on purpose. `undefined` means "cannot tell" — an unparseable or
+ * absent version must not be reported as either current or stale, because both
+ * are claims about the user's machine that we would be making up.
+ */
+export function isOlderThanPinned(version: string | undefined): boolean | undefined {
+  if (version === undefined) return undefined;
+  const running = semverParts(version);
+  const pinned = semverParts(PINNED_ENGINE_VERSION);
+  if (running === undefined || pinned === undefined) return undefined;
+  // Destructured rather than indexed in a loop: under `noUncheckedIndexedAccess`
+  // a variable index widens each element to `number | undefined`, which this
+  // comparison must not have to reason about.
+  const [rMajor, rMinor, rPatch] = running;
+  const [pMajor, pMinor, pPatch] = pinned;
+  if (rMajor !== pMajor) return rMajor < pMajor;
+  if (rMinor !== pMinor) return rMinor < pMinor;
+  return rPatch < pPatch;
+}
+
 /** Absolute path the pinned release installs to. */
 export function installedHelperPath(root: string = ENGINE_INSTALL_ROOT): string {
   return path.join(

--- a/packages/daemon/src/auto-approve/engine-install.ts
+++ b/packages/daemon/src/auto-approve/engine-install.ts
@@ -72,7 +72,7 @@ function semverParts(version: string): [number, number, number] | undefined {
 /**
  * Is `version` older than the helper remi pins?
  *
- * Three-way on purpose. `undefined` means "cannot tell" — an unparseable or
+ * Three-way on purpose. `undefined` means "cannot tell" — an unparsable or
  * absent version must not be reported as either current or stale, because both
  * are claims about the user's machine that we would be making up.
  */

--- a/packages/daemon/src/auto-approve/engine-models.ts
+++ b/packages/daemon/src/auto-approve/engine-models.ts
@@ -177,6 +177,38 @@ export async function listModels(baseUrl: string, timeoutMs?: number): Promise<E
   return { current: raw.current ?? '', available: raw.available ?? [] };
 }
 
+/**
+ * The running engine's own version, or undefined when it will not say.
+ *
+ * remi pins which helper it *installs* (`ENGINE_RELEASE.tag`), but ownership is
+ * about who STARTS an engine, not who holds it: an engine that is already
+ * answering gets attached to, however old it is. So the pin says nothing about
+ * what is actually on the far end of the socket, and until this existed remi
+ * had no way to ask — it inferred "old engine" from a field being missing and
+ * told users to "upgrade to 0.7.8+" without being able to name what they had.
+ *
+ * Never throws. A version we cannot read must degrade to "not reported", not to
+ * a failed status command.
+ */
+export async function getEngineVersion(
+  baseUrl: string,
+  timeoutMs = 2_000,
+): Promise<string | undefined> {
+  try {
+    const raw = await engineRequest<{ engineVersion?: string }>(baseUrl, '/v1/modules', {
+      method: 'GET',
+      timeoutMs,
+    });
+    // An engine old enough to lack the field is exactly the case this exists to
+    // report, so an empty string must read as "would not say", not as a version.
+    return raw.engineVersion !== undefined && raw.engineVersion.length > 0
+      ? raw.engineVersion
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Current load/download state. */
 export async function getStatus(baseUrl: string, timeoutMs?: number): Promise<EngineStatus> {
   return await engineRequest<EngineStatus>(baseUrl, '/v1/llm/status', {

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -18,6 +18,7 @@
  *   remi model load <id>       make resident (already-downloaded weights)
  *   remi model unload <id>     free its memory
  *   remi model use <id>        make it the configured default (persisted)
+ *   remi model restart         relaunch the engine on the version remi pins
  *
  * `ls` reads the DISK inventory (`GET /v1/models`), whose `sizeBytes` is the
  * engine's real measured footprint and whose `deletable` flag is what `rm`
@@ -51,12 +52,18 @@
 import { errorToString } from '@remi/shared';
 import { EngineHost } from '../auto-approve/engine-host.ts';
 import {
+  ENGINE_RELEASE,
+  PINNED_ENGINE_VERSION,
+  isOlderThanPinned,
+} from '../auto-approve/engine-install.ts';
+import {
   type EngineModel,
   type ManagedModel,
   type PullProgress,
   cancelDownload,
   cleanupModels,
   deleteModel,
+  getEngineVersion,
   listManagedModels,
   listModels,
   preloadAsync,
@@ -64,6 +71,7 @@ import {
   pullModel,
   unloadModel,
 } from '../auto-approve/engine-models.ts';
+import { FileEnginePidStore } from '../auto-approve/engine-process.ts';
 import { resolveProviderUrl } from '../auto-approve/llm-client.ts';
 import { displayId, findModel, lookupModel, matchesModel } from '../auto-approve/model-identity.ts';
 import type { RemiConfig } from '../config/config.ts';
@@ -92,6 +100,7 @@ const VERBS = [
   'load',
   'unload',
   'use',
+  'restart',
 ] as const;
 type Verb = (typeof VERBS)[number];
 
@@ -191,6 +200,14 @@ export interface ModelCommandDeps {
    * the developer's machine, which is exactly the accident #841 had to undo.
    */
   readonly ensureEngine?: (baseUrl: string, io: ModelCommandIO) => Promise<boolean>;
+  /** The running engine's own version, or undefined when it will not say. */
+  readonly engineVersion?: typeof getEngineVersion;
+  /**
+   * Stop the recorded engine, returning the pid signalled or null when none is
+   * recorded. A seam for the same reason `ensureEngine` is one: the real
+   * implementation signals a live process on the developer's machine.
+   */
+  readonly stopEngine?: () => number | null;
 }
 
 /**
@@ -293,7 +310,16 @@ export async function runModelCommand(
   // mid-generate on, or deleting a model the host manages, is hostile — so
   // these verbs refuse rather than mutating shared state. Read-only verbs
   // work identically in both modes.
-  const MUTATING: ReadonlySet<string> = new Set(['pull', 'cancel', 'rm', 'cleanup', 'unload']);
+  // `restart` is the most hostile of all against a shared engine — it does not
+  // touch weights, it kills somebody else's process.
+  const MUTATING: ReadonlySet<string> = new Set([
+    'pull',
+    'cancel',
+    'rm',
+    'cleanup',
+    'unload',
+    'restart',
+  ]);
   if (aa.engine === 'shared' && MUTATING.has(verb)) {
     io.err(
       `"remi model ${verb}" is not available against a shared engine: this remi is a guest (auto_approve.engine = "shared"), and another module may be using these weights.`,
@@ -307,6 +333,23 @@ export async function runModelCommand(
   // configure while the engine was down (#843).
   if (verb === 'use') {
     return await runUse(args[1], baseUrl, io, { list, probe, persistModel: deps.persistModel });
+  }
+
+  // `restart` runs its own engine flow. The autostart below fires only when
+  // NOTHING is listening, and the case this exists for is the opposite one: an
+  // engine that is answering, from an older helper than remi pins (#852).
+  if (verb === 'restart') {
+    return await runRestart(baseUrl, io, {
+      probe,
+      version: deps.engineVersion ?? getEngineVersion,
+      stop:
+        deps.stopEngine ??
+        (() =>
+          EngineHost.stopRecordedEngine(new FileEnginePidStore(), (pid) =>
+            process.kill(pid, 'SIGTERM'),
+          )),
+      ensure: deps.ensureEngine ?? ((url, out) => ensureEngineViaHost(config, url, out)),
+    });
   }
 
   // One probe up front so every verb can explain "nothing is listening" the
@@ -382,6 +425,22 @@ export async function runModelCommand(
         const found = rows.ok ? lookupModel(rows.rows, configured) : undefined;
 
         io.out(`engine:   ${baseUrl} (reachable, ${aa.engine})`);
+        // What is actually on the far end of the socket, which the pin does not
+        // determine: an engine already answering is attached to, however old
+        // (#852). Reporting the pin alongside it is what makes "upgrade the
+        // engine" a checkable statement rather than an instruction to guess.
+        const engineVersion = await (deps.engineVersion ?? getEngineVersion)(baseUrl);
+        const stale = isOlderThanPinned(engineVersion);
+        io.out(
+          engineVersion === undefined
+            ? `version:  not reported (remi pins ${PINNED_ENGINE_VERSION})`
+            : stale === true
+              ? `version:  ${engineVersion} — older than the ${PINNED_ENGINE_VERSION} remi pins`
+              : `version:  ${engineVersion} (remi pins ${PINNED_ENGINE_VERSION})`,
+        );
+        if (stale === true && aa.engine !== 'shared') {
+          io.out('          ("remi model restart" relaunches it on the pinned build)');
+        }
         io.out(`model:    ${configured}`);
         if (!rows.ok) {
           io.out("state:    could not read this engine's model inventory");
@@ -405,7 +464,9 @@ export async function runModelCommand(
           io.out(
             rows.ok && rows.rows.length === 0
               ? '          (nothing is cached yet; "remi model pull" fetches it)'
-              : '          (upgrade the engine to 0.7.8+ to resolve this)',
+              : stale === true
+                ? '          (this engine predates the alias listing; see "version" above)'
+                : '          (an engine that names models by repo id resolves this)',
           );
         } else {
           // Alias-aware rows, and none of them is this model. Now a negative
@@ -644,6 +705,99 @@ export async function runModelCommand(
     io.err(`remi model ${verb} failed: ${errorToString(err)}`);
     return 1;
   }
+}
+
+/**
+ * `remi model restart` — relaunch the engine on the version remi pins.
+ *
+ * Exists because pinning does not imply running. `EngineHost`'s rule is that
+ * ownership is about who STARTS an engine, not who holds it: an engine already
+ * answering gets attached to, however old. So upgrading remi never upgrades a
+ * running engine, and a 0.7.1 remi could sit indefinitely against a 0.7.7
+ * engine while telling the user to "upgrade to 0.7.8+" — advice whose only
+ * implementation was an uncalled function (#852).
+ */
+async function runRestart(
+  baseUrl: string,
+  io: ModelCommandIO,
+  deps: {
+    probe: typeof probeEngine;
+    version: typeof getEngineVersion;
+    stop: () => number | null;
+    ensure: (baseUrl: string, io: ModelCommandIO) => Promise<boolean>;
+  },
+): Promise<number> {
+  const before = await deps.probe(baseUrl);
+  const runningVersion = before.reachable ? await deps.version(baseUrl) : undefined;
+
+  if (before.reachable) {
+    const pid = deps.stop();
+    if (pid === null) {
+      // An engine is answering that remi has no pid for: started by hand, or
+      // by a remi whose pidfile has since been removed. Killing "whatever holds
+      // the port" on a guess is exactly the kind of thing that takes down
+      // something the user cared about, so say what is true and stop.
+      io.err(`An engine is answering on ${baseUrl}, but remi has no record of starting it.`);
+      io.err(
+        'Nothing was changed. Stop that process yourself, then any "remi model" verb starts the pinned engine.',
+      );
+      return 1;
+    }
+    io.out(`[Engine] Stopped engine pid ${pid}`);
+    // SIGTERM is asynchronous: the port stays bound for a moment after the
+    // signal returns, and starting into a still-bound port is how you get a
+    // second engine that fails to bind and exits, leaving the OLD one serving.
+    const released = await waitForPortToClose(baseUrl, deps.probe);
+    if (!released) {
+      io.err('The old engine is still holding the port; not starting a second one.');
+      io.err(`Check for a lingering "${ENGINE_RELEASE.binary}" process.`);
+      return 1;
+    }
+  }
+
+  await deps.ensure(baseUrl, io);
+  const after = await deps.probe(baseUrl);
+  if (!after.reachable) {
+    io.err(`No engine came up on ${baseUrl}: ${after.reason}`);
+    return 1;
+  }
+
+  const nowVersion = await deps.version(baseUrl);
+  const from =
+    runningVersion === undefined ? 'an engine that did not report a version' : `${runningVersion}`;
+  io.out(
+    runningVersion === undefined
+      ? `Engine restarted (was ${from}).`
+      : `Engine restarted: ${from} -> ${nowVersion ?? 'unreported'}.`,
+  );
+  if (nowVersion !== undefined && isOlderThanPinned(nowVersion) === true) {
+    // The helper on disk is older than the pin — restarting cannot fix that,
+    // and claiming success would be a lie the user finds out about later.
+    io.err(
+      `This engine is still ${nowVersion}, older than the ${PINNED_ENGINE_VERSION} remi pins.`,
+    );
+    io.err(
+      `A helper from an earlier release is being launched. Check auto_approve.engine_path, or remove ~/.remi/engine and let remi refetch ${ENGINE_RELEASE.tag}.`,
+    );
+    return 1;
+  }
+  io.out('Restart running daemons for them to use it.');
+  return 0;
+}
+
+/** Wait for the engine port to stop answering after a stop signal. */
+async function waitForPortToClose(
+  baseUrl: string,
+  probe: typeof probeEngine,
+  attempts = 20,
+  delayMs = 100,
+): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    const p = await probe(baseUrl, 500);
+    if (!p.reachable) return true;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  return false;
 }
 
 /**

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -157,6 +157,7 @@ const commandHelp: Record<Subcommand, string[]> = {
     entry('remi model load <id>', 'Load already-downloaded weights'),
     entry('remi model unload <id>', 'Free a model from memory'),
     entry('remi model use <id>', 'Set the default model (persisted in config)'),
+    entry('remi model restart', 'Relaunch the engine on the version remi pins'),
     '',
     '',
     dim('  Models are named by their registered HuggingFace repo id, e.g.'),

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -317,6 +317,22 @@ describe('EngineHost — lifetime independence', () => {
     expect(pids.current).toBeNull();
   });
 
+  test('a kill that throws still clears the record and does not escape', () => {
+    // `read()` drops a dead pid, but the engine can exit in the window between
+    // that check and the signal -- and `process.kill` throws ESRCH for it. If
+    // that escaped, `remi model restart` would abort with a raw stack trace
+    // BEFORE releasing the pidfile, leaving a record naming a dead process
+    // that the next run would then refuse to act on (#852).
+    const pids = pidStore(7777);
+
+    const pid = EngineHost.stopRecordedEngine(pids, () => {
+      throw new Error('ESRCH: no such process');
+    });
+
+    expect(pid).toBe(7777);
+    expect(pids.current).toBeNull();
+  });
+
   test('the operator teardown reports when there is nothing recorded', () => {
     expect(EngineHost.stopRecordedEngine(pidStore(null), () => {})).toBeNull();
   });

--- a/packages/daemon/tests/auto-approve/engine-models.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-models.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupModels,
   clearModelCache,
   deleteModel,
+  getEngineVersion,
   getModelState,
   getStatus,
   listManagedModels,
@@ -556,5 +557,64 @@ describe('pullModel — engine death mid-download', () => {
     await expect(pullModel(server.url, 'm', { sleep: noSleep })).rejects.toThrow(
       /stopped answering|unparsable|503/,
     );
+  });
+});
+
+describe('engine version (#852)', () => {
+  test('reads engineVersion from /v1/modules', async () => {
+    // Pins the real endpoint and field name. Both were previously asserted
+    // nowhere: `remi model status` only ever saw an injected fake, so a wrong
+    // path or a renamed field would have shipped silently.
+    const srv = engineServer(() =>
+      Response.json({ engineVersion: '0.7.8', buildVariant: 'llm', modules: [] }),
+    );
+    try {
+      expect(await getEngineVersion(srv.url)).toBe('0.7.8');
+      expect(srv.seen.map((r) => `${r.method} ${r.path}`)).toEqual(['GET /v1/modules']);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('an engine that omits the field reports no version, not an empty one', async () => {
+    // The engines this exists to detect are the OLD ones, so the missing-field
+    // case is the load-bearing one: '' must not read as a version.
+    const srv = engineServer(() => Response.json({ buildVariant: 'llm', modules: [] }));
+    try {
+      expect(await getEngineVersion(srv.url)).toBeUndefined();
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('an empty engineVersion string reports no version', async () => {
+    const srv = engineServer(() => Response.json({ engineVersion: '' }));
+    try {
+      expect(await getEngineVersion(srv.url)).toBeUndefined();
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('a non-2xx or unparsable body reports no version rather than throwing', async () => {
+    // `status` must still print a report when this fails; a throw here would
+    // take down the whole diagnostic.
+    const err = engineServer(() => new Response('nope', { status: 500 }));
+    try {
+      expect(await getEngineVersion(err.url)).toBeUndefined();
+    } finally {
+      err.stop();
+    }
+    const junk = engineServer(() => new Response('not json', { status: 200 }));
+    try {
+      expect(await getEngineVersion(junk.url)).toBeUndefined();
+    } finally {
+      junk.stop();
+    }
+  });
+
+  test('no engine at all reports no version rather than throwing', async () => {
+    // Port 1 is reserved and never listening.
+    expect(await getEngineVersion('http://127.0.0.1:1', 300)).toBeUndefined();
   });
 });

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { isOlderThanPinned } from '../../src/auto-approve/engine-install.ts';
 import type {
   EngineModelCatalog,
   EngineProbe,
@@ -1165,5 +1166,165 @@ describe('remi model — undecidable ownership is never asserted (legacy engine)
     expect(text).not.toContain("It is not remi's model");
     expect(text).toContain('cannot be determined');
     expect(text).toContain('remi model use <other>'); // offered, not denied
+  });
+});
+
+describe('engine version (#852)', () => {
+  test('isOlderThanPinned is three-way, never a guess', () => {
+    // "cannot tell" must not collapse into either answer: both are claims about
+    // the user's machine, and both were being made up before this existed.
+    expect(isOlderThanPinned('0.7.7')).toBe(true);
+    expect(isOlderThanPinned('0.7.8')).toBe(false);
+    expect(isOlderThanPinned('0.7.9')).toBe(false);
+    expect(isOlderThanPinned('0.8.0')).toBe(false);
+    expect(isOlderThanPinned('1.0.0')).toBe(false);
+    expect(isOlderThanPinned('0.6.24')).toBe(true);
+    expect(isOlderThanPinned(undefined)).toBeUndefined();
+    expect(isOlderThanPinned('not-a-version')).toBeUndefined();
+  });
+
+  test('a prerelease of the pinned version is not older than it', () => {
+    // `0.7.8-dev.1` carries the 0.7.8 features, which is what the comparison is
+    // actually asking. Ordering it below 0.7.8 would nag on every dev build.
+    expect(isOlderThanPinned('0.7.8-dev.1')).toBe(false);
+  });
+
+  test('status reports the running version alongside the pin', async () => {
+    const t = io();
+    const code = await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => '0.7.8',
+    });
+    expect(code).toBe(0);
+    const text = t.out.join('\n');
+    expect(text).toContain('0.7.8');
+    expect(text).toContain('remi pins 0.7.8');
+  });
+
+  test('status names the restart command when the engine is older than the pin', async () => {
+    // The 0.7.1 message said "upgrade the engine to 0.7.8+" and named no way to
+    // do it -- the only implementation was an uncalled function (#852).
+    const t = io();
+    await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => '0.7.7',
+    });
+    const text = t.out.join('\n');
+    expect(text).toContain('0.7.7');
+    expect(text).toContain('older than the 0.7.8');
+    expect(text).toContain('remi model restart');
+  });
+
+  test('status says "not reported" rather than inventing a version', async () => {
+    const t = io();
+    await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => undefined,
+    });
+    const text = t.out.join('\n');
+    expect(text).toContain('not reported');
+    expect(text).not.toContain('remi model restart');
+  });
+});
+
+describe('remi model restart (#852)', () => {
+  test('stops the running engine, then starts the pinned one', async () => {
+    const stopped: number[] = [];
+    let started = false;
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      // reachable -> (after stop) unreachable -> reachable again
+      probe: async () => {
+        calls++;
+        return calls === 1 || calls > 2 ? REACHABLE : { reachable: false, reason: 'down' };
+      },
+      engineVersion: async () => (started ? '0.7.8' : '0.7.7'),
+      stopEngine: () => {
+        stopped.push(4242);
+        return 4242;
+      },
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(stopped).toEqual([4242]);
+    expect(started).toBe(true);
+    expect(t.out.join('\n')).toContain('0.7.7 -> 0.7.8');
+  });
+
+  test('refuses to kill an engine remi has no record of starting', async () => {
+    // Killing whatever holds the port on a guess is how you take down something
+    // the user cared about. Nothing is stopped and nothing is started.
+    let started = false;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => REACHABLE,
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => null,
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(1);
+    expect(started).toBe(false);
+    expect(t.err.join('\n')).toContain('no record of starting it');
+  });
+
+  test('starts an engine when none is running', async () => {
+    let started = false;
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => {
+        calls++;
+        return calls === 1 ? { reachable: false, reason: 'down' } : REACHABLE;
+      },
+      engineVersion: async () => '0.7.8',
+      stopEngine: () => {
+        throw new Error('must not stop an engine that is not running');
+      },
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(started).toBe(true);
+  });
+
+  test('reports failure when the relaunched engine is still older than the pin', async () => {
+    // Restarting cannot fix a stale helper on disk, and claiming success would
+    // be a lie the user discovers later.
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => {
+        calls++;
+        return calls === 1 || calls > 2 ? REACHABLE : { reachable: false, reason: 'down' };
+      },
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => 4242,
+      ensureEngine: async () => true,
+    });
+    expect(code).toBe(1);
+    expect(t.err.join('\n')).toContain('still 0.7.7');
+  });
+
+  test('refuses against a shared engine', async () => {
+    const t = io();
+    const code = await run(['restart'], configWith({ engine: 'shared' }), t.io, {
+      stopEngine: () => {
+        throw new Error("must not kill another host's engine");
+      },
+    });
+    expect(code).toBe(1);
+    expect(t.err.join('\n')).toContain('shared engine');
   });
 });

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -1317,6 +1317,26 @@ describe('remi model restart (#852)', () => {
     expect(t.err.join('\n')).toContain('still 0.7.7');
   });
 
+  test('will not start a second engine when the old one keeps the port', async () => {
+    // SIGTERM is asynchronous. If the old engine never lets go, starting anyway
+    // yields a second engine that fails to bind and exits -- leaving the OLD
+    // one serving while the command claims success.
+    let started = false;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => REACHABLE, // never releases
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => 4242,
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(1);
+    expect(started).toBe(false);
+    expect(t.err.join('\n')).toContain('still holding the port');
+  });
+
   test('refuses against a shared engine', async () => {
     const t = io();
     const code = await run(['restart'], configWith({ engine: 'shared' }), t.io, {


### PR DESCRIPTION
Closes #852.

From a live run:

```
engine:   http://127.0.0.1:19924 (reachable, owned)
state:    unknown — this engine's listing does not name it
          (upgrade the engine to 0.7.8+ to resolve this)
```

That advice was unactionable in three compounding ways.

**remi never read the engine's version.** It pins which helper it *installs* and inferred "old engine" from the *absence* of the `huggingFaceID` field, so it could not tell you what you actually had — only that it wasn't new enough. The engine has always exposed it: `GET /v1/modules` returns `engineVersion`. remi just never asked.

**Pinning does not imply running.** `EngineHost`'s rule is that ownership is about who *starts* an engine, not who holds it — an engine already answering gets attached to, however old. So upgrading remi never upgrades the running engine, which is exactly how a 0.7.1 remi (pinning 0.7.8) sits against a 0.7.7 engine complaining about it.

**The remedy did not exist.** `EngineHost.stopRecordedEngine` is documented as *"Operator teardown from ANY process (`remi engine stop`)"* — but that command was never built and the function had **no callers anywhere**. The one message telling users to upgrade pointed at an unimplemented capability.

## Changes

- `getEngineVersion()` reads `engineVersion` from `/v1/modules`. Never throws: a version we cannot read degrades to "not reported", not to a failed `status`.
- `isOlderThanPinned()` is deliberately **three-way**. `undefined` means "cannot tell" — reporting an unparseable or absent version as either current or stale would be inventing a claim about the user's machine. A prerelease of the pin (`0.7.8-dev.1`) is not older than it, since it carries the features the comparison is actually asking about.
- `remi model status` shows the running version next to the pinned one, and when stale names `remi model restart`.
- **`remi model restart`** relaunches the engine on the pinned build. Safety properties, each tested:
  - refuses when remi has no recorded pid for the answering engine — killing whatever holds the port on a guess is how you take down something that mattered. Nothing is stopped, nothing is started.
  - refuses against a `shared` engine (added to `MUTATING`); it is the most hostile verb there, since it kills another host's process rather than touching weights.
  - waits for the port to actually close before starting, since SIGTERM is asynchronous and starting into a still-bound port yields a second engine that fails to bind and exits, leaving the *old* one serving.
  - reports failure, not success, if the relaunched engine is still older than the pin — restarting cannot fix a stale helper on disk.

## Testing

`bun test` full suite: **3813 pass, 0 fail**, 69 skip across 202 files. `tsc --noEmit` and biome clean.

Every new guard verified to discriminate by mutation:

| Mutation | Result |
|---|---|
| `isOlderThanPinned` collapses "cannot tell" into `false` | three-way test fails |
| `restart` kills anyway when no pid is recorded | refuse test fails |
| drop the still-stale-after-restart check | that test fails |

Unit tests inject `engineVersion` / `stopEngine` seams, so no test signals a real process (per the #841/#843 precedent).

**Live-verified against a real 0.7.7 engine** on a throwaway port (19931), not just mocks: `/v1/modules` returns `engineVersion: 0.7.7`, `getEngineVersion` reads it, `isOlderThanPinned` returns `true` against the 0.7.8 pin, and a missing engine yields `undefined` rather than throwing. Engine stopped afterwards; `~/.remi` config, pidfile and the running hub daemon all confirmed unchanged.

## Follow-up

#845 (superseded helpers under `~/.remi/engine/<tag>/` are never reclaimed, ~103 MB each) now matters more: an upgrade path makes that leak grow faster.