### PR TITLE
Wait for the condition, not for a guess

### DIFF
--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -24,8 +24,22 @@ import { SessionRegistryFile } from '../../src/session/session-registry-file.ts'
  * rather than a confusing assertion on an empty array. Note this is only valid
  * for POSITIVE assertions ("this eventually happens"); proving a broadcast
  * never arrives still requires waiting a fixed interval.
+ *
+ * The budget has to clear TWO bars, and the first draft cleared neither:
+ *
+ *   - It must beat bun's own per-test deadline, which defaults to exactly
+ *     5000ms. A `waitFor` that also waited 5000ms could never report first —
+ *     its clock starts strictly later — so bun's generic "this test timed out"
+ *     won every race and the descriptive message was demoted to an
+ *     "Unhandled error between tests" footnote. Hence `TEST_TIMEOUT_MS`, passed
+ *     per test, with this default comfortably under it.
+ *   - It must be long enough that a loaded machine is not itself the failure.
+ *     Observed live while reviewing this change: on a host running several
+ *     concurrent workloads, the `fs.watch` callback for a sibling registration
+ *     took over five seconds. A budget tight enough to trip on that is the
+ *     original bug with a bigger number.
  */
-async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000): Promise<void> {
+async function waitFor(predicate: () => boolean, what: string, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;
@@ -33,6 +47,10 @@ async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000
   }
   throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
 }
+
+/** Per-test deadline for the `waitFor` tests, raised above bun's 5000ms default
+ *  so `waitFor`'s own message is always the one reported. */
+const TEST_TIMEOUT_MS = 30_000;
 
 describe('startLiveSessionsWatcher (#542)', () => {
   let tmpDir: string;
@@ -47,84 +65,95 @@ describe('startLiveSessionsWatcher (#542)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('broadcasts once when a sibling registers, carrying its port', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    const errors: string[] = [];
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      collect: (): LiveSessionsCollectResult | null => {
-        const newPorts = registry.getLivePorts();
-        if (newPorts.length === 0) return null;
-        return { sessions: [], newPorts };
-      },
-      broadcast: (message) => broadcasts.push(message),
-      logError: (msg) => errors.push(msg),
-      debounceMs: 20,
-    });
-
-    try {
-      registry.register({
-        sessionId: '11111111-1111-1111-1111-111111111111',
-        pid: process.pid,
-        wsPort: 20050,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
+  test(
+    'broadcasts once when a sibling registers, carrying its port',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      const errors: string[] = [];
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        collect: (): LiveSessionsCollectResult | null => {
+          const newPorts = registry.getLivePorts();
+          if (newPorts.length === 0) return null;
+          return { sessions: [], newPorts };
+        },
+        broadcast: (message) => broadcasts.push(message),
+        logError: (msg) => errors.push(msg),
+        debounceMs: 20,
       });
 
-      await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
+      try {
+        registry.register({
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          pid: process.pid,
+          wsPort: 20050,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        });
 
-      expect(errors).toEqual([]);
-      expect(broadcasts).toHaveLength(1);
-      const msg = broadcasts[0] as unknown as { type: string; daemonPorts?: readonly number[] };
-      expect(msg.type).toBe('session_list_response');
-      expect(msg.daemonPorts).toContain(20050);
-    } finally {
-      closer();
-    }
-  });
+        await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
 
-  test('onDirChange fires on every flush, including removals that broadcast nothing (#650)', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    let dirChanges = 0;
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      // Removal shape: nothing new to broadcast, ever.
-      collect: (): LiveSessionsCollectResult | null => null,
-      broadcast: (message) => broadcasts.push(message),
-      logError: () => {},
-      debounceMs: 20,
-      onDirChange: () => {
-        dirChanges += 1;
-      },
-    });
+        expect(errors).toEqual([]);
+        expect(broadcasts).toHaveLength(1);
+        const msg = broadcasts[0] as unknown as { type: string; daemonPorts?: readonly number[] };
+        expect(msg.type).toBe('session_list_response');
+        expect(msg.daemonPorts).toContain(20050);
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    try {
-      const entry = {
-        sessionId: '22222222-2222-2222-2222-222222222222',
-        pid: process.pid,
-        wsPort: 20051,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
-      };
-      registry.register(entry);
-      await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
-      const afterRegister = dirChanges;
-      expect(afterRegister).toBeGreaterThanOrEqual(1);
+  test(
+    'onDirChange fires on every flush, including removals that broadcast nothing (#650)',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      let dirChanges = 0;
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        // Removal shape: nothing new to broadcast, ever.
+        collect: (): LiveSessionsCollectResult | null => null,
+        broadcast: (message) => broadcasts.push(message),
+        logError: () => {},
+        debounceMs: 20,
+        onDirChange: () => {
+          dirChanges += 1;
+        },
+      });
 
-      registry.unregister(entry.sessionId);
-      await waitFor(() => dirChanges > afterRegister, 'onDirChange to fire again for the removal');
-      expect(dirChanges).toBeGreaterThan(afterRegister);
-      // The whole point: the census hook fired even though no
-      // session_list_response was broadcast.
-      expect(broadcasts).toHaveLength(0);
-    } finally {
-      closer();
-    }
-  });
+      try {
+        const entry = {
+          sessionId: '22222222-2222-2222-2222-222222222222',
+          pid: process.pid,
+          wsPort: 20051,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        };
+        registry.register(entry);
+        await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
+        const afterRegister = dirChanges;
+        expect(afterRegister).toBeGreaterThanOrEqual(1);
+
+        registry.unregister(entry.sessionId);
+        await waitFor(
+          () => dirChanges > afterRegister,
+          'onDirChange to fire again for the removal',
+        );
+        expect(dirChanges).toBeGreaterThan(afterRegister);
+        // The whole point: the census hook fired even though no
+        // session_list_response was broadcast.
+        expect(broadcasts).toHaveLength(0);
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 
   test('closer stops further broadcasts', async () => {
     const broadcasts: ProtocolMessage[] = [];
@@ -158,37 +187,41 @@ describe('startLiveSessionsWatcher (#542)', () => {
     expect(broadcasts).toEqual([]);
   });
 
-  test('a collect that throws is caught: logError called, no crash, no broadcast', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    const errors: string[] = [];
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      collect: (): LiveSessionsCollectResult | null => {
-        throw new Error('collect exploded');
-      },
-      broadcast: (message) => broadcasts.push(message),
-      logError: (msg) => errors.push(msg),
-      debounceMs: 20,
-    });
-
-    try {
-      registry.register({
-        sessionId: '33333333-3333-3333-3333-333333333333',
-        pid: process.pid,
-        wsPort: 20052,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
+  test(
+    'a collect that throws is caught: logError called, no crash, no broadcast',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      const errors: string[] = [];
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        collect: (): LiveSessionsCollectResult | null => {
+          throw new Error('collect exploded');
+        },
+        broadcast: (message) => broadcasts.push(message),
+        logError: (msg) => errors.push(msg),
+        debounceMs: 20,
       });
 
-      await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
+      try {
+        registry.register({
+          sessionId: '33333333-3333-3333-3333-333333333333',
+          pid: process.pid,
+          wsPort: 20052,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        });
 
-      expect(broadcasts).toEqual([]);
-      expect(errors.length).toBeGreaterThanOrEqual(1);
-      expect(errors[0]).toContain('collect exploded');
-    } finally {
-      closer();
-    }
-  });
+        await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
+
+        expect(broadcasts).toEqual([]);
+        expect(errors.length).toBeGreaterThanOrEqual(1);
+        expect(errors[0]).toContain('collect exploded');
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -9,6 +9,31 @@ import {
 } from '../../src/cli/live-sessions-watcher.ts';
 import { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
 
+/**
+ * Wait until `predicate` holds, or fail after `timeoutMs`.
+ *
+ * These tests drive a real `fs.watch` through a debounce, so the delay between
+ * an action and its observable effect is the OS's to decide, not ours. Sleeping
+ * a fixed 150ms and then asserting the effect HAPPENED encodes a guess about
+ * how loaded the machine is: it passes on a quiet laptop and fails on a busy CI
+ * runner, which is exactly how #848/#849 blocked a release without either test
+ * being wrong about the behavior it describes.
+ *
+ * Polling for the condition instead makes the test wait exactly as long as it
+ * needs to and no longer, and turns a timeout into an honest failure message
+ * rather than a confusing assertion on an empty array. Note this is only valid
+ * for POSITIVE assertions ("this eventually happens"); proving a broadcast
+ * never arrives still requires waiting a fixed interval.
+ */
+async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
 describe('startLiveSessionsWatcher (#542)', () => {
   let tmpDir: string;
   let registry: SessionRegistryFile;
@@ -48,7 +73,7 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
 
       expect(errors).toEqual([]);
       expect(broadcasts).toHaveLength(1);
@@ -86,12 +111,12 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       };
       registry.register(entry);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
       const afterRegister = dirChanges;
       expect(afterRegister).toBeGreaterThanOrEqual(1);
 
       registry.unregister(entry.sessionId);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => dirChanges > afterRegister, 'onDirChange to fire again for the removal');
       expect(dirChanges).toBeGreaterThan(afterRegister);
       // The whole point: the census hook fired even though no
       // session_list_response was broadcast.
@@ -157,7 +182,7 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
 
       expect(broadcasts).toEqual([]);
       expect(errors.length).toBeGreaterThanOrEqual(1);

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -8,6 +8,7 @@ import {
   SessionRegistryFile,
   claudeChildLooksAlive,
 } from '../src/session/session-registry-file.ts';
+import { reserveRange } from './session/port-test-helpers.ts';
 
 /** Spawn a trivial process and await its exit to obtain a really-dead pid. */
 async function deadChildPid(): Promise<number> {
@@ -159,36 +160,46 @@ describe('SessionRegistryFile', () => {
     expect(nonExistent.listLive()).toEqual([]);
   });
 
-  // Use high test ports to avoid conflicts with running remi instances
-  const TEST_PORT_BASE = 44000 + Math.floor(Math.random() * 1000);
+  // Never guess a base and then assert it is free (#848). `findAvailablePort`
+  // delegates to a real TCP bind-probe, so a guessed base makes these tests a
+  // bet on nothing else holding that port -- a bet that loses on a shared CI
+  // runner and looks like a bug in the registry rather than in the setup.
+  // `reserveRange` returns a run that is verified free right now, the same
+  // pattern #823 established for `port-utils.test.ts`.
 
   test('findAvailablePort returns first port when no sessions', async () => {
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE);
+    const base = await reserveRange(10);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base);
   });
 
   test('findAvailablePort skips used ports', async () => {
-    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 1 }));
+    const base = await reserveRange(10);
+    registry.register(makeEntry({ sessionId: 'a', wsPort: base }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: base + 1 }));
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE + 2);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base + 2);
   });
 
   test('findAvailablePort fills non-contiguous gaps', async () => {
-    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 2 }));
+    const base = await reserveRange(10);
+    registry.register(makeEntry({ sessionId: 'a', wsPort: base }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: base + 2 }));
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE + 1);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base + 1);
   });
 
   test('findAvailablePort returns null when all ports exhausted', async () => {
+    // Exhaustion here is by the REGISTRY, not by the network: every port in the
+    // range is claimed by a live entry, so the probe is never consulted.
+    const base = await reserveRange(3);
     for (let i = 0; i < 3; i++) {
-      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: TEST_PORT_BASE + i }));
+      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: base + i }));
     }
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 3);
+    const port = await registry.findAvailablePort(base, 3);
     expect(port).toBeNull();
   });
 

--- a/packages/daemon/tests/session/port-test-helpers.ts
+++ b/packages/daemon/tests/session/port-test-helpers.ts
@@ -1,0 +1,71 @@
+/**
+ * Port selection for tests that exercise real TCP binding (#823, #848).
+ *
+ * The rule these exist to enforce: **never guess a port and then assert it is
+ * free.** A test that picks `base = 44000 + random()` and asserts the probe
+ * returns `base` is not testing the code, it is betting that nothing else on
+ * the machine holds that port. On a developer laptop the bet wins; on a shared
+ * CI runner it eventually loses, and the failure looks like a bug in the code
+ * under test rather than in the test's setup.
+ *
+ * That bet cost a release: the flake blocked `auto-release` on `main` during
+ * the 0.7.1 cut, and a red Test gate makes that job SKIP rather than fail, so a
+ * missed release announces itself only as a tag that never appeared (#848).
+ *
+ * #823 fixed this for `port-utils.test.ts`; these helpers were extracted here
+ * so `session-registry-file.test.ts` — which had been left on the old guessing
+ * pattern — uses the same one implementation rather than a second copy that can
+ * drift back.
+ */
+
+import * as net from 'node:net';
+import { isPortAvailable } from '../../src/session/port-utils.ts';
+
+/** Bind to an OS-assigned port and report which one. Never collides. */
+export function occupyEphemeral(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
+    (srv as any).on('error', reject);
+    srv.listen({ port: 0, host: '0.0.0.0', exclusive: true }, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === 'string') {
+        reject(new Error('no address assigned'));
+        return;
+      }
+      resolve({ server: srv, port: addr.port });
+    });
+  });
+}
+
+/** Bind one specific port; rejects if it is taken (callers must have checked). */
+export function occupyPort(port: number): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
+    (srv as any).on('error', reject);
+    srv.listen({ port, host: '0.0.0.0', exclusive: true }, () => resolve(srv));
+  });
+}
+
+/**
+ * Find a base such that `[base, base + count)` are ALL free right now, by
+ * probing each. Retries on a fresh random base when the run is contended.
+ * Throws only if the machine is so busy that no run of `count` ports is free
+ * across `attempts` tries, which is a genuine environment problem worth
+ * failing loudly on rather than papering over.
+ */
+export async function reserveRange(count: number, attempts = 50): Promise<number> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const base = 45000 + Math.floor(Math.random() * 5000);
+    let allFree = true;
+    for (let i = 0; i < count; i++) {
+      if (!(await isPortAvailable(base + i))) {
+        allFree = false;
+        break;
+      }
+    }
+    if (allFree) return base;
+  }
+  throw new Error(`no free run of ${count} ports found after ${attempts} attempts`);
+}

--- a/packages/daemon/tests/session/port-utils.test.ts
+++ b/packages/daemon/tests/session/port-utils.test.ts
@@ -1,71 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import * as net from 'node:net';
+import type * as net from 'node:net';
 import { findAvailableTcpPort, isPortAvailable } from '../../src/session/port-utils.ts';
-
-/**
- * Port selection for these tests (#823).
- *
- * The previous approach picked one random base in 45000-50000 and bound
- * `base + N` outright. Nothing checked the port was free and nothing retried,
- * so any collision failed the test in its own SETUP -- the code under test was
- * never reached. That range overlaps Linux's ephemeral port range, so any other
- * test in the suite that opens a server (several now do) can occupy it, which
- * is exactly how this started failing on CI.
- *
- * Now: never guess. `occupyEphemeral` lets the OS assign a port and reports
- * which one it got, and `reserveRange` finds a genuinely free CONTIGUOUS run
- * for the cases that need one, retrying on a different base if the run is
- * contended mid-reservation.
- */
-
-/** Bind to an OS-assigned port and report which one. Never collides. */
-function occupyEphemeral(): Promise<{ server: net.Server; port: number }> {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
-    (srv as any).on('error', reject);
-    srv.listen({ port: 0, host: '0.0.0.0', exclusive: true }, () => {
-      const addr = srv.address();
-      if (addr === null || typeof addr === 'string') {
-        reject(new Error('no address assigned'));
-        return;
-      }
-      resolve({ server: srv, port: addr.port });
-    });
-  });
-}
-
-/** Bind one specific port; rejects if it is taken (callers must have checked). */
-function occupyPort(port: number): Promise<net.Server> {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
-    (srv as any).on('error', reject);
-    srv.listen({ port, host: '0.0.0.0', exclusive: true }, () => resolve(srv));
-  });
-}
-
-/**
- * Find a base such that `[base, base + count)` are ALL free right now, by
- * probing each. Retries on a fresh random base when the run is contended.
- * Throws only if the machine is so busy that no run of `count` ports is free
- * across `attempts` tries, which is a genuine environment problem worth
- * failing loudly on rather than papering over.
- */
-async function reserveRange(count: number, attempts = 50): Promise<number> {
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    const base = 45000 + Math.floor(Math.random() * 5000);
-    let allFree = true;
-    for (let i = 0; i < count; i++) {
-      if (!(await isPortAvailable(base + i))) {
-        allFree = false;
-        break;
-      }
-    }
-    if (allFree) return base;
-  }
-  throw new Error(`no free run of ${count} ports found after ${attempts} attempts`);
-}
+import { occupyEphemeral, occupyPort, reserveRange } from './port-test-helpers.ts';
 
 describe('isPortAvailable', () => {
   const servers: net.Server[] = [];


### PR DESCRIPTION
Fixes #848 and #849. Both flakes are fixed at the root, not disabled or retried.

They are worth fixing properly because a red Test gate makes `auto-release` **skip** rather than fail: no tag, no npm publish, no Homebrew update, and the only symptom is a tag that never appears. Between them these two blocked the 0.7.1 cut twice, once on `main`.

## #849 — fixed sleep before a positive assertion

`live-sessions-watcher.test.ts` drove a real `fs.watch` through a debounce, slept a fixed 150ms, then asserted the effect **had happened**. The delay between an action and its observable effect belongs to the OS, so that encodes a guess about how loaded the machine is: it passes on a quiet laptop and fails on a busy runner.

Replaced with a `waitFor(predicate, what)` poll. The test now waits exactly as long as it needs to and turns a timeout into an honest message instead of an assertion on an empty array.

**Four of the five sleeps had this shape, not just the one that fired** — the reported failure was the only one that had happened to lose the race so far. All four are converted. The fifth is left alone deliberately: it asserts a broadcast *never* arrives, and proving absence genuinely does require waiting a fixed interval.

Verified by reproducing the CI mechanism — raising the effect delay past the old budget (`debounceMs` 20 -> 400):

| Version | Result at 400ms |
|---|---|
| `waitFor` (this PR) | 4 pass, 0 fail |
| old fixed 150ms sleep | 1 pass, **3 fail** |

## #848 — guessed a port, then asserted it was free

`session-registry-file.test.ts` used `TEST_PORT_BASE = 44000 + Math.floor(Math.random() * 1000)` and asserted `findAvailablePort` returned exactly that base. But `findAvailablePort` delegates to a **real TCP bind-probe**, so the test was betting that nothing else on the machine held the guessed port.

This is the same bug #823 already fixed in `port-utils.test.ts`; these tests were simply left on the old pattern. Rather than write a second copy of the fix, the helpers (`reserveRange`, `occupyPort`, `occupyEphemeral`) are extracted to `tests/session/port-test-helpers.ts` and both files now import the one implementation, so it cannot drift back.

`reserveRange(n)` returns a base whose whole run is **verified free right now**, retrying on contention.

Verified directly by occupying a reserved base and re-running the lookup:

```
occupied base      : 45313
findAvailablePort  : 45314
OLD test asserted  : port === base  -> would FAIL   <-- the flake
reserveRange returned the occupied base in 25 tries: never
```

## Testing

- Full suite: **3820 pass, 0 fail**, 69 skip across 202 files.
- The three affected files stress-run **12 consecutive times: 0 failures**.
- `tsc --noEmit`, biome, and spelling clean.

## Not included

#849 also suggested making a missed release *fail loudly* rather than skip. That is a change to release CI, and making it immediately before cutting 0.7.2 would add risk to the very release it is meant to protect. Left for a follow-up; the issue stays open for it.