### PR TITLE
macOS app: Ed25519 identity for loopback auth (#872)

### DIFF
--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		477C35A4907835166E4AECF6 /* HubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CA6F64B5FFA6B90233A956 /* HubClient.swift */; };
 		4DDC81BB89C55D2F2E819002 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
 		5470D493544A6D03CE17E9B3 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		55BD09EFD7CB8CA48CCE0840 /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7568FF36CA5C521240F3E18B /* ClientIdentity.swift */; };
 		56A2EE338C23F3064E056B31 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DD72A5787EF3FFBF772C89F /* Assets.xcassets */; };
 		5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */; };
@@ -30,6 +31,7 @@
 		954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */; };
 		A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
+		AD7C394E7D732D8388D54353 /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7568FF36CA5C521240F3E18B /* ClientIdentity.swift */; };
 		B02F8C5F4512A48DA88A1311 /* HubSetupCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBF3CF5E347134A46BF0076 /* HubSetupCommands.swift */; };
 		B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */; };
 		B380134DB301B91E8FB492B1 /* web in Resources */ = {isa = PBXBuildFile; fileRef = 5DB62EAF2230D75844C2E431 /* web */; };
@@ -39,6 +41,7 @@
 		D914DD758D12BA0F2F2192AA /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */; };
 		DCB33A9FC9A43C32D55F1C86 /* HubSetupCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */; };
 		E2A47A3FEF612AA225168AB6 /* HubSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C0F48CEB5BC01CC53529D /* HubSetupView.swift */; };
+		E930A603D1AABF15D2F6197D /* ClientIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D0D50141E60616E472B2C5 /* ClientIdentityTests.swift */; };
 		F1F060E53A0E11347B560DD6 /* NotificationDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEF3BCD8B2F7017165A715A /* NotificationDiffTests.swift */; };
 		FDB4E6B066502FF40FE283A5 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */; };
 		FDD33CD09342E7459B3AD7E1 /* WebViewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355697014B8A803D93F9E3EA /* WebViewWindow.swift */; };
@@ -55,12 +58,14 @@
 		4DD72A5787EF3FFBF772C89F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistSchemeHandlerTests.swift; sourceTree = "<group>"; };
 		5012C3ED6BF23506A3E5406C /* Remi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Remi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		55D0D50141E60616E472B2C5 /* ClientIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIdentityTests.swift; sourceTree = "<group>"; };
 		5A7875E7E74CA980AD4B502F /* IconState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconState.swift; sourceTree = "<group>"; };
 		5DB62EAF2230D75844C2E431 /* web */ = {isa = PBXFileReference; lastKnownFileType = folder; name = web; path = Remi/Resources/web; sourceTree = SOURCE_ROOT; };
 		69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubClientIntegrationTests.swift; sourceTree = "<group>"; };
 		6AEF3BCD8B2F7017165A715A /* NotificationDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDiffTests.swift; sourceTree = "<group>"; };
 		6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStateTests.swift; sourceTree = "<group>"; };
 		734962FBB7BBAF23FEFB57BC /* RemiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7568FF36CA5C521240F3E18B /* ClientIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIdentity.swift; sourceTree = "<group>"; };
 		76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
 		7A55AC9AACFAC1CAC46522A8 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		7A5E9CBEBA9AB7A3E199177A /* ActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyTests.swift; sourceTree = "<group>"; };
@@ -90,6 +95,7 @@
 				76E4FCE03EBFC0154443A767 /* ActivationPolicy.swift */,
 				C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */,
 				4DD72A5787EF3FFBF772C89F /* Assets.xcassets */,
+				7568FF36CA5C521240F3E18B /* ClientIdentity.swift */,
 				B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */,
 				81CA6F64B5FFA6B90233A956 /* HubClient.swift */,
 				C34698EE36B7B59AEAF65A27 /* HubProtocol.swift */,
@@ -112,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				7A5E9CBEBA9AB7A3E199177A /* ActivationPolicyTests.swift */,
+				55D0D50141E60616E472B2C5 /* ClientIdentityTests.swift */,
 				7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */,
 				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
 				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
@@ -266,6 +273,7 @@
 			files = (
 				465626B53BA0E06EC5B555C0 /* ActivationPolicy.swift in Sources */,
 				954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */,
+				AD7C394E7D732D8388D54353 /* ClientIdentity.swift in Sources */,
 				A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */,
 				779250B73CFF5A291C21A9A6 /* HubClient.swift in Sources */,
 				D5175153D73E308F27F71B07 /* HubProtocol.swift in Sources */,
@@ -286,6 +294,8 @@
 			files = (
 				2FB66887F1ABC6C53CA40C06 /* ActivationPolicy.swift in Sources */,
 				0282FAB49B260E7A3ABC043A /* ActivationPolicyTests.swift in Sources */,
+				55BD09EFD7CB8CA48CCE0840 /* ClientIdentity.swift in Sources */,
+				E930A603D1AABF15D2F6197D /* ClientIdentityTests.swift in Sources */,
 				5B9DAFE87B904A39428B55B0 /* DistSchemeHandler.swift in Sources */,
 				B2EF1C7D36471D46EACF2DD6 /* DistSchemeHandlerServingTests.swift in Sources */,
 				787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */,

--- a/packages/macos/Remi/ClientIdentity.swift
+++ b/packages/macos/Remi/ClientIdentity.swift
@@ -1,0 +1,134 @@
+//
+//  ClientIdentity.swift
+//  Remi
+//
+//  The app's own Ed25519 identity (#872, part 2 of #869). The CLI proves
+//  itself to the daemon with a capability token read from
+//  ~/.remi/capability.key (PR #874); this app is sandboxed and can never
+//  read that path — Remi.entitlements says so explicitly and that is
+//  deliberate (#649/#651). This is the sandboxed equivalent: a keypair
+//  generated on first launch, held in this app's own Keychain item, that
+//  never leaves the app and lets it complete the daemon's `auth_challenge`
+//  handshake exactly like the web/iOS clients do.
+//
+//  Wire format MUST match packages/shared/src/crypto.ts and
+//  packages/daemon/src/auth/authenticator.ts exactly:
+//  - the fingerprint is the first 16 hex characters of SHA-256(raw public
+//    key bytes) — see `fingerprint()` in crypto.ts.
+//  - `clientPublicKey` / `signature` on the wire are base64 of RAW bytes
+//    (32-byte Ed25519 public key, 64-byte signature), never PKCS8/DER.
+//  - the daemon signs/verifies over the DECODED challenge bytes, never the
+//    base64 string itself.
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+/// A holder for this app's Ed25519 signing keypair. Construction is cheap
+/// (no I/O); use `ClientIdentityStore.loadOrCreate()` to get the persisted
+/// instance.
+struct ClientIdentity {
+    let privateKey: Curve25519.Signing.PrivateKey
+
+    var publicKey: Curve25519.Signing.PublicKey { privateKey.publicKey }
+
+    /// Raw 32-byte Ed25519 public key — base64-encode this directly for the
+    /// wire (`clientPublicKey`), never wrap it in PKCS8/DER.
+    var publicKeyRaw: Data { publicKey.rawRepresentation }
+
+    /// First 16 hex characters of SHA-256(publicKeyRaw), matching
+    /// `fingerprint()` in packages/shared/src/crypto.ts exactly. The daemon
+    /// derives its own copy from the verified public key and does NOT trust
+    /// a client-claimed value for authorization (#671) — this is sent for
+    /// display/logging only, but it must still be correct.
+    var fingerprint: String { Self.fingerprint(ofPublicKeyRaw: publicKeyRaw) }
+
+    static func fingerprint(ofPublicKeyRaw raw: Data) -> String {
+        let digest = SHA256.hash(data: raw)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(16))
+    }
+
+    /// Sign raw bytes — the DECODED challenge, never the base64 string —
+    /// with this identity's private key.
+    func sign(_ data: Data) throws -> Data {
+        try privateKey.signature(for: data)
+    }
+}
+
+/// Loads or creates this app's `ClientIdentity`, persisted in the Keychain
+/// so the daemon's TOFU trust survives relaunches — regenerating a new key
+/// on every launch would mean re-earning trust (or, once `--no-tofu` is set
+/// on the daemon, never connecting at all) every single time.
+///
+/// No new entitlement is needed: a sandboxed app can create and read its own
+/// default-access-group Keychain items without the `keychain-access-groups`
+/// entitlement, which is only required to SHARE items with other apps. That
+/// matters here — Remi.entitlements is deliberately minimal (#649/#651) and
+/// this must not be the thing that grows it.
+enum ClientIdentityStore {
+    private static let defaultService = "live.yooz.remi.client-identity"
+    private static let defaultAccount = "ed25519-private-key"
+
+    /// Idempotent across calls and across relaunches: the first call
+    /// generates and persists a fresh keypair, every later call (this
+    /// process or a future one) returns the SAME key.
+    static func loadOrCreate(
+        service: String = defaultService, account: String = defaultAccount
+    ) -> ClientIdentity {
+        if let raw = read(service: service, account: account),
+            let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: raw)
+        {
+            return ClientIdentity(privateKey: key)
+        }
+        let fresh = Curve25519.Signing.PrivateKey()
+        write(fresh.rawRepresentation, service: service, account: account)
+        return ClientIdentity(privateKey: fresh)
+    }
+
+    /// Test-only teardown: deletes the Keychain item so a test can assert
+    /// fresh-vs-persisted behavior without leaking state into later runs.
+    #if DEBUG
+    static func resetForTesting(service: String = defaultService, account: String = defaultAccount)
+    {
+        SecItemDelete(query(service: service, account: account) as CFDictionary)
+    }
+    #endif
+
+    private static func query(service: String, account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    private static func read(service: String, account: String) -> Data? {
+        var attributes = query(service: service, account: account)
+        attributes[kSecReturnData as String] = true
+        attributes[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let status = SecItemCopyMatching(attributes as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return data
+    }
+
+    @discardableResult
+    private static func write(_ data: Data, service: String, account: String) -> Bool {
+        // Idempotent even if a previous write left something malformed
+        // (e.g. wrong length after a future format change) — always start
+        // from a clean slate rather than risk SecItemAdd's "already exists"
+        // error hiding a stale, unreadable key underneath.
+        SecItemDelete(query(service: service, account: account) as CFDictionary)
+
+        var attributes = query(service: service, account: account)
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        if status != errSecSuccess {
+            NSLog("[ClientIdentityStore] Keychain write failed: status \(status)")
+        }
+        return status == errSecSuccess
+    }
+}

--- a/packages/macos/Remi/HubClient.swift
+++ b/packages/macos/Remi/HubClient.swift
@@ -19,6 +19,7 @@
 //  to promote to.
 //
 
+import CryptoKit
 import Foundation
 
 @MainActor
@@ -34,14 +35,32 @@ final class HubClient: ObservableObject {
     /// whatever daemons happen to live on the standard range.
     private let scanPorts: [Int]
 
-    init(scanPorts: [Int] = Array(basePort..<(basePort + portRange))) {
+    /// This app's Ed25519 identity (#872), for completing the daemon's
+    /// `auth_challenge` handshake. Injectable so tests can give a client its
+    /// own throwaway identity instead of touching the real Keychain item.
+    private let identity: ClientIdentity
+
+    init(
+        scanPorts: [Int] = Array(basePort..<(basePort + portRange)),
+        identity: ClientIdentity = ClientIdentityStore.loadOrCreate()
+    ) {
         self.scanPorts = scanPorts
+        self.identity = identity
     }
 
     enum Phase: Equatable {
         case scanning
         case connected(port: Int, isHub: Bool)
         case unreachable
+        /// A peer answered but rejected this app's identity (#872):
+        /// `require_local_auth` is on and TOFU didn't (or couldn't) trust
+        /// the key — e.g. the daemon runs with `--no-tofu`, or a
+        /// previously-trusted key was later revoked. Distinct from
+        /// `.unreachable` so the UI can say WHY instead of just "not
+        /// running" (issue #872 acceptance: this must read in words, not a
+        /// spinner). `reason` is human-readable, derived from the wire
+        /// error code.
+        case rejected(port: Int, reason: String)
     }
 
     @Published private(set) var phase: Phase = .scanning
@@ -133,6 +152,8 @@ final class HubClient: ObservableObject {
             guard isHub else { return "Session daemon on \(port) (no hub)" }
             let sessionsPart = sessions == 1 ? "1 session" : "\(sessions) sessions"
             return "Hub: running on \(port) · \(sessionsPart)"
+        case let .rejected(port, reason):
+            return "Hub on \(port): \(reason)"
         }
     }
 
@@ -160,6 +181,13 @@ final class HubClient: ObservableObject {
     /// probed first.
     private var lastConnectedPort: Int?
 
+    /// Set while waiting on `auth_result` after signing an `auth_challenge`
+    /// (#872): the decoded challenge bytes and the daemon's raw public key,
+    /// kept so the mutual-auth signature in `auth_result` can be verified
+    /// against the SAME challenge. Cleared by `teardownSocket()` and on
+    /// every terminal outcome of the handshake.
+    private var pendingChallenge: (challengeData: Data, serverPublicKeyRaw: Data)?
+
     /// Stable client id, persisted so the daemon sees one device (#662).
     private let clientId: String = {
         let key = "remi.clientId"
@@ -179,16 +207,21 @@ final class HubClient: ObservableObject {
     }
 
     /// Manual re-check from the onboarding panel's "Check Again" button
-    /// (#773). Only meaningful while unreachable; the isScanning/phase
-    /// guards inside scanAndConnect make this safe to call at any time
-    /// without racing the scheduled backoff rescan into two sockets. If
-    /// this rescan itself fails, scheduleReconnect() cancels whatever
-    /// backoff Task was already pending before scheduling the next one
-    /// (#777 review, finding 3), so repeated manual rescans can't stack
-    /// independent reconnect timers.
+    /// (#773). Only meaningful while unreachable or rejected (#872: a
+    /// rejected connection resolves the same way — a fresh scan-and-connect
+    /// attempt); the isScanning/phase guards inside scanAndConnect make this
+    /// safe to call at any time without racing the scheduled backoff rescan
+    /// into two sockets. If this rescan itself fails, scheduleReconnect()
+    /// cancels whatever backoff Task was already pending before scheduling
+    /// the next one (#777 review, finding 3), so repeated manual rescans
+    /// can't stack independent reconnect timers.
     func rescanNow() {
-        guard case .unreachable = phase else { return }
-        Task { await scanAndConnect(preferring: lastConnectedPort) }
+        switch phase {
+        case .unreachable, .rejected:
+            Task { await scanAndConnect(preferring: lastConnectedPort) }
+        case .scanning, .connected:
+            return
+        }
     }
 
     #if DEBUG
@@ -285,8 +318,20 @@ final class HubClient: ObservableObject {
         self.task = task
         task.resume()
 
-        sendJSON(HelloFrame(clientVersion: clientVersion, clientId: clientId))
+        // Sent immediately, before knowing whether the daemon will
+        // challenge this connection (#872). When `require_local_auth` is
+        // on, the daemon answers this with an AUTH_REQUIRED error while its
+        // state is "authenticating" (harmlessly ignored below, same as any
+        // other unhandled frame type) and we resend hello once the real
+        // auth_challenge/auth_response/auth_result exchange succeeds. When
+        // it's off, this is the only hello sent — unchanged from before
+        // #872. Mirrors the web client (useConnectionManager.ts sendHello).
+        sendHello()
         receiveLoop(task: task, port: port)
+    }
+
+    private func sendHello() {
+        sendJSON(HelloFrame(clientVersion: clientVersion, clientId: clientId))
     }
 
     private func receiveLoop(task: URLSessionWebSocketTask, port: Int) {
@@ -352,8 +397,99 @@ final class HubClient: ObservableObject {
             }
         case "pong":
             missedPongs = 0
+        case "auth_challenge":
+            handleAuthChallenge(data: data, port: port)
+        case "auth_result":
+            handleAuthResult(data: data, port: port)
         default:
             break
+        }
+    }
+
+    // MARK: - Auth (#872)
+
+    /// Sign the challenge with this app's identity and reply with
+    /// `auth_response`. A malformed frame or a signing failure (CryptoKit
+    /// signing over a valid key does not fail in practice, but this app
+    /// must not silently swallow it if it ever does) is logged and leaves
+    /// the connection to time out and retry — there is nothing else useful
+    /// to do with a challenge this app cannot answer.
+    private func handleAuthChallenge(data: Data, port: Int) {
+        guard let frame = try? JSONDecoder().decode(AuthChallengeFrame.self, from: data),
+            let challengeData = Data(base64Encoded: frame.challenge),
+            let serverPublicKeyRaw = Data(base64Encoded: frame.serverPublicKey)
+        else {
+            NSLog("[HubClient] Malformed auth_challenge from port \(port)")
+            return
+        }
+        pendingChallenge = (challengeData, serverPublicKeyRaw)
+        do {
+            let signature = try identity.sign(challengeData)
+            let response = AuthResponseFrame(
+                clientPublicKey: identity.publicKeyRaw.base64EncodedString(),
+                signature: signature.base64EncodedString(),
+                clientFingerprint: identity.fingerprint)
+            sendJSON(response)
+        } catch {
+            NSLog("[HubClient] Failed to sign auth_challenge: \(error)")
+        }
+    }
+
+    /// On success, verify the daemon's mutual-auth signature over the SAME
+    /// challenge before trusting the connection — proof the peer on this
+    /// loopback port actually holds the private key for the fingerprint it
+    /// claims — then resend `hello` (the one sent at connect time was
+    /// rejected with AUTH_REQUIRED while this handshake was in flight). On
+    /// failure, or if the daemon's mutual-auth signature does not verify,
+    /// the connection is torn down and `phase` becomes `.rejected` so the UI
+    /// can say why instead of just "not running".
+    private func handleAuthResult(data: Data, port: Int) {
+        guard let frame = try? JSONDecoder().decode(AuthResultFrame.self, from: data) else {
+            return
+        }
+        guard frame.success else {
+            handleAuthRejected(port: port, reason: Self.describeAuthError(frame.error))
+            return
+        }
+        guard let pending = pendingChallenge,
+            let serverSignature = frame.serverSignature,
+            let signatureData = Data(base64Encoded: serverSignature),
+            let serverKey = try? Curve25519.Signing.PublicKey(
+                rawRepresentation: pending.serverPublicKeyRaw),
+            serverKey.isValidSignature(signatureData, for: pending.challengeData)
+        else {
+            handleAuthRejected(port: port, reason: "the hub's identity could not be verified")
+            return
+        }
+        pendingChallenge = nil
+        sendHello()
+    }
+
+    private func handleAuthRejected(port: Int, reason: String) {
+        teardownSocket()
+        phase = .rejected(port: port, reason: reason)
+        consecutiveFailures += 1
+        scheduleReconnect()
+    }
+
+    /// Human-readable copy for the wire error codes `AuthResultMessage` can
+    /// carry (packages/shared/src/protocol.ts, packages/daemon/src/auth/
+    /// authenticator.ts). `UNKNOWN_KEY` is the one an operator is likely to
+    /// actually hit — the daemon's TOFU defaults to auto-accept (cli.ts
+    /// `tofuMode`), so this only fires with `--no-tofu` or after this key
+    /// was later removed from authorized-keys.
+    nonisolated static func describeAuthError(_ code: String?) -> String {
+        switch code {
+        case "UNKNOWN_KEY":
+            return "the hub does not trust this app yet"
+        case "INVALID_SIGNATURE":
+            return "signature verification failed"
+        case "NO_PENDING_CHALLENGE":
+            return "the handshake timed out"
+        case let code?:
+            return "authentication failed (\(code))"
+        case nil:
+            return "authentication failed"
         }
     }
 
@@ -383,7 +519,12 @@ final class HubClient: ObservableObject {
         }
     }
 
-    private func handleDisconnect() {
+    /// Tears down the socket and per-connection state shared by every
+    /// disconnect path (#872 review: previously duplicated between
+    /// `handleDisconnect()` and the auth-rejected path). Callers are
+    /// responsible for setting `phase` to whichever terminal state applies
+    /// and calling `scheduleReconnect()`.
+    private func teardownSocket() {
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         pingTimer?.invalidate()
@@ -392,6 +533,7 @@ final class HubClient: ObservableObject {
         // running, its in-flight probe could race the backoff reconnect and
         // leave an orphaned socket behind.
         stopBackgroundRescan()
+        pendingChallenge = nil
         localClients = 0
         remoteClients = 0
         sessions = 0
@@ -405,6 +547,10 @@ final class HubClient: ObservableObject {
         // hub_status frame after reconnecting re-syncs both from the real
         // census.
         autostart = nil
+    }
+
+    private func handleDisconnect() {
+        teardownSocket()
         phase = .unreachable
         consecutiveFailures += 1
         scheduleReconnect()

--- a/packages/macos/Remi/HubProtocol.swift
+++ b/packages/macos/Remi/HubProtocol.swift
@@ -74,6 +74,63 @@ struct IncomingFrameType: Decodable {
     let type: String
 }
 
+/// Incoming `auth_challenge` (#872): sent by the daemon the instant a
+/// connection opens, before `hello_ack`, once `[daemon] require_local_auth`
+/// retires the loopback exemption (#869/#873) — or always, for a non-
+/// loopback peer. Mirrors AuthChallengeMessage in protocol.ts.
+///
+/// The daemon may also send `relayEphemeralKey`, `relayKexSignature` and
+/// `answerEncryptionKey` on some challenges (relay transport + phone
+/// lock-screen pinning). Deliberately NOT declared here: this client only
+/// ever uses the direct loopback WebSocket, never the relay, and Decodable
+/// silently ignores keys it doesn't declare — exactly the forward-compat
+/// behavior every other frame in this file already relies on.
+struct AuthChallengeFrame: Decodable {
+    let type: String
+    /// Base64-encoded 32-byte random nonce. Sign the DECODED bytes, never
+    /// this string.
+    let challenge: String
+    let serverFingerprint: String
+    /// Base64 of the daemon's raw 32-byte Ed25519 public key.
+    let serverPublicKey: String
+}
+
+/// Outgoing `auth_response` (#872). Mirrors AuthResponseMessage in
+/// protocol.ts exactly: `clientPublicKey`/`signature` are base64 of RAW
+/// bytes (never PKCS8/DER), `clientFingerprint` is hex. The daemon derives
+/// its own fingerprint from the verified public key and does not trust this
+/// field for authorization (#671) — sent correctly anyway.
+struct AuthResponseFrame: Encodable {
+    let type = "auth_response"
+    let id: String
+    let timestamp: String
+    let clientPublicKey: String
+    let signature: String
+    let clientFingerprint: String
+
+    init(clientPublicKey: String, signature: String, clientFingerprint: String) {
+        self.id = HubProtocol.newId()
+        self.timestamp = HubProtocol.isoTimestamp()
+        self.clientPublicKey = clientPublicKey
+        self.signature = signature
+        self.clientFingerprint = clientFingerprint
+    }
+}
+
+/// Incoming `auth_result` (#872). `error` is one of the codes documented on
+/// AuthResultMessage in protocol.ts (UNKNOWN_KEY, INVALID_SIGNATURE, ...).
+/// `serverSignature`, present only on success, is the daemon's signature
+/// over the same challenge — verifying it is mutual authentication: proof
+/// the peer on this loopback port actually holds the private key for the
+/// fingerprint it claims, not just some other process that happens to be
+/// listening on the port.
+struct AuthResultFrame: Decodable {
+    let type: String
+    let success: Bool
+    let error: String?
+    let serverSignature: String?
+}
+
 /// Incoming `hello_ack`. `sessionId` null means the peer is a session-less
 /// hub (#542); non-null means a legacy single-session daemon answered.
 struct HelloAckFrame: Decodable {

--- a/packages/macos/Remi/HubSetupView.swift
+++ b/packages/macos/Remi/HubSetupView.swift
@@ -15,13 +15,16 @@ struct HubSetupView: View {
 
     var body: some View {
         Group {
-            if case .scanning = hubClient.phase {
+            switch hubClient.phase {
+            case .scanning:
                 scanningView
-            } else {
+            case let .rejected(port, reason):
+                rejectedView(port: port, reason: reason)
+            default:
                 // RemiApp only shows this view while hubClient.hubURL is
-                // nil, which happens only in .scanning or .unreachable —
-                // .connected always has a hub URL. So anything reaching
-                // here that isn't .scanning is .unreachable.
+                // nil, which happens only in .scanning, .rejected or
+                // .unreachable — .connected always has a hub URL. So
+                // anything reaching here is .unreachable.
                 unreachableView
             }
         }
@@ -33,6 +36,44 @@ struct HubSetupView: View {
             ProgressView()
             Text("Looking for a Remi hub…")
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// #872: a hub answered but rejected this app's Ed25519 identity —
+    /// `[daemon] require_local_auth` is on and TOFU either didn't run
+    /// (`--no-tofu`) or a previously-trusted key was revoked. Distinct copy
+    /// from `unreachableView`: the hub IS running, so the install/start
+    /// instructions there would be actively misleading here.
+    private func rejectedView(port: Int, reason: String) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("This app isn't trusted by the hub yet")
+                        .font(.title2)
+                        .bold()
+                    Text(
+                        "Found a Remi hub on port \(port), but it rejected this app's identity: \(reason)."
+                    )
+                    .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(
+                        "New devices are trusted automatically the first time they connect, unless the hub was started with --no-tofu, or this app's key was later removed from its authorized keys."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Button("Check Again") { hubClient.rescanNow() }
+                    Text("This window checks automatically and closes on its own once trusted.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(32)
+            .frame(maxWidth: 560, alignment: .leading)
         }
     }
 

--- a/packages/macos/Remi/RemiApp.swift
+++ b/packages/macos/Remi/RemiApp.swift
@@ -35,6 +35,15 @@ struct RemiApp: App {
                     NSApp.activate(ignoringOtherApps: true)
                 }
             }
+            // A hub answered but rejected this app's identity (#872) — the
+            // onboarding panel explains why in words, same call-to-action
+            // shape as "Set Up Hub…" above.
+            if case .rejected = hubClient.phase {
+                Button("Hub Doesn't Trust This App…") {
+                    openWindow(id: "main")
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+            }
             // The hub confirmed no LaunchAgent is installed (#788): remote
             // access silently stops working after the next logout/reboot.
             // Routes to Settings, the same place the fix lives, via the

--- a/packages/macos/RemiTests/ClientIdentityTests.swift
+++ b/packages/macos/RemiTests/ClientIdentityTests.swift
@@ -1,0 +1,125 @@
+//
+//  ClientIdentityTests.swift
+//  RemiTests
+//
+//  #872: the macOS app's Ed25519 identity. Covers what's testable without a
+//  daemon — Keychain persistence, the fingerprint derivation, and Ed25519
+//  signing/verification — against REAL vectors generated from
+//  packages/shared/src/crypto.ts (the source of truth this must match on
+//  the wire), not invented ones.
+//
+//  Vectors captured via `bun run` against crypto.ts's generateKeyPair(),
+//  fingerprint(), and sign():
+//    publicKeyBase64:  hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc=
+//    fingerprint:      f851bb1f053baacf
+//    challengeBase64:  hbGyBAveiwqpVe4KOI9Ph3WjQ5rEBAjNBAY8JzZ0HSA=
+//    signatureBase64:  8OJYmBhAA/4694uebtoQssikFbMYHIhdmlxTAYZQTkon9EGlv1VQhKqsyDbwWahp3dcIf1EVWX2sfrZ3q/5mAw==
+//
+
+import CryptoKit
+import XCTest
+
+
+final class ClientIdentityTests: XCTestCase {
+    // Distinct service/account per test run so this suite never touches (or
+    // collides with) the real app's Keychain item.
+    private var service = ""
+    private var account = ""
+
+    override func setUp() {
+        super.setUp()
+        let unique = UUID().uuidString
+        service = "live.yooz.remi.tests.\(unique)"
+        account = "ed25519-private-key"
+    }
+
+    override func tearDown() {
+        ClientIdentityStore.resetForTesting(service: service, account: account)
+        super.tearDown()
+    }
+
+    // MARK: - Keychain persistence
+
+    func testLoadOrCreatePersistsAcrossInstantiations() {
+        let first = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        let second = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        XCTAssertEqual(
+            first.publicKeyRaw, second.publicKeyRaw,
+            "a fresh loadOrCreate() call must return the SAME key as before, not regenerate one")
+        XCTAssertEqual(first.fingerprint, second.fingerprint)
+    }
+
+    func testResetForTestingForcesAFreshKey() {
+        let first = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        ClientIdentityStore.resetForTesting(service: service, account: account)
+        let second = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        XCTAssertNotEqual(
+            first.publicKeyRaw, second.publicKeyRaw,
+            "with the Keychain item deleted, loadOrCreate() must generate a new key")
+    }
+
+    func testDistinctServiceAccountPairsGetIndependentKeys() {
+        let a = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        let otherAccount = "\(account)-other"
+        let b = ClientIdentityStore.loadOrCreate(service: service, account: otherAccount)
+        defer { ClientIdentityStore.resetForTesting(service: service, account: otherAccount) }
+        XCTAssertNotEqual(a.publicKeyRaw, b.publicKeyRaw)
+    }
+
+    // MARK: - Fingerprint (known vector from packages/shared/src/crypto.ts)
+
+    func testFingerprintMatchesTypeScriptVector() throws {
+        let publicKeyRaw = try XCTUnwrap(
+            Data(base64Encoded: "hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc="))
+        XCTAssertEqual(publicKeyRaw.count, 32, "Ed25519 public keys are 32 raw bytes")
+        XCTAssertEqual(
+            ClientIdentity.fingerprint(ofPublicKeyRaw: publicKeyRaw), "f851bb1f053baacf")
+    }
+
+    func testFingerprintIsSixteenHexCharacters() {
+        let identity = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        XCTAssertEqual(identity.fingerprint.count, 16)
+        XCTAssertTrue(identity.fingerprint.allSatisfy(\.isHexDigit))
+        // crypto.ts toHex() is lowercase; the daemon compares strings, so
+        // case must match exactly or a correct key would look unauthorized.
+        XCTAssertEqual(identity.fingerprint, identity.fingerprint.lowercased())
+    }
+
+    // MARK: - Signing / verification
+
+    func testSignedChallengeVerifiesAgainstOwnPublicKey() throws {
+        let identity = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        let challenge = Data("auth-challenge-fixture".utf8)
+        let signature = try identity.sign(challenge)
+        XCTAssertTrue(identity.publicKey.isValidSignature(signature, for: challenge))
+    }
+
+    func testSignedChallengeFailsAgainstADifferentKey() throws {
+        let identity = ClientIdentityStore.loadOrCreate(service: service, account: account)
+        let impostor = ClientIdentity(privateKey: .init())
+        let challenge = Data("auth-challenge-fixture".utf8)
+        let signature = try identity.sign(challenge)
+        XCTAssertFalse(impostor.publicKey.isValidSignature(signature, for: challenge))
+    }
+
+    /// Cross-language wire compatibility: a signature produced by the
+    /// TypeScript `sign()` (packages/shared/src/crypto.ts) over a real
+    /// base64 challenge, verified here with CryptoKit exactly the way
+    /// HubClient verifies a daemon's `auth_result.serverSignature`. If the
+    /// byte layout ever drifted (e.g. PKCS8 vs raw), this is what would
+    /// catch it — a same-process round trip (sign then verify with the same
+    /// library) cannot.
+    func testVerifiesASignatureProducedByTheTypeScriptImplementation() throws {
+        let publicKeyRaw = try XCTUnwrap(
+            Data(base64Encoded: "hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc="))
+        let challengeData = try XCTUnwrap(
+            Data(base64Encoded: "hbGyBAveiwqpVe4KOI9Ph3WjQ5rEBAjNBAY8JzZ0HSA="))
+        let signatureData = try XCTUnwrap(
+            Data(
+                base64Encoded:
+                    "8OJYmBhAA/4694uebtoQssikFbMYHIhdmlxTAYZQTkon9EGlv1VQhKqsyDbwWahp3dcIf1EVWX2sfrZ3q/5mAw=="
+            ))
+        let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKeyRaw)
+        XCTAssertTrue(publicKey.isValidSignature(signatureData, for: challengeData))
+    }
+}

--- a/packages/macos/RemiTests/HubClientIntegrationTests.swift
+++ b/packages/macos/RemiTests/HubClientIntegrationTests.swift
@@ -14,6 +14,7 @@
 //  these run for real.
 //
 
+import CryptoKit
 import XCTest
 
 
@@ -37,12 +38,31 @@ final class HubClientIntegrationTests: XCTestCase {
         return binary
     }
 
+    /// #872: how the spawned hub treats loopback auth. `.disabled` is the
+    /// pre-#872 default every other test in this file relies on (`--no-auth`,
+    /// no client identity involved at all). The other two flip on exactly
+    /// what #873 will make the real default: `[daemon] require_local_auth`,
+    /// which is config-file-only (no CLI flag) — see
+    /// packages/daemon/src/config/config.ts.
+    private enum AuthMode {
+        case disabled
+        /// `require_local_auth = true`, TOFU auto-accepts (the daemon's
+        /// real default per cli.ts `tofuMode` — no approval UI to build).
+        case requireLocalAuthTOFU
+        /// `require_local_auth = true` AND `--no-tofu`: an unknown key is
+        /// rejected outright. Exercises HubClient's `.rejected` phase.
+        case requireLocalAuthNoTOFU
+    }
+
     /// Spawns a real hub (session-less `serve`) on `port` with an isolated
     /// $HOME, stored on `process`/`homeDir` for tearDown to clean up. When
     /// `withAutostartInstalled` is set, pre-creates the exact LaunchAgent
     /// artifact `remi --install` would have written (#788) — no
     /// launchctl/systemctl involved, just the fs marker the hub checks for.
-    private func spawnHub(binary: String, port: Int, withAutostartInstalled: Bool = false) throws {
+    private func spawnHub(
+        binary: String, port: Int, withAutostartInstalled: Bool = false,
+        authMode: AuthMode = .disabled
+    ) throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("remi-macos-it-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
@@ -56,12 +76,28 @@ final class HubClientIntegrationTests: XCTestCase {
             try "<plist/>".write(to: plist, atomically: true, encoding: .utf8)
         }
 
+        var arguments = [
+            "serve", "--port", String(port), "--bind", "127.0.0.1",
+            "--no-mdns", "--no-relay", "--no-telegram",
+        ]
+        switch authMode {
+        case .disabled:
+            arguments.append("--no-auth")
+        case .requireLocalAuthTOFU, .requireLocalAuthNoTOFU:
+            arguments.append("--auth")
+            if authMode == .requireLocalAuthNoTOFU {
+                arguments.append("--no-tofu")
+            }
+            let remiDir = home.appendingPathComponent(".remi")
+            try FileManager.default.createDirectory(at: remiDir, withIntermediateDirectories: true)
+            let configPath = remiDir.appendingPathComponent("config.toml")
+            try "[daemon]\nrequire_local_auth = true\n".write(
+                to: configPath, atomically: true, encoding: .utf8)
+        }
+
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: binary)
-        proc.arguments = [
-            "serve", "--port", String(port), "--bind", "127.0.0.1",
-            "--no-mdns", "--no-relay", "--no-telegram", "--no-auth",
-        ]
+        proc.arguments = arguments
         var env = ProcessInfo.processInfo.environment
         env["HOME"] = home.path
         env.removeValue(forKey: "REMI_PORT")
@@ -260,5 +296,61 @@ final class HubClientIntegrationTests: XCTestCase {
         try await Task.sleep(nanoseconds: 2_000_000_000)  // short settle window
         let phaseAfter = await MainActor.run { client.phase }
         XCTAssertEqual(phaseAfter, .connected(port: port, isHub: true))
+    }
+
+    /// #872: with `require_local_auth = true` the daemon challenges this
+    /// connection on open (packages/daemon/src/server/connection.ts sends
+    /// `auth_challenge` immediately) instead of exempting it as a loopback
+    /// peer. The daemon's TOFU defaults to auto-accept (cli.ts `tofuMode`),
+    /// so a brand-new identity should still reach `connected(isHub: true)`
+    /// with no approval step — proving HubClient's sign-and-respond path
+    /// works against the REAL daemon, not just a hand-rolled fixture.
+    func testConnectsThroughRequiredLocalAuthWithTOFU() async throws {
+        let binary = try requireBinary()
+        let port = 18787
+        try spawnHub(binary: binary, port: port, authMode: .requireLocalAuthTOFU)
+
+        let identity = ClientIdentity(privateKey: .init())
+        let client = await MainActor.run { HubClient(scanPorts: [port], identity: identity) }
+        await MainActor.run { client.start() }
+        var connectedAsHub = false
+        for _ in 0..<60 {  // up to ~15 s
+            let phase = await MainActor.run { client.phase }
+            if case .connected(let p, let isHub) = phase, isHub {
+                XCTAssertEqual(p, port)
+                connectedAsHub = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        XCTAssertTrue(
+            connectedAsHub,
+            "HubClient never reached connected(isHub: true) through the real auth handshake")
+    }
+
+    /// #872: `--no-tofu` makes the daemon reject a key it has never seen
+    /// (`UNKNOWN_KEY`) instead of auto-accepting it. HubClient must land on
+    /// `.rejected` with a human-readable reason — not spin forever, and not
+    /// silently fall back to `.unreachable` as if the hub weren't there.
+    func testRejectedWhenNoTofuAndUnknownKey() async throws {
+        let binary = try requireBinary()
+        let port = 18788
+        try spawnHub(binary: binary, port: port, authMode: .requireLocalAuthNoTOFU)
+
+        let identity = ClientIdentity(privateKey: .init())
+        let client = await MainActor.run { HubClient(scanPorts: [port], identity: identity) }
+        await MainActor.run { client.start() }
+        var rejectedReason: String?
+        for _ in 0..<60 {  // up to ~15 s
+            let phase = await MainActor.run { client.phase }
+            if case .rejected(let p, let reason) = phase {
+                XCTAssertEqual(p, port)
+                rejectedReason = reason
+                break
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        let reason = try XCTUnwrap(rejectedReason, "HubClient never reached .rejected")
+        XCTAssertTrue(reason.contains("does not trust"), reason)
     }
 }

--- a/packages/macos/RemiTests/HubProtocolTests.swift
+++ b/packages/macos/RemiTests/HubProtocolTests.swift
@@ -108,6 +108,82 @@ final class HubProtocolTests: XCTestCase {
         XCTAssertEqual(envelope.type, "ack")
     }
 
+    // #872: auth handshake frames. serverPublicKey/challenge here are
+    // arbitrary well-formed base64, not a live capture (a real hub with
+    // require_local_auth needs a client identity to reach — covered instead
+    // by HubClientIntegrationTests' real end-to-end handshake). This test
+    // is about the wire SHAPE: extra fields the daemon may send
+    // (relayEphemeralKey/relayKexSignature/answerEncryptionKey, #543/#875)
+    // must decode cleanly without being declared.
+    private let authChallengeFixture = """
+        {"type":"auth_challenge","id":"b165ec10-6d38-4fc1-b733-fcabd58d1430","timestamp":"2026-07-08T01:29:44.322Z","challenge":"hbGyBAveiwqpVe4KOI9Ph3WjQ5rEBAjNBAY8JzZ0HSA=","serverFingerprint":"f851bb1f053baacf","serverPublicKey":"hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc=","relayEphemeralKey":"unrelated","relayKexSignature":"unrelated","answerEncryptionKey":"unrelated"}
+        """
+    private let authResultSuccessFixture = """
+        {"type":"auth_result","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-08T01:29:44.322Z","success":true,"serverSignature":"8OJYmBhAA/4694uebtoQssikFbMYHIhdmlxTAYZQTkon9EGlv1VQhKqsyDbwWahp3dcIf1EVWX2sfrZ3q/5mAw=="}
+        """
+    private let authResultFailureFixture = """
+        {"type":"auth_result","id":"fd070ecd-17da-4569-9509-55760a9b4ae5","timestamp":"2026-07-08T01:29:44.322Z","success":false,"error":"UNKNOWN_KEY"}
+        """
+
+    func testDecodesAuthChallengeIgnoringUnknownRelayFields() throws {
+        let frame = try JSONDecoder().decode(
+            AuthChallengeFrame.self, from: Data(authChallengeFixture.utf8))
+        XCTAssertEqual(frame.challenge, "hbGyBAveiwqpVe4KOI9Ph3WjQ5rEBAjNBAY8JzZ0HSA=")
+        XCTAssertEqual(frame.serverFingerprint, "f851bb1f053baacf")
+        XCTAssertEqual(frame.serverPublicKey, "hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc=")
+    }
+
+    func testDecodesSuccessfulAuthResult() throws {
+        let frame = try JSONDecoder().decode(
+            AuthResultFrame.self, from: Data(authResultSuccessFixture.utf8))
+        XCTAssertTrue(frame.success)
+        XCTAssertNil(frame.error)
+        XCTAssertEqual(
+            frame.serverSignature,
+            "8OJYmBhAA/4694uebtoQssikFbMYHIhdmlxTAYZQTkon9EGlv1VQhKqsyDbwWahp3dcIf1EVWX2sfrZ3q/5mAw=="
+        )
+    }
+
+    func testDecodesFailedAuthResult() throws {
+        let frame = try JSONDecoder().decode(
+            AuthResultFrame.self, from: Data(authResultFailureFixture.utf8))
+        XCTAssertFalse(frame.success)
+        XCTAssertEqual(frame.error, "UNKNOWN_KEY")
+        XCTAssertNil(frame.serverSignature)
+    }
+
+    func testAuthResponseFrameEncodesRawBase64Fields() throws {
+        let frame = AuthResponseFrame(
+            clientPublicKey: "hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc=",
+            signature: "8OJYmBhAA/4694uebtoQssikFbMYHIhdmlxTAYZQTkon9EGlv1VQhKqsyDbwWahp3dcIf1EVWX2sfrZ3q/5mAw==",
+            clientFingerprint: "f851bb1f053baacf")
+        let data = try JSONEncoder().encode(frame)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["type"] as? String, "auth_response")
+        XCTAssertEqual(
+            object["clientPublicKey"] as? String, "hTsqoOoMHpkLCHTMC3fmWZ0dPf944WBgvCA/zIkd1Lc=")
+        XCTAssertEqual(object["clientFingerprint"] as? String, "f851bb1f053baacf")
+        let id = try XCTUnwrap(object["id"] as? String)
+        XCTAssertNotNil(UUID(uuidString: id))
+        let timestamp = try XCTUnwrap(object["timestamp"] as? String)
+        XCTAssertNotNil(ISO8601DateFormatter.withFractionalSeconds.date(from: timestamp))
+    }
+
+    /// #872: the daemon's real error codes (authenticator.ts) each get
+    /// specific copy; anything else falls back to a generic-but-labeled
+    /// message rather than a blank "authentication failed".
+    func testDescribeAuthErrorCoversKnownAndUnknownCodes() {
+        XCTAssertEqual(
+            HubClient.describeAuthError("UNKNOWN_KEY"), "the hub does not trust this app yet")
+        XCTAssertEqual(
+            HubClient.describeAuthError("INVALID_SIGNATURE"), "signature verification failed")
+        XCTAssertEqual(
+            HubClient.describeAuthError("NO_PENDING_CHALLENGE"), "the handshake timed out")
+        XCTAssertEqual(
+            HubClient.describeAuthError("TOFU_FAILED"), "authentication failed (TOFU_FAILED)")
+        XCTAssertEqual(HubClient.describeAuthError(nil), "authentication failed")
+    }
+
     func testHelloFrameEncodesQueryModeAndWireBasics() throws {
         let hello = HelloFrame(clientVersion: "0.1.0", clientId: "client-1")
         let data = try JSONEncoder().encode(hello)


### PR DESCRIPTION
Part 2 of #869. Gives the macOS menu-bar app an Ed25519 identity so it
can authenticate on loopback once #873 retires the blanket loopback
exemption.

## Why

The capability token from PR #874 works for the CLI, which reads
`~/.remi/capability.key`. The macOS app is sandboxed
(`packages/macos/Remi/Remi.entitlements`: `network.client` only) and
can never read that path by design (#649/#651). It also had zero
`auth_challenge` handling anywhere in `packages/macos`. This gives it
its own identity instead, matching what the web/iOS clients already
do.

No entitlement changes. The sandbox is untouched.

## What changed

- `ClientIdentity.swift` (new): an Ed25519 keypair (CryptoKit),
  generated once and persisted in the app's own Keychain item so the
  daemon's TOFU trust survives relaunches. No new entitlement needed —
  a sandboxed app can read/write its own default-access-group Keychain
  items without `keychain-access-groups`.
- `HubProtocol.swift`: `AuthChallengeFrame` / `AuthResponseFrame` /
  `AuthResultFrame`, matching `AuthChallengeMessage` /
  `AuthResponseMessage` / `AuthResultMessage` in
  `packages/shared/src/protocol.ts` exactly. `relayEphemeralKey`,
  `relayKexSignature`, `answerEncryptionKey` are deliberately left
  undeclared on `AuthChallengeFrame` — `Decodable` ignores keys it
  doesn't know, so those relay/lock-screen-only fields decode cleanly
  without touching this client (which only ever uses the direct
  loopback WebSocket).
- `HubClient.swift`: signs `auth_challenge` with the app identity,
  sends `auth_response`, and on `auth_result` verifies the daemon's
  mutual-auth signature over the same challenge before trusting the
  connection. The `hello` sent immediately at connect time (unchanged
  from before this PR) gets rejected with `AUTH_REQUIRED` while the
  daemon is mid-handshake — harmless, silently ignored like any other
  unhandled frame type — and a second `hello` goes out once auth
  succeeds. This mirrors the web client's `useConnectionManager.ts`
  (`sendHello` on transport open, resent after `auth_result`), not an
  invented pattern.
- New `Phase.rejected(port:reason:)`, distinct from `.unreachable`: a
  hub that answers but rejects this app's key (unknown key under
  `--no-tofu`, or a previously-trusted key later revoked) shows a
  specific message in the onboarding panel and the menu instead of
  "not running" or a spinner.
- `HubSetupView.swift` / `RemiApp.swift`: render the rejected state in
  words, with a "Check Again" retry.

## What I verified

Built the app target and ran the full `RemiTests` suite via
`xcodebuild test` locally (56/56 passed, 0 failures), including two
new integration tests that spawn a **real** `remi serve` binary (not
a mock) with `[daemon] require_local_auth = true`:

- `testConnectsThroughRequiredLocalAuthWithTOFU` — a brand-new
  identity reaches `connected(isHub: true)` through the real
  challenge/response/mutual-verify handshake, with TOFU auto-accepting
  (the daemon's actual default per `cli.ts` `tofuMode` — confirmed by
  reading it, not assumed).
- `testRejectedWhenNoTofuAndUnknownKey` — with `--no-tofu`, the same
  new identity is rejected and `HubClient` lands on
  `.rejected(port, reason)` with "the hub does not trust this app
  yet".

Also added:
- `ClientIdentityTests.swift` — Keychain persistence across
  `loadOrCreate()` calls, a fresh key after `resetForTesting()`,
  fingerprint derivation against a REAL vector generated by running
  `packages/shared/src/crypto.ts`'s own `fingerprint()` via `bun`
  (`f851bb1f053baacf` for a known public key), and a signature
  produced by the TypeScript `sign()` verifying correctly under
  CryptoKit (cross-language wire-format proof, not just a
  sign-then-verify-with-itself round trip).
- `HubProtocolTests.swift` additions — frame decode/encode shape
  tests, including one proving unknown relay fields don't break
  decoding.

## What's untested

- No on-device TestFlight soak. The issue notes this needs a
  TestFlight build to land; I haven't built/shipped one.
- The Keychain item is scoped to `live.yooz.remi.client-identity` for
  the real app but the RemiTests bundle has its own bundle id
  (`live.yooz.remi.tests`, unhosted per `project.yml`), so the
  persistence tests exercise the same code path against a
  test-generated random service/account, not literally the shipping
  app's own Keychain entry.
- No test drives an ACTUAL key revocation mid-session (removing a
  previously-authorized key from the daemon's authorized-keys while
  the app is connected) — only the TOFU-reject-on-first-contact path
  (`--no-tofu`) is covered.

## Judgment calls

- Added mutual-auth verification (checking the daemon's
  `auth_result.serverSignature` against `serverPublicKey` from the
  same challenge) even though the issue's acceptance criteria don't
  explicitly require it. The web client already does this
  (`useConnectionManager.ts`), and skipping it would leave this client
  trusting any process on the port claiming success. Did not add
  persistent host-key pinning across relaunches (unlike the web
  client's known-hosts store) — that's a materially larger feature
  than "give the app an identity" and the daemon's own port can move
  across a rescan, so pinning felt like new lock-out surface the issue
  didn't ask for.
- `Phase.rejected` retries on the same backoff schedule as
  `.unreachable` rather than going terminal, so the app recovers
  automatically once the daemon starts trusting the key (TOFU flips
  it, or `--no-tofu` is removed) without requiring a relaunch.