### PR TITLE
Record ADRs 0009-0011 and refresh plan

### DIFF
--- a/.context/decisions/0009-transport-encryption-scope.md
+++ b/.context/decisions/0009-transport-encryption-scope.md
@@ -1,0 +1,68 @@
+# ADR 0009: Transport encryption applies to the relay only, never to direct connections
+
+**Status:** accepted
+**Date:** 2026-07-28
+**Owner:** Yahya
+
+## Context
+
+remi reaches a daemon over two structurally different transports. A **direct**
+connection (LAN, Tailscale, VPN, SSH tunnel, loopback) is point to point with no
+third party in the path. A **relay** connection routes every byte through a
+Cloudflare Worker that remi does not control.
+
+#543 established that the Worker was receiving `user_input`, answers and device
+tokens as plain JSON, in a product whose first principle is that session data
+never reaches a server. Fixing that raised the obvious follow-on question: does
+the same encryption belong on direct connections too, for consistency?
+
+## Decision
+
+**Encryption is scoped to the transport that has an untrusted intermediary.**
+Relay traffic is end-to-end encrypted; direct connections carry no relay
+encryption and never have. Where the transport already provides privacy and
+authentication (Tailscale, VPN, SSH tunnel, loopback), remi adds nothing on top.
+
+Concretely: `relay-crypto.ts` is imported only by `remote/relay-adapter.ts`.
+`grep -rn "relay-crypto|encryptRelayPayload|sessionKeys" packages/daemon/src/adapters/
+packages/daemon/src/server/` returns nothing, and that emptiness is the invariant
+this ADR protects.
+
+## Consequences
+
+Easier: direct connections stay simple and fast; no key exchange, no per-message
+crypto, no failure mode where a LAN session breaks because a handshake did not
+complete. Users on Tailscale pay nothing for a guarantee they already have.
+
+Harder: the honest description of remi's security is now conditional, and
+conditional claims are the ones that rot. Any statement of the form "remi is
+encrypted" must name the transport. This is exactly the drift `AGENTS.md`
+→ "Verify before you describe" exists to catch, and the relay claim has already
+produced three successive wrong descriptions (#881).
+
+New obligation: a future transport with an intermediary (a hosted broker, a
+push proxy, a third-party tunnel) inherits the relay's requirement, not the
+direct path's exemption. The test is "is there a party in the middle who is not
+the user", not "is it remote".
+
+## Alternatives considered
+
+- **Encrypt everything uniformly.** Rejected. It buys nothing over Tailscale or
+  an SSH tunnel, costs a handshake on every local connection, and adds a failure
+  mode to the path that must be the most reliable. Uniformity would be for the
+  sake of a simpler sentence in the README, not for the user.
+- **Encrypt nothing and document the relay as untrusted.** Rejected as the
+  #543 bug restated: the product claim is that session data does not reach a
+  server, and a documentation caveat does not make that true.
+- **Let the user choose per connection.** Rejected. The correct choice is fully
+  determined by whether an intermediary exists, so exposing it as a setting adds
+  a way to get it wrong with no compensating benefit.
+
+## Receipts
+
+- `packages/shared/src/relay-crypto.ts` — the signed-ephemeral exchange and its
+  own "what it does not do" section
+- `packages/daemon/src/remote/relay-adapter.ts` — sole consumer
+- #543 (relay encryption), #881 (the three wrong descriptions of it, and the
+  finding that the client half was never implemented)
+- `AGENTS.md` → "Verify before you describe"

--- a/.context/decisions/0010-allow-deny-matching-asymmetry.md
+++ b/.context/decisions/0010-allow-deny-matching-asymmetry.md
@@ -1,0 +1,73 @@
+# ADR 0010: Allow matching is precise, deny matching is broad
+
+**Status:** accepted
+**Date:** 2026-07-28
+**Owner:** Yahya
+
+## Context
+
+Auto-approve short-circuits the LLM with two user-supplied pattern lists. Until
+#536 both used the same rule: substring containment against the Bash command
+string. That symmetry looked clean and was a P0 security hole.
+
+With the shipped default `allow = ["Read", "Glob", "Grep"]`, the substring rule
+meant the literal command `cat secrets | sh` was **approved**, because the
+characters `Read` were never required to mean the Read tool — any command
+containing an allow string matched. Verified by running the matcher, not
+inferred.
+
+The fix forces a choice, because the two lists have opposite failure directions.
+An allow rule that matches too much silently grants permission. A deny rule that
+matches too little silently withholds a block. Symmetric matching cannot be
+correct for both.
+
+## Decision
+
+**Allow and deny deliberately do not match the same way.**
+
+Allow is precise. A Bash command is split on `; && || |`, and every segment must
+either match one of the user's prefixes or be a neutral no-op (`cd`, `pwd`,
+`echo`, `true`, `:`). Any segment carrying shell control (backticks, `$()`,
+redirects, `-exec` and its family) is refused even when a prefix matches. An
+entry shaped like a tool name (`Read`, `mcp__*`) matches that **tool** and never
+a Bash command containing the word.
+
+Deny stays a broad substring match, and so does `subagent_alert`. A rule whose
+purpose is to stop something should over-reach rather than under-reach.
+
+## Consequences
+
+Easier: an allow list now means what a reader thinks it means, and the
+catastrophic direction (over-granting) is structurally hard to reach.
+
+Harder: allow patterns are stricter than users expect coming from substring
+semantics, so `allow = ["git"]` no longer covers `git status`. The config
+validator warns on tool-name-shaped entries and on patterns short enough to
+match broadly, which is the mitigation.
+
+New obligation, and the reason this ADR exists: **the asymmetry will look like
+an inconsistency to a future reader and invite a "cleanup" that restores
+symmetry.** Any change making deny precise, or allow substring-based, reopens
+#536. The exec-primitive veto has a specific subtlety worth preserving — it
+fires unless the user's own matched entry already spells the primitive out, so
+`allow = ["find . -delete"]` still works while `allow = ["find ."]` does not
+silently cover `-delete`.
+
+## Alternatives considered
+
+- **Make both precise.** Rejected. A deny list that under-matches is a block the
+  user believes they have and does not. Precision is the wrong bias for a
+  stop rule.
+- **Make both substring.** This was the status quo and the P0.
+- **One list with per-entry mode flags.** Rejected. It pushes a security-critical
+  choice onto the user at the moment they are least likely to reason about it,
+  and the safe default per list is already known.
+
+## Receipts
+
+- `packages/daemon/src/auto-approve/pattern-matcher.ts` — `matchAllowPattern`,
+  `matchSubstringPattern`, `looksLikeToolName`
+- `packages/daemon/src/auto-approve/shell-safety.ts` — `splitCompound`,
+  `hasShellControl`, `hasExecPrimitive`, `NEUTRAL_PREFIXES`, `matchCoveredCommand`
+- #536 (the P0), PR #868 (fix), PR #882 (five stale "substring" descriptions
+  corrected, including the user-facing `remi --help` string)

--- a/.context/decisions/0011-verify-before-you-describe.md
+++ b/.context/decisions/0011-verify-before-you-describe.md
@@ -1,0 +1,80 @@
+# ADR 0011: Security descriptions must be verified against code before they are written
+
+**Status:** accepted
+**Date:** 2026-07-28
+**Owner:** Yahya
+
+## Context
+
+Over one working session, five separate places in this repo were found to
+describe security behavior the code did not have. These were not typos; each one
+hid a real defect, and two of them hid it for months.
+
+| Claim | Reality | Issue |
+|---|---|---|
+| "peer-to-peer, TURN relays encrypted blobs" (`AGENTS.md`) | no WebRTC exists; the Worker was the plaintext data path | #543 |
+| "auto = based on bind address" (`AuthConfig.enabled`) | resolves to `false` on every bind including `0.0.0.0` | #880 |
+| allow patterns match tool names (`config.ts`) | substring match; `Read` covered `cat x \| sh` | #536 (P0) |
+| `relay-adapter-auth.test.ts` "tests the relay adapter" | never constructs one; 29 tests that could not fail | — |
+| "the relay is end-to-end encrypted now" | the client half was never implemented | #881 |
+
+The mechanism is consistent: **a wrong security description reads as "this is
+handled", so nobody looks again.** Docs that overstate protection are more
+dangerous than docs that are missing, because missing docs prompt a reader to
+check.
+
+Two of the wrong claims were written *during the pass that was correcting the
+others*, which is the finding that motivated recording this as a decision rather
+than a style note.
+
+## Decision
+
+**A claim about security behavior must be verified against the code before it is
+written, and the verification is part of the change.**
+
+Codified in `AGENTS.md` → "## Verify before you describe" as five rules:
+
+1. Before citing a doc or comment as evidence something is safe, check the code.
+   One `grep`, one `curl`, one `git log -S`. Every case above was settled by a
+   single command.
+2. A claim about a live data path needs a caller trace. Grep for callers before
+   asserting impact, and before filing the issue.
+3. When code and comment disagree, fix the comment in the same change, even when
+   the behavior fix belongs to someone else. Leave the issue number in the comment.
+4. Say what ships, not what was intended. Aspirations belong in issues.
+5. A test named for a component must construct it.
+
+## Consequences
+
+Easier: claims in this repo become checkable, and a reader can trust a security
+comment enough to build on it.
+
+Harder: writing security documentation is slower, and correcting documentation
+is slower still — the correction pass is where confidence is highest and the
+check is most likely to be skipped. Both errors in this session were made there.
+
+New obligations: reviewers of documentation changes must verify claims rather
+than assess prose, since a well-written wrong claim is the failure mode. The
+`AGENTS.md` table is append-only; new instances get added rather than the
+section being tidied, because the list of past failures is the argument.
+
+## Alternatives considered
+
+- **Treat it as a review checklist item.** Rejected as insufficient: two of the
+  five were introduced *by* a careful review pass. The discipline has to sit with
+  the author at the moment of writing.
+- **Automate it (lint for security claims).** Attractive and not yet tractable —
+  there is no reliable way to detect "this sentence asserts a security
+  property". Revisit if a pattern emerges. Partial automation is possible for
+  the narrower rule 5 (a test file naming a class that it never imports).
+- **Write fewer security comments.** Rejected. The comments are load-bearing;
+  `relay-crypto.ts`'s "what it does not do" section is exactly what a future
+  reader needs. The problem is unverified comments, not comments.
+
+## Receipts
+
+- `AGENTS.md` → "## Verify before you describe"
+- PR #882 (the corrections, and the review that caught two fresh errors in them)
+- #881 — filed three times with three different severities, each earlier version
+  wrong in a way one grep would have prevented. The filing history is kept in
+  the issue body deliberately.

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -5,8 +5,45 @@ Current state, priorities, and the full backlog map live in
 Standing architecture decisions live in [decisions/](decisions/) as ADRs.
 Historical journals live in [archive/](archive/).
 
-Next up (from the handoff's "Important" table): the security floor first,
-#536 then #535, both re-verified live against 0.7.3 on 2026-07-28,
-then the #534 remainder and #375.
-Public documentation in the separate `yooz-docs` repo is being refreshed
-from the 0.5.1 era to 0.7.3 in parallel.
+## Where things stand (2026-07-28, end of day)
+
+**Shipped today, all merged to `develop` (0.7.4-dev):** the security floor
+(#536 allow/deny asymmetry, #535 origin policy), #543 relay encryption
+*daemon side only, see below*, #872 macOS Ed25519 identity, #875 sealed
+lock-screen answers, #869 part 1 (capability token). Public docs refreshed to
+0.7.3 and live at `docs.yooz.live`; `remi.yooz.live` live. TestFlight build 10
+uploaded for macOS and iOS.
+
+**Open, in priority order:**
+
+1. **#881 — the relay path is non-functional end to end.** #543 shipped the
+   daemon half of the key exchange and no client half
+   (`useConnectionManager.ts:213` never passes `relayKex`), so permanent-code
+   mode rejects every real client and rotating-code mode refuses to send.
+   *Latent, not live*: code-pairing is unreachable in the UI (`App.tsx` never
+   passes `onConnectCode`, `mode: 'relay'` is never assigned). Fix it **with**
+   whatever re-enables code-pairing, not before.
+2. **#880 — `auth.enabled = "auto"` resolves to `false` on every bind**,
+   including `0.0.0.0`. Documented, deliberately not fixed: changing the default
+   alters how running daemons accept connections and is the owner's call. Gates
+   #873, and makes #869/#875/#543 inert on a default install since each hangs
+   off an authenticator that does not exist when auth is off.
+3. **#883 — protocol-message fan-out**: 13 non-test files per message type, and
+   a missed consumer fails silently.
+
+**Two epics under exploration** (Fable architects, running as of 2026-07-28):
+
+- *Hook contract + question lifecycle + real-time state.* Map Claude Code's hook
+  contract as a durable artifact, rebuild the question lifecycle on it, then
+  exploit it for thinking/tool-activity/subagent state. Subsumes
+  [plan-eval-quality-and-question-lifecycle.md](plan-eval-quality-and-question-lifecycle.md),
+  which carries the measured baseline: 309 escalations, ~92% LLM verdicts, top
+  causes `rm -rf <build artifact>` (~48) and project file edits (~49).
+- *Module contracts* (#883). Derived from seams that measurably hurt, never
+  designed speculatively; every contract point needs a **two-sided** conformance
+  test. Boundary: the first epic owns the lifecycle state machine, this one owns
+  the declare/dispatch mechanism.
+
+**Standing constraint from today:** transport encryption is scoped to the relay
+only (ADR 0009). Direct, LAN, Tailscale, VPN and SSH-tunnel connections carry no
+relay crypto and should not gain any.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,29 @@ Rules, all cheap:
 5. **A test named for a component must construct it.** If it does not, the name
    is a claim about coverage that is not true.
 
+Recorded as [ADR 0011](.context/decisions/0011-verify-before-you-describe.md).
+
+## Architecture decisions
+
+Standing decisions live in [`.context/decisions/`](.context/decisions/) as ADRs.
+Read the relevant one before changing behavior it covers; several exist
+specifically because the decision looks like an inconsistency worth "cleaning
+up", and the cleanup would reopen a security hole.
+
+| ADR | Decision |
+|---|---|
+| [0001](.context/decisions/0001-transcript-path-source-of-truth.md) | Transcript path is the session source of truth |
+| [0002](.context/decisions/0002-model-b-hold-the-hook-notifications.md) | Hold-the-hook notification model |
+| [0003](.context/decisions/0003-synchronous-permission-decisions.md) | Synchronous permission decisions |
+| [0004](.context/decisions/0004-pty-as-arbiter-subagent-questions.md) | PTY is the arbiter for subagent questions |
+| [0005](.context/decisions/0005-hub-and-attach-only-clients.md) | Hub mode and attach-only clients |
+| [0006](.context/decisions/0006-cc-ref-disavowed.md) | `cc-ref` is not ground truth for Claude Code |
+| [0007](.context/decisions/0007-release-automation-and-pins.md) | Release automation and toolchain pins |
+| [0008](.context/decisions/0008-testflight-local-upload.md) | TestFlight uploads are local, not Xcode Cloud |
+| [0009](.context/decisions/0009-transport-encryption-scope.md) | Encryption is scoped to the relay; direct connections carry none |
+| [0010](.context/decisions/0010-allow-deny-matching-asymmetry.md) | Allow matching is precise, deny is broad — on purpose |
+| [0011](.context/decisions/0011-verify-before-you-describe.md) | Security descriptions must be verified against code |
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Documentation and decision-record consolidation. No code changes.

## Three new ADRs

**[0009] Transport encryption is scoped to the relay; direct connections carry none.**

Records the layering the owner articulated today: encryption exists for the transport with an untrusted intermediary. Direct, LAN, Tailscale, VPN and SSH-tunnel connections carry no relay crypto and never did, verified by `relay-crypto` having zero references in `daemon/src/adapters/` and `daemon/src/server/`. That emptiness is the invariant the ADR protects.

The generalization worth having on record: the test is "is there a party in the middle who is not the user", not "is it remote". A future hosted broker or push proxy inherits the relay requirement, not the direct-path exemption.

**[0010] Allow matching is precise, deny is broad — on purpose.**

The #536 asymmetry, written down because **it will look like an inconsistency and invite a cleanup that reopens the P0.** Under the old symmetric substring rule, the shipped default `allow = ["Read", "Glob", "Grep"]` approved `cat secrets | sh`.

Also preserves the exec-primitive subtlety, which is easy to lose in a refactor: the veto fires unless the user entry already spells the primitive out, so `allow = ["find . -delete"]` works while `allow = ["find ."]` does not silently cover `-delete`.

**[0011] Security descriptions must be verified against code before they are written.**

Records the five confirmed drift cases and the five rules now in `AGENTS.md`. Notes honestly that two of the wrong claims were written *during the pass correcting the others*, which is why this is a decision rather than a style note: the discipline has to sit with the author at the moment of writing, since a careful review pass introduced two of them.

Rejected alternatives are recorded too, including automation, which is not tractable for "does this sentence assert a security property" but may be for the narrower rule 5 (a test file naming a class it never imports).

## AGENTS.md

Adds an "Architecture decisions" index. There was previously **no reference to `.context/decisions/` anywhere in AGENTS.md**, so eleven ADRs were effectively undiscoverable to anyone following the documented read order.

## plan.md

Was stale within the same day: it listed #536 and #535 as "next up" and both merged this afternoon. Rewritten to current state, with the three open items in priority order and the two epics under exploration.

Notably it now records that **#881 is latent rather than live** — the relay is broken end to end, but code-pairing is unreachable in the UI (`App.tsx` never passes `onConnectCode`, `mode: "relay"` never assigned), so it should be fixed *with* whatever re-enables that path rather than ahead of it.

## Testing

Documentation only; no source changes. `bun run typecheck` unaffected.

Relates to #536, #535, #543, #880, #881, #883.