### PR TITLE
Release 0.7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,25 +167,49 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Fail loudly if main still carries an unreleased dev version
+      - name: Fail loudly if the release did not actually happen
         run: |
           # Read the CURRENT main, not this run's SHA: when auto-release works
           # it pushes the stripped version, and that commit is newer than the
           # ref this workflow started from.
           git fetch origin main
           VERSION=$(git show origin/main:package.json | jq -r '.version')
-          if [[ "$VERSION" != *"-dev"* ]]; then
-            echo "main is at $VERSION - release completed."
-            exit 0
+
+          # `jq` prints the string "null" for an absent field and exits 0, so an
+          # unguarded check would read that as "not a dev version" and pass.
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error title=Cannot read version::origin/main's package.json has no usable version field."
+            exit 1
           fi
-          echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
-          echo "" >&2
-          echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
-          echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
-          echo "" >&2
-          echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
-          echo "auto-release will then run and tag ${VERSION%%-*}." >&2
-          exit 1
+
+          if [[ "$VERSION" == *"-dev"* ]]; then
+            echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
+            echo "" >&2
+            echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
+            echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
+            echo "" >&2
+            echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
+            echo "auto-release will then run and tag ${VERSION%%-*}." >&2
+            exit 1
+          fi
+
+          # A stable version is NOT proof a release shipped. `bump-version.sh`
+          # pushes the commit and the tag as two separate, non-atomic commands
+          # (`git push origin HEAD` then `git push origin "v$NEW_VERSION"`), and
+          # only the TAG triggers release.yml. If the second push fails, main
+          # reads stable while nothing downstream ever fires -- precisely the
+          # "no tag, no npm, no Homebrew" outcome this job exists to catch.
+          if ! git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "::error title=Release tag missing::main is at $VERSION but tag v$VERSION does not exist on origin."
+            echo "" >&2
+            echo "Only the tag triggers release.yml, so no binaries, npm publish," >&2
+            echo "GitHub release or Homebrew update happened for $VERSION." >&2
+            echo "" >&2
+            echo "Re-point/push the tag at origin/main to trigger the release." >&2
+            exit 1
+          fi
+
+          echo "main is at $VERSION and tag v$VERSION exists - release completed." 
 
   # After a stable release on main, merge main back into develop and
   # bump to the next patch dev version (e.g. 0.4.13 -> 0.4.14-dev.1).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,49 @@ jobs:
           bun install --frozen-lockfile
           ./scripts/bump-version.sh --push --force stable
 
+  # A release that fails by DOING NOTHING is the hardest kind to notice (#856).
+  #
+  # `auto-release` declares `needs: [spelling, lint, typecheck, test]`, so a red
+  # gate -- including a flaky one -- SKIPS it rather than failing it: no tag, no
+  # npm publish, no GitHub release, no Homebrew update. The workflow reports an
+  # overall failure, but nothing anywhere says "your release did not happen",
+  # and the only symptom is a tag that never appeared. That is exactly what two
+  # different flaky tests did during the 0.7.1 cut, once on main.
+  #
+  # So assert the invariant directly: after a push to main, main must not still
+  # carry a -dev suffix. `always()` is load-bearing -- this has to run precisely
+  # when the gates failed.
+  release-guard:
+    name: Release Guard
+    needs: [spelling, lint, typecheck, test, auto-release]
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fail loudly if main still carries an unreleased dev version
+        run: |
+          # Read the CURRENT main, not this run's SHA: when auto-release works
+          # it pushes the stripped version, and that commit is newer than the
+          # ref this workflow started from.
+          git fetch origin main
+          VERSION=$(git show origin/main:package.json | jq -r '.version')
+          if [[ "$VERSION" != *"-dev"* ]]; then
+            echo "main is at $VERSION - release completed."
+            exit 0
+          fi
+          echo "::error title=Release did not happen::main is at $VERSION, which is still a dev version."
+          echo "" >&2
+          echo "auto-release SKIPS (it does not fail) when any gate is red, so no tag," >&2
+          echo "npm publish, GitHub release or Homebrew update happened for this merge." >&2
+          echo "" >&2
+          echo "If a gate failed on a flake, re-run the failed jobs on this workflow run;" >&2
+          echo "auto-release will then run and tag ${VERSION%%-*}." >&2
+          exit 1
+
   # After a stable release on main, merge main back into develop and
   # bump to the next patch dev version (e.g. 0.4.13 -> 0.4.14-dev.1).
   sync-develop:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`remi stop --all`** (#859) stops session daemons as well as the hub.
+
+### Fixed
+- **`remi stop` and `remi status` no longer deny that running daemons exist**
+  (#859). Both resolved the *hub* only, via `daemon.pid` / `daemon-status.json`;
+  session daemons write `status-<PORT>.json`, which nothing enumerated. So
+  `status` reported "Daemon is not running" while `remi ls` listed a daemon
+  right there. They now report session daemons too, and whatever `remi stop`
+  does not stop, it names.
+- **`remi kill` can stop a daemon that has stopped answering** (#859). It went
+  only over the WebSocket, so a daemon wedged badly enough to ignore its socket
+  was unreachable by every remi command and could be removed only with `pkill`
+  — which matches on a name and will happily take down something unrelated.
+  remi records that daemon's pid itself, so it now falls back to signalling it,
+  saying plainly that graceful shutdown was skipped.
+
 ## [0.7.2] - 2026-07-27
 
 Makes the engine's version visible and replaceable, and puts the model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-07-28
+
+Makes remi able to stop its own daemons, and to evict a model the engine
+was holding.
+
 ### Fixed
 - **A flaky gate can no longer cancel a release silently** (#856). `auto-release`
   declares the test gates as `needs`, so a red gate — including a flaky one —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`remi model rm` can now evict the engine's active model** (#860). It could
+  not, and no sequence of remi commands could: `isActive`/`deletable` in the
+  engine's inventory are owned by the **TouchUp (proofread) picker**, not the
+  LLM picker remi uses. `remi model use` writes remi's config and cannot
+  release it; `POST /v1/llm/model` moves the LLM selection and leaves it
+  undeletable; and restarting does not help, because a fresh engine re-selects
+  and re-loads that tier at boot — so the printed advice ("stop the engine
+  first") provably could not work. On an engine remi **owns**, `rm` now moves
+  that picker to another model of the same purpose and then deletes, reporting
+  both actions. On a `shared` engine it refuses, since repointing another
+  host's picker is hostile.
+- **`remi model ls` says what a model is active FOR** (#860) — `engine
+  proofread tier` rather than a bare `engine active`. Because that flag belongs
+  to a different picker, remi's own model could never carry it and a model remi
+  never uses always did, which read as "the engine is ignoring the model I
+  chose". It never was: remi passes its configured model explicitly on every
+  evaluation.
+
 ### Added
 - **`remi stop --all`** (#859) stops session daemons as well as the hub.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A flaky gate can no longer cancel a release silently** (#856). `auto-release`
+  declares the test gates as `needs`, so a red gate — including a flaky one —
+  *skips* it rather than failing it: no tag, no npm publish, no GitHub release,
+  no Homebrew update, and the only symptom is a tag that never appeared. Two
+  different flaky tests did exactly that during the 0.7.1 cut, once on `main`.
+  A new `Release Guard` job asserts the invariant directly: after a push to
+  `main`, `main` must not still carry a `-dev` suffix. It runs on `always()`,
+  because the case it exists for is precisely the one where the gates failed.
+
+### Fixed
 - **`remi model rm` can now evict the engine's active model** (#860). It could
   not, and no sequence of remi commands could: `isActive`/`deletable` in the
   engine's inventory are owned by the **TouchUp (proofread) picker**, not the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.2",
+  "version": "0.7.3-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.3-dev.3",
+  "version": "0.7.3-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.3-dev.1",
+  "version": "0.7.3-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.3-dev.2",
+  "version": "0.7.3-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.3-dev.4",
+  "version": "0.7.3-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/engine-models.ts
+++ b/packages/daemon/src/auto-approve/engine-models.ts
@@ -71,6 +71,14 @@ export interface EngineModel {
   readonly sizeBytes?: number | undefined;
   readonly loaded: boolean;
   readonly latencyHintMs?: number | undefined;
+  /**
+   * What the engine selects this model FOR: `general` (what remi's evaluator
+   * uses) or `proofread` (the TouchUp picker's tiers). It is the missing piece
+   * behind #860: `/v1/models`'s `isActive` is set by the TOUCHUP picker, so
+   * remi's own model can never carry it and a model remi never uses always
+   * does. Without the purpose there is no way to say which "active" is meant.
+   */
+  readonly purpose?: string | undefined;
   /** The model's registered HuggingFace repo id, which the engine also accepts
    *  as an alias wherever a model id is taken (yooz-engine#308). Absent on
    *  engines older than 0.7.8 — see `model-identity.ts` for why that absence
@@ -207,6 +215,31 @@ export async function getEngineVersion(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Point the TouchUp (proofread) picker at `id`.
+ *
+ * Necessary because `/v1/models`'s `isActive`/`deletable` belong to THIS
+ * picker, not the LLM one. Verified against a live v0.7.8 engine:
+ * `POST /v1/llm/model` returns 200 and moves the LLM `current`, while the
+ * inventory still reports the old model `isActive` and undeletable — only this
+ * endpoint releases it (#860).
+ *
+ * `preload: false` on purpose: this is called to RELEASE a model, and the
+ * default (`true` server-side) would immediately pull the replacement into
+ * memory, trading one resident multi-GB model for another.
+ */
+export async function setTouchUpModel(
+  baseUrl: string,
+  id: string,
+  timeoutMs?: number,
+): Promise<void> {
+  await engineRequest(baseUrl, '/v1/touchup/model', {
+    method: 'POST',
+    body: { id, preload: false },
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
 }
 
 /** Current load/download state. */

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.3-dev.2'; // REMI_COMPILED_VERSION
+      return '0.7.3-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.3-dev.2'; // REMI_COMPILED_VERSION
+    return '0.7.3-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.2'; // REMI_COMPILED_VERSION
+      return '0.7.3-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.2'; // REMI_COMPILED_VERSION
+    return '0.7.3-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.3-dev.4'; // REMI_COMPILED_VERSION
+      return '0.7.3-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.3-dev.4'; // REMI_COMPILED_VERSION
+    return '0.7.3-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -305,6 +305,7 @@ const cliDaemonMode = parsedArgs.daemonMode || serveMode;
 const cliCodeRefresh = parsedArgs.codeRefresh;
 const cliPermanentCode = parsedArgs.permanentCode;
 const cliForce = parsedArgs.force;
+const cliStopAll = parsedArgs.stopAll;
 const cliUsePassphrase = parsedArgs.usePassphrase;
 const cliDecrypt = parsedArgs.decrypt;
 const cliEncrypt = parsedArgs.encrypt;
@@ -511,6 +512,7 @@ if (
       ...(cliPushSecret !== undefined && { pushSecret: cliPushSecret }),
       ...(cliOrphanTimeout !== undefined && { orphanTimeout: cliOrphanTimeout }),
       remiVersion: REMI_VERSION,
+      all: cliStopAll,
     }),
   );
 }
@@ -555,6 +557,7 @@ if (cliSubcommand === 'kill') {
   process.exit(
     await runKillCommand(resolved, {
       getLivePorts: () => liveSessionsRegistry.getLivePorts(),
+      listLive: () => liveSessionsRegistry.listLive(),
       explicitPort: cliPort,
     }),
   );

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.3-dev.1'; // REMI_COMPILED_VERSION
+      return '0.7.3-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.3-dev.1'; // REMI_COMPILED_VERSION
+    return '0.7.3-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.3-dev.3'; // REMI_COMPILED_VERSION
+      return '0.7.3-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.3-dev.3'; // REMI_COMPILED_VERSION
+    return '0.7.3-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/arg-parser.ts
+++ b/packages/daemon/src/cli/arg-parser.ts
@@ -87,6 +87,8 @@ export interface ParsedArgs {
   readonly codeRefresh: boolean;
   readonly permanentCode: boolean;
   readonly force: boolean;
+  /** `remi stop --all`: also stop session daemons, not just the hub (#859). */
+  readonly stopAll: boolean;
   readonly usePassphrase: boolean;
   readonly decrypt: boolean;
   readonly encrypt: boolean;
@@ -137,6 +139,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
   let codeRefresh = false;
   let permanentCode = false;
   let force = false;
+  let stopAll = false;
   let usePassphrase = false;
   let decrypt = false;
   let encrypt = false;
@@ -266,6 +269,9 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       uninstall = true;
     } else if (arg === '--force') {
       force = true;
+    } else if (arg === '--all') {
+      // Only `stop` defines a top-level `--all` today; harmless elsewhere.
+      stopAll = true;
     } else if (arg === '--passphrase') {
       usePassphrase = true;
     } else if (arg === '--decrypt') {
@@ -466,6 +472,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     codeRefresh,
     permanentCode,
     force,
+    stopAll,
     usePassphrase,
     decrypt,
     encrypt,

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -22,6 +22,8 @@ export interface StartDaemonOptions {
   readonly orphanTimeout?: number;
   /** This binary's remi version, for the `status` drift warning (#539). */
   readonly remiVersion?: string;
+  /** `remi stop --all`: stop session daemons too, not only the hub (#859). */
+  readonly all?: boolean;
 }
 
 /** Subcommands this handler owns. */
@@ -65,7 +67,7 @@ export async function runDaemonLifecycleCommand(
     return 0;
   }
   if (sub === 'stop') {
-    dm.stopDaemon();
+    dm.stopDaemon({ all: opts.all === true });
     return 0;
   }
   if (sub === 'status') {

--- a/packages/daemon/src/cli/cmd-daemon.ts
+++ b/packages/daemon/src/cli/cmd-daemon.ts
@@ -53,7 +53,10 @@ export function buildStartDaemonArgs(opts: StartDaemonOptions): string[] {
 
 /**
  * Run one of the daemon lifecycle subcommands.
- * Always exits 0 — errors inside daemon-manager are handled there.
+ *
+ * `stop` returns daemon-manager's exit code, so a daemon that survived being
+ * signalled is not reported as a clean stop (#859); the rest exit 0 because
+ * daemon-manager handles their errors itself.
  */
 export async function runDaemonLifecycleCommand(
   sub: DaemonSubcommand,
@@ -67,8 +70,7 @@ export async function runDaemonLifecycleCommand(
     return 0;
   }
   if (sub === 'stop') {
-    dm.stopDaemon({ all: opts.all === true });
-    return 0;
+    return dm.stopDaemon({ all: opts.all === true });
   }
   if (sub === 'status') {
     dm.showDaemonStatus(opts.remiVersion);

--- a/packages/daemon/src/cli/cmd-kill.ts
+++ b/packages/daemon/src/cli/cmd-kill.ts
@@ -140,10 +140,24 @@ function killByRecordedPid(
   io: KillCommandIO,
 ): number | undefined {
   const entries = deps.listLive?.() ?? [];
-  const match = entries.find(
-    (e) => e.name === target || String(e.wsPort) === target || e.name.endsWith(`/${target}`),
-  );
-  if (match === undefined) return undefined;
+  // Exact matches only. `name` is `path.basename(workingDirectory)` and never
+  // contains a slash, so a prefix/suffix clause here would be dead code that
+  // reads like a safety net.
+  const matches = entries.filter((e) => e.name === target || String(e.wsPort) === target);
+  if (matches.length === 0) return undefined;
+
+  // Never pick one. `name` is a directory BASENAME, so two worktrees of the
+  // same project (`main`, `main`) collide routinely, and a directory named
+  // `18766` collides with the port branch. Choosing the first would SIGKILL
+  // somebody else's daemon and report success. The reachable-daemon path
+  // already refuses this via `AmbiguousSessionError`; this must too.
+  if (matches.length > 1) {
+    io.err(`"${target}" matches ${matches.length} unreachable daemons:`);
+    for (const m of matches) io.err(`  ${m.name} (PID ${m.pid}, port ${m.wsPort})`);
+    io.err('Nothing was stopped. Re-run with the port to pick one.');
+    return 1;
+  }
+  const match = matches[0] as { pid: number; wsPort: number; name: string };
 
   const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
   const out = io.out ?? ((msg: string) => console.log(msg));

--- a/packages/daemon/src/cli/cmd-kill.ts
+++ b/packages/daemon/src/cli/cmd-kill.ts
@@ -12,12 +12,23 @@ import type { ResolvedTarget } from './target-resolver.ts';
 
 export interface KillCommandIO {
   readonly err: (msg: string) => void;
+  readonly out?: (msg: string) => void;
 }
 
-const defaultIO: KillCommandIO = { err: (msg) => console.error(msg) };
+const defaultIO: KillCommandIO = {
+  err: (msg) => console.error(msg),
+  out: (msg) => console.log(msg),
+};
 
 export interface KillCommandDeps {
   readonly getLivePorts: () => number[];
+  /**
+   * Live-sessions entries, for the unreachable-daemon fallback (#859). Seam so
+   * tests never signal a real process.
+   */
+  readonly listLive?: () => readonly { pid: number; wsPort: number; name: string }[];
+  /** Signal a pid. Defaults to the real `process.kill`. */
+  readonly signal?: (pid: number, sig: NodeJS.Signals | 0) => void;
   readonly explicitPort: number | undefined;
 }
 
@@ -83,6 +94,12 @@ export async function runKillCommand(
         },
       );
       if (resolution.status === 'no-daemons') {
+        // A daemon that ignores its socket used to be unreachable by every
+        // remi command, leaving `pkill` as the only option -- which matches on
+        // a name and will happily take down something else (#859). remi
+        // recorded this daemon's pid itself, so use it.
+        const byPid = killByRecordedPid(killTarget, deps, io);
+        if (byPid !== undefined) return byPid;
         io.err(
           `Cannot reach any remi daemon (tried ${resolution.probedCount} port(s)). Is a daemon running?`,
         );
@@ -104,4 +121,44 @@ export async function runKillCommand(
     io.err(errorToString(err));
     return 1;
   }
+}
+
+/**
+ * Stop a daemon by the pid the live-sessions registry recorded, when its socket
+ * will not answer.
+ *
+ * Returns an exit code when it acted, or undefined when no recorded entry
+ * matches -- so the caller still prints its own "cannot reach" message rather
+ * than this silently swallowing an ordinary typo.
+ *
+ * Deliberately narrated: this skips the daemon's graceful shutdown, so a user
+ * must be able to tell from the output that it happened.
+ */
+function killByRecordedPid(
+  target: string,
+  deps: KillCommandDeps,
+  io: KillCommandIO,
+): number | undefined {
+  const entries = deps.listLive?.() ?? [];
+  const match = entries.find(
+    (e) => e.name === target || String(e.wsPort) === target || e.name.endsWith(`/${target}`),
+  );
+  if (match === undefined) return undefined;
+
+  const signal = deps.signal ?? ((pid, sig) => process.kill(pid, sig));
+  const out = io.out ?? ((msg: string) => console.log(msg));
+
+  io.err(`Daemon on port ${match.wsPort} is not answering; stopping PID ${match.pid} directly.`);
+  try {
+    signal(match.pid, 'SIGTERM');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+      out(`PID ${match.pid} was already gone.`);
+      return 0;
+    }
+    io.err(`Could not signal PID ${match.pid}: ${errorToString(err)}`);
+    return 1;
+  }
+  out(`Sent SIGTERM to PID ${match.pid} (${match.name}). Its session was not shut down cleanly.`);
+  return 0;
 }

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -650,26 +650,22 @@ export async function runModelCommand(
             // picker is remi's to do, and doing it is the whole point -- the
             // previous advice ("stop the engine first") provably cannot work,
             // because a fresh engine re-selects and re-loads that tier at boot.
-            if (aa.engine === 'owned') {
-              const released = await releaseActiveModel(
-                baseUrl,
-                target,
-                { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
-                io,
-              );
-              if (released) {
-                const result = await remove(baseUrl, target.id);
-                io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
-                return 0;
-              }
-              return 1;
-            }
-            io.err(
-              `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it. It is not remi's model (that is "${aa.model}"), and "remi model use" will not release it.`,
+            //
+            // No ownership check here: `rm` is in MUTATING, so a `shared`
+            // engine already returned at the top of this function (#818). A
+            // second `aa.engine === 'owned'` test would read as a live guard
+            // while being unreachable, and its `else` would rot unnoticed.
+            const released = await releaseActiveModel(
+              baseUrl,
+              target,
+              models,
+              { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
+              io,
             );
-            io.err(
-              'This engine is shared, so its picker belongs to the app that owns it; point that module elsewhere from there.',
-            );
+            if (!released) return 1;
+            const result = await remove(baseUrl, target.id);
+            io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
+            return 0;
           } else {
             io.err(
               `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it.`,
@@ -785,6 +781,7 @@ export async function runModelCommand(
 async function releaseActiveModel(
   baseUrl: string,
   target: ManagedModel,
+  inventory: readonly ManagedModel[],
   deps: { list: typeof listModels; setTouchUp: typeof setTouchUpModel },
   io: ModelCommandIO,
 ): Promise<boolean> {
@@ -793,22 +790,48 @@ async function releaseActiveModel(
     (m) => m.id === target.id || m.huggingFaceID === target.id,
   )?.purpose;
 
-  // A replacement has to serve the same purpose, or the picker would refuse it.
-  // Prefer one already on disk so releasing does not trigger a download.
+  // An engine that does not report `purpose` gives us no way to tell a valid
+  // replacement from an invalid one -- and `m.purpose === targetPurpose` with
+  // both absent is `undefined === undefined`, which matches EVERY row. That is
+  // the same trap `matchesModel` documents: comparing against an absent value
+  // silently turns a filter into a pass-through. Refuse instead of moving a
+  // picker to something the engine may not accept.
+  if (targetPurpose === undefined) {
+    io.err(
+      `This engine does not report what "${displayId(target)}" is used for, so remi cannot tell which model could safely replace it.`,
+    );
+    io.err('Nothing was changed. An engine that reports model purposes resolves this.');
+    return false;
+  }
+
   const candidates = (catalogue?.available ?? []).filter(
     (m) => m.id !== target.id && m.huggingFaceID !== target.id && m.purpose === targetPurpose,
   );
-  const replacement = candidates[0];
-  if (replacement === undefined) {
+  if (candidates.length === 0) {
     io.err(
-      `"${displayId(target)}" is the engine's only ${targetPurpose ?? target.module} model, so there is nothing to point the picker at.`,
+      `"${displayId(target)}" is the engine's only ${targetPurpose} model, so there is nothing to point the picker at.`,
     );
     io.err('Deleting it would leave that module with no model; refusing.');
     return false;
   }
 
+  // Prefer a replacement already on disk. The catalogue has no disk state --
+  // `cached` lives on the INVENTORY rows -- so cross-reference them. Without
+  // this, releasing a model could kick off a multi-GB HuggingFace download as
+  // a side effect of a delete, which is the opposite of what was asked for.
+  const onDisk = new Set(
+    inventory
+      .filter((m) => m.cached)
+      .flatMap((m) => (m.huggingFaceID ? [m.id, m.huggingFaceID] : [m.id])),
+  );
+  const replacement =
+    candidates.find(
+      (m) => onDisk.has(m.id) || (m.huggingFaceID !== undefined && onDisk.has(m.huggingFaceID)),
+    ) ?? candidates[0];
+  if (replacement === undefined) return false;
+
   io.out(
-    `"${displayId(target)}" is the engine's active ${targetPurpose ?? target.module} model; pointing that picker at "${displayId(replacement)}" to release it.`,
+    `"${displayId(target)}" is the engine's active ${targetPurpose} model; pointing that picker at "${displayId(replacement)}" to release it.`,
   );
   try {
     await deps.setTouchUp(baseUrl, replacement.id);

--- a/packages/daemon/src/cli/cmd-model.ts
+++ b/packages/daemon/src/cli/cmd-model.ts
@@ -69,6 +69,7 @@ import {
   preloadAsync,
   probeEngine,
   pullModel,
+  setTouchUpModel,
   unloadModel,
 } from '../auto-approve/engine-models.ts';
 import { FileEnginePidStore } from '../auto-approve/engine-process.ts';
@@ -108,6 +109,31 @@ function isVerb(s: string | undefined): s is Verb {
   return s !== undefined && (VERBS as readonly string[]).includes(s);
 }
 
+/**
+ * id -> purpose, from the LLM catalogue.
+ *
+ * The disk inventory (`/v1/models`) carries no `purpose`, so this is the only
+ * way to say what a model is the ACTIVE choice for. Best-effort: a catalogue
+ * we cannot read costs a qualifier on one label, and must not fail `ls`.
+ */
+async function purposeMap(
+  list: typeof listModels,
+  baseUrl: string,
+): Promise<ReadonlyMap<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const catalogue = await list(baseUrl);
+    for (const m of catalogue.available) {
+      if (m.purpose === undefined) continue;
+      map.set(m.id, m.purpose);
+      if (m.huggingFaceID !== undefined) map.set(m.huggingFaceID, m.purpose);
+    }
+  } catch {
+    // Label stays unqualified; every other column is unaffected.
+  }
+  return map;
+}
+
 /** Human-readable size. The engine reports bytes; a user thinks in GB.
  *  Zero is rendered as unknown rather than "0 MB": the inventory reports 0 for
  *  rows whose on-disk footprint it cannot measure (observed on swept hub
@@ -132,7 +158,11 @@ function fitColumn(text: string, width: number): string {
  *  to copy is not the thing that gets truncated. */
 const NAME_COLUMN = 40;
 
-function formatManagedRow(m: ManagedModel, configured: string): string {
+function formatManagedRow(
+  m: ManagedModel,
+  configured: string,
+  purposeById: ReadonlyMap<string, string> = new Map(),
+): string {
   // The marker means "this is the model REMI uses" — not the engine's active
   // tier. `isActive` belongs to whichever module owns the picker, and marking
   // that as the user's model is the same misattribution `rm` used to make.
@@ -146,7 +176,18 @@ function formatManagedRow(m: ManagedModel, configured: string): string {
   // instead of marking a row.
   const marker = matchesModel(m, configured) ? '*' : ' ';
   const state = m.loaded ? 'resident' : m.cached ? 'on disk' : 'not downloaded';
-  const engineActive = m.isActive ? ', engine active' : '';
+  // Say what it is active FOR. `isActive` is the TOUCHUP picker's selection, so
+  // an unqualified "engine active" reads as "the engine is using this instead
+  // of your model" -- which is what led a user to conclude their configured
+  // model was being ignored. It never was: remi passes its model explicitly on
+  // every generate (#860).
+  const purpose =
+    purposeById.get(m.id) ?? (m.huggingFaceID ? purposeById.get(m.huggingFaceID) : undefined);
+  const engineActive = m.isActive
+    ? purpose === undefined
+      ? ', engine active'
+      : `, engine ${purpose} tier`
+    : '';
   return `${marker} ${fitColumn(displayId(m), NAME_COLUMN)} ${fitColumn(m.module, 6)} ${formatSize(m.sizeBytes).padStart(8)}  ${state}${engineActive}`;
 }
 
@@ -208,6 +249,8 @@ export interface ModelCommandDeps {
    * implementation signals a live process on the developer's machine.
    */
   readonly stopEngine?: () => number | null;
+  /** Move the engine's TouchUp picker, to release a model for deletion (#860). */
+  readonly setTouchUpModel?: typeof setTouchUpModel;
 }
 
 /**
@@ -545,7 +588,8 @@ export async function runModelCommand(
           return 0;
         }
         io.out(`  ${'MODEL'.padEnd(NAME_COLUMN)} MODULE     SIZE  STATE`);
-        for (const m of models) io.out(formatManagedRow(m, aa.model));
+        const purposes = await purposeMap(list, baseUrl);
+        for (const m of models) io.out(formatManagedRow(m, aa.model, purposes));
         const hidden = all.length - models.length;
         if (hidden > 0) {
           io.out(
@@ -601,11 +645,30 @@ export async function runModelCommand(
               `"${id}" is the model remi is configured to use; switch with "remi model use <other>" (and restart running daemons) before removing it.`,
             );
           } else if (isOurs === false) {
+            // remi OWNS this helper: it fetched it, spawned it, and nothing
+            // else on the machine uses its proofread tier. Releasing the
+            // picker is remi's to do, and doing it is the whole point -- the
+            // previous advice ("stop the engine first") provably cannot work,
+            // because a fresh engine re-selects and re-loads that tier at boot.
+            if (aa.engine === 'owned') {
+              const released = await releaseActiveModel(
+                baseUrl,
+                target,
+                { list, setTouchUp: deps.setTouchUpModel ?? setTouchUpModel },
+                io,
+              );
+              if (released) {
+                const result = await remove(baseUrl, target.id);
+                io.out(`Removed ${result.id}, reclaimed ${formatSize(result.reclaimedBytes)}.`);
+                return 0;
+              }
+              return 1;
+            }
             io.err(
               `"${id}" is the engine's active ${target.module} model, so the engine refuses to delete it. It is not remi's model (that is "${aa.model}"), and "remi model use" will not release it.`,
             );
             io.err(
-              'Point that module at another model from the app that owns it, or stop the engine first.',
+              'This engine is shared, so its picker belongs to the app that owns it; point that module elsewhere from there.',
             );
           } else {
             io.err(
@@ -705,6 +768,56 @@ export async function runModelCommand(
     io.err(`remi model ${verb} failed: ${errorToString(err)}`);
     return 1;
   }
+}
+
+/**
+ * Move the engine's picker off `target` so it can be deleted.
+ *
+ * `/v1/models`'s `isActive`/`deletable` are owned by the TouchUp (proofread)
+ * picker, NOT the LLM picker remi uses -- verified live: `POST /v1/llm/model`
+ * moves the LLM `current` and leaves the model undeletable; only
+ * `POST /v1/touchup/model` releases it (#860). So the release has to go
+ * through that endpoint, and it needs somewhere to point.
+ *
+ * Returns whether the model is now released. Narrated either way: this mutates
+ * a second setting, and a user must be able to see that it happened.
+ */
+async function releaseActiveModel(
+  baseUrl: string,
+  target: ManagedModel,
+  deps: { list: typeof listModels; setTouchUp: typeof setTouchUpModel },
+  io: ModelCommandIO,
+): Promise<boolean> {
+  const catalogue = await deps.list(baseUrl).catch(() => undefined);
+  const targetPurpose = catalogue?.available.find(
+    (m) => m.id === target.id || m.huggingFaceID === target.id,
+  )?.purpose;
+
+  // A replacement has to serve the same purpose, or the picker would refuse it.
+  // Prefer one already on disk so releasing does not trigger a download.
+  const candidates = (catalogue?.available ?? []).filter(
+    (m) => m.id !== target.id && m.huggingFaceID !== target.id && m.purpose === targetPurpose,
+  );
+  const replacement = candidates[0];
+  if (replacement === undefined) {
+    io.err(
+      `"${displayId(target)}" is the engine's only ${targetPurpose ?? target.module} model, so there is nothing to point the picker at.`,
+    );
+    io.err('Deleting it would leave that module with no model; refusing.');
+    return false;
+  }
+
+  io.out(
+    `"${displayId(target)}" is the engine's active ${targetPurpose ?? target.module} model; pointing that picker at "${displayId(replacement)}" to release it.`,
+  );
+  try {
+    await deps.setTouchUp(baseUrl, replacement.id);
+  } catch (err) {
+    io.err(`Could not move the picker: ${errorToString(err)}`);
+    io.err('Nothing was deleted.');
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -305,9 +305,19 @@ function describeSessionDaemon(d: SessionDaemon): string {
  * and which, when wedged badly enough to ignore their socket, could previously
  * only be removed with `pkill` (#859).
  */
-function terminatePid(pid: number, graceMs = 3000): boolean {
+export interface SignalDeps {
+  readonly signal: (pid: number, sig: NodeJS.Signals | 0) => void;
+  readonly sleep: (ms: number) => void;
+}
+
+const realSignals: SignalDeps = {
+  signal: (pid, sig) => process.kill(pid, sig),
+  sleep: (ms) => Bun.sleepSync(ms),
+};
+
+export function terminatePid(pid: number, graceMs = 3000, deps: SignalDeps = realSignals): boolean {
   try {
-    process.kill(pid, 'SIGTERM');
+    deps.signal(pid, 'SIGTERM');
   } catch (err) {
     // Already gone is success; anything else is not ours to signal.
     return (err as NodeJS.ErrnoException).code === 'ESRCH';
@@ -315,20 +325,20 @@ function terminatePid(pid: number, graceMs = 3000): boolean {
   const deadline = Date.now() + graceMs;
   while (Date.now() < deadline) {
     try {
-      process.kill(pid, 0);
+      deps.signal(pid, 0);
     } catch {
       return true;
     }
-    Bun.sleepSync(100);
+    deps.sleep(100);
   }
   try {
-    process.kill(pid, 'SIGKILL');
+    deps.signal(pid, 'SIGKILL');
   } catch {
     // Raced with its own exit.
   }
-  Bun.sleepSync(200);
+  deps.sleep(200);
   try {
-    process.kill(pid, 0);
+    deps.signal(pid, 0);
     return false;
   } catch {
     return true;
@@ -336,10 +346,13 @@ function terminatePid(pid: number, graceMs = 3000): boolean {
 }
 
 /** Stop every session daemon, reporting each. Returns how many are now gone. */
-export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
+export function stopSessionDaemons(
+  daemons: readonly SessionDaemon[],
+  deps: SignalDeps = realSignals,
+): number {
   let stopped = 0;
   for (const d of daemons) {
-    if (terminatePid(d.pid)) {
+    if (terminatePid(d.pid, 3000, deps)) {
       console.log(`Stopped session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
       stopped++;
     } else {
@@ -349,7 +362,12 @@ export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
   return stopped;
 }
 
-export function stopDaemon(opts: { all?: boolean } = {}): void {
+/**
+ * Returns the exit code the CLI should use. Previously `void`, which meant a
+ * daemon that survived SIGKILL was still reported as a clean stop -- so
+ * `remi stop --all && echo ok` printed `ok` with a daemon still running.
+ */
+export function stopDaemon(opts: { all?: boolean } = {}): number {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
   const sessions = listSessionDaemons();
 
@@ -365,10 +383,10 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
       for (const d of sessions) console.log(describeSessionDaemon(d));
       console.log('');
       console.log('Stop them with "remi stop --all", or one at a time with "remi kill <name>".');
-      return;
+      // Nothing was stopped, so this is not a success.
+      return 1;
     }
-    stopSessionDaemons(sessions);
-    return;
+    return stopSessionDaemons(sessions) === sessions.length ? 0 : 1;
   }
 
   console.log(`Stopping daemon (PID ${pid})...`);
@@ -392,8 +410,7 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
     } catch {
       cleanupFiles(pid);
       console.log('Daemon stopped.');
-      finishSessionDaemons(sessions, opts.all === true);
-      return;
+      return finishSessionDaemons(sessions, opts.all === true);
     }
   }
 
@@ -411,7 +428,7 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
   Bun.sleepSync(200);
   cleanupFiles(pid);
   console.log('Daemon killed.');
-  finishSessionDaemons(sessions, opts.all === true);
+  return finishSessionDaemons(sessions, opts.all === true);
 }
 
 /**
@@ -421,16 +438,17 @@ export function stopDaemon(opts: { all?: boolean } = {}): void {
  * reported success, and left processes running that the user then had to find
  * with `pkill`. Whatever this does not stop, it says (#859).
  */
-function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): void {
-  if (sessions.length === 0) return;
+function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): number {
+  if (sessions.length === 0) return 0;
   if (all) {
-    stopSessionDaemons(sessions);
-    return;
+    return stopSessionDaemons(sessions) === sessions.length ? 0 : 1;
   }
   console.log('');
   console.log(`${sessions.length} session daemon(s) are still running:`);
   for (const d of sessions) console.log(describeSessionDaemon(d));
   console.log('Stop these too with "remi stop --all".');
+  // The hub stopped, which is what was asked for.
+  return 0;
 }
 
 export function showDaemonStatus(installedVersion?: string): void {

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
+import { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { rotateIfNeeded } from './log-rotation.ts';
 import { formatVersionDrift } from './version-drift.ts';
 
@@ -261,11 +262,113 @@ export async function startDaemon(opts?: StartOptions): Promise<number> {
   return pid;
 }
 
-export function stopDaemon(): void {
+/** A running session daemon, as recorded in the live-sessions registry. */
+export interface SessionDaemon {
+  readonly pid: number;
+  readonly wsPort: number;
+  readonly name: string;
+}
+
+/**
+ * The session daemons running right now, deduplicated by pid.
+ *
+ * `stop` and `status` resolve the HUB, via `daemon.pid` / `daemon-status.json`.
+ * Session daemons write `status-<PORT>.json` instead and are named in neither,
+ * so before this existed both commands would announce "Daemon is not running"
+ * while `remi ls` happily listed one (#859). The live-sessions registry is the
+ * right source: it already reaps entries whose process is gone, so anything it
+ * returns names a pid that was alive a moment ago.
+ *
+ * The hub deliberately never registers itself here, so it cannot appear twice.
+ */
+export function listSessionDaemons(
+  listLive = () => new SessionRegistryFile().listLive(),
+): SessionDaemon[] {
+  const byPid = new Map<number, SessionDaemon>();
+  for (const entry of listLive()) {
+    // One daemon can host several sessions; it is still one process to stop.
+    if (!byPid.has(entry.pid)) {
+      byPid.set(entry.pid, { pid: entry.pid, wsPort: entry.wsPort, name: entry.name });
+    }
+  }
+  return [...byPid.values()];
+}
+
+function describeSessionDaemon(d: SessionDaemon): string {
+  return `  PID ${d.pid}  port ${d.wsPort}  ${d.name}`;
+}
+
+/**
+ * SIGTERM, then SIGKILL if it will not go. Returns whether the process is gone.
+ *
+ * Used for session daemons, which have no graceful RPC path of their own here —
+ * and which, when wedged badly enough to ignore their socket, could previously
+ * only be removed with `pkill` (#859).
+ */
+function terminatePid(pid: number, graceMs = 3000): boolean {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    // Already gone is success; anything else is not ours to signal.
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    Bun.sleepSync(100);
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Raced with its own exit.
+  }
+  Bun.sleepSync(200);
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** Stop every session daemon, reporting each. Returns how many are now gone. */
+export function stopSessionDaemons(daemons: readonly SessionDaemon[]): number {
+  let stopped = 0;
+  for (const d of daemons) {
+    if (terminatePid(d.pid)) {
+      console.log(`Stopped session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
+      stopped++;
+    } else {
+      console.error(`Could not stop session daemon PID ${d.pid} (port ${d.wsPort}, ${d.name})`);
+    }
+  }
+  return stopped;
+}
+
+export function stopDaemon(opts: { all?: boolean } = {}): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
+  const sessions = listSessionDaemons();
+
   if (!pid) {
-    console.error('No running daemon found.');
-    process.exit(1);
+    // "No running daemon found" was a lie whenever session daemons existed,
+    // and it is the message that sent a user to `pkill` (#859).
+    if (sessions.length === 0) {
+      console.error('No running daemon found.');
+      process.exit(1);
+    }
+    if (opts.all !== true) {
+      console.log('No hub is running, but these session daemons are:');
+      for (const d of sessions) console.log(describeSessionDaemon(d));
+      console.log('');
+      console.log('Stop them with "remi stop --all", or one at a time with "remi kill <name>".');
+      return;
+    }
+    stopSessionDaemons(sessions);
+    return;
   }
 
   console.log(`Stopping daemon (PID ${pid})...`);
@@ -289,6 +392,7 @@ export function stopDaemon(): void {
     } catch {
       cleanupFiles(pid);
       console.log('Daemon stopped.');
+      finishSessionDaemons(sessions, opts.all === true);
       return;
     }
   }
@@ -307,12 +411,44 @@ export function stopDaemon(): void {
   Bun.sleepSync(200);
   cleanupFiles(pid);
   console.log('Daemon killed.');
+  finishSessionDaemons(sessions, opts.all === true);
+}
+
+/**
+ * Stop the session daemons too, or — when not asked to — NAME them.
+ *
+ * Silence here is what made `remi stop` feel broken: it stopped the hub,
+ * reported success, and left processes running that the user then had to find
+ * with `pkill`. Whatever this does not stop, it says (#859).
+ */
+function finishSessionDaemons(sessions: readonly SessionDaemon[], all: boolean): void {
+  if (sessions.length === 0) return;
+  if (all) {
+    stopSessionDaemons(sessions);
+    return;
+  }
+  console.log('');
+  console.log(`${sessions.length} session daemon(s) are still running:`);
+  for (const d of sessions) console.log(describeSessionDaemon(d));
+  console.log('Stop these too with "remi stop --all".');
 }
 
 export function showDaemonStatus(installedVersion?: string): void {
   const pid = readPidFileLive() ?? readStatusFilePidIfAlive();
+  const sessions = listSessionDaemons();
   if (!pid) {
-    console.log('Daemon is not running.');
+    // Saying "Daemon is not running" while `remi ls` lists one is how a user
+    // ends up reaching for `pkill` (#859). Both statements were about
+    // different things; only one of them said so.
+    if (sessions.length === 0) {
+      console.log('Daemon is not running.');
+      return;
+    }
+    console.log('No hub is running.');
+    console.log(`${sessions.length} session daemon(s) running:`);
+    for (const d of sessions) console.log(describeSessionDaemon(d));
+    console.log('');
+    console.log('Start a hub with "remi start"; stop these with "remi stop --all".');
     return;
   }
 
@@ -342,6 +478,12 @@ export function showDaemonStatus(installedVersion?: string): void {
   }
 
   console.log(`  Logs: ${LOG_FILE}`);
+
+  if (sessions.length > 0) {
+    console.log('');
+    console.log(`${sessions.length} session daemon(s) running:`);
+    for (const d of sessions) console.log(describeSessionDaemon(d));
+  }
 }
 
 export function showDaemonLogs(lines = 50): void {

--- a/packages/daemon/src/cli/help.ts
+++ b/packages/daemon/src/cli/help.ts
@@ -229,6 +229,7 @@ const commandHelp: Record<Subcommand, string[]> = {
     '',
     bold('Usage:'),
     entry('remi stop', 'Stop the running hub'),
+    entry('remi stop --all', 'Also stop every session daemon'),
   ],
   status: [
     'Show daemon status.',
@@ -373,7 +374,7 @@ export function formatHelp(version: string): string {
     '',
     bold('Service:'),
     entry('remi start', 'Start the hub in the background'),
-    entry('remi stop', 'Stop background daemon'),
+    entry('remi stop', 'Stop background daemon (--all: session daemons too)'),
     entry('remi status', 'Show daemon status'),
     entry('remi logs', 'Show daemon logs'),
     entry('remi serve', 'Run the session-less hub in the foreground'),

--- a/packages/daemon/tests/auto-approve/engine-models.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-models.test.ts
@@ -12,6 +12,7 @@ import {
   preloadAsync,
   probeEngine,
   pullModel,
+  setTouchUpModel,
   unloadModel,
 } from '../../src/auto-approve/engine-models.ts';
 
@@ -616,5 +617,43 @@ describe('engine version (#852)', () => {
   test('no engine at all reports no version rather than throwing', async () => {
     // Port 1 is reserved and never listening.
     expect(await getEngineVersion('http://127.0.0.1:1', 300)).toBeUndefined();
+  });
+});
+
+describe('setTouchUpModel (#860)', () => {
+  test('posts {id, preload:false} to /v1/touchup/model', async () => {
+    // Pins the endpoint, the body SHAPE (the engine takes `id`, not `model` --
+    // a `{model}` body returns 400 "data couldn't be read"), and preload:false.
+    const srv = engineServer(() => Response.json({ id: 'yooz-light-v3', isActive: true }));
+    try {
+      await setTouchUpModel(srv.url, 'yooz-light-v3');
+      expect(srv.seen).toHaveLength(1);
+      expect(srv.seen[0]?.method).toBe('POST');
+      expect(srv.seen[0]?.path).toBe('/v1/touchup/model');
+      expect(srv.seen[0]?.body).toEqual({ id: 'yooz-light-v3', preload: false });
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('preload stays false so releasing does not pull the replacement into memory', async () => {
+    // This is called to FREE memory; the server-side default is preload:true,
+    // which would swap one resident multi-GB model for another.
+    const srv = engineServer(() => Response.json({}));
+    try {
+      await setTouchUpModel(srv.url, 'yooz-quality-v3');
+      expect((srv.seen[0]?.body as { preload: boolean }).preload).toBe(false);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test('a rejected picker change throws rather than reporting success', async () => {
+    const srv = engineServer(() => new Response('nope', { status: 400 }));
+    try {
+      await expect(setTouchUpModel(srv.url, 'bad-id')).rejects.toThrow();
+    } finally {
+      srv.stop();
+    }
   });
 });

--- a/packages/daemon/tests/cli/arg-parser.test.ts
+++ b/packages/daemon/tests/cli/arg-parser.test.ts
@@ -827,4 +827,27 @@ describe('parseArgs - auto-approve flags', () => {
     expect(r.autoApproveDeny).toEqual(['sudo ']);
     expect(r.autoApproveInstructions).toBe('Be conservative');
   });
+
+  describe('--all (#859)', () => {
+    test('remi stop --all sets stopAll', () => {
+      expect(parseArgs(['stop', '--all']).stopAll).toBe(true);
+    });
+
+    test('plain remi stop does not', () => {
+      expect(parseArgs(['stop']).stopAll).toBe(false);
+    });
+
+    test('remi model ls --all still reaches the model subcommand', () => {
+      // `--all` is consumed by the model branch's OWN_FLAGS before the new
+      // top-level branch sees it. Nothing pinned that ordering, so a future
+      // edit to either branch could silently break `remi model ls --all`.
+      const r = parseArgs(['model', 'ls', '--all']);
+      expect(r.subcommand).toBe('model');
+      expect(r.subcommandArgs).toEqual(['ls', '--all']);
+    });
+
+    test('remi --sessions all still selects the sessions view', () => {
+      expect(parseArgs(['--sessions', 'all']).showSessions).toBe('all');
+    });
+  });
 });

--- a/packages/daemon/tests/cli/cmd-kill.test.ts
+++ b/packages/daemon/tests/cli/cmd-kill.test.ts
@@ -152,3 +152,98 @@ describe('runKillCommand', () => {
     expect(err).toEqual(['kill failed']);
   });
 });
+
+describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
+  /** IO that also captures stdout, which the fallback narrates to. */
+  function makeIO2() {
+    const err: string[] = [];
+    const out: string[] = [];
+    return {
+      io: { err: (m: string) => err.push(m), out: (m: string) => out.push(m) },
+      err,
+      out,
+    };
+  }
+
+  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality/main' }];
+
+  test('signals the recorded pid when no daemon answers', async () => {
+    // The state this exists for: the daemon is alive but ignoring its socket,
+    // so every RPC path fails and `pkill` was previously the only option.
+    const { io, err, out } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const signalled: Array<{ pid: number; sig: string }> = [];
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'neurality/main' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: (pid, sig) => signalled.push({ pid, sig: String(sig) }),
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(signalled).toEqual([{ pid: 4242, sig: 'SIGTERM' }]);
+    // It must be obvious that graceful shutdown was skipped.
+    expect(err.join('\n')).toContain('not answering');
+    expect(out.join('\n')).toContain('not shut down cleanly');
+  });
+
+  test('matches by port as well as name', async () => {
+    const { io } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const signalled: number[] = [];
+    const code = await runKillCommand(
+      mkTarget({ targetId: '18766' }),
+      { ...deps, listLive: () => WEDGED, signal: (pid) => signalled.push(pid) },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(signalled).toEqual([4242]);
+  });
+
+  test('an unknown target still reports "cannot reach", not a silent success', async () => {
+    // A typo must not be swallowed by the fallback.
+    const { io, err } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    let signalled = false;
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'no-such-session' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: () => {
+          signalled = true;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(signalled).toBe(false);
+    expect(err.join('\n')).toContain('Cannot reach any remi daemon');
+  });
+
+  test('a process that is already gone is success, not an error', async () => {
+    const { io, out } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'neurality/main' }),
+      {
+        ...deps,
+        listLive: () => WEDGED,
+        signal: () => {
+          const e = new Error('no such process') as NodeJS.ErrnoException;
+          e.code = 'ESRCH';
+          throw e;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(0);
+    expect(out.join('\n')).toContain('already gone');
+  });
+});

--- a/packages/daemon/tests/cli/cmd-kill.test.ts
+++ b/packages/daemon/tests/cli/cmd-kill.test.ts
@@ -165,7 +165,11 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     };
   }
 
-  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality/main' }];
+  // `name` is `path.basename(workingDirectory)` (cli.ts:2319), so a bare
+  // basename is the ONLY shape that occurs in production. Earlier fixtures used
+  // 'neurality/main', which cannot happen and quietly masked a dead
+  // prefix-matching clause.
+  const WEDGED = [{ pid: 4242, wsPort: 18766, name: 'neurality' }];
 
   test('signals the recorded pid when no daemon answers', async () => {
     // The state this exists for: the daemon is alive but ignoring its socket,
@@ -174,7 +178,7 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
     const signalled: Array<{ pid: number; sig: string }> = [];
     const code = await runKillCommand(
-      mkTarget({ targetId: 'neurality/main' }),
+      mkTarget({ targetId: 'neurality' }),
       {
         ...deps,
         listLive: () => WEDGED,
@@ -226,11 +230,40 @@ describe('runKillCommand — unreachable daemon pid fallback (#859)', () => {
     expect(err.join('\n')).toContain('Cannot reach any remi daemon');
   });
 
+  test('refuses to guess between two unreachable daemons with the same name', async () => {
+    // `name` is a directory basename, so two worktrees of one project collide
+    // routinely. Picking the first would SIGKILL the wrong daemon and report
+    // success -- the reachable path already refuses this via
+    // AmbiguousSessionError, and so must this one.
+    const { io, err } = makeIO2();
+    const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
+    let signalled = false;
+    const code = await runKillCommand(
+      mkTarget({ targetId: 'main' }),
+      {
+        ...deps,
+        listLive: () => [
+          { pid: 100, wsPort: 18765, name: 'main' },
+          { pid: 200, wsPort: 18766, name: 'main' },
+        ],
+        signal: () => {
+          signalled = true;
+        },
+      },
+      io,
+      async () => helpers,
+    );
+    expect(code).toBe(1);
+    expect(signalled).toBe(false);
+    expect(err.join('\n')).toContain('matches 2 unreachable daemons');
+    expect(err.join('\n')).toContain('Nothing was stopped');
+  });
+
   test('a process that is already gone is success, not an error', async () => {
     const { io, out } = makeIO2();
     const { helpers, deps } = makeHelpersAndDeps({ queryResults: [] });
     const code = await runKillCommand(
-      mkTarget({ targetId: 'neurality/main' }),
+      mkTarget({ targetId: 'neurality' }),
       {
         ...deps,
         listLive: () => WEDGED,

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -574,6 +574,109 @@ describe('remi model rm', () => {
     expect(t.out.join('\n')).toContain('pointing that picker at');
   });
 
+  test('refuses when the engine will not say what a model is used for', async () => {
+    // `m.purpose === targetPurpose` with both absent is `undefined ===
+    // undefined`, which matches EVERY row -- the same trap `matchesModel`
+    // documents. An engine that reports no purposes must stop the release,
+    // not silently make the filter a pass-through.
+    const t = io();
+    let pointedAt = '';
+    let removed = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true },
+            { id: 'yooz-light-v3', displayName: 'L', loaded: false },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 0 };
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(pointedAt).toBe('');
+    expect(removed).toBe('');
+    expect(t.err.join('\n')).toContain('does not report what');
+  });
+
+  test('prefers a replacement already on disk over one that would download', async () => {
+    // Releasing must not kick off a multi-GB download as a side effect of a
+    // delete. The catalogue has no disk state, so this cross-references the
+    // inventory's `cached`.
+    const t = io();
+    let pointedAt = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-instruct-4b', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => [
+          {
+            id: 'yooz-quality-v3',
+            module: 'llm',
+            displayName: 'Q',
+            sizeBytes: 1,
+            cached: true,
+            loaded: true,
+            isActive: true,
+            deletable: false,
+          },
+          {
+            id: 'not-downloaded',
+            module: 'llm',
+            displayName: 'N',
+            sizeBytes: 1,
+            cached: false,
+            loaded: false,
+            isActive: false,
+            deletable: true,
+          },
+          {
+            id: 'on-disk',
+            module: 'llm',
+            displayName: 'D',
+            sizeBytes: 1,
+            cached: true,
+            loaded: false,
+            isActive: false,
+            deletable: true,
+          },
+        ],
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            // Listed FIRST but NOT downloaded: picking by position would
+            // trigger a fetch.
+            { id: 'not-downloaded', displayName: 'N', loaded: false, purpose: 'proofread' },
+            { id: 'on-disk', displayName: 'D', loaded: false, purpose: 'proofread' },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => ({ id, reclaimedBytes: 0 }),
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(pointedAt).toBe('on-disk');
+  });
+
   test('refuses when the engine has no other model of that purpose', async () => {
     // Releasing by pointing the picker at nothing would leave that module
     // without a model, which is worse than refusing to delete.
@@ -608,6 +711,10 @@ describe('remi model rm', () => {
 
   test("never moves a SHARED engine's picker", async () => {
     // Repointing another host's picker is hostile: that app is using it.
+    // Note this is enforced by the pre-existing MUTATING guard (#818), which
+    // returns before any rm-specific code runs -- so this pins the OUTCOME,
+    // not the release branch. Stated because a reader could otherwise assume
+    // `releaseActiveModel` re-checks ownership; it deliberately does not.
     const t = io();
     let pointedAt = '';
     const code = await run(

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -531,28 +531,100 @@ describe('remi model rm', () => {
     expect(t.err.join('\n')).toContain('remi model use <other>');
   });
 
-  test("does not blame remi for the ENGINE's active model, nor advise a remedy that cannot work", async () => {
-    // The reported friction (#843). `isActive` is the engine picker's tier;
-    // remi's model here is something else entirely. Telling the user to run
-    // `remi model use <other>` sends them after a fix that provably does
-    // nothing: `use` writes remi's config and never touches the picker.
+  test("releases the ENGINE's active model on an owned engine, then deletes it", async () => {
+    // The reported friction (#860). `isActive` belongs to the TouchUp picker,
+    // so `remi model use` provably cannot release it -- and neither can
+    // restarting, because a fresh engine re-selects that tier at boot. On an
+    // engine remi owns, remi moves the picker itself.
     const t = io();
+    let pointedAt = '';
+    let removed = '';
     const code = await run(
       ['rm', 'yooz-quality-v3'],
-      configWith({ model: 'yooz-light-v3' }),
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
       t.io,
       {
         probe: async () => REACHABLE,
         inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            // Listed FIRST and of the WRONG purpose: the picker would refuse
+            // it, so choosing by position rather than purpose breaks here.
+            { id: 'yooz-instruct-4b', displayName: 'I', loaded: false, purpose: 'general' },
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            { id: 'yooz-light-v3', displayName: 'L', loaded: false, purpose: 'proofread' },
+          ],
+        }),
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 800_000_000 };
+        },
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(pointedAt).toBe('yooz-light-v3'); // same purpose, so the picker accepts it
+    expect(removed).toBe('yooz-quality-v3');
+    // The second mutation must be visible: this moved a setting the user did
+    // not name.
+    expect(t.out.join('\n')).toContain('pointing that picker at');
+  });
+
+  test('refuses when the engine has no other model of that purpose', async () => {
+    // Releasing by pointing the picker at nothing would leave that module
+    // without a model, which is worse than refusing to delete.
+    const t = io();
+    let removed = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'owned' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        list: async () => ({
+          current: 'yooz-quality-v3',
+          available: [
+            { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+            // A general-purpose model is NOT a substitute for a proofread tier.
+            { id: 'yooz-instruct-4b', displayName: 'I', loaded: false, purpose: 'general' },
+          ],
+        }),
+        remove: async (_url, id) => {
+          removed = id;
+          return { id, reclaimedBytes: 0 };
+        },
       },
     );
 
     expect(code).toBe(1);
-    const text = t.err.join('\n');
-    expect(text).toContain("engine's active llm model");
-    expect(text).toContain('yooz-light-v3'); // names what remi actually uses
-    expect(text).toContain('will not release it');
-    expect(text).not.toContain('remi model use <other>'); // the advice that does not work
+    expect(removed).toBe('');
+    expect(t.err.join('\n')).toContain('nothing to point the picker at');
+  });
+
+  test("never moves a SHARED engine's picker", async () => {
+    // Repointing another host's picker is hostile: that app is using it.
+    const t = io();
+    let pointedAt = '';
+    const code = await run(
+      ['rm', 'yooz-quality-v3'],
+      configWith({ model: 'yooz-light-v3', engine: 'shared' }),
+      t.io,
+      {
+        probe: async () => REACHABLE,
+        inventory: async () => INVENTORY,
+        setTouchUpModel: async (_url, id) => {
+          pointedAt = id;
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(pointedAt).toBe('');
   });
 
   test('requires an explicit id', async () => {
@@ -1166,6 +1238,46 @@ describe('remi model — undecidable ownership is never asserted (legacy engine)
     expect(text).not.toContain("It is not remi's model");
     expect(text).toContain('cannot be determined');
     expect(text).toContain('remi model use <other>'); // offered, not denied
+  });
+});
+
+describe('ls labels what the engine model is active FOR (#860)', () => {
+  test('names the purpose instead of a bare "engine active"', async () => {
+    // `isActive` is the TOUCHUP picker's choice, so remi's own model can never
+    // carry it and a model remi never uses always does. Unqualified, that reads
+    // as "the engine is using this instead of the model I chose" -- which is
+    // exactly the conclusion a user drew. remi's model was in use the whole
+    // time; only the label was wrong.
+    const t = io();
+    const code = await run(['ls'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      list: async () => ({
+        current: 'yooz-light-v3',
+        available: [
+          { id: 'yooz-light-v3', displayName: 'L', loaded: true, purpose: 'proofread' },
+          { id: 'yooz-quality-v3', displayName: 'Q', loaded: true, purpose: 'proofread' },
+        ],
+      }),
+    });
+    expect(code).toBe(0);
+    const text = t.out.join('\n');
+    expect(text).toContain('engine proofread tier');
+    expect(text).not.toContain(', engine active');
+  });
+
+  test('falls back to the bare label when the catalogue cannot be read', async () => {
+    // A catalogue we cannot read must cost one qualifier, not the whole listing.
+    const t = io();
+    const code = await run(['ls'], configWith({ model: 'yooz-quality-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      list: async () => {
+        throw new Error('catalogue unavailable');
+      },
+    });
+    expect(code).toBe(0);
+    expect(t.out.join('\n')).toContain('engine active');
   });
 });
 

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -6,6 +6,8 @@ import {
   formatVersionDrift,
   listSessionDaemons,
   readPidFileLive,
+  stopSessionDaemons,
+  terminatePid,
 } from '../../src/cli/daemon-manager.ts';
 import type { LiveSessionEntry } from '../../src/session/session-registry-file.ts';
 
@@ -177,5 +179,90 @@ describe('listSessionDaemons (#859)', () => {
 
   test('an empty registry reports none', () => {
     expect(listSessionDaemons(() => [])).toEqual([]);
+  });
+});
+
+describe('terminatePid (#859)', () => {
+  /** Records signals and never touches a real process. */
+  function recorder(aliveFor: number) {
+    const sent: string[] = [];
+    let probes = 0;
+    return {
+      sent,
+      deps: {
+        signal: (_pid: number, sig: NodeJS.Signals | 0) => {
+          if (sig === 0) {
+            probes++;
+            if (probes > aliveFor) throw new Error('ESRCH');
+            return;
+          }
+          sent.push(String(sig));
+        },
+        sleep: () => {},
+      },
+    };
+  }
+
+  test('SIGTERM alone is enough when the process exits', () => {
+    const r = recorder(0); // first liveness probe already reports gone
+    expect(terminatePid(1234, 3000, r.deps)).toBe(true);
+    expect(r.sent).toEqual(['SIGTERM']);
+  });
+
+  test('escalates to SIGKILL when SIGTERM is ignored', () => {
+    // The riskiest line in the change: it had no seam and no test.
+    const r = recorder(Number.MAX_SAFE_INTEGER); // never dies
+    const gone = terminatePid(1234, 0, r.deps); // zero grace: straight to escalation
+    expect(r.sent).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(gone).toBe(false); // still alive after SIGKILL -> reported as failure
+  });
+
+  test('a process already gone is success, not an error', () => {
+    const deps = {
+      signal: () => {
+        const e = new Error('no such process') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        throw e;
+      },
+      sleep: () => {},
+    };
+    expect(terminatePid(1234, 3000, deps)).toBe(true);
+  });
+
+  test('a signal we are not allowed to send is NOT reported as stopped', () => {
+    const deps = {
+      signal: () => {
+        const e = new Error('operation not permitted') as NodeJS.ErrnoException;
+        e.code = 'EPERM';
+        throw e;
+      },
+      sleep: () => {},
+    };
+    expect(terminatePid(1234, 3000, deps)).toBe(false);
+  });
+});
+
+describe('stopSessionDaemons (#859)', () => {
+  test('counts only the daemons that actually stopped', () => {
+    // The count feeds the exit code: "remi stop --all && echo ok" must not
+    // print ok while a daemon is still running.
+    const stubborn = 200;
+    const deps = {
+      signal: (pid: number, sig: NodeJS.Signals | 0) => {
+        if (pid === stubborn) return; // alive to every probe, ignores every signal
+        const e = new Error('gone') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        if (sig === 0) throw e;
+      },
+      sleep: () => {},
+    };
+    const stopped = stopSessionDaemons(
+      [
+        { pid: 100, wsPort: 18765, name: 'a' },
+        { pid: stubborn, wsPort: 18766, name: 'b' },
+      ],
+      deps,
+    );
+    expect(stopped).toBe(1);
   });
 });

--- a/packages/daemon/tests/cli/daemon-manager.test.ts
+++ b/packages/daemon/tests/cli/daemon-manager.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { formatVersionDrift, readPidFileLive } from '../../src/cli/daemon-manager.ts';
+import {
+  formatVersionDrift,
+  listSessionDaemons,
+  readPidFileLive,
+} from '../../src/cli/daemon-manager.ts';
+import type { LiveSessionEntry } from '../../src/session/session-registry-file.ts';
 
 const REMI_DIR = path.join(os.homedir(), '.remi');
 const PID_FILE = path.join(REMI_DIR, 'daemon.pid');
@@ -130,5 +135,47 @@ describe('formatVersionDrift (#539)', () => {
     expect(formatVersionDrift(undefined, '0.6.19')).toBeNull();
     expect(formatVersionDrift('0.6.19', undefined)).toBeNull();
     expect(formatVersionDrift('', '0.6.19')).toBeNull();
+  });
+});
+
+describe('listSessionDaemons (#859)', () => {
+  function entry(over: Partial<LiveSessionEntry> = {}): LiveSessionEntry {
+    return {
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      pid: 100,
+      wsPort: 18765,
+      hookPort: 0,
+      projectPath: '/tmp/p',
+      name: 'proj/main',
+      startedAt: new Date(0).toISOString(),
+      ...over,
+    } as LiveSessionEntry;
+  }
+
+  test('reports the session daemons stop/status previously could not see', () => {
+    // `stop`/`status` resolve only the hub's daemon.pid / daemon-status.json.
+    // Session daemons write status-<PORT>.json, which nothing enumerated -- so
+    // both commands announced "not running" while `remi ls` listed one.
+    const found = listSessionDaemons(() => [
+      entry({ pid: 100, wsPort: 18765, name: 'a/main' }),
+      entry({ pid: 200, wsPort: 18766, name: 'b/main' }),
+    ]);
+    expect(found).toEqual([
+      { pid: 100, wsPort: 18765, name: 'a/main' },
+      { pid: 200, wsPort: 18766, name: 'b/main' },
+    ]);
+  });
+
+  test('deduplicates by pid: one daemon hosting several sessions is one process', () => {
+    const found = listSessionDaemons(() => [
+      entry({ pid: 100, wsPort: 18765, name: 'a/main', sessionId: 'x' }),
+      entry({ pid: 100, wsPort: 18765, name: 'a/other', sessionId: 'y' }),
+    ]);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.pid).toBe(100);
+  });
+
+  test('an empty registry reports none', () => {
+    expect(listSessionDaemons(() => [])).toEqual([]);
   });
 });


### PR DESCRIPTION
Release 0.7.3. Closes the first three items of #861 — everything surfaced by running 0.7.2 in anger.

## remi can stop its own daemons again (#859)

`remi stop` and `remi status` resolved the **hub only** (`daemon.pid`, `daemon-status.json`); session daemons write `status-<PORT>.json`, which nothing enumerated. So `status` announced "Daemon is not running" while `remi ls` listed a daemon three lines later — and that message is what sent a user to `pkill`.

Verified live on a machine in exactly that state: installed 0.6.24 printed `Daemon is not running.` while PID 22635 was listening on 18766; the fixed build names the daemon, its port, and how to stop it.

- `stop`/`status` now report session daemons; `remi stop --all` stops them; whatever plain `remi stop` leaves running, **it names**.
- `remi kill` falls back to the pid remi itself recorded when a daemon stops answering its socket — the one state where killing matters most was the one state remi could not act on. It **refuses ambiguous matches** rather than guessing, since `name` is a directory basename and two worktrees of one project collide routinely.
- `remi stop --all` now exits non-zero if a daemon survived being signalled, instead of reporting success.

## The engine's model can be evicted (#860)

`remi model rm` of the engine's active model was impossible via **any** remi command. `isActive`/`deletable` are owned by the **TouchUp (proofread) picker**, not the LLM picker remi uses; `remi model use` cannot release it, `POST /v1/llm/model` moves a different selection, and restarting does not help because a fresh engine re-selects and re-loads that tier at boot. remi's advice ("stop the engine first") provably could not work.

On an engine remi owns, `rm` now moves that picker to another model **of the same purpose, preferring one already on disk**, then deletes — narrating both mutations. It refuses when there is no valid replacement, and refuses on a shared engine.

`ls` now says `engine proofread tier` rather than a bare `engine active`. Worth stating plainly: **auto-approve was using the configured model the whole time** — remi passes it explicitly on every evaluation. Only the label was wrong.

Root cause is upstream: yooz-engine#317.

## A release can no longer fail by doing nothing (#856)

`auto-release` declares the gates as `needs`, so a red gate — including a flaky one — **skips** it: no tag, no npm, no Homebrew, and the only symptom is a tag that never appeared. That happened twice during the 0.7.1 cut.

A `Release Guard` job now asserts, on `always()`, that after a push to `main` the version is not `-dev` **and the tag exists on origin** — the version alone was a false pass, because `bump-version.sh` pushes commit and tag non-atomically and only the tag triggers `release.yml`.

**This release is that guard's first live exercise.**

## Pins

Engine helper `v0.7.8`; bun 1.3.11 across all three workflows; typos v1.28.4; npm pinned to 11. `v0.7.3` unclaimed on npm and git. iOS/macOS app version is deliberately decoupled (#658).

## Testing

Full suite **3846 pass, 0 fail**, 69 skip across 202 files. Lint, typecheck, spelling clean. Every new guard mutation-tested; the release guard's shell body was extracted verbatim and run against real repos in all four states.

## Still open in #861

#845 (superseded helpers never reclaimed), #855 (fixed sleeps in four other test files), #834 (first-run model download), yooz-engine#316 (notarization), yooz-engine#317 (eager proofread load).