### PR TITLE
Stop and kill the daemons remi could not see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`remi stop --all`** (#859) stops session daemons as well as the hub.
+
+### Fixed
+- **`remi stop` and `remi status` no longer deny that running daemons exist**
+  (#859). Both resolved the *hub* only, via `daemon.pid` / `daemon-status.json`;
+  session daemons write `status-<PORT>.json`, which nothing enumerated. So
+  `status` reported "Daemon is not running" while `remi ls` listed a daemon
+  right there. They now report session daemons too, and whatever `remi stop`
+  does not stop, it names.
+- **`remi kill` can stop a daemon that has stopped answering** (#859). It went
+  only over the WebSocket, so a daemon wedged badly enough to ignore its socket
+  was unreachable by every remi command and could be removed only with `pkill`
+  — which matches on a name and will happily take down something unrelated.
+  remi records that daemon's pid itself, so it now falls back to signalling it,
+  saying plainly that graceful shutdown was skipped.
+
 ## [0.7.2] - 2026-07-27
 
 Makes the engine's version visible and replaceable, and puts the model

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -305,6 +305,7 @@ const cliDaemonMode = parsedArgs.daemonMode || serveMode;
 const cliCodeRefresh = parsedArgs.codeRefresh;
 const cliPermanentCode = parsedArgs.permanentCode;
 const cliForce = parsedArgs.force;
+const cliStopAll = parsedArgs.stopAll;
 const cliUsePassphrase = parsedArgs.usePassphrase;
 const cliDecrypt = parsedArgs.decrypt;
 const cliEncrypt = parsedArgs.encrypt;
@@ -511,6 +512,7 @@ if (
       ...(cliPushSecret !== undefined && { pushSecret: cliPushSecret }),
       ...(cliOrphanTimeout !== undefined && { orphanTimeout: cliOrphanTimeout }),
       remiVersion: REMI_VERSION,
+      all: cliStopAll,
     }),
   );
 }
@@ -555,6 +557,7 @@ if (cliSubcommand === 'kill') {
   process.exit(
     await runKillCommand(resolved, {
       getLivePorts: () => liveSessionsRegistry.getLivePorts(),
+      listLive: () => liveSessionsRegistry.listLive(),
       explicitPort: cliPort,
     }),
   );

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -87,6 +87,8 @@ export interface ParsedArgs {
   readonly codeRefresh: boolean;
   readonly permanentCode: boolean;
   readonly force: boolean;
+  /** `remi stop --all`: also stop session daemons, not just the hub (#859). */
+  readonly stopAll: boolean;
   readonly usePassphrase: boolean;
   readonly decrypt: boolean;
   readonly encrypt: boolean;
@@ -137,6 +139,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
   let codeRefresh = false;
   let permanentCode = false;
   let force = false;
+  let stopAll = false;
   let usePassphrase = false;
   let decrypt = false;
   let encrypt = false;
@@ -266,6 +269,9 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       uninstall = true;
     } else if (arg === '--force') {
       force = true;
+    } else if (arg === '--all') {
+      // Only `stop` defines a top-level `--all` today; harmless elsewhere.
+      stopAll = true;
     } else if (arg === '--passphrase') {
       usePassphrase = true;
     } else if (arg === '--decrypt') {
@@ -466,6 +472,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     codeRefresh,
     permanentCode,
     force,
+    stopAll,
     usePassphrase,
     decrypt,
     encrypt,

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -22,6 +22,8 @@ export interface StartDaemonOptions {
   readonly orphanTimeout?: number;
   /** This binary's remi version, for the `status` drift warning (#539). */
   readonly remiVersion?: string;
+  /** `remi stop --all`: stop session daemons too, not only the hub (#859). */
+  readonly all?: boolean;
 }
 
 /** Subcommands this handler owns. */
@@ -65,7 +67,7 @@ export async function runDaemonLifecycleCommand(
     return 0;
   }
   if (sub === 'stop') {
-    dm.stopDaemon();
+    dm.stopDaemon({ all: opts.all === true });
     return 0;
   }
   if (sub === 'status') {

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -53,7 +53,10 @@ export function buildStartDaemonArgs(opts: StartDaemonOptions): string[] {
 
 /**
  * Run one of the daemon lifecycle subcommands.
- * Always exits 0 — errors inside daemon-manager are handled there.
+ *
+ * `stop` returns daemon-manager's exit code, so a daemon that survived being
+ * signalled is not reported as a clean stop (#859); the rest exit 0 because
+ * daemon-manager handles their errors itself.
  */
 export async function runDaemonLifecycleCommand(
   sub: DaemonSubcommand,
@@ -67,8 +70,7 @@ export async function runDaemonLifecycleCommand(
     return 0;
   }
   if (sub === 'stop') {
-    dm.stopDaemon({ all: opts.all === true });
-    return 0;
+    return dm.stopDaemon({ all: opts.all === true });
   }
   if (sub === 'status') {
     dm.showDaemonStatus(opts.remiVersion);

--- a/packages/daemon/src/cli/cmd-kill.ts
+++ b/packages/daemon/src/cli/cmd-kill.ts
@@ -140,10 +140,24 @@ function killByRecordedPid(
   io: KillCommandIO,
 ): number | undefined {
   const entries = deps.listLive?.() ?? [];
-  const match = entries.find(
-    (e) => e.name === target || String(e.wsPort) === target || e.name.endsWith(`/${target}`),
-  );
-  if (match === undefined) return undefined;
+  // Exact matches only. `name` is `path.basename(workingDirectory)` and never
+  // contains a slash, so a prefix/suffix clause here would be dead code that
+  // reads like a safety net.
+  const matches = entries.filter((e) => e.name === target || String(e.wsPort) === target);
+  if (matches.length === 0) return undefined;
+
+  // Never pick one. `name` is a directory BASENAME, so two worktrees of the
+  // same project (`main`, `main`) collide routinely, and a directory named
+  // `18766` collides with the port branch. Choosing the first would SIGKILL
+  // somebody else's daemon and report success. The reachable-daemon path
+  // already refuses this via `AmbiguousSessionError`; this must too.
+  if (matches.length > 1) {
+    io.err(`"${target}" matches ${matches.length} unreachable daemons:`);
+    for (const m of matches) io.err(`  ${m.name} (PID ${m.pid}, port ${m.wsPort})`);
+    io.err('Nothing was stopped. Re-run with the port to pick one.');
+    return 1;
+  }
+  const match = matches[0] as { pid: number; wsPort: number; name: string };
 
   const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
   const out = io.out ?? ((msg: string) => console.log(msg));

--- a/packages/daemon/src/cli/cmd-kill.ts
+++ b/packages/daemon/src/cli/cmd-kill.ts
@@ -12,12 +12,23 @@ import type { ResolvedTarget } from './target-resolver.ts';
 
 export interface KillCommandIO {
   readonly err: (msg: string) => void;
+  readonly out?: (msg: string) => void;
 }
 
-const defaultIO: KillCommandIO = { err: (msg) => console.error(msg) };
+const defaultIO: KillCommandIO = {
+  err: (msg) => console.error(msg),
+  out: (msg) => console.log(msg),
+};
 
 export interface KillCommandDeps {
   readonly getLivePorts: () => number[];
+  /**
+   * Live-sessions entries, for the unreachable-daemon fallback (#859). Seam so
+   * tests never signal a real process.
+   */
+  readonly listLive?: () => readonly { pid: number; wsPort: number; name: string }[];
+  /** Signal a pid. Defaults to the real `process.kill`. */
+  readonly signal?: (pid: number, sig: NodeJS.Signals | 0) => void;
   readonly explicitPort: number | undefined;
 }
 
@@ -83,6 +94,12 @@ export async function runKillCommand(
         },
       );
       if (resolution.status === 'no-daemons') {
+        // A daemon that ignores its socket used to be unreachable by every
+        // remi command, leaving `pkill` as the only option -- which matches on
+        // a name and will happily take down something else (#859). remi
+        // recorded this daemon's pid itself, so use it.
+        const byPid = killByRecordedPid(killTarget, deps, io);
+        if (byPid !== undefined) return byPid;
         io.err(
           `Cannot reach any remi daemon (tried ${resolution.probedCount} port(s)). Is a daemon running?`,
         );
@@ -104,4 +121,44 @@ export async function runKillCommand(
     io.err(errorToString(err));
     return 1;
   }
+}
+
+/**
+ * Stop a daemon by the pid the live-sessions registry recorded, when its socket
+ * will not answer.
+ *
+ * Returns an exit code when it acted, or undefined when no recorded entry
+ * matches -- so the caller still prints its own "cannot reach" message rather
+ * than this silently swallowing an ordinary typo.
+ *
+ * Deliberately narrated: this skips the daemon's graceful shutdown, so a user
+ * must be able to tell from the output that it happened.
+ */
+function killByRecordedPid(
+  target: string,
+  deps: KillCommandDeps,
+  io: KillCommandIO,
+): number | undefined {
+  const entries = deps.listLive?.() ?? [];
+  const match = entries.find(
+    (e) => e.name === target || String(e.wsPort) === target || e.name.endsWith(`/${target}`),
+  );
+  if (match === undefined) return undefined;
+
+  const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
+  const out = io.out ?? ((msg: string) => console.log(msg));
+
+  io.err(`Daemon on port ${match.wsPort} is not answering; stopping PID ${match.pid} directly.`);
+  try {
+    signal(match.pid, 'SIGTERM');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+      out(`PID ${match.pid} was already gone.`);
+      return 0;
+    }
+    io.err(`Could not signal PID ${match.pid}: ${errorToString(err)}`);
+    return 1;
+  }
+  out(`Sent SIGTERM to PID ${match.pid} (${match.name}). Its session was not shut down cleanly.`);
+  return 0;
 }

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -305,9 +305,19 @@ function describeSessionDaemon(d: SessionDaemon): string {
  * and which, when wedged badly enough to ignore their socket, could previously
  * only be removed with `pkill` (#859).
  */
-function terminatePid(pid: number, graceMs = 3000): boolean {
+export interface SignalDeps {
+  readonly signal: (pid: number, sig: NodeJS.Signals | 0) => void;
+  readonly sleep: (ms: number) => void;
+}
+
+const realSignals: SignalDeps = {
+  signal: (pid, sig) => process.kill(pid, sig),
+  sleep: (ms) => Bun.sleepSync(ms),
+};
+
+export function terminatePid(pid: number, graceMs = 3000, deps: SignalDeps = realSignals): boolean {
   try {
-    process.kill(pid, 'SIGTERM');
+    deps.signal(pid, 'SIGTERM');
   } catch (err) {
     // Already gone is success; anything else is not ours to signal.
     return (err as NodeJS.ErrnoException).code === 'ESRCH';
@@ -315,20 +325,20 @@ function terminatePid(pid: number, graceMs = 3000): boolean {
   const deadline = Date.now() + graceMs;
   while (Date.now() < deadline) {
     try {
-      process.kill(pid, 0);
+      deps.signal(pid, 0);
     } catch {
       return true;
     }
-    Bun.sleepSync(100);
+    deps.sleep(100);
   }
   try {
-    process.kill(pid, 'SIGKILL');
+    deps.signal(pid, 'SIGKILL');
   } catch {
     // Raced with its own exit.
   }
-  Bun.sleepSync(200);
+  deps.sleep(200);
   try {
-    process.kill(pid, 0);
+    deps.signal(pid, 0);
     return false;
   } catch {
     return true;
@@ -336,10 +346,13 @@ function terminatePid(pid: number, graceMs = 3000): boolean {
 }
 
 /** Stop every session daemon, reporting each. Returns how many are now gone. */
-export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
+export function stopSessionDaemons(
+  daemons: readonly SessionDaemon[],
+  deps: SignalDeps = realSignals,
+): number {
   let stopped = 0;
   for (const d of daemons) {
-    if (terminatePid(d.pid)) {
+    if (terminatePid(d.pid, 3000, deps)) {
       console.log(`Stopped session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
       stopped++;
     } else {
@@ -349,7 +362,12 @@ export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
   return stopped;
 }
 
-export function stopDaemon(opts: { all?: boolean } = {}): void {
+/**
+ * Returns the exit code the CLI should use. Previously `void`, which meant a
+ * daemon that survived SIGKILL was still reported as a clean stop -- so
+ * `remi stop --all && echo ok` printed `ok` with a daemon still running.
+ */
+export function stopDaemon(opts: { all?: boolean } = {}): number {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
   const sessions = listSessionDaemons();
 
@@ -365,10 +383,10 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
       for (const d of sessions) console.log(describeSessionDaemon(d));
       console.log('');
       console.log('Stop them with "remi stop --all", or one at a time with "remi kill <name>".');
-      return;
+      // Nothing was stopped, so this is not a success.
+      return 1;
     }
-    stopSessionDaemons(sessions);
-    return;
+    return stopSessionDaemons(sessions) === sessions.length ? 0 : 1;
   }
 
   console.log(`Stopping daemon (PID ${pid})...`);
@@ -392,8 +410,7 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
     } catch {
       cleanupFiles(pid);
       console.log('Daemon stopped.');
-      finishSessionDaemons(sessions, opts.all === true);
-      return;
+      return finishSessionDaemons(sessions, opts.all === true);
     }
   }
 
@@ -411,7 +428,7 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
   Bun.sleepSync(200);
   cleanupFiles(pid);
   console.log('Daemon killed.');
-  finishSessionDaemons(sessions, opts.all === true);
+  return finishSessionDaemons(sessions, opts.all === true);
 }
 
 /**
@@ -421,16 +438,17 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
  * reported success, and left processes running that the user then had to find
  * with `pkill`. Whatever this does not stop, it says (#859).
  */
-function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): void {
-  if (sessions.length === 0) return;
+function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): number {
+  if (sessions.length === 0) return 0;
   if (all) {
-    stopSessionDaemons(sessions);
-    return;
+    return stopSessionDaemons(sessions) === sessions.length ? 0 : 1;
   }
   console.log('');
   console.log(`${sessions.length} session daemon(s) are still running:`);
   for (const d of sessions) console.log(describeSessionDaemon(d));
   console.log('Stop these too with "remi stop --all".');
+  // The hub stopped, which is what was asked for.
+  return 0;
 }
 
 export function showDaemonStatus(installedVersion?: string): void {

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
+import { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { rotateIfNeeded } from './log-rotation.ts';
 import { formatVersionDrift } from './version-drift.ts';
 
@@ -261,11 +262,113 @@ export async function startDaemon(opts?: StartOptions): Promise<number> {
   return pid;
 }
 
-export function stopDaemon(): void {
+/** A running session daemon, as recorded in the live-sessions registry. */
+export interface SessionDaemon {
+  readonly pid: number;
+  readonly wsPort: number;
+  readonly name: string;
+}
+
+/**
+ * The session daemons running right now, deduplicated by pid.
+ *
+ * `stop` and `status` resolve the HUB, via `daemon.pid` / `daemon-status.json`.
+ * Session daemons write `status-<PORT>.json` instead and are named in neither,
+ * so before this existed both commands would announce "Daemon is not running"
+ * while `remi ls` happily listed one (#859). The live-sessions registry is the
+ * right source: it already reaps entries whose process is gone, so anything it
+ * returns names a pid that was alive a moment ago.
+ *
+ * The hub deliberately never registers itself here, so it cannot appear twice.
+ */
+export function listSessionDaemons(
+  listLive = () => new SessionRegistryFile().listLive(),
+): SessionDaemon[] {
+  const byPid = new Map<number, SessionDaemon>();
+  for (const entry of listLive()) {
+    // One daemon can host several sessions; it is still one process to stop.
+    if (!byPid.has(entry.pid)) {
+      byPid.set(entry.pid, { pid: entry.pid, wsPort: entry.wsPort, name: entry.name });
+    }
+  }
+  return [...byPid.values()];
+}
+
+function describeSessionDaemon(d: SessionDaemon): string {
+  return `  PID ${d.pid}  port ${d.wsPort}  ${d.name}`;
+}
+
+/**
+ * SIGTERM, then SIGKILL if it will not go. Returns whether the process is gone.
+ *
+ * Used for session daemons, which have no graceful RPC path of their own here —
+ * and which, when wedged badly enough to ignore their socket, could previously
+ * only be removed with `pkill` (#859).
+ */
+function terminatePid(pid: number, graceMs = 3000): boolean {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    // Already gone is success; anything else is not ours to signal.
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    Bun.sleepSync(100);
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Raced with its own exit.
+  }
+  Bun.sleepSync(200);
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** Stop every session daemon, reporting each. Returns how many are now gone. */
+export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
+  let stopped = 0;
+  for (const d of daemons) {
+    if (terminatePid(d.pid)) {
+      console.log(`Stopped session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
+      stopped++;
+    } else {
+      console.error(`Could not stop session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
+    }
+  }
+  return stopped;
+}
+
+export function stopDaemon(opts: { all?: boolean } = {}): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
+  const sessions = listSessionDaemons();
+
   if (!pid) {
-    console.error('No running daemon found.');
-    process.exit(1);
+    // "No running daemon found" was a lie whenever session daemons existed,
+    // and it is the message that sent a user to `pkill` (#859).
+    if (sessions.length === 0) {
+      console.error('No running daemon found.');
+      process.exit(1);
+    }
+    if (opts.all !== true) {
+      console.log('No hub is running, but these session daemons are:');
+      for (const d of sessions) console.log(describeSessionDaemon(d));
+      console.log('');
+      console.log('Stop them with "remi stop --all", or one at a time with "remi kill <name>".');
+      return;
+    }
+    stopSessionDaemons(sessions);
+    return;
   }
 
   console.log(`Stopping daemon (PID ${pid})...`);
@@ -289,6 +392,7 @@ export function stopDaemon(): void {
     } catch {
       cleanupFiles(pid);
       console.log('Daemon stopped.');
+      finishSessionDaemons(sessions, opts.all === true);
       return;
     }
   }
@@ -307,12 +411,44 @@ export function stopDaemon(): void {
   Bun.sleepSync(200);
   cleanupFiles(pid);
   console.log('Daemon killed.');
+  finishSessionDaemons(sessions, opts.all === true);
+}
+
+/**
+ * Stop the session daemons too, or — when not asked to — NAME them.
+ *
+ * Silence here is what made `remi stop` feel broken: it stopped the hub,
+ * reported success, and left processes running that the user then had to find
+ * with `pkill`. Whatever this does not stop, it says (#859).
+ */
+function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): void {
+  if (sessions.length === 0) return;
+  if (all) {
+    stopSessionDaemons(sessions);
+    return;
+  }
+  console.log('');
+  console.log(`${sessions.length} session daemon(s) are still running:`);
+  for (const d of sessions) console.log(describeSessionDaemon(d));
+  console.log('Stop these too with "remi stop --all".');
 }
 
 export function showDaemonStatus(installedVersion?: string): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
+  const sessions = listSessionDaemons();
   if (!pid) {
-    console.log('Daemon is not running.');
+    // Saying "Daemon is not running" while `remi ls` lists one is how a user
+    // ends up reaching for `pkill` (#859). Both statements were about
+    // different things; only one of them said so.
+    if (sessions.length === 0) {
+      console.log('Daemon is not running.');
+      return;
+    }
+    console.log('No hub is running.');
+    console.log(`${sessions.length} session daemon(s) running:`);
+    for (const d of sessions) console.log(describeSessionDaemon(d));
+    console.log('');
+    console.log('Start a hub with "remi start"; stop these with "remi stop --all".');
     return;
   }
 
@@ -342,6 +478,12 @@ export function showDaemonStatus(installedVersion?: string): void {
   }
 
   console.log(`  Logs: ${LOG_FILE}`);
+
+  if (sessions.length > 0) {
+    console.log('');
+    console.log(`${sessions.length} session daemon(s) running:`);
+    for (const d of sessions) console.log(describeSessionDaemon(d));
+  }
 }
 
 export function showDaemonLogs(lines = 50): void {

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -229,6 +229,7 @@ const commandHelp: Record<Subcommand, string[]> = {
     '',
     bold('Usage:'),
     entry('remi stop', 'Stop the running hub'),
+    entry('remi stop --all', 'Also stop every session daemon'),
   ],
   status: [
     'Show daemon status.',
@@ -373,7 +374,7 @@ export function formatHelp(version: string): string {
     '',
     bold('Service:'),
     entry('remi start', 'Start the hub in the background'),
-    entry('remi stop', 'Stop background daemon'),
+    entry('remi stop', 'Stop background daemon (--all: session daemons too)'),
     entry('remi status', 'Show daemon status'),
     entry('remi logs', 'Show daemon logs'),
     entry('remi serve', 'Run the session-less hub in the foreground'),

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -827,4 +827,27 @@ describe('parseArgs - auto-approve flags', () => {
     expect(r.autoApproveDeny).toEqual(['sudo ']);
     expect(r.autoApproveInstructions).toBe('Be conservative');
   });
+
+  describe('--all (#859)', () => {
+    test('remi stop --all sets stopAll', () => {
+      expect(parseArgs(['stop', '--all']).stopAll).toBe(true);
+    });
+
+    test('plain remi stop does not', () => {
+      expect(parseArgs(['stop']).stopAll).toBe(false);
+    });
+
+    test('remi model ls --all still reaches the model subcommand', () => {
+      // `--all` is consumed by the model branch's OWN_FLAGS before the new
+      // top-level branch sees it. Nothing pinned that ordering, so a future
+      // edit to either branch could silently break `remi model ls --all`.
+      const r = parseArgs(['model', 'ls', '--all']);
+      expect(r.subcommand).toBe('model');
+      expect(r.subcommandArgs).toEqual(['ls', '--all']);
+    });
+
+    test('remi --sessions all still selects the sessions view', () => {
+      expect(parseArgs(['--sessions', 'all']).showSessions).toBe('all');
+    });
+  });
 });

--- a/packages/daemon/tests/cli/cmd-kill.test.ts
+++ b/packages/daemon/tests/cli/cmd-kill.test.ts
@@ -152,3 +152,98 @@ describe('runKillCommand', () => {
     expect(err).toEqual(['kill failed']);
   });
 });
+
+describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
+  /** IO that also captures stdout, which the fallback narrates to. */
+  function makeIO2() {
+    const err: string[] = [];
+    const out: string[] = [];
+    return {
+      io: { err: (m: string) => err.push(m), out: (m: string) => out.push(m) },
+      err,
+      out,
+    };
+  }
+
+  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality/main' }];
+
+  test('signals the recorded pid when no daemon answers', async () => {
+    // The state this exists for: the daemon is alive but ignoring its socket,
+    // so every RPC path fails and `pkill` was previously the only option.
+    const { io, err, out } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const signalled: Array<{ pid: number; sig: string }> = [];
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'neurality/main' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: (pid, sig) => signalled.push({ pid, sig: String(sig) }),
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(signalled).toEqual([{ pid: 4242, sig: 'SIGTERM' }]);
+    // It must be obvious that graceful shutdown was skipped.
+    expect(err.join('\n')).toContain('not answering');
+    expect(out.join('\n')).toContain('not shut down cleanly');
+  });
+
+  test('matches by port as well as name', async () => {
+    const { io } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const signalled: number[] = [];
+    const code = await runKillCommand(
+      mkTarget({ targetId: '18766' }),
+      { ...deps, listLive: () => WEDGED, signal: (pid) => signalled.push(pid) },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(signalled).toEqual([4242]);
+  });
+
+  test('an unknown target still reports "cannot reach", not a silent success', async () => {
+    // A typo must not be swallowed by the fallback.
+    const { io, err } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    let signalled = false;
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'no-such-session' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: () => {
+          signalled = true;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(signalled).toBe(false);
+    expect(err.join('\n')).toContain('Cannot reach any remi daemon');
+  });
+
+  test('a process that is already gone is success, not an error', async () => {
+    const { io, out } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'neurality/main' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: () => {
+          const e = new Error('no such process') as NodeJS.ErrnoException;
+          e.code = 'ESRCH';
+          throw e;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(out.join('\n')).toContain('already gone');
+  });
+});

--- a/packages/daemon/tests/cli/cmd-kill.test.ts
+++ b/packages/daemon/tests/cli/cmd-kill.test.ts
@@ -165,7 +165,11 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     };
   }
 
-  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality/main' }];
+  // `name` is `path.basename(workingDirectory)` (cli.ts:2319), so a bare
+  // basename is the ONLY shape that occurs in production. Earlier fixtures used
+  // 'neurality/main', which cannot happen and quietly masked a dead
+  // prefix-matching clause.
+  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality' }];
 
   test('signals the recorded pid when no daemon answers', async () => {
     // The state this exists for: the daemon is alive but ignoring its socket,
@@ -174,7 +178,7 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
     const signalled: Array<{ pid: number; sig: string }> = [];
     const code = await runKillCommand(
-      mkTarget({ targetId: 'neurality/main' }),
+      mkTarget({ targetId: 'neurality' }),
       {
         ...deps,
         listLive: () => WEDGED,
@@ -226,11 +230,40 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     expect(err.join('\n')).toContain('Cannot reach any remi daemon');
   });
 
+  test('refuses to guess between two unreachable daemons with the same name', async () => {
+    // `name` is a directory basename, so two worktrees of one project collide
+    // routinely. Picking the first would SIGKILL the wrong daemon and report
+    // success -- the reachable path already refuses this via
+    // AmbiguousSessionError, and so must this one.
+    const { io, err } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    let signalled = false;
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'main' }),
+      {
+        ...deps,
+        listLive: () => [
+          { pid: 100, wsPort: 18765, name: 'main' },
+          { pid: 200, wsPort: 18766, name: 'main' },
+        ],
+        signal: () => {
+          signalled = true;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(signalled).toBe(false);
+    expect(err.join('\n')).toContain('matches 2 unreachable daemons');
+    expect(err.join('\n')).toContain('Nothing was stopped');
+  });
+
   test('a process that is already gone is success, not an error', async () => {
     const { io, out } = makeIO2();
     const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
     const code = await runKillCommand(
-      mkTarget({ targetId: 'neurality/main' }),
+      mkTarget({ targetId: 'neurality' }),
       {
         ...deps,
         listLive: () => WEDGED,

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -6,6 +6,8 @@ import {
   formatVersionDrift,
   listSessionDaemons,
   readPidFileLive,
+  stopSessionDaemons,
+  terminatePid,
 } from '../../src/cli/daemon-manager.ts';
 import type { LiveSessionEntry } from '../../src/session/session-registry-file.ts';
 
@@ -177,5 +179,90 @@ describe('listSessionDaemons (#859)', () => {
 
   test('an empty registry reports none', () => {
     expect(listSessionDaemons(() => [])).toEqual([]);
+  });
+});
+
+describe('terminatePid (#859)', () => {
+  /** Records signals and never touches a real process. */
+  function recorder(aliveFor: number) {
+    const sent: string[] = [];
+    let probes = 0;
+    return {
+      sent,
+      deps: {
+        signal: (_pid: number, sig: NodeJS.Signals | 0) => {
+          if (sig === 0) {
+            probes++;
+            if (probes > aliveFor) throw new Error('ESRCH');
+            return;
+          }
+          sent.push(String(sig));
+        },
+        sleep: () => {},
+      },
+    };
+  }
+
+  test('SIGTERM alone is enough when the process exits', () => {
+    const r = recorder(0); // first liveness probe already reports gone
+    expect(terminatePid(1234, 3000, r.deps)).toBe(true);
+    expect(r.sent).toEqual(['SIGTERM']);
+  });
+
+  test('escalates to SIGKILL when SIGTERM is ignored', () => {
+    // The riskiest line in the change: it had no seam and no test.
+    const r = recorder(Number.MAX_SAFE_INTEGER); // never dies
+    const gone = terminatePid(1234, 0, r.deps); // zero grace: straight to escalation
+    expect(r.sent).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(gone).toBe(false); // still alive after SIGKILL -> reported as failure
+  });
+
+  test('a process already gone is success, not an error', () => {
+    const deps = {
+      signal: () => {
+        const e = new Error('no such process') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        throw e;
+      },
+      sleep: () => {},
+    };
+    expect(terminatePid(1234, 3000, deps)).toBe(true);
+  });
+
+  test('a signal we are not allowed to send is NOT reported as stopped', () => {
+    const deps = {
+      signal: () => {
+        const e = new Error('operation not permitted') as NodeJS.ErrnoException;
+        e.code = 'EPERM';
+        throw e;
+      },
+      sleep: () => {},
+    };
+    expect(terminatePid(1234, 3000, deps)).toBe(false);
+  });
+});
+
+describe('stopSessionDaemons (#859)', () => {
+  test('counts only the daemons that actually stopped', () => {
+    // The count feeds the exit code: "remi stop --all && echo ok" must not
+    // print ok while a daemon is still running.
+    const stubborn = 200;
+    const deps = {
+      signal: (pid: number, sig: NodeJS.Signals | 0) => {
+        if (pid === stubborn) return; // alive to every probe, ignores every signal
+        const e = new Error('gone') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        if (sig === 0) throw e;
+      },
+      sleep: () => {},
+    };
+    const stopped = stopSessionDaemons(
+      [
+        { pid: 100, wsPort: 18765, name: 'a' },
+        { pid: stubborn, wsPort: 18766, name: 'b' },
+      ],
+      deps,
+    );
+    expect(stopped).toBe(1);
   });
 });

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { formatVersionDrift, readPidFileLive } from '../../src/cli/daemon-manager.ts';
+import {
+  formatVersionDrift,
+  listSessionDaemons,
+  readPidFileLive,
+} from '../../src/cli/daemon-manager.ts';
+import type { LiveSessionEntry } from '../../src/session/session-registry-file.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
@@ -130,5 +135,47 @@ describe('formatVersionDrift (#539)', () => {
     expect(formatVersionDrift(undefined, '0.6.19')).toBeNull();
     expect(formatVersionDrift('0.6.19', undefined)).toBeNull();
     expect(formatVersionDrift('', '0.6.19')).toBeNull();
+  });
+});
+
+describe('listSessionDaemons (#859)', () => {
+  function entry(over: Partial<LiveSessionEntry> = {}): LiveSessionEntry {
+    return {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      pid: 100,
+      wsPort: 18765,
+      hookPort: 0,
+      projectPath: '/tmp/p',
+      name: 'proj/main',
+      startedAt: new Date(0).toISOString(),
+      ...over,
+    } as LiveSessionEntry;
+  }
+
+  test('reports the session daemons stop/status previously could not see', () => {
+    // `stop`/`status` resolve only the hub's daemon.pid / daemon-status.json.
+    // Session daemons write status-<PORT>.json, which nothing enumerated -- so
+    // both commands announced "not running" while `remi ls` listed one.
+    const found = listSessionDaemons(() => [
+      entry({ pid: 100, wsPort: 18765, name: 'a/main' }),
+      entry({ pid: 200, wsPort: 18766, name: 'b/main' }),
+    ]);
+    expect(found).toEqual([
+      { pid: 100, wsPort: 18765, name: 'a/main' },
+      { pid: 200, wsPort: 18766, name: 'b/main' },
+    ]);
+  });
+
+  test('deduplicates by pid: one daemon hosting several sessions is one process', () => {
+    const found = listSessionDaemons(() => [
+      entry({ pid: 100, wsPort: 18765, name: 'a/main', sessionId: 'x' }),
+      entry({ pid: 100, wsPort: 18765, name: 'a/other', sessionId: 'y' }),
+    ]);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.pid).toBe(100);
+  });
+
+  test('an empty registry reports none', () => {
+    expect(listSessionDaemons(() => [])).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #859. Part of #861.

Reported from a live session: remi processes that `remi stop` would not kill and `remi ls` would not show, removable only with `pkill`. Two independent gaps combined into "remi cannot stop its own daemon".

## 1. `stop` and `status` only ever saw the hub

Both resolved their target from `~/.remi/daemon.pid` and `~/.remi/daemon-status.json`. Those belong **exclusively to the hub**; every session daemon writes `~/.remi/status-<PORT>.json`, and nothing enumerated those. Hence:

```
$ remi stop     -> No running daemon found.
$ remi status   -> Daemon is not running.
$ remi ls       -> Daemon port: 18765 ... 1 session(s)
```

Each statement was true about the hub and useless to someone who just wanted remi stopped — and "No running daemon found" is what sent a user to `pkill`.

Now both enumerate session daemons from the live-sessions registry (which already reaps entries whose process is gone, so anything it returns names a pid that was alive a moment ago; the hub never registers there, so it cannot double-count). `remi stop --all` stops them too, and whatever plain `remi stop` does not stop, **it names**.

## 2. `kill` had no pid fallback, so a wedged daemon was unreachable

`remi kill` goes over the WebSocket, so the one state where killing matters most — a daemon alive but ignoring its socket — was the one state remi could not act on:

```
$ remi kill 18766
[kill] Failed to query localhost:18766: Timed out connecting to daemon at localhost:18766
Cannot reach any remi daemon (tried 1 port(s)). Is a daemon running?
```

The live-sessions entry proving that daemon exists records its **pid**, and nothing used it. Now, when no daemon answers and a recorded entry matches the target by name or port, remi signals that pid — and says so, because this skips graceful shutdown and the user must be able to tell. An unmatched target still gets the ordinary "cannot reach" error rather than being silently swallowed, and an already-dead process is success, not an error.

This replaces `pkill remi`, which matches on a name and will happily take down an unrelated binary or another user's process.

## Testing

Full suite **3827 pass, 0 fail**, 69 skip across 202 files. Typecheck, biome, spelling clean.

Every new guard verified to discriminate by mutation:

| Mutation | Result |
|---|---|
| remove the pid fallback | 3 fallback tests fail |
| fallback matches any entry instead of the target | unknown-target test fails |
| treat `ESRCH` as an error | already-gone test fails |
| drop the pid dedupe in `listSessionDaemons` | dedupe test fails |

Tests inject `listLive` and `signal` seams, so no test signals a real process.

## Note

I did **not** change what plain `remi stop` stops — it still stops the hub, and now names what it leaves behind. Making it kill session daemons by default is a bigger behavioural change than this bug needs; `--all` is opt-in. Say if you would rather it be the default.