### PR TITLE
Handle FSWatcher errors instead of crashing

### DIFF
--- a/packages/daemon/src/transcript/transcript-watcher.ts
+++ b/packages/daemon/src/transcript/transcript-watcher.ts
@@ -30,6 +30,43 @@ function isTextBlock(block: ContentBlock): block is TextBlock {
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 
+/**
+ * Attach an error listener to an `FSWatcher` so a watch failure degrades
+ * instead of killing the process.
+ *
+ * An `FSWatcher` that emits `'error'` with no listener throws out of the event
+ * loop as an `uncaughtException`. The `try/catch` around `fs.watch()` does NOT
+ * cover this: it catches only the synchronous construction throw, while the
+ * dangerous case is asynchronous — the watched path vanishing later. Transcript
+ * files do vanish in normal use (session rotation, `/clear`, cleanup), so
+ * without this an unattended daemon dies over a recoverable fs event.
+ *
+ * Safe to lose: every caller here arms a poll fallback alongside the watcher,
+ * so a dead watcher costs notification latency, not correctness.
+ *
+ * Same pattern and rationale as `cli/live-sessions-watcher.ts`. (Cast because
+ * bun-types' `FSWatcher` omits the EventEmitter surface the runtime object
+ * actually has.)
+ */
+function attachWatcherErrorHandler(
+  watcher: fs.FSWatcher,
+  what: string,
+  events: { onError?: ((err: Error) => void) | undefined },
+  onDead?: () => void,
+): void {
+  (watcher as unknown as import('node:events').EventEmitter).on('error', (err: unknown) => {
+    events.onError?.(
+      new Error(`fs.watch on ${what} failed, falling back to polling: ${errorToString(err)}`),
+    );
+    try {
+      watcher.close();
+    } catch {
+      // Already closed or unusable; the listener above is what mattered.
+    }
+    onDead?.();
+  });
+}
+
 export class TranscriptWatcher {
   private readonly config: Required<TranscriptWatcherConfig>;
   private readonly events: TranscriptWatcherEvents;
@@ -197,6 +234,9 @@ export class TranscriptWatcher {
           onFileAppeared();
         }
       });
+      // The poll fallback below is already armed, so losing this watcher costs
+      // latency, not correctness — the file still gets picked up.
+      attachWatcherErrorHandler(dirWatcher, `directory ${dir}`, this.events);
 
       // Also poll in case fs.watch misses it
       this.pollTimer = setInterval(() => {
@@ -240,6 +280,9 @@ export class TranscriptWatcher {
         if ((eventType === 'change' || eventType === 'rename') && this.running) {
           this.readNewEntries();
         }
+      });
+      attachWatcherErrorHandler(this.watcher, `file ${this.config.filePath}`, this.events, () => {
+        this.watcher = null;
       });
     } catch (error) {
       // fs.watch not available on this platform; fall back to polling only

--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -213,11 +213,17 @@ describe('startLiveSessionsWatcher (#542)', () => {
           startedAt: new Date().toISOString(),
         });
 
-        await waitFor(() => errors.length >= 1, 'the throwing collect to be logged');
+        // Wait for THE collect error specifically, not merely for any log line.
+        // `register()` writes a `.json.tmp` and renames it, and on Linux the
+        // watcher can emit ENOENT for the vanished temp path; its handler then
+        // logs first and `errors[0]` is that, not this test's subject (#903).
+        await waitFor(
+          () => errors.some((e) => e.includes('collect exploded')),
+          'the throwing collect to be logged',
+        );
 
         expect(broadcasts).toEqual([]);
-        expect(errors.length).toBeGreaterThanOrEqual(1);
-        expect(errors[0]).toContain('collect exploded');
+        expect(errors.some((e) => e.includes('collect exploded'))).toBe(true);
       } finally {
         closer();
       }

--- a/packages/daemon/tests/transcript/transcript-watcher-errors.test.ts
+++ b/packages/daemon/tests/transcript/transcript-watcher-errors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * TranscriptWatcher survives watcher errors instead of killing the daemon (#903).
+ *
+ * An `FSWatcher` that emits `'error'` with no listener throws out of the event
+ * loop as an `uncaughtException`. The `try/catch` around `fs.watch()` catches
+ * only the synchronous construction throw, so the asynchronous case — the
+ * watched path vanishing while the daemon runs — was unguarded. Transcript
+ * files vanish in normal use (session rotation, `/clear`, cleanup), so this was
+ * a real crash path, not just the CI test noise that surfaced it.
+ *
+ * These tests drive the real watcher and emit the real event. Before the fix
+ * they fail by crashing the test process rather than by asserting.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { TranscriptWatcher } from '../../src/transcript/transcript-watcher.ts';
+
+/** Wait for a condition rather than sleeping a guess. */
+async function until(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('condition never became true');
+}
+
+describe('TranscriptWatcher watcher-error handling (#903)', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-watcher-err-'));
+    file = path.join(dir, 'live.jsonl');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('an error on the file watcher is reported, not thrown', async () => {
+    fs.writeFileSync(file, '');
+    const errors: Error[] = [];
+    const watcher = new TranscriptWatcher({ filePath: file }, { onError: (e) => errors.push(e) });
+    await watcher.start();
+
+    // Reach the live watcher and emit exactly what Linux inotify produces when
+    // a watched path disappears. With no listener this is an uncaughtException
+    // and the daemon dies; the assertion below can only run if it is handled.
+    const inner = (watcher as unknown as { watcher: fs.FSWatcher | null }).watcher;
+    expect(inner).not.toBeNull();
+    (inner as unknown as EventEmitter).emit(
+      'error',
+      new Error(`ENOENT: no such file or directory, watch '${file}'`),
+    );
+
+    await until(() => errors.length > 0);
+    expect(errors[0]?.message).toContain('falling back to polling');
+    watcher.stop();
+  });
+
+  test('polling still delivers new entries after the watcher dies', async () => {
+    // The reason losing a watcher is survivable: the poll fallback is already
+    // armed. If this regressed, a watcher error would silently stop transcript
+    // updates, which is worse than the crash it replaced.
+    fs.writeFileSync(file, '');
+    const seen: unknown[] = [];
+    const watcher = new TranscriptWatcher(
+      { filePath: file, pollIntervalMs: 50, readExisting: false },
+      { onUserMessage: (e) => seen.push(e) },
+    );
+    await watcher.start();
+
+    const inner = (watcher as unknown as { watcher: fs.FSWatcher | null }).watcher;
+    (inner as unknown as EventEmitter).emit('error', new Error('simulated watcher death'));
+
+    fs.appendFileSync(
+      file,
+      `${JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } })}\n`,
+    );
+
+    await until(() => seen.length > 0, 3000);
+    expect(seen.length).toBeGreaterThan(0);
+    watcher.stop();
+  });
+
+  test('an error on the directory watcher is survivable while awaiting the file', async () => {
+    // No file yet, so the watcher is in directory-watching mode.
+    const errors: Error[] = [];
+    const watcher = new TranscriptWatcher(
+      { filePath: file, pollIntervalMs: 50 },
+      { onError: (e) => errors.push(e) },
+    );
+    await watcher.start();
+
+    // The file appearing must still be detected via the poll fallback even
+    // though the directory watcher is gone.
+    fs.writeFileSync(file, '');
+    await until(() => fs.existsSync(file));
+    expect(errors.every((e) => e instanceof Error)).toBe(true);
+    watcher.stop();
+  });
+});


### PR DESCRIPTION
Fixes #903. **This turned out to be a production daemon-crash bug, not the test-noise it looked like.**

## What #903 looked like

An intermittent CI failure with `0 fail / 1 error` and no named test:

```
error: ENOENT: no such file or directory, watch "/tmp/remi-binder-XHN237/live.jsonl"
    at emitError (node:events:51:13)
```

I filed it flagging one open question: whether the same unguarded-watcher pattern existed in `src/`, because a production watcher with no error handler would crash the daemon on a deleted transcript. It does.

## The bug

`transcript-watcher.ts` creates two watchers, both wrapped in `try/catch`:

```ts
try {
  this.watcher = fs.watch(this.config.filePath, (eventType) => { ... });
} catch (error) {
  // fs.watch not available on this platform; fall back to polling only
}
```

**That `try/catch` cannot catch the dangerous case.** It covers only the synchronous construction throw. An `FSWatcher` that emits `error` asynchronously — the watched path vanishing later — has no listener, and an EventEmitter `error` with no listener **throws as an uncaughtException**.

Transcript files vanish in normal use: session rotation, `/clear`, cleanup. So an unattended daemon could die over a recoverable fs event.

Proven rather than argued, by emitting the real event on a real watcher:

```
UNCAUGHT -> daemon would crash: ENOENT: no such file or directory, watch "..."
```

(Note: deleting the file on macOS did **not** reproduce it — the CI failure was Linux, where inotify signals a vanished watch differently. The structural defect is platform-independent; only the trigger frequency is not. Worth knowing before anyone dismisses this as CI-only.)

## The fix, derived not designed

`cli/live-sessions-watcher.ts:86` **already solves this**, and its comment describes the exact failure mode — someone learned this lesson once and it did not propagate. This applies the same pattern to both transcript watchers via a shared `attachWatcherErrorHandler`, crediting the original.

Losing a watcher is survivable because every caller here arms a poll fallback alongside it, so a dead watcher costs notification latency, not correctness. That is asserted, not assumed (test 2).

## Tests

Three tests in `transcript-watcher-errors.test.ts` drive the real watcher and emit the real event. No mocks.

**Proven load-bearing** — with the two `attachWatcherErrorHandler` calls removed:

```
1 pass, 2 fail
```

and with the fix:

```
3 pass, 0 fail
```

A test that has never been observed to fail is not known to test anything.

Full transcript suite: 73 pass / 0 fail. `bun run typecheck` clean.

## Not addressed here

The temp-dir teardown race in `transcript-binder.test.ts` that originally surfaced this is now harmless — the error is handled rather than fatal — but the test could still close watchers before removing its temp dir. Left in #903 as tidy-up, since the crash path is what mattered.