### PR TITLE
Q1: Claude Code hook contract reference + hook-types.ts drift fixes

### DIFF
--- a/docs/claude-code-hook-contract.md
+++ b/docs/claude-code-hook-contract.md
@@ -1,0 +1,392 @@
+# Claude Code hook contract reference
+
+**Version-stamped: Claude Code 2.1.220, extracted 2026-07-28.** This is a
+snapshot, not a promise — see "Version sensitivity" below for how fast this
+contract has already moved, and re-extract before trusting it against a
+different Claude Code version.
+
+Written for #886 (Q1 of epic #885). Produces the reference doc and the
+`hook-types.ts` drift fixes; the capture corpus (#886's second deliverable)
+is explicitly **not** included here — see "What's pending" at the bottom.
+
+## The rule this document follows
+
+**Binary and live captures are ground truth. The published docs page
+(code.claude.com/docs/en/hooks) is the map, not the territory — useful,
+frequently accurate, and demonstrably behind the binary in specific,
+checkable ways (it omits `permission_suggestions` entirely, and it does not
+mention the `DirectoryAdded` event at all — both confirmed below).
+`cc-ref` (`github.com/ultraworkers/claw-code`, a third-party Rust parity
+reimplementation) is not evidence for anything in this document and is not
+cited anywhere in it — see ADR 0006.**
+
+Every claim below is tagged with how it was established:
+
+| Tag | Meaning |
+|---|---|
+| **[B]** | Extracted directly from the installed Claude Code binary (`/Users/yahya/.local/share/claude/versions/2.1.220`) — either its embedded zod validation schemas (for response shapes and hook config) or its hook-input builder functions (for payload shapes). Highest confidence: this is the code that actually runs. |
+| **[D]** | From code.claude.com/docs/en/hooks. Used where it corroborates [B] (noted inline) or where [B] extraction wasn't attempted/possible. Treated as secondary per the rule above — where [B] and [D] disagreed, this document says so explicitly and keeps [B]. |
+| **[R]** | remi's own field notes: things learned from `REMI_HOOK_DEBUG` captures on real sessions (dated), or from remi's own runtime behavior/logging (e.g. observed hook-fire counts). Empirical but scoped to remi's own historical sessions, not a fresh capture for this document — see "What's pending." |
+
+### Extraction method (so this is reproducible against a future version)
+
+The installed binary is a single ~257 MB esbuild bundle containing readable
+(if minified) JavaScript source, including embedded zod (`E.object(...)`,
+`tc.object(...)`) schema definitions with human-readable `.describe(...)`
+strings — these describe fields more precisely than the binary needed to,
+which is presumably why they exist: internal documentation-generation tooling
+reads the same schemas. Two extraction passes:
+
+```bash
+# 1. Every hook-input object-literal construction site (finds all 31 events
+#    and their payload fields in one pass):
+rg -a -o -P 'hook_event_name:"[A-Za-z]+"[^}]{0,260}' <binary>
+
+# 2. The response-schema zod union (hookSpecificOutput per event) and the
+#    hook CONFIG schema (http/command/prompt/agent types), via ripgrep's
+#    dotall mode anchored on a known symbol and read until the containing
+#    expression closes:
+rg -a -o -P '(?s)hookSpecificOutput:E\.union\(\[E\.object\(\{hookEventName:E\.literal\("PreToolUse"\).*?\]\)\.optional\(\)\}\)\),wlt=Se' <binary>
+```
+
+`strings` alone under-extracts: it breaks a "string" at any non-printable
+byte, which chops long minified lines into short fragments. `rg -a` (treat
+binary as text) with a `(?s)`-flagged PCRE anchored on a recognizable
+substring pulls the full surrounding expression instead.
+
+---
+
+## Common fields
+
+Present on every hook input. Source: the shared payload builder in the
+binary, `function Kf(e,t,r){...}`, called at every one of the 31
+`hook_event_name:"..."` construction sites via `{...Kf(...), hook_event_name:
+"X", ...event-specific fields}` **[B]**. Independently corroborated by the
+docs page's own "Common input fields" list **[D]**, which matches field-for-field.
+
+| Field | Type | Notes |
+|---|---|---|
+| `session_id` | `string` | **[B][D]** |
+| `transcript_path` | `string` | **[B][D]** — derived from `session_id` (`nP(session_id)` in the binary) |
+| `cwd` | `string` | **[B][D]** |
+| `permission_mode` | `string` | **[B][D]** Observed enum: `default \| plan \| acceptEdits \| auto \| dontAsk \| bypassPermissions` (binary zod enum `Iet`, matches the docs page's own description of the field). |
+| `hook_event_name` | `string` | **[B][D]** discriminant |
+| `agent_id` | `string \| undefined` | **[B][D][R]** Present only on subagent/team events. remi's own `REMI_HOOK_DEBUG` capture (2026-04-16) is the empirical confirmation cited in `hook-types.ts`; matches the docs page's "for subagents: agent_id, agent_type." |
+| `agent_type` | `string \| undefined` | **[B][D][R]** Same as `agent_id` per remi's capture and the docs page. Worth flagging: the binary's *builder* computes this unconditionally (`o=r?.agentType??eB()`, where `eB()` reads a session-scoped "main thread agent type" default) rather than gating it on `agent_id` being set — so structurally the field is always attempted, and it is almost certainly `undefined` (dropped by `JSON.stringify`) outside agent-team sessions, which is consistent with remi's empirical finding rather than contradicting it. Not fully resolved without a live agent-teams capture — see "What's pending." |
+| `prompt_id` | `string \| undefined` | **[B][D]** — **remi does not currently capture this field anywhere** (`grep -c prompt_id packages/daemon/src/hooks/hook-types.ts` was 0 before this PR). Binary: `prompt_id:gAt()??void 0` (i.e. `Mt.promptId`). Docs page: "UUID identifying the user prompt... Absent until the first user input. Requires Claude Code v2.1.196 or later" — so this is itself a recent addition, and any Claude Code install older than 2.1.196 will never send it. This is the turn-scoped correlation key epic #885 wants for Q9 (authoritative `UserPromptSubmit`-based routing) in place of the current Stop-sweep heuristics. |
+| `effort` | `{ level: string } \| undefined` | **[B][D]** Reasoning-effort override active for the turn, when the model supports effort levels. Binary: `effort:a` where `a=i&&r?.getAppState&&FI(i)?{level:y9(i,s)}:void 0`. Docs page independently lists "effort — Object with a level field." Not something remi's known-drift list named going in; found by reading the builder function directly. |
+
+---
+
+## Blocking semantics — the most important section
+
+**Every hook Claude Code fires to remi's `http` transport is a synchronous
+HTTP roundtrip that Claude Code blocks on, bounded by the hook's configured
+timeout, regardless of whether the response can change anything.** That
+splits into two independent axes, and conflating them is the mistake to avoid
+when deciding what to register:
+
+### Axis 1: transport cost — always paid, for every registered event
+
+Verified directly against the binary's hook-config zod schema **[B]**. There
+are **four** hook transport types, not just the two remi's own code
+(`hook-config-manager.ts`) knows about:
+
+| Type | Fields (exact, from the zod schema) | Has `async`/`asyncRewake`? |
+|---|---|---|
+| `http` | `type, url, if, timeout, headers, allowedEnvVars, statusMessage, once` | **No** |
+| `command` | `type, command, args, if, shell, timeout, statusMessage, once, async, asyncRewake, rewakeMessage, rewakeSummary` | **Yes** |
+| `prompt` | `type, prompt, if, timeout, model, continueOnBlock` | No |
+| `agent` | `type, prompt, if, timeout, model, ...` (not fully enumerated) | No |
+
+`async`/`asyncRewake` ("If true, hook runs in background without blocking" /
+"...and wakes the model on exit code 2") exist **only** on the `command`
+type, confirmed by the exact field list above and independently by the docs
+page ("The `async` field is only defined for command hooks... HTTP hooks
+have only these fields: `type`, `if`, `timeout`, `statusMessage`, `url`,
+`headers`, and `allowedEnvVars`. No async support.") **[D]**.
+
+remi registers exclusively via `type: 'http'` (`hook-config-manager.ts`), and
+uses only `url` and `timeout` of the seven fields available to it (no `if`
+matcher, no `headers`/`allowedEnvVars`, no `statusMessage`, no `once`). One
+schema nuance worth flagging: the binary's zod object for `http` *does*
+accept a `once` field without validation error, but the docs page states
+`once` is "only honored for hooks declared in skill frontmatter; ignored in
+settings files and agent frontmatter" **[D]** — remi writes to
+`.claude/settings.local.json`, so `once` would be schema-legal but
+functionally inert for remi even if it started sending it. Schema tolerance
+and runtime effect are not the same thing; this document tries to be
+specific about which claim it's making in each row.
+
+**The practical consequence for remi: there is no way to register an HTTP
+hook that observes an event "for free."** Every event added to
+`REMI_REGISTERED_HOOK_EVENTS` makes Claude Code wait on remi's daemon before
+it can proceed with that action — a stale or slow daemon can make Claude Code
+unable to submit a prompt, create a worktree, or finish a session, purely
+because a hook nobody needed a decision from is still gating the action
+(#203). This is why `HOOK_EVENT_NAMES` (31, type-complete as of this PR) and
+`REMI_REGISTERED_HOOK_EVENTS` (11, unchanged by this PR) are and must stay
+two different lists.
+
+### Axis 2: semantic power — varies from zero to full override, per event
+
+Whether the hook's JSON response actually changes anything is a **separate**
+question from whether Claude Code waited for it. Source: the response zod
+schema, `Uzg=Se(()=>E.object({continue, suppressOutput, stopReason, decision,
+reason, systemMessage, terminalSequence, hookSpecificOutput}))` **[B]** — every
+hook response is validated against this shape (or, for `command` hooks only,
+the alternate `{async:true, asyncTimeout}` shape that defers the real
+response).
+
+The **generic envelope** — `continue`, `suppressOutput`, `stopReason`,
+`decision` (`"approve"|"block"`), `reason`, `systemMessage`, `terminalSequence`
+— applies to every event that gets dispatched to a resolver at all. Beyond
+that, `hookSpecificOutput` is a zod union of **20** per-event object shapes
+(not 31 — see the table below); sending `hookSpecificOutput` for an event
+outside that union of 20 would fail Claude Code's own response validation.
+
+| Semantic power | Events | What the response can do |
+|---|---|---|
+| **Full override** | `PreToolUse` | `permissionDecision` (allow/deny/ask/defer), `permissionDecisionReason`, `updatedInput` (rewrite the tool call), `additionalContext` |
+| **Full override** | `PermissionRequest` | `decision: {behavior:"allow", updatedInput?, updatedPermissions?}` or `{behavior:"deny", message?, interrupt?}` — this is Model B (ADR 0002/0003): the entire synchronous verdict channel remi uses today |
+| **Rewrite results** | `PostToolUse` | `updatedToolOutput`, `updatedMCPToolOutput` (rewrite what the model sees), `additionalContext` |
+| **Rewrite content** | `MessageDisplay` | `displayContent` — literally replaces a streamed message delta on screen |
+| **Steer the turn** | `UserPromptSubmit` | `additionalContext`, `sessionTitle`, `suppressOriginalPrompt`, plus the generic `decision:"block"` to reject the prompt outright |
+| **Steer the turn** | `SessionStart` | `additionalContext`, `initialUserMessage`, `sessionTitle`, `watchPaths`, `reloadSkills` |
+| **Resolve MCP dialog** | `Elicitation`, `ElicitationResult` | `action` (`accept\|decline\|cancel`), `content` — can programmatically answer or override an MCP elicitation |
+| **Retry signal** | `PermissionDenied` | `retry: boolean` |
+| **Watch registration** | `CwdChanged`, `FileChanged` | `watchPaths` |
+| **Required echo** | `WorktreeCreate` | `worktreePath` is **required** (not optional) in this one's response object — a hook handling this event must supply the created worktree's absolute path |
+| **Context only** | `UserPromptExpansion`, `Setup`, `SubagentStart`, `PostToolUseFailure`, `PostToolBatch`, `Stop`, `SubagentStop`, `Notification` | `additionalContext` only, beyond the generic envelope |
+| **Generic envelope only — no event-specific power at all** | `PreCompact`, `PostCompact`, `ConfigChange`, `DirectoryAdded`, `InstructionsLoaded`, `SessionEnd`, `StopFailure`, `TaskCreated`, `TaskCompleted`, `TeammateIdle`, `WorktreeRemove` | Sending `hookSpecificOutput` for any of these 11 events fails validation — nothing beyond `continue`/`decision`/`systemMessage`/`reason`/`terminalSequence` is honored |
+
+**Reading this table correctly:** a hook registered for, say, `SessionEnd`
+still costs a full synchronous roundtrip (axis 1) even though its response
+can do nothing but append a system message or block the generic decision
+(axis 2, bottom row). Cost is uniform; power is not. This is the analysis
+epic #885 asked this document to make explicit before Q4/Q7 decide what else
+to register — a genuinely powerful new capability (e.g. `PermissionDenied`'s
+`retry`, or `Elicitation`'s programmatic resolution) is a different cost/benefit
+case than an event whose response can only leave a comment.
+
+---
+
+## Full event catalog
+
+31 events total in the 2.1.220 binary, confirmed by counting distinct
+`hook_event_name:"..."` construction sites **[B]**. remi's `HOOK_EVENT_NAMES`
+tracked 22 before this PR; the 9 missing (`Setup`, `UserPromptExpansion`,
+`PermissionDenied`, `PostToolBatch`, `MessageDisplay`, `CwdChanged`,
+`FileChanged`, `DirectoryAdded`, `TaskCreated`) are added by this PR at the
+type level only (not registered — see the blocking-semantics section).
+
+Legend: **Reg.** = in `REMI_REGISTERED_HOOK_EVENTS` today. **Resp.** = has a
+dedicated `hookSpecificOutput` response schema (see the semantic-power table
+above for what it does).
+
+| Event | Reg. | Input fields beyond common | Resp. | Evidence |
+|---|:-:|---|:-:|---|
+| `PreToolUse` | Y | `tool_name, tool_input, tool_use_id?` | Y | [B] matches remi's pre-existing type |
+| `PostToolUse` | Y | `tool_name, tool_input, tool_response, tool_use_id?, duration_ms` | Y | [B] `duration_ms` was missing (named in #886) |
+| `PostToolUseFailure` | Y | `tool_name, tool_input, error, tool_use_id?, is_interrupt?, duration_ms?` | Y (context only) | [B] 3 input fields were missing (named in #886) |
+| `PostToolBatch` | — | `tool_calls: unknown[]` | Y | [B] new type this PR; per-item shape not traced |
+| `PermissionDenied` | — | `tool_name, tool_input, tool_use_id?, reason?` | Y (`retry`) | [B] new type this PR; unlike `PermissionRequest`, DOES carry `tool_use_id` |
+| `PermissionRequest` | Y | `tool_name, tool_input, permission_suggestions?` — **no `tool_use_id`** | Y (full decision) | [B] confirms the "no tool_use_id" conclusion in `hook-types.ts` was correct; only its citation (cc-ref) was wrong |
+| `UserPromptExpansion` | — | `expansion_type, command_name, command_args?, command_source?, prompt` | Y (context only) | [B] new type this PR |
+| `PreCompact` | — | `trigger, custom_instructions?` | — | [B] was typed `source`; binary sends `trigger`. Named in #886 |
+| `PostCompact` | — | `trigger, compact_summary?` | — | [B] same `source`→`trigger` correction; `compact_summary` named in #886 |
+| `ConfigChange` | — | `source, file_path` | — | [B] was typed `config_type: string`, which **does not exist** in the binary at all — see "Renames, not additions" below |
+| `DirectoryAdded` | — | `directory, source?` | — | [B] new type this PR. **Not documented on code.claude.com/docs/en/hooks** — confirmed by direct page search, see "Version sensitivity" |
+| `Elicitation` | — | `mcp_server_name, message?, mode?, url?, elicitation_id?, requested_schema?` | Y | [B] only `mcp_server_name` was typed before this PR |
+| `ElicitationResult` | — | `mcp_server_name, elicitation_id?, mode?, action?, content?` | Y | [B] same |
+| `CwdChanged` | — | `old_cwd, new_cwd` | Y (`watchPaths`) | [B] new type this PR |
+| `FileChanged` | — | `file_path, event` | Y (`watchPaths`) | [B] new type this PR |
+| `InstructionsLoaded` | — | `file_path, memory_type, load_reason, globs?, trigger_file_path?, parent_file_path?` | — | [B] was typed `source: string`, which **does not exist** in the binary at all |
+| `MessageDisplay` | — | `turn_id, message_id, index, final?, delta?` | Y (`displayContent`, can replace on-screen text) | [B] new type this PR |
+| `Notification` | Y | `message, title?, notification_type` (8-value enum, widened this PR — see below) | Y (context only) | [B][D] |
+| `SessionStart` | Y | `source?, model?, agent_type?, session_title?` | Y | [B][D] `model` was wrongly required; docs explicitly say "not guaranteed to be present." `agent_type`/`session_title` were untyped |
+| `Setup` | — | `trigger` | Y (context only) | [B] new type this PR |
+| `SubagentStart` | Y | `agent_type` | Y (context only) | [B] matches pre-existing type |
+| `SessionEnd` | Y | `reason` | — | [B] matches pre-existing type |
+| `StopFailure` | Y | `error_type` (kept, but see below), `error?, error_details?, last_assistant_message?` | — | [B] `error_type` **does not exist** in the binary; see "A real bug this verification found" |
+| `SubagentStop` | Y | `agent_type, agent_transcript_path?, last_assistant_message?, background_tasks?, session_crons?` | Y (context only) | [B] shares its builder with `Stop`; see below |
+| `Stop` | Y | `stop_hook_active, last_assistant_message?, background_tasks?, session_crons?` | Y (context only) | [B] issue #886 named this field `session_tasks`; binary shows `background_tasks` + `session_crons` instead — the issue's exploration guessed wrong here |
+| `TeammateIdle` | — | `teammate_name, team_name` | — | [B] was an empty event body |
+| `TaskCreated` | — | `task_id, task_subject, task_description, teammate_name, team_name` | — | [B] new type this PR |
+| `TaskCompleted` | — | `task_id, task_subject, task_description, teammate_name, team_name` | — | [B] was an empty event body |
+| `UserPromptSubmit` | — | `prompt, session_title` | Y | [B][D] this is Q9's proposed authority source — the human's typed input, direct from Claude Code, no transcript parsing |
+| `WorktreeCreate` | — | `name` | Y (`worktreePath` **required**) | [B] new field this PR |
+| `WorktreeRemove` | — | `worktree_path` | — | [B] new field this PR |
+
+### Renames, not additions: `ConfigChange` and `InstructionsLoaded`
+
+Two of the pre-existing types didn't just lack fields — the field they *did*
+have doesn't exist in the binary at all:
+
+- `ConfigChangeHookInput` was typed `config_type: string`. The binary's
+  builder sends `{source, file_path}`; there is no `config_type` key
+  anywhere. Checked for consumers before changing this (`grep -rn
+  "config_type\b" packages/`): the only occurrence in the whole repo was the
+  type definition itself. Nothing reads it, so this rename has no runtime
+  effect.
+- `InstructionsLoadedHookInput` was typed `source: string`. The binary sends
+  `{file_path, memory_type, load_reason, globs?, trigger_file_path?,
+  parent_file_path?}` — again, no `source` key. Same check, same result:
+  zero consumers.
+
+Both are corrected in this PR as straight renames (old field removed, real
+fields added), not additive shims, because leaving the wrong field present
+would misrepresent the contract for no benefit — nothing in this repo relies
+on the old name.
+
+### A real bug this verification found: `StopFailure.error_type`
+
+`StopFailureHookInput` was typed `error_type: string`, and
+`hook-event-bridge.ts:509` builds a user-facing retry prompt from it:
+`` `Session stop failed (${input.error_type}). Retry?` ``. The binary's
+StopFailure builder sends `{error, error_details, last_assistant_message}` —
+**no `error_type` field exists.** On every real `StopFailure` event,
+`input.error_type` is `undefined`, so that prompt has read **"Session stop
+failed (undefined). Retry?"** since it was written.
+
+This is a real, previously-unknown production bug, not a documentation gap —
+but fixing `hook-event-bridge.ts` to read `input.error` instead is a runtime
+behavior change, which is explicitly out of scope for this PR (see "Critical
+constraint" in the PR description). `hook_types.ts` now carries the real
+fields (`error`, `error_details?`, `last_assistant_message?`) alongside the
+legacy `error_type` (kept, unremoved, specifically so this PR doesn't also
+have to touch the three existing test fixtures that construct `{error_type:
+'timeout'}` payloads). Filed as **#905** with the fix and the fixture updates
+it needs; referenced from the type definition.
+
+### `Stop` / `SubagentStop`: `background_tasks` + `session_crons`, not `session_tasks`
+
+Issue #886's own known-drift list named the extra `Stop`/`SubagentStop` field
+`session_tasks`. The binary shows the actual shared builder constructs a
+conditional spread `...f` where `f = i ? {background_tasks:
+cip(i.taskRegistry.all()), session_crons: uip()} : void 0` — two fields, and
+neither is spelled the way the issue guessed. This is flagged explicitly
+because the issue was written from exploration rather than extraction, and
+this document's whole purpose is to stop propagating exactly that kind of
+plausible-but-wrong field name forward.
+
+### `Notification.notification_type`: widened from 4 to 8 values
+
+The pre-existing type had `'permission_prompt' | 'idle_prompt' |
+'auth_success' | 'elicitation_dialog'`. The binary contains a dedicated
+tab-separated documentation-table resource (`path:"notification_type",
+values:[...]`) listing exactly 8 values: the original 4 plus
+`elicitation_complete`, `elicitation_response`, `agent_needs_input`,
+`agent_completed`. Widened to all 8 (additive, so existing `===
+'permission_prompt'` comparisons in `hook-event-bridge.ts` keep typechecking
+unchanged).
+
+Left **out**: `computer_use_enter`, `computer_use_exit`, `push_notification`,
+`worker_permission_prompt`, `chrome_permission_prompt`,
+`workflow_permission_prompt` — these also appear as literal
+`notificationType:"..."` call-site values elsewhere in the binary, but they
+read as belonging to a different internal subsystem (a Chrome-extension
+bridge / desktop-notification path) rather than the `Notification` hook
+specifically. Not confident enough to assert either way from static
+extraction alone — an open question for the capture corpus.
+
+---
+
+## Version sensitivity
+
+This contract will drift, and has already drifted once inside the versions
+that matter to remi:
+
+- **`permission_suggestions` changed shape around Claude Code 2.0.54** — from
+  plain string labels (Edit's `["Yes","Always","No"]`) to a structured array
+  of typed "permission update entries" (`addRules`, `addDirectories`,
+  `setMode`, `removeRules`, `replaceRules`, `removeDirectories`). remi's
+  `PermissionSuggestion` type already models both shapes (#718); this
+  document's binary extraction of the `vlt` zod schema **[B]** confirms that
+  comment is accurate, and adds the one destination value it was missing
+  (`cliArg`, alongside `session`/`localSettings`/`projectSettings`/`userSettings`).
+- **`prompt_id` requires Claude Code >= 2.1.196** per the docs page **[D]** —
+  itself a recent addition, not something present since hooks shipped. An
+  install even a handful of versions behind 2.1.220 may not send it at all;
+  code consuming it needs to treat its absence as normal, not an error.
+- **The event set grows between versions, and remi's own knowledge of it has
+  lagged twice now.** `cc-ref` (disavowed, ADR 0006) modeled 3 of 25+ events
+  at the time it was in use. remi's own pre-#886 `HOOK_EVENT_NAMES` knew 22.
+  The installed 2.1.220 binary has 31. Nothing about this trend suggests 31
+  is final.
+- **The docs page lags the binary, in more than the already-known
+  `permission_suggestions` gap.** Verified directly for this document: the
+  string `"DirectoryAdded"` does not appear anywhere on
+  code.claude.com/docs/en/hooks (confirmed via a direct, targeted page
+  search, not an oversight in this document's own reading) even though the
+  event is live in the binary with its own input builder. Treat an event's
+  absence from the docs page as evidence of nothing — check the binary.
+- **`agent_type` on the common-fields envelope has a resolved-vs-structural
+  tension** noted in the common-fields table above: the builder computes it
+  unconditionally, but remi's own capture says it correlates with `agent_id`
+  presence in practice. Both can be true (default-undefined outside
+  agent-team sessions), but this needs a live capture to close out, not
+  another reading of the minified builder.
+
+---
+
+## Layering: hooks are upstream of, and orthogonal to, relay encryption
+
+The hook path and the relay-encryption path do not intersect. Verified for
+this document:
+
+```
+$ grep -rn "relay-crypto\|encryptRelay\|sessionKeys" packages/daemon/src/hooks/
+(no output)
+```
+
+`HookServer` (`packages/daemon/src/hooks/hook-server.ts`) is a **loopback-only
+HTTP listener** (`hostname: '127.0.0.1'` by default) that Claude Code's own
+`http`-type hook POSTs directly to on the same machine — it never touches the
+WebSocket transport, the signaling relay, or any of the relay's encryption
+machinery (ADR 0009: encryption is scoped to the relay; direct connections,
+including this loopback path, carry none by design, not by omission). The
+server's own doc comment underscores this is a real attack surface in its own
+right (#535: any local process, including a browser page, can POST a forged
+hook body to it — mitigated by an `Origin`-header refusal, not by scoping).
+The point for this document: a decision made in the hook layer (what remi
+registers, what it answers) has zero bearing on relay transport security, and
+vice versa — they are two separate trust boundaries that happen to both sit
+in front of the same daemon.
+
+---
+
+## What's pending: the capture corpus (#886 part 2)
+
+**Not included in this PR, and not fabricated to look included.** #886's
+second deliverable is a scrubbed fixture corpus built from a week of real
+Claude Code sessions run with `REMI_HOOK_DEBUG=1` (and `REMI_QUESTION_TRACE=1`
+for the question-lifecycle side), checked into the repo, that a drift test
+would validate this document's types against on every future Claude Code
+upgrade. That requires running the owner's real daily sessions over
+real work for about a week — it is not something producible inside this PR,
+and guessing at what such a capture would show would be exactly the kind of
+unverified claim ADR 0011 exists to prevent.
+
+Concretely still open:
+
+- No drift test exists. `hook-types.ts`'s new/corrected fields are verified
+  against static extraction from the 2.1.220 binary, which is strong evidence
+  for *shape* but cannot observe *runtime frequency*, *ordering*, or
+  *version-to-version stability* the way a capture corpus would.
+- The `agent_type` common-field tension (structural-vs-empirical, above) needs
+  a live agent-teams capture to resolve.
+- The `Notification.notification_type` values left out (Chrome-bridge /
+  desktop-notification-looking ones) need a capture to confirm whether any of
+  them can actually arrive via the `Notification` hook.
+- The sequential-tool-permission-hook-dispatch assumption
+  (`auto-approve-gate.ts`'s duplicate-re-request cancellation) is **explicitly
+  unverified** — see the PR description's "What I could NOT verify"
+  section. This is the #885 epic's named experiment and needs a live,
+  targeted capture (fire two identical-signature `PermissionRequest`s and
+  observe dispatch order), not the general-purpose corpus above.
+
+Until the corpus exists, treat every **[B]**-tagged claim in this document as
+"true of the 2.1.220 binary's static shape," not "observed live," and
+re-verify anything load-bearing before building on it across a Claude Code
+version boundary.

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -28,10 +28,21 @@
  * concurrent agents (main + a subagent, #419) keep separate records and a
  * later subagent hook cannot clobber the main agent's option labels (#425).
  *
- * Upstream context (anthropics/claude-code #23983): subagent / Agent-Teams
- * permission requests do not fire PermissionRequest hooks at all. The PTY
- * is the only source for those. A PTY-only push path (no preceding hook
- * record) is therefore a first-class case here, not a fallback.
+ * Stale-as-written correction (#886): this comment used to claim subagent /
+ * Agent-Teams permission requests never fire PermissionRequest hooks at all,
+ * citing upstream anthropics/claude-code #23983. That is contradicted by
+ * AutoApproveGate.resolvePermission's own logging (auto-approve-gate.ts
+ * ~1150): a live 0.6.22 session recorded 16 subagent-tagged (`agent_id`
+ * present) PermissionRequest hooks against only 2 PTY renders. Task-tool /
+ * background-subagent escalations DO fire the hook -- they are parked
+ * (ADR 0004) and passed through unconditionally, and MOST never render,
+ * which is different from "never fires." What #23983 may still describe
+ * correctly is narrower: native Agent-Teams teammate prompts specifically
+ * (as opposed to Task-tool subagents generally) possibly firing no hook at
+ * all. That narrower claim was not independently re-verified here. Either
+ * way, a PTY-only push path (no preceding hook record) stays a first-class
+ * case in this tracker, not a fallback -- it just is not the ONLY source for
+ * subagent prompts the way this comment previously implied.
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -2055,13 +2055,27 @@ export class AutoApproveGate {
       // so this can never find/cancel itself).
       //
       // Baked-in assumption: Claude Code processes a turn's tool-permission
-      // hooks SEQUENTIALLY (verified against the cc-ref reference source,
-      // conversation.rs:370's sequential for-loop), so two identical-signature
-      // MAIN-context escalations can never be genuinely concurrent/live at
-      // once -- an incoming duplicate always means the earlier one is dead. If
-      // Claude Code ever parallelizes main-context tool-permission dispatch,
-      // this invariant breaks and this check would need a stronger key (e.g.
+      // hooks SEQUENTIALLY, so two identical-signature MAIN-context
+      // escalations can never be genuinely concurrent/live at once -- an
+      // incoming duplicate always means the earlier one is dead. If Claude
+      // Code ever parallelizes main-context tool-permission dispatch, this
+      // invariant breaks and this check would need a stronger key (e.g.
       // requiring tool_use_id) before it could keep firing safely.
+      //
+      // UNVERIFIED (#886): this used to cite cc-ref's conversation.rs:370 as
+      // proof of sequential dispatch. cc-ref is a disavowed third-party
+      // reimplementation (ADR 0006) and was never valid evidence for Claude
+      // Code's actual concurrency model, and static extraction from the
+      // installed binary (strings + minified-source reading, #886's method
+      // for everything else in this file) cannot settle a runtime ordering
+      // question either -- there is no way to observe dispatch order without
+      // firing two identical-signature PermissionRequests back-to-back
+      // against a live Claude Code and watching what arrives. That capture
+      // is the #885 epic's named experiment and has not been run. Until it
+      // is, treat this as a load-bearing, unverified assumption, not a
+      // verified fact -- behavior is left unchanged here because the
+      // alternative (a stronger key) is a real design change that needs its
+      // own testing, not a side effect of a documentation pass.
       this.cancelExternallyResolved(observed, 'duplicate-re-request');
       this.openQuestionSignatures.set(questionId, {
         toolName: observed.toolName,

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -2,15 +2,30 @@
  * TypeScript types for Claude Code hook event payloads.
  *
  * Claude Code HTTP hooks POST JSON to a configured URL when events fire.
- * These types match the documented hook input schemas.
- * Reference: Claude Code hooks documentation (claude --help or docs.anthropic.com)
+ * These types are extracted from the installed Claude Code 2.1.220 binary
+ * (`strings` + a handful of targeted regex pulls over the minified bundle),
+ * cross-checked against code.claude.com/docs/en/hooks where the docs cover
+ * the same ground. The binary wins on any disagreement (ADR 0006 disavows
+ * cc-ref; it is not consulted here). Full extraction methodology, the
+ * response-schema side of the contract, and the blocking-semantics analysis
+ * live in `docs/claude-code-hook-contract.md` (#886) — read that first if
+ * you are about to add a field here from a hunch rather than a capture.
  */
 
-/** Fields present in all hook event payloads */
+/** Fields present in all hook event payloads. Source: the common payload
+ *  builder in the 2.1.220 binary (`function Kf(e,t,r){...return{session_id:n,
+ *  transcript_path:nP(n),cwd:xt(),prompt_id:gAt()??void 0,permission_mode:e,
+ *  agent_id:r?.agentId,agent_type:o,effort:a}}`, `o=r?.agentType??eB()`)
+ *  plus code.claude.com/docs/en/hooks "Common input fields", which lists the
+ *  same set independently (#886). */
 export interface HookCommonInput {
   session_id: string;
   transcript_path: string;
   cwd: string;
+  /** Values observed: 'default' | 'plan' | 'acceptEdits' | 'auto' | 'dontAsk' |
+   *  'bypassPermissions' (binary enum `Iet`, confirmed by the docs page's
+   *  permission_mode description, #886). Left as an open string because this
+   *  file doesn't need to reject a future 7th mode to stay useful. */
   permission_mode: string;
   hook_event_name: HookEventName;
   /** Set ONLY on events originating from a subagent (background Task/Agent).
@@ -21,8 +36,28 @@ export interface HookCommonInput {
    *  through auto-approve into main's PTY. */
   agent_id?: string;
   /** Subagent type identifier (e.g. "general-purpose", "feature-dev:code-architect").
-   *  Only present when agent_id is set. */
+   *  Only present when agent_id is set. code.claude.com/docs/en/hooks agrees
+   *  ("And for subagents: agent_id, agent_type") even though the raw builder
+   *  computes this unconditionally (`r?.agentType??eB()`, defaulting to a
+   *  session-scoped "main thread agent type" that reads as unset outside
+   *  agent-team sessions) — kept empirical rather than re-derived from the
+   *  builder shape alone; needs a live capture to fully resolve (#886 part 2). */
   agent_type?: string;
+  /** UUID identifying the current user turn (binary: `prompt_id:gAt()??void 0`,
+   *  i.e. `Mt.promptId`). Per the docs page, absent until the first user input
+   *  and requires Claude Code >= 2.1.196 — this file's version stamp (2.1.220)
+   *  postdates that, but older installs will not send it. remi does not
+   *  currently read this field anywhere; it is the turn-scoped correlation key
+   *  Q9 (#885) wants for authoritative UserPromptSubmit-based routing. */
+  prompt_id?: string;
+  /** Reasoning-effort override active for this turn, when the model in use
+   *  supports effort levels (binary: `effort:a` where
+   *  `a=i&&r?.getAppState&&FI(i)?{level:y9(i,s)}:void 0`; confirmed
+   *  independently by the docs page's "effort — Object with a level field").
+   *  `level` is drawn from the same set the model-info schema calls
+   *  `supportedEffortLevels` ("low"|"medium"|"high"|"xhigh"|"max") but that
+   *  mapping wasn't traced far enough to assert as a closed union here. */
+  effort?: { level: string };
 }
 
 // --- Original 5 events ---
@@ -42,18 +77,65 @@ export interface PostToolUseHookInput extends HookCommonInput {
   tool_input: Record<string, unknown>;
   tool_response: unknown;
   tool_use_id?: string;
+  /** Binary: `duration_ms:l` on the PostToolUse builder. How long the tool
+   *  call took, in milliseconds (#886). */
+  duration_ms?: number;
 }
 
 export interface NotificationHookInput extends HookCommonInput {
   hook_event_name: 'Notification';
   message: string;
   title?: string;
-  notification_type: 'permission_prompt' | 'idle_prompt' | 'auth_success' | 'elicitation_dialog';
+  /**
+   * Binary confirms `notification_type` is drawn from a wider set than this
+   * file tracked before #886. A dedicated docs-table resource inside the
+   * 2.1.220 binary (tab-separated `path:"notification_type",values:[...]`)
+   * lists exactly these 8: permission_prompt, idle_prompt, auth_success,
+   * elicitation_dialog, elicitation_complete, elicitation_response,
+   * agent_needs_input, agent_completed. Widened to that full 8 here — the
+   * original 4 are unchanged so existing `=== 'permission_prompt'` etc.
+   * comparisons (hook-event-bridge.ts) keep typechecking.
+   *
+   * NOT included: `computer_use_enter`/`computer_use_exit`/`push_notification`/
+   * `worker_permission_prompt`/`chrome_permission_prompt`/
+   * `workflow_permission_prompt`, which also appear as literal
+   * `notificationType:"..."` call-site values elsewhere in the binary. These
+   * look like they belong to a different internal notification subsystem
+   * (Chrome-extension bridge, desktop notifications) rather than the
+   * Notification hook specifically, but that boundary was not traced far
+   * enough to assert either way. Open question for the #886 part 2 capture.
+   */
+  notification_type:
+    | 'permission_prompt'
+    | 'idle_prompt'
+    | 'auth_success'
+    | 'elicitation_dialog'
+    | 'elicitation_complete'
+    | 'elicitation_response'
+    | 'agent_needs_input'
+    | 'agent_completed';
 }
 
 export interface StopHookInput extends HookCommonInput {
   hook_event_name: 'Stop';
   stop_hook_active: boolean;
+  /** Binary: `last_assistant_message:p` on the shared Stop/SubagentStop
+   *  builder. The final assistant turn text before Claude stopped (#886). */
+  last_assistant_message?: string;
+  /**
+   * Binary: a conditional spread `...f` where
+   * `f=i?{background_tasks:cip(i.taskRegistry.all()),session_crons:uip()}:void 0`
+   * on the SAME builder that produces both Stop and SubagentStop. Present
+   * when a tool-use context is available at fire time.
+   *
+   * NOTE: issue #886's known-drift list named this field `session_tasks`;
+   * the binary shows `background_tasks` + `session_crons` instead — this is
+   * one of the places the issue's own exploration guessed wrong (see the PR
+   * description). Left loosely typed since `cip`/`uip`'s per-item shape
+   * wasn't traced.
+   */
+  background_tasks?: unknown[];
+  session_crons?: unknown;
 }
 
 export interface SessionStartHookInput extends HookCommonInput {
@@ -63,18 +145,30 @@ export interface SessionStartHookInput extends HookCommonInput {
    *  session_id through flows that emit other source values (or omit the
    *  field entirely), and restart detection downstream is source-agnostic. */
   source?: string;
-  model: string;
+  /** code.claude.com/docs/en/hooks: "Only SessionStart hooks can receive a
+   *  model field, and it is not guaranteed to be present" — was typed
+   *  required here; corrected to optional (#886). */
+  model?: string;
+  /** Binary: `agent_type:n` on the SessionStart builder — distinct from (and
+   *  in addition to) the common `agent_type` field; not yet disambiguated
+   *  against it (#886). */
+  agent_type?: string;
+  /** Binary: `session_title:r??fv(t!==void 0?SA(t):kt())` — always resolves
+   *  to a string in practice (falls back to a derived title), but kept
+   *  optional pending a live capture (#886). */
+  session_title?: string;
 }
 
-// --- 20 new events ---
+// --- 20 new events (pre-#886) ---
 
 /**
  * One entry in `permission_suggestions`. Strings are the legacy binary-label
  * shape (e.g. Edit's `["Yes", "Always", "No"]`).
  *
- * Objects are a "permission update entry" (ground truth:
- * code.claude.com/docs/en/hooks, #718) — the SAME shape Claude Code's own
- * permission-update API uses, discriminated by `type`:
+ * Objects are a "permission update entry" — the SAME shape Claude Code's own
+ * permission-update API uses, discriminated by `type`. Confirmed directly
+ * against the 2.1.220 binary's zod schema (`vlt=Se(()=>tc.discriminatedUnion(
+ * "type",[...]))`, #886), not just the docs:
  *   - `{type:"addRules", rules:[{toolName, ruleContent?}], behavior:"allow"|
  *     "deny"|"ask", destination}` — add a rule; only `behavior:"allow"` is a
  *     "yes"-shaped suggestion the daemon can render as a one-tap option.
@@ -86,7 +180,8 @@ export interface SessionStartHookInput extends HookCommonInput {
  *     destination}` — grant/revoke directory access; only `addDirectories`
  *     is a "yes" variant.
  *   - `destination` is `"session" | "localSettings" | "projectSettings" |
- *     "userSettings"` on every variant.
+ *     "userSettings" | "cliArg"` on every variant (binary enum `hor`; the
+ *     5th value, `cliArg`, was missing from this comment until #886).
  *
  * `optionsFromSuggestions` (hook-event-bridge.ts) is the single place that
  * interprets this union into option labels; an answer that picks a
@@ -107,14 +202,19 @@ export interface PermissionRequestHookInput extends HookCommonInput {
   tool_input: Record<string, unknown>;
   permission_suggestions?: PermissionSuggestion[];
   /**
-   * Cheap future-proofing (#673): NOT sent by Claude Code today (confirmed
-   * against the cc-ref reference source — the PermissionRequest struct there
-   * carries only tool_name/input/modes/reason, no tool_use_id), unlike
-   * PreToolUse/PostToolUse which already do. Declared as an optional
-   * passthrough field so that if a future Claude Code version adds it, the
-   * external-resolution correlation in AutoApproveGate can prefer an exact
-   * id match over the tool_name+tool_input signature fallback with zero
-   * further plumbing.
+   * Cheap future-proofing (#673): NOT sent by Claude Code today. Verified
+   * directly against the installed 2.1.220 binary (#886): the PermissionRequest
+   * hook-input builder constructs exactly
+   * `{...Kf(o,void 0,n),hook_event_name:"PermissionRequest",tool_name:e,
+   * tool_input:r,permission_suggestions:i}` — no `tool_use_id` key anywhere in
+   * it, unlike PreToolUse/PostToolUse/PostToolUseFailure/PermissionDenied,
+   * which all do carry one. (Previously this comment cited cc-ref, a
+   * disavowed third-party reimplementation — ADR 0006 — for the same
+   * conclusion; the conclusion was right, the citation wasn't.) Declared as
+   * an optional passthrough field so that if a future Claude Code version
+   * adds it, the external-resolution correlation in AutoApproveGate can
+   * prefer an exact id match over the tool_name+tool_input signature
+   * fallback with zero further plumbing.
    */
   tool_use_id?: string;
 }
@@ -125,17 +225,44 @@ export interface PostToolUseFailureHookInput extends HookCommonInput {
   tool_name: string;
   tool_input: Record<string, unknown>;
   error: string;
+  /** Binary: PostToolUseFailure builder also carries `tool_use_id`,
+   *  `is_interrupt`, `duration_ms` alongside `error` (#886). */
+  tool_use_id?: string;
+  is_interrupt?: boolean;
+  duration_ms?: number;
 }
 
 /** Fired when the user submits a prompt */
 export interface UserPromptSubmitHookInput extends HookCommonInput {
   hook_event_name: 'UserPromptSubmit';
+  /** Binary: `hook_event_name:"UserPromptSubmit",prompt:e,...!1,
+   *  session_title:fv(kt())` — the human's typed input, handed to the hook
+   *  directly. This is the authority source Q9 (#885) wants in place of
+   *  transcript-JSONL filtering. Was typed as an empty event body before
+   *  #886; the `...!1` spread in the minified source looks like a
+   *  build-time-folded conditional (spreading `false` is a no-op in JS), not
+   *  a real extra field. */
+  prompt: string;
+  session_title: string;
 }
 
 /** Fired when instructions are loaded */
 export interface InstructionsLoadedHookInput extends HookCommonInput {
   hook_event_name: 'InstructionsLoaded';
-  source: string;
+  /**
+   * Binary: `{...Kf(void 0),hook_event_name:"InstructionsLoaded",file_path:e,
+   * memory_type:t,load_reason:r,globs:o,trigger_file_path:i,
+   * parent_file_path:s}` (#886) — there is no `source` field at all. The
+   * pre-#886 type (`source: string`) never matched anything Claude Code
+   * actually sends; nothing in this repo reads `.source` off this type, so
+   * the rename is a pure correction, not a behavior change.
+   */
+  file_path: string;
+  memory_type: string;
+  load_reason: string;
+  globs?: unknown;
+  trigger_file_path?: string;
+  parent_file_path?: string;
 }
 
 /** Fired when a subagent starts */
@@ -148,68 +275,247 @@ export interface SubagentStartHookInput extends HookCommonInput {
 export interface SubagentStopHookInput extends HookCommonInput {
   hook_event_name: 'SubagentStop';
   agent_type: string;
+  /** Binary: SubagentStop shares its builder with Stop (same `f`/`p`
+   *  locals); see StopHookInput for the background_tasks/session_crons
+   *  provenance note (#886). */
+  agent_transcript_path?: string;
+  last_assistant_message?: string;
+  background_tasks?: unknown[];
+  session_crons?: unknown;
 }
 
 /** Fired when a task completes */
 export interface TaskCompletedHookInput extends HookCommonInput {
   hook_event_name: 'TaskCompleted';
+  /** Binary: `{...Kf(i),hook_event_name:"TaskCompleted",task_id:e,
+   *  task_subject:t,task_description:r,teammate_name:n,team_name:o}` (#886).
+   *  Was typed as an empty event body before this. */
+  task_id: string;
+  task_subject: string;
+  task_description: string;
+  teammate_name: string;
+  team_name: string;
 }
 
 /** Fired when the stop hook itself fails */
 export interface StopFailureHookInput extends HookCommonInput {
   hook_event_name: 'StopFailure';
+  /**
+   * Binary: `{...Kf(void 0,void 0,t),hook_event_name:"StopFailure",
+   * error:s,error_details:e.errorDetails,last_assistant_message:i}` where
+   * `s=e.error??"unknown"` (#886) — there is no `error_type` field. `error`
+   * is kept alongside the pre-existing (wrong) `error_type` rather than
+   * replacing it, because `error_type` is read at runtime
+   * (hook-event-bridge.ts:509, `Session stop failed (${input.error_type})`)
+   * and by several test fixtures; removing it here would be a type change
+   * with a real behavior consequence (a user-facing message going from
+   * "undefined" to something else), which is out of scope for this PR. Filed
+   * as #905: `hook-event-bridge.ts` reads a field Claude Code never sends, so
+   * that retry prompt has shown "(undefined)" since it was written.
+   */
   error_type: string;
+  error?: string;
+  error_details?: unknown;
+  last_assistant_message?: string;
 }
 
 /** Fired when a teammate agent becomes idle */
 export interface TeammateIdleHookInput extends HookCommonInput {
   hook_event_name: 'TeammateIdle';
+  /** Binary: `{...Kf(r),hook_event_name:"TeammateIdle",teammate_name:e,
+   *  team_name:t}` (#886). Was typed as an empty event body before this. */
+  teammate_name: string;
+  team_name: string;
 }
 
 /** Fired when configuration changes */
 export interface ConfigChangeHookInput extends HookCommonInput {
   hook_event_name: 'ConfigChange';
-  config_type: string;
+  /**
+   * Binary: `{...Kf(void 0),hook_event_name:"ConfigChange",source:e,
+   * file_path:t}` (#886) — there is no `config_type` field; renamed to match.
+   * Nothing in this repo reads `.config_type` off this type (ConfigChange
+   * isn't in REMI_REGISTERED_HOOK_EVENTS and no dynamic listener uses it
+   * either), so this rename has no runtime consumers to break.
+   */
+  source: string;
+  file_path: string;
 }
 
 /** Fired when a git worktree is created */
 export interface WorktreeCreateHookInput extends HookCommonInput {
   hook_event_name: 'WorktreeCreate';
+  /** Binary: `{...Kf(void 0),hook_event_name:"WorktreeCreate",name:e}` (#886).
+   *  Note the RESPONSE schema for this event requires the hook to echo back
+   *  an absolute `worktreePath` (see docs/claude-code-hook-contract.md) —
+   *  the input's `name` is the worktree's short name, not its path. */
+  name: string;
 }
 
 /** Fired when a git worktree is removed */
 export interface WorktreeRemoveHookInput extends HookCommonInput {
   hook_event_name: 'WorktreeRemove';
+  /** Binary: `{...Kf(void 0),hook_event_name:"WorktreeRemove",
+   *  worktree_path:e}` (#886). */
+  worktree_path: string;
 }
 
 /** Fired before context compaction */
 export interface PreCompactHookInput extends HookCommonInput {
   hook_event_name: 'PreCompact';
-  source: string;
+  /** Binary: `{...Kf(void 0),hook_event_name:"PreCompact",trigger:e.trigger,
+   *  custom_instructions:e.customInstructions}` (#886) — was typed as
+   *  `source`; Claude Code sends `trigger` (values include "manual"|"auto"
+   *  per the docs matcher table). Renamed, not left as an alias, since
+   *  nothing in this repo reads `.source` off PreCompactHookInput either. */
+  trigger: string;
+  custom_instructions?: string;
 }
 
 /** Fired after context compaction */
 export interface PostCompactHookInput extends HookCommonInput {
   hook_event_name: 'PostCompact';
-  source: string;
+  /** Binary: `{...Kf(void 0),hook_event_name:"PostCompact",trigger:e.trigger,
+   *  compact_summary:e.compactSummary}` (#886) — same `source` -> `trigger`
+   *  correction as PreCompact. */
+  trigger: string;
+  compact_summary?: string;
 }
 
 /** Fired when an MCP server requests input via elicitation */
 export interface ElicitationHookInput extends HookCommonInput {
   hook_event_name: 'Elicitation';
   mcp_server_name: string;
+  /** Binary: `{...Kf(n),hook_event_name:"Elicitation",mcp_server_name:e,
+   *  message:t,mode:s,url:a,elicitation_id:l,requested_schema:r}` (#886) —
+   *  every field beyond mcp_server_name was previously untyped. */
+  message?: string;
+  mode?: string;
+  url?: string;
+  elicitation_id?: string;
+  requested_schema?: unknown;
 }
 
 /** Fired after an elicitation result is collected */
 export interface ElicitationResultHookInput extends HookCommonInput {
   hook_event_name: 'ElicitationResult';
   mcp_server_name: string;
+  /** Binary: `{...Kf(n),hook_event_name:"ElicitationResult",
+   *  mcp_server_name:e,elicitation_id:a,mode:s,action:t,content:r}` (#886). */
+  elicitation_id?: string;
+  mode?: string;
+  action?: string;
+  content?: unknown;
 }
 
 /** Fired when the session ends */
 export interface SessionEndHookInput extends HookCommonInput {
   hook_event_name: 'SessionEnd';
   reason: string;
+}
+
+// --- 9 events added in #886 (present in the 2.1.220 binary; the pre-#886
+// HOOK_EVENT_NAMES list only knew 22 of the 31 that actually exist) ---
+
+/** Fired once at session setup, before SessionStart proper. */
+export interface SetupHookInput extends HookCommonInput {
+  hook_event_name: 'Setup';
+  /** Binary: `{...Kf(void 0),hook_event_name:"Setup",trigger:e}` (#886). */
+  trigger: string;
+}
+
+/** Fired when a slash command / skill invocation expands into its prompt. */
+export interface UserPromptExpansionHookInput extends HookCommonInput {
+  hook_event_name: 'UserPromptExpansion';
+  /** Binary: `{...Kf(i),hook_event_name:"UserPromptExpansion",
+   *  expansion_type:e,command_name:t,command_args:r,command_source:n,
+   *  prompt:o}` (#886). */
+  expansion_type: string;
+  command_name: string;
+  command_args?: unknown;
+  command_source?: string;
+  prompt: string;
+}
+
+/** Fired when a permission classifier denies a tool call outright (no prompt
+ *  render). Unregistered in remi today (#885 epic context: "a classifier-
+ *  denied permission currently leaves a pending card with no resolution
+ *  signal"). */
+export interface PermissionDeniedHookInput extends HookCommonInput {
+  hook_event_name: 'PermissionDenied';
+  /** Binary: `{...Kf(i,void 0,o),hook_event_name:"PermissionDenied",
+   *  tool_name:e,tool_input:r,tool_use_id:t,reason:n}` (#886). Unlike
+   *  PermissionRequest, this one DOES carry tool_use_id. */
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_use_id?: string;
+  reason?: string;
+}
+
+/** Fired for a batch of tool calls post-execution (parallel tool calls). */
+export interface PostToolBatchHookInput extends HookCommonInput {
+  hook_event_name: 'PostToolBatch';
+  /** Binary: `{...Kf(n,void 0,r),hook_event_name:"PostToolBatch",
+   *  tool_calls:e}` (#886). Per-item shape of `tool_calls` wasn't traced. */
+  tool_calls: unknown[];
+}
+
+/** Fired per streamed-message-delta while a message is being displayed. The
+ *  response schema for this one can literally replace what's shown on
+ *  screen (`displayContent`) — see docs/claude-code-hook-contract.md. */
+export interface MessageDisplayHookInput extends HookCommonInput {
+  hook_event_name: 'MessageDisplay';
+  /** Binary: `{...Kf(void 0),hook_event_name:"MessageDisplay",
+   *  turn_id:e.turnId,message_id:e.messageId,index:e.index,final:e.final,
+   *  delta:e.delta}` (#886). */
+  turn_id: string;
+  message_id: string;
+  index: number;
+  final?: boolean;
+  delta?: string;
+}
+
+/** Fired when the working directory changes mid-session. */
+export interface CwdChangedHookInput extends HookCommonInput {
+  hook_event_name: 'CwdChanged';
+  /** Binary: `{...Kf(void 0),hook_event_name:"CwdChanged",old_cwd:e,
+   *  new_cwd:t}` (#886). */
+  old_cwd: string;
+  new_cwd: string;
+}
+
+/** Fired when a watched file changes (see SessionStart/CwdChanged/FileChanged
+ *  response schemas' `watchPaths`, docs/claude-code-hook-contract.md). */
+export interface FileChangedHookInput extends HookCommonInput {
+  hook_event_name: 'FileChanged';
+  /** Binary: `{...Kf(void 0),hook_event_name:"FileChanged",file_path:e,
+   *  event:t}` (#886). */
+  file_path: string;
+  event: string;
+}
+
+/** Fired when a directory is added to the allowed-directories set. NOT
+ *  documented on code.claude.com/docs/en/hooks as of this writing (verified
+ *  by direct page search, #886) — present in the binary only. */
+export interface DirectoryAddedHookInput extends HookCommonInput {
+  hook_event_name: 'DirectoryAdded';
+  /** Binary: `{...Kf(void 0),hook_event_name:"DirectoryAdded",directory:e,
+   *  source:t}` (#886). */
+  directory: string;
+  source?: string;
+}
+
+/** Fired when a teammate/task is created (Agent-Teams). Sibling of
+ *  TaskCompleted; same field set. */
+export interface TaskCreatedHookInput extends HookCommonInput {
+  hook_event_name: 'TaskCreated';
+  /** Binary: `{...Kf(i),hook_event_name:"TaskCreated",task_id:e,
+   *  task_subject:t,task_description:r,teammate_name:n,team_name:o}` (#886). */
+  task_id: string;
+  task_subject: string;
+  task_description: string;
+  teammate_name: string;
+  team_name: string;
 }
 
 /** Discriminated union of all hook event inputs */
@@ -235,9 +541,26 @@ export type HookInput =
   | PostCompactHookInput
   | ElicitationHookInput
   | ElicitationResultHookInput
-  | SessionEndHookInput;
+  | SessionEndHookInput
+  | SetupHookInput
+  | UserPromptExpansionHookInput
+  | PermissionDeniedHookInput
+  | PostToolBatchHookInput
+  | MessageDisplayHookInput
+  | CwdChangedHookInput
+  | FileChangedHookInput
+  | DirectoryAddedHookInput
+  | TaskCreatedHookInput;
 
-/** Valid hook event names */
+/** Valid hook event names. 31 total, matching the full set present in the
+ *  installed Claude Code 2.1.220 binary (#886) — the 22 above this line
+ *  predate #886; the 9 below it were added there (`Setup`,
+ *  `UserPromptExpansion`, `PermissionDenied`, `PostToolBatch`,
+ *  `MessageDisplay`, `CwdChanged`, `FileChanged`, `DirectoryAdded`,
+ *  `TaskCreated`). This is a type-level completeness fix only: adding a name
+ *  here does NOT register it (see REMI_REGISTERED_HOOK_EVENTS below, which is
+ *  unchanged by #886 — every registration is a synchronous HTTP roundtrip
+ *  that gates Claude Code, #203). */
 export const HOOK_EVENT_NAMES = [
   'PreToolUse',
   'PostToolUse',
@@ -261,6 +584,15 @@ export const HOOK_EVENT_NAMES = [
   'Elicitation',
   'ElicitationResult',
   'SessionEnd',
+  'Setup',
+  'UserPromptExpansion',
+  'PermissionDenied',
+  'PostToolBatch',
+  'MessageDisplay',
+  'CwdChanged',
+  'FileChanged',
+  'DirectoryAdded',
+  'TaskCreated',
 ] as const;
 
 export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
@@ -281,6 +613,13 @@ export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
  * you add a new typed handler in HookServer.dispatch or a dynamic listener
  * in setupHookBridge, also add the event name here so the registration
  * actually fires.
+ *
+ * Deliberately UNCHANGED by #886: that issue added 9 names to
+ * HOOK_EVENT_NAMES for type completeness (so HookServer/isValidHookEvent
+ * recognize them if Claude Code sends one unprompted), which is not the same
+ * decision as opting remi into paying for them on every turn. Registering
+ * PermissionDenied/Elicitation is Q4's call to make, deliberately, not a side
+ * effect of a documentation pass.
  */
 export const REMI_REGISTERED_HOOK_EVENTS = [
   'PreToolUse',

--- a/packages/daemon/src/hooks/index.ts
+++ b/packages/daemon/src/hooks/index.ts
@@ -36,5 +36,14 @@ export type {
   ElicitationHookInput,
   ElicitationResultHookInput,
   SessionEndHookInput,
+  SetupHookInput,
+  UserPromptExpansionHookInput,
+  PermissionDeniedHookInput,
+  PostToolBatchHookInput,
+  MessageDisplayHookInput,
+  CwdChangedHookInput,
+  FileChangedHookInput,
+  DirectoryAddedHookInput,
+  TaskCreatedHookInput,
 } from './hook-types.ts';
 export { HOOK_EVENT_NAMES, isValidHookEvent } from './hook-types.ts';

--- a/packages/daemon/src/hooks/subagent-context-tracker.ts
+++ b/packages/daemon/src/hooks/subagent-context-tracker.ts
@@ -26,7 +26,13 @@
 
 /** Tool names that spawn a nested agent context.
  *  - `Task`: standard Claude Code subagent spawn
- *  - `Agent`: cc-ref reference name; include for safety in case variants ship
+ *  - `Agent`: NOT a cc-ref-only name (that citation, ADR 0006, was wrong) --
+ *    the installed 2.1.220 binary carries a real tool-name alias table
+ *    (`TLi={Task:"Agent",KillShell:"TaskStop",...}`, looked up via
+ *    `s9(name)`) that maps the internal `Task` tool name to `Agent` for
+ *    permission-rule matching, so a user's `Agent(*)` rule matches calls
+ *    Claude Code fires as `Task`. Kept for the same defensive reason, now on
+ *    firmer evidence (#886).
  *  - Future tools: teammate-spawning, delegation, etc. Add here as Claude Code evolves.
  *  When adding, also extend the regression tests. */
 const NESTING_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent']);


### PR DESCRIPTION
## Summary

Implements the agent-doable portion of Q1 (#886): the contract reference doc
(part 1) and the `hook-types.ts` drift fixes (part 3). **Part 2 (the capture
corpus) is explicitly NOT included** — see "What's not here" below.

- `docs/claude-code-hook-contract.md` — version-stamped (Claude Code 2.1.220,
  extracted 2026-07-28), all 31 hook events with payloads and response
  schemas, the blocking-semantics analysis (transport cost vs semantic
  power), version-sensitivity notes, and the relay-encryption layering note.
- `packages/daemon/src/hooks/hook-types.ts` — corrected against the installed
  binary: 9 new event names added to `HOOK_EVENT_NAMES` (type-level only —
  `REMI_REGISTERED_HOOK_EVENTS`, which gates what actually costs Claude Code
  a synchronous roundtrip, is unchanged), `prompt_id` + `effort` added to
  common fields, and every known field drift fixed or extended.
- Both cc-ref citations named in the issue replaced, plus a third one found
  while doing this (`subagent-context-tracker.ts`) — see "cc-ref" below.
- The stale `question-presence-tracker.ts` comment claiming subagent
  permission requests fire no hooks, corrected.
- Filed **#905**: a real, previously-unknown bug this verification turned
  up (`StopFailure` retry prompts have read "(undefined)" since they were
  written — see below). Not fixed here; fixing it is a runtime behavior
  change, out of scope for a type/comment-only PR.

**These are type and comment changes only. `REMI_REGISTERED_HOOK_EVENTS` is
unchanged; no new hook is registered; no runtime behavior changes.**

## Evidence method

Extracted directly from the installed Claude Code binary
(`/Users/yahya/.local/share/claude/versions/2.1.220`) — an esbuild bundle
with readable (minified) source, including embedded zod schemas with
`.describe()` strings. Two passes: one over every
`hook_event_name:"X",...fields` object-literal construction site (payload
shapes, all 31 events), one over the response `hookSpecificOutput` zod union
and the hook-config schema (http/command/prompt/agent types). Full method is
in the doc's "Extraction method" section, reproducible against a future
version.

code.claude.com/docs/en/hooks was fetched and cross-checked against specific
claims (common fields, HTTP hook fields, `once`, event list) — used as
corroboration where it agreed, and as an explicit disagreement where it
didn't (see "Contradicts the issue" below). Where binary and docs disagreed,
binary wins, per the doc's own stated rule. `cc-ref` was not read or cited
anywhere in this PR (ADR 0006).

## Drift table (selected — full table + binary extraction quotes are in the
doc)

| Type | Field | Was | Now | Evidence |
|---|---|---|---|---|
| `HookCommonInput` | `prompt_id` | missing | `?: string` | **[B][D]** `Kf()`: `prompt_id:gAt()??void 0`; docs confirm, note >=2.1.196 |
| `HookCommonInput` | `effort` | missing | `?: {level:string}` | **[B][D]** not in issue's list; found reading `Kf()`, confirmed by docs independently |
| `SessionStartHookInput` | `model` | `string` (required) | `?: string` | **[D]** docs: "not guaranteed to be present" |
| `SessionStartHookInput` | `agent_type`, `session_title` | missing | both `?: string` | **[B]** |
| `NotificationHookInput` | `notification_type` | 4-value union | 8-value union | **[B]** binary docs-table resource lists 8; additive, non-breaking |
| `PostToolUseHookInput` | `duration_ms` | missing | `?: number` | **[B]** named in issue |
| `PostToolUseFailureHookInput` | `tool_use_id`, `is_interrupt`, `duration_ms` | missing | added, optional | **[B]** named in issue |
| `UserPromptSubmitHookInput` | `prompt`, `session_title` | empty body | both required | **[B][D]** named in issue |
| `InstructionsLoadedHookInput` | `source` | `string` | **removed** — replaced with `file_path, memory_type, load_reason, globs?, trigger_file_path?, parent_file_path?` | **[B]** `source` never existed in the binary at all; not in issue's list |
| `SubagentStopHookInput` / `StopHookInput` | `last_assistant_message`, `agent_transcript_path` | missing | added | **[B]** named in issue |
| `StopHookInput` / `SubagentStopHookInput` | `background_tasks`, `session_crons` | missing | added, optional | **[B]** issue named this field `session_tasks` — wrong, see below |
| `StopFailureHookInput` | `error_type` | `string` | **kept** (unused by binary) + `error?, error_details?, last_assistant_message?` added | **[B]** `error_type` doesn't exist in the binary; real bug filed as #905, not fixed |
| `TaskCompletedHookInput` / `TeammateIdleHookInput` | all fields | empty body | added (task_id/task_subject/... or teammate_name/team_name) | **[B]** |
| `ConfigChangeHookInput` | `config_type` | `string` | **removed** — replaced with `source, file_path` | **[B]** `config_type` never existed; zero consumers found, safe rename |
| `WorktreeCreateHookInput` / `WorktreeRemoveHookInput` | `name` / `worktree_path` | missing | added | **[B]** not in issue's list |
| `PreCompactHookInput` / `PostCompactHookInput` | `source` -> `trigger`, `+custom_instructions`/`+compact_summary` | — | done | **[B][D]** named in issue |
| `ElicitationHookInput` / `ElicitationResultHookInput` | `message, mode, url, elicitation_id, requested_schema` / `elicitation_id, mode, action, content` | only `mcp_server_name` | added | **[B]** not in issue's list |
| `HOOK_EVENT_NAMES` | +9 (`Setup`, `UserPromptExpansion`, `PermissionDenied`, `PostToolBatch`, `MessageDisplay`, `CwdChanged`, `FileChanged`, `DirectoryAdded`, `TaskCreated`), each with a full typed interface | 22 known | 31 | **[B]** matches binary exactly; `REMI_REGISTERED_HOOK_EVENTS` unchanged (still 11) |

## Contradicts the issue

The issue was written from exploration, not extraction, and it's wrong in a
few places worth calling out explicitly rather than silently correcting:

1. **`Stop`/`SubagentStop`'s extra field is not `session_tasks`.** The
   binary's shared builder does `f = i ? {background_tasks:
   cip(i.taskRegistry.all()), session_crons: uip()} : void 0` — two fields,
   neither spelled the way the issue guessed.
2. **The `hook-types.ts:111` PermissionRequest comment's *conclusion* (no
   `tool_use_id`) was already correct** — the issue (and epic #885) frame
   this as something to fix, but the only wrong part was the citation
   (cc-ref instead of the binary). Conclusion unchanged, citation replaced.
3. **A third cc-ref citation existed that neither #886 nor #885 named**:
   `subagent-context-tracker.ts:29`, justifying including `'Agent'` in
   `NESTING_TOOLS` "for safety in case variants ship." Fixed too — the
   binary actually has a real tool-name alias table (`Task`→`Agent`) that
   makes the *inclusion* correct on firmer evidence than cc-ref ever was.
4. **`StopFailureHookInput.error_type` doesn't exist in the binary at all**
   — not a missing-fields gap, the field remi has always had is simply
   wrong. This is the #905 bug (see below).
5. **`ConfigChangeHookInput.config_type` and `InstructionsLoadedHookInput.source`
   don't exist either** — same situation, both pre-existing fields renamed
   away entirely rather than extended. Verified zero consumers before doing
   this (`grep -rn "config_type\b"` / no callers read `.source` off
   `InstructionsLoadedHookInput`).

## A real bug this verification found (filed, not fixed here)

`hook-event-bridge.ts:509` builds a user-facing retry prompt from
`input.error_type` on `StopFailure`. The binary never sends that field (it
sends `error`, `error_details`, `last_assistant_message` instead), so that
prompt has read **"Session stop failed (undefined). Retry?"** since it was
written. Filed as **#905**. Not fixed in this PR — fixing the read site is a
runtime behavior change (the message users see would change), which is
explicitly out of scope here. `error_type` stays in the type (unused by
Claude Code, but read by `hook-event-bridge.ts` and three existing test
fixtures) specifically so this PR doesn't have to touch either.

## What I could NOT verify

**The sequential-tool-permission-hook-dispatch assumption
(`auto-approve-gate.ts` ~2057, the duplicate-re-request cancellation) is
explicitly left unverified.** This was cc-ref's most load-bearing citation —
the comment claimed Claude Code processes a turn's permission hooks
sequentially, sourced from cc-ref's `conversation.rs:370`. That claim cannot
be settled by static binary extraction (it's a runtime concurrency question,
not a shape question), and I did not run a live experiment to test it either
(firing two identical-signature `PermissionRequest`s back-to-back and
observing dispatch order — this is the #885 epic's named experiment). The
citation is replaced with an honest "unverified, here's why, here's what
would settle it" comment. **Behavior is unchanged** — the duplicate-re-request
cancellation still runs exactly as before; only the (wrong) evidence backing
it is corrected to (accurate) uncertainty.

Also left open, documented in the doc's "What's pending" section:

- The `agent_type` common-field tension: the binary's builder computes it
  unconditionally, but remi's own 2026-04-16 capture says it correlates with
  `agent_id`. Both readings can be simultaneously true (default-undefined
  outside agent-team sessions); not resolved without a live agent-teams
  capture.
- Whether `Notification.notification_type`'s Chrome-bridge-looking values
  (`computer_use_enter` etc.) can ever actually arrive via the `Notification`
  hook specifically, vs. belonging to an unrelated internal subsystem.
  Left out of the widened union pending a capture.

## What's not here: the capture corpus (#886 part 2)

Deliberately excluded, per the task scope. #886's second deliverable is a
scrubbed fixture corpus from a week of the owner's real Claude Code sessions
run with `REMI_HOOK_DEBUG=1`/`REMI_QUESTION_TRACE=1`, plus a drift test that
validates every captured fixture against these types. That requires running
real daily sessions over about a week; it is not something producible inside
this PR, and fabricating fixtures to look like a corpus would be exactly the
kind of unverified artifact ADR 0011 exists to prevent. The doc has a
dedicated "What's pending" section marking this explicitly, and this PR does
not add or claim a drift test.

## "Zero cc-ref citations" — literal vs. intent

Acceptance criterion says "Zero cc-ref citations remain in the codebase."
After this PR, `grep -rn cc-ref packages/` still returns 5 lines — but every
one of them is corrective/historical ("this used to cite cc-ref, here's why
that was wrong and what replaces it"), not a citation used as evidence for a
behavioral claim. Read literally as "the string cc-ref must not appear," the
criterion isn't met; read as its evident intent ("cc-ref must not be relied
on as ground truth"), it is. ADR 0006 itself and `.context/handoff.md` keep
permanent references to cc-ref for the same reason (explaining the
disavowal), so a hard "zero occurrences of the string" reading doesn't match
how the rest of the repo already treats this. Flagging this explicitly
rather than deciding unilaterally which reading governs.

## Testing

All run in the foreground against this branch, from repo root:

```
bun run typecheck        # clean
bun run typecheck:web    # clean
bunx biome check .       # 48 pre-existing warnings, 0 in touched files, exit 0
bun test                 # 4005 pass, 1 fail, 19965 expect() calls, 4006 tests / 209 files
typos <touched files>    # clean
```

The 1 failing test (`packages/daemon/tests/cli/cmd-model.test.ts` >
"remi model ls / ps > ls lists the DISK inventory with real footprints and
marks REMI's model") is unrelated to this PR: it asserts on live GPU/engine
residency state on this machine ("engine active" vs "resident, engine
proofread tier"), not on anything hooks-related. Confirmed pre-existing by
`git stash`-ing this branch's changes and re-running the same file against
unmodified `origin/develop` — identical failure, same assertion, same
mismatch. Not touched or investigated further; out of scope for a hook-types
PR.

Targeted runs before the full suite, all green, 0 failures:
- `packages/daemon/tests/hooks/` (all 12 files, hook-types/hook-server/
  hook-event-bridge/hook-config-manager/subagent-context-tracker/etc): 217
  tests
- `hook-bridge-setup.test.ts`: included above
- `auto-approve-gate.test.ts` (full file, since this PR edits
  `auto-approve-gate.ts`): 150 tests
- `question-presence-tracker.test.ts` + `question-dedup.test.ts`: 88 tests

No test needed updating — every field change was additive-optional, a
rename with zero existing consumers (`config_type`, `InstructionsLoaded.source`),
or a widened-superset union (`notification_type`), so nothing that
previously compiled or asserted stopped doing so.
