### PR TITLE
Refuse to let a release fail by doing nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,25 +167,49 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Fail loudly if main still carries an unreleased dev version
+      - name: Fail loudly if the release did not actually happen
         run: |
           # Read the CURRENT main, not this run's SHA: when auto-release works
           # it pushes the stripped version, and that commit is newer than the
           # ref this workflow started from.
           git fetch origin main
           VERSION=$(git show origin/main:package.json | jq -r '.version')
-          if [[ "$VERSION" != *"-dev"* ]]; then
-            echo "main is at $VERSION - release completed."
-            exit 0
+
+          # `jq` prints the string "null" for an absent field and exits 0, so an
+          # unguarded check would read that as "not a dev version" and pass.
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error title=Cannot read version::origin/main's package.json has no usable version field."
+            exit 1
           fi
-          echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
-          echo "" >&2
-          echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
-          echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
-          echo "" >&2
-          echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
-          echo "auto-release will then run and tag ${VERSION%%-*}." >&2
-          exit 1
+
+          if [[ "$VERSION" == *"-dev"* ]]; then
+            echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
+            echo "" >&2
+            echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
+            echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
+            echo "" >&2
+            echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
+            echo "auto-release will then run and tag ${VERSION%%-*}." >&2
+            exit 1
+          fi
+
+          # A stable version is NOT proof a release shipped. `bump-version.sh`
+          # pushes the commit and the tag as two separate, non-atomic commands
+          # (`git push origin HEAD` then `git push origin "v$NEW_VERSION"`), and
+          # only the TAG triggers release.yml. If the second push fails, main
+          # reads stable while nothing downstream ever fires -- precisely the
+          # "no tag, no npm, no Homebrew" outcome this job exists to catch.
+          if ! git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "::error title=Release tag missing::main is at $VERSION but tag v$VERSION does not exist on origin."
+            echo "" >&2
+            echo "Only the tag triggers release.yml, so no binaries, npm publish," >&2
+            echo "GitHub release or Homebrew update happened for $VERSION." >&2
+            echo "" >&2
+            echo "Re-point/push the tag at origin/main to trigger the release." >&2
+            exit 1
+          fi
+
+          echo "main is at $VERSION and tag v$VERSION exists - release completed." 
 
   # After a stable release on main, merge main back into develop and
   # bump to the next patch dev version (e.g. 0.4.13 -> 0.4.14-dev.1).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,49 @@ jobs:
           bun install --frozen-lockfile
           ./scripts/bump-version.sh --push --force stable
 
+  # A release that fails by DOING NOTHING is the hardest kind to notice (#856).
+  #
+  # `auto-release` declares `needs: [spelling, lint, typecheck, test]`, so a red
+  # gate -- including a flaky one -- SKIPS it rather than failing it: no tag, no
+  # npm publish, no GitHub release, no Homebrew update. The workflow reports an
+  # overall failure, but nothing anywhere says "your release did not happen",
+  # and the only symptom is a tag that never appeared. That is exactly what two
+  # different flaky tests did during the 0.7.1 cut, once on main.
+  #
+  # So assert the invariant directly: after a push to main, main must not still
+  # carry a -dev suffix. `always()` is load-bearing -- this has to run precisely
+  # when the gates failed.
+  release-guard:
+    name: Release Guard
+    needs: [spelling, lint, typecheck, test, auto-release]
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fail loudly if main still carries an unreleased dev version
+        run: |
+          # Read the CURRENT main, not this run's SHA: when auto-release works
+          # it pushes the stripped version, and that commit is newer than the
+          # ref this workflow started from.
+          git fetch origin main
+          VERSION=$(git show origin/main:package.json | jq -r '.version')
+          if [[ "$VERSION" != *"-dev"* ]]; then
+            echo "main is at $VERSION - release completed."
+            exit 0
+          fi
+          echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
+          echo "" >&2
+          echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
+          echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
+          echo "" >&2
+          echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
+          echo "auto-release will then run and tag ${VERSION%%-*}." >&2
+          exit 1
+
   # After a stable release on main, merge main back into develop and
   # bump to the next patch dev version (e.g. 0.4.13 -> 0.4.14-dev.1).
   sync-develop:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A flaky gate can no longer cancel a release silently** (#856). `auto-release`
+  declares the test gates as `needs`, so a red gate — including a flaky one —
+  *skips* it rather than failing it: no tag, no npm publish, no GitHub release,
+  no Homebrew update, and the only symptom is a tag that never appeared. Two
+  different flaky tests did exactly that during the 0.7.1 cut, once on `main`.
+  A new `Release Guard` job asserts the invariant directly: after a push to
+  `main`, `main` must not still carry a `-dev` suffix. It runs on `always()`,
+  because the case it exists for is precisely the one where the gates failed.
+
+### Fixed
 - **`remi model rm` can now evict the engine's active model** (#860). It could
   not, and no sequence of remi commands could: `isActive`/`deletable` in the
   engine's inventory are owned by the **TouchUp (proofread) picker**, not the


### PR DESCRIPTION
Closes #856. Part of #861.

`auto-release` declares `needs: [spelling, lint, typecheck, test]`, so a red gate — including a flaky one — **skips** it rather than failing it. No tag, no npm publish, no GitHub release, no Homebrew update. The run reports an overall failure, but nothing says *"your release did not happen"*; the only symptom is a tag that never appeared.

That is not hypothetical: during the 0.7.1 cut two different flaky tests did this, once on `main`, and the release only completed because the run was manually re-run.

## The guard

A new `release-guard` job asserts the invariant directly rather than trying to make the gates perfect: **after a push to `main`, `main` must not still carry a `-dev` suffix.**

Two details are load-bearing:

- **`if: always()`** — the case this exists for is precisely the one where the gates went red, so it must not be skipped along with them.
- **It reads `origin/main`, not the run's SHA.** When `auto-release` works it *pushes* the stripped version, so that commit is newer than the ref the workflow started from; checking the run's own SHA would report a false failure on every successful release.

The error is actionable: it names the version, explains that `auto-release` skips rather than fails, and says to re-run the failed jobs so the tag gets created.

## Testing

Extracted the guard's shell body verbatim from the workflow and ran it against real git repos in both states:

| version on main | exit | meaning |
|---|---|---|
| `0.7.3-dev.2` | 1 | release did not happen — fails loudly |
| `0.7.3` | 0 | release completed |
| `0.8.0-dev.1` | 1 | fails loudly |
| `1.0.0` | 0 | passes |

YAML validated; job graph is `spelling, lint, typecheck, test, e2e, auto-release, release-guard, sync-develop`.

## Deliberately not done

I did not add automatic retries for the Test job. That would hide real breakage, and the two flakes that caused this are already fixed at the root (#848, #849). This guard is about making a missed release *impossible to miss*, not about papering over red gates.