### PR TITLE
C8: macOS fixture conformance (#901)

### DIFF
--- a/packages/macos/Remi.xcodeproj/project.pbxproj
+++ b/packages/macos/Remi.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		868C031D66195475FDA1A60E /* IconStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */; };
 		89CA0A413FB87001E796F276 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DD72A5787EF3FFBF772C89F /* Assets.xcassets */; };
 		8A7968BC43F4E4D7069E3FD9 /* RemiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4E747A3D65101EAE2331D4 /* RemiApp.swift */; };
+		8BCCB2E79DA278B7FCC0EFC5 /* HubFixtureConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5BC89AD3E7A9A6DEE5A00C /* HubFixtureConformanceTests.swift */; };
 		954D114FF37A81A590B7D7B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25C1F16E2BEE0CED3C7DC54 /* AppDelegate.swift */; };
 		A66E1FF4E2632B780AC8EBEA /* DistSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FB8ECEE3FF5C62B33B122 /* DistSchemeHandler.swift */; };
 		AACDBAC70B24E6FD163F22C8 /* IconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7875E7E74CA980AD4B502F /* IconState.swift */; };
@@ -77,6 +78,7 @@
 		C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubSetupCommandsTests.swift; sourceTree = "<group>"; };
 		CA99F3FC4BB5441E52829DA8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		E3F7681BE2AB3DD90F39CD72 /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
+		EE5BC89AD3E7A9A6DEE5A00C /* HubFixtureConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubFixtureConformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -122,6 +124,7 @@
 				7D4E81DF5CF4E309840AF1F3 /* DistSchemeHandlerServingTests.swift */,
 				4E923886F516F41ACD4DCB26 /* DistSchemeHandlerTests.swift */,
 				69B5AB7DE462E44924AFDC25 /* HubClientIntegrationTests.swift */,
+				EE5BC89AD3E7A9A6DEE5A00C /* HubFixtureConformanceTests.swift */,
 				385800B7F484F9E71DADBC28 /* HubProtocolTests.swift */,
 				C385A2B0E9B3668B8E04A46E /* HubSetupCommandsTests.swift */,
 				6FD2A054319CF8855CD1AE45 /* IconStateTests.swift */,
@@ -301,6 +304,7 @@
 				787301FFD777594190359E77 /* DistSchemeHandlerTests.swift in Sources */,
 				477C35A4907835166E4AECF6 /* HubClient.swift in Sources */,
 				7366DDF55B2871EA5704D8B8 /* HubClientIntegrationTests.swift in Sources */,
+				8BCCB2E79DA278B7FCC0EFC5 /* HubFixtureConformanceTests.swift in Sources */,
 				B624FF6190079DE8CEC1ED90 /* HubProtocol.swift in Sources */,
 				61C341D2ECBBE9C35A242AF0 /* HubProtocolTests.swift in Sources */,
 				0624CA493FEF2D140B88CFF7 /* HubSetupCommands.swift in Sources */,

--- a/packages/macos/RemiTests/HubFixtureConformanceTests.swift
+++ b/packages/macos/RemiTests/HubFixtureConformanceTests.swift
@@ -1,0 +1,159 @@
+//
+//  HubFixtureConformanceTests.swift
+//  RemiTests
+//
+//  #901 (epic #883): decodes the SAME checked-in golden fixtures the TS
+//  side generates from its real protocol factories
+//  (packages/shared/tests/fixtures/protocol/, #895), through the exact
+//  decode calls HubClient.handleFrame makes in production. A wire-shape
+//  change that drops a field HubClient needs now fails HERE instead of
+//  handleFrame's `guard ... else { return }` silently dropping the frame
+//  (HubClient.swift:355-357).
+//
+//  `HubClient.handleFrame`'s switch (HubClient.swift:359-406) handles
+//  exactly 5 frame types: hello_ack, hub_status, pong, auth_challenge,
+//  auth_result. That is the real, current set -- verified by reading the
+//  switch, not by trusting the issue text.
+//
+//  Fixtures are read straight off disk via #filePath navigation to
+//  packages/shared/tests/fixtures/protocol/, mirroring IconStateTests.swift's
+//  Assets.xcassets lookup (see the comment there). They are NOT copied into
+//  this package -- there is exactly one copy of each fixture in the repo,
+//  and both the TS mirror test (packages/shared/tests/
+//  macos-fixture-conformance.test.ts) and this file read it.
+//
+//  All fixture fields are FIXED literals from
+//  packages/shared/tests/fixtures/protocol/builders.ts except the envelope
+//  `id`/`timestamp`, which are regenerated (new random UUID / timestamp) on
+//  every `generate.ts` run -- see that file's doc comment. Those two are
+//  checked only for well-formedness below; everything else is asserted
+//  exact, so a dropped or renamed field fails loudly here.
+//
+
+import XCTest
+
+
+final class HubFixtureConformanceTests: XCTestCase {
+    /// packages/shared/tests/fixtures/protocol, reached from this file's
+    /// own on-disk location (RemiTests/ -> packages/macos/ -> packages/ ->
+    /// shared/tests/fixtures/protocol). Same technique as
+    /// IconStateTests.swift's Assets.xcassets lookup.
+    private static let fixturesDir: URL =
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RemiTests/
+            .deletingLastPathComponent()  // packages/macos/
+            .deletingLastPathComponent()  // packages/
+            .appendingPathComponent("shared/tests/fixtures/protocol")
+
+    private func loadFixture(_ name: String) throws -> Data {
+        try Data(contentsOf: Self.fixturesDir.appendingPathComponent("\(name).json"))
+    }
+
+    /// Envelope fields every fixture carries (`type`, `id`, `timestamp`).
+    /// `id`/`timestamp` are the only fields regenerated per `generate.ts`
+    /// run, so they're checked for well-formedness only, never an exact
+    /// value.
+    private func assertEnvelope(_ data: Data, type: String) throws {
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["type"] as? String, type)
+        let id = try XCTUnwrap(object["id"] as? String, "\(type) fixture is missing id")
+        XCTAssertNotNil(UUID(uuidString: id), "\(type) fixture id is not a UUID: \(id)")
+        let timestamp = try XCTUnwrap(
+            object["timestamp"] as? String, "\(type) fixture is missing timestamp")
+        XCTAssertNotNil(
+            ISO8601DateFormatter.withFractionalSeconds.date(from: timestamp),
+            "\(type) fixture timestamp is not ISO8601: \(timestamp)")
+    }
+
+    // MARK: - hello_ack (HubClient.swift:360-382)
+
+    func testHelloAckFixtureDecodesAsHubClientRequires() throws {
+        let data = try loadFixture("hello_ack")
+        try assertEnvelope(data, type: "hello_ack")
+
+        // The exact decode handleFrame's "hello_ack" case performs to
+        // validate the frame before accepting a handshake
+        // (HubClient.swift:367).
+        let ack = try JSONDecoder().decode(HelloAckFrame.self, from: data)
+        XCTAssertEqual(ack.type, "hello_ack")
+        XCTAssertEqual(ack.sessionId, "fixture-session-id")
+        XCTAssertEqual(ack.serverVersion, "1.0.0")
+        XCTAssertEqual(ack.daemonVersion, "0.7.4-dev.1")
+    }
+
+    // MARK: - hub_status (HubClient.swift:383-397)
+
+    func testHubStatusFixtureDecodesAsHubClientRequires() throws {
+        let data = try loadFixture("hub_status")
+        try assertEnvelope(data, type: "hub_status")
+
+        // The exact decode handleFrame's "hub_status" case performs
+        // (HubClient.swift:384).
+        let status = try JSONDecoder().decode(HubStatusFrame.self, from: data)
+        XCTAssertEqual(status.localClients, 1)
+        XCTAssertEqual(status.remoteClients, 0)
+        XCTAssertEqual(status.sessions, 2)
+        XCTAssertEqual(status.hubVersion, "0.7.4-dev.1")
+        XCTAssertEqual(status.pendingQuestions, 1)
+        XCTAssertEqual(status.autostart, "installed")
+
+        // `questions` is optional on HubStatusFrame, but the fixture
+        // carries a non-empty array and Swift decodes array elements
+        // strictly: every HubPendingQuestionFrame field is required once
+        // the array is present, or the WHOLE HubStatusFrame decode above
+        // would already have thrown.
+        let questions = try XCTUnwrap(status.questions)
+        XCTAssertEqual(questions.count, 1)
+        XCTAssertEqual(questions[0].id, "fixture-question-id")
+        XCTAssertEqual(questions[0].sessionId, "fixture-session-id")
+        XCTAssertEqual(questions[0].sessionName, "fixture-session")
+        XCTAssertEqual(questions[0].label, "Permission: Bash")
+        XCTAssertEqual(questions[0].createdAt, "2026-01-01T00:00:00.000Z")
+    }
+
+    // MARK: - pong (HubClient.swift:398-399)
+
+    func testPongFixtureDecodesAsHubClientRequires() throws {
+        let data = try loadFixture("pong")
+        try assertEnvelope(data, type: "pong")
+
+        // handleFrame's "pong" case reads nothing but the envelope `type`
+        // (missedPongs = 0) -- there is no dedicated payload struct because
+        // nothing else is read. IncomingFrameType decoding successfully
+        // with type == "pong" IS the entire contract for this frame.
+        let envelope = try JSONDecoder().decode(IncomingFrameType.self, from: data)
+        XCTAssertEqual(envelope.type, "pong")
+    }
+
+    // MARK: - auth_challenge (HubClient.swift:400-401, handleAuthChallenge 417-436)
+
+    func testAuthChallengeFixtureDecodesAsHubClientRequires() throws {
+        let data = try loadFixture("auth_challenge")
+        try assertEnvelope(data, type: "auth_challenge")
+
+        // The exact decode handleAuthChallenge performs (HubClient.swift:418).
+        let frame = try JSONDecoder().decode(AuthChallengeFrame.self, from: data)
+        XCTAssertEqual(frame.challenge, "base64-challenge")
+        XCTAssertEqual(frame.serverFingerprint, "AA:BB:CC:DD")
+        XCTAssertEqual(frame.serverPublicKey, "base64-server-pubkey")
+        // relayEphemeralKey/relayKexSignature/answerEncryptionKey are on
+        // the fixture (relay-transport fields) but deliberately undeclared
+        // on AuthChallengeFrame (HubProtocol.swift:82-87): this app only
+        // ever uses the direct loopback socket, and Decodable silently
+        // ignores keys it doesn't declare.
+    }
+
+    // MARK: - auth_result (HubClient.swift:402-403, handleAuthResult 446-466)
+
+    func testAuthResultFixtureDecodesAsHubClientRequires() throws {
+        let data = try loadFixture("auth_result")
+        try assertEnvelope(data, type: "auth_result")
+
+        // The exact decode handleAuthResult performs (HubClient.swift:447).
+        let frame = try JSONDecoder().decode(AuthResultFrame.self, from: data)
+        XCTAssertTrue(frame.success)
+        XCTAssertNil(frame.error)
+        XCTAssertEqual(frame.serverSignature, "base64-server-signature")
+    }
+}

--- a/packages/shared/tests/macos-fixture-conformance.test.ts
+++ b/packages/shared/tests/macos-fixture-conformance.test.ts
@@ -1,0 +1,153 @@
+/**
+ * TypeScript-side mirror of the macOS fixture-conformance tests (#901,
+ * epic #883).
+ *
+ * `HubClient` (packages/macos/Remi/HubClient.swift) decodes exactly 5 frame
+ * types, all from these SAME checked-in golden fixtures
+ * (packages/shared/tests/fixtures/protocol/, #895): `hello_ack`,
+ * `hub_status`, `pong`, `auth_challenge`, `auth_result` — the cases of the
+ * `handleFrame` switch (HubClient.swift:359-406). An undecodable frame is
+ * dropped SILENTLY there (`guard ... else { return }`,
+ * HubClient.swift:355-357): today a TS-side wire change that drops a field
+ * Swift's `Decodable` structs require produces no failure anywhere the
+ * macOS app can see, it just stops seeing that frame.
+ *
+ * The macOS CI workflow (.github/workflows/macos-app.yml) is path-filtered
+ * to `packages/macos/**` — a change to `packages/shared/src/protocol.ts`
+ * alone does not trigger it, so the Swift decode tests
+ * (packages/macos/RemiTests/HubFixtureConformanceTests.swift) never even
+ * run against that change. THIS test is what actually catches the break,
+ * on the CI path that runs for every `protocol.ts`/fixture change.
+ *
+ * The required-field lists below were read directly off
+ * packages/macos/Remi/HubProtocol.swift (line numbers cited per field) when
+ * this test was written. They are a hand-verified snapshot of the Swift
+ * contract, not a derivation from it — there is no cross-language schema to
+ * derive them from, so keep them in sync by hand if HubProtocol.swift's
+ * required fields change.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'protocol');
+
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, `${name}.json`), 'utf-8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+/**
+ * A field a Swift `Decodable` struct requires: JSON key + the JS `typeof`
+ * it must decode as. Swift fails the WHOLE struct decode if a non-optional
+ * key is absent or type-mismatched; an optional (`String?` etc.) field is
+ * NOT listed here, since Swift decodes an absent/null optional to `nil`
+ * without error.
+ */
+interface RequiredField {
+  key: string;
+  type: 'string' | 'number' | 'boolean';
+}
+
+/** Missing/mismatched fields, or `[]` if every required field checks out. */
+function requiredFieldProblems(
+  fixture: Record<string, unknown>,
+  fields: readonly RequiredField[],
+): string[] {
+  const problems: string[] = [];
+  for (const field of fields) {
+    if (!(field.key in fixture)) {
+      problems.push(`missing "${field.key}"`);
+      continue;
+    }
+    const actual = typeof fixture[field.key];
+    if (actual !== field.type) {
+      problems.push(`"${field.key}" is ${actual}, not ${field.type}`);
+    }
+  }
+  return problems;
+}
+
+describe('macOS HubClient fixture conformance (#901)', () => {
+  // HubClient.swift:360-370, HubProtocol.swift:136-142 (HelloAckFrame).
+  // `sessionId`/`daemonVersion` are `String?` in Swift — not required.
+  test('hello_ack keeps the fields HelloAckFrame requires', () => {
+    const problems = requiredFieldProblems(loadFixture('hello_ack'), [
+      { key: 'type', type: 'string' },
+      { key: 'serverVersion', type: 'string' },
+    ]);
+    expect(problems).toEqual([]);
+  });
+
+  // HubClient.swift:383-397, HubProtocol.swift:155-172 (HubStatusFrame).
+  // `pendingQuestions`/`questions`/`autostart` are optional in Swift.
+  test('hub_status keeps the fields HubStatusFrame requires', () => {
+    const problems = requiredFieldProblems(loadFixture('hub_status'), [
+      { key: 'type', type: 'string' },
+      { key: 'localClients', type: 'number' },
+      { key: 'remoteClients', type: 'number' },
+      { key: 'sessions', type: 'number' },
+      { key: 'hubVersion', type: 'string' },
+    ]);
+    expect(problems).toEqual([]);
+  });
+
+  // The checked-in hub_status fixture carries a non-empty `questions`
+  // array. `questions` itself is optional on HubStatusFrame, but Swift
+  // decodes array ELEMENTS strictly: once the key is present, every
+  // HubPendingQuestionFrame field (HubProtocol.swift:146-152, all
+  // non-optional) must decode too, or the WHOLE HubStatusFrame decode
+  // throws — dropping the frame, not just the questions list.
+  test('hub_status.questions[0] keeps the fields HubPendingQuestionFrame requires', () => {
+    const fixture = loadFixture('hub_status');
+    const questions = fixture['questions'];
+    expect(Array.isArray(questions)).toBe(true);
+    const list = questions as Record<string, unknown>[];
+    expect(list.length).toBeGreaterThan(0);
+    const first = list[0];
+    if (!first) throw new Error('hub_status.questions[0] is missing');
+    const problems = requiredFieldProblems(first, [
+      { key: 'id', type: 'string' },
+      { key: 'sessionId', type: 'string' },
+      { key: 'sessionName', type: 'string' },
+      { key: 'label', type: 'string' },
+      { key: 'createdAt', type: 'string' },
+    ]);
+    expect(problems).toEqual([]);
+  });
+
+  // HubClient.swift:398-399: the "pong" case reads nothing but the
+  // envelope `type` (IncomingFrameType, HubProtocol.swift:73-75) — there is
+  // no dedicated payload struct, so `type` is the entire contract.
+  test('pong keeps the field the envelope decode requires', () => {
+    const problems = requiredFieldProblems(loadFixture('pong'), [{ key: 'type', type: 'string' }]);
+    expect(problems).toEqual([]);
+  });
+
+  // HubClient.swift:400-401 -> handleAuthChallenge (417-436),
+  // HubProtocol.swift:88-96 (AuthChallengeFrame).
+  test('auth_challenge keeps the fields AuthChallengeFrame requires', () => {
+    const problems = requiredFieldProblems(loadFixture('auth_challenge'), [
+      { key: 'type', type: 'string' },
+      { key: 'challenge', type: 'string' },
+      { key: 'serverFingerprint', type: 'string' },
+      { key: 'serverPublicKey', type: 'string' },
+    ]);
+    expect(problems).toEqual([]);
+  });
+
+  // HubClient.swift:402-403 -> handleAuthResult (446-466),
+  // HubProtocol.swift:127-132 (AuthResultFrame). `error`/`serverSignature`
+  // are optional in Swift.
+  test('auth_result keeps the fields AuthResultFrame requires', () => {
+    const problems = requiredFieldProblems(loadFixture('auth_result'), [
+      { key: 'type', type: 'string' },
+      { key: 'success', type: 'boolean' },
+    ]);
+    expect(problems).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #901 (epic #883). Both sides now decode the same checked-in fixtures
from C2 (#895, `packages/shared/tests/fixtures/protocol/`) for the 5 frame
types `HubClient` handles, so a TS-side wire change that breaks Swift
decoding now fails a test instead of silently dropping the frame.

## The real frame-type list (verified against code, not the issue text)

`HubClient.handleFrame`'s switch handles exactly 5 types — matches the issue
text, confirmed by reading the switch rather than trusting the description:

- `hello_ack` — `HubClient.swift:360`
- `hub_status` — `HubClient.swift:383`
- `pong` — `HubClient.swift:398`
- `auth_challenge` — `HubClient.swift:400` (decoded in `handleAuthChallenge`, `HubClient.swift:417-436`)
- `auth_result` — `HubClient.swift:402` (decoded in `handleAuthResult`, `HubClient.swift:446-466`)

An undecodable frame is dropped silently: `HubClient.swift:355-357`
(`guard let data = ..., let envelope = try? JSONDecoder().decode(...) else { return }`).

## What changed

1. **`packages/macos/RemiTests/HubFixtureConformanceTests.swift`** (new) —
   decodes each of the 5 fixtures through the *exact same* decode call
   `handleFrame`/`handleAuthChallenge`/`handleAuthResult` make in production
   (`HelloAckFrame`, `HubStatusFrame` + its nested `HubPendingQuestionFrame`,
   `IncomingFrameType` for `pong`, `AuthChallengeFrame`, `AuthResultFrame`),
   then asserts every fixed field value. `id`/`timestamp` are the only
   fields that legitimately vary between fixture regenerations (see
   `builders.ts`'s doc comment — every other field is a fixed literal), so
   those two are checked for well-formedness only; everything else is
   asserted exact.

2. **`packages/shared/tests/macos-fixture-conformance.test.ts`** (new) — TS
   mirror asserting the same 5 fixtures keep the fields Swift's `Decodable`
   structs require (hand-verified against `HubProtocol.swift` line numbers
   cited in the comments). This is the part that actually matters day to
   day: `.github/workflows/macos-app.yml` is path-filtered to
   `packages/macos/**`, so a `packages/shared/src/protocol.ts`-only change
   never triggers the Swift tests at all. This TS test runs on every PR
   through the normal `bun test` gate and catches the break before it ever
   reaches Swift.

3. **`packages/macos/Remi.xcodeproj/project.pbxproj`** — regenerated via
   `scripts/generate-macos-project.sh` (wraps `xcodegen generate`) to
   register the new test file. 4-line diff, only the new file's build/file
   references.

## How Swift locates the fixtures (single source of truth)

`HubFixtureConformanceTests.swift` reads the fixtures straight off disk via
`#filePath` navigation from the test file's own on-disk location up to
`packages/shared/tests/fixtures/protocol/` — three `.deletingLastPathComponent()`
calls (RemiTests/ -> packages/macos/ -> packages/) then append
`shared/tests/fixtures/protocol`. This mirrors the existing pattern in
`IconStateTests.swift` (reads `Remi/Assets.xcassets` the same way, with a
comment noting it "reaches the source tree in both local and CI runs").
`RemiTests` is an un-hosted, unsandboxed xctest bundle, so an arbitrary
absolute-path read works in both environments — no build-phase copy, no
resource bundling. The fixtures are **not duplicated into `packages/macos`**;
there is exactly one copy in the repo, and TS reads it with `readFileSync`
the same way.

## Break-it-then-fix-it (both sides, run for real, output below)

**Swift**, removing `hub_status.json`'s `hubVersion` and re-running
`-only-testing:RemiTests/HubFixtureConformanceTests`:
```
HubFixtureConformanceTests.swift:93: error: ... testHubStatusFixtureDecodesAsHubClientRequires :
failed: caught error: "DecodingError.keyNotFound: Key 'hubVersion' not found ..."
```
Restored -> `HubFixtureConformanceTests` suite green again.

**Both sides together**, removing `auth_result.json`'s `success` field:
- Swift: `testAuthResultFixtureDecodesAsHubClientRequires` failed —
  `DecodingError.keyNotFound: Key 'success' not found ...`
- TS: `auth_result keeps the fields AuthResultFrame requires` failed —
  `expect(problems).toEqual([])` got `["missing \"success\""]`

Restored via `git checkout`, both suites green again:
- `bun test packages/shared/tests/macos-fixture-conformance.test.ts` -> 6 pass, 0 fail
- `xcodebuild ... -only-testing:RemiTests/HubFixtureConformanceTests` -> `** TEST SUCCEEDED **`

Earlier in the same session I also removed `hello_ack.json`'s
`serverVersion` and got the equivalent TS failure, restored, green — same
shape, not repeated above for brevity.

## Full macOS suite (real `xcodebuild test`, this session)

```
xcodebuild -project Remi.xcodeproj -scheme Remi -destination "platform=macOS" \
  CODE_SIGNING_ALLOWED=NO test
```
`Test Suite 'All tests' passed ... Executed 61 tests, with 0 failures` (all
61, including `HubClientIntegrationTests`, when run with
`TEST_RUNNER_REMI_TEST_BINARY` pointing at a freshly-built `dist/remi`; 6
skip via `XCTSkip` without it, which is the documented default).

A `No such module 'XCTest'` diagnostic was flagged during review. It does
**not** reproduce under a real `xcodebuild test` run (confirmed fresh,
above) — the module resolves fine once Xcode supplies the platform SDK's
test-framework search paths. It's consistent with a bare `swiftc`/SourceKit
probe run outside `xcodebuild`'s SDK context (this project has no
`Package.swift`; XCTest isn't SPM-resolvable on its own). The pbxproj diff
confirms the file is a member of the `RemiTests` target (`grep -n
HubFixtureConformanceTests packages/macos/Remi.xcodeproj/project.pbxproj`
shows the `PBXBuildFile`/`PBXFileReference`/`PBXSourcesBuildPhase` entries).

## Gates run this session (foreground, no backgrounded waits)

- `bun run typecheck` — clean
- `bun run typecheck:web` — clean
- `bunx biome check .` — clean (454 files, 48 pre-existing warnings — same
  baseline as before this change — 0 errors). Note: running
  `bun run build:macos-web` locally (needed to build the `Remi` app target
  for `xcodebuild test`) stages a minified JS bundle into
  `packages/macos/Remi/Resources/web/`; biome has no `vcs.useIgnoreFile`
  config so it lints that gitignored bundle too and reports thousands of
  spurious diagnostics until it's removed again. Not a CI concern (the
  Gates workflow never runs `build:macos-web`) but worth documenting since
  it looks alarming locally. Cleaned up before every biome run captured here.
- `bun test packages/shared/tests` — 424 pass, 0 fail (654ms) — covers both
  new fixture-conformance tests plus the existing `protocol-fixtures.test.ts`
  / `protocol-registry.test.ts` etc. that read the same fixtures.
- Full `bun test --coverage` (root) — 4161 pass, 1 fail, ran across 213
  files. The single failure is
  `AutoApproveService - instructions affect LLM decision > unusual
  instruction marker steers LLM toward approve`, a 30s timeout in
  `packages/daemon/tests/auto-approve/` — the documented flake (LLM tests
  time out at 30s under suite contention; AGENTS.md /
  `feedback_skip_llm_tests`). Unrelated to this change; I did not touch
  `packages/daemon/src/auto-approve/` or anything it depends on.
- `xcodebuild test` (full `RemiTests` target, real daemon binary) — 61
  tests, 0 failures, per above.

## Scope

Touched only `packages/macos/` (new test + regenerated pbxproj) plus one TS
mirror test in `packages/shared/tests/`. No changes to
`packages/shared/src/protocol.ts` or the fixtures themselves (both
mutations above were made, verified, then reverted with `git checkout`
before committing — `git status` is clean of any fixture diff).

## Nothing contradicted the issue text

The 5-type list, the silent-drop behavior, and the file locations in the
issue all matched what's actually in the code.