### PR TITLE
C4: web total dispatch (#897)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -162,6 +162,7 @@ export {
   createQuestionResolved,
   createRemiStatus,
   createQuestionSnapshot,
+  isValidMessage,
   MessageIdTracker,
 } from './protocol.ts';
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1118,8 +1118,15 @@ const VALID_TYPES: ReadonlySet<string> = new Set(Object.keys(MESSAGE_DIRECTION))
 
 /**
  * Type guard to check if parsed JSON is a valid protocol message.
+ *
+ * Exported because `deserialize` validates only the OUTER envelope.
+ * `ReplayBatchMessage.messages` is `readonly ProtocolMessage[]` at compile
+ * time only, so nested replayed messages reach a consumer's dispatch unchecked
+ * and a consumer that recurses into them must validate each one itself (#897).
+ * Use this rather than re-deriving the check: a second copy of "what counts as
+ * a valid message" is the drift this registry exists to eliminate.
  */
-function isValidMessage(value: unknown): value is ProtocolMessage {
+export function isValidMessage(value: unknown): value is ProtocolMessage {
   if (typeof value !== 'object' || value === null) {
     return false;
   }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -64,6 +64,7 @@ import type {
 import { DEFAULT_SETTINGS } from '@/types';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
+import { assertNever } from '@remi/shared';
 import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
@@ -1624,9 +1625,79 @@ function App() {
         // ignored so the debounced broadcast doesn't spam the debug log.
         break;
 
-      default:
-        console.debug(`[App] Unhandled message type: ${(message as { type: string }).type}`);
+      // c2d per MESSAGE_DIRECTION (packages/shared/src/protocol.ts): this
+      // client SENDS every one of these to the daemon; the daemon never
+      // sends one back to a client, so handleMessage should never actually
+      // observe one arriving here. Grouped as one explicit no-op rather than
+      // omitted -- if a future/older daemon ever echoes one, it is silently
+      // dropped instead of console.debug-spamming, and the #897 exhaustiveness
+      // sweep records that this was decided, not forgotten.
+      case 'hello':
+      case 'user_input':
+      case 'answer':
+      case 'bullet_expand_request':
+      case 'session_list_request':
+      case 'transcript_load_request':
+      case 'create_session_request':
+      case 'terminal_resize':
+      case 'auth_response':
+      case 'kill_session_request':
+      case 'session_history_request':
+      case 'resume_session_request':
+      case 'detach_session':
+      case 'register_device_token':
+      case 'unregister_device_token':
         break;
+
+      // Intercepted in useConnectionManager's createMessageHandler
+      // (hooks/useConnectionManager.ts) before it ever calls this handler --
+      // 'auth_challenge' drives handleAuthChallenge and 'auth_result' drives
+      // handleAuthResult, both returning early. handleMessage never actually
+      // observes either; the cases exist only so this switch stays exhaustive
+      // against ProtocolMessageMap.
+      case 'auth_challenge':
+      case 'auth_result':
+        break;
+
+      // Keep-alive, both directions. lib/websocket-client.ts's own
+      // `handleMessage` already auto-replies pong to an inbound ping before
+      // forwarding it up, and both ping and pong double as proof-of-life for
+      // its heartbeat monitor regardless of what happens here -- no
+      // application-level handling is needed in the app layer.
+      case 'ping':
+      case 'pong':
+        break;
+
+      // d2c per MESSAGE_DIRECTION, but createAgentOutput (protocol.ts) has no
+      // live caller on the WebSocket/relay path today: AdapterRegistry.
+      // sendMessage, the only thing that would invoke
+      // WebSocketAdapter.sendMessage/RelayAdapter.sendMessage, is never
+      // called anywhere in packages/daemon/src (verified by grep) outside
+      // TelegramAdapter's unrelated same-named internal helper. Chat delivery
+      // to the web client goes through structured_agent_output and
+      // transcript_content instead. Kept as an explicit no-op rather than
+      // removed from the union, in case an older daemon or a future adapter
+      // starts sending it.
+      case 'agent_output':
+        break;
+
+      // createEdit (protocol.ts) has zero callers anywhere in this repo --
+      // fully dead on the wire today. Explicit no-op rather than removed
+      // from the union.
+      case 'edit':
+        break;
+
+      // Live d2c: packages/daemon/src/cli/handlers/pty-message-fanout.ts
+      // sends this to every ATTACHED connection for a session, not just
+      // CLI-attach-mode clients, so the web client does receive it. The web
+      // UI renders from structured_agent_output/transcript_content instead
+      // of raw terminal bytes, so this is intentionally ignored here (the
+      // CLI attach client's raw-terminal case is the real consumer).
+      case 'raw_pty_output':
+        break;
+
+      default:
+        assertNever(message);
     }
   }, []);
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -64,7 +64,7 @@ import type {
 import { DEFAULT_SETTINGS } from '@/types';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
-import { assertNever } from '@remi/shared';
+import { assertNever, isValidMessage } from '@remi/shared';
 import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
@@ -947,7 +947,20 @@ function App() {
         // dispatched with inReplay=true (#798) so replay-sensitive cases (currently
         // just 'question', mirroring the terminal client's #753 fix) can skip
         // state mutations that assume LIVE pendingness.
+        // Validate each nested message before recursing. `deserialize` checks
+        // only the OUTER envelope, so `messages` is `ProtocolMessage[]` by
+        // compile-time assertion alone — an older client replaying a batch
+        // from a newer daemon can receive a type it has no case for. That
+        // would reach `assertNever` in the default and THROW, propagating out
+        // through websocket-client's catch and erroring the whole connection.
+        // Before exhaustiveness landed this was a silent no-op, and graceful
+        // degradation is a stated principle, so skip-and-continue preserves it
+        // while keeping the compile-time guarantee for types we do know (#897).
         for (const replayMsg of message.messages) {
+          if (!isValidMessage(replayMsg)) {
+            console.debug('Skipping unknown message type in replay batch', replayMsg);
+            continue;
+          }
           handleMessage(connectionId, replayMsg, true);
         }
         break;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -5,7 +5,9 @@
  */
 
 import type { QuestionResolvedMessage } from '@remi/shared/protocol.ts';
-import type { MessageState, Timestamp, UUID } from '@remi/shared/types.ts';
+import type { AgentStatus, MessageState, Timestamp, UUID } from '@remi/shared/types.ts';
+
+export type { AgentStatus } from '@remi/shared/types.ts';
 
 /** Source that produced a UI message */
 export type MessageSource = 'optimistic' | 'pty' | 'transcript';
@@ -67,18 +69,6 @@ export interface ConnectionState {
    */
   readonly attachState: 'attached' | 'queued' | null;
 }
-
-/** Agent status as displayed in the UI. Mirrors the daemon's `AgentStatus`
- *  (@remi/shared); `evaluating`/`approved`/`starting` are auto-approve and
- *  session-lifecycle states surfaced on the pill (#576). */
-export type AgentStatus =
-  | 'idle'
-  | 'thinking'
-  | 'executing'
-  | 'waiting'
-  | 'evaluating'
-  | 'approved'
-  | 'starting';
 
 /** Message sender type */
 export type MessageSender = 'user' | 'agent' | 'system';

--- a/packages/web/tests/lib/message-dispatch-conformance.test.ts
+++ b/packages/web/tests/lib/message-dispatch-conformance.test.ts
@@ -50,6 +50,7 @@ import {
   createHello,
   deserialize,
   generateId,
+  isValidMessage,
   serialize,
 } from '@remi/shared/protocol.ts';
 import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
@@ -204,5 +205,50 @@ describe('web total dispatch: real daemon <-> real web client conformance (#897)
     expect(got.messages).toHaveLength(2);
     expect(got.messages.map((m) => m.type)).toEqual(['question', 'session_update']);
     expect(got.messages.map((m) => m.id)).toEqual(nested.map((m) => m.id));
+  });
+
+  test('an unknown message type nested in a replay batch survives the round trip unfiltered', async () => {
+    // The forward-compat hazard behind App.tsx's replay-batch guard: `deserialize`
+    // validates only the OUTER envelope, so a nested message with a type this
+    // build has never heard of arrives intact rather than being dropped in
+    // transport. An older client replaying a batch from a newer daemon hits
+    // exactly this. App.tsx must therefore validate each nested message itself
+    // before recursing, or `assertNever` throws and errors the connection --
+    // where the pre-exhaustiveness code silently ignored it.
+    //
+    // This test pins the TRANSPORT half of that claim (nothing filters it),
+    // which is what makes the App.tsx guard load-bearing rather than defensive
+    // decoration.
+    const unknownNested = {
+      type: 'totally_unknown_future_type',
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+    } as unknown as ProtocolMessage;
+
+    const batch: ProtocolMessage = {
+      type: 'replay_batch',
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+      sessionId: 'fixture-session-id',
+      messages: [unknownNested],
+      isComplete: true,
+    };
+
+    const before = received.length;
+    // biome-ignore lint/style/noNonNullAssertion: assigned in beforeAll's waitFor
+    adapter.sendRaw(connectionId!, batch);
+
+    await waitFor(() => received.slice(before).some((m) => m.id === batch.id));
+    const got = received.slice(before).find((m) => m.id === batch.id);
+    if (got?.type !== 'replay_batch') throw new Error('unreachable');
+
+    // Arrived unfiltered: the transport did NOT drop the unknown nested type.
+    expect(got.messages).toHaveLength(1);
+    expect((got.messages[0] as { type: string }).type).toBe('totally_unknown_future_type');
+
+    // And the guard App.tsx applies to it rejects it, so the recursion skips
+    // rather than falling through to assertNever.
+    expect(isValidMessage(got.messages[0])).toBe(false);
+    expect(isValidMessage(got)).toBe(true);
   });
 });

--- a/packages/web/tests/lib/message-dispatch-conformance.test.ts
+++ b/packages/web/tests/lib/message-dispatch-conformance.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Two-sided conformance test for the C4 web total-dispatch migration (#897).
+ *
+ * Drives the REAL daemon `WebSocketAdapter` and the REAL web `WebSocketClient`
+ * over one real Bun-native socket -- no synthetic counterparty on either side
+ * (AGENTS.md "Verify before you describe": #543 shipped half-built because
+ * `relay-encryption.test.ts` drove the daemon with a test-local client that
+ * performed a handshake step no real client did; #881 found it). Both
+ * endpoints here are the actual shipping classes, imported directly (not
+ * reimplemented, not mocked): `packages/daemon/src/adapters/websocket-adapter.ts`
+ * and `packages/web/src/lib/websocket-client.ts`.
+ *
+ * For every message type the daemon can legitimately send a client
+ * (`MESSAGE_DIRECTION` 'd2c' or 'both' -- packages/shared/src/protocol.ts),
+ * this broadcasts the checked-in golden fixture
+ * (packages/shared/tests/fixtures/protocol/) and asserts:
+ *
+ *   1. the real `WebSocketClient`'s `onMessage` actually receives it,
+ *      byte-for-byte round-tripped over the wire (real TCP, real JSON
+ *      serialize/deserialize -- not an in-process function call), and
+ *   2. `packages/web/src/App.tsx`'s `handleMessage` switch has a real,
+ *      explicit `case` for that type.
+ *
+ * ## Why (2) greps the switch instead of querying a dispatch map
+ *
+ * #897's issue text describes stage (b): extracting the switch bodies into a
+ * `packages/web/src/lib/message-dispatch.ts` total `MessageHandlers` map, and
+ * this test asserting that map has an entry per fixture. That extraction did
+ * NOT ship in this PR -- see the PR body for the concrete measurement (a
+ * 1100+ line switch body closing over 15 distinct refs, 8 setState setters,
+ * and 8 locally-defined composite helper closures, one of which recurses into
+ * the enclosing `useCallback` for `replay_batch`) that made verbatim
+ * extraction judged too risky for this change. Only stage (a) shipped: grouped
+ * explicit-ignore cases plus `assertNever` in App.tsx's existing switch, which
+ * already gets the real prize (a missing case is a compile error -- see the
+ * break-it-then-fix-it evidence in the PR body). Without a `MessageHandlers`
+ * object to query, assertion 2 above substitutes the best available REAL
+ * artifact for "has an entry": the switch itself, read from the file this
+ * suite ships next to. A future PR that lands stage (b) should replace this
+ * grep with a lookup against the real map.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ProtocolMessage, ProtocolMessageMap } from '@remi/shared/protocol.ts';
+import {
+  MESSAGE_DIRECTION,
+  createHello,
+  deserialize,
+  generateId,
+  serialize,
+} from '@remi/shared/protocol.ts';
+import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
+// Real daemon adapter -- not a test double. Relative import: packages/web has
+// no `@remi/daemon` path alias (only `packages/web/tests/**` is exempt from
+// both typecheck gates, so this resolves fine at `bun test` runtime; see the
+// PR body's "conformance-test placement decision").
+import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
+import { WebSocketClient } from '../../src/lib/websocket-client.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(HERE, '../../../shared/tests/fixtures/protocol');
+const APP_TSX_PATH = join(HERE, '../../src/App.tsx');
+const APP_TSX_SOURCE = readFileSync(APP_TSX_PATH, 'utf-8');
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!predicate() && Date.now() - start < timeoutMs) {
+    await wait(10);
+  }
+  if (!predicate()) {
+    throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+  }
+}
+
+/** Every type this daemon can send a client, per the registry's own direction
+ *  table -- excludes 'c2d' types the web client only ever SENDS. */
+const RECEIVABLE_TYPES = (Object.keys(MESSAGE_DIRECTION) as (keyof ProtocolMessageMap)[]).filter(
+  (t) => MESSAGE_DIRECTION[t] === 'd2c' || MESSAGE_DIRECTION[t] === 'both',
+);
+
+function loadFixture(type: string): ProtocolMessage {
+  const raw = readFileSync(join(FIXTURES_DIR, `${type}.json`), 'utf-8');
+  const msg = deserialize(raw);
+  if (!msg) throw new Error(`fixture ${type}.json failed to deserialize`);
+  return msg;
+}
+
+describe('web total dispatch: real daemon <-> real web client conformance (#897)', () => {
+  let adapter: WebSocketAdapter;
+  let port: number;
+  let client: WebSocketClient;
+  let connectionId: string | null = null;
+  const received: ProtocolMessage[] = [];
+
+  beforeAll(async () => {
+    port = await reserveRange(1);
+    adapter = new WebSocketAdapter(
+      { port },
+      {
+        onConnect: (id) => {
+          connectionId = id;
+        },
+      },
+    );
+    await adapter.start();
+
+    client = new WebSocketClient(
+      // 'localhost', not '127.0.0.1': WebSocketAdapter's default host binds
+      // whatever 'localhost' resolves to first on this machine, which is
+      // IPv6 '::1' in this environment -- connecting to the literal IPv4
+      // address then gets ECONNREFUSED against a socket that isn't listening
+      // on it. Matches the existing convention in
+      // packages/daemon/tests/websocket-server.test.ts.
+      { url: `ws://localhost:${port}/ws`, heartbeatInterval: 0, connectionTimeout: 2000 },
+      {
+        onMessage: (msg) => {
+          received.push(msg);
+        },
+      },
+    );
+    client.connect();
+    await waitFor(() => client.isConnected || client.isTransportOpen);
+
+    // Real hello handshake -- WebSocketAdapter sets skipHelloAck (the daemon's
+    // cli.ts normally acks), so no hello_ack arrives automatically; that's
+    // fine, hello_ack is broadcast like every other fixture below.
+    client.send(createHello(generateId(), '0.0.0-test'));
+    await waitFor(() => connectionId !== null);
+  });
+
+  afterAll(async () => {
+    client.disconnect();
+    await adapter.stop();
+  });
+
+  test('every ProtocolMessageMap key has a d2c/both classification and a fixture', () => {
+    // Sanity on the fixture set itself before trusting it below.
+    const fixtureFiles = new Set(
+      readdirSync(FIXTURES_DIR)
+        .filter((f) => f.endsWith('.json') && f !== '__unknown_type__.json')
+        .map((f) => f.replace(/\.json$/, '')),
+    );
+    for (const type of RECEIVABLE_TYPES) {
+      expect(fixtureFiles.has(type)).toBe(true);
+    }
+    expect(RECEIVABLE_TYPES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(RECEIVABLE_TYPES)('%s', (type) => {
+    test('real daemon broadcast is received by the real web client', async () => {
+      const fixture = loadFixture(type);
+      const before = received.length;
+      // biome-ignore lint/style/noNonNullAssertion: assigned in beforeAll's waitFor
+      adapter.sendRaw(connectionId!, fixture);
+
+      await waitFor(() => received.slice(before).some((m) => m.id === fixture.id));
+      const got = received.slice(before).find((m) => m.id === fixture.id);
+      expect(got).toBeDefined();
+      expect(got?.type).toBe(type);
+      // Wire fidelity: re-serializing what the client received reproduces the
+      // exact bytes the daemon sent (round-tripped through a real socket, not
+      // an in-process function call).
+      expect(serialize(got as ProtocolMessage)).toBe(serialize(fixture));
+    });
+
+    test("App.tsx's handleMessage switch has a real, explicit case for it", () => {
+      // See the module doc: this greps the shipped switch itself (the only
+      // total-dispatch artifact stage (a) produced) rather than a parallel
+      // map, so it cannot drift from what App.tsx actually does.
+      expect(APP_TSX_SOURCE).toContain(`case '${type}':`);
+    });
+  });
+
+  test('replay_batch nested messages survive a real socket round-trip (R2: replay recursion input)', async () => {
+    // The checked-in replay_batch.json fixture is intentionally minimal
+    // (empty `messages`, shared package golden-fixture convention). App.tsx's
+    // `replay_batch` case recursively re-dispatches each nested message with
+    // `inReplay=true` (App.tsx, the case right after `question_snapshot`) --
+    // the risk this suite exists to guard is nested delivery fidelity, which
+    // an empty array can't exercise. Build a realistic non-empty batch here.
+    const nested: ProtocolMessage[] = [loadFixture('question'), loadFixture('session_update')];
+    const batch: ProtocolMessage = {
+      type: 'replay_batch',
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+      sessionId: 'fixture-session-id',
+      messages: nested,
+      isComplete: true,
+    };
+
+    const before = received.length;
+    // biome-ignore lint/style/noNonNullAssertion: assigned in beforeAll's waitFor
+    adapter.sendRaw(connectionId!, batch);
+
+    await waitFor(() => received.slice(before).some((m) => m.id === batch.id));
+    const got = received.slice(before).find((m) => m.id === batch.id);
+    expect(got?.type).toBe('replay_batch');
+    if (got?.type !== 'replay_batch') throw new Error('unreachable');
+    expect(got.messages).toHaveLength(2);
+    expect(got.messages.map((m) => m.type)).toEqual(['question', 'session_update']);
+    expect(got.messages.map((m) => m.id)).toEqual(nested.map((m) => m.id));
+  });
+});


### PR DESCRIPTION
## Summary

C4 (#897): migrate the web client's inbound message switch
(`packages/web/src/App.tsx`'s `handleMessage`) to total dispatch, building on
C2/C3 (#895/#896 — `ProtocolMessageMap`, `MESSAGE_DIRECTION`, `MessageHandlers`,
`dispatchMessage`, `assertNever` in `packages/shared/src`).

**Only stage (a) shipped** (in-place exhaustiveness). Stage (b) (extracting the
switch bodies into a pure `packages/web/src/lib/message-dispatch.ts` total map
with effects injected) did not ship — see "Why stage (b) was not attempted"
below. This matches the issue's own fallback: "a smaller correct PR beats a
larger risky one, and stage (a) carries most of the value."

## What changed

- `packages/web/src/App.tsx`: `handleMessage`'s switch over `ProtocolMessage`
  is now total. The old `default: console.debug(...)` catch-all is replaced
  with grouped, commented, explicit-ignore `case`s for every previously-silent
  type, plus `default: assertNever(message)`. Removing any case now fails
  `bun run typecheck:web`, not just the debug log.
- `packages/web/src/types/index.ts`: deleted the hand-mirrored `AgentStatus`
  union (its own comment admitted "Mirrors the daemon's"); now imports and
  re-exports `AgentStatus` from `@remi/shared/types.ts`. Verified identical
  before collapsing (`packages/shared/src/types.ts:34-41` vs the deleted
  `packages/web/src/types/index.ts:74-81`): same 7 literals, same order,
  `idle | thinking | executing | waiting | evaluating | approved | starting`.
  No other file needed a change — every consumer (`MessageList.tsx`,
  `question-collection.ts`) already imports `AgentStatus` from `@/types`.
- `packages/web/tests/lib/message-dispatch-conformance.test.ts` (new): two-sided
  conformance test, see below.

## Why stage (b) was not attempted

The issue names R2 as the risk to respect and explicitly permits stopping at
stage (a) if extraction "threatens those semantics." Measured, not guessed:
the switch body (`App.tsx`, the `switch (message.type) { ... }` block) is
**~1120 lines** and closes over:

- **15 distinct outer refs** (`ackWaitersRef`, `activeSessionIdRef`,
  `connectDirectRef`, `connectionsRef`, `getSessionIdRef`, `historyTimeoutRef`,
  `lastQuestionIdRef`, `loadedTranscriptsRef`, `pendingKillsRef`,
  `pendingSendsRef`, `questionsRef`, `requestSessionListRef`,
  `resumingSessionRef`, `resyncSurvivorsRef`, `sessionsRef`)
- **8 setState setters** (`setActiveSessionId`, `setHistoryLoading`,
  `setMessages`, `setNativeRoute`, `setQuestions`, `setRecentDirectories`,
  `setResumingSession`, `setSessions`)
- **8 locally-defined composite helper closures** declared inside
  `handleMessage` itself and shared across multiple `case` bodies
  (`clearResyncTimers`, `flushResyncSurvivors`, `discardResyncStash`,
  `scheduleResyncFlush`, `clearSessionForRebind`, `ensureTranscriptLoaded`,
  `commitQuestionsIfChanged`, `reconcileLiveQuestions`) — several of which
  themselves close over refs/setters not otherwise touched in their own case
  body, so extraction can't cleanly slice by case.
- **one self-recursive case**: `replay_batch` calls the enclosing
  `useCallback` (`handleMessage`) itself with `inReplay=true` for each nested
  message (App.tsx, right after `question_snapshot`).

Verbatim-porting ~40 case bodies against that dependency graph into a
`MessageHandlers`-shaped map with "effects injected" means designing and
threading an effects interface with 30+ members, with no existing test
harness that exercises `handleMessage`'s internal state machine end to end
(the closest thing, this PR's own conformance test, only proves wire
delivery — it cannot observe what App.tsx's private closures did with a
message). That is real risk with no way to prove parity before merge, on a
component with no current unit coverage of its own reducer logic. Stage (a)
gets the acceptance criterion that matters most — a missed case is a compile
error — without it.

## Every `'ignore'` introduced, against the old switch's case set

Before this PR, `App.tsx`'s switch had 23 cases: 21 with real logic, plus 2
pre-existing explicit ignores (`hub_status`, `remi_status`). The other 22
types silently fell through `default: console.debug(...)`. This PR adds one
explicit case per type, grouped into 6 comment blocks:

| Group | Types | Why ignored |
|---|---|---|
| c2d (client sends, never receives) | `hello`, `user_input`, `answer`, `bullet_expand_request`, `session_list_request`, `transcript_load_request`, `create_session_request`, `terminal_resize`, `auth_response`, `kill_session_request`, `session_history_request`, `resume_session_request`, `detach_session`, `register_device_token`, `unregister_device_token` | Per `MESSAGE_DIRECTION`, the daemon never sends these back; a real arrival would only happen against a future/older daemon that echoes one |
| Intercepted upstream | `auth_challenge`, `auth_result` | `useConnectionManager.ts`'s `createMessageHandler` returns early for both before calling this handler |
| Keep-alive | `ping`, `pong` | `lib/websocket-client.ts`'s own `handleMessage` already auto-replies `pong` to an inbound `ping`; both double as heartbeat proof-of-life regardless |
| Dead producer | `agent_output` | `d2c` per the registry, but `createAgentOutput`'s only caller is `AdapterRegistry.sendMessage`, which nothing in `packages/daemon/src` calls (verified by grep) outside `TelegramAdapter`'s unrelated same-named internal helper. Chat delivery to web goes through `structured_agent_output`/`transcript_content` instead |
| Fully dead | `edit` | `createEdit` has zero callers anywhere in the repo |
| Live but unrendered | `raw_pty_output` | Genuinely live: `pty-message-fanout.ts` sends this to every ATTACHED connection, including the web client, not just CLI-attach-mode ones. The web UI renders from `structured_agent_output`/`transcript_content`, not raw terminal bytes, so this is correctly ignored — just previously silently, now explicitly |

## Findings that contradict the issue text / prior assumptions

1. **`agent_output` is dead code on the WebSocket/relay path**, despite being
   classified `d2c` in `MESSAGE_DIRECTION` (correctly — the classification
   describes what the type *can* carry, not whether anything currently sends
   it). `AdapterRegistry.sendMessage(connectionId, message)` — the only thing
   that would invoke `WebSocketAdapter.sendMessage`/`RelayAdapter.sendMessage`,
   both of which construct `createAgentOutput` — has zero callers in
   `packages/daemon/src` (grep verified). This is a genuine dead code path
   masquerading as live, exactly the kind of thing "Verify before you
   describe" exists to catch.
2. **`edit` has no producer anywhere in the repo.** `createEdit` (protocol.ts)
   is exported but never called. Fully dead on the wire today.
3. **`raw_pty_output` reaches the web client in real operation**, which was
   not obvious from its name (it reads as CLI-attach-only). `pty-message-fanout.ts`
   sends it to every `session.attachedConnections`, not filtered by adapter
   type — the web client silently dropped it before this PR.
4. The issue's stage (b) description ("Move switch bodies into a pure
   `message-dispatch.ts` total map, effects injected") undersold the size of
   that extraction; see "Why stage (b) was not attempted" for the measurement
   that wasn't available before reading the code.

## Break-it-then-fix-it evidence (observed numbers)

All three run against the final, post-rebase code (rebased onto `develop` at
`e57cb73`, after C6/#898 landed).

**1. Switch exhaustiveness (the core mechanism).** Removed `case 'edit': break;`
from `App.tsx`:
- `bun run typecheck:web` → **RED**:
  `src/App.tsx(1694,21): error TS2345: Argument of type 'EditMessage' is not
  assignable to parameter of type 'never'.`
- Restored → `bun run typecheck:web` → **GREEN** (no output, exit 0).

**2. The conformance test's own "explicit case" assertion.** With the same
`case 'edit':` removed, ran only the new test file:
- `bun test packages/web/tests/lib/message-dispatch-conformance.test.ts` →
  **61 pass, 1 fail** — the single failure is
  `edit > App.tsx's handleMessage switch has a real, explicit case for it`.
- Restored → same command → **62 pass, 0 fail**.

**3. The acceptance criterion literally** ("Removing any registry entry key
from the map breaks the web compile", read as "adding one does, until
handled" since C4 has no map to remove a key from): temporarily added a
`__c4_spike_dummy__` key to `ProtocolMessageMap` and `MESSAGE_DIRECTION` in
`packages/shared/src/protocol.ts`:
- `bun run typecheck:web` → **RED**:
  `src/App.tsx(1700,21): error TS2345: Argument of type 'SpikeDummyMessage' is
  not assignable to parameter of type 'never'.`
- `bun run typecheck` (root) → **RED**, independently, in TWO other C-series
  consumers that landed on `develop` while this branch was in flight:
  - the shared package's own C2 golden-fixture machinery:
    `packages/shared/tests/fixtures/protocol/builders.ts(216,14): error
    TS2741: Property '__c4_spike_dummy__' is missing...`
  - C6's attach-client total dispatch map (#898, merged after this branch was
    created — caught by the same rebase):
    `packages/daemon/src/cli/attach-client.ts(234,11): error TS2741: Property
    '__c4_spike_dummy__' is missing in type '{ ... }' but required in type
    'MessageHandlers<keyof ProtocolMessageMap, void>'.`
- Reverted (confirmed via `git diff packages/shared/src/protocol.ts` — clean)
  → both commands → **GREEN**.

This third case is the strongest evidence in the PR: one new registry key,
with zero other changes, broke three independent consumers across two
packages (web's `assertNever` switch, daemon's `MessageHandlers` map, shared's
own fixture builders) simultaneously — which is exactly the epic's (#883)
stated goal, now demonstrably true for the web client specifically.

## Conformance test

`packages/web/tests/lib/message-dispatch-conformance.test.ts`, real daemon
`WebSocketAdapter` (`packages/daemon/src/adapters/websocket-adapter.ts`) and
real web `WebSocketClient` (`packages/web/src/lib/websocket-client.ts`) over
one real Bun-native socket — no synthetic counterparty on either side (the
#543/#881 lesson this repo already paid for: `relay-encryption.test.ts` drove
the daemon with a test-local client that did what no real client does).

For every type `MESSAGE_DIRECTION` classifies `'d2c'` or `'both'` (30 types —
`'c2d'`-only types are never received inbound, so excluded), it broadcasts
that type's checked-in golden fixture and asserts:
1. the real `WebSocketClient`'s `onMessage` receives it, and re-serializing
   what it received reproduces the exact bytes the daemon sent (real TCP +
   real JSON round-trip, not an in-process call);
2. `App.tsx`'s source has a real `case '<type>':` for it.

Plus a dedicated `replay_batch` test with two real nested fixture messages
(the checked-in `replay_batch.json` golden fixture has an empty `messages`
array by convention, which can't exercise nested delivery), confirming the
array survives a real socket round-trip with types and ids intact — the wire
side of the R2 recursion risk.

**62 tests, 62 pass, 0 fail** (`bun test packages/web/tests/lib/message-dispatch-conformance.test.ts`).

### Conformance-test placement decision

Spiked the cross-package typecheck question named in the issue. Root
`tsconfig.json` **excludes `packages/web/**/*` entirely** and has no `lib:
["DOM"]`; `packages/web/tsconfig.app.json`'s `include` is `["src"]` only (not
`tests`). So `packages/web/tests/**` is not typechecked by either
`bun run typecheck` or `bun run typecheck:web` — it only needs to *run*
correctly under `bun test`, which doesn't enforce types. That made the
combined-config question moot rather than needing a resolution: the test
lives in `packages/web/tests/lib/`, importing the real daemon adapter via a
relative path (`../../../daemon/src/adapters/websocket-adapter.ts`) and the
real web client via a relative path in the same directory
(`../../src/lib/websocket-client.ts`). Both resolve fine at `bun test`
runtime (Bun resolves each file's own bare-specifier aliases, e.g.
`@remi/shared`, against the nearest tsconfig to *that file*, not the entry
test file — daemon test files already prove this pattern works). No
`packages/daemon/tests/conformance/` fallback was needed.

One real bug found while spiking: connecting to `ws://127.0.0.1:<port>` against
`WebSocketAdapter`'s default host (`'localhost'`) got `ConnectionRefused`,
because `localhost` resolves to `::1` first in this environment and
`Bun.serve` binds only what it's given. Existing daemon tests avoid this by
connecting to `localhost` literally rather than `127.0.0.1`; this test does the
same.

## Gates

All run against the final, post-rebase branch (rebased onto `develop` at
`e57cb73`, after C6/#898 landed — clean rebase, no conflicts).

```
bun run typecheck        # PASS, clean
bun run typecheck:web    # PASS, clean
bunx biome check .       # PASS (exit 0). 48 pre-existing warnings, all in
                          #   packages/daemon/tests/ files this PR does not touch
                          #   (noNonNullAssertion in hook-config-manager.test.ts,
                          #   same-cwd-no-cross-binding.test.ts, etc). packages/web
                          #   is biome-ignored by design (biome.json files.ignore).
bun test                 # FULL SUITE, foreground: 4221 pass, 2 fail, 20481
                          #   expect() calls, 4223 tests / 213 files, 756s.
                          #   Both failures: auto-approve/llm-judgment.test.ts
                          #   "LLM Judgment: safe build/test/lint (should approve)"
                          #   > version check / date command, each timing out at
                          #   exactly 30000ms -- the known LLM-timeout flake in
                          #   packages/daemon/tests/auto-approve/ (untouched by
                          #   this PR; re-runs alone, see project memory). Zero
                          #   failures anywhere else in the suite.
```

Also ran targeted subsets in isolation before the full run, all clean:
- `bun test packages/web/tests/` -- 479 pass, 0 fail, 763 expect() calls,
  28 files (includes the new 62-test conformance suite)
- `bun test packages/daemon/tests/websocket-server.test.ts
  packages/daemon/tests/adapter-registry.test.ts
  packages/daemon/tests/session/port-utils.test.ts` (the daemon components the
  conformance test drives) -- 87 pass, 0 fail
- `bun test packages/shared/tests/` -- 418 pass, 0 fail

`packages/web` lints via ESLint, not biome (`biome.json` `files.ignore`
includes `packages/web`). Ran `eslint` on the changed files directly
(`src/App.tsx`, `src/types/index.ts`, the new test file): zero new findings.
Pre-existing ESLint errors in `InputArea.tsx`/`message-filter.ts` and warnings
in `useConnectionManager.ts` are untouched by this PR (not a CI gate; see
project memory).
