### PR TITLE
Make ls purpose labels hermetic in tests

### DIFF
--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -194,8 +194,13 @@ describe('remi model ls / ps', () => {
     expect(text).toMatch(/\*\s+yooz-light-v3/);
     expect(text).not.toMatch(/\*\s+yooz-quality-v3/);
     // ...but the engine's choice is still visible, because it holds the GPU
-    // and cannot be deleted.
-    expect(text).toContain('engine active');
+    // and cannot be deleted. #860 made that label say what the model is active
+    // FOR, since a bare "engine active" read as "the engine is using this
+    // instead of yours" and sent a user chasing a problem that did not exist.
+    // This fixture gives the engine-active model a purpose, so it names the
+    // tier; `cmd-model.ts` falls back to a bare "engine active" only when the
+    // purpose is unknown.
+    expect(text).toContain('engine proofread tier');
   });
 
   test('ls distinguishes not-downloaded from on-disk', async () => {

--- a/packages/daemon/tests/cli/cmd-model.test.ts
+++ b/packages/daemon/tests/cli/cmd-model.test.ts
@@ -180,6 +180,12 @@ describe('remi model ls / ps', () => {
     const code = await run(['ls'], configWith({ model: 'yooz-light-v3' }), t.io, {
       probe: async () => REACHABLE,
       inventory: async () => INVENTORY,
+      // `ls` resolves purpose labels via `purposeMap`, which calls `list`.
+      // Without injecting it the call escapes to the REAL engine on :19924 and
+      // the assertion below depends on whether one happens to be running:
+      // locally it printed "engine proofread tier", in CI "engine active".
+      // CATALOG carries no `purpose`, which is the unqualified-label case.
+      list: async () => CATALOG,
     });
 
     expect(code).toBe(0);
@@ -194,13 +200,40 @@ describe('remi model ls / ps', () => {
     expect(text).toMatch(/\*\s+yooz-light-v3/);
     expect(text).not.toMatch(/\*\s+yooz-quality-v3/);
     // ...but the engine's choice is still visible, because it holds the GPU
-    // and cannot be deleted. #860 made that label say what the model is active
-    // FOR, since a bare "engine active" read as "the engine is using this
-    // instead of yours" and sent a user chasing a problem that did not exist.
-    // This fixture gives the engine-active model a purpose, so it names the
-    // tier; `cmd-model.ts` falls back to a bare "engine active" only when the
-    // purpose is unknown.
+    // and cannot be deleted. Unqualified here because CATALOG reports no
+    // purpose; the qualified form is pinned by the next test.
+    expect(text).toContain('engine active');
+  });
+
+  test('ls names what the engine-active model is active FOR when the purpose is known', async () => {
+    // The #860 half of the label. A bare "engine active" read as "the engine is
+    // using this INSTEAD of your model" and sent a user chasing a problem that
+    // did not exist, so the label names the tier when the engine reports one.
+    // Nothing covered this branch before, which is how the sibling test above
+    // could silently depend on a live engine supplying purposes.
+    const t = io();
+    const code = await run(['ls'], configWith({ model: 'yooz-light-v3' }), t.io, {
+      probe: async () => REACHABLE,
+      inventory: async () => INVENTORY,
+      list: async () => ({
+        current: 'yooz-quality-v3',
+        available: [
+          {
+            id: 'yooz-quality-v3',
+            displayName: 'Yooz-Quality',
+            sizeBytes: 2_400_000_000,
+            loaded: true,
+            purpose: 'proofread',
+          },
+        ],
+      }),
+    });
+
+    expect(code).toBe(0);
+    const text = t.out.join('\n');
     expect(text).toContain('engine proofread tier');
+    // The qualified form REPLACES the bare one; printing both would be noise.
+    expect(text).not.toMatch(/,\s+engine active/);
   });
 
   test('ls distinguishes not-downloaded from on-disk', async () => {


### PR DESCRIPTION
Fixes the failing `cmd-model` test on `develop`. **My first attempt at this was wrong and CI caught it — that turned out to be the useful part.**

## What I got wrong first

I saw the test expect `"engine active"` while the code printed `"engine proofread tier"`, matched that against the #860 label change, and concluded the assertion was stale. I updated the string, it passed locally, and **CI failed on the new assertion** — the exact inverse of the local failure.

That inversion is the tell: the test was not stale in either direction, it was **non-hermetic**.

## The actual root cause

`ls` resolves purpose labels through `purposeMap`, which makes a **real network call** and swallows failure:

```ts
// packages/daemon/src/cli/cmd-model.ts:119-135
async function purposeMap(list, baseUrl) {
  const map = new Map();
  try {
    const catalogue = await list(baseUrl);   // real engine call
    ...
  } catch {
    // Label stays unqualified; every other column is unaffected.
  }
  return map;
}
```

The test injected `probe` and `inventory` but **not `list`**, even though `list` is injectable (`cmd-model.ts:224`). So:

- **locally**, with an engine on `127.0.0.1:19924`: purposes resolve, label is `engine proofread tier`
- **in CI**, no engine: `catch`, empty map, label is `engine active`

Whichever string you assert, the test fails in the other environment. It had been passing on developer machines for whatever the local engine happened to report.

## The fix

Inject `list: async () => CATALOG`. `CATALOG` carries no `purpose`, so the unqualified branch is the deterministic outcome, and **the original `"engine active"` assertion is restored** — it was correct all along.

Added a second test pinning the other branch with a catalogue that *does* report a purpose. **Nothing covered that branch before**, which is precisely how the environment leak stayed invisible: the only test touching purpose labels got its purposes from whatever engine was running.

## Verification

Hermeticity proven rather than assumed — replaced the injected `list` with one that throws `ECONNREFUSED`, simulating CI exactly:

```
79 pass / 0 fail        (list throws — the CI condition)
79 pass / 0 fail        (list injected normally, engine running locally)
```

Passes both ways now. Before this change it could only pass one way at a time.

## Note on the other CI failure

That run also showed `push-answer-relay.test.ts > with a pinned key the Worker receives an opaque envelope` failing. Unrelated and intermittent: it passes locally on clean `develop` (22/22), it passed on #906 run, and it uses a real `Bun.serve` on an ephemeral port, so it is a port/timing flake rather than an environment dependency. Not fixed here; called out so it is not mistaken for fallout from this change.