### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`remi model restart`** (#852) — relaunch the engine on the version remi
+  pins. Pinning did not imply running: `EngineHost`'s rule is that ownership is
+  about who *starts* an engine, not who holds it, so an engine already answering
+  is attached to however old it is, and upgrading remi never upgraded the engine
+  it talks to. It refuses to kill an engine remi has no record of starting
+  (killing whatever holds the port on a guess is how you take down something
+  that mattered), refuses against a shared engine, and reports failure rather
+  than success if the relaunched engine is still older than the pin.
+
+### Fixed
+- **`remi model status` reports the engine's version** (#852). remi never read
+  it: it pinned which helper to *install* and inferred "old engine" from a
+  missing field, so it could not tell you what you actually had. It now shows
+  the running version next to the pinned one, and when the engine is older it
+  names `remi model restart` instead of saying "upgrade the engine to 0.7.8+" —
+  advice whose only implementation was a function with no callers.
+- **`remi --help` shows the model commands under Auto-Approve** (#850), at the
+  top of the section, rather than as the last line of Configuration where a
+  user read the whole output and did not find them.
+
 ## [0.7.1] - 2026-07-27
 
 Makes `remi model` usable on a fresh install and names models the way you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-07-27
+
+Makes the engine's version visible and replaceable, and puts the model
+commands where you would look for them.
+
 ### Added
 - **`remi model restart`** (#852) — relaunch the engine on the version remi
   pins. Pinning did not imply running: `EngineHost`'s rule is that ownership is
@@ -24,6 +29,12 @@ All notable changes to Remi are documented here.
 - **`remi --help` shows the model commands under Auto-Approve** (#850), at the
   top of the section, rather than as the last line of Configuration where a
   user read the whole output and did not find them.
+- **Two flaky tests that could silently cancel a release** (#848, #849). Both
+  guessed at something the machine decides — one asserted a randomly chosen TCP
+  port was free, the other slept a fixed 150ms and then asserted an `fs.watch`
+  effect had already happened. Each blocked the 0.7.1 cut once, and a red test
+  gate makes `auto-release` *skip*, so the only symptom is a tag that never
+  appears. Fixed at the root rather than retried or disabled.
 
 ## [0.7.1] - 2026-07-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.2-dev.2",
+  "version": "0.7.2-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.1",
+  "version": "0.7.2-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.2-dev.1",
+  "version": "0.7.2-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.2-dev.4",
+  "version": "0.7.2-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.2-dev.3",
+  "version": "0.7.2-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -268,7 +268,18 @@ export class EngineHost {
   static stopRecordedEngine(pids: PidStore, kill: (pid: number) => void): number | null {
     const pid = pids.read();
     if (pid === null) return null;
-    kill(pid);
+    // `read()` already drops a pid whose process is gone, but there is a real
+    // window between that check and this signal in which the engine can exit on
+    // its own — and `process.kill` throws synchronously for ESRCH (and EPERM).
+    // Letting that escape would abort the caller before the record is cleared,
+    // leaving a pidfile naming a dead process AND surfacing as a raw stack
+    // trace from a user-invoked command. Either way the record is now stale, so
+    // release it unconditionally — the same shape `killStarted` already uses.
+    try {
+      kill(pid);
+    } catch {
+      // Already gone, or not ours to signal. Both mean "stop looking here".
+    }
     pids.release(pid);
     return pid;
   }

--- a/packages/daemon/src/auto-approve/engine-install.ts
+++ b/packages/daemon/src/auto-approve/engine-install.ts
@@ -57,6 +57,40 @@ export const ENGINE_RELEASE = {
   binary: 'Yooz Engine (LLM)',
 } as const;
 
+/** The pinned engine version, without the tag's leading `v`. */
+export const PINNED_ENGINE_VERSION = ENGINE_RELEASE.tag.replace(/^v/, '');
+
+/** `[major, minor, patch]`, or undefined when the string is not a semver core.
+ *  Any prerelease suffix is dropped: `0.7.8-dev.1` compares as `0.7.8`, which
+ *  is what "does this build have the 0.7.8 features?" actually asks. */
+function semverParts(version: string): [number, number, number] | undefined {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version.replace(/^v/, ''));
+  if (m === null) return undefined;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * Is `version` older than the helper remi pins?
+ *
+ * Three-way on purpose. `undefined` means "cannot tell" — an unparseable or
+ * absent version must not be reported as either current or stale, because both
+ * are claims about the user's machine that we would be making up.
+ */
+export function isOlderThanPinned(version: string | undefined): boolean | undefined {
+  if (version === undefined) return undefined;
+  const running = semverParts(version);
+  const pinned = semverParts(PINNED_ENGINE_VERSION);
+  if (running === undefined || pinned === undefined) return undefined;
+  // Destructured rather than indexed in a loop: under `noUncheckedIndexedAccess`
+  // a variable index widens each element to `number | undefined`, which this
+  // comparison must not have to reason about.
+  const [rMajor, rMinor, rPatch] = running;
+  const [pMajor, pMinor, pPatch] = pinned;
+  if (rMajor !== pMajor) return rMajor < pMajor;
+  if (rMinor !== pMinor) return rMinor < pMinor;
+  return rPatch < pPatch;
+}
+
 /** Absolute path the pinned release installs to. */
 export function installedHelperPath(root: string = ENGINE_INSTALL_ROOT): string {
   return path.join(

--- a/packages/daemon/src/auto-approve/engine-install.ts
+++ b/packages/daemon/src/auto-approve/engine-install.ts
@@ -72,7 +72,7 @@ function semverParts(version: string): [number, number, number] | undefined {
 /**
  * Is `version` older than the helper remi pins?
  *
- * Three-way on purpose. `undefined` means "cannot tell" — an unparseable or
+ * Three-way on purpose. `undefined` means "cannot tell" — an unparsable or
  * absent version must not be reported as either current or stale, because both
  * are claims about the user's machine that we would be making up.
  */

--- a/packages/daemon/src/auto-approve/engine-models.ts
+++ b/packages/daemon/src/auto-approve/engine-models.ts
@@ -177,6 +177,38 @@ export async function listModels(baseUrl: string, timeoutMs?: number): Promise<E
   return { current: raw.current ?? '', available: raw.available ?? [] };
 }
 
+/**
+ * The running engine's own version, or undefined when it will not say.
+ *
+ * remi pins which helper it *installs* (`ENGINE_RELEASE.tag`), but ownership is
+ * about who STARTS an engine, not who holds it: an engine that is already
+ * answering gets attached to, however old it is. So the pin says nothing about
+ * what is actually on the far end of the socket, and until this existed remi
+ * had no way to ask — it inferred "old engine" from a field being missing and
+ * told users to "upgrade to 0.7.8+" without being able to name what they had.
+ *
+ * Never throws. A version we cannot read must degrade to "not reported", not to
+ * a failed status command.
+ */
+export async function getEngineVersion(
+  baseUrl: string,
+  timeoutMs = 2_000,
+): Promise<string | undefined> {
+  try {
+    const raw = await engineRequest<{ engineVersion?: string }>(baseUrl, '/v1/modules', {
+      method: 'GET',
+      timeoutMs,
+    });
+    // An engine old enough to lack the field is exactly the case this exists to
+    // report, so an empty string must read as "would not say", not as a version.
+    return raw.engineVersion !== undefined && raw.engineVersion.length > 0
+      ? raw.engineVersion
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Current load/download state. */
 export async function getStatus(baseUrl: string, timeoutMs?: number): Promise<EngineStatus> {
   return await engineRequest<EngineStatus>(baseUrl, '/v1/llm/status', {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.1'; // REMI_COMPILED_VERSION
+      return '0.7.2-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.1'; // REMI_COMPILED_VERSION
+    return '0.7.2-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.2-dev.2'; // REMI_COMPILED_VERSION
+      return '0.7.2-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.2-dev.2'; // REMI_COMPILED_VERSION
+    return '0.7.2-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.2-dev.1'; // REMI_COMPILED_VERSION
+      return '0.7.2-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.2-dev.1'; // REMI_COMPILED_VERSION
+    return '0.7.2-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.2-dev.3'; // REMI_COMPILED_VERSION
+      return '0.7.2-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.2-dev.3'; // REMI_COMPILED_VERSION
+    return '0.7.2-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.2-dev.4'; // REMI_COMPILED_VERSION
+      return '0.7.2-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.2-dev.4'; // REMI_COMPILED_VERSION
+    return '0.7.2-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -18,6 +18,7 @@
  *   remi model load <id>       make resident (already-downloaded weights)
  *   remi model unload <id>     free its memory
  *   remi model use <id>        make it the configured default (persisted)
+ *   remi model restart         relaunch the engine on the version remi pins
  *
  * `ls` reads the DISK inventory (`GET /v1/models`), whose `sizeBytes` is the
  * engine's real measured footprint and whose `deletable` flag is what `rm`
@@ -51,12 +52,18 @@
 import { errorToString } from '@remi/shared';
 import { EngineHost } from '../auto-approve/engine-host.ts';
 import {
+  ENGINE_RELEASE,
+  PINNED_ENGINE_VERSION,
+  isOlderThanPinned,
+} from '../auto-approve/engine-install.ts';
+import {
   type EngineModel,
   type ManagedModel,
   type PullProgress,
   cancelDownload,
   cleanupModels,
   deleteModel,
+  getEngineVersion,
   listManagedModels,
   listModels,
   preloadAsync,
@@ -64,6 +71,7 @@ import {
   pullModel,
   unloadModel,
 } from '../auto-approve/engine-models.ts';
+import { FileEnginePidStore } from '../auto-approve/engine-process.ts';
 import { resolveProviderUrl } from '../auto-approve/llm-client.ts';
 import { displayId, findModel, lookupModel, matchesModel } from '../auto-approve/model-identity.ts';
 import type { RemiConfig } from '../config/config.ts';
@@ -92,6 +100,7 @@ const VERBS = [
   'load',
   'unload',
   'use',
+  'restart',
 ] as const;
 type Verb = (typeof VERBS)[number];
 
@@ -191,6 +200,14 @@ export interface ModelCommandDeps {
    * the developer's machine, which is exactly the accident #841 had to undo.
    */
   readonly ensureEngine?: (baseUrl: string, io: ModelCommandIO) => Promise<boolean>;
+  /** The running engine's own version, or undefined when it will not say. */
+  readonly engineVersion?: typeof getEngineVersion;
+  /**
+   * Stop the recorded engine, returning the pid signalled or null when none is
+   * recorded. A seam for the same reason `ensureEngine` is one: the real
+   * implementation signals a live process on the developer's machine.
+   */
+  readonly stopEngine?: () => number | null;
 }
 
 /**
@@ -293,7 +310,16 @@ export async function runModelCommand(
   // mid-generate on, or deleting a model the host manages, is hostile — so
   // these verbs refuse rather than mutating shared state. Read-only verbs
   // work identically in both modes.
-  const MUTATING: ReadonlySet<string> = new Set(['pull', 'cancel', 'rm', 'cleanup', 'unload']);
+  // `restart` is the most hostile of all against a shared engine — it does not
+  // touch weights, it kills somebody else's process.
+  const MUTATING: ReadonlySet<string> = new Set([
+    'pull',
+    'cancel',
+    'rm',
+    'cleanup',
+    'unload',
+    'restart',
+  ]);
   if (aa.engine === 'shared' && MUTATING.has(verb)) {
     io.err(
       `"remi model ${verb}" is not available against a shared engine: this remi is a guest (auto_approve.engine = "shared"), and another module may be using these weights.`,
@@ -307,6 +333,23 @@ export async function runModelCommand(
   // configure while the engine was down (#843).
   if (verb === 'use') {
     return await runUse(args[1], baseUrl, io, { list, probe, persistModel: deps.persistModel });
+  }
+
+  // `restart` runs its own engine flow. The autostart below fires only when
+  // NOTHING is listening, and the case this exists for is the opposite one: an
+  // engine that is answering, from an older helper than remi pins (#852).
+  if (verb === 'restart') {
+    return await runRestart(baseUrl, io, {
+      probe,
+      version: deps.engineVersion ?? getEngineVersion,
+      stop:
+        deps.stopEngine ??
+        (() =>
+          EngineHost.stopRecordedEngine(new FileEnginePidStore(), (pid) =>
+            process.kill(pid, 'SIGTERM'),
+          )),
+      ensure: deps.ensureEngine ?? ((url, out) => ensureEngineViaHost(config, url, out)),
+    });
   }
 
   // One probe up front so every verb can explain "nothing is listening" the
@@ -382,6 +425,22 @@ export async function runModelCommand(
         const found = rows.ok ? lookupModel(rows.rows, configured) : undefined;
 
         io.out(`engine:   ${baseUrl} (reachable, ${aa.engine})`);
+        // What is actually on the far end of the socket, which the pin does not
+        // determine: an engine already answering is attached to, however old
+        // (#852). Reporting the pin alongside it is what makes "upgrade the
+        // engine" a checkable statement rather than an instruction to guess.
+        const engineVersion = await (deps.engineVersion ?? getEngineVersion)(baseUrl);
+        const stale = isOlderThanPinned(engineVersion);
+        io.out(
+          engineVersion === undefined
+            ? `version:  not reported (remi pins ${PINNED_ENGINE_VERSION})`
+            : stale === true
+              ? `version:  ${engineVersion} — older than the ${PINNED_ENGINE_VERSION} remi pins`
+              : `version:  ${engineVersion} (remi pins ${PINNED_ENGINE_VERSION})`,
+        );
+        if (stale === true && aa.engine !== 'shared') {
+          io.out('          ("remi model restart" relaunches it on the pinned build)');
+        }
         io.out(`model:    ${configured}`);
         if (!rows.ok) {
           io.out("state:    could not read this engine's model inventory");
@@ -405,7 +464,9 @@ export async function runModelCommand(
           io.out(
             rows.ok && rows.rows.length === 0
               ? '          (nothing is cached yet; "remi model pull" fetches it)'
-              : '          (upgrade the engine to 0.7.8+ to resolve this)',
+              : stale === true
+                ? '          (this engine predates the alias listing; see "version" above)'
+                : '          (an engine that names models by repo id resolves this)',
           );
         } else {
           // Alias-aware rows, and none of them is this model. Now a negative
@@ -644,6 +705,99 @@ export async function runModelCommand(
     io.err(`remi model ${verb} failed: ${errorToString(err)}`);
     return 1;
   }
+}
+
+/**
+ * `remi model restart` — relaunch the engine on the version remi pins.
+ *
+ * Exists because pinning does not imply running. `EngineHost`'s rule is that
+ * ownership is about who STARTS an engine, not who holds it: an engine already
+ * answering gets attached to, however old. So upgrading remi never upgrades a
+ * running engine, and a 0.7.1 remi could sit indefinitely against a 0.7.7
+ * engine while telling the user to "upgrade to 0.7.8+" — advice whose only
+ * implementation was an uncalled function (#852).
+ */
+async function runRestart(
+  baseUrl: string,
+  io: ModelCommandIO,
+  deps: {
+    probe: typeof probeEngine;
+    version: typeof getEngineVersion;
+    stop: () => number | null;
+    ensure: (baseUrl: string, io: ModelCommandIO) => Promise<boolean>;
+  },
+): Promise<number> {
+  const before = await deps.probe(baseUrl);
+  const runningVersion = before.reachable ? await deps.version(baseUrl) : undefined;
+
+  if (before.reachable) {
+    const pid = deps.stop();
+    if (pid === null) {
+      // An engine is answering that remi has no pid for: started by hand, or
+      // by a remi whose pidfile has since been removed. Killing "whatever holds
+      // the port" on a guess is exactly the kind of thing that takes down
+      // something the user cared about, so say what is true and stop.
+      io.err(`An engine is answering on ${baseUrl}, but remi has no record of starting it.`);
+      io.err(
+        'Nothing was changed. Stop that process yourself, then any "remi model" verb starts the pinned engine.',
+      );
+      return 1;
+    }
+    io.out(`[Engine] Stopped engine pid ${pid}`);
+    // SIGTERM is asynchronous: the port stays bound for a moment after the
+    // signal returns, and starting into a still-bound port is how you get a
+    // second engine that fails to bind and exits, leaving the OLD one serving.
+    const released = await waitForPortToClose(baseUrl, deps.probe);
+    if (!released) {
+      io.err('The old engine is still holding the port; not starting a second one.');
+      io.err(`Check for a lingering "${ENGINE_RELEASE.binary}" process.`);
+      return 1;
+    }
+  }
+
+  await deps.ensure(baseUrl, io);
+  const after = await deps.probe(baseUrl);
+  if (!after.reachable) {
+    io.err(`No engine came up on ${baseUrl}: ${after.reason}`);
+    return 1;
+  }
+
+  const nowVersion = await deps.version(baseUrl);
+  const from =
+    runningVersion === undefined ? 'an engine that did not report a version' : `${runningVersion}`;
+  io.out(
+    runningVersion === undefined
+      ? `Engine restarted (was ${from}).`
+      : `Engine restarted: ${from} -> ${nowVersion ?? 'unreported'}.`,
+  );
+  if (nowVersion !== undefined && isOlderThanPinned(nowVersion) === true) {
+    // The helper on disk is older than the pin — restarting cannot fix that,
+    // and claiming success would be a lie the user finds out about later.
+    io.err(
+      `This engine is still ${nowVersion}, older than the ${PINNED_ENGINE_VERSION} remi pins.`,
+    );
+    io.err(
+      `A helper from an earlier release is being launched. Check auto_approve.engine_path, or remove ~/.remi/engine and let remi refetch ${ENGINE_RELEASE.tag}.`,
+    );
+    return 1;
+  }
+  io.out('Restart running daemons for them to use it.');
+  return 0;
+}
+
+/** Wait for the engine port to stop answering after a stop signal. */
+async function waitForPortToClose(
+  baseUrl: string,
+  probe: typeof probeEngine,
+  attempts = 20,
+  delayMs = 100,
+): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    const p = await probe(baseUrl, 500);
+    if (!p.reachable) return true;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  return false;
 }
 
 /**

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -157,6 +157,7 @@ const commandHelp: Record<Subcommand, string[]> = {
     entry('remi model load <id>', 'Load already-downloaded weights'),
     entry('remi model unload <id>', 'Free a model from memory'),
     entry('remi model use <id>', 'Set the default model (persisted in config)'),
+    entry('remi model restart', 'Relaunch the engine on the version remi pins'),
     '',
     '',
     dim('  Models are named by their registered HuggingFace repo id, e.g.'),

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -319,6 +319,14 @@ export function formatHelp(version: string): string {
     entry('remi attach [name]', 'Attach to a session (Ctrl+B d to detach)'),
     '',
     bold('Auto-Approve (LLM):'),
+    // The model commands live here, not under Configuration, because the
+    // models exist only to serve this evaluator -- and commands come before
+    // flags because `remi model` is a ten-verb subsystem, not a setting. It
+    // spent 0.7.0-0.7.1 as one line at the bottom of Configuration, where a
+    // user read the whole help output and did not find it (#850).
+    entry('remi model ls', "What's downloaded, and which model is active"),
+    entry('remi model use <id>', 'Switch the model auto-approve runs on'),
+    entry('remi model --help', 'All model commands (pull, rm, ps, ...)'),
     entry('--auto-approve', 'Enable LLM auto-approve for permissions'),
     entry('--no-auto-approve', 'Disable auto-approve (overrides config)'),
     entry('--auto-approve-model M', 'LLM model (default: the engine 4B qat-lean)'),
@@ -355,7 +363,6 @@ export function formatHelp(version: string): string {
     entry('remi config', 'Show effective configuration'),
     entry('remi config init', 'Create default config file'),
     entry('remi reload', 'Hot-reload config on running daemons'),
-    entry('remi model', 'Manage the auto-approve LLM (see "remi model --help")'),
     '',
     bold('Service:'),
     entry('remi start', 'Start the hub in the background'),

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -322,9 +322,15 @@ export function formatHelp(version: string): string {
     // The model commands live here, not under Configuration, because the
     // models exist only to serve this evaluator -- and commands come before
     // flags because `remi model` is a ten-verb subsystem, not a setting. It
-    // spent 0.7.0-0.7.1 as one line at the bottom of Configuration, where a
-    // user read the whole help output and did not find it (#850).
-    entry('remi model ls', "What's downloaded, and which model is active"),
+    // shipped in 0.7.0 listed nowhere at all (#843), then spent 0.7.1 as one
+    // line at the bottom of Configuration, where a user read the whole help
+    // output and still did not find it (#850).
+    //
+    // "which one remi uses", not "active": `ls` marks remi's CONFIGURED model
+    // with `*`, while a possibly different row is labelled `engine active` for
+    // the engine picker's resident tier. Calling the first one "active" is the
+    // same conflation `remi model rm` used to make.
+    entry('remi model ls', "What's downloaded, and which one remi uses"),
     entry('remi model use <id>', 'Switch the model auto-approve runs on'),
     entry('remi model --help', 'All model commands (pull, rm, ps, ...)'),
     entry('--auto-approve', 'Enable LLM auto-approve for permissions'),

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -317,6 +317,22 @@ describe('EngineHost — lifetime independence', () => {
     expect(pids.current).toBeNull();
   });
 
+  test('a kill that throws still clears the record and does not escape', () => {
+    // `read()` drops a dead pid, but the engine can exit in the window between
+    // that check and the signal -- and `process.kill` throws ESRCH for it. If
+    // that escaped, `remi model restart` would abort with a raw stack trace
+    // BEFORE releasing the pidfile, leaving a record naming a dead process
+    // that the next run would then refuse to act on (#852).
+    const pids = pidStore(7777);
+
+    const pid = EngineHost.stopRecordedEngine(pids, () => {
+      throw new Error('ESRCH: no such process');
+    });
+
+    expect(pid).toBe(7777);
+    expect(pids.current).toBeNull();
+  });
+
   test('the operator teardown reports when there is nothing recorded', () => {
     expect(EngineHost.stopRecordedEngine(pidStore(null), () => {})).toBeNull();
   });

--- a/packages/daemon/tests/auto-approve/engine-models.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-models.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupModels,
   clearModelCache,
   deleteModel,
+  getEngineVersion,
   getModelState,
   getStatus,
   listManagedModels,
@@ -556,5 +557,64 @@ describe('pullModel — engine death mid-download', () => {
     await expect(pullModel(server.url, 'm', { sleep: noSleep })).rejects.toThrow(
       /stopped answering|unparsable|503/,
     );
+  });
+});
+
+describe('engine version (#852)', () => {
+  test('reads engineVersion from /v1/modules', async () => {
+    // Pins the real endpoint and field name. Both were previously asserted
+    // nowhere: `remi model status` only ever saw an injected fake, so a wrong
+    // path or a renamed field would have shipped silently.
+    const srv = engineServer(() =>
+      Response.json({ engineVersion: '0.7.8', buildVariant: 'llm', modules: [] }),
+    );
+    try {
+      expect(await getEngineVersion(srv.url)).toBe('0.7.8');
+      expect(srv.seen.map((r) => `${r.method} ${r.path}`)).toEqual(['GET /v1/modules']);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('an engine that omits the field reports no version, not an empty one', async () => {
+    // The engines this exists to detect are the OLD ones, so the missing-field
+    // case is the load-bearing one: '' must not read as a version.
+    const srv = engineServer(() => Response.json({ buildVariant: 'llm', modules: [] }));
+    try {
+      expect(await getEngineVersion(srv.url)).toBeUndefined();
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('an empty engineVersion string reports no version', async () => {
+    const srv = engineServer(() => Response.json({ engineVersion: '' }));
+    try {
+      expect(await getEngineVersion(srv.url)).toBeUndefined();
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('a non-2xx or unparsable body reports no version rather than throwing', async () => {
+    // `status` must still print a report when this fails; a throw here would
+    // take down the whole diagnostic.
+    const err = engineServer(() => new Response('nope', { status: 500 }));
+    try {
+      expect(await getEngineVersion(err.url)).toBeUndefined();
+    } finally {
+      err.stop();
+    }
+    const junk = engineServer(() => new Response('not json', { status: 200 }));
+    try {
+      expect(await getEngineVersion(junk.url)).toBeUndefined();
+    } finally {
+      junk.stop();
+    }
+  });
+
+  test('no engine at all reports no version rather than throwing', async () => {
+    // Port 1 is reserved and never listening.
+    expect(await getEngineVersion('http://127.0.0.1:1', 300)).toBeUndefined();
   });
 });

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { isOlderThanPinned } from '../../src/auto-approve/engine-install.ts';
 import type {
   EngineModelCatalog,
   EngineProbe,
@@ -1165,5 +1166,165 @@ describe('remi model — undecidable ownership is never asserted (legacy engine)
     expect(text).not.toContain("It is not remi's model");
     expect(text).toContain('cannot be determined');
     expect(text).toContain('remi model use <other>'); // offered, not denied
+  });
+});
+
+describe('engine version (#852)', () => {
+  test('isOlderThanPinned is three-way, never a guess', () => {
+    // "cannot tell" must not collapse into either answer: both are claims about
+    // the user's machine, and both were being made up before this existed.
+    expect(isOlderThanPinned('0.7.7')).toBe(true);
+    expect(isOlderThanPinned('0.7.8')).toBe(false);
+    expect(isOlderThanPinned('0.7.9')).toBe(false);
+    expect(isOlderThanPinned('0.8.0')).toBe(false);
+    expect(isOlderThanPinned('1.0.0')).toBe(false);
+    expect(isOlderThanPinned('0.6.24')).toBe(true);
+    expect(isOlderThanPinned(undefined)).toBeUndefined();
+    expect(isOlderThanPinned('not-a-version')).toBeUndefined();
+  });
+
+  test('a prerelease of the pinned version is not older than it', () => {
+    // `0.7.8-dev.1` carries the 0.7.8 features, which is what the comparison is
+    // actually asking. Ordering it below 0.7.8 would nag on every dev build.
+    expect(isOlderThanPinned('0.7.8-dev.1')).toBe(false);
+  });
+
+  test('status reports the running version alongside the pin', async () => {
+    const t = io();
+    const code = await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => '0.7.8',
+    });
+    expect(code).toBe(0);
+    const text = t.out.join('\n');
+    expect(text).toContain('0.7.8');
+    expect(text).toContain('remi pins 0.7.8');
+  });
+
+  test('status names the restart command when the engine is older than the pin', async () => {
+    // The 0.7.1 message said "upgrade the engine to 0.7.8+" and named no way to
+    // do it -- the only implementation was an uncalled function (#852).
+    const t = io();
+    await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => '0.7.7',
+    });
+    const text = t.out.join('\n');
+    expect(text).toContain('0.7.7');
+    expect(text).toContain('older than the 0.7.8');
+    expect(text).toContain('remi model restart');
+  });
+
+  test('status says "not reported" rather than inventing a version', async () => {
+    const t = io();
+    await run(['status'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      engineVersion: async () => undefined,
+    });
+    const text = t.out.join('\n');
+    expect(text).toContain('not reported');
+    expect(text).not.toContain('remi model restart');
+  });
+});
+
+describe('remi model restart (#852)', () => {
+  test('stops the running engine, then starts the pinned one', async () => {
+    const stopped: number[] = [];
+    let started = false;
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      // reachable -> (after stop) unreachable -> reachable again
+      probe: async () => {
+        calls++;
+        return calls === 1 || calls > 2 ? REACHABLE : { reachable: false, reason: 'down' };
+      },
+      engineVersion: async () => (started ? '0.7.8' : '0.7.7'),
+      stopEngine: () => {
+        stopped.push(4242);
+        return 4242;
+      },
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(stopped).toEqual([4242]);
+    expect(started).toBe(true);
+    expect(t.out.join('\n')).toContain('0.7.7 -> 0.7.8');
+  });
+
+  test('refuses to kill an engine remi has no record of starting', async () => {
+    // Killing whatever holds the port on a guess is how you take down something
+    // the user cared about. Nothing is stopped and nothing is started.
+    let started = false;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => REACHABLE,
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => null,
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(1);
+    expect(started).toBe(false);
+    expect(t.err.join('\n')).toContain('no record of starting it');
+  });
+
+  test('starts an engine when none is running', async () => {
+    let started = false;
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => {
+        calls++;
+        return calls === 1 ? { reachable: false, reason: 'down' } : REACHABLE;
+      },
+      engineVersion: async () => '0.7.8',
+      stopEngine: () => {
+        throw new Error('must not stop an engine that is not running');
+      },
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(started).toBe(true);
+  });
+
+  test('reports failure when the relaunched engine is still older than the pin', async () => {
+    // Restarting cannot fix a stale helper on disk, and claiming success would
+    // be a lie the user discovers later.
+    let calls = 0;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => {
+        calls++;
+        return calls === 1 || calls > 2 ? REACHABLE : { reachable: false, reason: 'down' };
+      },
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => 4242,
+      ensureEngine: async () => true,
+    });
+    expect(code).toBe(1);
+    expect(t.err.join('\n')).toContain('still 0.7.7');
+  });
+
+  test('refuses against a shared engine', async () => {
+    const t = io();
+    const code = await run(['restart'], configWith({ engine: 'shared' }), t.io, {
+      stopEngine: () => {
+        throw new Error("must not kill another host's engine");
+      },
+    });
+    expect(code).toBe(1);
+    expect(t.err.join('\n')).toContain('shared engine');
   });
 });

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -1317,6 +1317,26 @@ describe('remi model restart (#852)', () => {
     expect(t.err.join('\n')).toContain('still 0.7.7');
   });
 
+  test('will not start a second engine when the old one keeps the port', async () => {
+    // SIGTERM is asynchronous. If the old engine never lets go, starting anyway
+    // yields a second engine that fails to bind and exits -- leaving the OLD
+    // one serving while the command claims success.
+    let started = false;
+    const t = io();
+    const code = await run(['restart'], configWith(), t.io, {
+      probe: async () => REACHABLE, // never releases
+      engineVersion: async () => '0.7.7',
+      stopEngine: () => 4242,
+      ensureEngine: async () => {
+        started = true;
+        return true;
+      },
+    });
+    expect(code).toBe(1);
+    expect(started).toBe(false);
+    expect(t.err.join('\n')).toContain('still holding the port');
+  });
+
   test('refuses against a shared engine', async () => {
     const t = io();
     const code = await run(['restart'], configWith({ engine: 'shared' }), t.io, {

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -148,16 +148,32 @@ describe('formatCommandHelp', () => {
 });
 
 describe('help formatting', () => {
-  /** The lines under `heading`, up to the next blank line. */
+  /**
+   * The lines under `heading`, up to the next heading.
+   *
+   * Delimiting on the next HEADING rather than the next blank line matters:
+   * `Options:` already contains an internal blank line, so a blank-line rule
+   * would silently return a truncated section and let an assertion about a
+   * dropped entry pass green. Headings are unindented; entries are not.
+   */
   function sectionOf(text: string, heading: string): string {
     const plain = text.replace(/\x1b\[[0-9]+m/g, '');
     const lines = plain.split('\n');
     const start = lines.findIndex((l) => l.trim() === heading);
     if (start === -1) throw new Error(`no "${heading}" section in help output`);
     const rest = lines.slice(start + 1);
-    const end = rest.findIndex((l) => l.trim() === '');
+    const end = rest.findIndex((l) => /^\S/.test(l));
     return (end === -1 ? rest : rest.slice(0, end)).join('\n');
   }
+
+  test('sectionOf spans a section that contains a blank line', () => {
+    // Guards the helper itself: `Options:` has a blank line in the middle, and
+    // a blank-line-delimited reader drops everything after it while still
+    // looking like it worked.
+    const options = sectionOf(formatHelp('0.0.0-test'), 'Options:');
+    expect(options).toContain('--port PORT');
+    expect(options).toContain('--force'); // after the internal blank line
+  });
 
   test('the model commands sit in the Auto-Approve section, not Configuration', () => {
     // 0.7.0 shipped `remi model` with per-command help but no entry in the

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -150,7 +150,6 @@ describe('formatCommandHelp', () => {
 describe('help formatting', () => {
   /** The lines under `heading`, up to the next blank line. */
   function sectionOf(text: string, heading: string): string {
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI is the point
     const plain = text.replace(/\x1b\[[0-9]+m/g, '');
     const lines = plain.split('\n');
     const start = lines.findIndex((l) => l.trim() === heading);

--- a/packages/daemon/tests/cli/help.test.ts
+++ b/packages/daemon/tests/cli/help.test.ts
@@ -148,10 +148,33 @@ describe('formatCommandHelp', () => {
 });
 
 describe('help formatting', () => {
-  test('the global list mentions "remi model" so it is discoverable', () => {
-    // It shipped in 0.7.0 with per-command help but no entry in the command
-    // list, so the only way to find it was to already know it existed (#843).
-    expect(formatHelp('0.0.0-test')).toContain('remi model');
+  /** The lines under `heading`, up to the next blank line. */
+  function sectionOf(text: string, heading: string): string {
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI is the point
+    const plain = text.replace(/\x1b\[[0-9]+m/g, '');
+    const lines = plain.split('\n');
+    const start = lines.findIndex((l) => l.trim() === heading);
+    if (start === -1) throw new Error(`no "${heading}" section in help output`);
+    const rest = lines.slice(start + 1);
+    const end = rest.findIndex((l) => l.trim() === '');
+    return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+  }
+
+  test('the model commands sit in the Auto-Approve section, not Configuration', () => {
+    // 0.7.0 shipped `remi model` with per-command help but no entry in the
+    // global list (#843). The fix put one line at the BOTTOM of Configuration,
+    // where a user read the whole output and still did not find it (#850) --
+    // so asserting mere presence is not enough to call it discoverable.
+    const text = formatHelp('0.0.0-test');
+    expect(sectionOf(text, 'Auto-Approve (LLM):')).toContain('remi model');
+    expect(sectionOf(text, 'Configuration:')).not.toContain('remi model');
+  });
+
+  test('the model commands come before the auto-approve flags', () => {
+    // `remi model` is a ten-verb subsystem, not a setting; listing it after the
+    // flags would read as an afterthought of them.
+    const section = sectionOf(formatHelp('0.0.0-test'), 'Auto-Approve (LLM):');
+    expect(section.indexOf('remi model')).toBeLessThan(section.indexOf('--auto-approve'));
   });
 
   test('a term wider than the column still has a space before its description', () => {

--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -24,8 +24,22 @@ import { SessionRegistryFile } from '../../src/session/session-registry-file.ts'
  * rather than a confusing assertion on an empty array. Note this is only valid
  * for POSITIVE assertions ("this eventually happens"); proving a broadcast
  * never arrives still requires waiting a fixed interval.
+ *
+ * The budget has to clear TWO bars, and the first draft cleared neither:
+ *
+ *   - It must beat bun's own per-test deadline, which defaults to exactly
+ *     5000ms. A `waitFor` that also waited 5000ms could never report first —
+ *     its clock starts strictly later — so bun's generic "this test timed out"
+ *     won every race and the descriptive message was demoted to an
+ *     "Unhandled error between tests" footnote. Hence `TEST_TIMEOUT_MS`, passed
+ *     per test, with this default comfortably under it.
+ *   - It must be long enough that a loaded machine is not itself the failure.
+ *     Observed live while reviewing this change: on a host running several
+ *     concurrent workloads, the `fs.watch` callback for a sibling registration
+ *     took over five seconds. A budget tight enough to trip on that is the
+ *     original bug with a bigger number.
  */
-async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000): Promise<void> {
+async function waitFor(predicate: () => boolean, what: string, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;
@@ -33,6 +47,10 @@ async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000
   }
   throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
 }
+
+/** Per-test deadline for the `waitFor` tests, raised above bun's 5000ms default
+ *  so `waitFor`'s own message is always the one reported. */
+const TEST_TIMEOUT_MS = 30_000;
 
 describe('startLiveSessionsWatcher (#542)', () => {
   let tmpDir: string;
@@ -47,84 +65,95 @@ describe('startLiveSessionsWatcher (#542)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('broadcasts once when a sibling registers, carrying its port', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    const errors: string[] = [];
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      collect: (): LiveSessionsCollectResult | null => {
-        const newPorts = registry.getLivePorts();
-        if (newPorts.length === 0) return null;
-        return { sessions: [], newPorts };
-      },
-      broadcast: (message) => broadcasts.push(message),
-      logError: (msg) => errors.push(msg),
-      debounceMs: 20,
-    });
-
-    try {
-      registry.register({
-        sessionId: '11111111-1111-1111-1111-111111111111',
-        pid: process.pid,
-        wsPort: 20050,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
+  test(
+    'broadcasts once when a sibling registers, carrying its port',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      const errors: string[] = [];
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        collect: (): LiveSessionsCollectResult | null => {
+          const newPorts = registry.getLivePorts();
+          if (newPorts.length === 0) return null;
+          return { sessions: [], newPorts };
+        },
+        broadcast: (message) => broadcasts.push(message),
+        logError: (msg) => errors.push(msg),
+        debounceMs: 20,
       });
 
-      await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
+      try {
+        registry.register({
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          pid: process.pid,
+          wsPort: 20050,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        });
 
-      expect(errors).toEqual([]);
-      expect(broadcasts).toHaveLength(1);
-      const msg = broadcasts[0] as unknown as { type: string; daemonPorts?: readonly number[] };
-      expect(msg.type).toBe('session_list_response');
-      expect(msg.daemonPorts).toContain(20050);
-    } finally {
-      closer();
-    }
-  });
+        await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
 
-  test('onDirChange fires on every flush, including removals that broadcast nothing (#650)', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    let dirChanges = 0;
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      // Removal shape: nothing new to broadcast, ever.
-      collect: (): LiveSessionsCollectResult | null => null,
-      broadcast: (message) => broadcasts.push(message),
-      logError: () => {},
-      debounceMs: 20,
-      onDirChange: () => {
-        dirChanges += 1;
-      },
-    });
+        expect(errors).toEqual([]);
+        expect(broadcasts).toHaveLength(1);
+        const msg = broadcasts[0] as unknown as { type: string; daemonPorts?: readonly number[] };
+        expect(msg.type).toBe('session_list_response');
+        expect(msg.daemonPorts).toContain(20050);
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    try {
-      const entry = {
-        sessionId: '22222222-2222-2222-2222-222222222222',
-        pid: process.pid,
-        wsPort: 20051,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
-      };
-      registry.register(entry);
-      await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
-      const afterRegister = dirChanges;
-      expect(afterRegister).toBeGreaterThanOrEqual(1);
+  test(
+    'onDirChange fires on every flush, including removals that broadcast nothing (#650)',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      let dirChanges = 0;
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        // Removal shape: nothing new to broadcast, ever.
+        collect: (): LiveSessionsCollectResult | null => null,
+        broadcast: (message) => broadcasts.push(message),
+        logError: () => {},
+        debounceMs: 20,
+        onDirChange: () => {
+          dirChanges += 1;
+        },
+      });
 
-      registry.unregister(entry.sessionId);
-      await waitFor(() => dirChanges > afterRegister, 'onDirChange to fire again for the removal');
-      expect(dirChanges).toBeGreaterThan(afterRegister);
-      // The whole point: the census hook fired even though no
-      // session_list_response was broadcast.
-      expect(broadcasts).toHaveLength(0);
-    } finally {
-      closer();
-    }
-  });
+      try {
+        const entry = {
+          sessionId: '22222222-2222-2222-2222-222222222222',
+          pid: process.pid,
+          wsPort: 20051,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        };
+        registry.register(entry);
+        await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
+        const afterRegister = dirChanges;
+        expect(afterRegister).toBeGreaterThanOrEqual(1);
+
+        registry.unregister(entry.sessionId);
+        await waitFor(
+          () => dirChanges > afterRegister,
+          'onDirChange to fire again for the removal',
+        );
+        expect(dirChanges).toBeGreaterThan(afterRegister);
+        // The whole point: the census hook fired even though no
+        // session_list_response was broadcast.
+        expect(broadcasts).toHaveLength(0);
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 
   test('closer stops further broadcasts', async () => {
     const broadcasts: ProtocolMessage[] = [];
@@ -158,37 +187,41 @@ describe('startLiveSessionsWatcher (#542)', () => {
     expect(broadcasts).toEqual([]);
   });
 
-  test('a collect that throws is caught: logError called, no crash, no broadcast', async () => {
-    const broadcasts: ProtocolMessage[] = [];
-    const errors: string[] = [];
-    const closer = startLiveSessionsWatcher({
-      dirPath: tmpDir,
-      collect: (): LiveSessionsCollectResult | null => {
-        throw new Error('collect exploded');
-      },
-      broadcast: (message) => broadcasts.push(message),
-      logError: (msg) => errors.push(msg),
-      debounceMs: 20,
-    });
-
-    try {
-      registry.register({
-        sessionId: '33333333-3333-3333-3333-333333333333',
-        pid: process.pid,
-        wsPort: 20052,
-        hookPort: 0,
-        projectPath: tmpDir,
-        name: 'sibling',
-        startedAt: new Date().toISOString(),
+  test(
+    'a collect that throws is caught: logError called, no crash, no broadcast',
+    async () => {
+      const broadcasts: ProtocolMessage[] = [];
+      const errors: string[] = [];
+      const closer = startLiveSessionsWatcher({
+        dirPath: tmpDir,
+        collect: (): LiveSessionsCollectResult | null => {
+          throw new Error('collect exploded');
+        },
+        broadcast: (message) => broadcasts.push(message),
+        logError: (msg) => errors.push(msg),
+        debounceMs: 20,
       });
 
-      await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
+      try {
+        registry.register({
+          sessionId: '33333333-3333-3333-3333-333333333333',
+          pid: process.pid,
+          wsPort: 20052,
+          hookPort: 0,
+          projectPath: tmpDir,
+          name: 'sibling',
+          startedAt: new Date().toISOString(),
+        });
 
-      expect(broadcasts).toEqual([]);
-      expect(errors.length).toBeGreaterThanOrEqual(1);
-      expect(errors[0]).toContain('collect exploded');
-    } finally {
-      closer();
-    }
-  });
+        await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
+
+        expect(broadcasts).toEqual([]);
+        expect(errors.length).toBeGreaterThanOrEqual(1);
+        expect(errors[0]).toContain('collect exploded');
+      } finally {
+        closer();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -9,6 +9,31 @@ import {
 } from '../../src/cli/live-sessions-watcher.ts';
 import { SessionRegistryFile } from '../../src/session/session-registry-file.ts';
 
+/**
+ * Wait until `predicate` holds, or fail after `timeoutMs`.
+ *
+ * These tests drive a real `fs.watch` through a debounce, so the delay between
+ * an action and its observable effect is the OS's to decide, not ours. Sleeping
+ * a fixed 150ms and then asserting the effect HAPPENED encodes a guess about
+ * how loaded the machine is: it passes on a quiet laptop and fails on a busy CI
+ * runner, which is exactly how #848/#849 blocked a release without either test
+ * being wrong about the behavior it describes.
+ *
+ * Polling for the condition instead makes the test wait exactly as long as it
+ * needs to and no longer, and turns a timeout into an honest failure message
+ * rather than a confusing assertion on an empty array. Note this is only valid
+ * for POSITIVE assertions ("this eventually happens"); proving a broadcast
+ * never arrives still requires waiting a fixed interval.
+ */
+async function waitFor(predicate: () => boolean, what: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
 describe('startLiveSessionsWatcher (#542)', () => {
   let tmpDir: string;
   let registry: SessionRegistryFile;
@@ -48,7 +73,7 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => broadcasts.length > 0, 'the sibling registration to broadcast');
 
       expect(errors).toEqual([]);
       expect(broadcasts).toHaveLength(1);
@@ -86,12 +111,12 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       };
       registry.register(entry);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => dirChanges >= 1, 'onDirChange to fire for the registration');
       const afterRegister = dirChanges;
       expect(afterRegister).toBeGreaterThanOrEqual(1);
 
       registry.unregister(entry.sessionId);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => dirChanges > afterRegister, 'onDirChange to fire again for the removal');
       expect(dirChanges).toBeGreaterThan(afterRegister);
       // The whole point: the census hook fired even though no
       // session_list_response was broadcast.
@@ -157,7 +182,7 @@ describe('startLiveSessionsWatcher (#542)', () => {
         startedAt: new Date().toISOString(),
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
 
       expect(broadcasts).toEqual([]);
       expect(errors.length).toBeGreaterThanOrEqual(1);

--- a/packages/daemon/tests/session-registry-file.test.ts
+++ b/packages/daemon/tests/session-registry-file.test.ts
@@ -8,6 +8,7 @@ import {
   SessionRegistryFile,
   claudeChildLooksAlive,
 } from '../src/session/session-registry-file.ts';
+import { reserveRange } from './session/port-test-helpers.ts';
 
 /** Spawn a trivial process and await its exit to obtain a really-dead pid. */
 async function deadChildPid(): Promise<number> {
@@ -159,36 +160,46 @@ describe('SessionRegistryFile', () => {
     expect(nonExistent.listLive()).toEqual([]);
   });
 
-  // Use high test ports to avoid conflicts with running remi instances
-  const TEST_PORT_BASE = 44000 + Math.floor(Math.random() * 1000);
+  // Never guess a base and then assert it is free (#848). `findAvailablePort`
+  // delegates to a real TCP bind-probe, so a guessed base makes these tests a
+  // bet on nothing else holding that port -- a bet that loses on a shared CI
+  // runner and looks like a bug in the registry rather than in the setup.
+  // `reserveRange` returns a run that is verified free right now, the same
+  // pattern #823 established for `port-utils.test.ts`.
 
   test('findAvailablePort returns first port when no sessions', async () => {
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE);
+    const base = await reserveRange(10);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base);
   });
 
   test('findAvailablePort skips used ports', async () => {
-    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 1 }));
+    const base = await reserveRange(10);
+    registry.register(makeEntry({ sessionId: 'a', wsPort: base }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: base + 1 }));
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE + 2);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base + 2);
   });
 
   test('findAvailablePort fills non-contiguous gaps', async () => {
-    registry.register(makeEntry({ sessionId: 'a', wsPort: TEST_PORT_BASE }));
-    registry.register(makeEntry({ sessionId: 'b', wsPort: TEST_PORT_BASE + 2 }));
+    const base = await reserveRange(10);
+    registry.register(makeEntry({ sessionId: 'a', wsPort: base }));
+    registry.register(makeEntry({ sessionId: 'b', wsPort: base + 2 }));
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 10);
-    expect(port).toBe(TEST_PORT_BASE + 1);
+    const port = await registry.findAvailablePort(base, 10);
+    expect(port).toBe(base + 1);
   });
 
   test('findAvailablePort returns null when all ports exhausted', async () => {
+    // Exhaustion here is by the REGISTRY, not by the network: every port in the
+    // range is claimed by a live entry, so the probe is never consulted.
+    const base = await reserveRange(3);
     for (let i = 0; i < 3; i++) {
-      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: TEST_PORT_BASE + i }));
+      registry.register(makeEntry({ sessionId: `s-${i}`, wsPort: base + i }));
     }
 
-    const port = await registry.findAvailablePort(TEST_PORT_BASE, 3);
+    const port = await registry.findAvailablePort(base, 3);
     expect(port).toBeNull();
   });
 

--- a/packages/daemon/tests/session/port-test-helpers.ts
+++ b/packages/daemon/tests/session/port-test-helpers.ts
@@ -1,0 +1,71 @@
+/**
+ * Port selection for tests that exercise real TCP binding (#823, #848).
+ *
+ * The rule these exist to enforce: **never guess a port and then assert it is
+ * free.** A test that picks `base = 44000 + random()` and asserts the probe
+ * returns `base` is not testing the code, it is betting that nothing else on
+ * the machine holds that port. On a developer laptop the bet wins; on a shared
+ * CI runner it eventually loses, and the failure looks like a bug in the code
+ * under test rather than in the test's setup.
+ *
+ * That bet cost a release: the flake blocked `auto-release` on `main` during
+ * the 0.7.1 cut, and a red Test gate makes that job SKIP rather than fail, so a
+ * missed release announces itself only as a tag that never appeared (#848).
+ *
+ * #823 fixed this for `port-utils.test.ts`; these helpers were extracted here
+ * so `session-registry-file.test.ts` — which had been left on the old guessing
+ * pattern — uses the same one implementation rather than a second copy that can
+ * drift back.
+ */
+
+import * as net from 'node:net';
+import { isPortAvailable } from '../../src/session/port-utils.ts';
+
+/** Bind to an OS-assigned port and report which one. Never collides. */
+export function occupyEphemeral(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
+    (srv as any).on('error', reject);
+    srv.listen({ port: 0, host: '0.0.0.0', exclusive: true }, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === 'string') {
+        reject(new Error('no address assigned'));
+        return;
+      }
+      resolve({ server: srv, port: addr.port });
+    });
+  });
+}
+
+/** Bind one specific port; rejects if it is taken (callers must have checked). */
+export function occupyPort(port: number): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
+    (srv as any).on('error', reject);
+    srv.listen({ port, host: '0.0.0.0', exclusive: true }, () => resolve(srv));
+  });
+}
+
+/**
+ * Find a base such that `[base, base + count)` are ALL free right now, by
+ * probing each. Retries on a fresh random base when the run is contended.
+ * Throws only if the machine is so busy that no run of `count` ports is free
+ * across `attempts` tries, which is a genuine environment problem worth
+ * failing loudly on rather than papering over.
+ */
+export async function reserveRange(count: number, attempts = 50): Promise<number> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const base = 45000 + Math.floor(Math.random() * 5000);
+    let allFree = true;
+    for (let i = 0; i < count; i++) {
+      if (!(await isPortAvailable(base + i))) {
+        allFree = false;
+        break;
+      }
+    }
+    if (allFree) return base;
+  }
+  throw new Error(`no free run of ${count} ports found after ${attempts} attempts`);
+}

--- a/packages/daemon/tests/session/port-utils.test.ts
+++ b/packages/daemon/tests/session/port-utils.test.ts
@@ -1,71 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import * as net from 'node:net';
+import type * as net from 'node:net';
 import { findAvailableTcpPort, isPortAvailable } from '../../src/session/port-utils.ts';
-
-/**
- * Port selection for these tests (#823).
- *
- * The previous approach picked one random base in 45000-50000 and bound
- * `base + N` outright. Nothing checked the port was free and nothing retried,
- * so any collision failed the test in its own SETUP -- the code under test was
- * never reached. That range overlaps Linux's ephemeral port range, so any other
- * test in the suite that opens a server (several now do) can occupy it, which
- * is exactly how this started failing on CI.
- *
- * Now: never guess. `occupyEphemeral` lets the OS assign a port and reports
- * which one it got, and `reserveRange` finds a genuinely free CONTIGUOUS run
- * for the cases that need one, retrying on a different base if the run is
- * contended mid-reservation.
- */
-
-/** Bind to an OS-assigned port and report which one. Never collides. */
-function occupyEphemeral(): Promise<{ server: net.Server; port: number }> {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
-    (srv as any).on('error', reject);
-    srv.listen({ port: 0, host: '0.0.0.0', exclusive: true }, () => {
-      const addr = srv.address();
-      if (addr === null || typeof addr === 'string') {
-        reject(new Error('no address assigned'));
-        return;
-      }
-      resolve({ server: srv, port: addr.port });
-    });
-  });
-}
-
-/** Bind one specific port; rejects if it is taken (callers must have checked). */
-function occupyPort(port: number): Promise<net.Server> {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    // biome-ignore lint/suspicious/noExplicitAny: Bun's net.Server type is incomplete
-    (srv as any).on('error', reject);
-    srv.listen({ port, host: '0.0.0.0', exclusive: true }, () => resolve(srv));
-  });
-}
-
-/**
- * Find a base such that `[base, base + count)` are ALL free right now, by
- * probing each. Retries on a fresh random base when the run is contended.
- * Throws only if the machine is so busy that no run of `count` ports is free
- * across `attempts` tries, which is a genuine environment problem worth
- * failing loudly on rather than papering over.
- */
-async function reserveRange(count: number, attempts = 50): Promise<number> {
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    const base = 45000 + Math.floor(Math.random() * 5000);
-    let allFree = true;
-    for (let i = 0; i < count; i++) {
-      if (!(await isPortAvailable(base + i))) {
-        allFree = false;
-        break;
-      }
-    }
-    if (allFree) return base;
-  }
-  throw new Error(`no free run of ${count} ports found after ${attempts} attempts`);
-}
+import { occupyEphemeral, occupyPort, reserveRange } from './port-test-helpers.ts';
 
 describe('isPortAvailable', () => {
   const servers: net.Server[] = [];


### PR DESCRIPTION
Release 0.7.2.

## What users get

**The engine's version is visible, and replaceable.** 0.7.1's `remi model status` told you to "upgrade the engine to 0.7.8+" while never reading the engine's version — so it could not say what you had — and named a remedy that did not exist: `stopRecordedEngine` was documented as backing `remi engine stop`, but that command was never built and the function had no callers.

The root cause is that pinning does not imply running. `EngineHost`'s rule is that ownership is about who *starts* an engine, not who holds it, so an engine already answering is attached to however old it is, and upgrading remi never upgraded the engine it talks to.

- `remi model status` now reports the running version next to the pinned one, read from the engine's `GET /v1/modules`.
- `remi model restart` relaunches it on the pinned helper. It refuses to kill an engine remi has no record of starting, refuses against a shared engine, waits for the port to actually close first, and reports failure rather than success if the relaunched engine is still older than the pin.

**`remi --help` shows the model commands where you would look for them** (#850) — top of the Auto-Approve section rather than the last line of Configuration, where a user read the whole output and did not find them.

**Two flaky tests fixed at the root** (#848, #849), not retried or disabled. Both guessed at something the machine decides: one asserted a randomly chosen TCP port was free, the other slept a fixed 150ms then asserted an `fs.watch` effect had already happened. Each blocked the 0.7.1 cut once, one of them on `main`.

## Pins

- Engine helper pinned to yooz-engine `v0.7.8`; the pinned asset URL serves.
- bun 1.3.11 across all three workflows; `crate-ci/typos` v1.28.4; npm pinned to 11.
- `v0.7.2` unclaimed on both npm and git. Platform packages and their `optionalDependencies` are stamped from the tag by `release.yml`.
- iOS/macOS app version is deliberately decoupled from the daemon version (#658) and is not part of this release.

## Testing

Full suite **3820 pass, 0 fail**, 69 skip across 202 files. Lint, typecheck and spelling clean. The two previously-flaky files stress-run 12 consecutive times under four concurrent CPU-burner processes with zero failures.

## Known risk for this merge

A red Test gate makes `auto-release` **skip** rather than fail, so a flake on `main` silently cancels the release — no tag, no npm, no Homebrew, and the only symptom is a tag that never appears. That is exactly what happened twice during the 0.7.1 cut. This release fixes the two flakes that caused it, but the underlying visibility problem is filed as **#856** and deliberately not changed here: altering release CI immediately before a release adds risk to the very thing it protects.

I will watch the post-merge `main` run and confirm the tag, npm, GitHub release and Homebrew all landed.

## Follow-ups

#855 (same fixed-sleep pattern in other test files), #856 (silent release cancellation), #845 (superseded engine helpers are never reclaimed).