### PR TITLE
Seal lock-screen answers to the daemon (#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Security
+- **Lock-screen answers are sealed to the daemon** (#875). The signaling
+  Worker's `/answer/{code}` route accepted `sessionId`, `questionId` and the
+  answer text as plain JSON, and the client had a matching function to send
+  them. The phone now seals the whole body, `auth` block included, to a
+  long-lived P-256 key the daemon publishes in its auth challenge and the phone
+  pins beside the fingerprint. Ephemeral-static ECDH, so it costs one request
+  and no round trip, which is all a suspended phone gets.
+
+  The Worker sees an opaque envelope and the room code it routes by. The daemon
+  opens it, then verifies the signature that was inside, so sealing hides who
+  answered from the Worker without excusing the phone from proving it.
+
+  A phone with no pinned key **refuses to send** rather than falling back to
+  plaintext; reconnecting once re-pins it. A daemon that cannot open a sealed
+  answer drops it rather than acting on a partial one.
+
+  Scope, stated plainly: **this path has no caller today.**
+  `relayAnswerViaSignaling` has zero callers and the wired lock-screen path
+  (`relayAnswerDirect`, `App.tsx:1929`) POSTs straight to the daemon with no
+  Worker involved. So this seals a dormant route before #612 wires it, rather
+  than stopping traffic in flight. Doing it in this order means whoever
+  implements #612 inherits an encrypted path instead of adding a plaintext one.
+
+  No forward secrecy on the daemon's side: the static key opens every answer
+  ever sealed to it. A sleeping phone has no round trip to negotiate a fresh
+  key, and rotating invalidates every pin until each phone reconnects. Recorded
+  in `sealed-answer.ts` rather than left to be discovered.
+
+### Security
 - **The relay transport is encrypted end to end** (#543). The signaling Worker
   was built to relay a *handshake*; WebRTC was meant to carry the session and
   was never implemented, so the relay became the data path and

--- a/packages/daemon/src/auth/answer-key.ts
+++ b/packages/daemon/src/auth/answer-key.ts
@@ -1,0 +1,86 @@
+/**
+ * The daemon's long-lived answer key (#875).
+ *
+ * Phones seal lock-screen answers to this key's public half, which they pin
+ * when they connect. It therefore has to outlive restarts: regenerating per
+ * boot would invalidate every phone's pin and silently break the lock-screen
+ * path until each one reconnected.
+ *
+ * Stored beside the identity in `~/.remi`, mode 0600. Anyone who can read this
+ * file can open every answer ever sealed to it, including recorded ones; see
+ * the forward-secrecy note in `shared/src/sealed-answer.ts` for why that
+ * tradeoff exists and what it costs.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AnswerKeyPair } from '@remi/shared';
+import { generateAnswerKeyPair } from '@remi/shared';
+
+/** Owner read/write only. */
+const SECRET_MODE = 0o600;
+
+function defaultKeyPath(): string {
+  return path.join(os.homedir(), '.remi', 'answer-key.json');
+}
+
+/**
+ * Load the answer key, creating it on first use.
+ *
+ * Written with `wx` so two daemons starting together cannot clobber each
+ * other's key: the loser re-reads the winner's. A key that changed under a
+ * running phone would look like tampering rather than a race.
+ */
+export async function loadOrCreateAnswerKey(
+  keyPath: string = defaultKeyPath(),
+  logFn: (msg: string) => void = console.warn,
+): Promise<AnswerKeyPair> {
+  fs.mkdirSync(path.dirname(keyPath), { recursive: true });
+
+  const read = (): AnswerKeyPair | null => {
+    try {
+      const raw = fs.readFileSync(keyPath, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<AnswerKeyPair>;
+      if (
+        typeof parsed.publicKeyBase64 === 'string' &&
+        typeof parsed.privateKeyPkcs8Base64 === 'string'
+      ) {
+        const mode = fs.statSync(keyPath).mode & 0o777;
+        if (mode !== SECRET_MODE) {
+          fs.chmodSync(keyPath, SECRET_MODE);
+          logFn(
+            `[answer-key] ${keyPath} was mode ${mode.toString(8)}; tightened to 600. Any process that read it can open every answer sealed to this daemon: delete the file to rotate, then reconnect each phone.`,
+          );
+        }
+        return { ...(parsed as AnswerKeyPair) };
+      }
+      // A corrupt file is replaced rather than tolerated: a half-written key
+      // would fail every decryption with no obvious cause.
+      logFn(
+        `[answer-key] ${keyPath} is unreadable; generating a new key. Reconnect phones to re-pin.`,
+      );
+      return null;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+  };
+
+  const existing = read();
+  if (existing) return existing;
+
+  const generated = await generateAnswerKeyPair();
+  try {
+    fs.writeFileSync(keyPath, `${JSON.stringify(generated, null, 2)}\n`, {
+      mode: SECRET_MODE,
+      flag: 'wx',
+    });
+    return generated;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    const raced = read();
+    if (!raced) throw err;
+    return raced;
+  }
+}

--- a/packages/daemon/src/auth/authenticator.ts
+++ b/packages/daemon/src/auth/authenticator.ts
@@ -60,6 +60,8 @@ export class Authenticator {
   private readonly identity: UnlockedIdentity;
   private readonly store: IdentityStore;
   private readonly tofuMode: TofuMode;
+  /** Published in every challenge so phones can pin it (#875). */
+  private answerEncryptionKey: string | undefined;
   /** Active challenges keyed by connection ID */
   private readonly pendingChallenges = new Map<string, string>();
 
@@ -73,10 +75,24 @@ export class Authenticator {
    * Create an auth challenge for a new connection.
    * @param connectionId Unique connection identifier to track the challenge
    */
+  /**
+   * Publish the daemon's answer key (#875). Set once at startup; absent means
+   * clients must refuse to send a lock-screen answer rather than send plaintext.
+   */
+  setAnswerEncryptionKey(publicKeyBase64: string): void {
+    this.answerEncryptionKey = publicKeyBase64;
+  }
+
   createChallenge(connectionId: string): AuthChallengeMessage {
     const challenge = generateChallenge();
     this.pendingChallenges.set(connectionId, challenge);
-    return createAuthChallenge(challenge, this.identity.fingerprint, this.identity.publicKeyRaw);
+    return createAuthChallenge(
+      challenge,
+      this.identity.fingerprint,
+      this.identity.publicKeyRaw,
+      undefined,
+      this.answerEncryptionKey,
+    );
   }
 
   /**
@@ -101,10 +117,13 @@ export class Authenticator {
       this.identity.privateKey,
       kexSigningInput(challenge, ephemeralPublicKeyBase64, null),
     );
-    return createAuthChallenge(challenge, this.identity.fingerprint, this.identity.publicKeyRaw, {
-      ephemeralKey: ephemeralPublicKeyBase64,
-      signature,
-    });
+    return createAuthChallenge(
+      challenge,
+      this.identity.fingerprint,
+      this.identity.publicKeyRaw,
+      { ephemeralKey: ephemeralPublicKeyBase64, signature },
+      this.answerEncryptionKey,
+    );
   }
 
   /**

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -118,8 +118,10 @@ import {
 } from '@remi/shared';
 import type { ProtocolMessage, UUID, UnlockedIdentity } from '@remi/shared';
 import { isEncrypted, unlockIdentity } from '@remi/shared';
+import type { AnswerKeyPair } from '@remi/shared';
 import { AdapterRegistry, TelegramAdapter, WebSocketAdapter } from './adapters/index.ts';
 import { QuestionPresenceTracker } from './api/question-presence-tracker.ts';
+import { loadOrCreateAnswerKey } from './auth/answer-key.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { loadOrCreateCapabilityToken } from './auth/capability-token.ts';
 import { IdentityStore } from './auth/identity-store.ts';
@@ -1874,6 +1876,8 @@ const configAuth = remiConfig.auth.enabled;
 const authEnabled = cliAuth ?? (configAuth === 'auto' ? false : configAuth);
 
 let authenticator: Authenticator | undefined;
+/** Opens sealed lock-screen answers (#875); handed to the relay adapter. */
+let daemonAnswerKey: AnswerKeyPair | undefined;
 let serverFingerprint: string | undefined;
 
 if (authEnabled) {
@@ -1934,6 +1938,17 @@ if (authEnabled) {
 
   const tofuMode = cliNoTofu ? ('reject' as const) : ('auto-accept' as const);
   authenticator = new Authenticator({ identity: unlockedIdentity, identityStore, tofuMode });
+  // Published in every auth challenge so phones can pin it and seal
+  // lock-screen answers to this daemon (#875). Non-fatal: without it the
+  // daemon simply cannot open sealed answers and says so when one arrives,
+  // which is better than refusing to start.
+  try {
+    const answerKey = await loadOrCreateAnswerKey(undefined, logError);
+    authenticator.setAnswerEncryptionKey(answerKey.publicKeyBase64);
+    daemonAnswerKey = answerKey;
+  } catch (err) {
+    logError(`[answer-key] could not load or create the answer key: ${errorToString(err)}`);
+  }
   serverFingerprint = storedIdentity.fingerprint;
   console.log(`Authentication enabled (fingerprint: ${serverFingerprint}, TOFU: ${tofuMode})`);
 } else {
@@ -2011,6 +2026,7 @@ if (!cliNoRelay && remiConfig.network.relay) {
     );
   }
 
+  if (daemonAnswerKey) relayAdapter.setAnswerKey(daemonAnswerKey);
   registry.register(relayAdapter);
 }
 

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -25,9 +25,12 @@ import {
   errorToString,
   generateEphemeralKeyPair,
   generateId,
+  isSealedAnswer,
+  openSealedAnswer,
 } from '@remi/shared';
 import type {
   AgentStatus,
+  AnswerKeyPair,
   AuthResponseMessage,
   EphemeralKeyPair,
   Message,
@@ -123,6 +126,9 @@ export class RelayAdapter implements ConnectionAdapter {
   private ephemeralKeys: EphemeralKeyPair | null = null;
   private sessionKeys: RelaySessionKeys | null = null;
   private kexChallenge: string | null = null;
+
+  /** Opens sealed lock-screen answers (#875). Absent = cannot open them. */
+  private answerKey: AnswerKeyPair | null = null;
 
   constructor(config: RelayAdapterConfig, events: Partial<AdapterEvents> = {}) {
     this.config = config;
@@ -255,11 +261,12 @@ export class RelayAdapter implements ConnectionAdapter {
       // handshake-authenticated WS peer (there is none). Gate on the ABSENCE of a
       // connected peer so a normal connected peer's answer always uses the
       // standard onAnswer routing even if a future client signs WS answers.
+      // A sealed answer (#875) carries no readable `auth` block: the auth is
+      // inside the ciphertext, which is the point. Recognise it by shape.
       if (
         !this.clientConnectionId &&
         message.type === 'answer' &&
-        message.auth &&
-        typeof message.auth === 'object'
+        ((message.auth && typeof message.auth === 'object') || isSealedAnswer(message))
       ) {
         this.handleRelayedAnswer(message).catch((err) =>
           console.warn('Relayed answer error:', err instanceof Error ? err.message : err),
@@ -294,6 +301,11 @@ export class RelayAdapter implements ConnectionAdapter {
     } catch (e) {
       console.warn('Failed to parse relay payload:', e instanceof Error ? e.message : e);
     }
+  }
+
+  /** Give the adapter the key that opens sealed answers (#875). */
+  setAnswerKey(key: AnswerKeyPair): void {
+    this.answerKey = key;
   }
 
   /**
@@ -388,7 +400,30 @@ export class RelayAdapter implements ConnectionAdapter {
    * authenticator (rotating-code no-auth mode) the room code is the only gate,
    * consistent with the relay's WS path.
    */
-  private async handleRelayedAnswer(msg: Record<string, unknown>): Promise<void> {
+  private async handleRelayedAnswer(raw: Record<string, unknown>): Promise<void> {
+    // A sealed envelope (#875) is opened before anything else looks at it: the
+    // Worker forwards ciphertext, so sessionId/questionId/answer do not exist
+    // until this succeeds. A failure is a wrong key or a tampered request, never
+    // a benign shape, so the answer is dropped rather than partially honored.
+    let msg = raw;
+    if (isSealedAnswer(raw)) {
+      if (!this.answerKey) {
+        console.warn('Sealed answer dropped: this daemon has no answer key, so it cannot open it');
+        return;
+      }
+      try {
+        const opened = await openSealedAnswer(this.answerKey.privateKeyPkcs8Base64, raw);
+        if (opened === null || typeof opened !== 'object') {
+          console.warn('Sealed answer dropped: contents were not an object');
+          return;
+        }
+        msg = opened as Record<string, unknown>;
+      } catch (err) {
+        console.warn(`Sealed answer rejected: ${errorToString(err)}`);
+        return;
+      }
+    }
+
     const sessionId = typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '';
     const questionId = typeof msg['questionId'] === 'string' ? msg['questionId'] : '';
     const answer = typeof msg['answer'] === 'string' ? msg['answer'] : '';

--- a/packages/daemon/tests/remote/sealed-answer-relay.test.ts
+++ b/packages/daemon/tests/remote/sealed-answer-relay.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Sealed lock-screen answers, through the real relay path (#875).
+ *
+ * Drives a real `RelayAdapter` with a real answer key, feeding it exactly what
+ * the Worker forwards. The point is not that the crypto works, which
+ * `shared/tests/sealed-answer.test.ts` covers, but that the daemon opens what
+ * the phone sealed and refuses everything else.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateAnswerKeyPair, sealAnswer, sign, toBase64 } from '@remi/shared';
+import type { AnswerKeyPair } from '@remi/shared';
+import { Authenticator } from '../../src/auth/authenticator.ts';
+import { IdentityStore } from '../../src/auth/identity-store.ts';
+import { RelayAdapter, type RelayTransport } from '../../src/remote/relay-adapter.ts';
+
+class StubTransport implements RelayTransport {
+  readonly sent: string[] = [];
+  isConnected = true;
+  connectionCode: string | null = 'TEST-CODE';
+  private readonly handlers = new Map<string, ((...args: unknown[]) => void)[]>();
+  // biome-ignore lint/suspicious/noExplicitAny: mirrors the emitter's shape
+  on(event: string, cb: (...args: any[]) => void): void {
+    const list = this.handlers.get(event) ?? [];
+    list.push(cb);
+    this.handlers.set(event, list);
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const cb of this.handlers.get(event) ?? []) cb(...args);
+  }
+  sendRelay(payload: string): void {
+    this.sent.push(payload);
+  }
+  connect(): void {}
+  close(): void {}
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 12; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe('daemon opens sealed lock-screen answers', () => {
+  let dir: string;
+  let transport: StubTransport;
+  let adapter: RelayAdapter | null = null;
+  let answerKey: AnswerKeyPair;
+  let delivered: { sessionId: string; questionId: string; answer: string }[];
+  let clientPublicKeyRaw: string;
+  let clientFingerprint: string;
+  let signBody: (message: string) => Promise<string>;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-sealed-'));
+    transport = new StubTransport();
+    answerKey = await generateAnswerKeyPair();
+    delivered = [];
+
+    const store = new IdentityStore(dir);
+    await store.generate('serverpass');
+    const identity = await store.unlock('serverpass');
+    const authenticator = new Authenticator({
+      identity,
+      identityStore: store,
+      tofuMode: 'auto-accept',
+    });
+
+    // A phone the daemon already trusts.
+    const clientStore = new IdentityStore(path.join(dir, 'client'));
+    await clientStore.generate('clientpass');
+    const clientIdentity = await clientStore.unlock('clientpass');
+    clientPublicKeyRaw = clientIdentity.publicKeyRaw;
+    clientFingerprint = clientIdentity.fingerprint;
+    await store.addAuthorizedKey(clientPublicKeyRaw, 'test-phone');
+    signBody = (message: string) =>
+      sign(clientIdentity.privateKey, new TextEncoder().encode(message).buffer as ArrayBuffer);
+
+    adapter = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl: 'wss://example.invalid',
+        code: 'TEST-CODE',
+        rotateCode: false,
+        authenticator,
+        createTransport: () => transport,
+      },
+      {
+        onAnswerRelay: async (sessionId, questionId, answer) => {
+          delivered.push({ sessionId, questionId, answer });
+          return 'delivered';
+        },
+      },
+    );
+    adapter.setAnswerKey(answerKey);
+    await adapter.start();
+  });
+
+  afterEach(async () => {
+    await adapter?.stop();
+    adapter = null;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Exactly what the Worker forwards for a sealed answer. */
+  async function forwardSealed(
+    body: Record<string, unknown>,
+    key = answerKey.publicKeyBase64,
+  ): Promise<void> {
+    const envelope = await sealAnswer(key, body);
+    transport.emit('relay', JSON.stringify({ type: 'answer', ...envelope }));
+    await settle();
+  }
+
+  async function signedBody(answer: string): Promise<Record<string, unknown>> {
+    const sessionId = '0199f3a1-0000-7000-8000-000000000001';
+    const questionId = '0199f3a1-0000-7000-8000-000000000002';
+    return {
+      sessionId,
+      questionId,
+      answer,
+      auth: {
+        signature: await signBody(`${sessionId}|${questionId}|${answer}`),
+        clientPublicKey: clientPublicKeyRaw,
+        clientFingerprint,
+      },
+    };
+  }
+
+  test('a sealed answer from a trusted phone is delivered', async () => {
+    await forwardSealed(await signedBody('yes'));
+    expect(delivered.length).toBe(1);
+    expect(delivered[0]?.answer).toBe('yes');
+  });
+
+  test('the signature inside is still verified after opening', async () => {
+    // Sealing hides the answer from the Worker; it does not excuse the phone
+    // from proving who it is. A body whose signature covers different text
+    // must not be honored.
+    const body = await signedBody('yes');
+    await forwardSealed({ ...body, answer: 'no' });
+    expect(delivered.length).toBe(0);
+  });
+
+  test('an answer sealed to a different daemon is refused', async () => {
+    const other = await generateAnswerKeyPair();
+    await forwardSealed(await signedBody('yes'), other.publicKeyBase64);
+    expect(delivered.length).toBe(0);
+  });
+
+  test('a tampered envelope is refused', async () => {
+    const envelope = await sealAnswer(answerKey.publicKeyBase64, await signedBody('yes'));
+    const bytes = new Uint8Array(Buffer.from(envelope.sealed, 'base64'));
+    const last = bytes.length - 1;
+    bytes[last] = (bytes[last] ?? 0) ^ 0x01;
+    transport.emit(
+      'relay',
+      JSON.stringify({
+        type: 'answer',
+        ephemeralPublicKey: envelope.ephemeralPublicKey,
+        sealed: Buffer.from(bytes).toString('base64'),
+      }),
+    );
+    await settle();
+    expect(delivered.length).toBe(0);
+  });
+
+  test('a daemon with no answer key refuses rather than guessing', async () => {
+    // Its own transport: sharing the outer one would let the keyed adapter
+    // answer and the assertion would pass for the wrong reason.
+    const bareTransport = new StubTransport();
+    let bareDelivered = 0;
+    const bare = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl: 'wss://example.invalid',
+        code: 'TEST-CODE',
+        rotateCode: true,
+        createTransport: () => bareTransport,
+      },
+      {
+        onAnswerRelay: async () => {
+          bareDelivered++;
+          return 'delivered';
+        },
+      },
+    );
+    await bare.start();
+    const envelope = await sealAnswer(answerKey.publicKeyBase64, await signedBody('yes'));
+    bareTransport.emit('relay', JSON.stringify({ type: 'answer', ...envelope }));
+    await settle();
+    expect(bareDelivered).toBe(0);
+    await bare.stop();
+  });
+
+  test('the plaintext shape still works', async () => {
+    // A client that predates sealing keeps functioning; the daemon decides
+    // what it honors, and the Worker no longer decides anything.
+    const body = await signedBody('yes');
+    transport.emit('relay', JSON.stringify({ type: 'answer', ...body }));
+    await settle();
+    expect(delivered.length).toBe(1);
+  });
+
+  test('the sealed envelope really is opaque', async () => {
+    // Same assertion the Worker's own view would produce.
+    const body = await signedBody('deploy to production');
+    const envelope = await sealAnswer(answerKey.publicKeyBase64, body);
+    const wire = JSON.stringify({ type: 'answer', ...envelope });
+    expect(wire).not.toContain('deploy to production');
+    expect(wire).not.toContain(body['sessionId'] as string);
+    expect(wire).not.toContain(clientFingerprint);
+    void toBase64;
+  });
+});

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -66,6 +66,13 @@ export interface KnownHost {
   readonly publicKey: Base64;
   readonly firstSeen: string;
   readonly lastSeen: string;
+  /**
+   * The daemon's published P-256 answer key (#875), pinned so a lock-screen
+   * answer can be sealed with no live connection. Absent for a host last seen
+   * before this shipped: the client must then refuse to send an answer over the
+   * relay rather than send it in the clear, and it re-pins on next connect.
+   */
+  readonly answerEncryptionKey?: Base64;
 }
 
 /** Check whether an identity has an encrypted private key. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -165,6 +165,7 @@ export {
 // Crypto
 export type { Base64, Fingerprint, RawKeyPair, ExportedKeyPair, EncryptedData } from './crypto.ts';
 export * from './relay-crypto.ts';
+export * from './sealed-answer.ts';
 export {
   PBKDF2_ITERATIONS,
   SALT_SIZE,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -707,6 +707,13 @@ export interface AuthChallengeMessage {
    */
   readonly relayEphemeralKey?: string;
   readonly relayKexSignature?: string;
+  /**
+   * The daemon's long-lived P-256 answer key, base64 (#875). Phones pin this
+   * alongside the fingerprint so a lock-screen answer can be sealed with no
+   * live connection to negotiate over. Absent on a daemon that has none, in
+   * which case a client must refuse to send rather than send in the clear.
+   */
+  readonly answerEncryptionKey?: string;
 }
 
 /** Authentication response from client to server */
@@ -1615,6 +1622,7 @@ export function createAuthChallenge(
   serverFingerprint: string,
   serverPublicKey: string,
   relayKex?: { readonly ephemeralKey: string; readonly signature: string },
+  answerEncryptionKey?: string,
 ): AuthChallengeMessage {
   return {
     type: 'auth_challenge',
@@ -1627,6 +1635,7 @@ export function createAuthChallenge(
       relayEphemeralKey: relayKex.ephemeralKey,
       relayKexSignature: relayKex.signature,
     }),
+    ...(answerEncryptionKey !== undefined && { answerEncryptionKey }),
   };
 }
 

--- a/packages/shared/src/sealed-answer.ts
+++ b/packages/shared/src/sealed-answer.ts
@@ -1,0 +1,184 @@
+/**
+ * Sealed lock-screen answers (#875).
+ *
+ * ## Why this is not the relay's encryption
+ *
+ * `relay-crypto.ts` hangs a signed ephemeral exchange off the auth handshake,
+ * which works because both peers are live and talking. The lock-screen path has
+ * no handshake and often no connection at all: that is its entire purpose
+ * (#575 P4a). A phone answers from a push notification while the app is
+ * suspended, over a single HTTP POST, and the Worker forwards it.
+ *
+ * Today that POST carries `sessionId`, `questionId` and the answer text as
+ * plain JSON, so the Worker reads every answer given from a lock screen. This
+ * seals it.
+ *
+ * ## The shape
+ *
+ * Ephemeral-static ECDH. The daemon holds a long-lived P-256 "answer key" and
+ * publishes the public half; the phone pins it alongside the daemon's
+ * fingerprint. To answer, the phone generates an ephemeral keypair, derives a
+ * key against the pinned static one, and seals the body. Only the daemon can
+ * open it.
+ *
+ * One request, no round trip, nothing to negotiate while the app is asleep.
+ *
+ * ## Why a separate key rather than the Ed25519 identity the phone already pins
+ *
+ * An Ed25519 key can be converted to X25519 for ECDH, and that would need no
+ * new state at all. WebCrypto cannot do that conversion, and the clients here
+ * include an iOS WKWebView, so it would mean adding a crypto library to a
+ * security-critical path. A separate P-256 key costs one published field and
+ * uses primitives every target has had for years.
+ *
+ * ## What it does not do
+ *
+ * No forward secrecy for the daemon's side: the static key opens every answer
+ * sealed to it, so stealing that file retroactively opens recorded answers. The
+ * relay's exchange has forward secrecy because both peers are live; this one
+ * cannot without a round trip the sleeping phone does not have. Rotating the
+ * key invalidates every phone's pin until each reconnects, which is the real
+ * cost and the reason it is not rotated per boot.
+ *
+ * The Worker still sees the room code it routes by, and that an answer happened.
+ */
+
+import { fromBase64, toBase64 } from './crypto.ts';
+
+const SEAL_INFO = 'remi-sealed-answer-v1';
+const NONCE_BYTES = 12;
+
+/** The envelope that replaces the plaintext answer body on the wire. */
+export interface SealedAnswer {
+  /** Raw P-256 public key of the one-shot sender key, base64. */
+  readonly ephemeralPublicKey: string;
+  /** Base64 `nonce || ciphertext` over the JSON answer body. */
+  readonly sealed: string;
+}
+
+/** A long-lived keypair a daemon publishes so phones can seal answers to it. */
+export interface AnswerKeyPair {
+  readonly publicKeyBase64: string;
+  readonly privateKeyPkcs8Base64: string;
+}
+
+/** Generate a daemon answer key. Long-lived: phones pin the public half. */
+export async function generateAnswerKeyPair(): Promise<AnswerKeyPair> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+    'deriveBits',
+  ]);
+  const [raw, pkcs8] = await Promise.all([
+    crypto.subtle.exportKey('raw', pair.publicKey),
+    crypto.subtle.exportKey('pkcs8', pair.privateKey),
+  ]);
+  return { publicKeyBase64: toBase64(raw), privateKeyPkcs8Base64: toBase64(pkcs8) };
+}
+
+/** Derive the one AES-GCM key both sides reach, from either side's material. */
+async function deriveSealKey(
+  privateKey: CryptoKey,
+  peerPublicKeyBase64: string,
+  ephemeralPublicKeyBase64: string,
+): Promise<CryptoKey> {
+  const peerPublic = await crypto.subtle.importKey(
+    'raw',
+    fromBase64(peerPublicKeyBase64),
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  );
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: peerPublic },
+    privateKey,
+    256,
+  );
+  const hkdf = await crypto.subtle.importKey('raw', bits, 'HKDF', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      // The sender's ephemeral key is the salt, so two answers sealed to the
+      // same daemon key never derive the same AES key.
+      salt: new Uint8Array(fromBase64(ephemeralPublicKeyBase64)),
+      info: new TextEncoder().encode(SEAL_INFO),
+    },
+    hkdf,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/**
+ * Seal an answer body to a daemon's published answer key.
+ *
+ * @param daemonAnswerKeyBase64 the pinned public key, learned when the phone
+ *   last connected. A caller with no pinned key must refuse to send rather than
+ *   fall back to plaintext.
+ */
+export async function sealAnswer(
+  daemonAnswerKeyBase64: string,
+  body: unknown,
+): Promise<SealedAnswer> {
+  const ephemeral = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+    'deriveBits',
+  ]);
+  const ephemeralRaw = await crypto.subtle.exportKey('raw', ephemeral.publicKey);
+  const ephemeralPublicKey = toBase64(ephemeralRaw);
+
+  const key = await deriveSealKey(ephemeral.privateKey, daemonAnswerKeyBase64, ephemeralPublicKey);
+  const nonce = crypto.getRandomValues(new Uint8Array(NONCE_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce },
+    key,
+    new TextEncoder().encode(JSON.stringify(body)),
+  );
+
+  const packed = new Uint8Array(NONCE_BYTES + ciphertext.byteLength);
+  packed.set(nonce, 0);
+  packed.set(new Uint8Array(ciphertext), NONCE_BYTES);
+  return { ephemeralPublicKey, sealed: toBase64(packed.buffer) };
+}
+
+/**
+ * Open a sealed answer with the daemon's answer private key.
+ *
+ * Throws on a wrong key, a tampered envelope or malformed JSON. AES-GCM
+ * authenticates, so callers must treat a throw as a hostile or corrupt request
+ * and refuse the answer, never as an empty one.
+ */
+export async function openSealedAnswer(
+  privateKeyPkcs8Base64: string,
+  envelope: SealedAnswer,
+): Promise<unknown> {
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    fromBase64(privateKeyPkcs8Base64),
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    ['deriveBits'],
+  );
+  const key = await deriveSealKey(
+    privateKey,
+    envelope.ephemeralPublicKey,
+    envelope.ephemeralPublicKey,
+  );
+
+  const packed = new Uint8Array(fromBase64(envelope.sealed));
+  if (packed.byteLength <= NONCE_BYTES) {
+    throw new Error('Sealed answer is too short to contain a nonce and ciphertext');
+  }
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: packed.subarray(0, NONCE_BYTES) },
+    key,
+    packed.subarray(NONCE_BYTES),
+  );
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+/** True when a body looks like a sealed envelope rather than a plaintext answer. */
+export function isSealedAnswer(body: unknown): body is SealedAnswer {
+  if (body === null || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+  return typeof b['ephemeralPublicKey'] === 'string' && typeof b['sealed'] === 'string';
+}

--- a/packages/shared/tests/sealed-answer.test.ts
+++ b/packages/shared/tests/sealed-answer.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Sealed lock-screen answer tests (#875).
+ *
+ * Real WebCrypto on both sides. The assertions that matter are about what the
+ * Worker would see, since the Worker is the party this seals against.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  generateAnswerKeyPair,
+  isSealedAnswer,
+  openSealedAnswer,
+  sealAnswer,
+} from '../src/sealed-answer.ts';
+
+const BODY = {
+  sessionId: '0199f3a1-0000-7000-8000-000000000001',
+  questionId: '0199f3a1-0000-7000-8000-000000000002',
+  answer: 'yes, deploy to production',
+};
+
+describe('sealed answers', () => {
+  test('the daemon opens what the phone sealed', async () => {
+    const daemon = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    expect(await openSealedAnswer(daemon.privateKeyPkcs8Base64, envelope)).toEqual(BODY);
+  });
+
+  test('the Worker sees no answer text and no session identifiers', async () => {
+    // The Worker's entire view of the request body.
+    const daemon = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    const onTheWire = JSON.stringify(envelope);
+
+    expect(onTheWire).not.toContain(BODY.answer);
+    expect(onTheWire).not.toContain(BODY.sessionId);
+    expect(onTheWire).not.toContain(BODY.questionId);
+    expect(onTheWire).not.toContain('answer');
+  });
+
+  test('another daemon cannot open it', async () => {
+    const daemon = await generateAnswerKeyPair();
+    const other = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    await expect(openSealedAnswer(other.privateKeyPkcs8Base64, envelope)).rejects.toThrow();
+  });
+
+  test('the ephemeral key alone does not open it', async () => {
+    // The Worker holds exactly this: the envelope, including the sender's
+    // public key. It must not be enough.
+    const daemon = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    const attacker = await generateAnswerKeyPair();
+    await expect(
+      openSealedAnswer(attacker.privateKeyPkcs8Base64, {
+        ephemeralPublicKey: envelope.ephemeralPublicKey,
+        sealed: envelope.sealed,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('the same answer seals differently every time', async () => {
+    // A fresh ephemeral key per answer: identical envelopes would tell the
+    // Worker you answered the same way twice.
+    const daemon = await generateAnswerKeyPair();
+    const a = await sealAnswer(daemon.publicKeyBase64, BODY);
+    const b = await sealAnswer(daemon.publicKeyBase64, BODY);
+    expect(a.sealed).not.toBe(b.sealed);
+    expect(a.ephemeralPublicKey).not.toBe(b.ephemeralPublicKey);
+  });
+
+  test('tampering is rejected rather than yielding a different answer', async () => {
+    // The dangerous failure would be a flipped bit turning "no" into something
+    // the daemon acts on. AES-GCM authenticates, so it cannot.
+    const daemon = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    const bytes = new Uint8Array(Buffer.from(envelope.sealed, 'base64'));
+    const last = bytes.length - 1;
+    bytes[last] = (bytes[last] ?? 0) ^ 0x01;
+    await expect(
+      openSealedAnswer(daemon.privateKeyPkcs8Base64, {
+        ephemeralPublicKey: envelope.ephemeralPublicKey,
+        sealed: Buffer.from(bytes).toString('base64'),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('a swapped ephemeral key is rejected', async () => {
+    const daemon = await generateAnswerKeyPair();
+    const one = await sealAnswer(daemon.publicKeyBase64, BODY);
+    const two = await sealAnswer(daemon.publicKeyBase64, BODY);
+    await expect(
+      openSealedAnswer(daemon.privateKeyPkcs8Base64, {
+        ephemeralPublicKey: two.ephemeralPublicKey,
+        sealed: one.sealed,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('a truncated envelope reports what is wrong', async () => {
+    const daemon = await generateAnswerKeyPair();
+    const envelope = await sealAnswer(daemon.publicKeyBase64, BODY);
+    await expect(
+      openSealedAnswer(daemon.privateKeyPkcs8Base64, {
+        ephemeralPublicKey: envelope.ephemeralPublicKey,
+        sealed: Buffer.from(new Uint8Array(8)).toString('base64'),
+      }),
+    ).rejects.toThrow(/too short/);
+  });
+
+  test('unicode answers survive the round trip', async () => {
+    const daemon = await generateAnswerKeyPair();
+    const body = { ...BODY, answer: 'oui, déployez ☕ 好' };
+    const envelope = await sealAnswer(daemon.publicKeyBase64, body);
+    expect(await openSealedAnswer(daemon.privateKeyPkcs8Base64, envelope)).toEqual(body);
+  });
+
+  test('sealed envelopes are told apart from plaintext bodies', async () => {
+    // The daemon uses this to decide which shape arrived, so a plaintext body
+    // must never be mistaken for a sealed one.
+    const daemon = await generateAnswerKeyPair();
+    expect(isSealedAnswer(await sealAnswer(daemon.publicKeyBase64, BODY))).toBe(true);
+    expect(isSealedAnswer(BODY)).toBe(false);
+    expect(isSealedAnswer(null)).toBe(false);
+    expect(isSealedAnswer('sealed')).toBe(false);
+    expect(isSealedAnswer({ ephemeralPublicKey: 'x' })).toBe(false);
+  });
+});

--- a/packages/signaling/src/connection-room.ts
+++ b/packages/signaling/src/connection-room.ts
@@ -123,6 +123,9 @@ export class ConnectionRoom {
       answer?: string;
       claudeSessionId?: string;
       auth?: unknown;
+      /** Sealed-answer envelope (#875); mutually exclusive with the fields above. */
+      ephemeralPublicKey?: string;
+      sealed?: string;
     };
     try {
       body = (await request.json()) as typeof body;
@@ -133,8 +136,14 @@ export class ConnectionRoom {
       });
     }
 
+    // A sealed answer (#875) carries no readable fields by design: the whole
+    // point is that this Worker cannot see the session, the question or the
+    // answer text. Forward it as-is and let the daemon open it. The old
+    // plaintext shape is still accepted so a client that predates sealing keeps
+    // working; the daemon decides which it will honor.
     const { sessionId, questionId, answer, claudeSessionId, auth } = body;
-    if (!sessionId || !questionId || !answer) {
+    const sealed = typeof body.ephemeralPublicKey === 'string' && typeof body.sealed === 'string';
+    if (!sealed && (!sessionId || !questionId || !answer)) {
       return new Response(JSON.stringify({ result: 'missing-fields' }), {
         status: 400,
         headers: cors,
@@ -148,14 +157,23 @@ export class ConnectionRoom {
 
     // Wrap as the daemon's relay envelope (payload is a JSON-encoded protocol
     // message, matching what the phone's relay WebSocket sends for an answer).
-    const inner = JSON.stringify({
-      type: 'answer',
-      sessionId,
-      questionId,
-      answer,
-      ...(claudeSessionId ? { claudeSessionId } : {}),
-      ...(auth ? { auth } : {}),
-    });
+    // A sealed envelope forwards whole: everything the daemon needs, including
+    // the auth block, is inside the ciphertext. `type` stays outside only so
+    // the daemon's relay router can recognise it.
+    const inner = sealed
+      ? JSON.stringify({
+          type: 'answer',
+          ephemeralPublicKey: body.ephemeralPublicKey,
+          sealed: body.sealed,
+        })
+      : JSON.stringify({
+          type: 'answer',
+          sessionId,
+          questionId,
+          answer,
+          ...(claudeSessionId ? { claudeSessionId } : {}),
+          ...(auth ? { auth } : {}),
+        });
     const ok = this.send(hostWs, { type: 'relay', payload: inner });
     return new Response(JSON.stringify({ result: ok ? 'delivered' : 'send-failed' }), {
       status: ok ? 200 : 502,

--- a/packages/web/src/hooks/useConnectionManager.ts
+++ b/packages/web/src/hooks/useConnectionManager.ts
@@ -83,6 +83,8 @@ interface ManagedConnection {
     challenge: string;
     serverPublicKey: string;
     serverFingerprint: string;
+    /** Pinned alongside the fingerprint so answers can be sealed later (#875). */
+    answerEncryptionKey?: string;
   } | null;
   needsPassphrase: boolean;
   serverFingerprint: string | null;
@@ -304,6 +306,7 @@ export function useConnectionManager(
       challenge: string,
       srvFingerprint: string,
       srvPublicKey: string,
+      answerEncryptionKey?: string,
     ) => {
       mc.serverFingerprint = srvFingerprint;
 
@@ -323,6 +326,9 @@ export function useConnectionManager(
         challenge,
         serverPublicKey: srvPublicKey,
         serverFingerprint: srvFingerprint,
+        // Pinned with the fingerprint so a lock-screen answer can be sealed
+        // later, when there is no connection to ask over (#875).
+        ...(answerEncryptionKey !== undefined && { answerEncryptionKey }),
       };
 
       let identity = identityRef.current;
@@ -402,7 +408,12 @@ export function useConnectionManager(
 
       // TOFU: trust on first use
       const pending = mc.pendingChallenge;
-      trustHost(mc.url, pending.serverFingerprint, pending.serverPublicKey);
+      trustHost(
+        mc.url,
+        pending.serverFingerprint,
+        pending.serverPublicKey,
+        pending.answerEncryptionKey,
+      );
 
       mc.pendingChallenge = null;
       mc.needsPassphrase = false;
@@ -436,6 +447,7 @@ export function useConnectionManager(
             message.challenge,
             message.serverFingerprint,
             message.serverPublicKey,
+            message.answerEncryptionKey,
           ).catch((err) => {
             mc.error = err instanceof Error ? err : new Error(String(err));
             mc.client.disconnect();

--- a/packages/web/src/lib/identity-client.ts
+++ b/packages/web/src/lib/identity-client.ts
@@ -143,7 +143,12 @@ export function checkKnownHost(
 }
 
 /** Record a server fingerprint (TOFU - trust on first use) */
-export function trustHost(serverUrl: string, fingerprint: string, publicKey: string): void {
+export function trustHost(
+  serverUrl: string,
+  fingerprint: string,
+  publicKey: string,
+  answerEncryptionKey?: string,
+): void {
   const hosts = loadKnownHosts();
   const key = normalizeHostKey(serverUrl);
   const now = new Date().toISOString();
@@ -152,8 +157,21 @@ export function trustHost(serverUrl: string, fingerprint: string, publicKey: str
     publicKey,
     firstSeen: hosts[key]?.firstSeen ?? now,
     lastSeen: now,
+    // Keep the previously pinned key when a daemon stops publishing one, rather
+    // than silently dropping the ability to seal (#875).
+    ...(answerEncryptionKey !== undefined
+      ? { answerEncryptionKey }
+      : hosts[key]?.answerEncryptionKey !== undefined
+        ? { answerEncryptionKey: hosts[key]?.answerEncryptionKey }
+        : {}),
   };
   saveKnownHosts(hosts);
+}
+
+/** The pinned answer key for a host, or null when there is none to seal with (#875). */
+export function getAnswerEncryptionKey(serverUrl: string): string | null {
+  const hosts = loadKnownHosts();
+  return hosts[normalizeHostKey(serverUrl)]?.answerEncryptionKey ?? null;
 }
 
 /** Remove a known host */

--- a/packages/web/src/lib/push-answer-relay.ts
+++ b/packages/web/src/lib/push-answer-relay.ts
@@ -16,7 +16,7 @@
  * path (which has the same limitation) or surfaces an "open the app" failure.
  */
 
-import { sign } from '@remi/shared';
+import { sealAnswer, sign } from '@remi/shared';
 import { hasIdentity, isIdentityEncrypted, unlockStoredIdentity } from './identity-client';
 
 /** Outcome of a direct-relay attempt. */
@@ -216,6 +216,15 @@ interface SignalingRelayInput {
   readonly claudeSessionId?: string | undefined;
   /** When true, sign the request (the daemon verifies it on the relay path). */
   readonly authRequired: boolean;
+  /**
+   * The daemon's pinned answer key (#875). Present => the body is sealed and
+   * the Worker sees only ciphertext. Absent => this daemon has not published
+   * one, or this phone has not connected since it did; the caller decides
+   * whether to send in the clear, and `sealRequired` says it must not.
+   */
+  readonly answerEncryptionKey?: string | undefined;
+  /** Refuse to send unsealed. Default true: plaintext here is the bug (#875). */
+  readonly sealRequired?: boolean;
   readonly timeoutMs?: number;
 }
 
@@ -254,6 +263,32 @@ export async function relayAnswerViaSignaling(input: SignalingRelayInput): Promi
     auth = built;
   }
 
+  // Seal the body to the daemon's pinned answer key (#875). The Worker then
+  // sees an opaque envelope instead of the session, the question and the
+  // answer text. The `auth` block goes INSIDE, so the Worker cannot see which
+  // phone answered either; the daemon verifies it after opening.
+  const plainBody = {
+    sessionId: input.sessionId,
+    questionId: input.questionId,
+    answer: input.answer,
+    ...(input.claudeSessionId ? { claudeSessionId: input.claudeSessionId } : {}),
+    ...(auth ? { auth } : {}),
+  };
+  let requestBody: unknown = plainBody;
+  if (input.answerEncryptionKey) {
+    try {
+      requestBody = await sealAnswer(input.answerEncryptionKey, plainBody);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message || err.name : String(err);
+      return { kind: 'unreachable', reason: `seal failed: ${detail}` };
+    }
+  } else if (input.sealRequired !== false) {
+    // Refusing is the point. Falling back to plaintext would hand the Worker
+    // the answer, which is what this path exists to stop. Reconnecting the app
+    // once re-pins the key and this resolves itself.
+    return { kind: 'unreachable', reason: 'no pinned answer key; reconnect once to seal answers' };
+  }
+
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -262,13 +297,7 @@ export async function relayAnswerViaSignaling(input: SignalingRelayInput): Promi
     const res = await fetch(httpUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        sessionId: input.sessionId,
-        questionId: input.questionId,
-        answer: input.answer,
-        ...(input.claudeSessionId ? { claudeSessionId: input.claudeSessionId } : {}),
-        ...(auth ? { auth } : {}),
-      }),
+      body: JSON.stringify(requestBody),
       signal: controller.signal,
     });
 

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { createIdentity, serializeIdentity } from '@remi/shared';
+import {
+  createIdentity,
+  generateAnswerKeyPair,
+  openSealedAnswer,
+  serializeIdentity,
+} from '@remi/shared';
 import {
   answerUrl,
   relayAnswerDirect,
@@ -82,6 +87,9 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
       expect(received).toEqual({ sessionId: 's1', questionId: 'q1', answer: 'Yes' });
@@ -105,6 +113,9 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result.kind).toBe('rejected');
     } finally {
@@ -127,6 +138,9 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result.kind).toBe('auth-failed');
     } finally {
@@ -164,6 +178,7 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
+        sealRequired: false,
       });
       expect(result.kind).toBe('needs-passphrase');
       expect(hit).toBe(false); // failed fast, never reached the daemon
@@ -187,6 +202,7 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
+        sealRequired: false,
       });
       expect(result.kind).toBe('needs-passphrase');
       expect(hit).toBe(false);
@@ -216,6 +232,7 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
+        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
       expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
@@ -280,6 +297,9 @@ describe('relayAnswerViaSignaling (#591)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
       expect(path).toBe('/answer/WXYZ-2345');
@@ -305,6 +325,9 @@ describe('relayAnswerViaSignaling (#591)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result.kind).toBe('unreachable');
     } finally {
@@ -332,6 +355,7 @@ describe('relayAnswerViaSignaling (#591)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
+        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
       expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
@@ -369,6 +393,9 @@ describe('relayAnswerViaSignaling (#591)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result.kind).toBe('unreachable');
     } finally {
@@ -392,10 +419,119 @@ describe('relayAnswerViaSignaling (#591)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
+        // Pre-#875 daemon: publishes no answer key, so there is nothing to
+        // seal to. The sealed path has its own tests below.
+        sealRequired: false,
       });
       expect(result.kind).toBe('rejected');
     } finally {
       server.stop();
     }
+  });
+
+  describe('sealed answers (#875)', () => {
+    test('with a pinned key the Worker receives an opaque envelope', async () => {
+      const daemon = await generateAnswerKeyPair();
+      let received: Record<string, unknown> | null = null;
+      const server = Bun.serve({
+        port: 0,
+        fetch: async (req) => {
+          received = (await req.json()) as Record<string, unknown>;
+          return new Response(JSON.stringify({ result: 'delivered' }), { status: 200 });
+        },
+      });
+      try {
+        const result = await relayAnswerViaSignaling({
+          signalingUrl: `http://127.0.0.1:${server.port}`,
+          code: 'WXYZ-2345',
+          sessionId: 's1',
+          questionId: 'q1',
+          answer: 'Yes, deploy',
+          authRequired: false,
+          answerEncryptionKey: daemon.publicKeyBase64,
+        });
+        expect(result).toEqual({ kind: 'delivered' });
+
+        // The Worker's entire view.
+        const body = received as unknown as Record<string, unknown>;
+        const wire = JSON.stringify(body);
+        expect(wire).not.toContain('Yes, deploy');
+        expect(wire).not.toContain('s1');
+        expect(wire).not.toContain('q1');
+        expect(typeof body['sealed']).toBe('string');
+        expect(typeof body['ephemeralPublicKey']).toBe('string');
+
+        // ...and the daemon still gets everything it needs.
+        const opened = (await openSealedAnswer(
+          daemon.privateKeyPkcs8Base64,
+          body as unknown as { ephemeralPublicKey: string; sealed: string },
+        )) as Record<string, unknown>;
+        expect(opened['sessionId']).toBe('s1');
+        expect(opened['answer']).toBe('Yes, deploy');
+      } finally {
+        server.stop();
+      }
+    });
+
+    test('without a pinned key it refuses instead of sending plaintext', async () => {
+      // The whole point: a fallback here would hand the Worker the answer.
+      let called = false;
+      const server = Bun.serve({
+        port: 0,
+        fetch: () => {
+          called = true;
+          return new Response(JSON.stringify({ result: 'delivered' }), { status: 200 });
+        },
+      });
+      try {
+        const result = await relayAnswerViaSignaling({
+          signalingUrl: `http://127.0.0.1:${server.port}`,
+          code: 'WXYZ-2345',
+          sessionId: 's1',
+          questionId: 'q1',
+          answer: 'Yes',
+          authRequired: false,
+        });
+        expect(result.kind).toBe('unreachable');
+        expect(called).toBe(false);
+      } finally {
+        server.stop();
+      }
+    });
+
+    test('the auth block is sealed too, so the Worker cannot see who answered', async () => {
+      // Signing needs an identity present, same setup the auth tests above use.
+      const unencrypted = await createIdentity();
+      store.setItem('remi-identity', serializeIdentity(unencrypted));
+      const daemon = await generateAnswerKeyPair();
+      let received: Record<string, unknown> | null = null;
+      const server = Bun.serve({
+        port: 0,
+        fetch: async (req) => {
+          received = (await req.json()) as Record<string, unknown>;
+          return new Response(JSON.stringify({ result: 'delivered' }), { status: 200 });
+        },
+      });
+      try {
+        await relayAnswerViaSignaling({
+          signalingUrl: `http://127.0.0.1:${server.port}`,
+          code: 'WXYZ-2345',
+          sessionId: 's1',
+          questionId: 'q1',
+          answer: 'Yes',
+          authRequired: true,
+          answerEncryptionKey: daemon.publicKeyBase64,
+        });
+        const body = received as unknown as Record<string, unknown>;
+        expect(JSON.stringify(body)).not.toContain('clientFingerprint');
+        const opened = (await openSealedAnswer(
+          daemon.privateKeyPkcs8Base64,
+          body as unknown as { ephemeralPublicKey: string; sealed: string },
+        )) as Record<string, unknown>;
+        expect(opened['auth']).toBeTruthy();
+      } finally {
+        server.stop();
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #875. **Read the Scope section first: the premise in that issue is wrong and this PR corrects it.**

## Scope correction

I filed #875 saying every lock-screen answer crosses the signaling Worker in plaintext. That is not true, and I verified it while implementing this.

`relayAnswerViaSignaling` has **zero callers**. The wired lock-screen path is `relayAnswerDirect` (`App.tsx:1929`), which POSTs straight to the daemon's own `/answer` endpoint with no Worker involved. The native side says the same at `RemiAnswerRelay.swift:223`: the signaling reverse-relay is out of scope, tracked as #612.

So the Worker has a route that would accept plaintext, the client has a function that would send it, and **the two have never been connected**. Both halves are dormant.

This PR is therefore prophylactic, not remedial, exactly as #543 turned out to be. It seals the route before #612 wires it, so whoever implements that inherits an encrypted path instead of adding a plaintext one. It is not fixing a live leak, and the issue's severity should be read down accordingly.

## What it does

The phone seals the whole answer body, `auth` block included, to a long-lived P-256 key the daemon publishes in its auth challenge and the phone pins beside the fingerprint. Ephemeral-static ECDH: one request, no round trip, which is all a suspended phone gets.

The Worker sees an opaque envelope plus the room code it routes by. The daemon opens it and *then* verifies the signature that was inside, so sealing hides who answered from the Worker without excusing the phone from proving who it is.

Failure directions are deliberate:
- A phone with **no pinned key refuses to send** rather than falling back to plaintext. Reconnecting once re-pins it.
- A daemon that cannot open a sealed answer **drops it** rather than acting on a partial one.
- The Worker no longer decides anything: it forwards both shapes and the daemon chooses what it honors.

## Design notes worth reviewing

**A separate P-256 key, not the Ed25519 identity the phone already pins.** Converting Ed25519 to X25519 would need no new state, but WebCrypto cannot do that conversion and the clients include an iOS WKWebView, so it would mean adding a crypto library to a security-critical path. A published P-256 key costs one field and uses primitives every target has had for years.

**No forward secrecy on the daemon's side.** The static key opens every answer ever sealed to it, so stealing `~/.remi/answer-key.json` retroactively opens recorded answers. A sleeping phone has no round trip to negotiate a fresh key, and rotating invalidates every phone's pin until each reconnects. Documented in the module rather than left to be found.

**The key survives restarts** (`answer-key.json`, mode 0600, written with `wx` so racing daemons cannot clobber each other). Regenerating per boot would invalidate every pin and break the path silently.

**The plaintext shape still works,** so a client predating this keeps functioning. The daemon decides what it honors.

## Testing

**427 pass, 0 fail** across `tests/remote`, `shared/tests`, `packages/signaling`, and the authenticator and relay-adapter suites. `typecheck` clean on root and `packages/web`, `biome check` clean, and the web builds.

`shared/tests/sealed-answer.test.ts` (10), real WebCrypto: the Worker's entire view of a sealed request contains no answer text, no session IDs and not even the word `answer`; another daemon cannot open it; the ephemeral key alone is not enough (that is exactly what the Worker holds); tampering rejects rather than yielding a different answer, which is the dangerous failure here since a flipped bit must never turn "no" into something actionable; a swapped ephemeral key rejects.

`daemon/tests/remote/sealed-answer-relay.test.ts` (7) drives a real `RelayAdapter` with a real answer key, fed exactly what the Worker forwards: a sealed answer from a trusted phone is delivered; **the signature inside is still verified after opening** (a body whose signature covers different text is refused); an answer sealed to a different daemon is refused; a tampered envelope is refused; a daemon with no key refuses rather than guessing; the plaintext shape still works.

One test initially passed for the wrong reason: the no-key adapter shared a transport with the keyed one, so the keyed adapter answered. It now has its own transport, and the comment says why.