### PR TITLE
Typecheck packages/web in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
+      # The root tsconfig excludes packages/web, so the line above never sees
+      # it. Without this step a type error in the web client — including a
+      # non-exhaustive switch over a protocol message — merges green (#883).
+      # Verified clean when added, so this gate starts with no backlog.
+      - run: bun run typecheck:web
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
     "test:e2e": "bunx playwright test --config tests/e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit",
+    "typecheck:web": "cd packages/web && tsc -p tsconfig.app.json --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",


### PR DESCRIPTION
One-line gate for a real hole found while planning #883.

## The hole

The root `tsconfig.json` **excludes `packages/web/**/*`**, and CI runs only root `bun run typecheck`. Biome does not typecheck, and `bun test` strips types rather than checking them. The web e2e job is `if: false`.

So **`packages/web` has never been typechecked in CI.** A type error in the web client merges green.

This matters beyond the obvious: #883 aims to make a missed protocol consumer a *compile error* instead of a silent non-delivery. Every consumer-side default in the web client is silent today (`App.tsx:1627` is `console.debug`). Building an exhaustiveness mechanism whose failures CI cannot see would be theater. This is the prerequisite.

## The fix

Adds `typecheck:web` (`tsc -p tsconfig.app.json --noEmit` inside `packages/web`) and runs it in the existing Type Check job.

## Verification

**Clean today**, so the gate lands with zero fix-forward backlog:

```
$ bun run typecheck:web
$ echo $?
0
```

**And it actually catches errors** — proven rather than assumed, by appending a deliberate error to `web/src/types/index.ts`:

```
$ bun run typecheck:web 2>&1 | grep -c "error TS"
2
```

then restoring the file and confirming clean again. A gate that has never been observed to fail is not known to work.

## Scope

`tsconfig.app.json` covers `src` only. Web *tests* are typechecked nowhere (their config includes only `src`), which is a second gap — left for #883's conformance work, where a test-side config is needed anyway. Flagged rather than silently half-fixed.

Relates to #883.