### PR TITLE
C5: attach-client total dispatch (#898)

### DIFF
--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -7,10 +7,18 @@ import {
   createTerminalResize,
   createUserInput,
   deserialize,
+  dispatchMessage,
   generateId,
   serialize,
 } from '@remi/shared';
-import type { ProtocolMessage, Question, RemiStatus, UUID } from '@remi/shared';
+import type {
+  MessageHandlers,
+  ProtocolMessage,
+  ProtocolMessageMap,
+  Question,
+  RemiStatus,
+  UUID,
+} from '@remi/shared';
 import { performAuthHandshake } from './auth-helper.ts';
 import { capabilityWsOptions } from './capability-client.ts';
 import { DetachScanner } from './detach-scanner.ts';
@@ -208,50 +216,102 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     writeOutput(lines.join(''));
   }
 
+  /**
+   * #898: total dispatch over the full protocol registry, not just the
+   * `d2c`/`both`-tagged subset — `ReplayBatchMessage.messages` is typed
+   * `readonly ProtocolMessage[]` (no direction narrowing), and this function
+   * recurses into it, so a handler map scoped to a `DaemonToClientType`
+   * alias would not type-check against that recursive call without adding a
+   * new runtime narrowing step that doesn't exist today. Sizing the map to
+   * the full `keyof ProtocolMessageMap` is a strictly stronger guarantee
+   * than "every d2c entry decided" (it is a superset), needs no new
+   * machinery, and matches the type `renderMessage` already accepts.
+   *
+   * Rebuilt on every call (not hoisted) because the `question` handler
+   * closes over this call's `inReplay` argument.
+   */
   function renderMessage(msg: ProtocolMessage, inReplay = false): void {
-    switch (msg.type) {
-      case 'raw_pty_output':
+    const handlers: MessageHandlers<keyof ProtocolMessageMap, void> = {
+      raw_pty_output: (m) => {
         receivedRawPty = true;
-        writeRawBytes(msg.data);
-        break;
-      case 'remi_status':
+        writeRawBytes(m.data);
+      },
+      remi_status: (m) => {
         // #754: display state only — never printed as text. The bar's own
         // 250ms repaint loop reads the latest snapshot.
-        latestStatus = msg.status;
+        latestStatus = m.status;
         if (attachedSessionId) startStatusBar();
-        break;
-      case 'question':
+      },
+      question: (m) => {
         // #753: LIVE questions only. Replayed history is not trustworthy for
         // pendingness — question_resolved is broadcast-only (never recorded),
         // so an already-answered question replays indistinguishably from a
         // pending one. The daemon re-sends the authoritative pending set as
         // live messages right after the replay batch, which is what lands here.
-        if (!inReplay) renderQuestionBanner(msg.question);
-        break;
-      case 'question_resolved':
+        if (!inReplay) renderQuestionBanner(m.question);
+      },
+      question_resolved: (m) => {
         // Only acknowledge questions this client actually bannered; resolved
         // broadcasts for questions answered before attach are noise.
-        if (banneredQuestionIds.delete(msg.questionId)) {
+        if (banneredQuestionIds.delete(m.questionId)) {
           writeOutput('\r\n\x1b[2m[remi] question answered\x1b[0m\r\n');
         }
-        break;
-      case 'agent_output':
-      case 'structured_agent_output':
-      case 'session_update':
-      case 'transcript_content':
-        // Suppressed; raw PTY output already provides the full terminal view
-        break;
-      case 'replay_batch':
-        for (const m of msg.messages) {
-          renderMessage(m, true);
+      },
+      replay_batch: (m) => {
+        for (const nested of m.messages) {
+          renderMessage(nested, true);
         }
-        break;
-      case 'error':
-        writeOutput(`\n[error: ${msg.code} - ${msg.message}]\n`);
-        break;
-      default:
-        break;
-    }
+      },
+      error: (m) => {
+        writeOutput(`\n[error: ${m.code} - ${m.message}]\n`);
+      },
+      // Suppressed; raw PTY output already provides the full terminal view.
+      // Already-explicit no-ops in the pre-#898 switch (same behavior here).
+      agent_output: 'ignore',
+      structured_agent_output: 'ignore',
+      session_update: 'ignore',
+      transcript_content: 'ignore',
+      // Everything below fell through the pre-#898 switch's anonymous
+      // `default: break` — a silent drop. Behavior is unchanged (still a
+      // no-op); the entries are now explicit and greppable (#898). Full
+      // per-type rationale is in the PR description.
+      hello: 'ignore',
+      hello_ack: 'ignore',
+      user_input: 'ignore',
+      ack: 'ignore',
+      edit: 'ignore',
+      answer: 'ignore',
+      ping: 'ignore',
+      pong: 'ignore',
+      bullet_expand_request: 'ignore',
+      bullet_expand_response: 'ignore',
+      session_list_request: 'ignore',
+      session_list_response: 'ignore',
+      transcript_load_request: 'ignore',
+      transcript_load_complete: 'ignore',
+      create_session_request: 'ignore',
+      create_session_response: 'ignore',
+      terminal_resize: 'ignore',
+      auth_challenge: 'ignore',
+      auth_response: 'ignore',
+      auth_result: 'ignore',
+      kill_session_request: 'ignore',
+      kill_session_response: 'ignore',
+      session_history_request: 'ignore',
+      session_history_response: 'ignore',
+      resume_session_request: 'ignore',
+      resume_session_response: 'ignore',
+      detach_session: 'ignore',
+      detach_session_ack: 'ignore',
+      register_device_token: 'ignore',
+      unregister_device_token: 'ignore',
+      daemon_update_available: 'ignore',
+      hub_status: 'ignore',
+      session_rotated: 'ignore',
+      session_views: 'ignore',
+      question_snapshot: 'ignore',
+    };
+    dispatchMessage(msg, handlers);
   }
 
   function sendHello(): void {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -3,12 +3,15 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  MESSAGE_DIRECTION,
+  createAck,
   createAgentOutput,
   createError,
   createHelloAck,
   createPing,
   createQuestion,
   createQuestionResolved,
+  createRawPtyOutput,
   createRemiStatus,
   createReplayBatch,
   deserialize,
@@ -16,7 +19,7 @@ import {
   now,
   serialize,
 } from '@remi/shared';
-import type { Message, Question, UUID } from '@remi/shared';
+import type { Message, MessageHandlers, ProtocolMessageMap, Question, UUID } from '@remi/shared';
 import { runAttachClient } from '../../src/cli/attach-client.ts';
 
 const TEST_PORT = 9873;
@@ -547,5 +550,196 @@ describe('runAttachClient', () => {
     expect(output).not.toContain('| attached');
     expect(output).not.toContain('\x1b[7m');
     expect(output).not.toContain('\x1b[1;');
+  });
+
+  // #898: renderMessage's total-dispatch handler for raw_pty_output was
+  // exercised only indirectly before (nothing asserted on decoded bytes).
+  test('renders decoded raw_pty_output bytes to output', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const payload = Buffer.from('hello from the pty\n', 'utf-8').toString('base64');
+
+    server = Bun.serve({
+      port: TEST_PORT + 9,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(serialize(createRawPtyOutput(payload, targetSessionId as UUID)));
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 9,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('hello from the pty');
+  });
+
+  // #898: the generic `error` branch (any code other than the early-return
+  // SESSION_ENDED/SESSION_BUSY specials handled before renderMessage is
+  // reached) was never exercised by name.
+  test('renders a generic error inline without ending the session', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 10,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(serialize(createError('SOME_OTHER_CODE', 'transient glitch')));
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 10,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('[error: SOME_OTHER_CODE - transient glitch]');
+    // Unlike SESSION_ENDED/SESSION_BUSY, a generic error code does not end
+    // the attach session; the connection just closes normally afterward.
+    expect(result.reason).toBe('connection_closed');
+  });
+
+  // #898: `ack` is direction 'both' and genuinely arrives here — the daemon
+  // acks messages this client sends (e.g. terminal_resize, user_input) — but
+  // attach-client has never rendered acks and must keep not rendering them.
+  // Proves the 'ignore' entry for a real (not merely hypothetical) inbound
+  // type is correct, not just unreachable code. (Sent right after hello_ack,
+  // not gated on a specific client message, since process.stdout.columns/
+  // rows are unset in this non-TTY test environment and attach-client skips
+  // its own resize sends in that case.)
+  test('ignores a real ack reply without printing or crashing', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 11,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createAck({ messageId: generateId(), state: 'delivered', timestamp: now() }),
+                ),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    const result = await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 11,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+    });
+
+    const output = readOutput();
+    expect(output).not.toContain('ack');
+    expect(output).not.toContain('[error');
+    expect(result.reason).toBe('connection_closed');
+  });
+});
+
+// --- Compile-time totality demonstration (#898 acceptance criterion) ---
+//
+// attach-client.ts's renderMessage builds a `MessageHandlers<keyof
+// ProtocolMessageMap, void>` literal covering every registry key (see the
+// doc comment on renderMessage for why the map is sized to the full
+// registry rather than a narrower daemon-to-client-only alias). This proves
+// the mechanism directly against that same type: a handler map missing one
+// key does not satisfy it. Verified live (not just present): removing
+// `question_snapshot: 'ignore'` from attach-client.ts's actual handlers
+// object and running `bun run typecheck` produced `TS2741: Property
+// 'question_snapshot' is missing in type '{...}' but required in type
+// 'MessageHandlers<keyof ProtocolMessageMap, void>'` at the object literal;
+// restoring the entry made it pass again.
+describe('renderMessage handler map is total (compile-time, #898)', () => {
+  test('a handler map missing one registry key is rejected by MessageHandlers<keyof ProtocolMessageMap>', () => {
+    const registryTypes = Object.keys(MESSAGE_DIRECTION) as (keyof ProtocolMessageMap)[];
+    const allButOne = registryTypes.filter((t) => t !== 'question_snapshot');
+    const missingOneHandler = Object.fromEntries(
+      allButOne.map((t) => [t, 'ignore' as const]),
+    ) as MessageHandlers<Exclude<keyof ProtocolMessageMap, 'question_snapshot'>>;
+
+    expect(Object.keys(missingOneHandler).length).toBe(registryTypes.length - 1);
+
+    // @ts-expect-error - deliberately missing 'question_snapshot'; assigning
+    // to the full MessageHandlers<keyof ProtocolMessageMap> type must fail.
+    // This is the shape attach-client.ts's renderMessage handler map has:
+    // forgetting a registry key is a build error here, not a silent runtime
+    // no-op (#898's acceptance criterion). Removing this comment to check
+    // the assignment is unguarded is how this was verified (see file header
+    // note above and the dispatch.ts pattern this mirrors).
+    const incomplete: MessageHandlers<keyof ProtocolMessageMap> = missingOneHandler;
+    void incomplete;
+  });
+
+  test('the same map WITH the key present satisfies the full type', () => {
+    const registryTypes = Object.keys(MESSAGE_DIRECTION) as (keyof ProtocolMessageMap)[];
+    const complete = Object.fromEntries(
+      registryTypes.map((t) => [t, 'ignore' as const]),
+    ) as MessageHandlers<keyof ProtocolMessageMap>;
+
+    const total: MessageHandlers<keyof ProtocolMessageMap> = complete;
+    expect(Object.keys(total).length).toBe(registryTypes.length);
   });
 });


### PR DESCRIPTION
Closes #898 (C5, epic #883).

## Summary

- `packages/daemon/src/cli/attach-client.ts`'s `renderMessage` ended in a
  silent `default: break;` — any protocol message type without an explicit
  `case` was dropped with no trace. Replaced the `switch` with a total
  `MessageHandlers<keyof ProtocolMessageMap, void>` map dispatched via
  `dispatchMessage` (#895/#896). Forgetting a type is now a compile error
  (`Property '<type>' is missing`), not a silent no-op.
- Behavior is unchanged for every message type — see the ignore list below,
  which is the actual review surface for this PR.

## Deviation from the issue text (found while implementing, not made to match)

The issue says to dispatch "over `DaemonToClientType`" and to read that type
in `protocol.ts`. **No such type exists anywhere in the repo** (verified:
`grep -rn "DaemonToClientType" packages/` returns nothing). `protocol.ts` has
`MESSAGE_DIRECTION`, a `Record<key, 'c2d' | 'd2c' | 'both'>`, not a derived
type alias — C2/C3 (#895/#896) landed the direction tags and the
`MessageHandlers`/`dispatchMessage` mechanism, but no daemon-to-client type
alias.

More importantly, even a locally-derived `DaemonToClientType` (the 30 keys
tagged `d2c` or `both`) would not type-check here.
`ReplayBatchMessage.messages` is typed `readonly ProtocolMessage[]` — the
full 45-member union, not narrowed by direction — and `renderMessage`
recurses into it for replay batches. Passing that general `ProtocolMessage`
into `dispatchMessage<TType>` against a `MessageHandlers<DaemonToClientType>`
does not type-check without adding a new runtime narrowing/guard that
doesn't exist in the codebase today.

Rather than invent that machinery, the handler map is sized to the full
`keyof ProtocolMessageMap` (45 keys), which:
- matches the type `renderMessage` already accepts (no new narrowing needed),
- is a strictly *stronger* guarantee than "every d2c entry decided" (all 45
  types must be decided, not just the 30 d2c/both ones), and
- still satisfies the acceptance criterion verbatim: a new registry key of
  any direction breaks this file's compile until handled or ignored.

Flagging this because "convert to a total map over `DaemonToClientType`" is
prose about a type that isn't there; I did not add a decorative alias just
to make the description literally true. Full reasoning is in the doc comment
on `renderMessage`.

## The ignore list (review requirement)

45 registry keys total. 6 get real handlers (unchanged from before):
`raw_pty_output`, `remi_status`, `question`, `question_resolved`,
`replay_batch`, `error`. The remaining **39 are `'ignore'`**, split by what
the *old* switch actually did with them:

**Group A — already an explicit no-op in the old switch** (grouped under one
`case` list with a "Suppressed; raw PTY output already provides the full
terminal view" comment): `agent_output`, `structured_agent_output`,
`session_update`, `transcript_content`. No behavior change; now four
individually-greppable entries instead of one shared case.

**Group B — fell through the old switch's anonymous `default: break;`**
(the silent drop this PR removes). All 35 are unchanged no-ops in the new
code; each is now a name that greps and was reviewed, not an implicit
fallthrough:

- **c2d-only, structurally can't arrive from a daemon** (15): `hello`,
  `user_input`, `answer`, `bullet_expand_request`, `session_list_request`,
  `transcript_load_request`, `create_session_request`, `terminal_resize`,
  `auth_response`, `kill_session_request`, `session_history_request`,
  `resume_session_request`, `detach_session`, `register_device_token`,
  `unregister_device_token`.
- **d2c/both, but already fully handled *before* `renderMessage` is
  reached** (4): `hello_ack`, `ping`, `auth_challenge` — each short-circuits
  earlier in `handleProtocolMessage`/`ws.onmessage` and never reaches
  `renderMessage` at the top level — and `detach_session_ack`, which reaches
  `renderMessage` only when `detachPending` is `false` (the daemon-initiated
  case), where doing nothing is correct.
- **d2c/both, genuinely reachable, verified as real no-ops today** (2):
  `ack` — the daemon acks `terminal_resize`/`user_input`/`detach_session`
  this client sends; attach-client has never rendered acks. `pong` — the
  daemon periodically pings this client (`startPingTimer` in
  `connection.ts`) and this client answers with `pong`
  (`attach-client.ts:372`); an unprompted `pong` *from* the daemon would
  only occur if the daemon received a `ping` from this client, which it
  never sends — theoretically reachable, never actually reached.
- **d2c-only, no attach-client relevance** (14): `edit`,
  `bullet_expand_response`, `session_list_response`,
  `transcript_load_complete`, `create_session_response`, `auth_result`,
  `kill_session_response`, `session_history_response`,
  `resume_session_response`, `daemon_update_available`, `hub_status`,
  `session_rotated`, `session_views`, `question_snapshot` — all consumed by
  the web client (`App.tsx`, out of scope here / C4 #897) or other CLI
  tooling, never by the raw-PTY attach terminal.

Added a dedicated runtime test for the one previously-untested but *really*
reachable ignore (`ack`, see "ignores a real ack reply without printing or
crashing").

## Tests

Extended `packages/daemon/tests/cli/attach-client.test.ts` (not duplicated):

- New: `renders decoded raw_pty_output bytes to output` — the `raw_pty_output`
  handler had no direct assertion on decoded bytes before.
- New: `renders a generic error inline without ending the session` — the
  generic `error` handler (any code other than the early-return
  `SESSION_ENDED`/`SESSION_BUSY` specials) had no test.
- New: `ignores a real ack reply without printing or crashing` — proves the
  `ack` ignore entry is correct for a message that genuinely arrives, not
  just unreachable code.
- New: `renderMessage handler map is total (compile-time, #898)` — two tests
  mirroring `packages/shared/tests/dispatch.test.ts`'s own pattern: a handler
  map missing one registry key fails to satisfy
  `MessageHandlers<keyof ProtocolMessageMap>` (`@ts-expect-error`,
  `tsc --noEmit`-enforced), and the same map with the key restored compiles.

## Break-it-then-fix-it evidence (observed, not asserted)

All cycles: broke → ran the specific test(s) → observed the failure text
below → restored → reran → confirmed the full file's 15/15 pass. Final
`diff` against the pre-experiment file was empty (clean restore).

| Break | Command | Observed red | Restored green |
|---|---|---|---|
| `question` handler: `!inReplay` → `inReplay` | `bun test attach-client.test.ts` | **7 pass / 3 fail** — "renders a banner for a LIVE held question", "suppresses questions inside a replay batch", "acknowledges question_resolved only for questions it bannered" all failed with wrong-content `toContain`/`not.toContain` mismatches | 10/10 |
| `agent_output: 'ignore'` → a handler that writes `m.message.content` | `bun test attach-client.test.ts` | **9 pass / 1 fail** — "suppresses agent_output in replay batch" failed: output contained "Hello from replay" | 10/10 |
| Removed `question_snapshot: 'ignore'` from the map | `bun run typecheck` | `TS2741: Property 'question_snapshot' is missing in type '{...}' but required in type 'MessageHandlers<keyof ProtocolMessageMap, void>'` at the object literal | clean |
| `raw_pty_output` handler: dropped the `writeRawBytes(m.data)` call | `bun test -t "raw_pty_output"` | **0 pass / 1 fail** — expected output to contain "hello from the pty", got only the attach banner | pass |
| `error: (m) => writeOutput(...)` → `error: 'ignore'` | `bun test -t "generic error"` | **0 pass / 1 fail** — expected `[error: SOME_OTHER_CODE - transient glitch]`, not present | pass |
| `ack: 'ignore'` → a handler that writes `[ack: <id>]` | `bun test -t "ignores a real ack"` | **0 pass / 1 fail** — output contained the injected `[ack: ...]` text, violating `not.toContain('ack')` | pass |
| Removed the `@ts-expect-error` comment on the compile-time test | `bun run typecheck` | `TS2741: Property 'question_snapshot' is missing...` at `attach-client.test.ts:725` (i.e. the directive is load-bearing, not stale) | restored, clean |

Full-file result after every restore: `bun test
packages/daemon/tests/cli/attach-client.test.ts` → **15 pass, 0 fail, 30
expect() calls**.

## Gates

Ran in the foreground, targeted to this change plus the shared package it
imports from. **Did not run the full repo-wide `bun test`** (multiple
concurrent agents in this session were saturating the machine and it did not
finish in a reasonable window backgrounded or foreground); this is an
explicit, stated partial, not an implied full pass.

Ran and green:
- `bun run typecheck` — clean
- `bun run typecheck:web` — clean (unaffected by this change; ran per
  instructions)
- `bunx biome check .` — exit 0 (48 pre-existing warnings elsewhere in the
  repo — `same-cwd-no-cross-binding.test.ts` non-null-assertion style nits,
  etc. — none in `attach-client.ts` or its test file)
- `bun test packages/daemon/tests/cli/` — 996 pass, 0 fail (60 files)
- `bun test packages/daemon/tests/cli/attach-client.test.ts
  packages/shared/tests/dispatch.test.ts
  packages/shared/tests/protocol-registry.test.ts` — 27 pass, 0 fail (the
  file this PR changes, plus the two suites covering the `MessageHandlers`/
  `dispatchMessage`/registry mechanism it consumes)

Not run: the full `bun test` across every package (signaling, web,
integration, auto-approve). Nothing in this diff touches those areas —
change is confined to one daemon CLI file and its test file, no shared/
protocol/dispatch edits — but that is inference from the diff's scope, not a
substitute for having actually run them. Flagging per the ground rules
rather than implying a full pass. Known pre-existing flakes noted in the
task brief (`push-answer-relay.test.ts` opaque-envelope timing,
`tests/cli/shell-path.test.ts` subprocess timeouts) were not encountered
because those suites were not run.

## Coordination

Touched only `packages/daemon/src/cli/attach-client.ts` and
`packages/daemon/tests/cli/attach-client.test.ts`. No changes to
`packages/shared/src/protocol.ts` or `packages/shared/src/dispatch.ts`.
