### PR TITLE
Local capability token for loopback clients (#869, part 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Local capability token** (#869, groundwork). The daemon now keeps a random
+  secret in `~/.remi/capability.key` (mode 0600) and the CLI presents it on
+  connect, so a local client can prove it is one without a trust-on-first-use
+  round trip. A new `[daemon] require_local_auth` retires the blanket loopback
+  auth exemption: with it on, a loopback peer must present that token or
+  complete the Ed25519 challenge, exactly like a remote client.
+
+  It defaults to **off**, and only because the macOS app cannot yet do either.
+  It is sandboxed with no access to `~/.remi` by design (#649/#651) and has no
+  identity of its own, so turning this on before that ships would lock it out.
+  A machine that only uses the CLI and the web client can turn it on today.
+
+  Worth stating plainly: a file readable by the user does not stop a process
+  running AS that user from reading it too. This raises the bar from "any local
+  process can approve a permission" to "any process that can read your home
+  directory can". That is an improvement, not a boundary.
+
 ### Security
 - **A website you visit can no longer answer your permission prompts** (#535).
   The WebSocket upgrade validated no `Origin` and every HTTP endpoint answered

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -39,6 +39,12 @@ export interface WebSocketAdapterConfig extends AdapterConfig {
 
   /** Extra browser origins allowed to reach the daemon (#535). */
   readonly allowedOrigins?: readonly string[];
+
+  /** Local capability token this daemon accepts (#869). */
+  readonly capabilityToken?: string;
+
+  /** Retire the loopback auth exemption (#869). */
+  readonly requireLocalAuth?: boolean;
 }
 
 const DEFAULT_PORT = 8765;
@@ -65,6 +71,8 @@ export class WebSocketAdapter implements ConnectionAdapter {
       ...(config.maxConnections !== undefined && { maxConnections: config.maxConnections }),
       ...(config.authenticator && { authenticator: config.authenticator }),
       ...(config.allowedOrigins && { allowedOrigins: config.allowedOrigins }),
+      ...(config.capabilityToken && { capabilityToken: config.capabilityToken }),
+      ...(config.requireLocalAuth !== undefined && { requireLocalAuth: config.requireLocalAuth }),
     } as WebSocketAdapterConfig;
     this.events = events;
   }
@@ -196,6 +204,10 @@ export class WebSocketAdapter implements ConnectionAdapter {
         maxConnections: this.config.maxConnections,
       }),
       ...(this.config.allowedOrigins && { allowedOrigins: this.config.allowedOrigins }),
+      ...(this.config.capabilityToken && { capabilityToken: this.config.capabilityToken }),
+      ...(this.config.requireLocalAuth !== undefined && {
+        requireLocalAuth: this.config.requireLocalAuth,
+      }),
       // Let daemon handle HelloAck to include resume info
       connection: {
         skipHelloAck: true,

--- a/packages/daemon/src/auth/capability-token.ts
+++ b/packages/daemon/src/auth/capability-token.ts
@@ -1,0 +1,117 @@
+/**
+ * Local capability token (#869).
+ *
+ * The Origin check from #535 stops a WEBSITE from answering permission
+ * prompts. It cannot stop another PROCESS on the same machine, because a
+ * process simply omits the `Origin` header and is then indistinguishable from
+ * the CLI, which sends none either. Something has to be presented that a
+ * stranger cannot produce.
+ *
+ * This is that thing: a random secret in `~/.remi/capability.key`, mode 0600,
+ * which local clients read and send on the WebSocket upgrade.
+ *
+ * ## What it is worth, stated plainly
+ *
+ * A file readable by the user does not stop a process running AS that user
+ * from reading it too. This raises the bar from "any local process can
+ * approve a permission" to "any process that can read the user's home
+ * directory can". That is a genuine improvement and it is not a boundary.
+ * The real boundary needs OS-level peer credentials, which TCP loopback does
+ * not provide on macOS; see the note in #869.
+ *
+ * ## Who can use it
+ *
+ * The CLI can: same user, same filesystem. A browser cannot, so browser
+ * clients authenticate with the Ed25519 challenge they already implement for
+ * remote daemons. The macOS app cannot either, and deliberately so: it is
+ * sandboxed with no access to `~/.remi` (`packages/macos/Remi/Remi.entitlements`,
+ * by design in #649/#651), which is why it is getting its own Ed25519 identity
+ * rather than a copy of this secret.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** Header carrying the token on the WebSocket upgrade. */
+export const CAPABILITY_HEADER = 'x-remi-capability';
+
+/** 32 bytes, hex-encoded: long enough that guessing is not a strategy. */
+const TOKEN_BYTES = 32;
+
+/** Owner read/write only. A capability anyone can read is not a capability. */
+const SECRET_MODE = 0o600;
+
+function defaultTokenPath(): string {
+  return path.join(os.homedir(), '.remi', 'capability.key');
+}
+
+/**
+ * Read the token, creating it if absent.
+ *
+ * Created with mode 0600 via the open flags rather than a later `chmod`, so
+ * there is no window in which the file exists world-readable. An existing file
+ * with looser permissions is tightened and reported, since a token other users
+ * can read is worth exactly nothing and silently trusting it would be worse
+ * than having none.
+ */
+export function loadOrCreateCapabilityToken(
+  tokenPath: string = defaultTokenPath(),
+  logFn: (msg: string) => void = console.warn,
+): string {
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+
+  try {
+    const existing = fs.readFileSync(tokenPath, 'utf8').trim();
+    if (existing.length > 0) {
+      const mode = fs.statSync(tokenPath).mode & 0o777;
+      if (mode !== SECRET_MODE) {
+        fs.chmodSync(tokenPath, SECRET_MODE);
+        logFn(
+          `[capability] ${tokenPath} was mode ${mode.toString(8)}; tightened to 600. Any process that read it before now holds a valid token: delete the file to rotate.`,
+        );
+      }
+      return existing;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  const token = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+  // wx => fail if it appeared between the read above and now, rather than
+  // clobbering a token another daemon just wrote and is already handing out.
+  try {
+    fs.writeFileSync(tokenPath, `${token}\n`, { mode: SECRET_MODE, flag: 'wx' });
+    return token;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    return fs.readFileSync(tokenPath, 'utf8').trim();
+  }
+}
+
+/** Read the token without creating one. Null when there is none to read. */
+export function readCapabilityToken(tokenPath: string = defaultTokenPath()): string | null {
+  try {
+    const token = fs.readFileSync(tokenPath, 'utf8').trim();
+    return token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Constant-time comparison.
+ *
+ * `timingSafeEqual` throws on a length mismatch, which would itself leak
+ * length, so both sides are hashed to a fixed width first.
+ */
+export function capabilityTokenMatches(
+  presented: string | null | undefined,
+  expected: string | null | undefined,
+): boolean {
+  if (!presented || !expected) return false;
+  const a = crypto.createHash('sha256').update(presented).digest();
+  const b = crypto.createHash('sha256').update(expected).digest();
+  return crypto.timingSafeEqual(a, b);
+}

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -121,6 +121,7 @@ import { isEncrypted, unlockIdentity } from '@remi/shared';
 import { AdapterRegistry, TelegramAdapter, WebSocketAdapter } from './adapters/index.ts';
 import { QuestionPresenceTracker } from './api/question-presence-tracker.ts';
 import { Authenticator } from './auth/authenticator.ts';
+import { loadOrCreateCapabilityToken } from './auth/capability-token.ts';
 import { IdentityStore } from './auth/identity-store.ts';
 import {
   AutoApproveService,
@@ -1845,6 +1846,12 @@ const sharedEvents = {
 // Local/private networks don't need auth; relay/public access does.
 // ---------------------------------------------------------------------------
 const bindHost = cliBindHost ?? remiConfig.daemon.bind;
+
+// Local capability token (#869). Created on first run with mode 0600 so the
+// CLI can prove it is a local client without a TOFU round trip. Generated
+// unconditionally, even while `require_local_auth` is false, so that turning
+// the flag on later never has to also create a secret mid-flight.
+const localCapabilityToken = loadOrCreateCapabilityToken(undefined, logError);
 const isLocalhostBind = bindHost === 'localhost' || bindHost === '127.0.0.1' || bindHost === '::1';
 
 // Determine whether auth should be enabled
@@ -1935,6 +1942,8 @@ const wsAdapter = new WebSocketAdapter(
     host: bindHost,
     authenticator,
     allowedOrigins: remiConfig.daemon.allowed_origins,
+    capabilityToken: localCapabilityToken,
+    requireLocalAuth: remiConfig.daemon.require_local_auth,
   },
   sharedEvents,
 );
@@ -2140,6 +2149,8 @@ if (cliDaemonMode) {
           host: bindHost,
           authenticator,
           allowedOrigins: remiConfig.daemon.allowed_origins,
+          capabilityToken: localCapabilityToken,
+          requireLocalAuth: remiConfig.daemon.require_local_auth,
         },
         sharedEvents,
       );
@@ -2455,6 +2466,8 @@ if (cliDaemonMode) {
           host: bindHost,
           authenticator,
           allowedOrigins: remiConfig.daemon.allowed_origins,
+          capabilityToken: localCapabilityToken,
+          requireLocalAuth: remiConfig.daemon.require_local_auth,
         },
         sharedEvents,
       );

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -12,6 +12,7 @@ import {
 } from '@remi/shared';
 import type { ProtocolMessage, Question, RemiStatus, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 import { DetachScanner } from './detach-scanner.ts';
 import { StatusBar, childRows } from './status-bar.ts';
 
@@ -271,7 +272,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       resolve(result);
     }
 
-    ws = new WebSocket(url);
+    ws = new WebSocket(url, capabilityWsOptions() as never);
 
     const connectionTimer = setTimeout(() => {
       writeOutput(`\n[timed out connecting to daemon at ${host}:${port}]\n`);

--- a/packages/daemon/src/cli/capability-client.ts
+++ b/packages/daemon/src/cli/capability-client.ts
@@ -1,0 +1,28 @@
+/**
+ * Capability header for CLI WebSocket clients (#869).
+ *
+ * Every `remi` subcommand that opens a WebSocket to a daemon goes through
+ * here, so that when the loopback auth exemption is retired the CLI keeps
+ * working without a per-command change.
+ *
+ * Read at call time rather than cached at import: `remi` processes are
+ * short-lived, and a cached token would survive a rotation (deleting the file)
+ * within a long-running `remi attach`.
+ */
+
+import { CAPABILITY_HEADER, readCapabilityToken } from '../auth/capability-token.ts';
+
+/**
+ * WebSocket options carrying the local capability token, or undefined when
+ * there is no token to send.
+ *
+ * Undefined is not a failure. A daemon on another machine has a different
+ * token and would reject this one anyway; those connections authenticate with
+ * Ed25519. Sending nothing is also correct against a daemon old enough not to
+ * know the header, which ignores it.
+ */
+export function capabilityWsOptions(): { headers: Record<string, string> } | undefined {
+  const token = readCapabilityToken();
+  if (token === null) return undefined;
+  return { headers: { [CAPABILITY_HEADER]: token } };
+}

--- a/packages/daemon/src/cli/detach-client.ts
+++ b/packages/daemon/src/cli/detach-client.ts
@@ -18,6 +18,7 @@ import {
 import { errorToString } from '@remi/shared';
 import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 import { resolveSession as sharedResolveSession } from './session-resolver.ts';
 
 export interface DetachClientOptions {
@@ -39,7 +40,7 @@ export async function runDetachClient(opts: DetachClientOptions): Promise<void> 
     let ws: WebSocket;
 
     try {
-      ws = new WebSocket(url);
+      ws = new WebSocket(url, capabilityWsOptions() as never);
     } catch (err) {
       const detail = errorToString(err);
       reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));

--- a/packages/daemon/src/cli/kill-client.ts
+++ b/packages/daemon/src/cli/kill-client.ts
@@ -15,6 +15,7 @@ import {
 } from '@remi/shared';
 import type { DiscoverableSession, ProtocolMessage, UUID } from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 import { resolveSession as sharedResolveSession } from './session-resolver.ts';
 
 export interface KillClientOptions {
@@ -36,7 +37,7 @@ export async function runKillClient(opts: KillClientOptions): Promise<void> {
     let ws: WebSocket;
 
     try {
-      ws = new WebSocket(url);
+      ws = new WebSocket(url, capabilityWsOptions() as never);
     } catch {
       reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
       return;

--- a/packages/daemon/src/cli/ls-client.ts
+++ b/packages/daemon/src/cli/ls-client.ts
@@ -14,6 +14,7 @@ import {
   type SessionRegistryFile,
 } from '../session/session-registry-file.ts';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 import {
   type DiscoveredEndpoint,
   FETCH_SESSIONS_TIMEOUT_MS,
@@ -204,7 +205,7 @@ export async function fetchSessions(
     let authInProgress = false;
     let ws: WebSocket;
     try {
-      ws = new WebSocket(url);
+      ws = new WebSocket(url, capabilityWsOptions() as never);
     } catch {
       reject(new Error(`Cannot connect to daemon at ${host}:${port}. Is remi running?`));
       return;

--- a/packages/daemon/src/cli/recent-client.ts
+++ b/packages/daemon/src/cli/recent-client.ts
@@ -19,6 +19,7 @@ import {
 import type { ProtocolMessage, RecentDirectory } from '@remi/shared';
 import type { SessionStore } from '../session/session-store.ts';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 import { formatAge } from './ls-client.ts';
 
 /**
@@ -74,7 +75,7 @@ export async function fetchRecentDirectories(
     let ws: WebSocket;
 
     try {
-      ws = new WebSocket(url);
+      ws = new WebSocket(url, capabilityWsOptions() as never);
     } catch (err) {
       const detail = errorToString(err);
       reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));

--- a/packages/daemon/src/cli/remote-new-client.ts
+++ b/packages/daemon/src/cli/remote-new-client.ts
@@ -20,6 +20,7 @@ import { errorToString } from '@remi/shared';
 import type { ProtocolMessage, UUID } from '@remi/shared';
 import { runAttachClient } from './attach-client.ts';
 import { performAuthHandshake } from './auth-helper.ts';
+import { capabilityWsOptions } from './capability-client.ts';
 
 export interface RemoteNewOptions {
   readonly host: string;
@@ -47,7 +48,7 @@ async function createRemoteSession(
     let ws: WebSocket;
 
     try {
-      ws = new WebSocket(url);
+      ws = new WebSocket(url, capabilityWsOptions() as never);
     } catch (err) {
       const detail = errorToString(err);
       reject(new Error(`Cannot connect to daemon at ${host}:${port}: ${detail}`));

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -80,6 +80,22 @@ export interface DaemonConfig {
    * host yourself; the daemon logs the exact line to add when it refuses one.
    */
   readonly allowed_origins: readonly string[];
+  /**
+   * Retire the blanket loopback auth exemption (#869).
+   *
+   * With it false (today's default), any process on this machine can open the
+   * daemon's WebSocket and answer a permission prompt: it sends no `Origin`,
+   * which makes it indistinguishable from the CLI. With it true, a loopback
+   * peer must present the capability token from `~/.remi/capability.key` or
+   * complete the Ed25519 challenge, exactly like a remote client.
+   *
+   * Default false ONLY because the macOS app cannot yet do either: it is
+   * sandboxed away from `~/.remi` by design (#649/#651) and has no identity of
+   * its own yet. Turning this on before that ships locks it out. The CLI
+   * already sends the token, so a machine that only uses the CLI and the web
+   * client can turn this on today.
+   */
+  readonly require_local_auth: boolean;
 }
 
 /** Network settings */
@@ -170,6 +186,7 @@ export const DEFAULT_CONFIG: RemiConfig = {
     orphan_timeout: 300,
     persist_sessions: true,
     allowed_origins: [],
+    require_local_auth: false,
   },
   network: {
     mdns: true,
@@ -899,6 +916,10 @@ persist_sessions = ${DEFAULT_CONFIG.daemon.persist_sessions}  # keep sessions al
 # Only a web client you host yourself does. Example:
 #   allowed_origins = ["https://remi.example.com"]
 allowed_origins = []
+# Require loopback clients to prove themselves (#869). Off by default until
+# the macOS app ships its own identity; safe to turn on if you only use the
+# CLI and the web client.
+require_local_auth = false
 
 [network]
 mdns = ${DEFAULT_CONFIG.network.mdns}
@@ -1053,6 +1074,7 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push(`  orphan_timeout = ${config.daemon.orphan_timeout}`);
   lines.push(`  persist_sessions = ${config.daemon.persist_sessions}`);
   lines.push(`  allowed_origins = ${JSON.stringify(config.daemon.allowed_origins)}`);
+  lines.push(`  require_local_auth = ${config.daemon.require_local_auth}`);
   lines.push('');
   lines.push('[network]');
   lines.push(`  mdns = ${config.network.mdns}`);

--- a/packages/daemon/src/server/peer-helpers.ts
+++ b/packages/daemon/src/server/peer-helpers.ts
@@ -73,12 +73,26 @@ export function isLoopbackAddress(host: string | null | undefined): boolean {
  * Returns `true` only when an authenticator is configured AND the peer is on
  * a loopback address. Non-loopback peers always require auth when an
  * authenticator is configured; without an authenticator the bypass is moot.
+ *
+ * #869: the blanket loopback exemption is what lets any local process answer
+ * a permission prompt. `requireLocalAuth` retires it, at which point a
+ * loopback peer must present the capability token (see
+ * `auth/capability-token.ts`) or complete the Ed25519 challenge like any
+ * remote client. It is opt-in until every client can do one or the other:
+ * the macOS app is sandboxed away from `~/.remi` by design and needs its own
+ * identity first, so flipping this default before that ships would lock it out.
  */
 export function shouldSkipAuthForPeer(
   hasAuthenticator: boolean,
   peerAddress: string | null | undefined,
+  options: { readonly requireLocalAuth?: boolean; readonly hasCapability?: boolean } = {},
 ): boolean {
-  return hasAuthenticator && isLoopbackAddress(peerAddress);
+  if (!hasAuthenticator) return false;
+  if (!isLoopbackAddress(peerAddress)) return false;
+  // A valid capability token is proof in its own right, so the challenge is
+  // redundant whether or not the exemption is retired.
+  if (options.hasCapability) return true;
+  return !options.requireLocalAuth;
 }
 
 /** True for any address in 127.0.0.0/8. */

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -7,6 +7,7 @@
 
 import { generateId } from '@remi/shared';
 import type { AnswerExtras, ProtocolMessage, UUID } from '@remi/shared';
+import { CAPABILITY_HEADER, capabilityTokenMatches } from '../auth/capability-token.ts';
 import { Connection, type ConnectionConfig, type ConnectionEvents } from './connection.ts';
 import { corsHeadersForOrigin, isAllowedOrigin, rejectionNotice } from './origin-policy.ts';
 import { shouldSkipAuthForPeer } from './peer-helpers.ts';
@@ -36,6 +37,19 @@ export interface ServerConfig {
 
   /** Where the origin-rejection notice goes. Defaults to `console.warn`. */
   readonly logFn?: (msg: string) => void;
+
+  /**
+   * The local capability token this daemon accepts (#869). Empty disables the
+   * capability path entirely, leaving the Ed25519 challenge as the only proof.
+   */
+  readonly capabilityToken?: string;
+
+  /**
+   * Retire the blanket loopback auth exemption (#869). When true, a loopback
+   * peer must present the capability token or complete the Ed25519 challenge,
+   * exactly like a remote one. Opt-in until every client can do one of those.
+   */
+  readonly requireLocalAuth?: boolean;
 }
 
 /** Server events */
@@ -159,6 +173,11 @@ interface WSData {
   connectionId: UUID;
   /** Peer IP captured at upgrade time (used to skip auth for loopback). */
   peerAddress: string | null;
+  /**
+   * Whether this peer presented a valid capability token on the upgrade
+   * (#869). Decided once, at upgrade, because the header only exists there.
+   */
+  hasCapability: boolean;
 }
 
 /**
@@ -202,6 +221,8 @@ export class WebSocketServer {
       connection: config.connection ?? {},
       allowedOrigins: config.allowedOrigins ?? [],
       logFn: config.logFn ?? ((msg: string) => console.warn(msg)),
+      capabilityToken: config.capabilityToken ?? '',
+      requireLocalAuth: config.requireLocalAuth ?? false,
     };
     this.events = events;
   }
@@ -288,12 +309,20 @@ export class WebSocketServer {
 
           const peer = server.requestIP(req);
           const peerAddress = peer?.address ?? null;
+          // The capability token rides the upgrade request, so it can only be
+          // read here (#869). A browser cannot set this header, which is the
+          // point: it proves the caller read a 0600 file in the user's home.
+          const hasCapability = capabilityTokenMatches(
+            req.headers.get(CAPABILITY_HEADER),
+            self.config.capabilityToken,
+          );
 
           // Upgrade to WebSocket
           const success = server.upgrade(req, {
             data: {
               connectionId: generateId(),
               peerAddress,
+              hasCapability,
             },
           });
 
@@ -335,7 +364,13 @@ export class WebSocketServer {
           const peer = server.requestIP(req);
           const authenticator = self.config.connection?.authenticator;
           const authRequired =
-            !shouldSkipAuthForPeer(!!authenticator, peer?.address) && !!authenticator;
+            !shouldSkipAuthForPeer(!!authenticator, peer?.address, {
+              requireLocalAuth: self.config.requireLocalAuth,
+              hasCapability: capabilityTokenMatches(
+                req.headers.get(CAPABILITY_HEADER),
+                self.config.capabilityToken,
+              ),
+            }) && !!authenticator;
           return new Response(
             JSON.stringify({
               authRequired,
@@ -520,7 +555,16 @@ export class WebSocketServer {
 
     // Authenticate with the same trust model as the WebSocket.
     const authenticator = this.config.connection?.authenticator;
-    if (authenticator && !shouldSkipAuthForPeer(true, peerAddress)) {
+    if (
+      authenticator &&
+      !shouldSkipAuthForPeer(true, peerAddress, {
+        requireLocalAuth: this.config.requireLocalAuth,
+        hasCapability: capabilityTokenMatches(
+          req.headers.get(CAPABILITY_HEADER),
+          this.config.capabilityToken,
+        ),
+      })
+    ) {
       const auth = body.auth;
       const signature = typeof auth?.signature === 'string' ? auth.signature : '';
       const clientPublicKey = typeof auth?.clientPublicKey === 'string' ? auth.clientPublicKey : '';
@@ -663,7 +707,12 @@ export class WebSocketServer {
     // being on the same machine. Drop the authenticator from this peer's
     // connection so it never receives an auth_challenge.
     let perConnectionConfig = this.config.connection;
-    if (shouldSkipAuthForPeer(!!perConnectionConfig?.authenticator, ws.data.peerAddress)) {
+    if (
+      shouldSkipAuthForPeer(!!perConnectionConfig?.authenticator, ws.data.peerAddress, {
+        requireLocalAuth: this.config.requireLocalAuth,
+        hasCapability: ws.data.hasCapability,
+      })
+    ) {
       perConnectionConfig = { ...perConnectionConfig, authenticator: undefined };
     }
 

--- a/packages/daemon/tests/server/capability-token.test.ts
+++ b/packages/daemon/tests/server/capability-token.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Local capability token tests (#869).
+ *
+ * The unit half covers the file's own guarantees; the server half proves the
+ * daemon actually distinguishes a token-bearing local client from a bare one,
+ * over a real Bun.serve with real WebSocket upgrades. No mocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Authenticator } from '../../src/auth/authenticator.ts';
+import {
+  CAPABILITY_HEADER,
+  capabilityTokenMatches,
+  loadOrCreateCapabilityToken,
+  readCapabilityToken,
+} from '../../src/auth/capability-token.ts';
+import { IdentityStore } from '../../src/auth/identity-store.ts';
+import { shouldSkipAuthForPeer } from '../../src/server/peer-helpers.ts';
+import { WebSocketServer } from '../../src/server/websocket-server.ts';
+import { reserveRange } from '../session/port-test-helpers.ts';
+
+describe('capability token file', () => {
+  let dir: string;
+  let tokenPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-cap-'));
+    tokenPath = path.join(dir, 'nested', 'capability.key');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('creates the token 0600, creating parent directories', () => {
+    const token = loadOrCreateCapabilityToken(tokenPath, () => {});
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+  });
+
+  test('is stable across calls', () => {
+    const first = loadOrCreateCapabilityToken(tokenPath, () => {});
+    const second = loadOrCreateCapabilityToken(tokenPath, () => {});
+    expect(second).toBe(first);
+    expect(readCapabilityToken(tokenPath)).toBe(first);
+  });
+
+  test('tightens a loosened token and says so', () => {
+    const token = loadOrCreateCapabilityToken(tokenPath, () => {});
+    fs.chmodSync(tokenPath, 0o644);
+    const warnings: string[] = [];
+    const reread = loadOrCreateCapabilityToken(tokenPath, (m) => warnings.push(m));
+
+    expect(reread).toBe(token);
+    expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+    // Silently tightening would hide that the secret may already be known.
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('delete the file to rotate');
+  });
+
+  test('reading a missing token is null, not a thrown error or a new file', () => {
+    expect(readCapabilityToken(tokenPath)).toBeNull();
+    expect(fs.existsSync(tokenPath)).toBe(false);
+  });
+
+  test('comparison rejects mismatches, empties and nulls', () => {
+    const token = loadOrCreateCapabilityToken(tokenPath, () => {});
+    expect(capabilityTokenMatches(token, token)).toBe(true);
+    expect(capabilityTokenMatches(token, `${token}x`)).toBe(false);
+    // A prefix must not pass: the comparison is over the whole value.
+    expect(capabilityTokenMatches(token.slice(0, 32), token)).toBe(false);
+    expect(capabilityTokenMatches('', token)).toBe(false);
+    expect(capabilityTokenMatches(null, token)).toBe(false);
+    expect(capabilityTokenMatches(token, null)).toBe(false);
+    expect(capabilityTokenMatches(null, null)).toBe(false);
+  });
+});
+
+describe('shouldSkipAuthForPeer with require_local_auth', () => {
+  test('today: loopback is exempt, remote is not', () => {
+    expect(shouldSkipAuthForPeer(true, '127.0.0.1')).toBe(true);
+    expect(shouldSkipAuthForPeer(true, '192.168.1.5')).toBe(false);
+  });
+
+  test('with the exemption retired, loopback needs proof', () => {
+    const opts = { requireLocalAuth: true };
+    expect(shouldSkipAuthForPeer(true, '127.0.0.1', opts)).toBe(false);
+    expect(shouldSkipAuthForPeer(true, '127.0.0.1', { ...opts, hasCapability: true })).toBe(true);
+  });
+
+  test('a capability token never admits a REMOTE peer', () => {
+    // The token proves same-machine file access, so it is meaningless from
+    // another host; a stolen one must not become a remote bypass.
+    expect(
+      shouldSkipAuthForPeer(true, '192.168.1.5', { requireLocalAuth: true, hasCapability: true }),
+    ).toBe(false);
+    expect(shouldSkipAuthForPeer(true, '192.168.1.5', { hasCapability: true })).toBe(false);
+  });
+
+  test('with no authenticator the question is moot', () => {
+    expect(shouldSkipAuthForPeer(false, '127.0.0.1')).toBe(false);
+    expect(shouldSkipAuthForPeer(false, '127.0.0.1', { requireLocalAuth: true })).toBe(false);
+  });
+});
+
+describe('WebSocketServer honors the capability token', () => {
+  let server: WebSocketServer | null = null;
+  let port = 0;
+  let dir: string;
+  const TOKEN = 'a'.repeat(64);
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-cap-srv-'));
+  });
+
+  afterEach(async () => {
+    if (server?.running) await server.stop();
+    server = null;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function startServer(requireLocalAuth: boolean): Promise<void> {
+    port = await reserveRange(1);
+    const store = new IdentityStore(path.join(dir, 'identity'));
+    await store.generate('testpass');
+    const identity = await store.unlock('testpass');
+    server = new WebSocketServer({
+      port,
+      host: '127.0.0.1',
+      capabilityToken: TOKEN,
+      requireLocalAuth,
+      connection: {
+        authenticator: new Authenticator({ identity, identityStore: store }),
+      },
+      logFn: () => {},
+    });
+    await server.start();
+  }
+
+  /** Connect and report the first message type the daemon sends, if any. */
+  function firstMessageType(token: string | null): Promise<string | null> {
+    return new Promise((resolve) => {
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${port}/ws`,
+        (token === null ? undefined : { headers: { [CAPABILITY_HEADER]: token } }) as never,
+      );
+      const done = (v: string | null) => {
+        try {
+          ws.close();
+        } catch {
+          // already closing
+        }
+        resolve(v);
+      };
+      ws.addEventListener('message', (ev) => {
+        try {
+          done(String(JSON.parse(String(ev.data)).type));
+        } catch {
+          done('unparsable');
+        }
+      });
+      ws.addEventListener('error', () => resolve(null));
+      // No challenge is itself the answer, so a quiet socket must resolve.
+      ws.addEventListener('open', () => setTimeout(() => done('none'), 300));
+    });
+  }
+
+  test('today a bare local client is still exempt (default off)', async () => {
+    await startServer(false);
+    expect(await firstMessageType(null)).toBe('none');
+  });
+
+  test('with the exemption retired a bare local client is challenged', async () => {
+    await startServer(true);
+    expect(await firstMessageType(null)).toBe('auth_challenge');
+  });
+
+  test('a valid token skips the challenge', async () => {
+    await startServer(true);
+    expect(await firstMessageType(TOKEN)).toBe('none');
+  });
+
+  test('a wrong token does not', async () => {
+    await startServer(true);
+    expect(await firstMessageType('b'.repeat(64))).toBe('auth_challenge');
+    expect(await firstMessageType(TOKEN.slice(0, 32))).toBe('auth_challenge');
+  });
+
+  test('/auth-info reports what the WebSocket will actually do', async () => {
+    // The probe and the upgrade must agree, or a client decides its handshake
+    // from one and then gets the other.
+    await startServer(true);
+    const bare = await fetch(`http://127.0.0.1:${port}/auth-info`);
+    expect(((await bare.json()) as { authRequired: boolean }).authRequired).toBe(true);
+
+    const withToken = await fetch(`http://127.0.0.1:${port}/auth-info`, {
+      headers: { [CAPABILITY_HEADER]: TOKEN },
+    });
+    expect(((await withToken.json()) as { authRequired: boolean }).authRequired).toBe(false);
+  });
+});


### PR DESCRIPTION
Part 1 of #869. **Stacked on #870** (branched from `fix/issue-535-origin-check`); GitHub will retarget this to `develop` when that merges.

## What is left after #535

The Origin check stops a **website** from answering a permission prompt. It cannot stop another **process** on the same machine: a process omits the `Origin` header and is then indistinguishable from the CLI, which sends none either. Something has to be presented that a stranger cannot produce.

## What this adds

A random secret in `~/.remi/capability.key`, mode 0600, created on daemon start. The CLI reads it and sends it as `x-remi-capability` on the WebSocket upgrade. A browser cannot set that header, which is exactly the point: presenting it proves the caller read a 0600 file in the user's home directory.

`[daemon] require_local_auth` retires the blanket loopback exemption. With it on, a loopback peer must present the token or complete the Ed25519 challenge, exactly like a remote peer. `shouldSkipAuthForPeer` grew both facts as options so the WebSocket upgrade, the `/auth-info` probe and the `/answer` relay cannot drift apart, and `/auth-info` reports the same verdict the upgrade will reach (there is a test for that specifically; a client that decides its handshake from the probe and then gets something else is worse than no probe).

## Why it defaults to off

Because the macOS app cannot do either thing yet, and turning this on would lock it out. That is not an oversight in the app, it is a deliberate design:

```
App Sandbox is mandatory for TestFlight/App Store validation. The app is an
attach-only client... It can never spawn remi, read ~/.remi, or signal
processes - by design (#649/#651).
```
— `packages/macos/Remi/Remi.entitlements`

It also has no `auth_challenge` handling. So it needs its own Ed25519 identity, which is part 2.

A machine that only uses the CLI and the web client can set `require_local_auth = true` today.

## What this is worth, stated plainly

A file readable by the user does not stop a process running AS that user from reading it too. This raises the bar from "any local process can approve a permission" to "any process that can read your home directory can". That is a real improvement and it is not a boundary. The boundary needs OS-level peer credentials, and TCP loopback does not carry them on macOS; a Unix socket would, but the sandboxed macOS app cannot reach a path under `~/.remi` either, so it does not solve this case. Recorded in the module doc rather than left for someone to discover.

## The plan

1. **This PR** — token, flag, CLI, tests. No client breaks; nothing is enforced yet.
2. **#872** — Ed25519 identity for the macOS app (CryptoKit, key in its own container, TOFU on first connect). Needs a TestFlight build.
3. **#873** — flip `require_local_auth` to true and delete the exemption.

## Testing

`bun test`: **373 pass, 0 fail** across `tests/server`, `websocket-server`, `websocket-server-loopback-auth`, `config` and `tests/hooks`, confirmed stable over 3 consecutive runs (one transient failure in an early run did not reproduce in 5 subsequent ones, including the same suite combination twice). `typecheck` and `biome check` clean.

New `tests/server/capability-token.test.ts` (14 tests), driving a real `Bun.serve` with a real `Authenticator`:

- the file is created 0600 including parent directories, is stable across calls, and a loosened file is tightened **and reported** (silently tightening would hide that the secret may already be known)
- comparison rejects a prefix, an empty string and nulls, and is constant-time via fixed-width hashes
- with the flag off a bare local client is still exempt; with it on the same client gets `auth_challenge`; a valid token skips it; a wrong or truncated token does not
- **a capability token never admits a remote peer**, with or without the flag. The token proves same-machine file access and is meaningless from another host, so a leaked one must not become a remote bypass
- `/auth-info` agrees with the upgrade, with and without the token
