### PR TITLE
Release the engine's picker so rm can work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`remi model rm` can now evict the engine's active model** (#860). It could
+  not, and no sequence of remi commands could: `isActive`/`deletable` in the
+  engine's inventory are owned by the **TouchUp (proofread) picker**, not the
+  LLM picker remi uses. `remi model use` writes remi's config and cannot
+  release it; `POST /v1/llm/model` moves the LLM selection and leaves it
+  undeletable; and restarting does not help, because a fresh engine re-selects
+  and re-loads that tier at boot — so the printed advice ("stop the engine
+  first") provably could not work. On an engine remi **owns**, `rm` now moves
+  that picker to another model of the same purpose and then deletes, reporting
+  both actions. On a `shared` engine it refuses, since repointing another
+  host's picker is hostile.
+- **`remi model ls` says what a model is active FOR** (#860) — `engine
+  proofread tier` rather than a bare `engine active`. Because that flag belongs
+  to a different picker, remi's own model could never carry it and a model remi
+  never uses always did, which read as "the engine is ignoring the model I
+  chose". It never was: remi passes its configured model explicitly on every
+  evaluation.
+
 ### Added
 - **`remi stop --all`** (#859) stops session daemons as well as the hub.
 

--- a/packages/daemon/src/auto-approve/engine-models.ts
+++ b/packages/daemon/src/auto-approve/engine-models.ts
@@ -71,6 +71,14 @@ export interface EngineModel {
   readonly sizeBytes?: number | undefined;
   readonly loaded: boolean;
   readonly latencyHintMs?: number | undefined;
+  /**
+   * What the engine selects this model FOR: `general` (what remi's evaluator
+   * uses) or `proofread` (the TouchUp picker's tiers). It is the missing piece
+   * behind #860: `/v1/models`'s `isActive` is set by the TOUCHUP picker, so
+   * remi's own model can never carry it and a model remi never uses always
+   * does. Without the purpose there is no way to say which "active" is meant.
+   */
+  readonly purpose?: string | undefined;
   /** The model's registered HuggingFace repo id, which the engine also accepts
    *  as an alias wherever a model id is taken (yooz-engine#308). Absent on
    *  engines older than 0.7.8 — see `model-identity.ts` for why that absence
@@ -207,6 +215,31 @@ export async function getEngineVersion(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Point the TouchUp (proofread) picker at `id`.
+ *
+ * Necessary because `/v1/models`'s `isActive`/`deletable` belong to THIS
+ * picker, not the LLM one. Verified against a live v0.7.8 engine:
+ * `POST /v1/llm/model` returns 200 and moves the LLM `current`, while the
+ * inventory still reports the old model `isActive` and undeletable — only this
+ * endpoint releases it (#860).
+ *
+ * `preload: false` on purpose: this is called to RELEASE a model, and the
+ * default (`true` server-side) would immediately pull the replacement into
+ * memory, trading one resident multi-GB model for another.
+ */
+export async function setTouchUpModel(
+  baseUrl: string,
+  id: string,
+  timeoutMs?: number,
+): Promise<void> {
+  await engineRequest(baseUrl, '/v1/touchup/model', {
+    method: 'POST',
+    body: { id, preload: false },
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
 }
 
 /** Current load/download state. */

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -650,26 +650,22 @@ export async function runModelCommand(
             // picker is remi's to do, and doing it is the whole point -- the
             // previous advice ("stop the engine first") provably cannot work,
             // because a fresh engine re-selects and re-loads that tier at boot.
-            if (aa.engine === 'owned') {
-              const released = await releaseActiveModel(
-                baseUrl,
-                target,
-                { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
-                io,
-              );
-              if (released) {
-                const result = await remove(baseUrl, target.id);
-                io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
-                return 0;
-              }
-              return 1;
-            }
-            io.err(
-              `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it. It is not remi's model (that is "${aa.model}"), and "remi model use" will not release it.`,
+            //
+            // No ownership check here: `rm` is in MUTATING, so a `shared`
+            // engine already returned at the top of this function (#818). A
+            // second `aa.engine === 'owned'` test would read as a live guard
+            // while being unreachable, and its `else` would rot unnoticed.
+            const released = await releaseActiveModel(
+              baseUrl,
+              target,
+              models,
+              { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
+              io,
             );
-            io.err(
-              'This engine is shared, so its picker belongs to the app that owns it; point that module elsewhere from there.',
-            );
+            if (!released) return 1;
+            const result = await remove(baseUrl, target.id);
+            io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
+            return 0;
           } else {
             io.err(
               `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it.`,
@@ -785,6 +781,7 @@ export async function runModelCommand(
 async function releaseActiveModel(
   baseUrl: string,
   target: ManagedModel,
+  inventory: readonly ManagedModel[],
   deps: { list: typeof listModels; setTouchUp: typeof setTouchUpModel },
   io: ModelCommandIO,
 ): Promise<boolean> {
@@ -793,22 +790,48 @@ async function releaseActiveModel(
     (m) => m.id === target.id || m.huggingFaceID === target.id,
   )?.purpose;
 
-  // A replacement has to serve the same purpose, or the picker would refuse it.
-  // Prefer one already on disk so releasing does not trigger a download.
+  // An engine that does not report `purpose` gives us no way to tell a valid
+  // replacement from an invalid one -- and `m.purpose === targetPurpose` with
+  // both absent is `undefined === undefined`, which matches EVERY row. That is
+  // the same trap `matchesModel` documents: comparing against an absent value
+  // silently turns a filter into a pass-through. Refuse instead of moving a
+  // picker to something the engine may not accept.
+  if (targetPurpose === undefined) {
+    io.err(
+      `This engine does not report what "${displayId(target)}" is used for, so remi cannot tell which model could safely replace it.`,
+    );
+    io.err('Nothing was changed. An engine that reports model purposes resolves this.');
+    return false;
+  }
+
   const candidates = (catalogue?.available ?? []).filter(
     (m) => m.id !== target.id && m.huggingFaceID !== target.id && m.purpose === targetPurpose,
   );
-  const replacement = candidates[0];
-  if (replacement === undefined) {
+  if (candidates.length === 0) {
     io.err(
-      `"${displayId(target)}" is the engine's only ${targetPurpose ?? target.module} model, so there is nothing to point the picker at.`,
+      `"${displayId(target)}" is the engine's only ${targetPurpose} model, so there is nothing to point the picker at.`,
     );
     io.err('Deleting it would leave that module with no model; refusing.');
     return false;
   }
 
+  // Prefer a replacement already on disk. The catalogue has no disk state --
+  // `cached` lives on the INVENTORY rows -- so cross-reference them. Without
+  // this, releasing a model could kick off a multi-GB HuggingFace download as
+  // a side effect of a delete, which is the opposite of what was asked for.
+  const onDisk = new Set(
+    inventory
+      .filter((m) => m.cached)
+      .flatMap((m) => (m.huggingFaceID ? [m.id, m.huggingFaceID] : [m.id])),
+  );
+  const replacement =
+    candidates.find(
+      (m) => onDisk.has(m.id) || (m.huggingFaceID !== undefined && onDisk.has(m.huggingFaceID)),
+    ) ?? candidates[0];
+  if (replacement === undefined) return false;
+
   io.out(
-    `"${displayId(target)}" is the engine's active ${targetPurpose ?? target.module} model; pointing that picker at "${displayId(replacement)}" to release it.`,
+    `"${displayId(target)}" is the engine's active ${targetPurpose} model; pointing that picker at "${displayId(replacement)}" to release it.`,
   );
   try {
     await deps.setTouchUp(baseUrl, replacement.id);

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -69,6 +69,7 @@ import {
   preloadAsync,
   probeEngine,
   pullModel,
+  setTouchUpModel,
   unloadModel,
 } from '../auto-approve/engine-models.ts';
 import { FileEnginePidStore } from '../auto-approve/engine-process.ts';
@@ -108,6 +109,31 @@ function isVerb(s: string | undefined): s is Verb {
   return s !== undefined && (VERBS as readonly string[]).includes(s);
 }
 
+/**
+ * id -> purpose, from the LLM catalogue.
+ *
+ * The disk inventory (`/v1/models`) carries no `purpose`, so this is the only
+ * way to say what a model is the ACTIVE choice for. Best-effort: a catalogue
+ * we cannot read costs a qualifier on one label, and must not fail `ls`.
+ */
+async function purposeMap(
+  list: typeof listModels,
+  baseUrl: string,
+): Promise<ReadonlyMap<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const catalogue = await list(baseUrl);
+    for (const m of catalogue.available) {
+      if (m.purpose === undefined) continue;
+      map.set(m.id, m.purpose);
+      if (m.huggingFaceID !== undefined) map.set(m.huggingFaceID, m.purpose);
+    }
+  } catch {
+    // Label stays unqualified; every other column is unaffected.
+  }
+  return map;
+}
+
 /** Human-readable size. The engine reports bytes; a user thinks in GB.
  *  Zero is rendered as unknown rather than "0 MB": the inventory reports 0 for
  *  rows whose on-disk footprint it cannot measure (observed on swept hub
@@ -132,7 +158,11 @@ function fitColumn(text: string, width: number): string {
  *  to copy is not the thing that gets truncated. */
 const NAME_COLUMN = 40;
 
-function formatManagedRow(m: ManagedModel, configured: string): string {
+function formatManagedRow(
+  m: ManagedModel,
+  configured: string,
+  purposeById: ReadonlyMap<string, string> = new Map(),
+): string {
   // The marker means "this is the model REMI uses" — not the engine's active
   // tier. `isActive` belongs to whichever module owns the picker, and marking
   // that as the user's model is the same misattribution `rm` used to make.
@@ -146,7 +176,18 @@ function formatManagedRow(m: ManagedModel, configured: string): string {
   // instead of marking a row.
   const marker = matchesModel(m, configured) ? '*' : ' ';
   const state = m.loaded ? 'resident' : m.cached ? 'on disk' : 'not downloaded';
-  const engineActive = m.isActive ? ', engine active' : '';
+  // Say what it is active FOR. `isActive` is the TOUCHUP picker's selection, so
+  // an unqualified "engine active" reads as "the engine is using this instead
+  // of your model" -- which is what led a user to conclude their configured
+  // model was being ignored. It never was: remi passes its model explicitly on
+  // every generate (#860).
+  const purpose =
+    purposeById.get(m.id) ?? (m.huggingFaceID ? purposeById.get(m.huggingFaceID) : undefined);
+  const engineActive = m.isActive
+    ? purpose === undefined
+      ? ', engine active'
+      : `, engine ${purpose} tier`
+    : '';
   return `${marker} ${fitColumn(displayId(m), NAME_COLUMN)} ${fitColumn(m.module, 6)} ${formatSize(m.sizeBytes).padStart(8)}  ${state}${engineActive}`;
 }
 
@@ -208,6 +249,8 @@ export interface ModelCommandDeps {
    * implementation signals a live process on the developer's machine.
    */
   readonly stopEngine?: () => number | null;
+  /** Move the engine's TouchUp picker, to release a model for deletion (#860). */
+  readonly setTouchUpModel?: typeof setTouchUpModel;
 }
 
 /**
@@ -545,7 +588,8 @@ export async function runModelCommand(
           return 0;
         }
         io.out(`  ${'MODEL'.padEnd(NAME_COLUMN)} MODULE     SIZE  STATE`);
-        for (const m of models) io.out(formatManagedRow(m, aa.model));
+        const purposes = await purposeMap(list, baseUrl);
+        for (const m of models) io.out(formatManagedRow(m, aa.model, purposes));
         const hidden = all.length - models.length;
         if (hidden > 0) {
           io.out(
@@ -601,11 +645,30 @@ export async function runModelCommand(
               `"${id}" is the model remi is configured to use; switch with "remi model use <other>" (and restart running daemons) before removing it.`,
             );
           } else if (isOurs === false) {
+            // remi OWNS this helper: it fetched it, spawned it, and nothing
+            // else on the machine uses its proofread tier. Releasing the
+            // picker is remi's to do, and doing it is the whole point -- the
+            // previous advice ("stop the engine first") provably cannot work,
+            // because a fresh engine re-selects and re-loads that tier at boot.
+            if (aa.engine === 'owned') {
+              const released = await releaseActiveModel(
+                baseUrl,
+                target,
+                { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
+                io,
+              );
+              if (released) {
+                const result = await remove(baseUrl, target.id);
+                io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
+                return 0;
+              }
+              return 1;
+            }
             io.err(
               `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it. It is not remi's model (that is "${aa.model}"), and "remi model use" will not release it.`,
             );
             io.err(
-              'Point that module at another model from the app that owns it, or stop the engine first.',
+              'This engine is shared, so its picker belongs to the app that owns it; point that module elsewhere from there.',
             );
           } else {
             io.err(
@@ -705,6 +768,56 @@ export async function runModelCommand(
     io.err(`remi model ${verb} failed: ${errorToString(err)}`);
     return 1;
   }
+}
+
+/**
+ * Move the engine's picker off `target` so it can be deleted.
+ *
+ * `/v1/models`'s `isActive`/`deletable` are owned by the TouchUp (proofread)
+ * picker, NOT the LLM picker remi uses -- verified live: `POST /v1/llm/model`
+ * moves the LLM `current` and leaves the model undeletable; only
+ * `POST /v1/touchup/model` releases it (#860). So the release has to go
+ * through that endpoint, and it needs somewhere to point.
+ *
+ * Returns whether the model is now released. Narrated either way: this mutates
+ * a second setting, and a user must be able to see that it happened.
+ */
+async function releaseActiveModel(
+  baseUrl: string,
+  target: ManagedModel,
+  deps: { list: typeof listModels; setTouchUp: typeof setTouchUpModel },
+  io: ModelCommandIO,
+): Promise<boolean> {
+  const catalogue = await deps.list(baseUrl).catch(() => undefined);
+  const targetPurpose = catalogue?.available.find(
+    (m) => m.id === target.id || m.huggingFaceID === target.id,
+  )?.purpose;
+
+  // A replacement has to serve the same purpose, or the picker would refuse it.
+  // Prefer one already on disk so releasing does not trigger a download.
+  const candidates = (catalogue?.available ?? []).filter(
+    (m) => m.id !== target.id && m.huggingFaceID !== target.id && m.purpose === targetPurpose,
+  );
+  const replacement = candidates[0];
+  if (replacement === undefined) {
+    io.err(
+      `"${displayId(target)}" is the engine's only ${targetPurpose ?? target.module} model, so there is nothing to point the picker at.`,
+    );
+    io.err('Deleting it would leave that module with no model; refusing.');
+    return false;
+  }
+
+  io.out(
+    `"${displayId(target)}" is the engine's active ${targetPurpose ?? target.module} model; pointing that picker at "${displayId(replacement)}" to release it.`,
+  );
+  try {
+    await deps.setTouchUp(baseUrl, replacement.id);
+  } catch (err) {
+    io.err(`Could not move the picker: ${errorToString(err)}`);
+    io.err('Nothing was deleted.');
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/daemon/tests/auto-approve/engine-models.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-models.test.ts
@@ -12,6 +12,7 @@ import {
   preloadAsync,
   probeEngine,
   pullModel,
+  setTouchUpModel,
   unloadModel,
 } from '../../src/auto-approve/engine-models.ts';
 
@@ -616,5 +617,43 @@ describe('engine version (#852)', () => {
   test('no engine at all reports no version rather than throwing', async () => {
     // Port 1 is reserved and never listening.
     expect(await getEngineVersion('http://127.0.0.1:1', 300)).toBeUndefined();
+  });
+});
+
+describe('setTouchUpModel (#860)', () => {
+  test('posts {id, preload:false} to /v1/touchup/model', async () => {
+    // Pins the endpoint, the body SHAPE (the engine takes `id`, not `model` --
+    // a `{model}` body returns 400 "data couldn't be read"), and preload:false.
+    const srv = engineServer(() => Response.json({ id: 'yooz-light-v3', isActive: true }));
+    try {
+      await setTouchUpModel(srv.url, 'yooz-light-v3');
+      expect(srv.seen).toHaveLength(1);
+      expect(srv.seen[0]?.method).toBe('POST');
+      expect(srv.seen[0]?.path).toBe('/v1/touchup/model');
+      expect(srv.seen[0]?.body).toEqual({ id: 'yooz-light-v3', preload: false });
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('preload stays false so releasing does not pull the replacement into memory', async () => {
+    // This is called to FREE memory; the server-side default is preload:true,
+    // which would swap one resident multi-GB model for another.
+    const srv = engineServer(() => Response.json({}));
+    try {
+      await setTouchUpModel(srv.url, 'yooz-quality-v3');
+      expect((srv.seen[0]?.body as { preload: boolean }).preload).toBe(false);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('a rejected picker change throws rather than reporting success', async () => {
+    const srv = engineServer(() => new Response('nope', { status: 400 }));
+    try {
+      await expect(setTouchUpModel(srv.url, 'bad-id')).rejects.toThrow();
+    } finally {
+      srv.stop();
+    }
   });
 });

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -574,6 +574,109 @@ describe('remi model rm', () => {
     expect(t.out.join('\n')).toContain('pointing that picker at');
   });
 
+  test('refuses when the engine will not say what a model is used for', async () => {
+    // `m.purpose === targetPurpose` with both absent is `undefined ===
+    // undefined`, which matches EVERY row -- the same trap `matchesModel`
+    // documents. An engine that reports no purposes must stop the release,
+    // not silently make the filter a pass-through.
+    const t = io();
+    let pointedAt = '';
+    let removed = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true },
+            { id: 'yooz-light-v3', displayName: 'L', loaded: false },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 0 };
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(pointedAt).toBe('');
+    expect(removed).toBe('');
+    expect(t.err.join('\n')).toContain('does not report what');
+  });
+
+  test('prefers a replacement already on disk over one that would download', async () => {
+    // Releasing must not kick off a multi-GB download as a side effect of a
+    // delete. The catalogue has no disk state, so this cross-references the
+    // inventory's `cached`.
+    const t = io();
+    let pointedAt = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-instruct-4b', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => [
+          {
+            id: 'yooz-quality-v3',
+            module: 'llm',
+            displayName: 'Q',
+            sizeBytes: 1,
+            cached: true,
+            loaded: true,
+            isActive: true,
+            deletable: false,
+          },
+          {
+            id: 'not-downloaded',
+            module: 'llm',
+            displayName: 'N',
+            sizeBytes: 1,
+            cached: false,
+            loaded: false,
+            isActive: false,
+            deletable: true,
+          },
+          {
+            id: 'on-disk',
+            module: 'llm',
+            displayName: 'D',
+            sizeBytes: 1,
+            cached: true,
+            loaded: false,
+            isActive: false,
+            deletable: true,
+          },
+        ],
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            // Listed FIRST but NOT downloaded: picking by position would
+            // trigger a fetch.
+            { id: 'not-downloaded', displayName: 'N', loaded: false, purpose: 'proofread' },
+            { id: 'on-disk', displayName: 'D', loaded: false, purpose: 'proofread' },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => ({ id, reclaimedBytes: 0 }),
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(pointedAt).toBe('on-disk');
+  });
+
   test('refuses when the engine has no other model of that purpose', async () => {
     // Releasing by pointing the picker at nothing would leave that module
     // without a model, which is worse than refusing to delete.
@@ -608,6 +711,10 @@ describe('remi model rm', () => {
 
   test("never moves a SHARED engine's picker", async () => {
     // Repointing another host's picker is hostile: that app is using it.
+    // Note this is enforced by the pre-existing MUTATING guard (#818), which
+    // returns before any rm-specific code runs -- so this pins the OUTCOME,
+    // not the release branch. Stated because a reader could otherwise assume
+    // `releaseActiveModel` re-checks ownership; it deliberately does not.
     const t = io();
     let pointedAt = '';
     const code = await run(

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -531,28 +531,100 @@ describe('remi model rm', () => {
     expect(t.err.join('\n')).toContain('remi model use <other>');
   });
 
-  test("does not blame remi for the ENGINE's active model, nor advise a remedy that cannot work", async () => {
-    // The reported friction (#843). `isActive` is the engine picker's tier;
-    // remi's model here is something else entirely. Telling the user to run
-    // `remi model use <other>` sends them after a fix that provably does
-    // nothing: `use` writes remi's config and never touches the picker.
+  test("releases the ENGINE's active model on an owned engine, then deletes it", async () => {
+    // The reported friction (#860). `isActive` belongs to the TouchUp picker,
+    // so `remi model use` provably cannot release it -- and neither can
+    // restarting, because a fresh engine re-selects that tier at boot. On an
+    // engine remi owns, remi moves the picker itself.
     const t = io();
+    let pointedAt = '';
+    let removed = '';
     const code = await run(
       ['rm', 'yooz-quality-v3'],
-      configWith({ model: 'yooz-light-v3' }),
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
       t.io,
       {
         probe: async () => REACHABLE,
         inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            // Listed FIRST and of the WRONG purpose: the picker would refuse
+            // it, so choosing by position rather than purpose breaks here.
+            { id: 'yooz-instruct-4b', displayName: 'I', loaded: false, purpose: 'general' },
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            { id: 'yooz-light-v3', displayName: 'L', loaded: false, purpose: 'proofread' },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 800_000_000 };
+        },
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(pointedAt).toBe('yooz-light-v3'); // same purpose, so the picker accepts it
+    expect(removed).toBe('yooz-quality-v3');
+    // The second mutation must be visible: this moved a setting the user did
+    // not name.
+    expect(t.out.join('\n')).toContain('pointing that picker at');
+  });
+
+  test('refuses when the engine has no other model of that purpose', async () => {
+    // Releasing by pointing the picker at nothing would leave that module
+    // without a model, which is worse than refusing to delete.
+    const t = io();
+    let removed = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            // A general-purpose model is NOT a substitute for a proofread tier.
+            { id: 'yooz-instruct-4b', displayName: 'I', loaded: false, purpose: 'general' },
+          ],
+        }),
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 0 };
+        },
       },
     );
 
     expect(code).toBe(1);
-    const text = t.err.join('\n');
-    expect(text).toContain("engine's active llm model");
-    expect(text).toContain('yooz-light-v3'); // names what remi actually uses
-    expect(text).toContain('will not release it');
-    expect(text).not.toContain('remi model use <other>'); // the advice that does not work
+    expect(removed).toBe('');
+    expect(t.err.join('\n')).toContain('nothing to point the picker at');
+  });
+
+  test("never moves a SHARED engine's picker", async () => {
+    // Repointing another host's picker is hostile: that app is using it.
+    const t = io();
+    let pointedAt = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'shared' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(pointedAt).toBe('');
   });
 
   test('requires an explicit id', async () => {
@@ -1166,6 +1238,46 @@ describe('remi model — undecidable ownership is never asserted (legacy engine)
     expect(text).not.toContain("It is not remi's model");
     expect(text).toContain('cannot be determined');
     expect(text).toContain('remi model use <other>'); // offered, not denied
+  });
+});
+
+describe('ls labels what the engine model is active FOR (#860)', () => {
+  test('names the purpose instead of a bare "engine active"', async () => {
+    // `isActive` is the TOUCHUP picker's choice, so remi's own model can never
+    // carry it and a model remi never uses always does. Unqualified, that reads
+    // as "the engine is using this instead of the model I chose" -- which is
+    // exactly the conclusion a user drew. remi's model was in use the whole
+    // time; only the label was wrong.
+    const t = io();
+    const code = await run(['ls'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      list: async () => ({
+        current: 'yooz-light-v3',
+        available: [
+          { id: 'yooz-light-v3', displayName: 'L', loaded: true, purpose: 'proofread' },
+          { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+        ],
+      }),
+    });
+    expect(code).toBe(0);
+    const text = t.out.join('\n');
+    expect(text).toContain('engine proofread tier');
+    expect(text).not.toContain(', engine active');
+  });
+
+  test('falls back to the bare label when the catalogue cannot be read', async () => {
+    // A catalogue we cannot read must cost one qualifier, not the whole listing.
+    const t = io();
+    const code = await run(['ls'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      list: async () => {
+        throw new Error('catalogue unavailable');
+      },
+    });
+    expect(code).toBe(0);
+    expect(t.out.join('\n')).toContain('engine active');
   });
 });
 


### PR DESCRIPTION
Closes #860. Part of #861.

A user could not delete `yooz-light-v3`, and **no sequence of remi commands could have worked**. Diagnosed against a real v0.7.8 engine rather than from the code.

## What was actually wrong

`isActive` / `deletable` in `/v1/models` are owned by the **TouchUp (proofread) picker**, not the LLM picker remi uses:

```
fresh engine, before any request:
  yooz-light-v3     isActive=True   loaded=True   deletable=False   purpose=proofread
  yooz-instruct-4b  isActive=False  loaded=False  deletable=True    purpose=general
```

- The engine **selects and loads the proofread tier at boot**, unprompted — which is why it returned after `remi model restart`.
- `POST /v1/llm/model` returns 200 and moves the LLM `current`, but the inventory still reports the old model `isActive` and undeletable.
- Only `POST /v1/touchup/model {"id":..,"preload":false}` releases it. Verified: `isActive=False deletable=True`.

So remi printed *"stop the engine first"* — advice that provably cannot work, since a fresh engine re-selects that tier — and offered no other path.

## Changes

- **`setTouchUpModel()`** posts to `/v1/touchup/model`. `preload: false` deliberately: this is called to *free* memory, and the server-side default (`true`) would swap one resident multi-GB model for another. The body takes `id`, not `model` — a `{model}` body returns 400.
- **`rm` on an engine remi owns** moves that picker to another model **of the same purpose** and then deletes, narrating both actions since it mutates a setting the user did not name. remi fetched and spawned that helper and nothing else on the machine uses its proofread tier.
- **Refuses when there is no same-purpose replacement**, rather than leaving that module with no model.
- **Refuses on a `shared` engine** — repointing another host's picker is hostile.
- **`ls` labels the purpose**: `engine proofread tier`, not a bare `engine active`.

## Worth stating plainly

**Auto-approve was using the configured model the whole time.** `llm-client.ts` passes `model: config.model` explicitly on every `/v1/llm/generate`. The user reasonably concluded otherwise from `ls`, because that flag can only ever appear on a model remi does not use. The label was wrong, not the evaluator.

## Testing

Full suite **3844 pass, 0 fail**, 69 skip across 202 files. Typecheck, biome, spelling clean.

`setTouchUpModel` is tested against a real local `Bun.serve` (per that file's no-mocks pattern), pinning the endpoint, the body shape and `preload: false`.

| Mutation | Result |
|---|---|
| remove the release path entirely | 2 tests fail |
| release even with no replacement available | refusal test fails |
| ignore `purpose` when choosing a replacement | 2 tests fail |
| `preload: true` | 2 endpoint tests fail |
| bare `engine active` label | label test fails |

The purpose-filter mutation initially did **not** fail — both fixtures shared a purpose, so the filter was unpinned. Fixtures now put a wrong-purpose model first, so choosing by position instead of purpose breaks.

## Root cause is upstream

yooz-engine#317: the LLM-only variant should not eagerly load a proofread tier it never serves, nor let the TouchUp picker own `deletable` for the whole inventory. These changes are worth having regardless, since remi must degrade honestly against engines that behave this way.