### PR TITLE
Changelog for 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-07-28
+
+Makes remi able to stop its own daemons, and to evict a model the engine
+was holding.
+
 ### Fixed
 - **A flaky gate can no longer cancel a release silently** (#856). `auto-release`
   declares the test gates as `needs`, so a red gate — including a flaky one —


### PR DESCRIPTION
Dates the 0.7.3 section.

Content: #859 (stop/status see session daemons, `remi stop --all`, kill pid fallback), #860 (release the engine's picker so `rm` works, purpose-labelled `ls`), #856 (Release Guard).

Pins re-verified: engine helper `v0.7.8`, bun 1.3.11 across all workflows, `v0.7.3` unclaimed on npm and git.